### PR TITLE
bugfix: Fix formatting/pretty-printing of MLIR in the OPT tool

### DIFF
--- a/SSA/Core/Framework.lean
+++ b/SSA/Core/Framework.lean
@@ -245,7 +245,7 @@ mutual
 
   /-- Format string for sequence of assignments and return in a Com. -/
   partial def comReprAux (prec : Nat) : Com d Γ eff t → Format
-    | .ret v => f!"llvm.return {reprPrec v prec} : ({repr t}) -> ()"
+    | .ret v => f!"\"llvm.return\"({reprPrec v prec}): ({repr t}) -> ()"
     | .var e body =>
       f!"%{repr <| Γ.length} = {e.repr prec}" ++ Format.line ++
       comReprAux prec body

--- a/SSA/Core/Framework.lean
+++ b/SSA/Core/Framework.lean
@@ -233,7 +233,7 @@ mutual
         let outTy := DialectSignature.outTy op
         let argTys := DialectSignature.sig op
         let regArgs := Format.parenIfNonempty " (" ")" Format.line (reprRegArgsAux regArgs)
-        f!"{repr op}{formatArgTuple args}{regArgs} : {formatTypeTuple argTys} → ({repr outTy})"
+        f!"{repr op}{formatArgTuple args}{regArgs} : {formatTypeTuple argTys} -> {repr outTy}"
 
   /-- Format string for a Com, with the region parentheses and formal argument list. -/
   partial def Com.repr (prec : Nat) (com : Com d Γ eff t) : Format :=
@@ -245,7 +245,7 @@ mutual
 
   /-- Format string for sequence of assignments and return in a Com. -/
   partial def comReprAux (prec : Nat) : Com d Γ eff t → Format
-    | .ret v => f!"return {reprPrec v prec} : ({repr t}) → ()"
+    | .ret v => f!"llvm.return {reprPrec v prec} : ({repr t}) -> ()"
     | .var e body =>
       f!"%{repr <| Γ.length} = {e.repr prec}" ++ Format.line ++
       comReprAux prec body

--- a/SSA/Projects/InstCombine/Base.lean
+++ b/SSA/Projects/InstCombine/Base.lean
@@ -84,8 +84,12 @@ inductive MOp.UnaryOp : Type
   | neg
   | not
   | copy
-deriving Repr, DecidableEq, Inhabited
-
+deriving  DecidableEq, Inhabited
+instance : Repr (MOp.UnaryOp) := ⟨ fun x _ => match x with
+  | MOp.UnaryOp.neg  => "neg"
+  | MOp.UnaryOp.not => "not"
+  | MOp.UnaryOp.copy  => "copy"
+  ⟩
 /-- Homogeneous, binary operations -/
 inductive MOp.BinaryOp : Type
   | and
@@ -101,8 +105,22 @@ inductive MOp.BinaryOp : Type
   | sub
   | sdiv
   | udiv
-deriving Repr, DecidableEq, Inhabited
-
+deriving  DecidableEq, Inhabited
+instance : Repr (MOp.BinaryOp) := ⟨ fun x _ => match x with
+  | MOp.BinaryOp.and  => "llvm.and"
+  | MOp.BinaryOp.or => "llvm.or"
+  | MOp.BinaryOp.xor  => "llvm.xor"
+  | MOp.BinaryOp.shl  => "llvm.shl"
+  | MOp.BinaryOp.lshr  => "llvm.lshr"
+  | MOp.BinaryOp.ashr  => "llvm.ashr"
+  | MOp.BinaryOp.urem  => "llvm.urem"
+  | MOp.BinaryOp.srem  => "llvm.srem"
+  | MOp.BinaryOp.add  => "llvm.add"
+  | MOp.BinaryOp.mul  => "llvm.mul"
+  | MOp.BinaryOp.sub  => "llvm.sub"
+  | MOp.BinaryOp.sdiv  => "llvm.sdiv"
+  | MOp.BinaryOp.udiv  => "llvm.udiv"
+  ⟩
 -- See: https://releases.llvm.org/14.0.0/docs/LangRef.html#bitwise-binary-operations
 inductive MOp (φ : Nat) : Type
   | unary   (w : Width φ) (op : MOp.UnaryOp) :  MOp φ
@@ -111,7 +129,14 @@ inductive MOp (φ : Nat) : Type
   | icmp    (c : IntPredicate) (w : Width φ) : MOp φ
   /-- Since the width of the const might not be known, we just store the value as an `Int` -/
   | const (w : Width φ) (val : ℤ) : MOp φ
