### PR TITLE
Chore: Change Automata Tactic from Equality to Congruence on w Bits

### DIFF
--- a/SSA/Experimental/Bits/Fast/BitStream.lean
+++ b/SSA/Experimental/Bits/Fast/BitStream.lean
@@ -377,10 +377,17 @@ local notation a " ≈  " b  => EqualUpTo w a b
 
 @[simp] theorem ofBitVec_sub2 : ofBitVec (x - y) ≈ (ofBitVec x) - (ofBitVec y)  := sorry
 
+theorem eq_ofBitVec (e : a ≈ b) : toBitVec w a = toBitVec w b := by
+  sorry
+
+theorem eq_toBitVec (e  : toBitVec w a = toBitVec w b) : a ≈ b := by
+  sorry
+
 @[simp] theorem ofBitVec_add2 : ofBitVec (x + y) ≈ (ofBitVec x) + (ofBitVec y)  := sorry
 
-@[simp] theorem ofBitVec_neg2 : ofBitVec (- x) ≈  - (ofBitVec x) := sorry
-
+@[simp] theorem ofBitVec_neg2 : ofBitVec (- x) ≈  - (ofBitVec x) := by
+  intros n a
+  sorry
 
 theorem equal_up_to_refl  : a ≈ a := by
   intros  j _
@@ -390,30 +397,41 @@ theorem equal_up_to_symm (e : a ≈ b)  : b ≈ a := by
   intros j h
   symm
   exact e j h
+
 theorem equal_up_to_trans (e1 : a ≈ b) (e2 : b ≈ c) : a ≈ c := by
-  intros  j h
+  intros j h
   trans (b j)
   exact e1 j h
   exact e2 j h
 
+theorem sub_congr  (e1 : a ≈ b) (e2 : c  ≈ d) : (a - c) ≈ (b - d) := by
+  intros n h
+  have sub_congr_lemma : a.subAux c n = b.subAux d n := by
+    induction n
+    simp only [subAux, Prod.mk.injEq, (e1 0 h),(e2 0 h), and_self]
+    rename_i n ih
+    simp only [subAux, Prod.mk.injEq]
+    simp only [(ih (by omega)), Bool.bne_right_inj, (e1 (n + 1) h),(e2 (n + 1) h), and_self]
+  simp only [HSub.hSub, Sub.sub, BitStream.sub, (sub_congr_lemma)]
 
-theorem sub_congr  (e1 : a ≈ b) (e2 : c  ≈ d) : (a - c) ≈ (b - d) := sorry
-
-theorem add_congr  (e1 : a ≈ b) (e2 : c  ≈ d) : (a + c) ≈ (b + d) := sorry
-
-lemma neg_congr_lemma  (e1 : a ≈ b)  (n : Nat) (h : n < w) : a.negAux n = b.negAux n := by
-  induction n
-  simp only [negAux, Prod.mk.injEq, (e1 0 h), and_self]
-  rename_i n ih
-  simp only [negAux, Prod.mk.injEq]
-  have  ff : n < w := by omega
-  simp only [(ih ff), Bool.bne_right_inj, (e1 (n + 1) h), and_self]
+theorem add_congr  (e1 : a ≈ b) (e2 : c  ≈ d) : (a + c) ≈ (b + d) := by
+  intros n h
+  have add_congr_lemma : a.addAux c n = b.addAux d n := by
+    induction n
+    simp only [addAux, Prod.mk.injEq, (e1 0 h),(e2 0 h), and_self]
+    rename_i n ih
+    simp only [addAux, Prod.mk.injEq]
+    simp only [(ih (by omega)), Bool.bne_right_inj, (e1 (n + 1) h),(e2 (n + 1) h), and_self]
+  simp only [HAdd.hAdd, Add.add, BitStream.add, add_congr_lemma]
 
 theorem neg_congr  (e1 : a ≈ b)  : (-a) ≈ -b := by
-  intros g h
-  have := neg_congr_lemma e1 g h
-  simp only [Neg.neg, BitStream.neg, this]
-
+  intros n h
+  have neg_congr_lemma : a.negAux n = b.negAux n := by
+    induction n
+    all_goals simp only [negAux, Prod.mk.injEq, (e1 _ h), and_self]
+    rename_i n ih
+    simp only [(ih (by omega)), Bool.bne_right_inj, (e1 (n + 1) h), and_self]
+  simp only [Neg.neg, BitStream.neg, neg_congr_lemma]
 
 theorem not_congr  (e1 : a ≈ b)  : (~~~a) ≈ ~~~b := by
   intros g h

--- a/SSA/Experimental/Bits/Fast/BitStream.lean
+++ b/SSA/Experimental/Bits/Fast/BitStream.lean
@@ -1,7 +1,7 @@
 import Mathlib.Tactic.NormNum
 
 import Mathlib.Logic.Function.Iterate
-
+-- import SSA.Experimental.Bits.Propagate
 -- TODO: upstream the following section
 section UpStream
 
@@ -373,48 +373,148 @@ Crucially, our decision procedure works by considering which equalities hold for
 
 variable {w : Nat} { x y : BitVec w} {a b a' b' : BitStream}
 
-local notation a " ≈  " b  => EqualUpTo w a b
+local notation a " ≈ʷ  " b  => EqualUpTo w a b
 
-@[simp] theorem ofBitVec_sub2 : ofBitVec (x - y) ≈ (ofBitVec x) - (ofBitVec y)  := sorry
+@[simp] theorem ofBitVec_sub2 : ofBitVec (x - y) ≈ʷ (ofBitVec x) - (ofBitVec y)  := sorry
 
-theorem eq_ofBitVec (e : a ≈ b) : toBitVec w a = toBitVec w b := by
+-- theorem eq_ofBitVec (e : a ≈ʷ b) : toBitVec w a = toBitVec w b := by
+--   sorry
+
+-- theorem eq_toBitVec (e  : toBitVec w a = toBitVec w b) : a ≈ʷ b := by
+--   sorry
+theorem getLsb_add {w : Nat} {i : Nat} (i_lt : i < w) (x : BitVec w) :
+    BitVec.getLsb (x) i =
+      (BitVec.getLsb x i).xor (BitVec.carry i x 1 false) := by
   sorry
-
-theorem eq_toBitVec (e  : toBitVec w a = toBitVec w b) : a ≈ b := by
-  sorry
-
-@[simp] theorem ofBitVec_add2 : ofBitVec (x + y) ≈ (ofBitVec x) + (ofBitVec y)  := sorry
-
-@[simp] theorem ofBitVec_neg2 : ofBitVec (- x) ≈  - (ofBitVec x) := by
+@[simp] theorem ofBitVec_add2 : ofBitVec (x + y) ≈ʷ (ofBitVec x) + (ofBitVec y)  := by
   intros n a
