### PR TITLE
Fix dc example

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,6 @@ jobs:
           lake -R build SSA.Projects.CIRCT.DC # compile and check CIRCT's DC Dialect
           lake -R build SSA.Projects.CIRCT.DCExample # test CIRCT's DC Dialect
 
-
       - uses: actions/github-script@v6
         if: github.event_name == 'pull_request'
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,8 @@ jobs:
         run: |
           lake -R exe cache get # download cache of mathlib docs.
           lake -R build SSA.Projects.CIRCT.DC # compile and check CIRCT's DC Dialect
+          lake -R build SSA.Projects.CIRCT.DCExample # test CIRCT's DC Dialect
+
 
       - uses: actions/github-script@v6
         if: github.event_name == 'pull_request'

--- a/SSA/Projects/CIRCT/DC.lean
+++ b/SSA/Projects/CIRCT/DC.lean
@@ -208,21 +208,14 @@ def mkTy2 : String → MLIR.AST.ExceptM (DC) Ty2
   | "Bool" => return (.bool)
   | _ => throw .unsupportedType
 
-
 def mkTy : MLIR.AST.MLIRType φ → MLIR.AST.ExceptM DC DC.Ty
   | MLIR.AST.MLIRType.undefined s => do
-    match s with
-    | "Stream_Int" =>
-      return (.stream .int)
-    | "Stream_Bool" =>
-      return (.stream .bool)
-    | "Stream2_Int" =>
-      return (.stream2 .int)
-    | "Stream2_Bool" =>
-      return (.stream2 .bool)
+    match s.splitOn "_" with
+    | ["Stream", r] =>
+      return .stream (← mkTy2 r)
+    | ["Stream2", r] =>
+      return .stream2 (← mkTy2 r)
     | _ => throw .unsupportedType
-    -- | ["Stream2", r] =>
-    --   return .stream2 (← mkTy2 r)
   | _ => throw .unsupportedType
 
 instance instTransformTy : MLIR.AST.TransformTy DC 0 where

--- a/SSA/Projects/CIRCT/DC.lean
+++ b/SSA/Projects/CIRCT/DC.lean
@@ -211,12 +211,18 @@ def mkTy2 : String → MLIR.AST.ExceptM (DC) Ty2
 
 def mkTy : MLIR.AST.MLIRType φ → MLIR.AST.ExceptM DC DC.Ty
   | MLIR.AST.MLIRType.undefined s => do
-    match s.splitOn "_" with
-    | ["Stream", r] =>
-      return .stream (← mkTy2 r)
-    | ["Stream2", r] =>
-      return .stream2 (← mkTy2 r)
+    match s with
+    | "Stream_Int" =>
+      return (.stream .int)
+    | "Stream_Bool" =>
+      return (.stream .bool)
+    | "Stream2_Int" =>
+      return (.stream2 .int)
+    | "Stream2_Bool" =>
+      return (.stream2 .bool)
     | _ => throw .unsupportedType
+    -- | ["Stream2", r] =>
+    --   return .stream2 (← mkTy2 r)
   | _ => throw .unsupportedType
 
 instance instTransformTy : MLIR.AST.TransformTy DC 0 where

--- a/SSA/Projects/CIRCT/DC.lean
+++ b/SSA/Projects/CIRCT/DC.lean
@@ -1,10 +1,5 @@
-import Qq
-import Lean
-import SSA.Core.Framework
 import SSA.Projects.CIRCT.DC.Stream
-import SSA.Core.MLIRSyntax.GenericParser
 import SSA.Core.MLIRSyntax.EDSL
-
 
 open MLIR AST Ctxt
 
@@ -155,7 +150,6 @@ toType := fun
 
 
 set_option linter.dupNamespace false in
-/-- `FHE` is the dialect for fully homomorphic encryption -/
 abbrev DC : Dialect where
   Op := Op
   Ty := Ty

--- a/SSA/Projects/CIRCT/DCExample.lean
+++ b/SSA/Projects/CIRCT/DCExample.lean
@@ -12,12 +12,12 @@ namespace DC
 namespace Examples
 
 def BranchEg1 := [dc_com| {
-  ^entry(%0: !Stream_Bool, %1: !Stream_Bool):
-    %out = "dc.branch" (%0, %1) : (!Stream_Bool, !Stream_Bool) -> (!Stream2_Bool)
-    %0 = "dc.fst" (%out) : (!Stream2_Bool) -> (!Stream_Bool)
-    %outs = "dc.snd" (%out) : (!Stream2_Bool) -> (!Stream_Bool)
-    %out2 = "dc.merge" (%outf, %outs) : (!Stream_Bool, !Stream_Bool) -> (!Stream_Bool)
-    "return" (%out) : (!Stream_Bool) -> ()
+  ^entry(%0: !Stream_Int, %1: !Stream_Bool):
+    %out = "dc.branch" (%0, %1) : (!Stream_Int, !Stream_Bool) -> (!Stream2_Int)
+    %outf = "dc.fst" (%out) : (!Stream2_Int) -> (!Stream_Int)
+    %outs = "dc.snd" (%out) : (!Stream2_Int) -> (!Stream_Int)
+    %out2 = "dc.merge" (%outs, %outf) : (!Stream_Int, !Stream_Int) -> (!Stream_Int)
+    "return" (%out2) : (!Stream_Int) -> ()
   }]
 
 
