### PR TITLE
chore: prove that negation on bitstreams is the same as negation on bitvectors

### DIFF
--- a/SSA/Experimental/Bits/Fast/BitStream.lean
+++ b/SSA/Experimental/Bits/Fast/BitStream.lean
@@ -456,13 +456,12 @@ lemma ofBitVec_ofNat : @ofBitVec w 1 ≈ʷ ofNat 1 := by
   exact ofBitVec_ofNat' (by omega)
 
 theorem ofBitVec_neg : ofBitVec (- x) ≈ʷ - (ofBitVec x) := by
-  rw [BitVec.neg_eq_not_add]
-  trans ~~~ ofBitVec x + (ofBitVec (1 : BitVec w ))
-  trans ofBitVec (~~~ x) + (ofBitVec (1 : BitVec w ))
-  exact ofBitVec_add
-  exact add_congr ofBitVec_not' equal_up_to_refl
-  simp only [neg_eq_not_add]
-  exact add_congr equal_up_to_refl ofBitVec_ofNat
+  calc
+  _ ≈ʷ ofBitVec (~~~ x + 1)            := by rw [BitVec.neg_eq_not_add]
+  _ ≈ʷ ofBitVec (~~~ x) + (ofBitVec 1) := ofBitVec_add
+  _ ≈ʷ ~~~ ofBitVec x   + (ofBitVec 1) := add_congr ofBitVec_not' equal_up_to_refl
+  _ ≈ʷ ~~~ ofBitVec x   + 1            := add_congr equal_up_to_refl ofBitVec_ofNat
+  _ ≈ʷ - (ofBitVec x)                  := by rw [neg_eq_not_add]
 
 theorem sub_congr (e1 : a ≈ʷ b) (e2 : c ≈ʷ d) : (a - c) ≈ʷ (b - d) := by
   intros n h

--- a/SSA/Experimental/Bits/Fast/BitStream.lean
+++ b/SSA/Experimental/Bits/Fast/BitStream.lean
@@ -418,7 +418,7 @@ theorem not_congr (e1 : a ≈ʷ b) : (~~~a) ≈ʷ ~~~b := by
   intros g h
   simp only [not_eq, e1 g h]
 
-theorem ofBitVec_not_eq_to : ofBitVec (~~~ x) ≈ʷ ~~~ ofBitVec x := by
+theorem ofBitVec_not_eqTo : ofBitVec (~~~ x) ≈ʷ ~~~ ofBitVec x := by
   intros _ a
   simp [ofBitVec, a]
 
@@ -436,7 +436,7 @@ theorem ofNat_one (i : Nat) : ofNat 1 i = decide (0 = i) := by
   cases i
   <;> simp [ofNat, Nat.shiftRight]
 
-theorem ofBitVec_ofNat : @ofBitVec w 1 ≈ʷ ofNat 1 := by
+theorem ofBitVec_one_eqTo_ofNat : @ofBitVec w 1 ≈ʷ ofNat 1 := by
   by_cases h : w = 0
   · simp [EqualUpTo ,h]
   · intros n a
@@ -447,7 +447,7 @@ theorem ofBitVec_neg : ofBitVec (- x) ≈ʷ - (ofBitVec x) := by
   calc
   _ ≈ʷ ofBitVec (~~~ x + 1)            := by rw [BitVec.neg_eq_not_add]
   _ ≈ʷ ofBitVec (~~~ x) + (ofBitVec 1) := ofBitVec_add
-  _ ≈ʷ ~~~ ofBitVec x   + 1            := add_congr ofBitVec_not_eq_to ofBitVec_ofNat
+  _ ≈ʷ ~~~ ofBitVec x   + 1            := add_congr ofBitVec_not_eqTo ofBitVec_one_eqTo_ofNat
   _ ≈ʷ - (ofBitVec x)                  := by rw [neg_eq_not_add]
 
 theorem sub_congr (e1 : a ≈ʷ b) (e2 : c ≈ʷ d) : (a - c) ≈ʷ (b - d) := by

--- a/SSA/Experimental/Bits/Fast/BitStream.lean
+++ b/SSA/Experimental/Bits/Fast/BitStream.lean
@@ -381,10 +381,7 @@ local infix:20 " ≈ʷ " => EqualUpTo w
   sorry
 
 /--
-This function says returns
-true iff ∀ i < n, x[i] = 0
-and returns false
-iff   ∃ i < n , x[i] = 1
+Does the nth bit overflow/carry in calculating the negation of x?
 -/
 def doesNegCarry? (x : BitVec w) (n : Nat) : Bool := match n with
   | Nat.zero => !x.getLsb 0

--- a/SSA/Experimental/Bits/Fast/BitStream.lean
+++ b/SSA/Experimental/Bits/Fast/BitStream.lean
@@ -422,6 +422,13 @@ theorem ofBitVec_not_eqTo : ofBitVec (~~~ x) ≈ʷ ~~~ ofBitVec x := by
   intros _ a
   simp [ofBitVec, a]
 
+/--
+  Clarification: the reason that this theorem (unexpectedly) contains Prod.swap is
+  that in BitStream.negAux, the carry bit is in the left bit of the pair and
+  in BitStream.addAux, the carry bit is in the right bit of the pair.
+
+  TODO: Possibly investigate changing the behavior of BitStream.addAux?
+-/
 theorem negAux_eq_not_addAux : a.negAux = Prod.swap ∘ (~~~a).addAux 1 := by
   funext i
   induction' i with _ ih

--- a/SSA/Experimental/Bits/Fast/BitStream.lean
+++ b/SSA/Experimental/Bits/Fast/BitStream.lean
@@ -1,5 +1,4 @@
 import Mathlib.Tactic.NormNum
-import Mathlib.Tactic.SlimCheck
 
 import Mathlib.Logic.Function.Iterate
 -- TODO: upstream the following section

--- a/SSA/Experimental/Bits/Fast/BitStream.lean
+++ b/SSA/Experimental/Bits/Fast/BitStream.lean
@@ -424,8 +424,8 @@ theorem ofBitVec_not' : ofBitVec (~~~ x) ≈ʷ ~~~ ofBitVec x := by
 
 theorem neg_eq_not_add' (i : Nat) : a.negAux i = ((~~~a).addAux 1 i).swap := by
   induction' i with _ ih
-  · simp [negAux, addAux, BitVec.adcb, OfNat.ofNat, ofNat]
-  · simp [negAux, addAux, BitVec.adcb, OfNat.ofNat, ofNat, ih]
+  <;> simp [negAux, addAux, BitVec.adcb, OfNat.ofNat, ofNat]
+  · simp [ih, OfNat.ofNat, ofNat]
 
 theorem neg_eq_not_add : - a = ~~~ a + 1 := by
   ext i

--- a/SSA/Experimental/Bits/Fast/BitStream.lean
+++ b/SSA/Experimental/Bits/Fast/BitStream.lean
@@ -423,13 +423,11 @@ theorem ofBitVec_not' : ofBitVec (~~~ x) ≈ʷ ~~~ ofBitVec x := by
   simp only [ofBitVec, a, ↓reduceIte, BitVec.getLsb_not, decide_True, Bool.true_and, not_eq]
 
 theorem neg_eq_not_add : - a = ~~~ a + 1 := by
-  have neg_eq_not_add' (i : Nat) : a.negAux i = Prod.swap ((~~~a).addAux 1 i) := by
+  have neg_eq_not_add' (i : Nat) : a.negAux i = ((~~~a).addAux 1 i).swap := by
     induction' i with _ ih