-  sorry
+  -- simp [BitVec.add_eq_adc]
+  -- simp [BitVec.adc]
+  -- rw [BitVec.iunfoldr_replace_snd]
+  -- sorry
+  have add_lemma  : ⟨x.toNat % 2^(n + 1) + y.toNat % 2^(n + 1) ≥ 2^(n + 1), (x.add y).getLsb n   ⟩  = (ofBitVec x).addAux (ofBitVec y) n := by
+    -- simp [BitVec.carry_succ]
+    -- sorry
+    induction n
+    simp [BitVec.carry_zero, BitVec.getLsb, BitVec.add_eq, BitVec.toNat_add, Nat.testBit_zero,
+      addAux, BitVec.adcb, ofBitVec, a, ↓reduceIte, Bool.atLeastTwo_false_right, Bool.bne_false,
+      Prod.mk.injEq, Bool.false_eq, Bool.and_eq_false_imp, decide_eq_true_eq,
+      decide_eq_false_iff_not, Nat.mod_two_ne_one, BitVec.carry, ← Bool.decide_and]
+    constructor
 
-theorem equal_up_to_refl  : a ≈ a := by
+    omega
+    -- omega
+
+    sorry
+
+    rename_i n ih
+    have ihg := ih (by omega)
+    simp [addAux]
+    rw [← ihg]
+    simp
+    simp [ofBitVec,a]
+    simp only [BitVec.getLsb_add, BitVec.adcb]
+    simp [ofBitVec]
+    constructor
+
+    sorry
+
+    -- rw [BitVec.carry_succ (n+1)]
+
+    -- rw [getLsb_add]
+    -- simp [← BitVec.adc]
+    -- ring_nf
+
+    -- rw [BitVec.adc_spec]
+
+    sorry
+
+  simp only [HAdd.hAdd, BitStream.add, Add.add]
+  rw [← add_lemma]
+  simp only [ofBitVec,a,↓reduceIte]
+@[simp] theorem ofBitVec_neg3 : ofBitVec (- x) ≈ʷ  - (ofBitVec x) := by
+  intros n a
+  have neg_lemma  : ⟨ x.neg.getLsb (n) ,  !x.getLsb (n)  ⟩  = (ofBitVec x).negAux n := by
+    induction n
+    simp only [BitVec.getLsb, BitVec.neg_eq, BitVec.toNat_neg, Nat.testBit_zero, zero_add, negAux, ofBitVec, a, ↓reduceIte, Prod.mk.injEq, decide_eq_decide]
+    constructor
+    -- omega
+    -- rw [Int.sub_emod]
+    -- omega
+    -- easy, chil
+    sorry
+
+    sorry
+
+    -- sorry
+    rename_i n ih
+    have ihg := ih (by omega)
+    unfold negAux
+    simp only [BitVec.neg_eq, Prod.mk.injEq, and_true]
+    unfold Neg.neg
+    unfold BitVec.instNeg
+    simp only [BitVec.neg]
+    rw [← ihg]
+    simp
+    constructor
+    sorry
+    simp [ofBitVec,a]
+    sorry
+  simp only [Neg.neg]
+  simp only [BitStream.neg]
+  rw [← neg_lemma]
+  simp only [ofBitVec,a,↓reduceIte]
+
+@[simp] theorem ofBitVec_neg2 : ofBitVec (- x) ≈ʷ  - (ofBitVec x) := by
+  intros n a
+  have neg_lemma  : ⟨ x.neg.getLsb n , !x.getLsb (n)  ⟩  = (ofBitVec x).negAux n := by
+    induction n
+    simp only [BitVec.getLsb, BitVec.neg_eq, BitVec.toNat_neg, Nat.testBit_zero, zero_add, negAux, ofBitVec, a, ↓reduceIte, Prod.mk.injEq, decide_eq_decide]
+    constructor
+    sorry
+    trivial
+    rename_i n ih
+    have ihg := ih (by omega)
+    unfold negAux
+    simp only [BitVec.neg_eq, Prod.mk.injEq, and_true]
+    unfold Neg.neg
+    unfold BitVec.instNeg
+    simp only [BitVec.neg]
+    rw [← ihg]
+    simp
+    constructor
+    sorry
+    sorry
+  simp only [Neg.neg]
+  simp only [BitStream.neg]
+  rw [← neg_lemma]
+  simp only [ofBitVec,a,↓reduceIte]
+
+theorem equal_up_to_refl  : a ≈ʷ a := by
   intros  j _
   rfl
 
-theorem equal_up_to_symm (e : a ≈ b)  : b ≈ a := by
+theorem equal_up_to_symm (e : a ≈ʷ b)  : b ≈ʷ a := by
   intros j h
   symm
   exact e j h
 
-theorem equal_up_to_trans (e1 : a ≈ b) (e2 : b ≈ c) : a ≈ c := by
+theorem equal_up_to_trans (e1 : a ≈ʷ b) (e2 : b ≈ʷ c) : a ≈ʷ c := by
   intros j h
   trans (b j)
   exact e1 j h
   exact e2 j h
 
-theorem sub_congr  (e1 : a ≈ b) (e2 : c  ≈ d) : (a - c) ≈ (b - d) := by
+theorem sub_congr  (e1 : a ≈ʷ b) (e2 : c  ≈ʷ d) : (a - c) ≈ʷ (b - d) := by
   intros n h
   have sub_congr_lemma : a.subAux c n = b.subAux d n := by
     induction n
-    simp only [subAux, Prod.mk.injEq, (e1 0 h),(e2 0 h), and_self]
-    rename_i n ih
-    simp only [subAux, Prod.mk.injEq]
-    simp only [(ih (by omega)), Bool.bne_right_inj, (e1 (n + 1) h),(e2 (n + 1) h), and_self]
+    <;> simp only [subAux, Prod.mk.injEq, subAux, Prod.mk.injEq, (e1 _ h),(e2 _ h), and_self]
+    rename_i _ ih
+    simp only [(ih (by omega)), and_self]
   simp only [HSub.hSub, Sub.sub, BitStream.sub, (sub_congr_lemma)]
 
-theorem add_congr  (e1 : a ≈ b) (e2 : c  ≈ d) : (a + c) ≈ (b + d) := by
+theorem add_congr  (e1 : a ≈ʷ b) (e2 : c  ≈ʷ d) : (a + c) ≈ʷ (b + d) := by
   intros n h
   have add_congr_lemma : a.addAux c n = b.addAux d n := by
     induction n
