### PR TITLE
feat: implement evalM for monadic evaluation

### DIFF
--- a/SSA/Core/WellTypedFramework.lean
+++ b/SSA/Core/WellTypedFramework.lean
@@ -226,7 +226,6 @@ def TSSA.evalM {Op β : Type} {M : Type → Type} [Goedel β] [TUSM : TypedUserS
 def TypeSemantics : Type 1 :=
   ℕ → Type
 
-#check Id
 inductive NatBaseType (TS : TypeSemantics) : Type
   | ofNat : ℕ → NatBaseType TS
 deriving DecidableEq


### PR DESCRIPTION
This allows us to express undefined behaviour such as division by zero in a way that represents program sequencing.
- Implementation is straightforward, since I had thought of the type signatures beforehand for ITrees. Sprinkle an `M` at the appropriate locations to make it all work.
- We still keep around the old `eval`. This gives us the version with the cleaner unfolding properties when we want to reason about pure programs, while retaining the monadic version for the cases we really want to unfold through the layers of `Option`s this will create.