-    <;> simp only [negAux, OfNat.ofNat, addAux, BitVec.adcb, not_eq, ofNat, Nat.testBit_zero, Nat.mod_succ,
-      decide_True, Bool.atLeastTwo_false_right, Bool.and_true, Bool.bne_false, Bool.bne_true, Bool.not_not,
-      Prod.swap_prod_mk, Nat.testBit_add_one, Nat.reduceDiv,
-      Nat.zero_testBit, Bool.atLeastTwo_false_mid,Bool.false_bne, Prod.swap_prod_mk, Prod.mk.injEq, Bool.bne_left_inj]
-    simp only [ih, OfNat.ofNat, ofNat, Prod.snd_swap, and_self]
+    --- These simps are terminal, no need for "simp only".
+    · simp [negAux,addAux,BitVec.adcb, OfNat.ofNat, ofNat]
+    · simp [negAux,addAux,BitVec.adcb, OfNat.ofNat, ofNat, ih]
   ext i
   simp only [neg_eq_not_add' i, Neg.neg, neg, negAux, HAdd.hAdd, Add.add, add, addAux, BitVec.adcb, Prod.fst_swap]
 

--- a/SSA/Experimental/Bits/Fast/BitStream.lean
+++ b/SSA/Experimental/Bits/Fast/BitStream.lean
@@ -433,13 +433,6 @@ lemma neg_eq_not_add : - a = ~~~ a + 1 := by
   ext i
   simp only [neg_eq_not_add' i, Neg.neg, neg, negAux, HAdd.hAdd, Add.add, add, addAux, BitVec.adcb, Prod.fst_swap]
 
-lemma mod_mod (x : Nat) (w : Nat) (h : 0 < w) : x % 2 ^ w % 2 = x % 2 := by
-  -- We need to show that the least significant bit of x % 2 ^ w is the same as the least significant bit of x
-  -- Since 2 is a power of 2, the least significant bit of x % 2 ^ w is the same as the least significant bit of x
-  have y : 2 ^ 1 ∣ 2 ^ w := Nat.pow_dvd_pow 2 (by omega)
-  simp only [pow_one] at y
-  exact Nat.mod_mod_of_dvd x y
-
 lemma ofBitVec_ofNat (h : 0 < w) : @ofBitVec w 1 ≈ʷ ofNat 1 := by
   intros n a
   simp only [ofBitVec, a, ↓reduceIte, OfNat.ofNat, BitVec.getLsb_one, ofNat, Nat.testBit,
@@ -465,8 +458,7 @@ theorem ofBitVec_neg : ofBitVec (- x) ≈ʷ - (ofBitVec x) := by
     exact ofBitVec_add
     exact add_congr ofBitVec_not' equal_up_to_refl) (by
     simp only [neg_eq_not_add]
-    exact add_congr equal_up_to_refl (by
-      exact ofBitVec_ofNat (by omega)))
+    exact add_congr equal_up_to_refl (ofBitVec_ofNat (by omega)))
 
 theorem sub_congr (e1 : a ≈ʷ b) (e2 : c ≈ʷ d) : (a - c) ≈ʷ (b - d) := by
   intros n h

--- a/SSA/Experimental/Bits/Fast/BitStream.lean
+++ b/SSA/Experimental/Bits/Fast/BitStream.lean
@@ -424,12 +424,12 @@ theorem ofBitVec_not' : ofBitVec (~~~ x) ≈ʷ ~~~ ofBitVec x := by
 
 theorem neg_eq_not_add' (i : Nat) : a.negAux i = ((~~~a).addAux 1 i).swap := by
   induction' i with _ ih
-  <;> simp [negAux, addAux, BitVec.adcb, OfNat.ofNat, ofNat]
-  · simp [ih, OfNat.ofNat, ofNat]
+  · simp [negAux, addAux, BitVec.adcb, OfNat.ofNat, ofNat]
+  · simp [negAux, addAux, BitVec.adcb, OfNat.ofNat, ofNat, ih]
 
 theorem neg_eq_not_add : - a = ~~~ a + 1 := by
   ext i
-  simp [neg_eq_not_add' i, Neg.neg, neg, negAux, HAdd.hAdd, Add.add, add, addAux, BitVec.adcb]
+  simp [neg_eq_not_add' i, Neg.neg, neg, HAdd.hAdd, Add.add, add, addAux, BitVec.adcb]
 
 theorem one_bit (i : Nat) : (ofNat 1) i = decide (0 = i) := by
   cases' i with k

--- a/SSA/Experimental/Bits/Fast/BitStream.lean
+++ b/SSA/Experimental/Bits/Fast/BitStream.lean
@@ -411,9 +411,8 @@ instance congr_equiv : Equivalence (EqualUpTo w) := {
 theorem add_congr (e1 : a ≈ʷ b) (e2 : c ≈ʷ d) : (a + c) ≈ʷ (b + d) := by
   intros n h
   have add_congr_lemma : a.addAux c n = b.addAux d n := by
-    induction n
+    induction' n with _ ih
     <;> simp only [addAux, Prod.mk.injEq, e1 _ h, e2 _ h]
-    rename_i _ ih
     simp only [ih (by omega), Bool.bne_right_inj]
   simp only [HAdd.hAdd, Add.add, BitStream.add, add_congr_lemma]
 
@@ -468,23 +467,20 @@ theorem ofBitVec_neg : ofBitVec (- x) ≈ʷ - (ofBitVec x) := by
 theorem sub_congr (e1 : a ≈ʷ b) (e2 : c ≈ʷ d) : (a - c) ≈ʷ (b - d) := by
   intros n h
   have sub_congr_lemma : a.subAux c n = b.subAux d n := by
-    induction n
+    induction' n with _ ih
     <;> simp only [subAux, Prod.mk.injEq, e1 _ h, e2 _ h, and_self]
-    rename_i _ ih
     simp only [ih (by omega), and_self]
   simp only [HSub.hSub, Sub.sub, BitStream.sub, sub_congr_lemma]
 
 theorem neg_congr (e1 : a ≈ʷ b) : (-a) ≈ʷ -b := by
   intros n h
   have neg_congr_lemma : a.negAux n = b.negAux n := by
-    induction n
+    induction' n with _ ih
     <;> simp only [negAux, Prod.mk.injEq, (e1 _ h)]
-    rename_i _ ih
     simp only [ih (by omega), Bool.bne_right_inj, and_self]
   simp only [Neg.neg, BitStream.neg, neg_congr_lemma]
 
-
-theorem equal_trans  (e1 : a ≈ʷ b) (e2 : c ≈ʷ d) : (a ≈ʷ c) = (b ≈ʷ d) := by
+theorem equal_congr_congr  (e1 : a ≈ʷ b) (e2 : c ≈ʷ d) : (a ≈ʷ c) = (b ≈ʷ d) := by
   apply propext
   constructor
   <;> intros h

--- a/SSA/Experimental/Bits/Fast/BitStream.lean
+++ b/SSA/Experimental/Bits/Fast/BitStream.lean
@@ -426,8 +426,8 @@ lemma neg_eq_not_add : - a = ~~~ a + 1 := by
     induction i
     all_goals simp only [negAux, OfNat.ofNat, addAux, BitVec.adcb, not_eq, ofNat, Nat.testBit_zero, Nat.mod_succ,
       decide_True, Bool.atLeastTwo_false_right, Bool.and_true, Bool.bne_false, Bool.bne_true, Bool.not_not,
-      Prod.swap_prod_mk, negAux, OfNat.ofNat, addAux, BitVec.adcb, not_eq, ofNat, Nat.testBit_add_one, Nat.reduceDiv,
-      Nat.zero_testBit, Bool.atLeastTwo_false_mid, Bool.false_bne, Prod.swap_prod_mk, Prod.mk.injEq, Bool.bne_left_inj]
+      Prod.swap_prod_mk, Nat.testBit_add_one, Nat.reduceDiv,
+      Nat.zero_testBit, Bool.atLeastTwo_false_mid,Bool.false_bne, Prod.swap_prod_mk, Prod.mk.injEq, Bool.bne_left_inj]
     rename_i i ih
     simp only [ih, Prod.snd_swap]
     constructor
@@ -446,22 +446,22 @@ theorem ofBitVec_neg : ofBitVec (- x) ≈ʷ - (ofBitVec x) := by
     exact add_congr ofBitVec_not' equal_up_to_refl) (by
     simp only [neg_eq_not_add]
     exact add_congr equal_up_to_refl (by
-        intros n a
-        simp only [ofBitVec, a, ↓reduceIte, OfNat.ofNat, BitVec.getLsb_one, ofNat, Nat.testBit,
-          Nat.one_and_eq_mod_two]
-        match n with
-          | 0 =>
-            simp only [decide_True, Bool.and_true, Nat.shiftRight_zero, Nat.mod_succ, Nat.reduceBNe,
-              decide_eq_true_eq, gt_iff_lt]
+      intros n a
+      simp only [ofBitVec, a, ↓reduceIte, OfNat.ofNat, BitVec.getLsb_one, ofNat, Nat.testBit,
+        Nat.one_and_eq_mod_two]
+      match n with
+        | 0 =>
+          simp only [decide_True, Bool.and_true, Nat.shiftRight_zero, Nat.mod_succ, Nat.reduceBNe,
+            decide_eq_true_eq, gt_iff_lt]
+          omega
+        | k + 1 =>
+          simp only [show w > 0 by omega, decide_True, self_eq_add_left, add_eq_zero, one_ne_zero, and_false,
+            decide_False, Bool.and_false, Bool.false_eq, bne_eq_false_iff_eq, HShiftRight.hShiftRight, ShiftRight.shiftRight, Nat.shiftRight]
+          have : Nat.shiftRight 1 k ≤ 1 := by
+            induction k
+            <;> simp only [Nat.shiftRight, le_refl]
             omega
-          | k + 1 =>
-            simp only [show w > 0 by omega, decide_True, self_eq_add_left, add_eq_zero, one_ne_zero, and_false,
-              decide_False, Bool.and_false, Bool.false_eq, bne_eq_false_iff_eq, HShiftRight.hShiftRight, ShiftRight.shiftRight, Nat.shiftRight]
-            have : Nat.shiftRight 1 k ≤ 1 := by
-              induction k
-              <;> simp only [Nat.shiftRight, le_refl]
-              omega
-            omega))
+          omega))
 
 theorem sub_congr (e1 : a ≈ʷ b) (e2 : c ≈ʷ d) : (a - c) ≈ʷ (b - d) := by
   intros n h

