### PR TITLE
[NFC] Chore: Canonicalise Bits of BitStream.addAux to match subAux and negAux

### DIFF
--- a/SSA/Experimental/Bits/Fast/BitStream.lean
+++ b/SSA/Experimental/Bits/Fast/BitStream.lean
@@ -444,13 +444,6 @@ theorem ofBitVec_not_eqTo : ofBitVec (~~~ x) ≈ʷ ~~~ ofBitVec x := by
   intros _ a
   simp [ofBitVec, a]
 
-/--
-  Clarification: the reason that this theorem (unexpectedly) contains Prod.swap is
-  that in BitStream.negAux, the carry bit is in the left bit of the pair and
-  in BitStream.addAux, the carry bit is in the right bit of the pair.
-
-  TODO: Possibly investigate changing the behavior of BitStream.addAux?
--/
 theorem negAux_eq_not_addAux : a.negAux = (~~~a).addAux 1 := by
   funext i
   induction' i with _ ih

--- a/SSA/Experimental/Bits/Fast/BitStream.lean
+++ b/SSA/Experimental/Bits/Fast/BitStream.lean
@@ -272,39 +272,11 @@ end BitwiseOps
 /-! # Addition, Subtraction, Negation -/
 section Arith
 
-/--
-addAux' is the old version of addAux, which is kept around for backward-compatability reasons.
-To use the new version, use addAux
--/
--- def addAux' (x y : BitStream) : Nat → Bool × Bool
---   | 0 => BitVec.adcb (x 0) (y 0) false
---   | n+1 =>
---     let carry := (addAux' x y n).1
---     let a := x (n + 1)
---     let b := y (n + 1)
---     BitVec.adcb a b carry
 def addAux (x y : BitStream) (i : Nat) :  Bool × Bool :=
   let carry : Bool := match i with
     | 0 => false
     | i + 1 => (addAux x y i).2
   Prod.swap (BitVec.adcb (x i) (y i) carry)
-  -- | 0 => Prod.swap (BitVec.adcb (x 0) (y 0) false)
-  -- | n+1 =>
-  --   let carry := (addAux' x y n).1
-  --   let a := x (n + 1)
-  --   let b := y (n + 1)
-  --   Prod.swap (BitVec.adcb a b carry)
-/--
-The reason that there is a Prod.swap in the definition of addAux is that
-BitVec.adcb returns the carry bit on the left and the result bit on the right.
-
-In order to preserve the same design as subAux and negAux, we use Prod.swap
-so that the result bit is on the left and the carry bit is on the right.
-
-The un-swapped version is still availiable as addAux'
--/
--- @[simp]
--- def addAux (x y : BitStream) : Nat →  Bool × Bool := Prod.swap ∘ (addAux' x y)
 
 def add (x y : BitStream) : BitStream :=
   fun n => (addAux x y n).1
@@ -458,8 +430,8 @@ theorem ofBitVec_not_eqTo : ofBitVec (~~~ x) ≈ʷ ~~~ ofBitVec x := by
 theorem negAux_eq_not_addAux : a.negAux = (~~~a).addAux 1 := by
   funext i
   induction' i with _ ih
-  · simp [negAux, BitVec.adcb, OfNat.ofNat, ofNat, addAux]
-  · simp [negAux, BitVec.adcb, OfNat.ofNat, ofNat, addAux, ih]
+  · simp [negAux, addAux, BitVec.adcb, OfNat.ofNat, ofNat]
+  · simp [negAux, addAux, BitVec.adcb, OfNat.ofNat, ofNat, ih]
 
 theorem neg_eq_not_add : - a = ~~~ a + 1 := by
   ext _

--- a/SSA/Experimental/Bits/Fast/BitStream.lean
+++ b/SSA/Experimental/Bits/Fast/BitStream.lean
@@ -377,7 +377,7 @@ theorem ofBitVec_getLsb (n : Nat) (h : n < w) : ofBitVec x n = x.getLsb n := by
 
 theorem ofBitVec_add : ofBitVec (x + y) ≈ʷ (ofBitVec x) + (ofBitVec y) := by
   intros n a
-  have add_lemma : ⟨(x + y).getLsb n ,BitVec.carry (n + 1) x y false ⟩ = (ofBitVec x).addAux (ofBitVec y) n := by
+  have add_lemma : ⟨(x + y).getLsb n, BitVec.carry (n + 1) x y false ⟩ = (ofBitVec x).addAux (ofBitVec y) n := by
     induction' n with n ih
     · simp [addAux, BitVec.adcb, a, BitVec.getLsb, BitVec.carry, ← Bool.decide_and,
         Bool.xor_decide, Nat.two_le_add_iff_odd_and_odd, Nat.add_odd_iff_neq]

--- a/SSA/Experimental/Bits/Fast/BitStream.lean
+++ b/SSA/Experimental/Bits/Fast/BitStream.lean
@@ -272,6 +272,10 @@ end BitwiseOps
 /-! # Addition, Subtraction, Negation -/
 section Arith
 
+/--
+addAux' is the old version of addAux, which is kept around for backward-compatability reasons.
+To use the new version, use addAux
+-/
 def addAux' (x y : BitStream) : Nat → Bool × Bool
   | 0 => BitVec.adcb (x 0) (y 0) false
   | n+1 =>
@@ -291,9 +295,6 @@ The un-swapped version is still availiable as addAux'
 -/
 @[simp]
 def addAux (x y : BitStream) : Nat →  Bool × Bool := Prod.swap ∘ (addAux' x y)
-
-@[simp]
-theorem reduce_addAux : addAux x y = Prod.swap ∘ (addAux' x y) := by rfl
 
 def add (x y : BitStream) : BitStream :=
   fun n => (addAux x y n).1
@@ -447,8 +448,8 @@ theorem ofBitVec_not_eqTo : ofBitVec (~~~ x) ≈ʷ ~~~ ofBitVec x := by
 theorem negAux_eq_not_addAux : a.negAux = (~~~a).addAux 1 := by
   funext i
   induction' i with _ ih
-  · simp [negAux, addAux, BitVec.adcb, OfNat.ofNat, ofNat, Prod.swap, addAux']
-  · simp [negAux, addAux, BitVec.adcb, OfNat.ofNat, ofNat, Prod.swap, addAux', ih]
+  · simp [negAux, BitVec.adcb, OfNat.ofNat, ofNat, addAux']
+  · simp [negAux, BitVec.adcb, OfNat.ofNat, ofNat, addAux', ih]
 
 theorem neg_eq_not_add : - a = ~~~ a + 1 := by
   ext _

--- a/SSA/Experimental/Bits/Fast/FiniteStateMachine.lean
+++ b/SSA/Experimental/Bits/Fast/FiniteStateMachine.lean
@@ -271,7 +271,7 @@ theorem carry_add_succ (x : Bool → BitStream) (n : ℕ) :
   cases n
   · show Bool.xor _ _ = Bool.xor _ _; simp
   · rw [carry_add_succ]
-    conv => {rhs; simp only [(· + ·), BitStream.add, Add.add, BitStream.addAux, BitStream.addAux, BitVec.adcb]}
+    conv => {rhs; simp only [(· + ·), BitStream.add, Add.add, BitStream.addAux, BitVec.adcb]}
     simp [nextBit, eval, add, BitStream.addAux, BitVec.adcb]
 /-!
 We don't really need subtraction or negation FSMs,

--- a/SSA/Experimental/Bits/Fast/FiniteStateMachine.lean
+++ b/SSA/Experimental/Bits/Fast/FiniteStateMachine.lean
@@ -272,7 +272,7 @@ theorem carry_add_succ (x : Bool → BitStream) (n : ℕ) :
   · show Bool.xor _ _ = Bool.xor _ _; simp
   · rw [carry_add_succ]
     conv => {rhs; simp only [(· + ·), BitStream.add, Add.add, BitStream.addAux, BitVec.adcb]}
-    simp [nextBit, eval, add, BitStream.addAux, BitVec.adcb]
+    simp [nextBit, eval, add]
 /-!
 We don't really need subtraction or negation FSMs,
 given that we can reduce both those operations to just addition and bitwise complement -/

--- a/SSA/Experimental/Bits/Fast/FiniteStateMachine.lean
+++ b/SSA/Experimental/Bits/Fast/FiniteStateMachine.lean
@@ -253,14 +253,14 @@ def add : FSM Bool :=
 the carry bit of addition as implemented on bitstreams -/
 theorem carry_add_succ (x : Bool → BitStream) (n : ℕ) :
     add.carry x (n+1) =
-      fun _ => (BitStream.addAux' (x true) (x false) n).1 := by
+      fun _ => (BitStream.addAux (x true) (x false) n).2 := by
   ext a; obtain rfl : a = () := rfl
   induction n with
   | zero      =>
-    simp [carry, BitStream.addAux', nextBit, add, BitVec.adcb]
+    simp [carry, BitStream.addAux, nextBit, add, BitVec.adcb]
   | succ n ih =>
     unfold carry
-    simp [nextBit, ih, Circuit.eval, BitStream.addAux', BitVec.adcb]
+    simp [nextBit, ih, Circuit.eval, BitStream.addAux, BitVec.adcb]
 
 @[simp] theorem carry_zero (x : arity → BitStream) : carry p x 0 = p.initCarry := rfl
 @[simp] theorem initCarry_add : add.initCarry = (fun _ => false) := rfl
@@ -271,8 +271,8 @@ theorem carry_add_succ (x : Bool → BitStream) (n : ℕ) :
   cases n
   · show Bool.xor _ _ = Bool.xor _ _; simp
   · rw [carry_add_succ]
-    conv => {rhs; simp only [(· + ·), BitStream.add, Add.add, BitStream.addAux, BitStream.addAux', BitVec.adcb]}
-    simp [nextBit, eval, add, BitStream.addAux', BitVec.adcb]
+    conv => {rhs; simp only [(· + ·), BitStream.add, Add.add, BitStream.addAux, BitStream.addAux, BitVec.adcb]}
+    simp [nextBit, eval, add, BitStream.addAux, BitVec.adcb]
 /-!
 We don't really need subtraction or negation FSMs,
 given that we can reduce both those operations to just addition and bitwise complement -/

--- a/SSA/Experimental/Bits/Fast/FiniteStateMachine.lean
+++ b/SSA/Experimental/Bits/Fast/FiniteStateMachine.lean
@@ -253,14 +253,14 @@ def add : FSM Bool :=
 the carry bit of addition as implemented on bitstreams -/
 theorem carry_add_succ (x : Bool → BitStream) (n : ℕ) :
     add.carry x (n+1) =
-      fun _ => (BitStream.addAux (x true) (x false) n).1 := by
+      fun _ => (BitStream.addAux' (x true) (x false) n).1 := by
   ext a; obtain rfl : a = () := rfl
   induction n with
   | zero      =>
-    simp [carry, BitStream.addAux, nextBit, add, BitVec.adcb]
+    simp [carry, BitStream.addAux', nextBit, add, BitVec.adcb]
   | succ n ih =>
     unfold carry
-    simp [nextBit, ih, Circuit.eval, BitStream.addAux, BitVec.adcb]
+    simp [nextBit, ih, Circuit.eval, BitStream.addAux', BitVec.adcb]
 
 @[simp] theorem carry_zero (x : arity → BitStream) : carry p x 0 = p.initCarry := rfl
 @[simp] theorem initCarry_add : add.initCarry = (fun _ => false) := rfl
@@ -271,9 +271,8 @@ theorem carry_add_succ (x : Bool → BitStream) (n : ℕ) :
   cases n
   · show Bool.xor _ _ = Bool.xor _ _; simp
   · rw [carry_add_succ]
-    conv => {rhs; simp only [(· + ·), BitStream.add, Add.add, BitStream.addAux, BitVec.adcb]}
-    simp [nextBit, eval, add]
-
+    conv => {rhs; simp only [(· + ·), BitStream.add, Add.add, BitStream.addAux, BitStream.addAux', BitVec.adcb]}
+    simp [nextBit, eval, add, BitStream.addAux', BitVec.adcb]
 /-!
 We don't really need subtraction or negation FSMs,
 given that we can reduce both those operations to just addition and bitwise complement -/

--- a/SSA/Experimental/Bits/Propagate.lean
+++ b/SSA/Experimental/Bits/Propagate.lean
@@ -290,7 +290,7 @@ lemma neg_eq_propagate (x : BitStream) :
   match n with
   | 0 => simp [BitStream.neg, BitStream.negAux]
   | 1 => simp [BitStream.neg, BitStream.negAux, propagate, propagateAux]
-  | n+2 => simp [BitStream.neg, BitStream.negAux, BitStream.negAux_eq_propagateCarry, BitStream.neg, BitStream.negAux, BitStream.negAux_eq_propagateCarry, propagate_succ]
+  | n+2 => simp [BitStream.neg, BitStream.negAux, BitStream.negAux_eq_propagateCarry, propagate_succ]
 
 lemma BitStream.incrAux_eq_propagateCarry (x : BitStream) (n : ℕ) :
     (BitStream.incrAux x n).2 = propagateCarry (λ _ => true)

--- a/SSA/Experimental/Bits/Propagate.lean
+++ b/SSA/Experimental/Bits/Propagate.lean
@@ -228,19 +228,13 @@ lemma ls_eq_propagate (b : Bool) (x : BitStream) :
   | 1 => rfl
   | n+2 => simp [propagate_succ, BitStream.concat]
 
-lemma addAux'_eq_propagateCarry (x y : BitStream) (n : ℕ) :
-    (addAux' x y n).1 = propagateCarry (λ _ => false)
-      (λ (carry : Unit → Bool) (bits : Bool → Bool) =>
-        λ _ => (bits true && bits false) || (bits true && carry ()) || (bits false && carry ()) )
-    (λ b => cond b x y) n () := by
-  induction n <;> simp [addAux', BitVec.adcb, Bool.atLeastTwo, *]
-
 lemma addAux_eq_propagateCarry (x y : BitStream) (n : ℕ) :
     (addAux x y n).2 = propagateCarry (λ _ => false)
       (λ (carry : Unit → Bool) (bits : Bool → Bool) =>
         λ _ => (bits true && bits false) || (bits true && carry ()) || (bits false && carry ()) )
     (λ b => cond b x y) n () := by
-  simp [addAux'_eq_propagateCarry]
+  induction n <;> simp [addAux, BitVec.adcb, Bool.atLeastTwo, *]
+
 
 lemma add_eq_propagate (x y : BitStream) :
     x + y = propagate (λ _ => false)
@@ -251,12 +245,12 @@ lemma add_eq_propagate (x y : BitStream) :
   ext n
   match n with
   | 0 =>
-    simp  [HAdd.hAdd, Add.add, BitStream.add, BitStream.addAux', BitVec.adcb]
+    simp  [HAdd.hAdd, Add.add, BitStream.add, BitStream.addAux, BitVec.adcb]
   | 1 =>
-    simp [HAdd.hAdd, Add.add,BitVec.adcb, BitStream.add, addAux, addAux', propagate, propagateAux,  -BitVec.add_eq, -Nat.add_eq, -Nat.add_def]
+    simp [HAdd.hAdd, Add.add,BitVec.adcb, BitStream.add, addAux, addAux, propagate, propagateAux,  -BitVec.add_eq, -Nat.add_eq, -Nat.add_def]
   | n+2 =>
     simp only [HAdd.hAdd, Add.add,BitVec.adcb, BitStream.add
-      , BitVec.adcb, addAux, Function.comp, addAux', addAux'_eq_propagateCarry, propagate_succ,Bool.or_assoc]
+      , BitVec.adcb, addAux, Function.comp, addAux, addAux_eq_propagateCarry, propagate_succ,Bool.or_assoc]
     simp [Bool.or_comm]
 
 lemma BitStream.subAux_eq_propagateCarry (x y : BitStream) (n : ℕ) :

--- a/SSA/Experimental/Bits/Propagate.lean
+++ b/SSA/Experimental/Bits/Propagate.lean
@@ -296,10 +296,7 @@ lemma neg_eq_propagate (x : BitStream) :
   match n with
   | 0 => simp [BitStream.neg, BitStream.negAux]
   | 1 => simp [BitStream.neg, BitStream.negAux, propagate, propagateAux]
-  | n+2 =>
-    simp [BitStream.neg, BitStream.negAux]
-    simp [ BitStream.negAux_eq_propagateCarry]
-    simp [BitStream.neg, BitStream.negAux, BitStream.negAux_eq_propagateCarry, propagate_succ]
+  | n+2 => simp [BitStream.neg, BitStream.negAux, BitStream.negAux_eq_propagateCarry, BitStream.neg, BitStream.negAux, BitStream.negAux_eq_propagateCarry, propagate_succ]
 
 lemma BitStream.incrAux_eq_propagateCarry (x : BitStream) (n : ℕ) :
     (BitStream.incrAux x n).2 = propagateCarry (λ _ => true)

--- a/SSA/Experimental/Bits/Propagate.lean
+++ b/SSA/Experimental/Bits/Propagate.lean
@@ -254,10 +254,9 @@ lemma add_eq_propagate (x y : BitStream) :
     simp  [HAdd.hAdd, Add.add, BitStream.add, BitStream.addAux', BitVec.adcb]
   | 1 =>
     simp [HAdd.hAdd, Add.add,BitVec.adcb, BitStream.add, addAux, addAux', propagate, propagateAux,  -BitVec.add_eq, -Nat.add_eq, -Nat.add_def]
-    -- simp
   | n+2 =>
     simp only [HAdd.hAdd, Add.add,BitVec.adcb, BitStream.add
-      ,BitVec.adcb, addAux, Function.comp, addAux', addAux'_eq_propagateCarry, propagate_succ,Bool.or_assoc]
+      , BitVec.adcb, addAux, Function.comp, addAux', addAux'_eq_propagateCarry, propagate_succ,Bool.or_assoc]
     simp [Bool.or_comm]
 
 lemma BitStream.subAux_eq_propagateCarry (x y : BitStream) (n : ℕ) :

--- a/SSA/Experimental/Bits/Propagate.lean
+++ b/SSA/Experimental/Bits/Propagate.lean
@@ -249,7 +249,7 @@ lemma add_eq_propagate (x y : BitStream) :
     simp [HAdd.hAdd, Add.add,BitVec.adcb, BitStream.add, addAux, addAux, propagate, propagateAux,  -BitVec.add_eq, -Nat.add_eq, -Nat.add_def]
   | n+2 =>
     simp only [HAdd.hAdd, Add.add,BitVec.adcb, BitStream.add
-      , BitVec.adcb, addAux, Function.comp, addAux, addAux_eq_propagateCarry, propagate_succ,Bool.or_assoc]
+      , BitVec.adcb, addAux, addAux_eq_propagateCarry, propagate_succ, Bool.or_assoc]
     simp [Bool.or_comm]
 
 lemma BitStream.subAux_eq_propagateCarry (x y : BitStream) (n : ℕ) :

--- a/SSA/Experimental/Bits/Propagate.lean
+++ b/SSA/Experimental/Bits/Propagate.lean
@@ -235,7 +235,6 @@ lemma addAux_eq_propagateCarry (x y : BitStream) (n : ℕ) :
     (λ b => cond b x y) n () := by
   induction n <;> simp [addAux, BitVec.adcb, Bool.atLeastTwo, *]
 
-
 lemma add_eq_propagate (x y : BitStream) :
     x + y = propagate (λ _ => false)
       (λ (carry : Unit → Bool) (bits : Bool → Bool) =>

--- a/SSA/Experimental/Bits/Propagate.lean
+++ b/SSA/Experimental/Bits/Propagate.lean
@@ -228,12 +228,19 @@ lemma ls_eq_propagate (b : Bool) (x : BitStream) :
   | 1 => rfl
   | n+2 => simp [propagate_succ, BitStream.concat]
 
-lemma addAux_eq_propagateCarry (x y : BitStream) (n : ℕ) :
-    (addAux x y n).1 = propagateCarry (λ _ => false)
+lemma addAux'_eq_propagateCarry (x y : BitStream) (n : ℕ) :
+    (addAux' x y n).1 = propagateCarry (λ _ => false)
       (λ (carry : Unit → Bool) (bits : Bool → Bool) =>
         λ _ => (bits true && bits false) || (bits true && carry ()) || (bits false && carry ()) )
     (λ b => cond b x y) n () := by
-  induction n <;> simp [addAux, BitVec.adcb, Bool.atLeastTwo, *]
+  induction n <;> simp [addAux', BitVec.adcb, Bool.atLeastTwo, *]
+
+lemma addAux_eq_propagateCarry (x y : BitStream) (n : ℕ) :
+    (addAux x y n).2 = propagateCarry (λ _ => false)
+      (λ (carry : Unit → Bool) (bits : Bool → Bool) =>
+        λ _ => (bits true && bits false) || (bits true && carry ()) || (bits false && carry ()) )
+    (λ b => cond b x y) n () := by
+  simp [addAux'_eq_propagateCarry]
 
 lemma add_eq_propagate (x y : BitStream) :
     x + y = propagate (λ _ => false)
@@ -244,15 +251,13 @@ lemma add_eq_propagate (x y : BitStream) :
   ext n
   match n with
   | 0 =>
-    simp  [HAdd.hAdd, Add.add, BitStream.add, BitStream.addAux, BitVec.adcb]
+    simp  [HAdd.hAdd, Add.add, BitStream.add, BitStream.addAux', BitVec.adcb]
   | 1 =>
-    simp only [HAdd.hAdd, Add.add,BitVec.adcb, BitStream.add, addAux, propagate, propagateAux]
-    simp
+    simp [HAdd.hAdd, Add.add,BitVec.adcb, BitStream.add, addAux, addAux', propagate, propagateAux,  -BitVec.add_eq, -Nat.add_eq, -Nat.add_def]
+    -- simp
   | n+2 =>
-    simp only [HAdd.hAdd, Add.add,BitVec.adcb]
-    simp only [BitStream.add,BitStream.addAux,BitVec.adcb]
-    simp [addAux_eq_propagateCarry, propagate_succ]
-    simp [Bool.or_assoc]
+    simp only [HAdd.hAdd, Add.add,BitVec.adcb, BitStream.add
+      ,BitVec.adcb, addAux, Function.comp, addAux', addAux'_eq_propagateCarry, propagate_succ,Bool.or_assoc]
     simp [Bool.or_comm]
 
 lemma BitStream.subAux_eq_propagateCarry (x y : BitStream) (n : ℕ) :
@@ -292,7 +297,10 @@ lemma neg_eq_propagate (x : BitStream) :
   match n with
   | 0 => simp [BitStream.neg, BitStream.negAux]
   | 1 => simp [BitStream.neg, BitStream.negAux, propagate, propagateAux]
-  | n+2 => simp [BitStream.neg, BitStream.negAux, BitStream.negAux_eq_propagateCarry, propagate_succ]
+  | n+2 =>
+    simp [BitStream.neg, BitStream.negAux]
+    simp [ BitStream.negAux_eq_propagateCarry]
+    simp [BitStream.neg, BitStream.negAux, BitStream.negAux_eq_propagateCarry, propagate_succ]
 
 lemma BitStream.incrAux_eq_propagateCarry (x : BitStream) (n : ℕ) :
     (BitStream.incrAux x n).2 = propagateCarry (λ _ => true)


### PR DESCRIPTION
Before, there was an in-congruity where subAux and negAux would return the result bit on the left and the carry bit on the right.
However, addAux was defined in such a way so that the result bit was on the right and the carry bit is on the left.

This PR swaps the bits for addAux so that addAux matches the convention of subAux and negAux.

This is a non-functional refactor. It does not add any new features.