### PR TITLE
chore: drop lowering of abs after recent lean update

### DIFF
--- a/SSA/Projects/InstCombine/ForLean.lean
+++ b/SSA/Projects/InstCombine/ForLean.lean
@@ -105,10 +105,6 @@ theorem abs_eq_add_xor {x : BitVec w} :
   · simp [h, ← allOnes_sub_eq_not]
   · simp [h]
 
-theorem abs_eq_if {x : BitVec w} :
-    x.abs = if x.msb then -x else x := by
-  simp only [BitVec.abs, neg_eq]
-
 @[simp, bv_toNat]
 lemma toNat_shiftLeft' (A B : BitVec w) :
     BitVec.toNat (A <<< B) = (BitVec.toNat A) * 2 ^ BitVec.toNat B % 2 ^w := by

--- a/SSA/Projects/InstCombine/TacticAuto.lean
+++ b/SSA/Projects/InstCombine/TacticAuto.lean
@@ -162,7 +162,6 @@ macro "bv_auto": tactic =>
               bv_automata'
             )
           |
-            simp (config := {failIfUnchanged := false}) only [BitVec.abs_eq_if]
             try split
             all_goals bv_decide
           | bv_distrib


### PR DESCRIPTION
This is not necessary anymore, as `bv_decide` has native support for `abs`.