### PR TITLE
Chore: Remove warnings due to .

### DIFF
--- a/SSA/Core/ErasedContext.lean
+++ b/SSA/Core/ErasedContext.lean
@@ -268,8 +268,8 @@ def Valuation.snoc {Γ : Ctxt Ty} {t : Ty} (s : Γ.Valuation) (x : toType t) :
   intro t' v
   revert s x
   refine Ctxt.Var.casesOn v ?_ ?_
-  . intro _ _ _ v s _; exact s v
-  . intro _ _ _ x; exact x
+  · intro _ _ _ v s _; exact s v
+  · intro _ _ _ x; exact x
 
 infixl:50 "::ᵥ" => Valuation.snoc
 

--- a/SSA/Core/Framework.lean
+++ b/SSA/Core/Framework.lean
@@ -1877,15 +1877,15 @@ theorem subset_entries :
     split at hvarMap
     case h_1 _p q r _s =>
       split_ifs at hvarMap
-      . simp_all
+      · simp_all
     case h_2 _a _b _c _d e f =>
       simp only [Option.some.injEq] at hvarMap
       subst hvarMap
       rcases x with ⟨x, y⟩
       simp only [← AList.mem_lookup_iff] at *
       by_cases hx : x = ⟨t, w⟩
-      . subst hx; simp_all
-      . rwa [AList.lookup_insert_ne hx]
+      · subst hx; simp_all
+      · rwa [AList.lookup_insert_ne hx]
   · intro w ma v₂
     intro b? c? varMap hvarMap
     simp only [Ctxt.get?, Var.succ_eq_toSnoc, Option.mem_def] at *
@@ -1905,7 +1905,7 @@ theorem subset_entries :
     split at hvarMap
     case h_1 _p q r _s =>
       split_ifs at hvarMap
-      . simp_all
+      · simp_all
     case h_2 _a _b _c _d e f =>
       simp only [Option.some.injEq] at hvarMap
       subst hvarMap
@@ -1913,8 +1913,8 @@ theorem subset_entries :
       rcases x with ⟨x, y⟩
       simp only [← AList.mem_lookup_iff] at *
       by_cases hx : x = ⟨t, w⟩
-      . subst hx; simp_all
-      . rwa [AList.lookup_insert_ne hx]
+      · subst hx; simp_all
+      · rwa [AList.lookup_insert_ne hx]
 
 theorem subset_entries_matchArg [DecidableEq d.Op]
     {Γ_out Δ_in Δ_out : Ctxt d.Ty}
