### PR TITLE
Chore: Add support for zero-width equalities in the bv_automata tactic

### DIFF
--- a/SSA/Experimental/Bits/Fast/BitStream.lean
+++ b/SSA/Experimental/Bits/Fast/BitStream.lean
@@ -84,7 +84,7 @@ abbrev map₂ (f : Bool → Bool → Bool) : BitStream → BitStream → BitStre
 
 def corec {β} (f : β → β × Bool) (b : β) : BitStream :=
   fun i => f ((Prod.fst ∘ f)^[i] b) |>.snd
--- def sub_co
+
 /-- `mapAccum₂` ("binary map accumulate") maps a binary function `f` over two streams,
 while accumulating some state -/
 def mapAccum₂ {α} (f : α → Bool → Bool → α × Bool) (init : α) (x y : BitStream) : BitStream :=
@@ -191,12 +191,12 @@ variable (x y : BitVec (w+1))
   simp only [ofBitVec, BitVec.getLsbD_not, BitVec.msb_not, not_eq]
   split <;> simp_all
 
-@[simp] theorem ofBitVec_and  {w : Nat} {x y : BitVec w}  : ofBitVec (x &&& y) = (ofBitVec x) &&& (ofBitVec y) := by
+@[simp] theorem ofBitVec_and {w : Nat} {x y : BitVec w} : ofBitVec (x &&& y) = (ofBitVec x) &&& (ofBitVec y) := by
   funext i
   simp only [ofBitVec, BitVec.getLsbD_and, BitVec.msb_and, and_eq]
   split <;> simp_all
 
-@[simp] theorem ofBitVec_or  {w : Nat} {x y : BitVec w}  : ofBitVec (x ||| y) = (ofBitVec x) ||| (ofBitVec y) := by
+@[simp] theorem ofBitVec_or {w : Nat} {x y : BitVec w} : ofBitVec (x ||| y) = (ofBitVec x) ||| (ofBitVec y) := by
   funext i
   simp only [ofBitVec, BitVec.getLsbD_or, BitVec.msb_or, or_eq]
   split <;> simp_all
@@ -225,20 +225,9 @@ def addAux (x y : BitStream) (i : Nat) :  Bool × Bool :=
     | i + 1 => (addAux x y i).2
   Prod.swap (BitVec.adcb (x i) (y i) carry)
 
-def addCorec (x y : BitStream) :  BitStream :=
-  corec (fun (i, carry) =>
-    let (a, b) := BitVec.adcb (x i) (y i) carry
-    ((i + 1, a), b)) (0, false)
-
 def add (x y : BitStream) : BitStream :=
   fun n => (addAux x y n).1
-theorem add_eq_corec : addCorec = add := by
-  funext a b
-  ext i
-  unfold add addCorec corec
-  induction' i with i ih
-  · simp [BitVec.adcb, addAux]
-  sorry
+
 def subAux (x y : BitStream) : Nat → Bool × Bool
   | 0 => (_root_.xor (x 0) (y 0), !(x 0) && y 0)
   | n+1 =>

--- a/SSA/Experimental/Bits/Fast/BitStream.lean
+++ b/SSA/Experimental/Bits/Fast/BitStream.lean
@@ -538,7 +538,7 @@ theorem ofBitVec_or_congr (h1 : ofBitVec x ≈ʷ a) (h2 : ofBitVec y ≈ʷ b) : 
   exact or_congr h1 h2
 
 theorem ofBitVec_not_congr (h1 : ofBitVec x ≈ʷ a) : ofBitVec (~~~ x) ≈ʷ ~~~ a := by
-  cases' w with w
+  cases w
   · intros _ le
     simp at le
   · rw [ofBitVec_not]

--- a/SSA/Experimental/Bits/Fast/Tactic.lean
+++ b/SSA/Experimental/Bits/Fast/Tactic.lean
@@ -256,7 +256,6 @@ let vars (n : Nat) : BitStream := BitStream.ofBitVec (if n = 0 then v0 else if n
 Term.var 0 -- represent the 0th variable
 Term.var 1 -- represent the 1st variable
 -/
--- deriving Repr LocalContext
 
 def introduceMapIndexToFVar : TacticM Unit := withMainContext <|  do
   let context : LocalContext ← getLCtx
@@ -325,8 +324,6 @@ macro "bv_automata" : tactic =>
   apply congrFun
   native_decide
   ))
--- def bv2  : TacticM Unit := by
---   bv_automata
 
 /-!
 # Test Cases

--- a/SSA/Experimental/Bits/Fast/Tactic.lean
+++ b/SSA/Experimental/Bits/Fast/Tactic.lean
@@ -76,15 +76,13 @@ theorem termNat_correct (f : Nat → BitStream) (w n : Nat) : BitStream.EqualUpT
     exact BitStream.ofBitVec_incr
     exact BitStream.incr_congr ih
 
