### PR TITLE
chose: clean up CSE

### DIFF
--- a/SSA/Projects/CSE/CSE.lean
+++ b/SSA/Projects/CSE/CSE.lean
@@ -331,9 +331,9 @@ unsafe def State.cseExpr
         intros V
         simp (config := { zetaDelta := true}) [E, hargs', Expr.denote_unfold]
         congr 1
-        unfold Ctxt.Valuation.eval at hargs'
-        rw [hargs']
-        rw [hregArgs']
+        · unfold Ctxt.Valuation.eval at hargs'
+          rw [hargs']
+        · rw [hregArgs']
       }⟩,
         match s.expr2cache _ e with
         | .some ⟨v', hv'⟩ =>


### PR DESCRIPTION
This mostly adds `only` to non-terminal simps and adds dots to distinguish cases.