### PR TITLE
chore: Add guard messages to automata proof, remove dependence on sorry axiom

### DIFF
--- a/SSA/Experimental/Bits/Fast/BitStream.lean
+++ b/SSA/Experimental/Bits/Fast/BitStream.lean
@@ -416,6 +416,18 @@ theorem add_congr (e1 : a ≈ʷ b) (e2 : c ≈ʷ d) : (a + c) ≈ʷ (b + d) := b
     · simp only [addAux, e1 _ h, e2 _ h, ih (by omega)]
   simp [HAdd.hAdd, Add.add, BitStream.add, add_congr_lemma, addAux]
 
+theorem and_congr (e1 : a ≈ʷ b) (e2 : c ≈ʷ d) : (a &&& c) ≈ʷ (b &&& d) := by
+  intros n h
+  simp [e1 n h, e2 n h]
+
+theorem or_congr (e1 : a ≈ʷ b) (e2 : c ≈ʷ d) : (a ||| c) ≈ʷ (b ||| d) := by
+  intros n h
+  simp [e1 n h, e2 n h]
+
+theorem xor_congr (e1 : a ≈ʷ b) (e2 : c ≈ʷ d) : (a ^^^ c) ≈ʷ (b ^^^ d) := by
+  intros n h
+  simp [e1 n h, e2 n h]
+
 theorem not_congr (e1 : a ≈ʷ b) : (~~~a) ≈ʷ ~~~b := by
   intros g h
   simp only [not_eq, e1 g h]
@@ -458,6 +470,30 @@ theorem ofBitVec_sub : ofBitVec (x - y) ≈ʷ (ofBitVec x) - (ofBitVec y)  := by
   _ ≈ʷ ofBitVec x + ofBitVec (-y) := ofBitVec_add
   _ ≈ʷ ofBitVec x + -(ofBitVec y) := add_congr equal_up_to_refl ofBitVec_neg
   _ ≈ʷ ofBitVec x - ofBitVec y := by rw [sub_eq_add_neg]
+
+theorem incr_add : a + (@ofBitVec w 1) ≈ʷ a.incr := by
+  have lemma_1 (i : Nat) (le : i < w) : a.addAux (@ofBitVec w 1) i = a.incrAux i := by
+    induction' i with _ ih
+    · simp [incrAux,addAux, BitVec.adcb, BitVec.msb, BitVec.getMsb, ofBitVec, le]
+    · simp only [addAux, incrAux]
+      rw [ih (by omega)]
+      simp [BitVec.adcb, Bool.atLeastTwo, ofBitVec, le]
+  intros i le
+  simp only [incr, HAdd.hAdd, Add.add, add, lemma_1 i le]
+
+theorem ofBitVec_incr (n : Nat) : ofBitVec (BitVec.ofNat w n.succ) ≈ʷ  (ofBitVec (BitVec.ofNat w n)).incr := by
+  calc
+  _ ≈ʷ ofBitVec (BitVec.ofNat w n + BitVec.ofNat w 1) := by intros _ il ; simp [ofBitVec, il, -BitVec.ofNat_eq_ofNat, Nat.testBit, BitVec.getLsb]
+  _ ≈ʷ ofBitVec (BitVec.ofNat w n) + ofBitVec 1 := ofBitVec_add
+  _ ≈ʷ (ofBitVec (BitVec.ofNat w n)).incr := by intros i il ; rw [incr_add] ; exact il
+
+theorem incr_congr (h  : a ≈ʷ b) : a.incr ≈ʷ b.incr := by
+  intros i le
+  have incr_congr_lemma : a.incrAux i = b.incrAux i := by
+    induction' i with n ih
+    <;> simp only [incrAux, h _ le]
+    simp [ih (by omega)]
+  simp [incr, incr_congr_lemma]
 
 theorem sub_congr (e1 : a ≈ʷ b) (e2 : c ≈ʷ d) : (a - c) ≈ʷ (b - d) := by
   intros n h

--- a/SSA/Experimental/Bits/Fast/BitStream.lean
+++ b/SSA/Experimental/Bits/Fast/BitStream.lean
@@ -472,22 +472,21 @@ theorem ofBitVec_sub : ofBitVec (x - y) ≈ʷ (ofBitVec x) - (ofBitVec y)  := by
   _ ≈ʷ ofBitVec x - ofBitVec y := by rw [sub_eq_add_neg]
 
 theorem incr_add : a + (@ofBitVec w 1) ≈ʷ a.incr := by
