### PR TITLE
chore: use BitVec.ofBool_*_ofBool

### DIFF
--- a/SSA/Projects/InstCombine/ForLean.lean
+++ b/SSA/Projects/InstCombine/ForLean.lean
@@ -448,17 +448,9 @@ theorem and_add_xor_eq_or {a b : BitVec w} : (a &&& b) + (a ^^^ b) = a ||| b := 
   simp only [Bool.bne_assoc]
   cases a.getLsbD ↑i <;> simp [carry_and_xor_false]
 
-@[bv_ofBool]
-theorem ofBool_or {a b : Bool} : BitVec.ofBool a ||| BitVec.ofBool b = ofBool (a || b) := by
-  simp only [toNat_eq, toNat_or, toNat_ofBool]; rcases a <;> rcases b <;> rfl
-
-@[bv_ofBool]
-theorem ofBool_and {a b : Bool} : BitVec.ofBool a &&& BitVec.ofBool b = ofBool (a && b) := by
-  simp only [toNat_eq, toNat_and, toNat_ofBool]; rcases a <;> rcases b <;> rfl
-
-@[bv_ofBool]
-theorem ofBool_xor {a b : Bool} : BitVec.ofBool a ^^^ BitVec.ofBool b = ofBool (a.xor b) := by
-  simp only [toNat_eq, toNat_xor, toNat_ofBool]; rcases a <;> rcases b <;> rfl
+attribute [bv_ofBool] ofBool_or_ofBool
+attribute [bv_ofBool] ofBool_and_ofBool
+attribute [bv_ofBool] ofBool_xor_ofBool
 
 @[simp, bv_ofBool]
 theorem ofBool_eq' : ofBool a = ofBool b ↔ a = b:= by


### PR DESCRIPTION
These became available in nightly-testing-2024-09-19.