### PR TITLE
chore: remove oldSectionVars in FHE

### DIFF
--- a/SSA/Projects/FullyHomomorphicEncryption/Basic.lean
+++ b/SSA/Projects/FullyHomomorphicEncryption/Basic.lean
@@ -515,7 +515,7 @@ variable {q n : Nat}
 /-- an equivalent implementation of `fromTensor` that uses `Finsupp`
   to enable reasoning about values using mathlib's notions of
   support, coefficients, etc. -/
-noncomputable def R.fromTensorFinsupp (coeffs : List Int) : (ZMod q)[X] :=
+noncomputable def R.fromTensorFinsupp (q : Nat) (coeffs : List Int) : (ZMod q)[X] :=
   Polynomial.ofFinsupp (List.toFinsupp (coeffs.map Int.cast))
 
 theorem Polynomial.degree_toFinsupp [Semiring M] [DecidableEq M]
@@ -545,7 +545,7 @@ theorem Polynomial.degree_toFinsupp [Semiring M] [DecidableEq M]
 
 /-- degree of fromTensorFinsupp is at most the length of the coefficient list. -/
 theorem R.fromTensorFinsupp_degree (coeffs : List Int):
-  (R.fromTensorFinsupp (q := q) coeffs).degree ≤ coeffs.length := by
+  (R.fromTensorFinsupp q coeffs).degree ≤ coeffs.length := by
   rw [fromTensorFinsupp]
   have hdeg := Polynomial.degree_toFinsupp (List.map (Int.cast (R := ZMod q)) coeffs)
   simp only [List.length_map] at hdeg
@@ -553,7 +553,7 @@ theorem R.fromTensorFinsupp_degree (coeffs : List Int):
 
 /-- the ith coefficient of fromTensorFinsupp is a coercion of the 'coeffs' into the right list. -/
 theorem R.fromTensorFinsupp_coeffs (coeffs : List Int) :
-  Polynomial.coeff (fromTensorFinsupp (q:=q) coeffs) i = ↑(List.getD coeffs i 0) := by
+  Polynomial.coeff (fromTensorFinsupp q coeffs) i = ↑(List.getD coeffs i 0) := by
   rw [fromTensorFinsupp]
   rw [coeff_ofFinsupp]
   rw [List.toFinsupp_apply]
@@ -562,8 +562,8 @@ theorem R.fromTensorFinsupp_coeffs (coeffs : List Int) :
 
 /-- concatenating into a `fromTensorFinsupp` is the same as adding a ⟨Finsupp.single⟩. -/
 theorem R.fromTensorFinsupp_concat_finsupp (c : Int) (cs : List Int) :
-    (R.fromTensorFinsupp (q := q) (cs ++ [c])) =
-      (R.fromTensorFinsupp (q := q) cs) + ⟨Finsupp.single cs.length (Int.cast c : (ZMod q))⟩ := by
+    (R.fromTensorFinsupp q (cs ++ [c])) =
+      (R.fromTensorFinsupp q cs) + ⟨Finsupp.single cs.length (Int.cast c : (ZMod q))⟩ := by
     simp only [fromTensorFinsupp]
     simp only [← Polynomial.ofFinsupp_add]
     simp only [List.map_append, List.map]
@@ -572,8 +572,8 @@ theorem R.fromTensorFinsupp_concat_finsupp (c : Int) (cs : List Int) :
 
 /-- concatenating into a `fromTensorFinsupp` is the same as adding a monomial. -/
 theorem R.fromTensorFinsupp_concat_monomial (c : Int) (cs : List Int) :
-    (R.fromTensorFinsupp (q := q) (cs ++ [c])) =
-      (R.fromTensorFinsupp (q := q) cs) +
+    (R.fromTensorFinsupp q (cs ++ [c])) =
+      (R.fromTensorFinsupp q cs) +
         (Polynomial.monomial cs.length (Int.cast c : (ZMod q))) := by
     simp only [fromTensorFinsupp, List.map_append, List.map_cons, List.map_nil]
     rw [←Polynomial.ofFinsupp_single]