-  have lemma_1 (i : Nat) (le : i < w) : a.addAux (@ofBitVec w 1) i = a.incrAux i := by
+  have incr_add_aux {i : Nat} (le : i < w) : a.addAux (@ofBitVec w 1) i = a.incrAux i := by
     induction' i with _ ih
     · simp [incrAux,addAux, BitVec.adcb, BitVec.msb, BitVec.getMsb, ofBitVec, le]
-    · simp only [addAux, incrAux]
-      rw [ih (by omega)]
+    · simp only [addAux, incrAux, ih (by omega)]
       simp [BitVec.adcb, Bool.atLeastTwo, ofBitVec, le]
   intros i le
-  simp only [incr, HAdd.hAdd, Add.add, add, lemma_1 i le]
+  simp only [incr, HAdd.hAdd, Add.add, add, incr_add_aux le]
 
-theorem ofBitVec_incr (n : Nat) : ofBitVec (BitVec.ofNat w n.succ) ≈ʷ  (ofBitVec (BitVec.ofNat w n)).incr := by
+theorem ofBitVec_incr {n : Nat} : ofBitVec (BitVec.ofNat w n.succ) ≈ʷ (ofBitVec (BitVec.ofNat w n)).incr := by
   calc
   _ ≈ʷ ofBitVec (BitVec.ofNat w n + BitVec.ofNat w 1) := by intros _ il ; simp [ofBitVec, il, -BitVec.ofNat_eq_ofNat, Nat.testBit, BitVec.getLsb]
   _ ≈ʷ ofBitVec (BitVec.ofNat w n) + ofBitVec 1 := ofBitVec_add
-  _ ≈ʷ (ofBitVec (BitVec.ofNat w n)).incr := by intros i il ; rw [incr_add] ; exact il
+  _ ≈ʷ (ofBitVec (BitVec.ofNat w n)).incr := incr_add
 
-theorem incr_congr (h  : a ≈ʷ b) : a.incr ≈ʷ b.incr := by
+theorem incr_congr (h : a ≈ʷ b) : a.incr ≈ʷ b.incr := by
   intros i le
   have incr_congr_lemma : a.incrAux i = b.incrAux i := by
     induction' i with n ih

--- a/SSA/Experimental/Bits/Fast/Tactic.lean
+++ b/SSA/Experimental/Bits/Fast/Tactic.lean
@@ -84,8 +84,7 @@ def quoteThm (qMapIndexToFVar : Q(Nat → BitStream)) (w : Q(Nat)) (nat: Nat) :
 /--
 Given an Expr e, return a pair e', p where e' is an expression and p is a proof that e and e' are equal on the fist w bits
 -/
-partial def first_rep (w : Q(Nat)) (e : Q( BitStream)) : SimpM (Σ (x : Q(BitStream)) ,  Q(@BitStream.EqualUpTo $w $e $x))  := do
-  -- logInfo m!"checking {e}"
+partial def first_rep (w : Q(Nat)) (e : Q( BitStream)) : SimpM (Σ (x : Q(BitStream)) ,  Q(@BitStream.EqualUpTo $w $e $x))  :=
   match e with
     | ~q(@HSub.hSub BitStream BitStream BitStream _ $a $b) => do
       let ⟨ anext, aproof ⟩ ← first_rep w a
