### PR TITLE
Chore: Prove BitStream.neg_neg

### DIFF
--- a/SSA/Experimental/Bits/Fast/BitStream.lean
+++ b/SSA/Experimental/Bits/Fast/BitStream.lean
@@ -384,7 +384,7 @@ theorem neg_neg : a = - - a := by
     induction' i with i ih
     · simp [neg, negAux]
     · simp [neg, negAux, ih, xor_xor_eq_not, xor_and_eq_and]
-  simp [Neg.neg,neg,negAux,neg_lemma]
+  simp [Neg.neg, neg, neg_lemma]
 
 -- TODO: This sorry is difficult, and will be proven in a later Pull Request.
 theorem ofBitVec_sub : ofBitVec (x - y) ≈ʷ (ofBitVec x) - (ofBitVec y)  := by

--- a/SSA/Experimental/Bits/Fast/BitStream.lean
+++ b/SSA/Experimental/Bits/Fast/BitStream.lean
@@ -367,6 +367,25 @@ variable {w : Nat} {x y : BitVec w} {a b a' b' : BitStream}
 
 local infix:20 " ≈ʷ " => EqualUpTo w
 
+theorem xor_xor_eq_not {a b : Bool} : xor (!xor a b) b = !a := by
+  cases a
+  <;> cases b
+  <;> simp
+
+theorem xor_and_eq_and {a b : Bool} : (!xor a b && b) = (a && b) := by
+  cases a
+  <;> cases b
+  <;> simp
+
+theorem neg_neg : a = - - a := by
+  ext i
+  have neg_lemma :
+    a.neg.negAux i = ⟨a i, (a.negAux i).2⟩ := by
+    induction' i with i ih
+    · simp [neg, negAux]
+    · simp [neg, negAux, ih, xor_xor_eq_not, xor_and_eq_and]
+  simp [Neg.neg,neg,negAux,neg_lemma]
+
 -- TODO: This sorry is difficult, and will be proven in a later Pull Request.
 theorem ofBitVec_sub : ofBitVec (x - y) ≈ʷ (ofBitVec x) - (ofBitVec y)  := by
   sorry


### PR DESCRIPTION
See
https://github.com/opencompl/lean-mlir/pull/554#issuecomment-2301951442
for more information.

This PR proves that 

```lean
BitStream.neg_neg {a : BitStream} : a = - -a
```