@@ -584,7 +584,7 @@ theorem R.fromTensorFinsupp_concat_monomial (c : Int) (cs : List Int) :
 /-- show that `fromTensor` is the same as `fromPoly ∘ fromTensorFinsupp`. -/
 theorem R.fromTensor_eq_fromTensorFinsupp_fromPoly {coeffs : List Int} :
     R.fromTensor (q := q) (n := n) coeffs =
-  R.fromPoly (q := q) (n := n) (R.fromTensorFinsupp (q:=q) coeffs) := by
+  R.fromPoly (q := q) (n := n) (R.fromTensorFinsupp q coeffs) := by
     simp only [fromTensor]
     induction coeffs using List.reverseRecOn
     case nil => simp [List.enum, fromTensorFinsupp]

--- a/SSA/Projects/FullyHomomorphicEncryption/Basic.lean
+++ b/SSA/Projects/FullyHomomorphicEncryption/Basic.lean
@@ -25,15 +25,14 @@ import Mathlib.Data.List.ToFinsupp
 import Mathlib.Data.List.Basic
 import SSA.Core.Framework
 
-set_option deprecated.oldSectionVars true
-
 open Polynomial -- for R[X] notation
 
+section CommRing
 /-
 We assume that `q > 1` is a natural number (not necessarily a prime) and `n` is a natural number.
 We will use these to build `ℤ/qℤ[X]/(X^(2^n) + 1)`
 -/
-variable (q t : Nat) [ hqgt1 : Fact (q > 1)] (n : Nat)
+variable (q t : Nat) [Fact (q > 1)] (n : Nat)
 
 -- Can we make this computable?
 -- see: https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/Way.20to.20recover.20computability.3F/near/322382109