-deriving Repr, DecidableEq, Inhabited
+deriving  DecidableEq, Inhabited
+instance : Repr (MOp φ) := ⟨ fun x _ => match x with
+  | MOp.unary w op => repr  (op)
+  | MOp.binary w op => repr  (op)
+  | MOp.select w  => "llvm.mlir.select"
+  | MOp.icmp c w => "llvm.mlir.icmp"
+  | MOp.const w val => s!"llvm.mlir.const ⦃value = {val} : i32⦄"
+  ⟩
 
 namespace MOp
 

--- a/SSA/Projects/InstCombine/Base.lean
+++ b/SSA/Projects/InstCombine/Base.lean
@@ -107,19 +107,19 @@ inductive MOp.BinaryOp : Type
   | udiv
 deriving  DecidableEq, Inhabited
 instance : Repr (MOp.BinaryOp) := ⟨ fun x _ => match x with
-  | MOp.BinaryOp.and  => "llvm.and"
-  | MOp.BinaryOp.or => "llvm.or"
-  | MOp.BinaryOp.xor  => "llvm.xor"
-  | MOp.BinaryOp.shl  => "llvm.shl"
-  | MOp.BinaryOp.lshr  => "llvm.lshr"
-  | MOp.BinaryOp.ashr  => "llvm.ashr"
-  | MOp.BinaryOp.urem  => "llvm.urem"
-  | MOp.BinaryOp.srem  => "llvm.srem"
-  | MOp.BinaryOp.add  => "llvm.add"
-  | MOp.BinaryOp.mul  => "llvm.mul"
-  | MOp.BinaryOp.sub  => "llvm.sub"
-  | MOp.BinaryOp.sdiv  => "llvm.sdiv"
-  | MOp.BinaryOp.udiv  => "llvm.udiv"
+  | MOp.BinaryOp.and => "\"llvm.and\""
+  | MOp.BinaryOp.or => "\"llvm.or\""
+  | MOp.BinaryOp.xor => "\"llvm.xor\""
+  | MOp.BinaryOp.shl => "\"llvm.shl\""
+  | MOp.BinaryOp.lshr => "\"llvm.lshr\""
+  | MOp.BinaryOp.ashr => "\"llvm.ashr\""
+  | MOp.BinaryOp.urem => "\"llvm.urem\""
+  | MOp.BinaryOp.srem => "\"llvm.srem\""
+  | MOp.BinaryOp.add => "\"llvm.add\""
+  | MOp.BinaryOp.mul => "\"llvm.mul\""
+  | MOp.BinaryOp.sub => "\"llvm.sub\""
+  | MOp.BinaryOp.sdiv => "\"llvm.sdiv\""
+  | MOp.BinaryOp.udiv => "\"llvm.udiv\""
   ⟩
 -- See: https://releases.llvm.org/14.0.0/docs/LangRef.html#bitwise-binary-operations
 inductive MOp (φ : Nat) : Type
@@ -131,11 +131,11 @@ inductive MOp (φ : Nat) : Type
   | const (w : Width φ) (val : ℤ) : MOp φ
 deriving  DecidableEq, Inhabited
 instance : Repr (MOp φ) := ⟨ fun x _ => match x with
-  | MOp.unary w op => repr  (op)
-  | MOp.binary w op => repr  (op)
-  | MOp.select w  => "llvm.mlir.select"
-  | MOp.icmp c w => "llvm.mlir.icmp"
-  | MOp.const w val => s!"llvm.mlir.const ⦃value = {val} : i32⦄"
+  | MOp.unary w op => repr op
+  | MOp.binary w op => repr op
+  | MOp.select w => "\"llvm.mlir.select\""
+  | MOp.icmp c w => "\"llvm.mlir.icmp\""
+  | MOp.const w val => "\"llvm.mlir.const\"() {value = " ++ repr val ++  " : i32}"
   ⟩
 
 namespace MOp


### PR DESCRIPTION
Ideally, we want the OPT tool (without any optimizations applied) to output the same MLIR as it was inputted. Before, the OPT tool did not display (pretty print) MLIR using the same syntax as the parser.

I changed the `Repr` class of `MOp` to bring the display of MLIR in line with the parser.

Note that I have only tried this on one example: `test/LLVMDialect/InstCombine/bb0.mlir`, because OPT doesn't seem to work on other examples in `test/LLVMDialect/InstCombine/**`.