@@ -33,8 +33,8 @@ def ofList (vals : List (Option α)) : Stream α :=
 def x : Stream Bool := ofList [some true, none, some false, some true, some false]
 def c : Stream Bool := ofList [some true, some false, none, some true]
 
-def test : Stream Bool :=
-  BranchEg1.denote (Valuation.ofPair c x)
+-- def test : Stream Bool :=
+--   BranchEg1.denote (Valuation.ofPair c x)
 
 def remNone (lst : List (Option Bool)) : List (Option Bool) :=
   lst.filter (fun | some x => true

--- a/SSA/Projects/CIRCT/DCExample.lean
+++ b/SSA/Projects/CIRCT/DCExample.lean
@@ -9,6 +9,7 @@ import SSA.Projects.CIRCT.DC.Stream
 namespace DC
 namespace Examples
 
+unseal String.splitOnAux in
 def BranchEg1 := [dc_com| {
   ^entry(%0: !Stream_Int, %1: !Stream_Bool):
     %out = "dc.branch" (%0, %1) : (!Stream_Int, !Stream_Bool) -> (!Stream2_Int)

--- a/SSA/Projects/CIRCT/DCExample.lean
+++ b/SSA/Projects/CIRCT/DCExample.lean
@@ -3,8 +3,6 @@ import SSA.Core.MLIRSyntax.GenericParser
 import SSA.Projects.CIRCT.DC
 import SSA.Projects.CIRCT.DC.Stream
 
-
-
 /-!
 ## Examples
 -/
@@ -30,11 +28,11 @@ def BranchEg1 := [dc_com| {
 def ofList (vals : List (Option α)) : Stream α :=
   fun i => (vals.get? i).join
 
-def x : Stream Bool := ofList [some true, none, some false, some true, some false]
-def c : Stream Bool := ofList [some true, some false, none, some true]
+def c : Stream Bool := ofList [some true, none, some false, some true, some false]
+def x : Stream Int := ofList [some 1, some 2, none, some 3]
 
--- def test : Stream Bool :=
---   BranchEg1.denote (Valuation.ofPair c x)
+def test : Stream Int :=
+  BranchEg1.denote (Ctxt.Valuation.ofPair c x)
 
 def remNone (lst : List (Option Bool)) : List (Option Bool) :=
   lst.filter (fun | some x => true

--- a/SSA/Projects/CIRCT/DCExample.lean
+++ b/SSA/Projects/CIRCT/DCExample.lean
@@ -18,7 +18,6 @@ def BranchEg1 := [dc_com| {
     "return" (%out2) : (!Stream_Int) -> ()
   }]
 
-
 #check BranchEg1
 #eval BranchEg1
 #reduce BranchEg1
@@ -37,7 +36,6 @@ def test : Stream Int :=
 def remNone (lst : List (Option Bool)) : List (Option Bool) :=
   lst.filter (fun | some x => true
                   | none => false)
-
 
 end Examples
 end DC

--- a/SSA/Projects/CIRCT/DCExample.lean
+++ b/SSA/Projects/CIRCT/DCExample.lean
@@ -1,5 +1,3 @@
-
-import SSA.Core.MLIRSyntax.GenericParser
 import SSA.Projects.CIRCT.DC
 import SSA.Projects.CIRCT.DC.Stream
 
@@ -9,6 +7,10 @@ import SSA.Projects.CIRCT.DC.Stream
 namespace DC
 namespace Examples
 
+/-
+splitOn is defined using splitOnAux, which is defined by well-founded recursion and thus marked with @[irreducible],
+we need to manually set the it back to semireducible.
+-/
 unseal String.splitOnAux in
 def BranchEg1 := [dc_com| {
   ^entry(%0: !Stream_Int, %1: !Stream_Bool):
@@ -33,10 +35,6 @@ def x : Stream Int := ofList [some 1, some 2, none, some 3]
 
 def test : Stream Int :=
   BranchEg1.denote (Ctxt.Valuation.ofPair c x)
-
-def remNone (lst : List (Option Bool)) : List (Option Bool) :=
-  lst.filter (fun | some x => true
-                  | none => false)
 
 end Examples
 end DC


### PR DESCRIPTION
Function `splitOn` is defined using `splitOnAux`, which is defined by well-founded recursion and marked @[irreducible] by default. As [advised](https://github.com/leanprover/lean4/pull/4061), we set `splitOnAux` back to semireducible by using `unseal` to use it in `DCExample`. CC: @ymherklotz @alexkeizer 