@@ -119,6 +118,11 @@ theorem R.surjective_fromPoly (q n : ℕ) : Function.Surjective (R.fromPoly (q :
   simp only [fromPoly]
   apply Ideal.Quotient.mk_surjective
 
+end CommRing
+section Representative
+
+variable (q t n : Nat)
+
 private noncomputable def R.representative' :
     R q n → (ZMod q)[X] := Function.surjInv (R.surjective_fromPoly q n)
 
@@ -156,7 +160,7 @@ theorem R.fromPoly_kernel_eq_zero (x : (ZMod q)[X]) : R.fromPoly (n := n) (f q n
 `R.representative` is in fact a representative of the equivalence class.
 -/
 @[simp]
-theorem R.fromPoly_representative :
+theorem R.fromPoly_representative [Fact (q > 1)]:
     forall a : R q n, (R.fromPoly (n:=n) (R.representative q n a)) = a := by
  intro a
  simp only [representative]
@@ -239,14 +243,30 @@ theorem R.representative'_zero_elem :
   rw [hk]
   exists k
 
+/-- pushing and pulling negation through mod -/
+theorem neg_modByMonic (p mod : (ZMod q)[X]) : (-p) %ₘ mod = - (p %ₘ mod) := by
+    have H : -p = (-1 : ZMod q) • p := by norm_num
+    have H' : - (p %ₘ mod) = (-1 : ZMod q) • (p %ₘ mod) := by norm_num
+    rw [H, H']
+    apply smul_modByMonic (R := (ZMod q)) (c := -1) (p := p) (q := mod)
+
+/-- %ₘ is a subtraction homomorphism (obviously)-/
+@[simp]
+theorem sub_modByMonic (a b mod : (ZMod q)[X]) : (a - b) %ₘ mod = a %ₘ mod - b %ₘ mod := by
+  ring_nf
+  repeat rw [sub_eq_add_neg]
+  simp only [add_modByMonic, add_right_inj]
+  rw [Polynomial.neg_modByMonic]
+
 /-- Representative of (0 : R) is (0 : Z/qZ[X]) -/
-theorem R.representative_zero : R.representative q n 0 = 0 := by
+theorem R.representative_zero [Fact (q > 1)] : R.representative q n 0 = 0 := by
   simp only [representative]
   obtain ⟨k, hk⟩ := R.representative'_zero_elem q n
   rw [hk, modByMonic_eq_zero_iff_dvd]
   simp only [dvd_mul_left]
   exact (f_monic q n)
 
+variable [Fact (q > 1)]
 /--
 Characterization theorem for the representative.
 Taking the representative of the equivalence class of a polynomial  `a : (ZMod q)[X]` is
@@ -278,7 +298,7 @@ theorem R.representative_fromPoly :
 
 /-- Representative is an additive homomorphism -/
 @[simp]
-theorem R.representative_add [Fact (q > 1)](a b : R q n) :
+theorem R.representative_add (a b : R q n) :
     (a + b).representative = a.representative + b.representative := by
   have ⟨a', ha'⟩ := R.surjective_fromPoly q n a
   have ⟨b', hb'⟩ := R.surjective_fromPoly q n b
@@ -291,24 +311,9 @@ theorem R.representative_add [Fact (q > 1)](a b : R q n) :
   repeat rw [R.representative_fromPoly]
   rw [Polynomial.add_modByMonic]
 
-/-- pushing and pulling negation through mod -/
-theorem neg_modByMonic (p mod : (ZMod q)[X]) : (-p) %ₘ mod = - (p %ₘ mod) := by
-    have H : -p = (-1 : ZMod q) • p := by norm_num
-    have H' : - (p %ₘ mod) = (-1 : ZMod q) • (p %ₘ mod) := by norm_num
-    rw [H, H']
-    apply smul_modByMonic (R := (ZMod q)) (c := -1) (p := p) (q := mod)
-
-/-- %ₘ is a subtraction homomorphism (obviously)-/
-@[simp]
-theorem sub_modByMonic (a b mod : (ZMod q)[X]) : (a - b) %ₘ mod = a %ₘ mod - b %ₘ mod := by
-  ring_nf
-  repeat rw [sub_eq_add_neg]
-  simp only [add_modByMonic, add_right_inj]
-  rw [Polynomial.neg_modByMonic]
-
 /-- Representative is an multiplicative homomorphism upto modulo -/
 @[simp]
-theorem R.representative_mul [Fact (q > 1)] (a b : R q n) :
+theorem R.representative_mul (a b : R q n) :
     (a * b).representative = (a.representative * b.representative) %ₘ (f q n) := by
   have ⟨a', ha'⟩ := R.surjective_fromPoly q n a
   have ⟨b', hb'⟩ := R.surjective_fromPoly q n b
@@ -376,11 +381,13 @@ theorem R.rep_degree_lt_n : forall a : R q n, (R.representative q n a).degree < 
 
 /-- The representative `a : R q n` is the (unique) representative with degree
 less than degree of `f`. -/
-theorem R.representative_degree_lt_f_degree {q n : ℕ} [Fact (q > 1)] :
+theorem R.representative_degree_lt_f_degree :
     forall a : R q n, (R.representative q n a).degree < (f q n).degree := by
   rw [f_deg_eq (q := q)]
   intros a
   apply R.rep_degree_lt_n
+
+end Representative
 
 noncomputable def R.repLength {q n} (a : R q n) : Nat := match
   Polynomial.degree a.representative with
@@ -394,9 +401,7 @@ theorem R.repLength_leq_representative_degree_plus_1 (a : R q n) :
   generalize hdegree : degree (representative q n a) = d
   cases' d with d <;> simp [natDegree, hdegree, WithBot.unbot', WithBot.recBotCoe]
 
-
-
-theorem R.repLength_lt_n_plus_1 : forall a : R q n, a.repLength < 2^n + 1 := by
+theorem R.repLength_lt_n_plus_1 [Fact (q > 1)]: forall a : R q n, a.repLength < 2^n + 1 := by
   intro a
   simp only [R.repLength, representative]
   have : Polynomial.degree ( R.representative' q n a %ₘ f q n) < 2^n := by
@@ -412,6 +417,7 @@ theorem R.repLength_lt_n_plus_1 : forall a : R q n, a.repLength < 2^n + 1 := by
     cases VAL
     norm_cast at VAL_EQN
 
+section Coeff
 /--
 This function gets the `i`th coefficient of the polynomial representative
 (with degree `< 2^n`) of an element `a : R q n`. Note that this is not
@@ -491,9 +497,9 @@ theorem R.fromTensor_eq_fromTensor'_fromPoly_aux (coeffs : List Int) (rp : R q n
 /-- fromTensor = R.fromPoly ∘ fromTensor'.
 This permits reasoning about fromTensor directly on the polynomial ring.
 -/
-theorem R.fromTensor_eq_fromTensor'_fromPoly {q n} {coeffs : List Int} :
+theorem R.fromTensor_eq_fromTensor'_fromPoly {q n} [Fact (q > 1)] {coeffs : List Int} :
     R.fromTensor (q := q) (n := n) coeffs =
-  R.fromPoly (q := q) (n := n) (R.fromTensor' q coeffs) := by
+  R.fromPoly (q := q) (n := n) (R.fromTensor' coeffs) := by
     simp only [fromTensor, fromTensor']
     induction coeffs
     · simp [List.enum]
@@ -501,7 +507,11 @@ theorem R.fromTensor_eq_fromTensor'_fromPoly {q n} {coeffs : List Int} :
       apply fromTensor_eq_fromTensor'_fromPoly_aux
       simp [monomial]
 
+end Coeff
 
+section FinnSupp
+
+variable {q n : Nat}
 /-- an equivalent implementation of `fromTensor` that uses `Finsupp`
   to enable reasoning about values using mathlib's notions of
   support, coefficients, etc. -/
@@ -534,8 +544,8 @@ theorem Polynomial.degree_toFinsupp [Semiring M] [DecidableEq M]
         apply Nat.le_of_lt ha₆
 
 /-- degree of fromTensorFinsupp is at most the length of the coefficient list. -/
-theorem R.fromTensorFinsupp_degree (coeffs : List Int) :
-  (R.fromTensorFinsupp q coeffs).degree ≤ coeffs.length := by
+theorem R.fromTensorFinsupp_degree (coeffs : List Int):
+  (R.fromTensorFinsupp (q := q) coeffs).degree ≤ coeffs.length := by
   rw [fromTensorFinsupp]
   have hdeg := Polynomial.degree_toFinsupp (List.map (Int.cast (R := ZMod q)) coeffs)
   simp only [List.length_map] at hdeg
@@ -543,7 +553,7 @@ theorem R.fromTensorFinsupp_degree (coeffs : List Int) :
 
 /-- the ith coefficient of fromTensorFinsupp is a coercion of the 'coeffs' into the right list. -/
 theorem R.fromTensorFinsupp_coeffs (coeffs : List Int) :
-  Polynomial.coeff (fromTensorFinsupp q coeffs) i = ↑(List.getD coeffs i 0) := by
+  Polynomial.coeff (fromTensorFinsupp (q:=q) coeffs) i = ↑(List.getD coeffs i 0) := by
   rw [fromTensorFinsupp]
   rw [coeff_ofFinsupp]
   rw [List.toFinsupp_apply]
@@ -551,7 +561,7 @@ theorem R.fromTensorFinsupp_coeffs (coeffs : List Int) :
   rw [hzero, List.getD_map]
 
 /-- concatenating into a `fromTensorFinsupp` is the same as adding a ⟨Finsupp.single⟩. -/
-theorem R.fromTensorFinsupp_concat_finsupp {q : Nat} (c : Int) (cs : List Int) :
+theorem R.fromTensorFinsupp_concat_finsupp (c : Int) (cs : List Int) :
     (R.fromTensorFinsupp (q := q) (cs ++ [c])) =
       (R.fromTensorFinsupp (q := q) cs) + ⟨Finsupp.single cs.length (Int.cast c : (ZMod q))⟩ := by
     simp only [fromTensorFinsupp]
@@ -561,7 +571,7 @@ theorem R.fromTensorFinsupp_concat_finsupp {q : Nat} (c : Int) (cs : List Int) :
     simp only [List.length_map]
 
 /-- concatenating into a `fromTensorFinsupp` is the same as adding a monomial. -/
-theorem R.fromTensorFinsupp_concat_monomial {q : Nat} (c : Int) (cs : List Int) :
+theorem R.fromTensorFinsupp_concat_monomial (c : Int) (cs : List Int) :
     (R.fromTensorFinsupp (q := q) (cs ++ [c])) =
       (R.fromTensorFinsupp (q := q) cs) +
         (Polynomial.monomial cs.length (Int.cast c : (ZMod q))) := by
@@ -572,9 +582,9 @@ theorem R.fromTensorFinsupp_concat_monomial {q : Nat} (c : Int) (cs : List Int) 
     rw [List.length_map]
 
 /-- show that `fromTensor` is the same as `fromPoly ∘ fromTensorFinsupp`. -/
-theorem R.fromTensor_eq_fromTensorFinsupp_fromPoly {q n} {coeffs : List Int} :
+theorem R.fromTensor_eq_fromTensorFinsupp_fromPoly {coeffs : List Int} :
     R.fromTensor (q := q) (n := n) coeffs =
-  R.fromPoly (q := q) (n := n) (R.fromTensorFinsupp q coeffs) := by
+  R.fromPoly (q := q) (n := n) (R.fromTensorFinsupp (q:=q) coeffs) := by
     simp only [fromTensor]
     induction coeffs using List.reverseRecOn
     case nil => simp [List.enum, fromTensorFinsupp]
@@ -584,8 +594,14 @@ theorem R.fromTensor_eq_fromTensorFinsupp_fromPoly {q n} {coeffs : List Int} :
       rw [hcs]
       congr
 
+end FinnSupp
+
+section Tensor
+
+variable {q n : Nat} [Fact (q > 1)]
+
 /-- `coeff (p % f) = coeff p` if the degree of `p` is less than the degree of `f`. -/
-theorem coeff_modByMonic_degree_lt_f {q n i : Nat} [Fact (q > 1)] (p : (ZMod q)[X])
+theorem coeff_modByMonic_degree_lt_f {i : Nat} (p : (ZMod q)[X])
     (DEGREE : p.degree < (f q n).degree) :
   (p %ₘ f q n).coeff i = p.coeff i := by
   have H := (modByMonic_eq_self_iff (hq := f_monic q n) (p := p)).mpr DEGREE
@@ -593,7 +609,7 @@ theorem coeff_modByMonic_degree_lt_f {q n i : Nat} [Fact (q > 1)] (p : (ZMod q)[
 
 /-- The coefficient of `fromPoly p` is the coefficient of `p` modulo `f q n`. -/
 @[simp]
-theorem R.coeff_fromPoly {q n : Nat} [Fact (q > 1)] (p : (ZMod q)[X]) :
+theorem R.coeff_fromPoly (p : (ZMod q)[X]) :
     R.coeff (R.fromPoly (q := q) (n := n) p) = Polynomial.coeff (p %ₘ (f q n)) := by
   unfold R.coeff
   simp [R.coeff]
@@ -607,15 +623,15 @@ theorem R.coeff_fromPoly {q n : Nat} [Fact (q > 1)] (p : (ZMod q)[X]) :
   3.
 -/
 /-- The coefficient of `fromTensor` is the same as the values available in the tensor input. -/
-theorem R.coeff_fromTensor [hqgt1 : Fact (q > 1)] (tensor : List Int)
+theorem R.coeff_fromTensor (tensor : List Int)
     (htensorlen : tensor.length < 2^n) :
     (R.fromTensor (q := q) (n := n) tensor).coeff i = (tensor.getD i 0) := by
   rw [fromTensor_eq_fromTensorFinsupp_fromPoly]
-  have hfromTensorFinsuppDegree := fromTensorFinsupp_degree q tensor
+  have hfromTensorFinsuppDegree := fromTensorFinsupp_degree (q:=q) tensor
   rw [coeff, representative_fromPoly_eq]
   apply fromTensorFinsupp_coeffs
   case DEGREE =>
-    generalize htensor_degree : degree (fromTensorFinsupp q tensor) = tensor_degree
+    generalize htensor_degree : degree (fromTensorFinsupp (q:=q) tensor) = tensor_degree
     rw [f_deg_eq]
     cases tensor_degree
     case bot => norm_cast; apply WithBot.bot_lt_coe
@@ -632,7 +648,7 @@ theorem R.coeff_fromTensor [hqgt1 : Fact (q > 1)] (tensor : List Int)
 
 theorem R.representative_fromTensor_eq_fromTensor' (tensor : List Int) :
     R.representative q n (R.fromTensor tensor) =
-      R.representative' q n (R.fromTensor' q tensor)  %ₘ (f q n) := by
+      R.representative' q n (R.fromTensor' (q:=q) tensor)  %ₘ (f q n) := by
   simp only [representative]
   rw [fromTensor_eq_fromTensor'_fromPoly];
 
@@ -641,12 +657,12 @@ Converts an element of `R` into a tensor (modeled as a `List Int`)
 with the representatives of the coefficients of the representative.
 The length of the list is the degree of the representative + 1.
 -/
-noncomputable def R.toTensor {q n} [Fact (q > 1)] (a : R q n) : List Int :=
+noncomputable def R.toTensor {q n} (a : R q n) : List Int :=
   List.range a.repLength |>.map fun i =>
         a.coeff i |>.toInt
 
 /-- The length of the tensor `R.toTensor a` equals `a.repLength` -/
-theorem R.toTensor_length {q n} [Fact (q > 1)] (a : R q n) :
+theorem R.toTensor_length {q n} (a : R q n) :
     (R.toTensor a).length = a.repLength := by
   simp only [toTensor, List.length_map, List.length_range]
 
@@ -655,13 +671,18 @@ Converts an element of `R` into a tensor (modeled as a `List Int`)
 with the representatives of the coefficients of the representative.
 The length of the list is the degree of the generator polynomial `f` + 1.
 -/
-noncomputable def R.toTensor' {q n} [Fact (q > 1)] (a : R q n) : List Int :=
+noncomputable def R.toTensor' {q n} (a : R q n) : List Int :=
   let t := a.toTensor
   t ++ List.replicate (2^n - t.length + 1) 0
 
 def trimTensor (tensor : List Int) : List Int
   := tensor.reverse.dropWhile (· = 0) |>.reverse
 
+end Tensor
+
+section Signature
+
+variable [Fact (q > 1)]
 /--
 We define the base type of the representation, which encodes both natural numbers
 and elements in the ring `R q n` (which in FHE are sometimes called 'polynomials'
@@ -669,7 +690,7 @@ and elements in the ring `R q n` (which in FHE are sometimes called 'polynomials
 
  In this context, `Tensor is a 1-D tensor, which we model here as a list of integers.
 -/
-inductive Ty (q : Nat) (n : Nat) [Fact (q > 1)]
+inductive Ty (q : Nat) (n : Nat)
   | index : Ty q n
   | integer : Ty q n
   | tensor : Ty q n
@@ -691,7 +712,7 @@ two parameters `p` and `n` that characterize the ring `R q n`.
 We parametrize the entire type by these since it makes no sense to mix
 operations in different rings.
 -/
-inductive Op (q : Nat) (n : Nat) [Fact (q > 1)]
+inductive Op (q : Nat) (n : Nat)
   | add : Op q n-- Addition in `R q n`
   | sub : Op q n-- Substraction in `R q n`
   | mul : Op q n-- Multiplication in `R q n`
@@ -716,7 +737,7 @@ open TyDenote (toType)
 
 
 @[simp, reducible]
-def Op.sig : Op  q n → List (Ty q n)
+def Op.sig : Op q n → List (Ty q n)
 | Op.add => [Ty.polynomialLike, Ty.polynomialLike]
 | Op.sub => [Ty.polynomialLike, Ty.polynomialLike]
 | Op.mul => [Ty.polynomialLike, Ty.polynomialLike]
@@ -741,9 +762,9 @@ def Op.outTy : Op q n → Ty q n
 
 @[simp, reducible]
 def Op.signature : Op q n → Signature (Ty q n) :=
-  fun o => {sig := Op.sig q n o, outTy := Op.outTy q n o, regSig := []}
+  fun o => {sig := Op.sig o, outTy := Op.outTy o, regSig := []}
 
-instance : DialectSignature (FHE q n) := ⟨Op.signature q n⟩
+instance : DialectSignature (FHE q n) := ⟨Op.signature⟩
 
 @[simp]
 noncomputable instance : DialectDenote (FHE q n) where

--- a/SSA/Projects/FullyHomomorphicEncryption/Basic.lean
+++ b/SSA/Projects/FullyHomomorphicEncryption/Basic.lean
@@ -544,7 +544,7 @@ theorem Polynomial.degree_toFinsupp [Semiring M] [DecidableEq M]
         apply Nat.le_of_lt ha₆
 
 /-- degree of fromTensorFinsupp is at most the length of the coefficient list. -/
-theorem R.fromTensorFinsupp_degree (coeffs : List Int):
+theorem R.fromTensorFinsupp_degree (q : Nat) (coeffs : List Int):
   (R.fromTensorFinsupp q coeffs).degree ≤ coeffs.length := by
   rw [fromTensorFinsupp]
   have hdeg := Polynomial.degree_toFinsupp (List.map (Int.cast (R := ZMod q)) coeffs)
@@ -627,11 +627,11 @@ theorem R.coeff_fromTensor (tensor : List Int)
     (htensorlen : tensor.length < 2^n) :
     (R.fromTensor (q := q) (n := n) tensor).coeff i = (tensor.getD i 0) := by
   rw [fromTensor_eq_fromTensorFinsupp_fromPoly]
-  have hfromTensorFinsuppDegree := fromTensorFinsupp_degree (q:=q) tensor
+  have hfromTensorFinsuppDegree := fromTensorFinsupp_degree q tensor
   rw [coeff, representative_fromPoly_eq]
   apply fromTensorFinsupp_coeffs
   case DEGREE =>
-    generalize htensor_degree : degree (fromTensorFinsupp (q:=q) tensor) = tensor_degree
+    generalize htensor_degree : degree (fromTensorFinsupp q tensor) = tensor_degree
     rw [f_deg_eq]
     cases tensor_degree
     case bot => norm_cast; apply WithBot.bot_lt_coe

--- a/SSA/Projects/FullyHomomorphicEncryption/Statements.lean
+++ b/SSA/Projects/FullyHomomorphicEncryption/Statements.lean
@@ -5,11 +5,6 @@ import SSA.Projects.FullyHomomorphicEncryption.Basic
 import Batteries.Data.List.Lemmas
 import Mathlib.Data.List.Basic
 
-set_option deprecated.oldSectionVars true
-
--- variable {q t : Nat} [ hqgt1 : Fact (q > 1)] {n : Nat}
--- variable (a b : R q n)
-
 namespace Poly
 
 theorem mul_comm (a b : R q n) : a * b = b * a := by
@@ -67,7 +62,7 @@ theorem monomial_mul_mul (x y : Nat) :
 
 end Poly
 
-theorem R.toTensor_getD [hqgt1 : Fact (q > 1)] (a : R q n) (i : Nat) :
+theorem R.toTensor_getD [Fact (q > 1)] (a : R q n) (i : Nat) :
     a.toTensor.getD i 0 = (a.coeff i).toInt := by
   simp only [toTensor, coeff]
   have hLength :
@@ -191,7 +186,7 @@ theorem R.fromTensor_eq_fromTensor_trimTensor (tensor : List Int) :
     rw [hn]
   simp [R.fromTensor_eq_concat_zeroes]
 
-theorem R.trimTensor_toTensor'_eq_trimTensor_toTensor [hqgt1 : Fact (q > 1)] (a : R q n) :
+theorem R.trimTensor_toTensor'_eq_trimTensor_toTensor [Fact (q > 1)] (a : R q n) :
   trimTensor a.toTensor' = trimTensor a.toTensor := by
   apply R.trimTensor_append_zeroes_eq
 
@@ -206,15 +201,15 @@ theorem eq_iff_coeff_eq [hqgt1 : Fact (q > 1)] (a b : R q n) :
      apply Polynomial.coeff_inj.1
      exact h
 
-theorem toTensor_length_eq_rep_length [hqgt1 : Fact (q > 1)] (a : R q n) :
+theorem toTensor_length_eq_rep_length [Fact (q > 1)] (a : R q n) :
   a.toTensor.length = a.repLength := by
   simp [R.repLength, R.toTensor]
 
 -- Surely this doesn't need to be this annoying
-theorem toTensor_length_eq_f_deg_plus_1 [hqgt1 : Fact (q > 1)] (a : R q n) :
+theorem toTensor_length_eq_f_deg_plus_1 [Fact (q > 1)] (a : R q n) :
   a.toTensor'.length = 2^n + 1 := by
   rw [R.toTensor', List.length_append, toTensor_length_eq_rep_length, List.length_replicate]
-  have h : R.repLength a ≤ 2^n  := Nat.le_of_lt_succ (R.repLength_lt_n_plus_1 q n a)
+  have h : R.repLength a ≤ 2^n  := Nat.le_of_lt_succ (R.repLength_lt_n_plus_1 a)
   calc
        R.repLength a + (2 ^ n - R.repLength a + 1)
      = R.repLength a + (Nat.succ (2 ^ n) - R.repLength a) := by rw
@@ -222,7 +217,7 @@ theorem toTensor_length_eq_f_deg_plus_1 [hqgt1 : Fact (q > 1)] (a : R q n) :
    _ = 2^n + 1 := by rw [Nat.add_sub_cancel' (Nat.le_succ_of_le h)]
 
 
-theorem toTensor_trimTensor_eq_toTensor [hqgt1 : Fact (q > 1)] (a : R q n) :
+theorem toTensor_trimTensor_eq_toTensor [Fact (q > 1)] (a : R q n) :
   trimTensor a.toTensor = a.toTensor := by
   unfold R.toTensor
   cases h : Polynomial.degree a.representative with
@@ -249,7 +244,7 @@ theorem toTensor_fromTensor [hqgt1 : Fact (q > 1)] (tensor : List Int) (i : Nat)
   (R.fromTensor tensor (q:=q) (n :=n)).toTensor.getD i 0 = (tensor.getD i 0) % q := by
   simp only [R.toTensor_getD]
   simp only [ZMod.toInt]
-  rw [R.coeff_fromTensor (hqgt1 := hqgt1) (htensorlen := htensorlen)]
+  rw [R.coeff_fromTensor (htensorlen := htensorlen)]
   norm_cast
   simp only [Int.cast, ZMod.cast]
   cases q;
@@ -291,7 +286,7 @@ theorem fromTensor_toTensor [hqgt1 : Fact (q > 1)] (a : R q n)
         rw [← ZMod.coe_intCast]
         norm_cast
         · simp only [R.toTensor_length]
-          have hdeg := R.repLength_leq_representative_degree_plus_1 q n a
+          have hdeg := R.repLength_leq_representative_degree_plus_1 a
           linarith
 
 theorem fromTensor_toTensor' [hqgt1 : Fact (q > 1)] (a : R q n)


### PR DESCRIPTION
introduces sections more carefully to manage typeclasses in FHE, and gets rid of oldSectionVars this way