### PR TITLE
Removed `Sorry` from bitvec_AddSub_1202

### DIFF
--- a/SSA/Projects/InstCombine/AliveStatements.lean
+++ b/SSA/Projects/InstCombine/AliveStatements.lean
@@ -67,19 +67,7 @@ theorem bitvec_AddSub_1176 :
 
 theorem bitvec_AddSub_1202 :
     ∀ (e e_1 : LLVM.IntW w), LLVM.add (LLVM.xor e_1 (LLVM.const? (-1))) e ⊑ LLVM.sub (LLVM.sub e (LLVM.const? 1)) e_1 := by
-  simp_alive_undef
-  simp_alive_ops
-  simp_alive_case_bash
-  try alive_auto
-  rename_i a b
-  rw [add_comm]
-  simp only [add_right_inj]
-  rw  [← allOnes_sub_eq_xor]
-  simp only [sub_left_inj]
-  symm
-  exact negOne_eq_allOnes'
-
-
+  alive_auto
 
 
 theorem bitvec_AddSub_1295 :

--- a/SSA/Projects/InstCombine/AliveStatements.lean
+++ b/SSA/Projects/InstCombine/AliveStatements.lean
@@ -71,7 +71,16 @@ theorem bitvec_AddSub_1202 :
   simp_alive_ops
   simp_alive_case_bash
   try alive_auto
-  all_goals sorry
+  rename_i a b
+  rw [add_comm]
+  simp only [add_right_inj]
+  rw  [← allOnes_sub_eq_xor]
+  simp only [sub_left_inj]
+  symm
+  exact negOne_eq_allOnes'
+
+
+
 
 theorem bitvec_AddSub_1295 :
     ∀ (e e_1 : LLVM.IntW w), LLVM.add (LLVM.and e_1 e) (LLVM.xor e_1 e) ⊑ LLVM.or e_1 e := by

--- a/SSA/Projects/InstCombine/TacticAuto.lean
+++ b/SSA/Projects/InstCombine/TacticAuto.lean
@@ -91,6 +91,8 @@ macro "simp_alive_bitvec": tactic =>
                      try cases BitVec.getLsb _ _ <;> try simp;
                      try cases BitVec.getLsb _ _ <;> try simp;)
         try solve | (simp [bv_ofBool])
+        try solve | (simp only   [← BitVec.allOnes_sub_eq_xor,  BitVec.negOne_eq_allOnes'];  ring_nf)
+
       )
    )
 
@@ -102,6 +104,7 @@ macro "alive_auto": tactic =>
         try (
           simp_alive_case_bash
           ensure_only_goal
+
         )
         simp_alive_bitvec
       )

--- a/SSA/Projects/InstCombine/TacticAuto.lean
+++ b/SSA/Projects/InstCombine/TacticAuto.lean
@@ -91,8 +91,7 @@ macro "simp_alive_bitvec": tactic =>
                      try cases BitVec.getLsb _ _ <;> try simp;
                      try cases BitVec.getLsb _ _ <;> try simp;)
         try solve | (simp [bv_ofBool])
-        try solve | (simp only   [← BitVec.allOnes_sub_eq_xor,  BitVec.negOne_eq_allOnes'];  ring_nf)
-
+        try solve | (simp only [← BitVec.allOnes_sub_eq_xor, BitVec.negOne_eq_allOnes']; ring_nf)
       )
    )
 


### PR DESCRIPTION
I used theorems on BitVectors to prove the statement `bitvec_AddSub_1202`.

Tobias asked me to do a "day 1 patch", so I proved a simple theorem in `AliveStatements.lean`.

That theorem was:

```
w : ℕ
a b : BitVec w
⊢ (b ^^^ allOnes w) + a = a + (-1#w - b)
```