@@ -424,7 +524,7 @@ theorem add_congr  (e1 : a ≈ b) (e2 : c  ≈ d) : (a + c) ≈ (b + d) := by
     simp only [(ih (by omega)), Bool.bne_right_inj, (e1 (n + 1) h),(e2 (n + 1) h), and_self]
   simp only [HAdd.hAdd, Add.add, BitStream.add, add_congr_lemma]
 
-theorem neg_congr  (e1 : a ≈ b)  : (-a) ≈ -b := by
+theorem neg_congr  (e1 : a ≈ʷ b)  : (-a) ≈ʷ -b := by
   intros n h
   have neg_congr_lemma : a.negAux n = b.negAux n := by
     induction n
@@ -433,13 +533,13 @@ theorem neg_congr  (e1 : a ≈ b)  : (-a) ≈ -b := by
     simp only [(ih (by omega)), Bool.bne_right_inj, (e1 (n + 1) h), and_self]
   simp only [Neg.neg, BitStream.neg, neg_congr_lemma]
 
-theorem not_congr  (e1 : a ≈ b)  : (~~~a) ≈ ~~~b := by
+theorem not_congr  (e1 : a ≈ʷ b)  : (~~~a) ≈ʷ ~~~b := by
   intros g h
   simp only [not_eq]
   congr
   exact e1 g h
 
-theorem equal_trans  (e1 :  a ≈ b) (e2 : c ≈ d)  : (a ≈ c) = (b ≈ d) := by
+theorem equal_trans  (e1 :  a ≈ʷ b) (e2 : c ≈ʷ d)  : (a ≈ʷ c) = (b ≈ʷ d) := by
   apply propext
   constructor
   all_goals (intros h)

--- a/SSA/Experimental/Bits/Fast/BitStream.lean
+++ b/SSA/Experimental/Bits/Fast/BitStream.lean
@@ -269,7 +269,6 @@ variable (x y : BitVec (w+1))
     zero_lt_one, or_true, decide_True, Bool.true_and, not_eq]
   split <;> simp_all
 
-
 end Lemmas
 
 end BitwiseOps
@@ -372,7 +371,7 @@ Crucially, our decision procedure works by considering which equalities hold for
 
 variable {w : Nat} {x y : BitVec w} {a b a' b' : BitStream}
 
-local notation a " ≈ʷ  " b  => EqualUpTo w a b
+local infix:20 " ≈ʷ " => EqualUpTo w
 
 -- TODO: These sorries are difficult, and will be proven in a later Pull Request.
 @[simp] theorem ofBitVec_sub : ofBitVec (x - y) ≈ʷ (ofBitVec x) - (ofBitVec y)  := by
@@ -398,6 +397,12 @@ theorem equal_up_to_trans (e1 : a ≈ʷ b) (e2 : b ≈ʷ c) : a ≈ʷ c := by
   trans b j
   exact e1 j h
   exact e2 j h
+
+instance congr_equiv : Equivalence (EqualUpTo w) := {
+  refl := fun _ => equal_up_to_refl,
+  symm := equal_up_to_symm,
+  trans := equal_up_to_trans
+}
 
 theorem sub_congr (e1 : a ≈ʷ b) (e2 : c  ≈ʷ d) : (a - c) ≈ʷ (b - d) := by
   intros n h