@@ -102,14 +101,13 @@ partial def first_rep (w : Q(Nat)) (e : Q( BitStream)) : SimpM (Σ (x : Q(BitStr
       let contextLength := context.getFVarIds.size - 1
       let lastFVar  ← context.getAt? contextLength
       let qMapIndexToFVar : Q(Nat → BitStream) := .fvar lastFVar.fvarId
-      -- let p : Q(Nat) := quoteFVar x
       match nat with
         | .some nat =>
           return ⟨
             q(Term.eval (termNat $nat) $qMapIndexToFVar),
-            (quoteThm qMapIndexToFVar length nat)
+            quoteThm qMapIndexToFVar length nat
           ⟩
-        | .none => throwError m!"{repr b} is not a nat literal"
+        | .none => throwError m!"The bv_automata tactic expects {repr b} to be of the form of a nat literal, but it is not"
     | ~q(@BitStream.ofBitVec $w ($a - $b)) =>
       return ⟨
         q((@BitStream.ofBitVec $w $a) -  (@BitStream.ofBitVec $w $b)),

--- a/SSA/Experimental/Bits/Fast/Tactic.lean
+++ b/SSA/Experimental/Bits/Fast/Tactic.lean
@@ -95,19 +95,17 @@ partial def first_rep (w : Q(Nat)) (e : Q( BitStream)) : SimpM (Σ (x : Q(BitStr
       ⟩
     | ~q(BitStream.ofBitVec (OfNat.ofNat $b)) => do
       let ofNat := q(OfNat.ofNat $b)
-      let nat := ofNat.nat?
+      let .some nat := ofNat.nat?
+        | throwError m!"The bv_automata tactic expects {repr ofNat} to be of the form of a nat literal, but it is not"
       let length : Q(Nat) := w
       let context  ← getLCtx
       let contextLength := context.getFVarIds.size - 1
       let lastFVar  ← context.getAt? contextLength
       let qMapIndexToFVar : Q(Nat → BitStream) := .fvar lastFVar.fvarId
-      match nat with
-        | .some nat =>
-          return ⟨
-            q(Term.eval (termNat $nat) $qMapIndexToFVar),
-            quoteThm qMapIndexToFVar length nat
-          ⟩
-        | .none => throwError m!"The bv_automata tactic expects {repr b} to be of the form of a nat literal, but it is not"
+      return ⟨
+        q(Term.eval (termNat $nat) $qMapIndexToFVar),
+        quoteThm qMapIndexToFVar length nat
+      ⟩
     | ~q(@BitStream.ofBitVec $w ($a - $b)) =>
       return ⟨
         q((@BitStream.ofBitVec $w $a) -  (@BitStream.ofBitVec $w $b)),

--- a/SSA/Experimental/Bits/Fast/Tactic.lean
+++ b/SSA/Experimental/Bits/Fast/Tactic.lean
@@ -67,24 +67,24 @@ def termNat (n : Nat) : _root_.Term :=
   | 0 => Term.zero
   | x + 1 => Term.incr (termNat x)
 
-def termNatCorrect (f : Nat → BitStream) (w n : Nat) :  BitStream.EqualUpTo w (BitStream.ofBitVec (BitVec.ofNat w n))  ((termNat n).eval f) := by
+theorem termNat_correct (f : Nat → BitStream) (w n : Nat) : BitStream.EqualUpTo w (BitStream.ofBitVec (BitVec.ofNat w n)) ((termNat n).eval f) := by
   induction' n with n ih
-  · intros i _
-    simp only [Term.eval ,termNat, BitStream.zero_eq, Bool.ite_eq_false_distrib, BitVec.getLsb_zero, BitVec.msb_zero, ite_self]
-  · simp only [Term.eval ,termNat, ← Nat.succ_eq_add_one ]
+  · intros _ _
+    simp only [Term.eval, termNat, BitStream.zero_eq, Bool.ite_eq_false_distrib, BitVec.getLsb_zero, BitVec.msb_zero, ite_self]
+  · simp only [Term.eval, termNat, ← Nat.succ_eq_add_one]
     trans (BitStream.ofBitVec (BitVec.ofNat w n)).incr
-    exact BitStream.ofBitVec_incr n
+    exact BitStream.ofBitVec_incr
     exact BitStream.incr_congr ih
 
 
 def quoteThm (qMapIndexToFVar : Q(Nat → BitStream)) (w : Q(Nat)) (nat: Nat) :
-  Q(@BitStream.EqualUpTo $w (BitStream.ofBitVec (@BitVec.ofNat $w $nat)) (@Term.eval (termNat $nat) $qMapIndexToFVar)) := q(termNatCorrect $qMapIndexToFVar $w $nat)
+  Q(@BitStream.EqualUpTo $w (BitStream.ofBitVec (@BitVec.ofNat $w $nat)) (@Term.eval (termNat $nat) $qMapIndexToFVar)) := q(termNat_correct $qMapIndexToFVar $w $nat)
 
 
 /--
 Given an Expr e, return a pair e', p where e' is an expression and p is a proof that e and e' are equal on the fist w bits
 -/
-partial def first_rep (w : Q(Nat)) (e : Q( BitStream)) : SimpM (Σ (x : Q(BitStream)) ,  Q(@BitStream.EqualUpTo $w $e $x))  :=
+partial def first_rep (w : Q(Nat)) (e : Q( BitStream)) : SimpM (Σ (x : Q(BitStream)),  Q(@BitStream.EqualUpTo $w $e $x))  :=
   match e with
     | ~q(@HSub.hSub BitStream BitStream BitStream _ $a $b) => do
       let ⟨ anext, aproof ⟩ ← first_rep w a


### PR DESCRIPTION
This PR add `guard_msgs` to the automata file. This ensures that none of the test cases accidentally depend on the sorry axiom, thus resulting in unsound proofs.

Any proofs produced by the automata tactic depends on the axioms
[propext, Classical.choice, Lean.ofReduceBool, Quot.sound]
but not on the sorry axiom.

This PR was particularly important to @bollu .