### PR TITLE
feat: Adding boolean notation to llvm constant declaration

### DIFF
--- a/SSA/Core/MLIRSyntax/GenericParser.lean
+++ b/SSA/Core/MLIRSyntax/GenericParser.lean
@@ -312,6 +312,10 @@ macro_rules
         if xstr == "index"
         then
           `(MLIRType.index)
+        else if xstr == "false"
+        then `(MLIRType.int .Signless 1)
+        else if xstr == "true"
+        then `(MLIRType.int .Signless 1)
         else if xstr.front == 'i' || xstr.front == 'f'
         then do
           let xstr' := (xstr.drop 1).toString

--- a/SSA/Projects/InstCombine/LLVM/EDSL.lean
+++ b/SSA/Projects/InstCombine/LLVM/EDSL.lean
@@ -201,7 +201,29 @@ def mkExpr (Γ : Ctxt (MetaLLVM φ).Ty) (opStx : MLIR.AST.Op φ) :
             HVector.nil,
             HVector.nil
           ⟩⟩
-      | _ => throw <| .generic "invalid constant attribute"
+      | .bool _ =>  throw <| .generic "that's a bool"
+      | .symbol _ =>  throw <| .generic "that's a symbol"
+      | .str _ =>  throw <| .generic "that's a strnig"
+      | .nat _ =>  throw <| .generic "that's a nat"
+      | .float _ _ =>  throw <| .generic "that's a float"
+      | .type  _ =>  throw <| .generic "that's a type"
+      | .affine  _ =>  throw <| .generic "that's a affine"
+      | .permutation _ =>  throw <| .generic "that's a permutation"
+      | .list _ =>  throw <| .generic "that's a list"
+      | .nestedsymbol _ _ =>  throw <| .generic "that's a nested"
+      | .alias _ =>  throw <| .generic "that's a alias"
+      | .dict _ =>  throw <| .generic "that's a dict"
+      | .opaque_ _ _ =>  throw <| .generic "that's a opaque"
+      | .opaqueElements _ _ _ =>  throw <| .generic "that's a opaqueelements"
+      | .unit =>  throw <| .generic "that's a unit"
+      -- return ⟨.pure, .bitvec (ConcreteOrMVar.concrete 1), ⟨
+      --       MOp.const (ConcreteOrMVar.concrete 1) (if b then 1 else 0),
+      --       by simp [DialectSignature.outTy, signature, *],
+      --       by constructor,
+      --       HVector.nil,
+      --       HVector.nil
+      --     ⟩⟩5tgb
+      -- | _ => throw <| .generic s!"invalid constant attribute"
     else
       throw <| .generic s!"invalid (0-ary) expression {opStx.name}"
   | _ => throw <| .generic s!"unsupported expression (with unsupported arity) {opStx.name}"

--- a/SSA/Projects/InstCombine/LLVM/PrettyEDSL.lean
+++ b/SSA/Projects/InstCombine/LLVM/PrettyEDSL.lean
@@ -165,6 +165,16 @@ private def pretty_test_trunc :=
     llvm.return %1 : i64
   }]
 
+private def test_bool := [llvm|
+{
+^0():
+  %0 = "llvm.mlir.constant"() <{value = false}> : () -> i1
+  %1 = "llvm.mlir.constant"() <{value = true}> : () -> i1
+  %2 = llvm.and %0, %1 : i1
+  "llvm.return"(%2) : (i1) -> ()
+}
+]
+
 example : pretty_test = prettier_test_generic 32 := by
   unfold pretty_test prettier_test_generic
   simp_alive_meta

--- a/SSA/Projects/InstCombine/scripts/files/minimal.lean
+++ b/SSA/Projects/InstCombine/scripts/files/minimal.lean
@@ -1,0 +1,24 @@
+
+import SSA.Projects.InstCombine.LLVM.PrettyEDSL
+import SSA.Projects.InstCombine.TacticAuto
+import SSA.Projects.InstCombine.LLVM.Semantics
+open LLVM
+open BitVec
+
+open MLIR AST
+open Ctxt (Var)
+
+set_option linter.deprecated false
+set_option linter.unreachableTactic false
+set_option linter.unusedTactic false
+
+
+def minimal_bool := [llvm|
+{
+^0():
+  %0 = "llvm.mlir.constant"() <{value = false}> : () -> i1
+  %1 = "llvm.mlir.constant"() <{value = true}> : () -> i1
+  %2 = llvm.and %0, %1 : i1
+  "llvm.return"(%2) : (i1) -> ()
+}
+]


### PR DESCRIPTION
The goal is to make the minimal definition in [SSA/Projects/InstCombine/scripts/files/minimal.lean](https://github.com/opencompl/lean-mlir/compare/instcombine-bool?expand=1#diff-ae27b88181224ab18e88f86dab646614a0ac054f918a9ad392df4c0251af6ae9) able to be interpreted