### PR TITLE
feat: make context generalization in simp_peephole tactic optional

### DIFF
--- a/SSA/Core/Tactic.lean
+++ b/SSA/Core/Tactic.lean
@@ -121,9 +121,7 @@ macro "simp_peephole" "[" ts: Lean.Parser.Tactic.simpLemma,* "]" "at" Γv:ident 
   ))
 
 /-- `simp_peephole` with no extra user defined theorems. -/
-macro "simp_peephole" Γv:("at" ident)? : tactic =>
-  match Γv with
-    | none    => `(tactic| simp_peephole [])
-    | some Γv => `(tactic| simp_peephole [] at $(⟨Γv.raw[0]⟩):ident)
+macro "simp_peephole" "at" Γv:ident : tactic => `(tactic| simp_peephole [] at $Γv)
+macro "simp_peephole"               : tactic => `(tactic| simp_peephole [])
 
 end SSA


### PR DESCRIPTION
This PR separates the framework simplification done in `simp_peephole` from the valuation massaging, by making the final `at \Gv:ident` part of the tactic syntax optional.

This came up in a pair programming session with @ymherklotz, where we had already massaged the valuation to be in terms of Lean variables using Valuation.ofPair, so we did not really need to pass a valuation, but we did want the simplification.