### PR TITLE
refactor: bring the LeanSAT script into the age of post 2005

### DIFF
--- a/SSA/Projects/InstCombine/TacticAuto.lean
+++ b/SSA/Projects/InstCombine/TacticAuto.lean
@@ -184,7 +184,7 @@ macro "alive_auto": tactic =>
 macro "bv_compare'": tactic =>
   `(tactic|
       (
-        -- bv_compare "/usr/local/bin/bitwuzla"
+        -- bv_compare -- for evaluating performance
         bv_decide -- replace this with bv_compare to evaluate performance
       )
    )

--- a/bv-evaluation/compare-leansat-vs-bitwuzla-llvm.py
+++ b/bv-evaluation/compare-leansat-vs-bitwuzla-llvm.py
@@ -1,31 +1,58 @@
 import subprocess
-import os 
+import os
+import concurrent.futures
+import argparse
 
-results_dir = "bv-evaluation/results/llvm/"
+ROOT_DIR = subprocess.check_output(['git', 'rev-parse', '--show-toplevel']).decode('utf-8').strip()
 
-benchmark_dir = "../SSA/Projects/InstCombine/tests/proofs/"
-benchmark_dir_lake = "SSA.Projects.InstCombine.tests.proofs"
+RESULTS_DIR = ROOT_DIR + '/bv-evaluation/results/llvm/'
 
-reps = 1
+BENCHMARK_DIR = ROOT_DIR + '/SSA/Projects/InstCombine/tests/proofs/'
 
-bv_width = [4, 8, 16, 32, 64]
+REPS = 1
 
-# import Leanwuzla and uncomment relevant line 
+def run_file(file: str):
+    file_path = BENCHMARK_DIR + file
+    file_title = file.split('.')[0]
+    subprocess.Popen('sed -i -E \'s,sorry,bv_compare\'\\\'\',g\' ' + file_path, cwd=ROOT_DIR, shell=True).wait()
 
-subprocess.Popen('sed -i -E \'s,-- import Leanwuzla,import Leanwuzla,g\' ../SSA/Projects/InstCombine/TacticAuto.lean', shell=True).wait()
-subprocess.Popen('sed -i -E \'s,-- bv_compare \",bv_compare \",g\' ../SSA/Projects/InstCombine/TacticAuto.lean', shell=True).wait()
-subprocess.Popen('sed -i -E \'s,bv_decide -- replace this with bv_compare to evaluate performance,-- bv_decide -- replace this with bv_compare to evaluate performance,g\' ../SSA/Projects/InstCombine/TacticAuto.lean', shell=True).wait()
+    for r in range(REPS):
+        log_file_path = RESULTS_DIR + file_title + '_' + 'r' + str(r) + '.txt'
+        with open(log_file_path, 'w') as log_file:
+            cmd = 'lake lean ' + file_path
+            print(cmd)
+            subprocess.Popen(cmd, cwd=ROOT_DIR, stdout=log_file, stderr=log_file, shell=True).wait()
+    subprocess.Popen('sed -i -E \'s,bv_compare\'\\\'\',sorry,g\' ' + file_path, cwd=ROOT_DIR, shell=True).wait()
 
+def process(jobs: int):
+    os.makedirs(RESULTS_DIR, exist_ok=True)
+    tactic_auto_path = f'{ROOT_DIR}/SSA/Projects/InstCombine/TacticAuto.lean'
 
-for file in os.listdir(benchmark_dir):
-    if "_proof" in file: # currently discard broken chapter
-        subprocess.Popen('sed -i -E \'s,sorry,by bv_compare\'\\\'\',g\' '+benchmark_dir+file, shell=True).wait()
-        for r in range(reps):
-            print(f'cd .. && lake build '+benchmark_dir_lake+'.'+file.split(".")[0]+' 2>&1 > '+results_dir+file.split(".")[0]+'_'+'r'+str(r)+'.txt')
-            subprocess.Popen(f'cd .. && lake build '+benchmark_dir_lake+'.'+file.split(".")[0]+' 2>&1 > '+results_dir+file.split(".")[0]+'_'+'r'+str(r)+'.txt', shell=True).wait()
-        subprocess.Popen('sed -i -E \'s,by bv_compare\'\\\'\',sorry,g\' '+benchmark_dir+file, shell=True).wait()
+    # import Leanwuzla and uncomment relevant line
+    subprocess.Popen(f'sed -i -E \'s,-- import Leanwuzla,import Leanwuzla,g\' {tactic_auto_path}', cwd=ROOT_DIR, shell=True).wait()
+    subprocess.Popen(f'sed -i -E \'s,-- bv_compare --,bv_compare --,g\' {tactic_auto_path}', cwd=ROOT_DIR, shell=True).wait()
+    subprocess.Popen(f'sed -i -E \'s,bv_decide -- replace this with bv_compare to evaluate performance,-- bv_decide -- replace this with bv_compare to evaluate performance,g\' {tactic_auto_path}', cwd=ROOT_DIR, shell=True).wait()
 
+    with concurrent.futures.ThreadPoolExecutor(max_workers=jobs) as executor:
+        futures = {}
+        for file in os.listdir(BENCHMARK_DIR):
+            if "_proof" in file and "gshifthaddhinseltpoison_proof" in file: # currently discard broken chapter
+                future = executor.submit(run_file, file)
+                futures[future] = file
 
-subprocess.Popen('sed -i -E \'s,import Leanwuzla,-- import Leanwuzla,g\' ../SSA/Projects/InstCombine/TacticAuto.lean', shell=True).wait()
-subprocess.Popen('sed -i -E \'s,bv_compare \",-- bv_compare \",g\' ../SSA/Projects/InstCombine/TacticAuto.lean', shell=True).wait()
-subprocess.Popen('sed -i -E \'s,-- bv_decide -- replace this with bv_compare to evaluate performance,bv_decide -- replace this with bv_compare to evaluate performance,g\' ../SSA/Projects/InstCombine/TacticAuto.lean', shell=True).wait()
+        total = len(futures)
+        for idx, future in enumerate(concurrent.futures.as_completed(futures)):
+            file = futures[future]
+            future.result()
+            percentage = ((idx + 1) / total) * 100
+            print(f'{file} completed, {percentage}%')
+
+    # revert the preamble
+    subprocess.Popen(f'sed -i -E \'s,import Leanwuzla,-- import Leanwuzla,g\' {tactic_auto_path}', cwd=ROOT_DIR, shell=True).wait()
+    subprocess.Popen(f'sed -i -E \'s,bv_compare --,-- bv_compare --,g\' {tactic_auto_path}', cwd=ROOT_DIR, shell=True).wait()
+    subprocess.Popen(f'sed -i -E \'s,-- bv_decide -- replace this with bv_compare to evaluate performance,bv_decide -- replace this with bv_compare to evaluate performance,g\' {tactic_auto_path}', cwd=ROOT_DIR, shell=True).wait()
+
+parser = argparse.ArgumentParser(prog='compare-leansat-vs-bitwuzla-llvm')
+parser.add_argument('-j', '--jobs', type=int, default=1)
+args = parser.parse_args()
+process(args.jobs)


### PR DESCRIPTION
This PR:
- turns the shell script into a python script
- fixes the unexpected by error. The old code was assuming something of the form `:= sorry` to be replaced with `:= by tac` but now it's substituting inside of a tactic block
- brings the script into the age of multi core CPUs, though care needs to be taken when running with too many jobs as some of this stuff can be quite memory hungry
- uses `lake lean` so you can actually run it multiple times in a row without cleaning a lake cache (assuming you haven't actually compiled the benchmark files of course)