### PR TITLE
chore: move Bool theorems to ForLean

### DIFF
--- a/SSA/Experimental/Bits/Fast/BitStream.lean
+++ b/SSA/Experimental/Bits/Fast/BitStream.lean
@@ -367,16 +367,6 @@ variable {w : Nat} {x y : BitVec w} {a b a' b' : BitStream}
 
 local infix:20 " ≈ʷ " => EqualUpTo w
 
-theorem xor_xor_eq_not {a b : Bool} : xor (!xor a b) b = !a := by
-  cases a
-  <;> cases b
-  <;> simp
-
-theorem xor_and_eq_and {a b : Bool} : (!xor a b && b) = (a && b) := by
-  cases a
-  <;> cases b
-  <;> simp
-
 theorem neg_neg : a = - - a := by
   ext i
   have neg_lemma :

--- a/SSA/Experimental/Bits/Fast/BitStream.lean
+++ b/SSA/Experimental/Bits/Fast/BitStream.lean
@@ -373,7 +373,7 @@ theorem neg_neg : a = - - a := by
     a.neg.negAux i = ⟨a i, (a.negAux i).2⟩ := by
     induction' i with i ih
     · simp [neg, negAux]
-    · simp [neg, negAux, ih, xor_xor_eq_not, xor_and_eq_and]
+    · simp [neg, negAux, ih, Bool.xor_not_xor, Bool.not_xor_and_self]
   simp [Neg.neg, neg, neg_lemma]
 
 -- TODO: This sorry is difficult, and will be proven in a later Pull Request.

--- a/SSA/Projects/InstCombine/ForLean.lean
+++ b/SSA/Projects/InstCombine/ForLean.lean
@@ -586,7 +586,23 @@ theorem and_add_or {A B : BitVec w} : (B &&& A) + (B ||| A) = B + A := by
       <;> rfl
 end BitVec
 
-theorem Bool.xor_decide (p q : Prop) [dp : Decidable p] [Decidable q] :
+section Bool
+
+theorem xor_decide (p q : Prop) [dp : Decidable p] [Decidable q] :
     (decide p).xor (decide q) = decide (p ≠ q) := by
   cases' dp with pt pt
   <;> simp [pt]
+
+@[simp]
+theorem xor_not_xor {a b : Bool} : xor (!xor a b) b = !a := by
+  cases a
+  <;> cases b
+  <;> simp
+
+@[simp]
+theorem not_xor_and_self {a b : Bool} : (!xor a b && b) = (a && b) := by
+  cases a
+  <;> cases b
+  <;> simp
+
+end Bool

--- a/SSA/Projects/InstCombine/ForLean.lean
+++ b/SSA/Projects/InstCombine/ForLean.lean
@@ -586,7 +586,7 @@ theorem and_add_or {A B : BitVec w} : (B &&& A) + (B ||| A) = B + A := by
       <;> rfl
 end BitVec
 
-section Bool
+namespace Bool
 
 theorem xor_decide (p q : Prop) [dp : Decidable p] [Decidable q] :
     (decide p).xor (decide q) = decide (p ≠ q) := by


### PR DESCRIPTION
In the process, we create a section for `Bool.` theorems and fix the naming of the theorems.