### PR TITLE
chore: use canonical form for BitVec.two_mul

### DIFF
--- a/SSA/Projects/InstCombine/ForLean.lean
+++ b/SSA/Projects/InstCombine/ForLean.lean
@@ -488,7 +488,7 @@ theorem signExtend_succ (i : Nat) (x : BitVec w) :
   split <;> split <;> simp_all <;> omega
 
 theorem two_mul {x : BitVec w} :
-    2 * x = x + x := by
+    2#w * x = x + x := by
   by_cases h : w = 0
   · subst h
     simp [BitVec.eq_nil x]

--- a/SSA/Projects/InstCombine/TacticAuto.lean
+++ b/SSA/Projects/InstCombine/TacticAuto.lean
@@ -115,10 +115,6 @@ macro "simp_alive_bitvec": tactic =>
   `(tactic|
       (
         intros
-        try (
-          simp (config := {failIfUnchanged := false}) only [(BitVec.two_mul)]
-          bv_automata
-        )
         try simp (config := {failIfUnchanged := false}) [(BitVec.negOne_eq_allOnes)]
         try ring_nf
         /-
@@ -146,6 +142,11 @@ macro "simp_alive_bitvec": tactic =>
             simp only [← BitVec.negOne_eq_allOnes]
             ring_nf
           | of_bool_tactic
+
+          | (
+              simp (config := {failIfUnchanged := false}) only [(BitVec.two_mul)]
+              bv_automata
+            )
           | bv_decide
       )
    )


### PR DESCRIPTION
This is possible after 57ad5ebf8b219ca352eac3b753d31d83c31a8ad5.