### PR TITLE
chore: resize logo in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,7 @@
 <img src="./images/logo.png"
      alt="LeanMLIR" title="LeanMLIR"
      class="center"
-     width=30vh height=30vh
-     style=""/>
+     style="width: 30vh; height: 30vh"/>
 </p>
 
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 <img src="./images/logo.png"
      alt="LeanMLIR" title="LeanMLIR"
      class="center"
-     width=70% height=70%
+     width=30vh height=30vh
      style=""/>
 </p>
 


### PR DESCRIPTION
This ensures the logo always takes up 30% of the viewport's height, making it look decently sized on both desktop and mobile. (See https://github.com/opencompl/lean-mlir/blob/resize-readme-logo/README.md for a preview).