@@ -434,13 +439,14 @@ theorem equal_trans  (e1 :  a ≈ʷ b) (e2 : c ≈ʷ d)  : (a ≈ʷ c) = (b ≈�
   apply propext
   constructor
   <;> intros h
-  apply equal_up_to_trans _ e2
-  apply equal_up_to_trans _ h
-  apply equal_up_to_symm
-  assumption
-  apply equal_up_to_trans _ (equal_up_to_symm e2)
-  apply equal_up_to_trans _ h
-  assumption
+  · apply equal_up_to_trans _ e2
+    apply equal_up_to_trans _ h
+    apply equal_up_to_symm
+    assumption
+  · apply equal_up_to_trans _
+    apply (equal_up_to_symm e2)
+    apply equal_up_to_trans _ h
+    assumption
 
 end Lemmas
 

--- a/SSA/Experimental/Bits/Fast/BitStream.lean
+++ b/SSA/Experimental/Bits/Fast/BitStream.lean
@@ -364,10 +364,14 @@ Crucially, our decision procedure works by considering which equalities hold for
 --   have ⟨h₁, h₂⟩ : True ∧ True := sorry
 --   sorry
 @[simp] theorem ofBitVec_sub : ofBitVec (x - y) = (ofBitVec x) - (ofBitVec y) := sorry
+@[simp] theorem ofBitVec_sub2 {w : Nat} {x y : BitVec w} : EqualUpTo w (ofBitVec (x - y)) ((ofBitVec x) - (ofBitVec y)) := sorry
+
 @[simp] theorem ofBitVec_add : ofBitVec (x + y) = (ofBitVec x) + (ofBitVec y) := sorry
 @[simp] theorem ofBitVec_neg : ofBitVec (-x) = -(ofBitVec x) := sorry
 @[simp] theorem ofBitVec_not : ofBitVec (~~~ x) = ~~~ (ofBitVec x) := sorry
-
+theorem equal_up_to_refl (w : Nat) (e : BitStream) : EqualUpTo w e e := sorry
+theorem sub_congr {w : Nat} {a b c d : BitStream} (e1 : EqualUpTo w a b) (e2 : EqualUpTo w c d) : EqualUpTo w (a - c) (b - d) := sorry
+theorem equal_trans {w : Nat} {a a1 b b1 : BitStream} (e1 : EqualUpTo w a a1) (e2 : EqualUpTo w  b b1)  :EqualUpTo w a b  = EqualUpTo  w a1 b1 := sorry
 end Lemmas
 
 end Arith

--- a/SSA/Experimental/Bits/Fast/BitStream.lean
+++ b/SSA/Experimental/Bits/Fast/BitStream.lean
@@ -388,7 +388,7 @@ theorem equal_up_to_refl : a ≈ʷ a := by
   intros  j _
   rfl
 
-theorem equal_up_to_symm (e : a ≈ʷ b)  : b ≈ʷ a := by
+theorem equal_up_to_symm (e : a ≈ʷ b) : b ≈ʷ a := by
   intros j h
   symm
   exact e j h
@@ -417,7 +417,7 @@ theorem add_congr (e1 : a ≈ʷ b) (e2 : c  ≈ʷ d) : (a + c) ≈ʷ (b + d) := 
     simp only [ih (by omega), Bool.bne_right_inj]
   simp only [HAdd.hAdd, Add.add, BitStream.add, add_congr_lemma]
 
-theorem neg_congr (e1 : a ≈ʷ b)  : (-a) ≈ʷ -b := by
+theorem neg_congr (e1 : a ≈ʷ b) : (-a) ≈ʷ -b := by
   intros n h
   have neg_congr_lemma : a.negAux n = b.negAux n := by
     induction n
@@ -426,7 +426,7 @@ theorem neg_congr (e1 : a ≈ʷ b)  : (-a) ≈ʷ -b := by
     simp only [ih (by omega), Bool.bne_right_inj, and_self]
   simp only [Neg.neg, BitStream.neg, neg_congr_lemma]
 
-theorem not_congr (e1 : a ≈ʷ b)  : (~~~a) ≈ʷ ~~~b := by
+theorem not_congr (e1 : a ≈ʷ b) : (~~~a) ≈ʷ ~~~b := by
   intros g h
   simp only [not_eq, e1 g h]
 

--- a/SSA/Experimental/Bits/Fast/BitStream.lean
+++ b/SSA/Experimental/Bits/Fast/BitStream.lean
@@ -1,7 +1,6 @@
 import Mathlib.Tactic.NormNum
 
 import Mathlib.Logic.Function.Iterate
--- import SSA.Experimental.Bits.Propagate
 -- TODO: upstream the following section
 section UpStream
 
@@ -375,236 +374,14 @@ variable {w : Nat} { x y : BitVec w} {a b a' b' : BitStream}
 
 local notation a " ≈ʷ  " b  => EqualUpTo w a b
 
-@[simp] theorem ofBitVec_sub2 : ofBitVec (x - y) ≈ʷ (ofBitVec x) - (ofBitVec y)  := sorry
-
--- theorem eq_ofBitVec (e : a ≈ʷ b) : toBitVec w a = toBitVec w b := by
---   sorry
-
--- theorem eq_toBitVec (e  : toBitVec w a = toBitVec w b) : a ≈ʷ b := by
---   sorry
-theorem getLsb_add {w : Nat} {i : Nat} (i_lt : i < w) (x : BitVec w) :
-    BitVec.getLsb (x) i =
-      (BitVec.getLsb x i).xor (BitVec.carry i x 1 false) := by
-  sorry
-@[simp] theorem ofBitVec_add2 : ofBitVec (x + y) ≈ʷ (ofBitVec x) + (ofBitVec y)  := by
-  intros n a
-  -- simp [BitVec.add_eq_adc]
-  -- simp [BitVec.adc]
-  -- rw [BitVec.iunfoldr_replace_snd]
-  -- sorry
-  have add_lemma  : ⟨x.toNat % 2^(n + 1) + y.toNat % 2^(n + 1) ≥ 2^(n + 1), (x.add y).getLsb n   ⟩  = (ofBitVec x).addAux (ofBitVec y) n := by
-    -- simp [BitVec.carry_succ]
-    -- sorry
-    induction n
-    simp [BitVec.carry_zero, BitVec.getLsb, BitVec.add_eq, BitVec.toNat_add, Nat.testBit_zero,
-      addAux, BitVec.adcb, ofBitVec, a, ↓reduceIte, Bool.atLeastTwo_false_right, Bool.bne_false,
-      Prod.mk.injEq, Bool.false_eq, Bool.and_eq_false_imp, decide_eq_true_eq,
-      decide_eq_false_iff_not, Nat.mod_two_ne_one, BitVec.carry, ← Bool.decide_and]
-    constructor
-
-    omega
-    -- omega
-
-    sorry
-
-    rename_i n ih
-    have ihg := ih (by omega)
-    simp [addAux]
-    rw [← ihg]
-    simp
-    simp [ofBitVec,a]
-    simp only [BitVec.getLsb_add, BitVec.adcb]
-    simp [ofBitVec]
-    constructor
-
-    sorry
-
-    -- rw [BitVec.carry_succ (n+1)]
-
-    -- rw [getLsb_add]
-    -- simp [← BitVec.adc]
-    -- ring_nf
-
-    -- rw [BitVec.adc_spec]
-
-    sorry
-
-  simp only [HAdd.hAdd, BitStream.add, Add.add]
-  rw [← add_lemma]
-  simp only [ofBitVec,a,↓reduceIte]
-
-@[simp] theorem ofBitVec_neg4 : ofBitVec (- x) ≈ʷ  - (ofBitVec x) := by
-  intros n a
-  induction n
-
-  sorry
-  rename_i n ih
-  have ihg  := ih (by omega)
-  unfold ofBitVec
-  simp [a]
-  -- simp [Neg.neg]
-  unfold Neg.neg
-  simp [instNeg, neg, negAux,a]
-  sorry
-@[simp] theorem ofBitVec_neg3 : ofBitVec (- x) ≈ʷ  - (ofBitVec x) := by
-  intros n a
-
-  have neg_lemma  : ⟨ x.neg.getLsb (n) ,  !x.getLsb (n)  ⟩  = (ofBitVec x).negAux n := by
-    induction n
-    simp only [BitVec.getLsb, BitVec.neg_eq, BitVec.toNat_neg, Nat.testBit_zero, zero_add, negAux, ofBitVec, a, ↓reduceIte, Prod.mk.injEq, decide_eq_decide]
-    constructor
-    -- omega
-    -- rw [Int.sub_emod]
-    -- omega
-
-    sorry
-
-    sorry
-
-    -- sorry
-    rename_i n ih
-    have ihg := ih (by omega)
-    unfold negAux
-    simp only [BitVec.neg_eq, Prod.mk.injEq, and_true]
-    unfold Neg.neg
-    unfold BitVec.instNeg
-    simp only [BitVec.neg]
-    rw [← ihg]
-    simp
-    constructor
-    sorry
-    simp [ofBitVec,a]
-    sorry
-  simp only [Neg.neg]
-  simp only [BitStream.neg]
-  rw [← neg_lemma]
-  simp only [ofBitVec,a,↓reduceIte]
-
-
-
-@[simp]
-def f {w : Nat} (x : BitVec w) (n : Nat) : Bool := match n with
-  | Nat.zero => !x.getLsb 0
-  | Nat.succ y => !x.getLsb (Nat.succ y) && f x y
-
-
-@[simp]
-def f2 {w : Nat} (x : BitVec w) (n : Nat) : Bool := (-x).toNat % 2^ (n + 1) < 2^(n)
--- def
-theorem stuff {w : Nat} (x : BitVec w) (n : Nat) : (-x).getLsb (n + 1) = xor (!x.getLsb (n + 1)) (f2 x n) := by
-  rw [BitVec.neg_eq_not_add]
-  rw [BitVec.getLsb_add sorry]
-  rw [BitVec.getLsb_not]
-  simp
-  induction n
-  simp [f]
-  -- simp [Neg.neg]
-  -- unfold Neg.neg
-  -- unfold  BitVec.instNeg
-  -- unfold BitVec.neg
-  simp [BitVec.getLsb, ← decide_not, ← Bool.decide_and, BitVec.carry, Bool.xor, xor]
-  congr
-
+@[simp] theorem ofBitVec_sub : ofBitVec (x - y) ≈ʷ (ofBitVec x) - (ofBitVec y)  := by
   sorry
 
-  sorry
-  rename_i n ih
-  -- simp [f2]
-  congr
-
-  sorry
+@[simp] theorem ofBitVec_add : ofBitVec (x + y) ≈ʷ (ofBitVec x) + (ofBitVec y)  := by
   sorry
 
--- theorem Bool.xor_comm (a b  : Bool) : a.xor b = b.xor a := by sorry
-theorem neg_bit {w : Nat}  (x  : BitVec w) :  (-x).getLsb 0 = x.getLsb 0 := by
-  by_cases 0 < w
-  all_goals (rename_i c )
-  rw [BitVec.neg_eq_not_add]
-  rw [BitVec.getLsb_add c]
-  rw [BitVec.getLsb_not]
-  simp
-  simp [Bool.xor_comm]
-  simp [c]
-  have : w = 0 := by omega
-  simp [this]
-
-@[simp] theorem ofBitVec_neg5 : ofBitVec (- x) ≈ʷ  - (ofBitVec x) := by
-  intros n a
-  have neg_lemma  : ⟨ x.neg.getLsb n , f2 x n ⟩  = (ofBitVec x).negAux n := by
-    induction n
-    simp [negAux]
-    constructor
-    all_goals simp [ofBitVec,a]
-    exact neg_bit x
-    sorry
-    rename_i n ih
-    have ihg := ih (by omega)
-    unfold negAux
-    simp [← ihg]
-    constructor
-    simp [ofBitVec, a]
-    exact stuff x n
-    congr
-    simp [ofBitVec,a]
-    sorry
-  simp only [Neg.neg]
-  simp only [BitStream.neg]
-  rw [← neg_lemma]
-  simp only [ofBitVec,a,↓reduceIte]
-@[simp] theorem ofBitVec_neg6 : ofBitVec (- x) ≈ʷ  - (ofBitVec x) := by
-  intros n a
-  rw [BitVec.neg_eq_not_add]
-  simp [ofBitVec,a]
-  rw [BitVec.getLsb_add a]
-  rw [BitVec.getLsb_not]
-  simp only [Neg.neg]
-  simp [BitStream.neg,a]
-  -- rw [← neg_lemma]
+@[simp] theorem ofBitVec_neg : ofBitVec (- x) ≈ʷ  - (ofBitVec x) := by
   sorry
-  -- simp only [ofBitVec,a,↓reduceIte]
-
-
-
-
-
-
-
-@[simp] theorem ofBitVec_neg2 : ofBitVec (- x) ≈ʷ  - (ofBitVec x) := by
-  intros n a
-  --Bool.xor (!(x.getLsb (n))) (sorryAx (Nat → Bool) false n)
-  have neg_lemma  : ⟨ x.neg.getLsb n , Bool.xor (!(x.getLsb (n))) ( Bool.xor (!(x.getLsb (n + 1))) (x.neg.getLsb (n + 1))) ⟩  = (ofBitVec x).negAux n := by
-    induction n
-    simp only [BitVec.getLsb, BitVec.neg_eq, BitVec.toNat_neg, Nat.testBit_zero, zero_add, negAux, ofBitVec, a, ↓reduceIte, Prod.mk.injEq, decide_eq_decide]
-    constructor
-
-    sorry
-    unfold Nat.testBit
-    simp
-    -- simp
-
-    -- trivial
-    sorry
-    rename_i n ih
-    have ihg := ih (by omega)
-    unfold negAux
-    simp only [BitVec.neg_eq, Prod.mk.injEq, and_true]
-    unfold Neg.neg
-    unfold BitVec.instNeg
-    simp only [BitVec.neg]
-    rw [← ihg]
-    simp
-    constructor
-
-    simp [BitVec.getLsb  , Nat.testBit, a]
-
-    sorry
-
-    -- simp [a]
-    sorry
-  simp only [Neg.neg]
-  simp only [BitStream.neg]
-  rw [← neg_lemma]
-  simp only [ofBitVec,a,↓reduceIte]
 
 theorem equal_up_to_refl  : a ≈ʷ a := by
   intros  j _
@@ -652,7 +429,6 @@ theorem neg_congr  (e1 : a ≈ʷ b)  : (-a) ≈ʷ -b := by
 theorem not_congr  (e1 : a ≈ʷ b)  : (~~~a) ≈ʷ ~~~b := by
   intros g h
   simp only [not_eq,e1 g h]
-
 
 theorem equal_trans  (e1 :  a ≈ʷ b) (e2 : c ≈ʷ d)  : (a ≈ʷ c) = (b ≈ʷ d) := by
   apply propext

--- a/SSA/Experimental/Bits/Fast/BitStream.lean
+++ b/SSA/Experimental/Bits/Fast/BitStream.lean
@@ -432,8 +432,23 @@ theorem getLsb_add {w : Nat} {i : Nat} (i_lt : i < w) (x : BitVec w) :
   simp only [HAdd.hAdd, BitStream.add, Add.add]
   rw [← add_lemma]
   simp only [ofBitVec,a,↓reduceIte]
+
+@[simp] theorem ofBitVec_neg4 : ofBitVec (- x) ≈ʷ  - (ofBitVec x) := by
+  intros n a
+  induction n
+
+  sorry
+  rename_i n ih
+  have ihg  := ih (by omega)
+  unfold ofBitVec
+  simp [a]
+  -- simp [Neg.neg]
+  unfold Neg.neg
+  simp [instNeg, neg, negAux,a]
+  sorry
 @[simp] theorem ofBitVec_neg3 : ofBitVec (- x) ≈ʷ  - (ofBitVec x) := by
   intros n a
+
   have neg_lemma  : ⟨ x.neg.getLsb (n) ,  !x.getLsb (n)  ⟩  = (ofBitVec x).negAux n := by
     induction n
     simp only [BitVec.getLsb, BitVec.neg_eq, BitVec.toNat_neg, Nat.testBit_zero, zero_add, negAux, ofBitVec, a, ↓reduceIte, Prod.mk.injEq, decide_eq_decide]
@@ -441,7 +456,7 @@ theorem getLsb_add {w : Nat} {i : Nat} (i_lt : i < w) (x : BitVec w) :
     -- omega
     -- rw [Int.sub_emod]
     -- omega
-    -- easy, chil
+
     sorry
 
     sorry
@@ -465,14 +480,110 @@ theorem getLsb_add {w : Nat} {i : Nat} (i_lt : i < w) (x : BitVec w) :
   rw [← neg_lemma]
   simp only [ofBitVec,a,↓reduceIte]
 
+
+
+@[simp]
+def f {w : Nat} (x : BitVec w) (n : Nat) : Bool := match n with
+  | Nat.zero => !x.getLsb 0
+  | Nat.succ y => !x.getLsb (Nat.succ y) && f x y
+
+
+@[simp]
+def f2 {w : Nat} (x : BitVec w) (n : Nat) : Bool := (-x).toNat % 2^ (n + 1) < 2^(n)
+-- def
+theorem stuff {w : Nat} (x : BitVec w) (n : Nat) : (-x).getLsb (n + 1) = xor (!x.getLsb (n + 1)) (f2 x n) := by
+  rw [BitVec.neg_eq_not_add]
+  rw [BitVec.getLsb_add sorry]
+  rw [BitVec.getLsb_not]
+  simp
+  induction n
+  simp [f]
+  -- simp [Neg.neg]
+  -- unfold Neg.neg
+  -- unfold  BitVec.instNeg
+  -- unfold BitVec.neg
+  simp [BitVec.getLsb, ← decide_not, ← Bool.decide_and, BitVec.carry, Bool.xor, xor]
+  congr
+
+  sorry
+
+  sorry
+  rename_i n ih
+  -- simp [f2]
+  congr
+
+  sorry
+  sorry
+
+-- theorem Bool.xor_comm (a b  : Bool) : a.xor b = b.xor a := by sorry
+theorem neg_bit {w : Nat}  (x  : BitVec w) :  (-x).getLsb 0 = x.getLsb 0 := by
+  by_cases 0 < w
+  all_goals (rename_i c )
+  rw [BitVec.neg_eq_not_add]
+  rw [BitVec.getLsb_add c]
+  rw [BitVec.getLsb_not]
+  simp
+  simp [Bool.xor_comm]
+  simp [c]
+  have : w = 0 := by omega
+  simp [this]
+
+@[simp] theorem ofBitVec_neg5 : ofBitVec (- x) ≈ʷ  - (ofBitVec x) := by
+  intros n a
+  have neg_lemma  : ⟨ x.neg.getLsb n , f2 x n ⟩  = (ofBitVec x).negAux n := by
+    induction n
+    simp [negAux]
+    constructor
+    all_goals simp [ofBitVec,a]
+    exact neg_bit x
+    sorry
+    rename_i n ih
+    have ihg := ih (by omega)
+    unfold negAux
+    simp [← ihg]
+    constructor
+    simp [ofBitVec, a]
+    exact stuff x n
+    congr
+    simp [ofBitVec,a]
+    sorry
+  simp only [Neg.neg]
+  simp only [BitStream.neg]
+  rw [← neg_lemma]
+  simp only [ofBitVec,a,↓reduceIte]
+@[simp] theorem ofBitVec_neg6 : ofBitVec (- x) ≈ʷ  - (ofBitVec x) := by
+  intros n a
+  rw [BitVec.neg_eq_not_add]
+  simp [ofBitVec,a]
+  rw [BitVec.getLsb_add a]
+  rw [BitVec.getLsb_not]
+  simp only [Neg.neg]
+  simp [BitStream.neg,a]
+  -- rw [← neg_lemma]
+  sorry
+  -- simp only [ofBitVec,a,↓reduceIte]
+
+
+
+
+
+
+
 @[simp] theorem ofBitVec_neg2 : ofBitVec (- x) ≈ʷ  - (ofBitVec x) := by
   intros n a
-  have neg_lemma  : ⟨ x.neg.getLsb n , !x.getLsb (n)  ⟩  = (ofBitVec x).negAux n := by
+  --Bool.xor (!(x.getLsb (n))) (sorryAx (Nat → Bool) false n)
+  have neg_lemma  : ⟨ x.neg.getLsb n , Bool.xor (!(x.getLsb (n))) ( Bool.xor (!(x.getLsb (n + 1))) (x.neg.getLsb (n + 1))) ⟩  = (ofBitVec x).negAux n := by
     induction n
     simp only [BitVec.getLsb, BitVec.neg_eq, BitVec.toNat_neg, Nat.testBit_zero, zero_add, negAux, ofBitVec, a, ↓reduceIte, Prod.mk.injEq, decide_eq_decide]
     constructor
+
     sorry
-    trivial
+    unfold Nat.testBit
+    simp
+    -- simp
+
+    -- trivial
+    sorry
     rename_i n ih
     have ihg := ih (by omega)
     unfold negAux
@@ -483,7 +594,12 @@ theorem getLsb_add {w : Nat} {i : Nat} (i_lt : i < w) (x : BitVec w) :
     rw [← ihg]
     simp
     constructor
+
+    simp [BitVec.getLsb  , Nat.testBit, a]
+
     sorry
+
+    -- simp [a]
     sorry
   simp only [Neg.neg]
   simp only [BitStream.neg]
@@ -512,7 +628,7 @@ theorem sub_congr  (e1 : a ≈ʷ b) (e2 : c  ≈ʷ d) : (a - c) ≈ʷ (b - d) :=
     <;> simp only [subAux, Prod.mk.injEq, subAux, Prod.mk.injEq, (e1 _ h),(e2 _ h), and_self]
     rename_i _ ih
     simp only [(ih (by omega)), and_self]
-  simp only [HSub.hSub, Sub.sub, BitStream.sub, (sub_congr_lemma)]
+  simp only [HSub.hSub, Sub.sub, BitStream.sub, sub_congr_lemma]
 
 theorem add_congr  (e1 : a ≈ʷ b) (e2 : c  ≈ʷ d) : (a + c) ≈ʷ (b + d) := by
   intros n h
@@ -535,9 +651,8 @@ theorem neg_congr  (e1 : a ≈ʷ b)  : (-a) ≈ʷ -b := by
 
 theorem not_congr  (e1 : a ≈ʷ b)  : (~~~a) ≈ʷ ~~~b := by
   intros g h
-  simp only [not_eq]
-  congr
-  exact e1 g h
+  simp only [not_eq,e1 g h]
+
 
 theorem equal_trans  (e1 :  a ≈ʷ b) (e2 : c ≈ʷ d)  : (a ≈ʷ c) = (b ≈ʷ d) := by
   apply propext

--- a/SSA/Experimental/Bits/Fast/BitStream.lean
+++ b/SSA/Experimental/Bits/Fast/BitStream.lean
@@ -370,7 +370,7 @@ Crucially, our decision procedure works by considering which equalities hold for
 --   have ⟨h₁, h₂⟩ : True ∧ True := sorry
 --   sorry
 
-variable {w : Nat} { x y : BitVec w} {a b a' b' : BitStream}
+variable {w : Nat} {x y : BitVec w} {a b a' b' : BitStream}
 
 local notation a " ≈ʷ  " b  => EqualUpTo w a b
 
@@ -384,7 +384,7 @@ local notation a " ≈ʷ  " b  => EqualUpTo w a b
 @[simp] theorem ofBitVec_neg : ofBitVec (- x) ≈ʷ  - (ofBitVec x) := by
   sorry
 
-theorem equal_up_to_refl  : a ≈ʷ a := by
+theorem equal_up_to_refl : a ≈ʷ a := by
   intros  j _
   rfl
 
@@ -395,53 +395,52 @@ theorem equal_up_to_symm (e : a ≈ʷ b)  : b ≈ʷ a := by
 
 theorem equal_up_to_trans (e1 : a ≈ʷ b) (e2 : b ≈ʷ c) : a ≈ʷ c := by
   intros j h
-  trans (b j)
+  trans b j
   exact e1 j h
   exact e2 j h
 
-theorem sub_congr  (e1 : a ≈ʷ b) (e2 : c  ≈ʷ d) : (a - c) ≈ʷ (b - d) := by
+theorem sub_congr (e1 : a ≈ʷ b) (e2 : c  ≈ʷ d) : (a - c) ≈ʷ (b - d) := by
   intros n h
   have sub_congr_lemma : a.subAux c n = b.subAux d n := by
     induction n
-    <;> simp only [subAux, Prod.mk.injEq, subAux, Prod.mk.injEq, (e1 _ h),(e2 _ h), and_self]
+    <;> simp only [subAux, Prod.mk.injEq, e1 _ h, e2 _ h, and_self]
     rename_i _ ih
-    simp only [(ih (by omega)), and_self]
+    simp only [ih (by omega), and_self]
   simp only [HSub.hSub, Sub.sub, BitStream.sub, sub_congr_lemma]
 
-theorem add_congr  (e1 : a ≈ʷ b) (e2 : c  ≈ʷ d) : (a + c) ≈ʷ (b + d) := by
+theorem add_congr (e1 : a ≈ʷ b) (e2 : c  ≈ʷ d) : (a + c) ≈ʷ (b + d) := by
   intros n h
   have add_congr_lemma : a.addAux c n = b.addAux d n := by
     induction n
-    simp only [addAux, Prod.mk.injEq, (e1 0 h),(e2 0 h), and_self]
-    rename_i n ih
-    simp only [addAux, Prod.mk.injEq]
-    simp only [(ih (by omega)), Bool.bne_right_inj, (e1 (n + 1) h),(e2 (n + 1) h), and_self]
+    <;> simp only [addAux, Prod.mk.injEq, e1 _ h, e2 _ h]
+    rename_i _ ih
+    simp only [ih (by omega), Bool.bne_right_inj]
   simp only [HAdd.hAdd, Add.add, BitStream.add, add_congr_lemma]
 
-theorem neg_congr  (e1 : a ≈ʷ b)  : (-a) ≈ʷ -b := by
+theorem neg_congr (e1 : a ≈ʷ b)  : (-a) ≈ʷ -b := by
   intros n h
   have neg_congr_lemma : a.negAux n = b.negAux n := by
     induction n
-    all_goals simp only [negAux, Prod.mk.injEq, (e1 _ h), and_self]
-    rename_i n ih
-    simp only [(ih (by omega)), Bool.bne_right_inj, (e1 (n + 1) h), and_self]
+    <;> simp only [negAux, Prod.mk.injEq, (e1 _ h)]
+    rename_i _ ih
+    simp only [ih (by omega), Bool.bne_right_inj, and_self]
   simp only [Neg.neg, BitStream.neg, neg_congr_lemma]
 
-theorem not_congr  (e1 : a ≈ʷ b)  : (~~~a) ≈ʷ ~~~b := by
+theorem not_congr (e1 : a ≈ʷ b)  : (~~~a) ≈ʷ ~~~b := by
   intros g h
-  simp only [not_eq,e1 g h]
+  simp only [not_eq, e1 g h]
 
 theorem equal_trans  (e1 :  a ≈ʷ b) (e2 : c ≈ʷ d)  : (a ≈ʷ c) = (b ≈ʷ d) := by
   apply propext
   constructor
-  all_goals (intros h)
+  <;> intros h
   apply equal_up_to_trans _ e2
   apply equal_up_to_trans _ h
   apply equal_up_to_symm
-  exact e1
+  assumption
   apply equal_up_to_trans _ (equal_up_to_symm e2)
   apply equal_up_to_trans _ h
-  exact e1
+  assumption
 
 end Lemmas
 

--- a/SSA/Experimental/Bits/Fast/BitStream.lean
+++ b/SSA/Experimental/Bits/Fast/BitStream.lean
@@ -374,6 +374,7 @@ variable {w : Nat} { x y : BitVec w} {a b a' b' : BitStream}
 
 local notation a " ≈ʷ  " b  => EqualUpTo w a b
 
+-- TODO: These sorries are difficult, and will be proven in a later Pull Request.
 @[simp] theorem ofBitVec_sub : ofBitVec (x - y) ≈ʷ (ofBitVec x) - (ofBitVec y)  := by
   sorry
 

--- a/SSA/Experimental/Bits/Fast/Tactic.lean
+++ b/SSA/Experimental/Bits/Fast/Tactic.lean
@@ -1,5 +1,4 @@
 import Lean.Meta.Tactic.Simp.BuiltinSimprocs
--- import SSA.Experimental.Bits.Fast.FiniteStateMachine
 import SSA.Experimental.Bits.Fast.BitStream
 import SSA.Experimental.Bits.Fast.Decide
 import SSA.Experimental.Bits.Lemmas
@@ -80,7 +79,7 @@ def termNatCorrect (f : Nat → BitStream) (w n : Nat) :  BitStream.ofBitVec (Bi
   exact incrBit w n
 
 
-def quoteThm (qMapIndexToFVar : Q(Nat → BitStream)) (w : Q(Nat)) (nat: Nat) : Q(@Eq BitStream (BitStream.ofBitVec (@BitVec.ofNat $w $nat)) (@Term.eval (termNat $(nat)) $qMapIndexToFVar)) := q(termNatCorrect $qMapIndexToFVar $w $nat)
+def quoteThm (qMapIndexToFVar : Q(Nat → BitStream)) (w : Q(Nat)) (nat: Nat) : Q(@Eq BitStream (BitStream.ofBitVec (@BitVec.ofNat $w $nat)) (@Term.eval (termNat $nat) $qMapIndexToFVar)) := q(termNatCorrect $qMapIndexToFVar $w $nat)
 
 /--
 Simplify BitStream.ofBitVec x where x is an FVar.

--- a/SSA/Experimental/Bits/Fast/Tactic.lean
+++ b/SSA/Experimental/Bits/Fast/Tactic.lean
@@ -1,5 +1,5 @@
 import Lean.Meta.Tactic.Simp.BuiltinSimprocs
-import SSA.Experimental.Bits.Fast.FiniteStateMachine
+-- import SSA.Experimental.Bits.Fast.FiniteStateMachine
 import SSA.Experimental.Bits.Fast.BitStream
 import SSA.Experimental.Bits.Fast.Decide
 import SSA.Experimental.Bits.Lemmas
@@ -80,7 +80,7 @@ def termNatCorrect (f : Nat → BitStream) (w n : Nat) :  BitStream.ofBitVec (Bi
   exact incrBit w n
 
 
-def quoteThm (qMapIndexToFVar : Q(Nat → BitStream)) (w : Q(Nat)) (nat: Nat) : Q(@Eq (BitStream) (BitStream.ofBitVec (@BitVec.ofNat $w $nat)) (@Term.eval (termNat $(nat)) $qMapIndexToFVar)) := q(termNatCorrect $qMapIndexToFVar $w $nat)
+def quoteThm (qMapIndexToFVar : Q(Nat → BitStream)) (w : Q(Nat)) (nat: Nat) : Q(@Eq BitStream (BitStream.ofBitVec (@BitVec.ofNat $w $nat)) (@Term.eval (termNat $(nat)) $qMapIndexToFVar)) := q(termNatCorrect $qMapIndexToFVar $w $nat)
 
 /--
 Simplify BitStream.ofBitVec x where x is an FVar.
@@ -273,6 +273,7 @@ macro "bv_automata" : tactic =>
 # Test Cases
 -/
 
+
 def test0 {w : Nat} (x y : BitVec (w + 1)) : x + 0 = x := by
   bv_automata
 
@@ -291,7 +292,7 @@ def test3 (x y : BitVec 300) : ((x ||| y) - (x ^^^ y)) = (x &&& y) := by
 def test4 (x y : BitVec 2) : (x + -y) = (x - y) := by
   bv_automata
 
-def test5 (x y : BitVec 2) : (x + y) = (y + x) := by
+def test5 (x y z : BitVec 2) : (x + y + z) = (z + y + x) := by
   bv_automata
 
 def test6 (x y z : BitVec 2) : (x + (y + z)) = (x + y + z) := by

--- a/SSA/Experimental/Bits/Fast/Tactic.lean
+++ b/SSA/Experimental/Bits/Fast/Tactic.lean
@@ -134,7 +134,7 @@ def first_rep (w : Expr) (e : Q( BitStream)) : SimpM (Q(BitStream) ×  Expr)  :=
       let myInst : Q(HSub BitStream BitStream BitStream) := q(instHSub)
       return ⟨
         (.app (.app (.app (.app (.app (.app (.const ``HSub.hSub levels) (.const ``BitStream [])) (.const ``BitStream [])) (.const ``BitStream []) ) myInst ) (.app (.app (.const ``BitStream.ofBitVec []) w)  a)   ) (.app (.app (.const ``BitStream.ofBitVec []) w)  b)),
-        .app (.app (.app (.const ``BitStream.ofBitVec_sub2 []) w) a ) b
+        .app (.app (.app (.const ``BitStream.ofBitVec_sub []) w) a ) b
       ⟩
     | .app (.app (.app (.app (.app (.app (.const ``HAdd.hAdd _) _) _) _ ) _ ) a) b => do
       let ⟨ anext, aproof ⟩ ← first_rep w a
@@ -147,7 +147,7 @@ def first_rep (w : Expr) (e : Q( BitStream)) : SimpM (Q(BitStream) ×  Expr)  :=
       let myInst : Q(HAdd BitStream BitStream BitStream) := q(instHAdd)
       return ⟨
         (.app (.app (.app (.app (.app (.app (.const ``HAdd.hAdd levels) (.const ``BitStream [])) (.const ``BitStream [])) (.const ``BitStream []) ) myInst ) (.app (.app (.const ``BitStream.ofBitVec []) w)  a)   ) (.app (.app (.const ``BitStream.ofBitVec []) w)  b)),
-        .app (.app (.app (.const ``BitStream.ofBitVec_add2 []) w) a ) b
+        .app (.app (.app (.const ``BitStream.ofBitVec_add []) w) a ) b
       ⟩
     | .app (.app (.app (.const ``Neg.neg [])  _ ) _ ) a => do
       let ⟨ anext, aproof ⟩ ← first_rep w a
@@ -159,7 +159,7 @@ def first_rep (w : Expr) (e : Q( BitStream)) : SimpM (Q(BitStream) ×  Expr)  :=
       let myExpr : Q(BitStream → BitStream) := q(Neg.neg)
       return ⟨
         .app myExpr (.app (.app (.const ``BitStream.ofBitVec []) w)  a)    ,
-        .app (.app (.const ``BitStream.ofBitVec_neg2 []) w) a
+        .app (.app (.const ``BitStream.ofBitVec_neg []) w) a
       ⟩
     | .app (.app (.app (.const ``Complement.complement _) _ ) _ ) a => do
       let ⟨ anext, aproof ⟩ ← first_rep w a


### PR DESCRIPTION
In a previous version of the Automata tactic, I had relied on statements for re-writing that were not true, for example

```lean
@[simp] theorem ofBitVec_add : ofBitVec (x + y) = (ofBitVec x) + (ofBitVec y) := sorry
```

But in this patch, I use a Simproc to only require a weaker statement:

```lean
@[simp] theorem ofBitVec_add : EqualUpTo w (ofBitVec (x + y))  ((ofBitVec x) + (ofBitVec y)) := sorry
```

So the code has become uglier and more complicated, but at least all the sorries are provable now.

The main new point of complication is that I introduced a new Simproc (because I no longer rely on the congruence properties of equality), and this makes the code more complicated.

The reason why is that for equality, congruence comes for free, i.e. if a=b, then f(a) = f(b). For other equivalence relations, congruence is not automatic, so we have to prove and apply congruence manually.

There are still three sorries in the tactic, namely

```lean

@[simp] theorem ofBitVec_sub : ofBitVec (x - y) ≈ʷ (ofBitVec x) - (ofBitVec y)  := by
  sorry

@[simp] theorem ofBitVec_add : ofBitVec (x + y) ≈ʷ (ofBitVec x) + (ofBitVec y)  := by
  sorry

@[simp] theorem ofBitVec_neg : ofBitVec (- x) ≈ʷ  - (ofBitVec x) := by
  sorry
```

But as I find these statements difficult to prove, I will prove them in a later PR.

cc: @Equilibris 