--- a/SSA/Experimental/Bits/Fast/BitStream.lean
+++ b/SSA/Experimental/Bits/Fast/BitStream.lean
@@ -422,32 +422,35 @@ theorem ofBitVec_not' : ofBitVec (~~~ x) ≈ʷ ~~~ ofBitVec x := by
   intros n a
   simp [ofBitVec, a]
 
-theorem neg_eq_not_add : - a = ~~~ a + 1 := by
-  have neg_eq_not_add' (i : Nat) : a.negAux i = ((~~~a).addAux 1 i).swap := by
-    induction' i with _ ih
-    · simp [negAux,addAux,BitVec.adcb, OfNat.ofNat, ofNat]
-    · simp [negAux,addAux,BitVec.adcb, OfNat.ofNat, ofNat, ih]
-  ext i
-  simp only [neg_eq_not_add' i, Neg.neg, neg, negAux, HAdd.hAdd, Add.add, add, addAux, BitVec.adcb, Prod.fst_swap]
+theorem neg_eq_not_add' (i : Nat) : a.negAux i = ((~~~a).addAux 1 i).swap := by
+  induction' i with _ ih
+  · simp [negAux, addAux, BitVec.adcb, OfNat.ofNat, ofNat]
+  · simp [negAux, addAux, BitVec.adcb, OfNat.ofNat, ofNat, ih]
 
-theorem ofBitVec_ofNat' (h : 0 < w) : @ofBitVec w 1 ≈ʷ ofNat 1 := by
-  intros n a
-  simp only [ofBitVec, a, ↓reduceIte, OfNat.ofNat, BitVec.getLsb_one, ofNat, Nat.testBit,
-    Nat.one_and_eq_mod_two, h, decide_True, Bool.true_and, HShiftRight.hShiftRight, ShiftRight.shiftRight]
-  cases' n with k
+theorem neg_eq_not_add : - a = ~~~ a + 1 := by
+  ext i
+  simp [neg_eq_not_add' i, Neg.neg, neg, negAux, HAdd.hAdd, Add.add, add, addAux, BitVec.adcb]
+
+theorem one_bit (i : Nat) : (ofNat 1) i = decide (0 = i) := by
+  cases' i with k
+  <;> unfold ofNat
   · simp
   · have : Nat.shiftRight 1 k ≤ 1 := by
       induction k
       <;> simp only [Nat.shiftRight, le_refl]
       omega
     simp [Nat.shiftRight]
-    omega
 
-theorem ofBitVec_ofNat : @ofBitVec w 1 ≈ʷ ofNat 1 := by
+theorem ofBitVec_ofNat' (h : 0 < w) : @ofBitVec w 1 ≈ʷ ofNat 1 := by
+  intros n a
+  simp [one_bit n, ofBitVec, a, h]
+
+ theorem ofBitVec_ofNat : @ofBitVec w 1 ≈ʷ ofNat 1 := by
   by_cases wz : w = 0
   · intros _ a
     simp only [wz, not_lt_zero'] at a
-  · exact ofBitVec_ofNat' (by omega)
+  · apply ofBitVec_ofNat'
+    omega
 
 theorem ofBitVec_neg : ofBitVec (- x) ≈ʷ - (ofBitVec x) := by
   calc

--- a/SSA/Experimental/Bits/Fast/BitStream.lean
+++ b/SSA/Experimental/Bits/Fast/BitStream.lean
@@ -381,20 +381,16 @@ theorem ofBitVec_add : ofBitVec (x + y) ≈ʷ (ofBitVec x) + (ofBitVec y)  := by
   sorry
 
 @[refl]
-@[refl]
 theorem equal_up_to_refl : a ≈ʷ a := by
-  intros _ _
   intros _ _
   rfl
 
-@[symm]
 @[symm]
 theorem equal_up_to_symm (e : a ≈ʷ b) : b ≈ʷ a := by
   intros j h
   symm
   exact e j h
 
-@[trans]
 @[trans]
 theorem equal_up_to_trans (e1 : a ≈ʷ b) (e2 : b ≈ʷ c) : a ≈ʷ c := by
   intros j h
@@ -403,7 +399,6 @@ theorem equal_up_to_trans (e1 : a ≈ʷ b) (e2 : b ≈ʷ c) : a ≈ʷ c := by
   exact e2 j h
 
 instance congr_trans : Trans (EqualUpTo w) (EqualUpTo w) (EqualUpTo w) where
-instance congr_trans : Trans (EqualUpTo w) (EqualUpTo w) (EqualUpTo w) where
   trans := equal_up_to_trans
 
 instance congr_equiv : Equivalence (EqualUpTo w) where
@@ -411,16 +406,10 @@ instance congr_equiv : Equivalence (EqualUpTo w) where
   symm := equal_up_to_symm
   trans := equal_up_to_trans
 
-instance congr_equiv : Equivalence (EqualUpTo w) where
-  refl := fun _ => equal_up_to_refl
-  symm := equal_up_to_symm
-  trans := equal_up_to_trans
 
-theorem add_congr (e1 : a ≈ʷ b) (e2 : c ≈ʷ d) : (a + c) ≈ʷ (b + d) := by
 theorem add_congr (e1 : a ≈ʷ b) (e2 : c ≈ʷ d) : (a + c) ≈ʷ (b + d) := by
   intros n h
   have add_congr_lemma : a.addAux c n = b.addAux d n := by
-    induction' n with _ ih
     induction' n with _ ih
     <;> simp only [addAux, Prod.mk.injEq, e1 _ h, e2 _ h]
     simp only [ih (by omega), Bool.bne_right_inj]
@@ -485,12 +474,10 @@ theorem neg_congr (e1 : a ≈ʷ b) : (-a) ≈ʷ -b := by
   intros n h
   have neg_congr_lemma : a.negAux n = b.negAux n := by
     induction' n with _ ih
-    induction' n with _ ih
     <;> simp only [negAux, Prod.mk.injEq, (e1 _ h)]
     simp only [ih (by omega), Bool.bne_right_inj, and_self]
   simp only [Neg.neg, BitStream.neg, neg_congr_lemma]
 
-theorem equal_congr_congr  (e1 : a ≈ʷ b) (e2 : c ≈ʷ d) : (a ≈ʷ c) = (b ≈ʷ d) := by
 theorem equal_congr_congr  (e1 : a ≈ʷ b) (e2 : c ≈ʷ d) : (a ≈ʷ c) = (b ≈ʷ d) := by
   apply propext
   constructor

--- a/SSA/Experimental/Bits/Fast/BitStream.lean
+++ b/SSA/Experimental/Bits/Fast/BitStream.lean
@@ -446,6 +446,8 @@ theorem ofBitVec_ofNat : @ofBitVec w 1 ≈ʷ ofNat 1 := by
 /-!
 There are multiple styles/ways to write the proof of ofBitVec_neg
 choose which style you want.
+You can either write the proof without calc (option 1)
+or with calc (option 2).
 -/
 theorem ofBitVec_neg : ofBitVec (- x) ≈ʷ - (ofBitVec x) := by
   rw [BitVec.neg_eq_not_add]

--- a/SSA/Experimental/Bits/Fast/BitStream.lean
+++ b/SSA/Experimental/Bits/Fast/BitStream.lean
@@ -437,7 +437,7 @@ lemma ofBitVec_ofNat (h : 0 < w) : @ofBitVec w 1 ≈ʷ ofNat 1 := by
   intros n a
   simp only [ofBitVec, a, ↓reduceIte, OfNat.ofNat, BitVec.getLsb_one, ofNat, Nat.testBit,
     Nat.one_and_eq_mod_two]
-  simp [BitVec.getLsb, Nat.testBit,h, HShiftRight.hShiftRight, ShiftRight.shiftRight,Nat.shiftRight]
+  simp only [h, decide_True, Bool.true_and, HShiftRight.hShiftRight, ShiftRight.shiftRight]
   match n with
     | 0 => simp only [decide_True, Bool.true_eq, bne_iff_ne, ne_eq, not_false_eq_true]
     | k + 1 =>

--- a/SSA/Experimental/Bits/Fast/BitStream.lean
+++ b/SSA/Experimental/Bits/Fast/BitStream.lean
@@ -390,7 +390,7 @@ def doesNegCarry? (x : BitVec w) (n : Nat) : Bool := match n with
   | Nat.zero => !x.getLsb 0
   | Nat.succ y => !x.getLsb (Nat.succ y) &&  doesNegCarry? x y
 
-def state (x : BitVec w) (n : Nat) : Bool := match n with
+def iunfolder_state (x : BitVec w) (n : Nat) : Bool := match n with
   | 0 => false
   | i + 1 => doesNegCarry? x i
 
@@ -433,27 +433,27 @@ theorem ofBitVec_neg : ofBitVec (- x) ≈ʷ - (ofBitVec x) := by
     simp only [BitVec.getLsb_not, Fin.is_lt, decide_True, Bool.true_and, BitVec.getLsb_one,
       Nat.succ_eq_add_one, Prod.mk.injEq]
     constructor
-    rw [show n + 1 = (↑(⟨n + 1, a⟩ : Fin w)) by rfl]
-    rw [show false = state x 0 by rfl]
-    rw [BitVec.iunfoldr_getLsb (state x) ⟨n+1, a⟩]
-    rw [← ihg]
+    rw [show n + 1 = (↑(⟨n + 1, a⟩ : Fin w)) by rfl
+      , show false = iunfolder_state x 0 by rfl
+      , BitVec.iunfoldr_getLsb (iunfolder_state x) ⟨n+1, a⟩
+      , ← ihg]
     simp only [self_eq_add_left, add_eq_zero, one_ne_zero, and_false, decide_False, Bool.and_false,
       Bool.decide_eq_true]
     unfold BitVec.adcb
     unfold Bool.atLeastTwo
-    simp only [Bool.false_bne, state,ofBitVec,a]
+    simp only [Bool.false_bne, iunfolder_state,ofBitVec,a]
     simp only [↓reduceIte]
     intro i
     induction i.val
     simp only [BitVec.adcb, BitVec.getLsb, Nat.testBit_zero, ← decide_not, Nat.mod_two_ne_one,
-      decide_True, Bool.and_true, state, Bool.atLeastTwo_false_right, ← Bool.decide_and,
+      decide_True, Bool.and_true, iunfolder_state, Bool.atLeastTwo_false_right, ← Bool.decide_and,
       Bool.bne_false, doesNegCarry?, decide_eq_decide, and_iff_left_iff_imp]
     intro _
     omega
-    rename_i nn thing
+    rename_i i ih2
     simp only [self_eq_add_left, add_eq_zero, one_ne_zero, and_false, decide_False, Bool.and_false,
-      state, doesNegCarry?, Nat.succ_eq_add_one]
-    simp only [state] at thing
+      iunfolder_state, doesNegCarry?, Nat.succ_eq_add_one]
+    simp only [iunfolder_state] at ih2
     unfold BitVec.adcb
     simp only [Bool.atLeastTwo_false_mid]
     simp only [ofBitVec, a, ↓reduceIte]
@@ -462,7 +462,7 @@ theorem ofBitVec_neg : ofBitVec (- x) ≈ʷ - (ofBitVec x) := by
   simp only [Neg.neg]
   simp only [BitStream.neg]
   rw [← neg_lemma]
-  simp only [ofBitVec,a,↓reduceIte, Neg.neg]
+  simp only [ofBitVec, a, ↓reduceIte, Neg.neg]
 
 theorem equal_up_to_refl : a ≈ʷ a := by
   intros j _

--- a/SSA/Experimental/Bits/Fast/BitStream.lean
+++ b/SSA/Experimental/Bits/Fast/BitStream.lean
@@ -1,4 +1,5 @@
 import Mathlib.Tactic.NormNum
+import Mathlib.Tactic.SlimCheck
 
 import Mathlib.Logic.Function.Iterate
 -- TODO: upstream the following section
@@ -425,13 +426,15 @@ lemma mod_mod (x : Nat) (w : Nat) (h : 0 < w) : x % 2 ^ w % 2 = x % 2 := by
 lemma pow_mod (a : 0 < w) : 2 ^ w % 2 = 0 := by
   simp only [Nat.pow_mod 2 w 2, Nat.mod_self, Nat.zero_pow a, Nat.zero_mod]
 
-lemma lemma7 {w t : Nat} (a : 0 < w) (h : t < 2 ^ w) : (2 ^ w - 1 - t + 1) % 2 = 1 ↔ t % 2 = 1 := by
-  sorry
+theorem neg_mod_odd {w t : Nat} (hw : 0 < w) (h : t < 2 ^ w) : (2 ^ w - 1 - t + 1) % 2 = 1 ↔ t % 2 = 1 := by
+  rcases w with rfl | w
+  · simp at hw
+  · omega
 
-lemma extracted_2 (a : 0 < w) :
+lemma neg_mod_mod_odd (a : 0 < w) :
   (2 ^ w - 1 - x.toNat + 1) % 2 ^ w % 2 = 1 ↔ x.toNat % 2 = 1 := by
   rw [mod_mod (2 ^ w - 1 - x.toNat + 1) w a]
-  exact lemma7 a x.toFin.isLt
+  exact neg_mod_odd a x.toFin.isLt
 
 theorem ofBitVec_neg : ofBitVec (- x) ≈ʷ - (ofBitVec x) := by
   intros n a
@@ -442,7 +445,7 @@ theorem ofBitVec_neg : ofBitVec (- x) ≈ʷ - (ofBitVec x) := by
       BitVec.toNat_ofNat, Nat.add_mod_mod, Nat.testBit_zero, doesNegCarry?, ← decide_not,
       Nat.mod_two_ne_one, decide_eq_true_eq, negAux, ofBitVec, a, ↓reduceIte, Prod.mk.injEq,
       decide_eq_decide, and_true]
-    exact extracted_2 a
+    exact neg_mod_mod_odd a
     rename_i n ih
     simp only [BitVec.ofNat_eq_ofNat, BitVec.add_eq_adc, Bool.decide_eq_true]
     unfold BitVec.adc

--- a/SSA/Experimental/Bits/Fast/BitStream.lean
+++ b/SSA/Experimental/Bits/Fast/BitStream.lean
@@ -377,7 +377,28 @@ local infix:20 " ≈ʷ " => EqualUpTo w
 @[simp] theorem ofBitVec_sub : ofBitVec (x - y) ≈ʷ (ofBitVec x) - (ofBitVec y)  := by
   sorry
 
+
+def doesAddCarry? ( x y : BitVec w) (n : Nat) : Bool := match n with
+  | 0 =>  (x.getLsb 0) && (y.getLsb 0)
+  | i + 1 => (doesAddCarry? x y i).atLeastTwo (x.getLsb (i + 1)) (y.getLsb (i + 1))
 @[simp] theorem ofBitVec_add : ofBitVec (x + y) ≈ʷ (ofBitVec x) + (ofBitVec y)  := by
+  intros n a
+  have neg_lemma : ⟨ doesAddCarry? x y n, (x + y).getLsb n⟩ = (ofBitVec x).addAux (ofBitVec y) n := by
+    induction n
+    -- simp
+    unfold addAux
+    simp [BitVec.adcb]
+    constructor
+    simp [doesAddCarry?, ofBitVec,a]
+    -- sorry
+
+    unfold HAdd.hAdd
+    unfold instHAdd
+    simp only  [Add.add, BitVec.add, ofBitVec,a]
+    simp
+    sorry
+    -- simp
+    sorry
   sorry
 
 /--

--- a/SSA/Experimental/Bits/Fast/BitStream.lean
+++ b/SSA/Experimental/Bits/Fast/BitStream.lean
@@ -445,12 +445,11 @@ theorem ofBitVec_ofNat' (h : 0 < w) : @ofBitVec w 1 ≈ʷ ofNat 1 := by
   intros n a
   simp [one_bit n, ofBitVec, a, h]
 
- theorem ofBitVec_ofNat : @ofBitVec w 1 ≈ʷ ofNat 1 := by
-  by_cases wz : w = 0
-  · intros _ a
-    simp only [wz, not_lt_zero'] at a
-  · apply ofBitVec_ofNat'
-    omega
+theorem ofBitVec_ofNat {w : Nat} : EqualUpTo w (@ofBitVec w 1) (ofNat 1) := by
+  cases w
+  simp [EqualUpTo]
+  apply ofBitVec_ofNat'
+  simp
 
 theorem ofBitVec_neg : ofBitVec (- x) ≈ʷ - (ofBitVec x) := by
   calc

--- a/SSA/Experimental/Bits/Fast/BitStream.lean
+++ b/SSA/Experimental/Bits/Fast/BitStream.lean
@@ -432,7 +432,7 @@ theorem neg_eq_not_add : - a = ~~~ a + 1 := by
   simp [neg_eq_not_add' i, Neg.neg, neg, HAdd.hAdd, Add.add, add, addAux, BitVec.adcb]
 
 theorem one_bit (i : Nat) : (ofNat 1) i = decide (0 = i) := by
-  cases' i with k
+  cases i
   <;> simp [ofNat, Nat.shiftRight]
 
 theorem ofBitVec_ofNat' (h : 0 < w) : @ofBitVec w 1 ≈ʷ ofNat 1 := by

--- a/SSA/Experimental/Bits/Fast/BitStream.lean
+++ b/SSA/Experimental/Bits/Fast/BitStream.lean
@@ -443,19 +443,6 @@ theorem ofBitVec_ofNat : @ofBitVec w 1 ≈ʷ ofNat 1 := by
     simp [ofNat_one n, ofBitVec, a]
     omega
 
-/-!
-There are multiple styles/ways to write the proof of ofBitVec_neg
-choose which style you want.
-You can either write the proof without calc (option 1)
-or with calc (option 2).
--/
-theorem ofBitVec_neg : ofBitVec (- x) ≈ʷ - (ofBitVec x) := by
-  rw [BitVec.neg_eq_not_add]
-  apply equal_up_to_trans ofBitVec_add
-  apply equal_up_to_trans (add_congr ofBitVec_not_eq_to ofBitVec_ofNat)
-  rw [neg_eq_not_add]
-  exact equal_up_to_refl
-
 theorem ofBitVec_neg2 : ofBitVec (- x) ≈ʷ - (ofBitVec x) := by
   calc
   _ ≈ʷ ofBitVec (~~~ x + 1)            := by rw [BitVec.neg_eq_not_add]

--- a/SSA/Experimental/Bits/Fast/BitStream.lean
+++ b/SSA/Experimental/Bits/Fast/BitStream.lean
@@ -404,7 +404,7 @@ lemma mod_mod (x : Nat) (w : Nat) (h : 0 < w) : x % 2 ^ w % 2 = x % 2 := by
 lemma pow_mod (a : 0 < w) : 2 ^ w % 2 = 0 := by
   simp only [Nat.pow_mod 2 w 2, Nat.mod_self, Nat.zero_pow a, Nat.zero_mod]
 
-lemma lemma7 {t : Nat} (a : 0 < w) (h : t < 2 ^ w) : (2 ^ w - 1 - t + 1) % 2 = 1 ↔ t % 2 = 1 := by
+lemma lemma7 {w t : Nat} (a : 0 < w) (h : t < 2 ^ w) : (2 ^ w - 1 - t + 1) % 2 = 1 ↔ t % 2 = 1 := by
   sorry
 
 lemma extracted_2 (a : 0 < w) :
@@ -414,7 +414,7 @@ lemma extracted_2 (a : 0 < w) :
 
 theorem ofBitVec_neg : ofBitVec (- x) ≈ʷ - (ofBitVec x) := by
   intros n a
-  have neg_lemma : ⟨(-x).getLsb n , decide (doesNegCarry? x n)⟩ = (ofBitVec x).negAux n := by
+  have neg_lemma : ⟨(-x).getLsb n, doesNegCarry? x n⟩ = (ofBitVec x).negAux n := by
     rw [BitVec.neg_eq_not_add]
     induction n
     simp only [BitVec.getLsb, BitVec.ofNat_eq_ofNat, BitVec.toNat_add, BitVec.toNat_not,

--- a/SSA/Experimental/Bits/Fast/BitStream.lean
+++ b/SSA/Experimental/Bits/Fast/BitStream.lean
@@ -420,12 +420,11 @@ theorem not_congr (e1 : a ≈ʷ b) : (~~~a) ≈ʷ ~~~b := by
 
 theorem ofBitVec_not' : ofBitVec (~~~ x) ≈ʷ ~~~ ofBitVec x := by
   intros n a
-  simp only [ofBitVec, a, ↓reduceIte, BitVec.getLsb_not, decide_True, Bool.true_and, not_eq]
+  simp [ofBitVec, a]
 
 theorem neg_eq_not_add : - a = ~~~ a + 1 := by
   have neg_eq_not_add' (i : Nat) : a.negAux i = ((~~~a).addAux 1 i).swap := by
     induction' i with _ ih
-    --- These simps are terminal, no need for "simp only".
     · simp [negAux,addAux,BitVec.adcb, OfNat.ofNat, ofNat]
     · simp [negAux,addAux,BitVec.adcb, OfNat.ofNat, ofNat, ih]
   ext i
@@ -436,13 +435,12 @@ theorem ofBitVec_ofNat' (h : 0 < w) : @ofBitVec w 1 ≈ʷ ofNat 1 := by
   simp only [ofBitVec, a, ↓reduceIte, OfNat.ofNat, BitVec.getLsb_one, ofNat, Nat.testBit,
     Nat.one_and_eq_mod_two, h, decide_True, Bool.true_and, HShiftRight.hShiftRight, ShiftRight.shiftRight]
   cases' n with k
-  · simp only [decide_True, Bool.true_eq, bne_iff_ne, ne_eq, not_false_eq_true]
-  · simp only [self_eq_add_left, add_eq_zero, one_ne_zero, and_false, decide_False,
-    Nat.shiftRight, Bool.false_eq, bne_eq_false_iff_eq]
-    have : Nat.shiftRight 1 k ≤ 1 := by
+  · simp
+  · have : Nat.shiftRight 1 k ≤ 1 := by
       induction k
       <;> simp only [Nat.shiftRight, le_refl]
       omega
+    simp [Nat.shiftRight]
     omega
 
 theorem ofBitVec_ofNat : @ofBitVec w 1 ≈ʷ ofNat 1 := by

--- a/SSA/Experimental/Bits/Fast/BitStream.lean
+++ b/SSA/Experimental/Bits/Fast/BitStream.lean
@@ -447,9 +447,9 @@ theorem ofBitVec_ofNat' (h : 0 < w) : @ofBitVec w 1 ≈ʷ ofNat 1 := by
 
 theorem ofBitVec_ofNat {w : Nat} : EqualUpTo w (@ofBitVec w 1) (ofNat 1) := by
   cases w
-  simp [EqualUpTo]
-  apply ofBitVec_ofNat'
-  simp
+  · simp [EqualUpTo]
+  · apply ofBitVec_ofNat'
+    simp
 
 theorem ofBitVec_neg : ofBitVec (- x) ≈ʷ - (ofBitVec x) := by
   calc

--- a/SSA/Experimental/Bits/Fast/BitStream.lean
+++ b/SSA/Experimental/Bits/Fast/BitStream.lean
@@ -401,9 +401,6 @@ lemma mod_mod (x : Nat) (w : Nat) (h : 0 < w) : x % 2 ^ w % 2 = x % 2 := by
   simp only [pow_one] at y
   exact Nat.mod_mod_of_dvd x y
 
-lemma pow_mod (a : 0 < w) : 2 ^ w % 2 = 0 := by
-  simp only [Nat.pow_mod 2 w 2, Nat.mod_self, Nat.zero_pow a, Nat.zero_mod]
-
 theorem neg_mod_odd {w t : Nat} (hw : 0 < w) (h : t < 2 ^ w) : (2 ^ w - 1 - t + 1) % 2 = 1 ↔ t % 2 = 1 := by
   rcases w with rfl | w
   · simp at hw

--- a/SSA/Experimental/Bits/Fast/BitStream.lean
+++ b/SSA/Experimental/Bits/Fast/BitStream.lean
@@ -422,14 +422,15 @@ theorem ofBitVec_not' : ofBitVec (~~~ x) ≈ʷ ~~~ ofBitVec x := by
   intros _ a
   simp [ofBitVec, a]
 
-theorem neg_eq_not_add' (i : Nat) : a.negAux i = ((~~~a).addAux 1 i).swap := by
+theorem neg_eq_not_add' : a.negAux = Prod.swap ∘ (~~~a).addAux 1 := by
+  funext i
   induction' i with _ ih
   · simp [negAux, addAux, BitVec.adcb, OfNat.ofNat, ofNat]
   · simp [negAux, addAux, BitVec.adcb, OfNat.ofNat, ofNat, ih]
 
 theorem neg_eq_not_add : - a = ~~~ a + 1 := by
-  ext i
-  simp [neg_eq_not_add' i, Neg.neg, neg, HAdd.hAdd, Add.add, add, addAux, BitVec.adcb]
+  ext _
+  simp [neg_eq_not_add', Neg.neg, neg, HAdd.hAdd, Add.add, add, addAux, BitVec.adcb]
 
 theorem one_bit (i : Nat) : (ofNat 1) i = decide (0 = i) := by
   cases i

--- a/SSA/Experimental/Bits/Fast/BitStream.lean
+++ b/SSA/Experimental/Bits/Fast/BitStream.lean
@@ -433,13 +433,7 @@ theorem neg_eq_not_add : - a = ~~~ a + 1 := by
 
 theorem one_bit (i : Nat) : (ofNat 1) i = decide (0 = i) := by
   cases' i with k
-  <;> unfold ofNat
-  · simp
-  · have : Nat.shiftRight 1 k ≤ 1 := by
-      induction k
-      <;> simp only [Nat.shiftRight, le_refl]
-      omega
-    simp [Nat.shiftRight]
+  <;> simp [ofNat, Nat.shiftRight]
 
 theorem ofBitVec_ofNat' (h : 0 < w) : @ofBitVec w 1 ≈ʷ ofNat 1 := by
   intros n a

--- a/SSA/Experimental/Bits/Fast/BitStream.lean
+++ b/SSA/Experimental/Bits/Fast/BitStream.lean
@@ -378,28 +378,7 @@ local infix:20 " ≈ʷ " => EqualUpTo w
 @[simp] theorem ofBitVec_sub : ofBitVec (x - y) ≈ʷ (ofBitVec x) - (ofBitVec y)  := by
   sorry
 
-
-def doesAddCarry? ( x y : BitVec w) (n : Nat) : Bool := match n with
-  | 0 =>  (x.getLsb 0) && (y.getLsb 0)
-  | i + 1 => (doesAddCarry? x y i).atLeastTwo (x.getLsb (i + 1)) (y.getLsb (i + 1))
 @[simp] theorem ofBitVec_add : ofBitVec (x + y) ≈ʷ (ofBitVec x) + (ofBitVec y)  := by
-  intros n a
-  have neg_lemma : ⟨ doesAddCarry? x y n, (x + y).getLsb n⟩ = (ofBitVec x).addAux (ofBitVec y) n := by
-    induction n
-    -- simp
-    unfold addAux
-    simp [BitVec.adcb]
-    constructor
-    simp [doesAddCarry?, ofBitVec,a]
-    -- sorry
-
-    unfold HAdd.hAdd
-    unfold instHAdd
-    simp only  [Add.add, BitVec.add, ofBitVec,a]
-    simp
-    sorry
-    -- simp
-    sorry
   sorry
 
 /--

--- a/SSA/Experimental/Bits/Fast/BitStream.lean
+++ b/SSA/Experimental/Bits/Fast/BitStream.lean
@@ -431,12 +431,9 @@ theorem ofBitVec_neg : ofBitVec (- x) ≈ʷ - (ofBitVec x) := by
     simp only [BitVec.getLsb_not, Fin.is_lt, decide_True, Bool.true_and, BitVec.getLsb_one,
       Nat.succ_eq_add_one, Prod.mk.injEq]
     constructor
-    have xl : (↑(⟨n + 1, a⟩ : Fin w)) = n + 1 := by rfl
-    rw [← xl]
-    have gg : false = state x 0 := by
-      rfl
-    rw [gg]
-    rw [BitVec.iunfoldr_getLsb (state x) ⟨n+1 ,a ⟩]
+    rw [show n + 1 = (↑(⟨n + 1, a⟩ : Fin w)) by rfl]
+    rw [show false = state x 0 by rfl]
+    rw [BitVec.iunfoldr_getLsb (state x) ⟨n+1, a⟩]
     rw [← ihg]
     simp only [self_eq_add_left, add_eq_zero, one_ne_zero, and_false, decide_False, Bool.and_false,
       Bool.decide_eq_true]

--- a/SSA/Experimental/Bits/Fast/BitStream.lean
+++ b/SSA/Experimental/Bits/Fast/BitStream.lean
@@ -418,11 +418,11 @@ theorem not_congr (e1 : a ≈ʷ b) : (~~~a) ≈ʷ ~~~b := by
   intros g h
   simp only [not_eq, e1 g h]
 
-lemma ofBitVec_not' : ofBitVec (~~~ x) ≈ʷ ~~~ ofBitVec x := by
+theorem ofBitVec_not' : ofBitVec (~~~ x) ≈ʷ ~~~ ofBitVec x := by
   intros n a
   simp only [ofBitVec, a, ↓reduceIte, BitVec.getLsb_not, decide_True, Bool.true_and, not_eq]
 
-lemma neg_eq_not_add : - a = ~~~ a + 1 := by
+theorem neg_eq_not_add : - a = ~~~ a + 1 := by
   have neg_eq_not_add' (i : Nat) : a.negAux i = Prod.swap ((~~~a).addAux 1 i) := by
     induction' i with _ ih
     <;> simp only [negAux, OfNat.ofNat, addAux, BitVec.adcb, not_eq, ofNat, Nat.testBit_zero, Nat.mod_succ,
@@ -433,25 +433,25 @@ lemma neg_eq_not_add : - a = ~~~ a + 1 := by
   ext i
   simp only [neg_eq_not_add' i, Neg.neg, neg, negAux, HAdd.hAdd, Add.add, add, addAux, BitVec.adcb, Prod.fst_swap]
 
-lemma ofBitVec_ofNat' (h : 0 < w) : @ofBitVec w 1 ≈ʷ ofNat 1 := by
+theorem ofBitVec_ofNat' (h : 0 < w) : @ofBitVec w 1 ≈ʷ ofNat 1 := by
   intros n a
   simp only [ofBitVec, a, ↓reduceIte, OfNat.ofNat, BitVec.getLsb_one, ofNat, Nat.testBit,
     Nat.one_and_eq_mod_two, h, decide_True, Bool.true_and, HShiftRight.hShiftRight, ShiftRight.shiftRight]
   cases' n with k
-  simp only [decide_True, Bool.true_eq, bne_iff_ne, ne_eq, not_false_eq_true]
-  simp only [self_eq_add_left, add_eq_zero, one_ne_zero, and_false, decide_False,
+  · simp only [decide_True, Bool.true_eq, bne_iff_ne, ne_eq, not_false_eq_true]
+  · simp only [self_eq_add_left, add_eq_zero, one_ne_zero, and_false, decide_False,
     Nat.shiftRight, Bool.false_eq, bne_eq_false_iff_eq]
-  have : Nat.shiftRight 1 k ≤ 1 := by
-    induction k
-    <;> simp only [Nat.shiftRight, le_refl]
+    have : Nat.shiftRight 1 k ≤ 1 := by
+      induction k
+      <;> simp only [Nat.shiftRight, le_refl]
+      omega
     omega
-  omega
 
-lemma ofBitVec_ofNat : @ofBitVec w 1 ≈ʷ ofNat 1 := by
+theorem ofBitVec_ofNat : @ofBitVec w 1 ≈ʷ ofNat 1 := by
   by_cases wz : w = 0
-  intros _ a
-  simp only [wz, not_lt_zero'] at a
-  exact ofBitVec_ofNat' (by omega)
+  · intros _ a
+    simp only [wz, not_lt_zero'] at a
+  · exact ofBitVec_ofNat' (by omega)
 
 theorem ofBitVec_neg : ofBitVec (- x) ≈ʷ - (ofBitVec x) := by
   calc

--- a/SSA/Experimental/Bits/Fast/BitStream.lean
+++ b/SSA/Experimental/Bits/Fast/BitStream.lean
@@ -436,8 +436,7 @@ lemma neg_eq_not_add : - a = ~~~ a + 1 := by
 lemma ofBitVec_ofNat (h : 0 < w) : @ofBitVec w 1 ≈ʷ ofNat 1 := by
   intros n a
   simp only [ofBitVec, a, ↓reduceIte, OfNat.ofNat, BitVec.getLsb_one, ofNat, Nat.testBit,
-    Nat.one_and_eq_mod_two]
-  simp only [h, decide_True, Bool.true_and, HShiftRight.hShiftRight, ShiftRight.shiftRight]
+    Nat.one_and_eq_mod_two, h, decide_True, Bool.true_and, HShiftRight.hShiftRight, ShiftRight.shiftRight]
   match n with
     | 0 => simp only [decide_True, Bool.true_eq, bne_iff_ne, ne_eq, not_false_eq_true]
     | k + 1 =>

--- a/SSA/Experimental/Bits/Fast/BitStream.lean
+++ b/SSA/Experimental/Bits/Fast/BitStream.lean
@@ -1,6 +1,4 @@
 import Mathlib.Tactic.NormNum
-import Mathlib.Tactic.Ring
-import Mathlib.Data.Fintype.Card
 
 import Mathlib.Logic.Function.Iterate
 -- TODO: upstream the following section
@@ -388,35 +386,35 @@ true iff ∀ i < n, x[i] = 0
 and returns false
 iff   ∃ i < n , x[i] = 1
 -/
-def doesNegCarry? {w : Nat} (x : BitVec w) (n : Nat) : Bool := match n with
+def doesNegCarry? (x : BitVec w) (n : Nat) : Bool := match n with
   | Nat.zero => !x.getLsb 0
   | Nat.succ y => !x.getLsb (Nat.succ y) &&  doesNegCarry? x y
 
-def state {w : Nat} (x : BitVec w) (n : Nat) : Bool := match n with
+def state (x : BitVec w) (n : Nat) : Bool := match n with
   | 0 => false
-  | i + 1 => doesNegCarry? x i --sorryAx (Nat → Bool) false i
+  | i + 1 => doesNegCarry? x i
 
-lemma modmod (x : Nat) (w : Nat) (h : 0 < w) : x % 2 ^ w % 2 = x % 2 := by
+lemma mod_mod (x : Nat) (w : Nat) (h : 0 < w) : x % 2 ^ w % 2 = x % 2 := by
   -- We need to show that the least significant bit of x % 2 ^ w is the same as the least significant bit of x
   -- Since 2 is a power of 2, the least significant bit of x % 2 ^ w is the same as the least significant bit of x
   have y : 2 ^ 1 ∣ 2 ^ w := Nat.pow_dvd_pow 2 (by omega)
   simp only [pow_one] at y
   exact Nat.mod_mod_of_dvd x y
 
-lemma powmod (a : 0 < w) : 2 ^ w % 2 = 0 := by
+lemma pow_mod (a : 0 < w) : 2 ^ w % 2 = 0 := by
   simp only [Nat.pow_mod 2 w 2, Nat.mod_self, Nat.zero_pow a, Nat.zero_mod]
 
-lemma lemma7 {w t : Nat} (a : 0  < w) (h : t < 2 ^ w) : (2 ^ w - 1 - t + 1) % 2 = 1 ↔ t % 2 = 1 := by
+lemma lemma7 {t : Nat} (a : 0 < w) (h : t < 2 ^ w) : (2 ^ w - 1 - t + 1) % 2 = 1 ↔ t % 2 = 1 := by
   sorry
 
-lemma  extracted_2 {w : ℕ} {x : BitVec w} (a : 0 < w) :
+lemma extracted_2 (a : 0 < w) :
   (2 ^ w - 1 - x.toNat + 1) % 2 ^ w % 2 = 1 ↔ x.toNat % 2 = 1 := by
-  rw [modmod (2 ^ w - 1 -  x.toNat + 1) w a]
-  exact lemma7 a (x.toFin.isLt)
+  rw [mod_mod (2 ^ w - 1 - x.toNat + 1) w a]
+  exact lemma7 a x.toFin.isLt
 
-theorem ofBitVec_neg : ofBitVec (- x) ≈ʷ  - (ofBitVec x) := by
+theorem ofBitVec_neg : ofBitVec (- x) ≈ʷ - (ofBitVec x) := by
   intros n a
-  have neg_lemma  : ⟨(-x).getLsb n , decide (doesNegCarry? x n)⟩  = (ofBitVec x).negAux n := by
+  have neg_lemma : ⟨(-x).getLsb n , decide (doesNegCarry? x n)⟩ = (ofBitVec x).negAux n := by
     rw [BitVec.neg_eq_not_add]
     induction n
     simp only [BitVec.getLsb, BitVec.ofNat_eq_ofNat, BitVec.toNat_add, BitVec.toNat_not,
@@ -438,7 +436,7 @@ theorem ofBitVec_neg : ofBitVec (- x) ≈ʷ  - (ofBitVec x) := by
     have gg : false = state x 0 := by
       rfl
     rw [gg]
-    rw [BitVec.iunfoldr_getLsb (state x) ⟨n+1 ,a ⟩ ]
+    rw [BitVec.iunfoldr_getLsb (state x) ⟨n+1 ,a ⟩]
     rw [← ihg]
     simp only [self_eq_add_left, add_eq_zero, one_ne_zero, and_false, decide_False, Bool.and_false,
       Bool.decide_eq_true]
@@ -468,7 +466,7 @@ theorem ofBitVec_neg : ofBitVec (- x) ≈ʷ  - (ofBitVec x) := by
   simp only [ofBitVec,a,↓reduceIte, Neg.neg]
 
 theorem equal_up_to_refl : a ≈ʷ a := by
-  intros  j _
+  intros j _
   rfl
 
 theorem equal_up_to_symm (e : a ≈ʷ b) : b ≈ʷ a := by
@@ -488,7 +486,7 @@ instance congr_equiv : Equivalence (EqualUpTo w) := {
   trans := equal_up_to_trans
 }
 
-theorem sub_congr (e1 : a ≈ʷ b) (e2 : c  ≈ʷ d) : (a - c) ≈ʷ (b - d) := by
+theorem sub_congr (e1 : a ≈ʷ b) (e2 : c ≈ʷ d) : (a - c) ≈ʷ (b - d) := by
   intros n h
   have sub_congr_lemma : a.subAux c n = b.subAux d n := by
     induction n
@@ -497,7 +495,7 @@ theorem sub_congr (e1 : a ≈ʷ b) (e2 : c  ≈ʷ d) : (a - c) ≈ʷ (b - d) := 
     simp only [ih (by omega), and_self]
   simp only [HSub.hSub, Sub.sub, BitStream.sub, sub_congr_lemma]
 
-theorem add_congr (e1 : a ≈ʷ b) (e2 : c  ≈ʷ d) : (a + c) ≈ʷ (b + d) := by
+theorem add_congr (e1 : a ≈ʷ b) (e2 : c ≈ʷ d) : (a + c) ≈ʷ (b + d) := by
   intros n h
   have add_congr_lemma : a.addAux c n = b.addAux d n := by
     induction n
@@ -519,7 +517,7 @@ theorem not_congr (e1 : a ≈ʷ b) : (~~~a) ≈ʷ ~~~b := by
   intros g h
   simp only [not_eq, e1 g h]
 
-theorem equal_trans  (e1 :  a ≈ʷ b) (e2 : c ≈ʷ d)  : (a ≈ʷ c) = (b ≈ʷ d) := by
+theorem equal_trans  (e1 : a ≈ʷ b) (e2 : c ≈ʷ d) : (a ≈ʷ c) = (b ≈ʷ d) := by
   apply propext
   constructor
   <;> intros h

--- a/SSA/Experimental/Bits/Fast/BitStream.lean
+++ b/SSA/Experimental/Bits/Fast/BitStream.lean
@@ -406,7 +406,6 @@ instance congr_equiv : Equivalence (EqualUpTo w) where
   symm := equal_up_to_symm
   trans := equal_up_to_trans
 
-
 theorem add_congr (e1 : a ≈ʷ b) (e2 : c ≈ʷ d) : (a + c) ≈ʷ (b + d) := by
   intros n h
   have add_congr_lemma : a.addAux c n = b.addAux d n := by

--- a/SSA/Experimental/Bits/Fast/BitStream.lean
+++ b/SSA/Experimental/Bits/Fast/BitStream.lean
@@ -433,7 +433,7 @@ lemma neg_eq_not_add : - a = ~~~ a + 1 := by
   ext i
   simp only [neg_eq_not_add' i, Neg.neg, neg, negAux, HAdd.hAdd, Add.add, add, addAux, BitVec.adcb, Prod.fst_swap]
 
-lemma ofBitVec_ofNat (h : 0 < w) : @ofBitVec w 1 ≈ʷ ofNat 1 := by
+lemma ofBitVec_ofNat' (h : 0 < w) : @ofBitVec w 1 ≈ʷ ofNat 1 := by
   intros n a
   simp only [ofBitVec, a, ↓reduceIte, OfNat.ofNat, BitVec.getLsb_one, ofNat, Nat.testBit,
     Nat.one_and_eq_mod_two, h, decide_True, Bool.true_and, HShiftRight.hShiftRight, ShiftRight.shiftRight]
@@ -448,17 +448,20 @@ lemma ofBitVec_ofNat (h : 0 < w) : @ofBitVec w 1 ≈ʷ ofNat 1 := by
         omega
       omega
 
-theorem ofBitVec_neg : ofBitVec (- x) ≈ʷ - (ofBitVec x) := by
+lemma ofBitVec_ofNat : @ofBitVec w 1 ≈ʷ ofNat 1 := by
   by_cases wz : w = 0
   intros _ a
   simp only [wz, not_lt_zero'] at a
+  exact ofBitVec_ofNat' (by omega)
+
+theorem ofBitVec_neg : ofBitVec (- x) ≈ʷ - (ofBitVec x) := by
   rw [BitVec.neg_eq_not_add]
   exact equal_up_to_trans (by
     trans ofBitVec (~~~ x) + (ofBitVec (1 : BitVec w ))
     exact ofBitVec_add
     exact add_congr ofBitVec_not' equal_up_to_refl) (by
     simp only [neg_eq_not_add]
-    exact add_congr equal_up_to_refl (ofBitVec_ofNat (by omega)))
+    exact add_congr equal_up_to_refl ofBitVec_ofNat)
 
 theorem sub_congr (e1 : a ≈ʷ b) (e2 : c ≈ʷ d) : (a - c) ≈ʷ (b - d) := by
   intros n h

--- a/SSA/Experimental/Bits/Fast/BitStream.lean
+++ b/SSA/Experimental/Bits/Fast/BitStream.lean
@@ -398,15 +398,13 @@ theorem equal_up_to_trans (e1 : a ≈ʷ b) (e2 : b ≈ʷ c) : a ≈ʷ c := by
   exact e1 j h
   exact e2 j h
 
-instance congr_trans : Trans (EqualUpTo w) (EqualUpTo w) (EqualUpTo w) := {
+instance congr_trans : Trans (EqualUpTo w) (EqualUpTo w) (EqualUpTo w) where
   trans := equal_up_to_trans
-}
 
-instance congr_equiv : Equivalence (EqualUpTo w) := {
-  refl := fun _ => equal_up_to_refl,
-  symm := equal_up_to_symm,
+instance congr_equiv : Equivalence (EqualUpTo w) where
+  refl := fun _ => equal_up_to_refl
+  symm := equal_up_to_symm
   trans := equal_up_to_trans
-}
 
 theorem add_congr (e1 : a ≈ʷ b) (e2 : c ≈ʷ d) : (a + c) ≈ʷ (b + d) := by
   intros n h

--- a/SSA/Experimental/Bits/Fast/BitStream.lean
+++ b/SSA/Experimental/Bits/Fast/BitStream.lean
@@ -419,7 +419,7 @@ theorem not_congr (e1 : a ≈ʷ b) : (~~~a) ≈ʷ ~~~b := by
   simp only [not_eq, e1 g h]
 
 theorem ofBitVec_not' : ofBitVec (~~~ x) ≈ʷ ~~~ ofBitVec x := by
-  intros n a
+  intros _ a
   simp [ofBitVec, a]
 
 theorem neg_eq_not_add' (i : Nat) : a.negAux i = ((~~~a).addAux 1 i).swap := by

--- a/SSA/Experimental/Bits/Fast/BitStream.lean
+++ b/SSA/Experimental/Bits/Fast/BitStream.lean
@@ -440,7 +440,8 @@ lemma ofBitVec_ofNat (h : 0 < w) : @ofBitVec w 1 ≈ʷ ofNat 1 := by
   match n with
     | 0 => simp only [decide_True, Bool.true_eq, bne_iff_ne, ne_eq, not_false_eq_true]
     | k + 1 =>
-      simp [Nat.shiftRight]
+      simp only [self_eq_add_left, add_eq_zero, one_ne_zero, and_false, decide_False,
+        Nat.shiftRight, Bool.false_eq, bne_eq_false_iff_eq]
       have : Nat.shiftRight 1 k ≤ 1 := by
         induction k
         <;> simp only [Nat.shiftRight, le_refl]

--- a/SSA/Experimental/Bits/Fast/BitStream.lean
+++ b/SSA/Experimental/Bits/Fast/BitStream.lean
@@ -443,7 +443,7 @@ theorem ofBitVec_ofNat : @ofBitVec w 1 ≈ʷ ofNat 1 := by
     simp [ofNat_one n, ofBitVec, a]
     omega
 
-theorem ofBitVec_neg2 : ofBitVec (- x) ≈ʷ - (ofBitVec x) := by
+theorem ofBitVec_neg : ofBitVec (- x) ≈ʷ - (ofBitVec x) := by
   calc
   _ ≈ʷ ofBitVec (~~~ x + 1)            := by rw [BitVec.neg_eq_not_add]
   _ ≈ʷ ofBitVec (~~~ x) + (ofBitVec 1) := ofBitVec_add

--- a/SSA/Experimental/Bits/Fast/Tactic.lean
+++ b/SSA/Experimental/Bits/Fast/Tactic.lean
@@ -180,7 +180,7 @@ simproc reduce_bitvec2 (BitStream.EqualUpTo (_ : Nat) _ _) := fun e => do
       return .done {
         expr := .app (.app (.app (.const ``BitStream.EqualUpTo []) w) lterm) rterm
         proof? :=
-        some (.app (.app (.app (.app (.app (.app (.app (.const ``BitStream.equal_trans []) w) l) lterm) r) rterm) lproof) rproof)
+        some (.app (.app (.app (.app (.app (.app (.app (.const ``BitStream.equal_congr_congr []) w) l) lterm) r) rterm) lproof) rproof)
       }
     | _ => throwError m!"Expression {e} is not of the expected form. Expected something of the form BitStream.EqualUpTo (w : Nat) (lhs : BitStream) (rhs : BitStream) : Prop"
 


### PR DESCRIPTION
There are currently three sorries in SSA/Experimental/Bits/Fast/BitStream.Lean.

In this current PR, I only remove the sorry from "neg" to keep each PR small and atomic. 