@@ -2313,8 +2313,8 @@ theorem denote_matchVarMap2 [LawfulMonad d.m] {Γ_in Γ_out Δ_in Δ_out : Ctxt 
     funext t v
     simp only [Valuation.comap]
     split
-    . split <;> simp_all
-    . have := AList.lookup_isSome.2 (mem_matchVar hm (hvars _ v))
+    · split <;> simp_all
+    · have := AList.lookup_isSome.2 (mem_matchVar hm (hvars _ v))
       simp_all
 
 
@@ -2417,8 +2417,8 @@ theorem denote_rewriteAt [LawfulMonad d.m] (lhs rhs : Com d Γ₁ .pure t₁)
     split_ifs at hrew
     subst t₁
     split at hrew
-    . simp at hrew
-    . simp only [Option.some.injEq] at hrew
+    · simp at hrew
+    · simp only [Option.some.injEq] at hrew
       subst hrew
       rename_i _ _ h
       simp only [Zipper.denote_toCom, Zipper.denote_insertPureCom, ← hl,
@@ -2451,13 +2451,13 @@ instance {Γ : List d.Ty} {t' : d.Ty} {lhs : Com d (.ofList Γ) .pure t'} :
       let v : Var (.ofList Γ) (Γ.get i) := ⟨i, by simp [List.get?_eq_get, Ctxt.ofList]⟩
       ⟨_, v⟩ ∈ lhs.vars) <|  by
   constructor
-  . intro h t v
+  · intro h t v
     rcases v with ⟨i, hi⟩
     try simp only [Erased.out_mk] at hi
     rcases List.get?_eq_some.1 hi with ⟨h', rfl⟩
     simp at h'
     convert h ⟨i, h'⟩
-  . intro h i
+  · intro h i
     apply h
 
 def rewritePeepholeAt (pr : PeepholeRewrite d Γ t)

--- a/SSA/Experimental/Bits/Fast/Circuit.lean
+++ b/SSA/Experimental/Bits/Fast/Circuit.lean
@@ -88,11 +88,11 @@ lemma le_def : ∀ (c₁ c₂ : Circuit α), c₁ ≤ c₂ ↔ ∀ f, eval c₁ 
 lemma exists_eval_iff_exists_evalv [DecidableEq α] (c : Circuit α) :
     (∃ x, eval c x) ↔ ∃ x, evalv c x := by
   constructor
-  . rintro ⟨x, hx⟩
+  · rintro ⟨x, hx⟩
     use λ a _ => x a
     rw [eval_eq_evalv] at hx
     exact hx
-  . rintro ⟨x, hx⟩
+  · rintro ⟨x, hx⟩
     refine ⟨λ a => dite (a ∈ c.vars) (x a) (λ _ => false), ?_⟩
     convert hx
     rw [eval_eq_evalv]
@@ -367,16 +367,16 @@ def bOr : ∀ (_s : List α) (_f : α → Circuit β), Circuit β
   rw [List.foldl_cons, eval_foldl_or l]
   simp only [eval_or, Bool.or_eq_true, List.mem_cons]
   constructor
-  . intro h
+  · intro h
     rcases h with (h₁ | h₂) | ⟨a, ha⟩
-    . simp [*]
-    . exact Or.inr ⟨_, Or.inl rfl, h₂⟩
-    . exact Or.inr ⟨_, Or.inr ha.1, ha.2⟩
-  . intro h
+    · simp [*]
+    · exact Or.inr ⟨_, Or.inl rfl, h₂⟩
+    · exact Or.inr ⟨_, Or.inr ha.1, ha.2⟩
+  · intro h
     rcases h with h | ⟨a, rfl| ha, h⟩
-    . simp [*]
-    . simp [*]
-    . exact Or.inr ⟨_, ha, h⟩
+    · simp [*]
+    · simp [*]
+    · exact Or.inr ⟨_, ha, h⟩
 
 @[simp] lemma eval_bOr :
   ∀ {s : List α} {f : α → Circuit β} {g : β → Bool},
@@ -399,10 +399,10 @@ def bAnd : ∀ (_s : List α) (_f : α → Circuit β), Circuit β
     rw [List.foldl_cons, eval_foldl_and l]
     simp only [eval_and, Bool.and_eq_true, List.mem_cons]
     constructor
-    . intro h
+    · intro h
       rcases h with ⟨⟨h₁, h₂⟩, h⟩
       simpa [*] using h
-    . intro h
+    · intro h
       rcases h with ⟨h₁, h₂⟩
       simp only [h₁, true_and, h₂ a (Or.inl rfl)]
       aesop
@@ -547,8 +547,8 @@ theorem card_varsFinset_assignVars_lt [DecidableEq α] [DecidableEq β]
           use ha'
           simp only [mem_varsFinset.1 ha', dite_true]
           split at hb₂
-          . simpa [*, eq_comm] using hb₂
-          . simp at hb₂
+          · simpa [*, eq_comm] using hb₂
+          · simp at hb₂
    _ ≤ _ := Finset.card_image_le
 
 lemma eval_assignVars [DecidableEq α] : ∀ {c : Circuit α}
@@ -614,7 +614,7 @@ def snd {α β : Type _} [DecidableEq α] [DecidableEq β]
 --  (λ x => Circuit.assignVars c
 --    (λ i => Sum.rec (fun i hi => Sum.inr (x i (by simp [hi]))) (fun i _ => Sum.inl i) i))
 
-theorem eval_snd {α β : Type _} [DecidableEq α] [DecidableEq β]
+theorem eval_sn.d {α β : Type _} [DecidableEq α] [DecidableEq β]
     (c : Circuit (α ⊕ β)) (g : β → Bool) :
     c.snd.eval g ↔ ∃ g' : α → Bool, c.eval (Sum.elim g' g) := by
   -- TODO: Fix sorry
@@ -670,12 +670,12 @@ def single [DecidableEq α] {s : List α} (x : ∀ a ∈ s, Bool) : Circuit α :
   rw [single]
   simp
   constructor
-  . intros h a ha
+  · intros h a ha
     specialize h a ha
     rw [dif_pos ha] at h
     revert h
     cases x a ha <;> simp
-  . intros h a ha
+  · intros h a ha
     rw [dif_pos ha]
     specialize h a ha
     revert h
@@ -699,12 +699,12 @@ def nonemptyAux [DecidableEq α] :
     | [], hv => ⟨eval c (λ _ => false), by
         rw [exists_eval_iff_exists_evalv, eq_iff_iff, eval_eq_evalv]
         constructor
-        . rintro ⟨x, hx⟩
+        · rintro ⟨x, hx⟩
           rw [← hx]
           congr
           funext i hi
           simp [hv] at hi
-        . intro h
+        · intro h
           use λ i _ => false
           ⟩
     | i::l, hv =>
@@ -723,26 +723,26 @@ def nonemptyAux [DecidableEq α] :
         rw [← b₁.prop, ← b₂.prop]
         simp! only [(eval_assignVars)]
         constructor
-        . rintro ⟨x, hx⟩
+        · rintro ⟨x, hx⟩
           cases hi : x i
-          . right
+          · right
             use x
             convert hx
             split_ifs
-            . subst i
+            · subst i
               simp [hi]
-            . simp
-          . left
+            · simp
+          · left
             use x
             convert hx
             split_ifs
-            . subst i
+            · subst i
               simp [hi]
-            . simp
-        . intro h
+            · simp
+        · intro h
           rcases h with ⟨x, hx⟩ | ⟨x, hx⟩
-          . refine ⟨_, hx⟩
-          . refine ⟨_, hx⟩⟩
+          · refine ⟨_, hx⟩
+          · refine ⟨_, hx⟩⟩
 termination_by c l _ => c.varsFinset.card
 
 def nonempty [DecidableEq α] (c : Circuit α) : Bool :=
@@ -764,7 +764,7 @@ lemma always_true_iff [DecidableEq α] (c : Circuit α) :
     always_true c ↔ ∀ x, eval c x := by
   simp [always_true, nonempty_eq_false_iff, not_not]
 
-instance [DecidableEq α] : DecidableRel ((. ≤. ) : Circuit α → Circuit α → Prop) :=
+instance [DecidableEq α] : DecidableRel ((· ≤· ) : Circuit α → Circuit α → Prop) :=
   λ c₁ c₂ => decidable_of_iff (always_true ((~~~ c₁).or c₂)) <|
     by simp [always_true_iff, le_def, or_iff_not_imp_left]
 

--- a/SSA/Experimental/Bits/Fast/FiniteStateMachine.lean
+++ b/SSA/Experimental/Bits/Fast/FiniteStateMachine.lean
@@ -162,23 +162,23 @@ lemma carry_compose [Fintype arity] [DecidableEq arity]
       rw [carry, carry_compose _ _ _ _ _ n]
       ext y
       cases y
-      . simp [carry, nextBit, compose, Circuit.eval_bind, eval]
+      · simp [carry, nextBit, compose, Circuit.eval_bind, eval]
         congr
         ext z
         cases z
-        . simp
-        . simp [Circuit.eval_map, carry]
+        · simp
+        · simp [Circuit.eval_map, carry]
           congr
           ext s
           cases s
-          . simp
-          . simp
-      . simp [Circuit.eval_map, carry, compose, eval, carry, nextBit]
+          · simp
+          · simp
+      · simp [Circuit.eval_map, carry, compose, eval, carry, nextBit]
         congr
         ext z
         cases z
-        . simp
-        . simp
+        · simp
+        · simp
 
 /-- Evaluating a composed fsm is equivalent to composing the evaluations of the constituent FSMs -/
 lemma eval_compose [Fintype arity] [DecidableEq arity]
@@ -269,8 +269,8 @@ theorem carry_add_succ (x : Bool → BitStream) (n : ℕ) :
   ext n
   simp only [eval]
   cases n
-  . show Bool.xor _ _ = Bool.xor _ _; simp
-  . rw [carry_add_succ]
+  · show Bool.xor _ _ = Bool.xor _ _; simp
+  · rw [carry_add_succ]
     conv => {rhs; simp only [(· + ·), BitStream.add, Add.add, BitStream.addAux, BitVec.adcb]}
     simp [nextBit, eval, add]
 
@@ -304,8 +304,8 @@ theorem eval_sub (x : Bool → BitStream) : sub.eval x = (x true) - (x false) :=
   simp only [(· - ·), Sub.sub]
   ext n
   cases n
-  . simp [eval, sub, nextBit, BitStream.sub, BitStream.subAux, carry]
-  . rw [eval, carry_sub]
+  · simp [eval, sub, nextBit, BitStream.sub, BitStream.subAux, carry]
+  · rw [eval, carry_sub]
     simp [nextBit, eval, sub, BitStream.sub, BitStream.subAux]
 
 def neg : FSM Unit :=
@@ -329,8 +329,8 @@ theorem carry_neg (x : Unit → BitStream) : ∀ (n : ℕ), neg.carry x (n+1) =
   show _ = BitStream.neg _
   ext n
   cases n
-  . simp [eval, neg, nextBit, BitStream.neg, BitStream.negAux, carry]
-  . rw [eval, carry_neg]
+  · simp [eval, neg, nextBit, BitStream.neg, BitStream.negAux, carry]
+  · rw [eval, carry_neg]
     simp [nextBit, eval, neg, BitStream.neg, BitStream.negAux]
 
 def not : FSM Unit :=
@@ -365,8 +365,8 @@ def one : FSM (Fin 0) :=
 @[simp] lemma eval_one (x : Fin 0 → BitStream) : one.eval x = BitStream.one := by
   ext n
   cases n
-  . rfl
-  . simp [eval, carry_one, nextBit]
+  · rfl
+  · simp [eval, carry_one, nextBit]
 
 def negOne : FSM (Fin 0) :=
   { α := Empty,
@@ -397,8 +397,8 @@ theorem carry_ls (b : Bool) (x : Unit → BitStream) : ∀ (n : ℕ),
     (ls b).eval x = (x ()).concat b := by
   ext n
   cases n
-  . rfl
-  . simp [carry_ls, eval, nextBit, BitStream.concat]
+  · rfl
+  · simp [carry_ls, eval, nextBit, BitStream.concat]
 
 def var (n : ℕ) : FSM (Fin (n+1)) :=
   { α := Empty,
@@ -428,8 +428,8 @@ theorem carry_incr (x : Unit → BitStream) : ∀ (n : ℕ),
 @[simp] lemma eval_incr (x : Unit → BitStream) : incr.eval x = (x ()).incr := by
   ext n
   cases n
-  . simp [eval, incr, nextBit, carry, BitStream.incr, BitStream.incrAux]
-  . rw [eval, carry_incr]; rfl
+  · simp [eval, incr, nextBit, carry, BitStream.incr, BitStream.incrAux]
+  · rw [eval, carry_incr]; rfl
 
 def decr : FSM Unit :=
   { α := Unit,
@@ -451,8 +451,8 @@ theorem carry_decr (x : Unit → BitStream) : ∀ (n : ℕ), decr.carry x (n+1) 
 @[simp] lemma eval_decr (x : Unit → BitStream) : decr.eval x = BitStream.decr (x ()) := by
   ext n
   cases n
-  . simp [eval, decr, nextBit, carry, BitStream.decr, BitStream.decrAux]
-  . rw [eval, carry_decr]; rfl
+  · simp [eval, decr, nextBit, carry, BitStream.decr, BitStream.decrAux]
+  · rw [eval, carry_decr]; rfl
 
 theorem evalAux_eq_zero_of_set {arity : Type _} (p : FSM arity)
     (R : Set (p.α → Bool)) (hR : ∀ x s, (p.nextBit s x).1 ∈ R → s ∈ R)
@@ -635,20 +635,20 @@ theorem decideIfZerosAux_correct {arity : Type _} [DecidableEq arity]
     decideIfZerosAux p c = true ↔ ∀ n x, p.eval x n = false := by
   rw [decideIfZerosAux]
   split_ifs with h
-  . simp
+  · simp
     exact hc p.initCarry h
-  . dsimp
+  · dsimp
     split_ifs with h'
-    . simp only [true_iff]
+    · simp only [true_iff]
       intro n x
       rw [p.eval_eq_zero_of_set {x | c.eval x = true}]
-      . intro y s
+      · intro y s
         simp [Circuit.le_def, Circuit.eval_fst, Circuit.eval_bind] at h'
         simp [Circuit.eval_fst, FSM.nextBit]
         apply h'
-      . assumption
-      . exact hc₂
-    . let c' := (c.bind (p.nextBitCirc ∘ some)).fst
+      · assumption
+      · exact hc₂
+    · let c' := (c.bind (p.nextBitCirc ∘ some)).fst
       have _wf : card_compl (c' ||| c) < card_compl c :=
         decideIfZeroAux_wf h'
       stop
@@ -671,12 +671,12 @@ theorem decideIfZerosAux_correct {arity : Type _} [DecidableEq arity]
 theorem decideIfZeros_correct {arity : Type _} [DecidableEq arity]
     (p : FSM arity) : decideIfZeros p = true ↔ ∀ n x, p.eval x n = false := by
   apply decideIfZerosAux_correct
-  . simp only [Circuit.eval_fst, forall_exists_index]
+  · simp only [Circuit.eval_fst, forall_exists_index]
     intro s x h
     use 0
     use (fun a _ => x a)
     simpa [FSM.eval, FSM.changeInitCarry, FSM.nextBit, FSM.carry]
-  . simp only [Circuit.eval_fst]
+  · simp only [Circuit.eval_fst]
     intro x s h
     use x
     exact h

--- a/SSA/Experimental/Bits/Propagate.lean
+++ b/SSA/Experimental/Bits/Propagate.lean
@@ -121,8 +121,8 @@ lemma propagateCarry_propagate {δ : β → Type} {β' : Type}
     congr
     dsimp
     induction' n with n ih
-    . simp
-    . simp [ih]
+    · simp
+    · simp [ih]
 
 lemma propagate_propagate {δ : β → Type} {β' : Type}
       (f : ∀ a, δ a → β') : ∀ (n : ℕ) (init_carry : α → Bool)
@@ -153,8 +153,8 @@ lemma propagate_propagate {δ : β → Type} {β' : Type}
     ext
     congr
     induction' n with n ih
-    . simp
-    . simp [ih]
+    · simp
+    · simp [ih]
 
 lemma propagateCarry_changeVars {β' : Type}
     (init_carry : α → Bool)
@@ -166,8 +166,8 @@ lemma propagateCarry_changeVars {β' : Type}
     propagateCarry init_carry (λ (carry : α → Bool) (bits : β' → Bool) =>
       next_bit carry (λ b => bits (changeVars b))) x i := by
   induction i
-  . simp
-  . simp [*]
+  · simp
+  · simp [*]
 
 lemma propagate_changeVars {β' : Type}
     (init_carry : α → Bool)
@@ -179,8 +179,8 @@ lemma propagate_changeVars {β' : Type}
     propagate init_carry (λ (carry : α → Bool) (bits : β' → Bool) =>
       next_bit carry (λ b => bits (changeVars b))) x i := by
   induction' i with i ih
-  . rfl
-  . simp only [propagate_succ, propagateCarry_changeVars, ih]
+  · rfl
+  · simp only [propagate_succ, propagateCarry_changeVars, ih]
 
 open Term
 
@@ -765,10 +765,10 @@ lemma propagate_eq_of_carry_eq (seq₁ seq₂ : β → BitStream)
   { erw [Nat.add_succ, propagate_succ2, propagate_succ2, Nat.add_eq]
     simp [← Nat.succ_eq_add_one, ← Nat.add_succ, h₃ _ _ (le_refl _)]
     congr
-    . apply propagateCarry2_eq_of_carry_eq
-      . assumption
-      . exact λ y b h => h₃ y b (Nat.le_succ_of_le h)
-    . funext i
+    · apply propagateCarry2_eq_of_carry_eq
+      · assumption
+      · exact λ y b h => h₃ y b (Nat.le_succ_of_le h)
+    · funext i
       rw [h₃]
       exact Nat.le_succ _ }
 

--- a/SSA/Projects/DCE/DCE.lean
+++ b/SSA/Projects/DCE/DCE.lean
@@ -139,11 +139,11 @@ def Var.tryDelete? [TyDenote Ty] {Γ Γ' : Ctxt Ty} {delv : Γ.Var α}
       -- No way I need this to prove this?
       have H := Nat.lt_trichotomy v.val delv.val
       cases H;
-      . contradiction
-      . case inr H =>
+      · contradiction
+      · case inr H =>
         cases H;
-        . contradiction
-        . linarith
+        · contradiction
+        · linarith
     }
     simp only [Deleted] at DEL
     subst DEL
@@ -163,11 +163,11 @@ def Var.tryDelete? [TyDenote Ty] {Γ Γ' : Ctxt Ty} {delv : Γ.Var α}
           -- No way I need this to prove this?
           have H := Nat.lt_trichotomy v.val delv.val
           cases H;
-          . contradiction
-          . case inr H =>
+          · contradiction
+          · case inr H =>
             cases H;
-            . contradiction
-            . linarith
+            · contradiction
+            · linarith
         simp only [Deleted] at DEL
         subst DEL
         have ⟨vix, vproof⟩ := v

--- a/SSA/Projects/FullyHomomorphicEncryption/Basic.lean
+++ b/SSA/Projects/FullyHomomorphicEncryption/Basic.lean
@@ -466,8 +466,8 @@ theorem R.fromTensor_eq_fromTensor'_fromPoly {q n} {coeffs : List Int} : R.fromT
   R.fromPoly (q := q) (n := n) (R.fromTensor' q coeffs) := by
     simp only [fromTensor, fromTensor']
     induction coeffs
-    . simp [List.enum]
-    . simp only [List.enum_cons]
+    · simp [List.enum]
+    · simp only [List.enum_cons]
       apply fromTensor_eq_fromTensor'_fromPoly_aux
       simp [monomial]
 
@@ -491,11 +491,11 @@ theorem Polynomial.degree_toFinsupp [Semiring M] [DecidableEq M]
       obtain ⟨ha₁, ha₂⟩ := Finset.mem_filter.mp ha
       have ha₃ := Finset.mem_insert.mp ha₁
       cases' ha₃ with ha₄ ha₅
-      . subst ha₄
+      · subst ha₄
         norm_cast
         apply WithBot.coe_le_coe.mpr
         simp [Nat.cast]
-      . have ha₆ := Finset.mem_range.mp ha₅
+      · have ha₆ := Finset.mem_range.mp ha₅
         norm_cast
         apply WithBot.coe_le_coe.mpr
         norm_cast

--- a/SSA/Projects/FullyHomomorphicEncryption/Statements.lean
+++ b/SSA/Projects/FullyHomomorphicEncryption/Statements.lean
@@ -77,10 +77,10 @@ theorem R.toTensor_getD [hqgt1 : Fact (q > 1)] (a : R q n) (i : Nat) : a.toTenso
     unfold R.repLength at h
     cases hDeg : Polynomial.degree (R.representative q n a)
     · apply WithBot.bot_lt_coe
-    . simp only [hDeg] at h
+    · simp only [hDeg] at h
       apply WithBot.coe_lt_coe.2
       linarith
-    . rw[← hLength] at h
+    · rw[← hLength] at h
       linarith
 
 theorem R.toTensor_getD' [hqgt1 : Fact (q > 1)] (a : R q n) (i : Nat) : ↑(a.toTensor.getD i 0) = a.coeff i := by
@@ -155,8 +155,8 @@ theorem R.trimTensor_getD_0 (tensor: List Int) :
     lhs
     rw[H]
   by_cases INBOUNDS:(i < List.length (trimTensor tensor))
-  . rw[List.getD_append (h := INBOUNDS)]
-  . have OUT_OF_BOUNDS : List.length (trimTensor tensor) ≤ i := by linarith
+  · rw[List.getD_append (h := INBOUNDS)]
+  · have OUT_OF_BOUNDS : List.length (trimTensor tensor) ≤ i := by linarith
     rw[List.getD_eq_default (hn := OUT_OF_BOUNDS)]
     rw[List.getD_append_right (h := OUT_OF_BOUNDS)]
     simp
@@ -186,7 +186,7 @@ namespace Poly
 
 theorem eq_iff_coeff_eq [hqgt1 : Fact (q > 1)] (a b : R q n) : a = b ↔ Polynomial.coeff a.representative = Polynomial.coeff b.representative := by
   constructor
-  .  intro h; rw [h]
+  ·  intro h; rw [h]
   ·  intro h
      apply (eq_iff_rep_eq _ _).1
      apply Polynomial.coeff_inj.1
@@ -271,7 +271,7 @@ theorem fromTensor_toTensor [hqgt1 : Fact (q > 1)] (a : R q n) (adeg : (R.repres
         rw [toTensor_fromTensor]
         rw [← ZMod.coe_intCast]
         norm_cast
-        . simp only [R.toTensor_length]
+        · simp only [R.toTensor_length]
           have hdeg := R.repLength_leq_representative_degree_plus_1 q n a
           linarith
 

--- a/SSA/Projects/InstCombine/AliveHandwrittenExamples.lean
+++ b/SSA/Projects/InstCombine/AliveHandwrittenExamples.lean
@@ -65,8 +65,8 @@ theorem alive_DivRemOfSelect (w : Nat) :
        rcases vcond with zero | vcond <;> simp;
        rcases vcond with zero | vcond <;> simp;
        linarith
-     . subst h
+     · subst h
        simp
-     . subst h; simp
+     · subst h; simp
 
 end AliveHandwritten

--- a/SSA/Projects/InstCombine/ForLean.lean
+++ b/SSA/Projects/InstCombine/ForLean.lean
@@ -585,10 +585,10 @@ BitVec.toNat (BitVec.ofInt w 0) = 0 := by
     (x ^^^ y).getLsb i = xor (x.getLsb i) (y.getLsb i) := by
     have hi : i < w ∨ i ≥ w := Nat.lt_or_ge _ _
     rcases hi with h | h
-    . have hi : i = (Fin.mk i h).val := rfl
+    · have hi : i = (Fin.mk i h).val := rfl
       rw [hi]
       simp
-    . simp [getLsb_geX _ h]
+    · simp [getLsb_geX _ h]
 
 /-
 https://github.com/leanprover/std4/commit/ecf1ec23eac8997d5964d480511ba93970fa455b#diff-8f36f4c14ec3f02f7b8ea0a193114c273871d6b0ddad6083cd74090b3befcb1eR227-R229
@@ -638,14 +638,14 @@ theorem neg_toNat_nonzero {n : Nat} (x : BitVec n) (hx : x ≠ 0) :  BitVec.toNa
   simp
   apply Nat.pos_of_ne_zero
   cases x
-  . contradiction
-  . simp
+  · contradiction
+  · simp
 
 theorem toInt_eq' (w : Nat) (x : BitVec w): BitVec.toInt x = if x.toNat < (2 : Nat)^(w - 1) then x else x - 2^w := by
   cases w <;> simp
   · case zero =>
     simp [BitVec.eq_nil x]
-  . case succ w' =>
+  · case succ w' =>
       unfold BitVec.toInt
       simp
       have hcases : (BitVec.toNat x < 2 ^ w') ∨ (BitVec.toNat x ≥ 2 ^ w') := by

--- a/SSA/Projects/Scf/ScfFunctor.lean
+++ b/SSA/Projects/Scf/ScfFunctor.lean
@@ -184,8 +184,8 @@ theorem const_index_fn_iterate (δ : Int)
   obtain ⟨hf, hf'⟩ := f.eq_invariant_fn f' (by intros i v; rw [hf])
   rw [IndexInvariant.iterate hf]; simp
   apply And.intro
-  . linarith
-  . rw [hf']
+  · linarith
+  · rw [hf']
 
 /-- counterDecorator on a constant function -/
 @[simp]


### PR DESCRIPTION
cc: @tobiasgrosser 
See
https://grosser.zulipchat.com/#narrow/stream/248449-Project---Lean4/topic/New.20Warnings
for more information.
In the newest version of Lean, there is a warning

```
warning: ././././SSA/Projects/FullyHomomorphicEncryption/Basic.lean:494:6: Please, use '·' (typed as \·) instead of '.' as 'cdot'.
```
I replaced all instances of `.` with `\cdot` to remove this warning.