-
 def quoteThm (qMapIndexToFVar : Q(Nat → BitStream)) (w : Q(Nat)) (nat: Nat) :
   Q(@BitStream.EqualUpTo $w (BitStream.ofBitVec (@BitVec.ofNat $w $nat)) (@Term.eval (termNat $nat) $qMapIndexToFVar)) := q(termNat_correct $qMapIndexToFVar $w $nat)
-
 
 /--
 Given an Expr e, return a pair e', p where e' is an expression and p is a proof that e and e' are equal on the fist w bits
 -/
-partial def first_rep (w : Q(Nat)) (e : Q( BitStream)) : SimpM (Σ (x : Q(BitStream)),  Q(@BitStream.EqualUpTo $w $e $x))  :=
+partial def first_rep (w : Q(Nat)) (e : Q( BitStream)) : SimpM (Σ (x : Q(BitStream)),  Q(@BitStream.EqualUpTo $w $e $x))  := do
   match e with
     | ~q(@HSub.hSub BitStream BitStream BitStream _ $a $b) => do
       let ⟨ anext, aproof ⟩ ← first_rep w a
@@ -118,10 +116,20 @@ partial def first_rep (w : Q(Nat)) (e : Q( BitStream)) : SimpM (Σ (x : Q(BitStr
         q(Term.eval (termNat $nat) $qMapIndexToFVar),
         quoteThm qMapIndexToFVar length nat
       ⟩
-    | ~q(@BitStream.ofBitVec $w ($a - $b)) =>
+    | ~q(@BitStream.ofBitVec $w ($a - $b)) => do
+      let ⟨ anext, aproof ⟩ ← first_rep w q(@BitStream.ofBitVec $w $a)
+      let ⟨ bnext, bproof ⟩ ← first_rep w q(@BitStream.ofBitVec $w $b)
+      let eproof ← mkAppM ``BitStream.ofBitVec_sub_congr #[aproof, bproof]
       return ⟨
-        q((@BitStream.ofBitVec $w $a) -  (@BitStream.ofBitVec $w $b)),
-        .app (.app (.app (.const ``BitStream.ofBitVec_sub []) w) a ) b
+        q(@HSub.hSub BitStream BitStream BitStream _ $anext $bnext),
+        eproof
+      ⟩
+    | ~q(@BitStream.ofBitVec $w (- $a)) => do
+      let ⟨ anext, aproof ⟩ ← first_rep w q(@BitStream.ofBitVec $w $a)
+      let eproof ← mkAppM ``BitStream.ofBitVec_neg_congr #[aproof]
+      return ⟨
+        q(@Neg.neg BitStream _ $anext),
+        eproof
       ⟩
     | ~q(@HAdd.hAdd BitStream BitStream BitStream _ $a $b) => do
       let ⟨ anext, aproof ⟩ ← first_rep w a
@@ -151,10 +159,44 @@ partial def first_rep (w : Q(Nat)) (e : Q( BitStream)) : SimpM (Σ (x : Q(BitStr
         q($anext ^^^ $bnext),
         .app (.app (.app (.app (.app (.app (.app (.const ``BitStream.xor_congr []) w) a) anext) b) bnext) aproof) bproof
       ⟩
-    | ~q(@BitStream.ofBitVec $w ($a + $b)) =>
+    | ~q(@BitStream.ofBitVec $w ($a + $b)) => do
+      let ⟨ anext, aproof ⟩ ← first_rep w q(@BitStream.ofBitVec $w $a)
+      let ⟨ bnext, bproof ⟩ ← first_rep w q(@BitStream.ofBitVec $w $b)
+      let eproof ← mkAppM ``BitStream.ofBitVec_add_congr #[aproof, bproof]
       return ⟨
-        q(@HAdd.hAdd BitStream BitStream BitStream _ (@BitStream.ofBitVec $w $a) (@BitStream.ofBitVec $w $b)),
-        .app (.app (.app (.const ``BitStream.ofBitVec_add []) w) a ) b
+        q(@HAdd.hAdd BitStream BitStream BitStream _ $anext $bnext),
+        eproof
+      ⟩
+    | ~q(@BitStream.ofBitVec $w ($a ^^^ $b)) => do
+      let ⟨ anext, aproof ⟩ ← first_rep w q(@BitStream.ofBitVec $w $a)
+      let ⟨ bnext, bproof ⟩ ← first_rep w q(@BitStream.ofBitVec $w $b)
+      let eproof ← mkAppM ``BitStream.ofBitVec_xor_congr #[aproof, bproof]
+      return ⟨
+        q(@HXor.hXor BitStream BitStream BitStream _ $anext $bnext),
+        eproof
+      ⟩
+    | ~q(@BitStream.ofBitVec $w ($a &&& $b)) => do
+      let ⟨ anext, aproof ⟩ ← first_rep w q(@BitStream.ofBitVec $w $a)
+      let ⟨ bnext, bproof ⟩ ← first_rep w q(@BitStream.ofBitVec $w $b)
+      let eproof ← mkAppM ``BitStream.ofBitVec_and_congr #[aproof, bproof]
+      return ⟨
+        q(@HAnd.hAnd BitStream BitStream BitStream _ $anext $bnext),
+        eproof
+      ⟩
+    | ~q(@BitStream.ofBitVec $w ($a ||| $b)) => do
+      let ⟨ anext, aproof ⟩ ← first_rep w q(@BitStream.ofBitVec $w $a)
+      let ⟨ bnext, bproof ⟩ ← first_rep w q(@BitStream.ofBitVec $w $b)
+      let eproof ← mkAppM ``BitStream.ofBitVec_or_congr #[aproof, bproof]
+      return ⟨
+        q(@HOr.hOr BitStream BitStream BitStream _ $anext $bnext),
+        eproof
+      ⟩
+    | ~q(@BitStream.ofBitVec $w (~~~ $a)) => do
+      let ⟨ anext, aproof ⟩ ← first_rep w q(@BitStream.ofBitVec $w $a)
+      let eproof ← mkAppM ``BitStream.ofBitVec_not_congr #[aproof]
+      return ⟨
+        q(@Complement.complement BitStream _ $anext),
+        eproof
       ⟩
     | ~q(@Neg.neg BitStream _ $a)=> do
       let ⟨ anext, aproof ⟩ ← first_rep w a
@@ -190,10 +232,6 @@ partial def first_rep (w : Q(Nat)) (e : Q( BitStream)) : SimpM (Σ (x : Q(BitStr
       ⟩
     | e =>
       throwError m!"bv_automata does not support the expression {e} (representation is: {repr e})"
-      -- return ⟨
-      --   e,
-      --   .app (.app (.const ``BitStream.equal_up_to_refl []) w) e
-      -- ⟩
 
 /--
 Push all ofBitVecs down to the lowest level
@@ -218,7 +256,9 @@ let vars (n : Nat) : BitStream := BitStream.ofBitVec (if n = 0 then v0 else if n
 Term.var 0 -- represent the 0th variable
 Term.var 1 -- represent the 1st variable
 -/
-def introduceMapIndexToFVar : TacticM Unit := do withMainContext <| do
+-- deriving Repr LocalContext
+
+def introduceMapIndexToFVar : TacticM Unit := withMainContext <|  do
   let context : LocalContext ← getLCtx
   let fVars : List FVarId :=  (PersistentArray.toList context.decls).filterMap (fun d => match d with
     | .none => .none
@@ -260,17 +300,14 @@ elab "introduceMapIndexToFVar" : tactic => introduceMapIndexToFVar
 /--
 Create bv_automata tactic which solves equalities on bitvectors.
 -/
+
 macro "bv_automata" : tactic =>
   `(tactic| (
   apply BitStream.eq_of_ofBitVec_eq
   introduceMapIndexToFVar
   intro mapIndexToFVar
-  repeat simp only [
+  simp only [
     reduce_bitvec2,
-    BitStream.ofBitVec_not,
-    BitStream.ofBitVec_xor,
-    BitStream.ofBitVec_and,
-    BitStream.ofBitVec_or,
   ]
   try simp only [
     ← eval_sub,
@@ -288,11 +325,18 @@ macro "bv_automata" : tactic =>
   apply congrFun
   native_decide
   ))
-
+-- def bv2  : TacticM Unit := by
+--   bv_automata
 
 /-!
 # Test Cases
 -/
+
+def alive_1 {w : ℕ} (x x_1 x_2 : BitVec w) : (x_2 &&& x_1 ^^^ x_1) + 1#w + x = x - (x_2 ||| ~~~x_1) := by
+  bv_automata
+
+/-- info: 'alive_1' depends on axioms: [propext, Classical.choice, Lean.ofReduceBool, Quot.sound] -/
+#guard_msgs in #print axioms alive_1
 
 def test_OfNat_ofNat (x : BitVec 1) : 1 + x = x + 1 := by
   bv_automata


### PR DESCRIPTION
Before, the bv_automata tactic would not support theorems of the form:

```lean
def alive_1 {w : ℕ} (x x_1 x_2 : BitVec w) : (x_2 &&& x_1 ^^^ x_1) + 1#w + x = x - (x_2 ||| ~~~x_1) := by
  bv_automata
```

because it did not support the bit-width w = 0.

This PR adds support for the bit-width w = 0 , and the above example has been added as a test case to the test-suite.

As a benefit, the error messages should now be better for bv_automata.