### PR TITLE
feat: theorem for distributivity of `shiftLeft` over `^^^` and `&&&`

### DIFF
--- a/SSA/Projects/InstCombine/AliveStatements.lean
+++ b/SSA/Projects/InstCombine/AliveStatements.lean
@@ -766,13 +766,6 @@ theorem bv_InstCombineShift__279 :
   try alive_auto
   all_goals sorry
 
-@[simp]
-theorem shiftRight_xor_and_shiftLeft_distrib {x y z : BitVec w} {n : Nat}:
-    (x ^^^ y >>> n &&& z) <<< n = y &&& z <<< n ^^^ x <<< n := by
-  simp [BitVec.shiftLeft_xor_distrib]
-  simp [BitVec.shiftLeft_and_distrib]
-  rw [BitVec.xor_comm]
-
 theorem bv_InstCombineShift__440 :
     ∀ (e e_1 e_2 e_3 : LLVM.IntW w),
       LLVM.shl (LLVM.xor e_3 (LLVM.and (LLVM.lshr e_2 e_1) e)) e_1 ⊑
@@ -780,7 +773,8 @@ theorem bv_InstCombineShift__440 :
   simp_alive_undef
   simp_alive_ops
   simp_alive_case_bash
-  bv_auto
+  try alive_auto
+  all_goals sorry
 
 theorem bv_InstCombineShift__476 :
     ∀ (e e_1 e_2 e_3 : LLVM.IntW w),

--- a/SSA/Projects/InstCombine/AliveStatements.lean
+++ b/SSA/Projects/InstCombine/AliveStatements.lean
@@ -766,6 +766,13 @@ theorem bv_InstCombineShift__279 :
   try alive_auto
   all_goals sorry
 
+@[simp]
+theorem shiftRight_xor_and_shiftLeft_distrib {x y z : BitVec w} {n : Nat}:
+    (x ^^^ y >>> n &&& z) <<< n = y &&& z <<< n ^^^ x <<< n := by
+  simp [BitVec.shiftLeft_xor_distrib]
+  simp [BitVec.shiftLeft_and_distrib]
+  rw [BitVec.xor_comm]
+
 theorem bv_InstCombineShift__440 :
     ∀ (e e_1 e_2 e_3 : LLVM.IntW w),
       LLVM.shl (LLVM.xor e_3 (LLVM.and (LLVM.lshr e_2 e_1) e)) e_1 ⊑
@@ -773,8 +780,7 @@ theorem bv_InstCombineShift__440 :
   simp_alive_undef
   simp_alive_ops
   simp_alive_case_bash
-  try alive_auto
-  all_goals sorry
+  bv_auto
 
 theorem bv_InstCombineShift__476 :
     ∀ (e e_1 e_2 e_3 : LLVM.IntW w),

--- a/SSA/Projects/InstCombine/ForLean.lean
+++ b/SSA/Projects/InstCombine/ForLean.lean
@@ -648,16 +648,12 @@ theorem and_shiftLeft_allOnes {x y : BitVec w} (n : Nat):
 @[simp]
 theorem shiftRight_and_or_shiftLeft_distrib {x y z : BitVec w} {n : Nat}:
     (x >>> n &&& y ||| z) <<< n = x &&& y <<< n ||| z <<< n := by
-  rw [BitVec.shiftLeft_or_distrib]
-  rw [BitVec.shiftLeft_and_distrib]
-  simp
+  simp [BitVec.shiftLeft_or_distrib, BitVec.shiftLeft_and_distrib]
 
 @[simp]
 theorem shiftRight_xor_and_shiftLeft_distrib {x y z : BitVec w} {n : Nat}:
     (x ^^^ y >>> n &&& z) <<< n = y &&& z <<< n ^^^ x <<< n := by
-  rw [BitVec.shiftLeft_xor_distrib]
-  rw [BitVec.shiftLeft_and_distrib]
-  simp
+  simp [BitVec.shiftLeft_xor_distrib, BitVec.shiftLeft_and_distrib]
   rw [BitVec.xor_comm]
 
 end BitVec

--- a/SSA/Projects/InstCombine/ForLean.lean
+++ b/SSA/Projects/InstCombine/ForLean.lean
@@ -653,7 +653,7 @@ theorem shiftRight_and_or_shiftLeft_distrib {x y z : BitVec w} {n : Nat}:
   simp
 
 @[simp]
-theorem shiftRight_xor_and_shiftLeft_distrib {x y z : BitVec w} {n : Nat}:
+theorem shiftRight_xor_and_shiftLeft_distrib {x y z : BitVec w} {n : Nat} :
     (x ^^^ y >>> n &&& z) <<< n = y &&& z <<< n ^^^ x <<< n := by
   rw [BitVec.shiftLeft_xor_distrib]
   rw [BitVec.shiftLeft_and_distrib]

--- a/SSA/Projects/InstCombine/ForLean.lean
+++ b/SSA/Projects/InstCombine/ForLean.lean
@@ -652,6 +652,14 @@ theorem shiftRight_and_or_shiftLeft_distrib {x y z : BitVec w} {n : Nat}:
   rw [BitVec.shiftLeft_and_distrib]
   simp
 
+@[simp]
+theorem shiftRight_xor_and_shiftLeft_distrib {x y z : BitVec w} {n : Nat}:
+    (x ^^^ y >>> n &&& z) <<< n = y &&& z <<< n ^^^ x <<< n := by
+  rw [BitVec.shiftLeft_xor_distrib]
+  rw [BitVec.shiftLeft_and_distrib]
+  simp
+  rw [BitVec.xor_comm]
+
 end BitVec
 
 namespace Bool


### PR DESCRIPTION
proves `bv_InstCombineShift__440`, to be later refactored with the other shift-related theorems into a more consistent family of proofs