### PR TITLE
chore: fix encoding issues

### DIFF
--- a/SSA/Projects/InstCombine/scripts/test-gen.py
+++ b/SSA/Projects/InstCombine/scripts/test-gen.py
@@ -134,7 +134,7 @@ def process_file(file):
             run_process1,
             shell=True,
             capture_output=True,
-            encoding="utf-8"
+            encoding="ISO-8859-1"
     )
     
     module1 = parse_module(
@@ -145,7 +145,7 @@ def process_file(file):
             f"mlir-translate -import-llvm {full_name} | mlir-opt --mlir-print-op-generic",
             shell=True,
             capture_output=True,
-            encoding="utf-8"
+            encoding="ISO-8859-1"
     )
     
     module2 = parse_module(


### PR DESCRIPTION
When rebuilding the test cases I run into encoding issues that lead to the error:

  codec can't decode byte 0xe2 in position

This change fixes this issue.