### PR TITLE
chore: clean and strenghten `simp_alive_undef`

### DIFF
--- a/SSA/Projects/InstCombine/AliveHandwrittenLargeExamples.lean
+++ b/SSA/Projects/InstCombine/AliveHandwrittenLargeExamples.lean
@@ -130,9 +130,6 @@ def alive_simplifyMulDivRem805 (w : Nat) :
       rw [LLVM.sdiv?_denom_zero_eq_none]
       apply Refinement.none_left
     case neg =>
-      simp only [Bool.false_eq_true, add_tsub_cancel_right, ge_iff_le, false_and, toNat_ofNat,
-        lt_add_iff_pos_left, add_pos_iff, zero_lt_one, or_true, Nat.one_mod_two_pow, _root_.or_self,
-        ↓reduceIte, Option.some_bind]
       rw [BitVec.ult_toNat]
       rw [BitVec.toNat_ofNat]
       cases w'

--- a/SSA/Projects/InstCombine/ForLean.lean
+++ b/SSA/Projects/InstCombine/ForLean.lean
@@ -525,3 +525,6 @@ theorem not_bne' {a b : Bool} : (!bne a b) = (a == b) := by
   <;> simp
 
 end Bool
+
+theorem Option.some_bind'' (x : α) (f : α → Option β) : some x >>= f = f x := by
+  simp

--- a/SSA/Projects/InstCombine/LLVM/Semantics.lean
+++ b/SSA/Projects/InstCombine/LLVM/Semantics.lean
@@ -22,7 +22,7 @@ def and? {w : Nat} (x y : BitVec w) : IntW w :=
   pure <| x &&& y
 
 @[simp_llvm_option]
-theorem and?_eq : LLVM.and? a b  = .some (BitVec.and a b) := rfl
+theorem and?_eq : LLVM.and? a b  = .some (a &&& b) := rfl
 
 @[simp_llvm_option]
 def and {w : Nat} (x y : IntW w) : IntW w := do
@@ -39,7 +39,7 @@ def or? {w : Nat} (x y : BitVec w) : IntW w :=
   pure <| x ||| y
 
 @[simp_llvm_option]
-theorem or?_eq : LLVM.or? a b  = .some (BitVec.or a b) := rfl
+theorem or?_eq : LLVM.or? a b  = .some (a ||| b) := rfl
 
 structure DisjointFlag where
   disjoint : Bool := false
@@ -64,7 +64,7 @@ def xor? {w : Nat} (x y : BitVec w) : IntW w :=
   pure <| x ^^^ y
 
 @[simp_llvm_option]
-theorem xor?_eq : LLVM.xor? a b  = .some (BitVec.xor a b) := rfl
+theorem xor?_eq : LLVM.xor? a b  = .some (a ^^^ b) := rfl
 
 @[simp_llvm_option]
 def xor {w : Nat} (x y : IntW w) : IntW w := do
@@ -82,7 +82,7 @@ def add? {w : Nat} (x y : BitVec w) : IntW w :=
   pure <| x + y
 
 @[simp_llvm_option]
-theorem add?_eq : LLVM.add? a b  = .some (BitVec.add a b) := rfl
+theorem add?_eq : LLVM.add? a b  = .some (a + b) := rfl
 
 structure NoWrapFlags where
   nsw : Bool := false
@@ -110,7 +110,7 @@ def sub? {w : Nat} (x y : BitVec w) : IntW w :=
   pure <| x - y
 
 @[simp_llvm_option]
-theorem sub?_eq : LLVM.sub? a b  = .some (BitVec.sub a b) := rfl
+theorem sub?_eq : LLVM.sub? a b  = .some (a - b) := rfl
 
 @[simp_llvm_option]
 def sub {w : Nat} (x y : IntW w) (flags : NoWrapFlags := {nsw := false , nuw := false}) : IntW w := do
@@ -143,7 +143,7 @@ def mul? {w : Nat} (x y : BitVec w) : IntW w :=
   pure <| x * y
 
 @[simp_llvm_option]
-theorem mul?_eq : LLVM.mul? a b  = .some (BitVec.mul a b) := rfl
+theorem mul?_eq : LLVM.mul? a b  = .some (a * b) := rfl
 
 @[simp_llvm_option]
 def mul {w : Nat} (x y : IntW w) (flags : NoWrapFlags := {nsw := false , nuw := false}) : IntW w := do
@@ -543,7 +543,7 @@ def not? {w : Nat} (x : BitVec w) : IntW w := do
   pure (~~~x)
 
 @[simp_llvm_option]
-theorem not?_eq : LLVM.not? a = .some (BitVec.not a) := rfl
+theorem not?_eq : LLVM.not? a = .some (~~~ a) := rfl
 
 @[simp_llvm_option]
 def not {w : Nat} (x : IntW w) : IntW w := do
@@ -555,7 +555,7 @@ def neg? {w : Nat} (x : BitVec w) : IntW w := do
   pure <| (-.) x
 
 @[simp_llvm_option]
-theorem neg?_eq : LLVM.neg? a = .some (BitVec.neg a) := rfl
+theorem neg?_eq : LLVM.neg? a = .some (-a) := rfl
 
 @[simp_llvm_option]
 def neg {w : Nat} (x : IntW w) : IntW w := do

--- a/SSA/Projects/InstCombine/TacticAuto.lean
+++ b/SSA/Projects/InstCombine/TacticAuto.lean
@@ -96,7 +96,7 @@ macro "simp_alive_undef" : tactic =>
             BitVec.Refinement, bind_assoc,
             Bool.false_eq_true, false_and, reduceIte,
             (BitVec.ofInt_ofNat),
-            pure_bind
+            Option.some_bind''
           ]
       )
   )

--- a/SSA/Projects/InstCombine/TacticAuto.lean
+++ b/SSA/Projects/InstCombine/TacticAuto.lean
@@ -94,6 +94,9 @@ macro "simp_alive_undef" : tactic =>
         simp (config := {failIfUnchanged := false}) only [
             simp_llvm_option,
             BitVec.Refinement, bind_assoc,
+            Bool.false_eq_true, false_and, reduceIte,
+            (BitVec.ofInt_ofNat),
+            pure_bind
           ]
       )
   )

--- a/SSA/Projects/InstCombine/tests/proofs/gxor2_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gxor2_proof.lean
@@ -7,7 +7,7 @@ open LLVM
 section gxor2_proof
 theorem test0_thm (e : IntW 32) :
   icmp IntPredicate.sgt (LLVM.xor e (const? 32 (-2147483648))) (const? 32 (-1)) ⊑
-    icmp IntPredicate.slt e (const? 32 0) := by
+    icmp IntPredicate.slt e (const? 32 0) := by 
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -16,7 +16,7 @@ theorem test0_thm (e : IntW 32) :
 
 
 theorem test1_thm (e : IntW 32) :
-  icmp IntPredicate.slt (LLVM.xor e (const? 32 12345)) (const? 32 0) ⊑ icmp IntPredicate.slt e (const? 32 0) := by
+  icmp IntPredicate.slt (LLVM.xor e (const? 32 12345)) (const? 32 0) ⊑ icmp IntPredicate.slt e (const? 32 0) := by 
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -26,7 +26,7 @@ theorem test1_thm (e : IntW 32) :
 
 theorem test2_thm (e : IntW 32) :
   LLVM.xor (add (LLVM.and e (const? 32 32)) (const? 32 145)) (const? 32 153) ⊑
-    LLVM.or (LLVM.and e (const? 32 32)) (const? 32 8) := by
+    LLVM.or (LLVM.and e (const? 32 32)) (const? 32 8) := by 
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -36,7 +36,7 @@ theorem test2_thm (e : IntW 32) :
 
 theorem test3_thm (e : IntW 32) :
   LLVM.xor (LLVM.and (LLVM.or e (const? 32 145)) (const? 32 177)) (const? 32 153) ⊑
-    LLVM.or (LLVM.and e (const? 32 32)) (const? 32 8) := by
+    LLVM.or (LLVM.and e (const? 32 32)) (const? 32 8) := by 
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -46,7 +46,7 @@ theorem test3_thm (e : IntW 32) :
 
 theorem test5_thm (e : IntW 32) :
   add (LLVM.xor (lshr (LLVM.xor e (const? 32 1234)) (const? 32 8)) (const? 32 1)) (LLVM.xor e (const? 32 1234)) ⊑
-    add (LLVM.xor (lshr e (const? 32 8)) (const? 32 5)) (LLVM.xor e (const? 32 1234)) := by
+    add (LLVM.xor (lshr e (const? 32 8)) (const? 32 5)) (LLVM.xor e (const? 32 1234)) := by 
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -56,7 +56,7 @@ theorem test5_thm (e : IntW 32) :
 
 theorem test6_thm (e : IntW 32) :
   add (lshr (LLVM.xor e (const? 32 1234)) (const? 32 16)) (LLVM.xor e (const? 32 1234)) ⊑
-    add (lshr e (const? 32 16)) (LLVM.xor e (const? 32 1234)) := by
+    add (lshr e (const? 32 16)) (LLVM.xor e (const? 32 1234)) := by 
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -65,7 +65,7 @@ theorem test6_thm (e : IntW 32) :
 
 
 theorem test7_thm (e e_1 : IntW 32) :
-  LLVM.xor (LLVM.or e_1 e) (LLVM.xor e_1 (const? 32 (-1))) ⊑ LLVM.or e_1 (LLVM.xor e (const? 32 (-1))) := by
+  LLVM.xor (LLVM.or e_1 e) (LLVM.xor e_1 (const? 32 (-1))) ⊑ LLVM.or e_1 (LLVM.xor e (const? 32 (-1))) := by 
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -74,7 +74,7 @@ theorem test7_thm (e e_1 : IntW 32) :
 
 
 theorem test8_thm (e e_1 : IntW 32) :
-  LLVM.xor (LLVM.xor e_1 (const? 32 (-1))) (LLVM.or e_1 e) ⊑ LLVM.or e_1 (LLVM.xor e (const? 32 (-1))) := by
+  LLVM.xor (LLVM.xor e_1 (const? 32 (-1))) (LLVM.or e_1 e) ⊑ LLVM.or e_1 (LLVM.xor e (const? 32 (-1))) := by 
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -82,7 +82,7 @@ theorem test8_thm (e e_1 : IntW 32) :
     all_goals sorry
 
 
-theorem test9_thm (e e_1 : IntW 32) : LLVM.xor (LLVM.and e_1 e) (LLVM.xor e_1 e) ⊑ LLVM.or e_1 e := by
+theorem test9_thm (e e_1 : IntW 32) : LLVM.xor (LLVM.and e_1 e) (LLVM.xor e_1 e) ⊑ LLVM.or e_1 e := by 
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -90,7 +90,7 @@ theorem test9_thm (e e_1 : IntW 32) : LLVM.xor (LLVM.and e_1 e) (LLVM.xor e_1 e)
     all_goals sorry
 
 
-theorem test9b_thm (e e_1 : IntW 32) : LLVM.xor (LLVM.and e_1 e) (LLVM.xor e e_1) ⊑ LLVM.or e_1 e := by
+theorem test9b_thm (e e_1 : IntW 32) : LLVM.xor (LLVM.and e_1 e) (LLVM.xor e e_1) ⊑ LLVM.or e_1 e := by 
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -98,7 +98,7 @@ theorem test9b_thm (e e_1 : IntW 32) : LLVM.xor (LLVM.and e_1 e) (LLVM.xor e e_1
     all_goals sorry
 
 
-theorem test10_thm (e e_1 : IntW 32) : LLVM.xor (LLVM.xor e_1 e) (LLVM.and e_1 e) ⊑ LLVM.or e_1 e := by
+theorem test10_thm (e e_1 : IntW 32) : LLVM.xor (LLVM.xor e_1 e) (LLVM.and e_1 e) ⊑ LLVM.or e_1 e := by 
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -106,7 +106,7 @@ theorem test10_thm (e e_1 : IntW 32) : LLVM.xor (LLVM.xor e_1 e) (LLVM.and e_1 e
     all_goals sorry
 
 
-theorem test10b_thm (e e_1 : IntW 32) : LLVM.xor (LLVM.xor e_1 e) (LLVM.and e e_1) ⊑ LLVM.or e_1 e := by
+theorem test10b_thm (e e_1 : IntW 32) : LLVM.xor (LLVM.xor e_1 e) (LLVM.and e e_1) ⊑ LLVM.or e_1 e := by 
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -116,7 +116,7 @@ theorem test10b_thm (e e_1 : IntW 32) : LLVM.xor (LLVM.xor e_1 e) (LLVM.and e e_
 
 theorem test11_thm (e e_1 : IntW 32) :
   LLVM.and (LLVM.xor e_1 e) (LLVM.xor (LLVM.xor e (const? 32 (-1))) e_1) ⊑
-    LLVM.and (LLVM.xor e_1 e) (LLVM.xor (LLVM.xor e e_1) (const? 32 (-1))) := by
+    LLVM.and (LLVM.xor e_1 e) (LLVM.xor (LLVM.xor e e_1) (const? 32 (-1))) := by 
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -126,7 +126,7 @@ theorem test11_thm (e e_1 : IntW 32) :
 
 theorem test11b_thm (e e_1 : IntW 32) :
   LLVM.and (LLVM.xor (LLVM.xor e_1 (const? 32 (-1))) e) (LLVM.xor e e_1) ⊑
-    LLVM.and (LLVM.xor e e_1) (LLVM.xor (LLVM.xor e_1 e) (const? 32 (-1))) := by
+    LLVM.and (LLVM.xor e e_1) (LLVM.xor (LLVM.xor e_1 e) (const? 32 (-1))) := by 
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -136,7 +136,7 @@ theorem test11b_thm (e e_1 : IntW 32) :
 
 theorem test11c_thm (e e_1 : IntW 32) :
   LLVM.and (LLVM.xor e_1 e) (LLVM.xor (LLVM.xor e_1 (const? 32 (-1))) e) ⊑
-    LLVM.and (LLVM.xor e_1 e) (LLVM.xor (LLVM.xor e_1 e) (const? 32 (-1))) := by
+    LLVM.and (LLVM.xor e_1 e) (LLVM.xor (LLVM.xor e_1 e) (const? 32 (-1))) := by 
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -146,7 +146,7 @@ theorem test11c_thm (e e_1 : IntW 32) :
 
 theorem test11d_thm (e e_1 : IntW 32) :
   LLVM.and (LLVM.xor (LLVM.xor e_1 (const? 32 (-1))) e) (LLVM.xor e_1 e) ⊑
-    LLVM.and (LLVM.xor e_1 e) (LLVM.xor (LLVM.xor e_1 e) (const? 32 (-1))) := by
+    LLVM.and (LLVM.xor e_1 e) (LLVM.xor (LLVM.xor e_1 e) (const? 32 (-1))) := by 
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -156,7 +156,7 @@ theorem test11d_thm (e e_1 : IntW 32) :
 
 theorem test11e_thm (e e_1 e_2 : IntW 32) :
   LLVM.and (LLVM.xor (mul e_2 e_1) e) (LLVM.xor (mul e_2 e_1) (LLVM.xor e (const? 32 (-1)))) ⊑
-    LLVM.and (LLVM.xor (mul e_2 e_1) e) (LLVM.xor (LLVM.xor e (mul e_2 e_1)) (const? 32 (-1))) := by
+    LLVM.and (LLVM.xor (mul e_2 e_1) e) (LLVM.xor (LLVM.xor e (mul e_2 e_1)) (const? 32 (-1))) := by 
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -166,7 +166,7 @@ theorem test11e_thm (e e_1 e_2 : IntW 32) :
 
 theorem test11f_thm (e e_1 e_2 : IntW 32) :
   LLVM.and (LLVM.xor (mul e_2 e_1) (LLVM.xor e (const? 32 (-1)))) (LLVM.xor (mul e_2 e_1) e) ⊑
-    LLVM.and (LLVM.xor (mul e_2 e_1) e) (LLVM.xor (LLVM.xor e (mul e_2 e_1)) (const? 32 (-1))) := by
+    LLVM.and (LLVM.xor (mul e_2 e_1) e) (LLVM.xor (LLVM.xor e (mul e_2 e_1)) (const? 32 (-1))) := by 
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -176,7 +176,7 @@ theorem test11f_thm (e e_1 e_2 : IntW 32) :
 
 theorem test12_thm (e e_1 : IntW 32) :
   LLVM.xor (LLVM.and e_1 (LLVM.xor e (const? 32 (-1)))) (LLVM.xor e_1 (const? 32 (-1))) ⊑
-    LLVM.xor (LLVM.and e_1 e) (const? 32 (-1)) := by
+    LLVM.xor (LLVM.and e_1 e) (const? 32 (-1)) := by 
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -186,7 +186,7 @@ theorem test12_thm (e e_1 : IntW 32) :
 
 theorem test12commuted_thm (e e_1 : IntW 32) :
   LLVM.xor (LLVM.and (LLVM.xor e_1 (const? 32 (-1))) e) (LLVM.xor e (const? 32 (-1))) ⊑
-    LLVM.xor (LLVM.and e e_1) (const? 32 (-1)) := by
+    LLVM.xor (LLVM.and e e_1) (const? 32 (-1)) := by 
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -196,7 +196,7 @@ theorem test12commuted_thm (e e_1 : IntW 32) :
 
 theorem test13_thm (e e_1 : IntW 32) :
   LLVM.xor (LLVM.xor e_1 (const? 32 (-1))) (LLVM.and e_1 (LLVM.xor e (const? 32 (-1)))) ⊑
-    LLVM.xor (LLVM.and e_1 e) (const? 32 (-1)) := by
+    LLVM.xor (LLVM.and e_1 e) (const? 32 (-1)) := by 
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -206,7 +206,7 @@ theorem test13_thm (e e_1 : IntW 32) :
 
 theorem test13commuted_thm (e e_1 : IntW 32) :
   LLVM.xor (LLVM.xor e_1 (const? 32 (-1))) (LLVM.and (LLVM.xor e (const? 32 (-1))) e_1) ⊑
-    LLVM.xor (LLVM.and e_1 e) (const? 32 (-1)) := by
+    LLVM.xor (LLVM.and e_1 e) (const? 32 (-1)) := by 
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -215,7 +215,7 @@ theorem test13commuted_thm (e e_1 : IntW 32) :
 
 
 theorem xor_or_xor_common_op_commute1_thm (e e_1 e_2 : IntW 32) :
-  LLVM.xor (LLVM.xor e_2 e_1) (LLVM.or e_2 e) ⊑ LLVM.xor (LLVM.and e (LLVM.xor e_2 (const? 32 (-1)))) e_1 := by
+  LLVM.xor (LLVM.xor e_2 e_1) (LLVM.or e_2 e) ⊑ LLVM.xor (LLVM.and e (LLVM.xor e_2 (const? 32 (-1)))) e_1 := by 
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -224,7 +224,7 @@ theorem xor_or_xor_common_op_commute1_thm (e e_1 e_2 : IntW 32) :
 
 
 theorem xor_or_xor_common_op_commute2_thm (e e_1 e_2 : IntW 32) :
-  LLVM.xor (LLVM.xor e_2 e_1) (LLVM.or e_1 e) ⊑ LLVM.xor (LLVM.and e (LLVM.xor e_1 (const? 32 (-1)))) e_2 := by
+  LLVM.xor (LLVM.xor e_2 e_1) (LLVM.or e_1 e) ⊑ LLVM.xor (LLVM.and e (LLVM.xor e_1 (const? 32 (-1)))) e_2 := by 
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -233,7 +233,7 @@ theorem xor_or_xor_common_op_commute2_thm (e e_1 e_2 : IntW 32) :
 
 
 theorem xor_or_xor_common_op_commute3_thm (e e_1 e_2 : IntW 32) :
-  LLVM.xor (LLVM.xor e_2 e_1) (LLVM.or e e_2) ⊑ LLVM.xor (LLVM.and e (LLVM.xor e_2 (const? 32 (-1)))) e_1 := by
+  LLVM.xor (LLVM.xor e_2 e_1) (LLVM.or e e_2) ⊑ LLVM.xor (LLVM.and e (LLVM.xor e_2 (const? 32 (-1)))) e_1 := by 
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -242,7 +242,7 @@ theorem xor_or_xor_common_op_commute3_thm (e e_1 e_2 : IntW 32) :
 
 
 theorem xor_or_xor_common_op_commute4_thm (e e_1 e_2 : IntW 32) :
-  LLVM.xor (LLVM.xor e_2 e_1) (LLVM.or e e_1) ⊑ LLVM.xor (LLVM.and e (LLVM.xor e_1 (const? 32 (-1)))) e_2 := by
+  LLVM.xor (LLVM.xor e_2 e_1) (LLVM.or e e_1) ⊑ LLVM.xor (LLVM.and e (LLVM.xor e_1 (const? 32 (-1)))) e_2 := by 
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -251,7 +251,7 @@ theorem xor_or_xor_common_op_commute4_thm (e e_1 e_2 : IntW 32) :
 
 
 theorem xor_or_xor_common_op_commute5_thm (e e_1 e_2 : IntW 32) :
-  LLVM.xor (LLVM.or e_2 e_1) (LLVM.xor e_2 e) ⊑ LLVM.xor (LLVM.and e_1 (LLVM.xor e_2 (const? 32 (-1)))) e := by
+  LLVM.xor (LLVM.or e_2 e_1) (LLVM.xor e_2 e) ⊑ LLVM.xor (LLVM.and e_1 (LLVM.xor e_2 (const? 32 (-1)))) e := by 
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -260,7 +260,7 @@ theorem xor_or_xor_common_op_commute5_thm (e e_1 e_2 : IntW 32) :
 
 
 theorem xor_or_xor_common_op_commute6_thm (e e_1 e_2 : IntW 32) :
-  LLVM.xor (LLVM.or e_2 e_1) (LLVM.xor e e_2) ⊑ LLVM.xor (LLVM.and e_1 (LLVM.xor e_2 (const? 32 (-1)))) e := by
+  LLVM.xor (LLVM.or e_2 e_1) (LLVM.xor e e_2) ⊑ LLVM.xor (LLVM.and e_1 (LLVM.xor e_2 (const? 32 (-1)))) e := by 
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -269,7 +269,7 @@ theorem xor_or_xor_common_op_commute6_thm (e e_1 e_2 : IntW 32) :
 
 
 theorem xor_or_xor_common_op_commute7_thm (e e_1 e_2 : IntW 32) :
-  LLVM.xor (LLVM.or e_2 e_1) (LLVM.xor e_1 e) ⊑ LLVM.xor (LLVM.and e_2 (LLVM.xor e_1 (const? 32 (-1)))) e := by
+  LLVM.xor (LLVM.or e_2 e_1) (LLVM.xor e_1 e) ⊑ LLVM.xor (LLVM.and e_2 (LLVM.xor e_1 (const? 32 (-1)))) e := by 
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -278,7 +278,7 @@ theorem xor_or_xor_common_op_commute7_thm (e e_1 e_2 : IntW 32) :
 
 
 theorem xor_or_xor_common_op_commute8_thm (e e_1 e_2 : IntW 32) :
-  LLVM.xor (LLVM.or e_2 e_1) (LLVM.xor e e_1) ⊑ LLVM.xor (LLVM.and e_2 (LLVM.xor e_1 (const? 32 (-1)))) e := by
+  LLVM.xor (LLVM.or e_2 e_1) (LLVM.xor e e_1) ⊑ LLVM.xor (LLVM.and e_2 (LLVM.xor e_1 (const? 32 (-1)))) e := by 
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -289,7 +289,7 @@ theorem xor_or_xor_common_op_commute8_thm (e e_1 e_2 : IntW 32) :
 theorem test15_thm (e e_1 : IntW 8) :
   mul (LLVM.and (LLVM.xor e_1 e) (LLVM.xor (LLVM.xor e (const? 8 33)) e_1)) (LLVM.xor (LLVM.xor e (const? 8 33)) e_1) ⊑
     mul (LLVM.and (LLVM.xor e_1 e) (LLVM.xor (LLVM.xor e e_1) (const? 8 33)))
-      (LLVM.xor (LLVM.xor e e_1) (const? 8 33)) := by
+      (LLVM.xor (LLVM.xor e e_1) (const? 8 33)) := by 
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -300,7 +300,7 @@ theorem test15_thm (e e_1 : IntW 8) :
 theorem test16_thm (e e_1 : IntW 8) :
   mul (LLVM.and (LLVM.xor (LLVM.xor e_1 (const? 8 33)) e) (LLVM.xor e e_1)) (LLVM.xor (LLVM.xor e_1 (const? 8 33)) e) ⊑
     mul (LLVM.and (LLVM.xor (LLVM.xor e_1 e) (const? 8 33)) (LLVM.xor e e_1))
-      (LLVM.xor (LLVM.xor e_1 e) (const? 8 33)) := by
+      (LLVM.xor (LLVM.xor e_1 e) (const? 8 33)) := by 
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -310,7 +310,7 @@ theorem test16_thm (e e_1 : IntW 8) :
 
 theorem not_xor_to_or_not1_thm (e e_1 e_2 : IntW 3) :
   LLVM.xor (LLVM.xor (LLVM.and e_2 e_1) (LLVM.or e e_1)) (const? 3 (-1)) ⊑
-    LLVM.or (LLVM.and e_2 e_1) (LLVM.xor (LLVM.or e e_1) (const? 3 (-1))) := by
+    LLVM.or (LLVM.and e_2 e_1) (LLVM.xor (LLVM.or e e_1) (const? 3 (-1))) := by 
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -320,7 +320,7 @@ theorem not_xor_to_or_not1_thm (e e_1 e_2 : IntW 3) :
 
 theorem not_xor_to_or_not2_thm (e e_1 e_2 : IntW 3) :
   LLVM.xor (LLVM.xor (LLVM.and e_2 e_1) (LLVM.or e_1 e)) (const? 3 (-1)) ⊑
-    LLVM.or (LLVM.and e_2 e_1) (LLVM.xor (LLVM.or e_1 e) (const? 3 (-1))) := by
+    LLVM.or (LLVM.and e_2 e_1) (LLVM.xor (LLVM.or e_1 e) (const? 3 (-1))) := by 
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -330,7 +330,7 @@ theorem not_xor_to_or_not2_thm (e e_1 e_2 : IntW 3) :
 
 theorem not_xor_to_or_not3_thm (e e_1 e_2 : IntW 3) :
   LLVM.xor (LLVM.xor (LLVM.and e_2 e_1) (LLVM.or e_2 e)) (const? 3 (-1)) ⊑
-    LLVM.or (LLVM.and e_2 e_1) (LLVM.xor (LLVM.or e_2 e) (const? 3 (-1))) := by
+    LLVM.or (LLVM.and e_2 e_1) (LLVM.xor (LLVM.or e_2 e) (const? 3 (-1))) := by 
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -340,7 +340,7 @@ theorem not_xor_to_or_not3_thm (e e_1 e_2 : IntW 3) :
 
 theorem not_xor_to_or_not4_thm (e e_1 e_2 : IntW 3) :
   LLVM.xor (LLVM.xor (LLVM.and e_2 e_1) (LLVM.or e e_2)) (const? 3 (-1)) ⊑
-    LLVM.or (LLVM.and e_2 e_1) (LLVM.xor (LLVM.or e e_2) (const? 3 (-1))) := by
+    LLVM.or (LLVM.and e_2 e_1) (LLVM.xor (LLVM.or e e_2) (const? 3 (-1))) := by 
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -350,7 +350,7 @@ theorem not_xor_to_or_not4_thm (e e_1 e_2 : IntW 3) :
 
 theorem xor_notand_to_or_not1_thm (e e_1 e_2 : IntW 3) :
   LLVM.xor (LLVM.xor (LLVM.and e_2 e_1) (const? 3 (-1))) (LLVM.or e e_1) ⊑
-    LLVM.or (LLVM.and e_2 e_1) (LLVM.xor (LLVM.or e e_1) (const? 3 (-1))) := by
+    LLVM.or (LLVM.and e_2 e_1) (LLVM.xor (LLVM.or e e_1) (const? 3 (-1))) := by 
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -360,7 +360,7 @@ theorem xor_notand_to_or_not1_thm (e e_1 e_2 : IntW 3) :
 
 theorem xor_notand_to_or_not2_thm (e e_1 e_2 : IntW 3) :
   LLVM.xor (LLVM.xor (LLVM.and e_2 e_1) (const? 3 (-1))) (LLVM.or e_1 e) ⊑
-    LLVM.or (LLVM.and e_2 e_1) (LLVM.xor (LLVM.or e_1 e) (const? 3 (-1))) := by
+    LLVM.or (LLVM.and e_2 e_1) (LLVM.xor (LLVM.or e_1 e) (const? 3 (-1))) := by 
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -370,7 +370,7 @@ theorem xor_notand_to_or_not2_thm (e e_1 e_2 : IntW 3) :
 
 theorem xor_notand_to_or_not3_thm (e e_1 e_2 : IntW 3) :
   LLVM.xor (LLVM.xor (LLVM.and e_2 e_1) (const? 3 (-1))) (LLVM.or e_2 e) ⊑
-    LLVM.or (LLVM.and e_2 e_1) (LLVM.xor (LLVM.or e_2 e) (const? 3 (-1))) := by
+    LLVM.or (LLVM.and e_2 e_1) (LLVM.xor (LLVM.or e_2 e) (const? 3 (-1))) := by 
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -380,9 +380,11 @@ theorem xor_notand_to_or_not3_thm (e e_1 e_2 : IntW 3) :
 
 theorem xor_notand_to_or_not4_thm (e e_1 e_2 : IntW 3) :
   LLVM.xor (LLVM.xor (LLVM.and e_2 e_1) (const? 3 (-1))) (LLVM.or e e_2) ⊑
-    LLVM.or (LLVM.and e_2 e_1) (LLVM.xor (LLVM.or e e_2) (const? 3 (-1))) := by
+    LLVM.or (LLVM.and e_2 e_1) (LLVM.xor (LLVM.or e e_2) (const? 3 (-1))) := by 
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
     try alive_auto
     all_goals sorry
+
+

--- a/SSA/Projects/InstCombine/tests/proofs/gxor2_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gxor2_proof.lean
@@ -7,7 +7,7 @@ open LLVM
 section gxor2_proof
 theorem test0_thm (e : IntW 32) :
   icmp IntPredicate.sgt (LLVM.xor e (const? 32 (-2147483648))) (const? 32 (-1)) ⊑
-    icmp IntPredicate.slt e (const? 32 0) := by 
+    icmp IntPredicate.slt e (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -16,7 +16,7 @@ theorem test0_thm (e : IntW 32) :
 
 
 theorem test1_thm (e : IntW 32) :
-  icmp IntPredicate.slt (LLVM.xor e (const? 32 12345)) (const? 32 0) ⊑ icmp IntPredicate.slt e (const? 32 0) := by 
+  icmp IntPredicate.slt (LLVM.xor e (const? 32 12345)) (const? 32 0) ⊑ icmp IntPredicate.slt e (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -26,7 +26,7 @@ theorem test1_thm (e : IntW 32) :
 
 theorem test2_thm (e : IntW 32) :
   LLVM.xor (add (LLVM.and e (const? 32 32)) (const? 32 145)) (const? 32 153) ⊑
-    LLVM.or (LLVM.and e (const? 32 32)) (const? 32 8) := by 
+    LLVM.or (LLVM.and e (const? 32 32)) (const? 32 8) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -36,7 +36,7 @@ theorem test2_thm (e : IntW 32) :
 
 theorem test3_thm (e : IntW 32) :
   LLVM.xor (LLVM.and (LLVM.or e (const? 32 145)) (const? 32 177)) (const? 32 153) ⊑
-    LLVM.or (LLVM.and e (const? 32 32)) (const? 32 8) := by 
+    LLVM.or (LLVM.and e (const? 32 32)) (const? 32 8) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -46,7 +46,7 @@ theorem test3_thm (e : IntW 32) :
 
 theorem test5_thm (e : IntW 32) :
   add (LLVM.xor (lshr (LLVM.xor e (const? 32 1234)) (const? 32 8)) (const? 32 1)) (LLVM.xor e (const? 32 1234)) ⊑
-    add (LLVM.xor (lshr e (const? 32 8)) (const? 32 5)) (LLVM.xor e (const? 32 1234)) := by 
+    add (LLVM.xor (lshr e (const? 32 8)) (const? 32 5)) (LLVM.xor e (const? 32 1234)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -56,7 +56,7 @@ theorem test5_thm (e : IntW 32) :
 
 theorem test6_thm (e : IntW 32) :
   add (lshr (LLVM.xor e (const? 32 1234)) (const? 32 16)) (LLVM.xor e (const? 32 1234)) ⊑
-    add (lshr e (const? 32 16)) (LLVM.xor e (const? 32 1234)) := by 
+    add (lshr e (const? 32 16)) (LLVM.xor e (const? 32 1234)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -65,7 +65,7 @@ theorem test6_thm (e : IntW 32) :
 
 
 theorem test7_thm (e e_1 : IntW 32) :
-  LLVM.xor (LLVM.or e_1 e) (LLVM.xor e_1 (const? 32 (-1))) ⊑ LLVM.or e_1 (LLVM.xor e (const? 32 (-1))) := by 
+  LLVM.xor (LLVM.or e_1 e) (LLVM.xor e_1 (const? 32 (-1))) ⊑ LLVM.or e_1 (LLVM.xor e (const? 32 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -74,7 +74,7 @@ theorem test7_thm (e e_1 : IntW 32) :
 
 
 theorem test8_thm (e e_1 : IntW 32) :
-  LLVM.xor (LLVM.xor e_1 (const? 32 (-1))) (LLVM.or e_1 e) ⊑ LLVM.or e_1 (LLVM.xor e (const? 32 (-1))) := by 
+  LLVM.xor (LLVM.xor e_1 (const? 32 (-1))) (LLVM.or e_1 e) ⊑ LLVM.or e_1 (LLVM.xor e (const? 32 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -82,7 +82,7 @@ theorem test8_thm (e e_1 : IntW 32) :
     all_goals sorry
 
 
-theorem test9_thm (e e_1 : IntW 32) : LLVM.xor (LLVM.and e_1 e) (LLVM.xor e_1 e) ⊑ LLVM.or e_1 e := by 
+theorem test9_thm (e e_1 : IntW 32) : LLVM.xor (LLVM.and e_1 e) (LLVM.xor e_1 e) ⊑ LLVM.or e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -90,7 +90,7 @@ theorem test9_thm (e e_1 : IntW 32) : LLVM.xor (LLVM.and e_1 e) (LLVM.xor e_1 e)
     all_goals sorry
 
 
-theorem test9b_thm (e e_1 : IntW 32) : LLVM.xor (LLVM.and e_1 e) (LLVM.xor e e_1) ⊑ LLVM.or e_1 e := by 
+theorem test9b_thm (e e_1 : IntW 32) : LLVM.xor (LLVM.and e_1 e) (LLVM.xor e e_1) ⊑ LLVM.or e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -98,7 +98,7 @@ theorem test9b_thm (e e_1 : IntW 32) : LLVM.xor (LLVM.and e_1 e) (LLVM.xor e e_1
     all_goals sorry
 
 
-theorem test10_thm (e e_1 : IntW 32) : LLVM.xor (LLVM.xor e_1 e) (LLVM.and e_1 e) ⊑ LLVM.or e_1 e := by 
+theorem test10_thm (e e_1 : IntW 32) : LLVM.xor (LLVM.xor e_1 e) (LLVM.and e_1 e) ⊑ LLVM.or e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -106,7 +106,7 @@ theorem test10_thm (e e_1 : IntW 32) : LLVM.xor (LLVM.xor e_1 e) (LLVM.and e_1 e
     all_goals sorry
 
 
-theorem test10b_thm (e e_1 : IntW 32) : LLVM.xor (LLVM.xor e_1 e) (LLVM.and e e_1) ⊑ LLVM.or e_1 e := by 
+theorem test10b_thm (e e_1 : IntW 32) : LLVM.xor (LLVM.xor e_1 e) (LLVM.and e e_1) ⊑ LLVM.or e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -116,7 +116,7 @@ theorem test10b_thm (e e_1 : IntW 32) : LLVM.xor (LLVM.xor e_1 e) (LLVM.and e e_
 
 theorem test11_thm (e e_1 : IntW 32) :
   LLVM.and (LLVM.xor e_1 e) (LLVM.xor (LLVM.xor e (const? 32 (-1))) e_1) ⊑
-    LLVM.and (LLVM.xor e_1 e) (LLVM.xor (LLVM.xor e e_1) (const? 32 (-1))) := by 
+    LLVM.and (LLVM.xor e_1 e) (LLVM.xor (LLVM.xor e e_1) (const? 32 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -126,7 +126,7 @@ theorem test11_thm (e e_1 : IntW 32) :
 
 theorem test11b_thm (e e_1 : IntW 32) :
   LLVM.and (LLVM.xor (LLVM.xor e_1 (const? 32 (-1))) e) (LLVM.xor e e_1) ⊑
-    LLVM.and (LLVM.xor e e_1) (LLVM.xor (LLVM.xor e_1 e) (const? 32 (-1))) := by 
+    LLVM.and (LLVM.xor e e_1) (LLVM.xor (LLVM.xor e_1 e) (const? 32 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -136,7 +136,7 @@ theorem test11b_thm (e e_1 : IntW 32) :
 
 theorem test11c_thm (e e_1 : IntW 32) :
   LLVM.and (LLVM.xor e_1 e) (LLVM.xor (LLVM.xor e_1 (const? 32 (-1))) e) ⊑
-    LLVM.and (LLVM.xor e_1 e) (LLVM.xor (LLVM.xor e_1 e) (const? 32 (-1))) := by 
+    LLVM.and (LLVM.xor e_1 e) (LLVM.xor (LLVM.xor e_1 e) (const? 32 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -146,7 +146,7 @@ theorem test11c_thm (e e_1 : IntW 32) :
 
 theorem test11d_thm (e e_1 : IntW 32) :
   LLVM.and (LLVM.xor (LLVM.xor e_1 (const? 32 (-1))) e) (LLVM.xor e_1 e) ⊑
-    LLVM.and (LLVM.xor e_1 e) (LLVM.xor (LLVM.xor e_1 e) (const? 32 (-1))) := by 
+    LLVM.and (LLVM.xor e_1 e) (LLVM.xor (LLVM.xor e_1 e) (const? 32 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -156,7 +156,7 @@ theorem test11d_thm (e e_1 : IntW 32) :
 
 theorem test11e_thm (e e_1 e_2 : IntW 32) :
   LLVM.and (LLVM.xor (mul e_2 e_1) e) (LLVM.xor (mul e_2 e_1) (LLVM.xor e (const? 32 (-1)))) ⊑
-    LLVM.and (LLVM.xor (mul e_2 e_1) e) (LLVM.xor (LLVM.xor e (mul e_2 e_1)) (const? 32 (-1))) := by 
+    LLVM.and (LLVM.xor (mul e_2 e_1) e) (LLVM.xor (LLVM.xor e (mul e_2 e_1)) (const? 32 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -166,7 +166,7 @@ theorem test11e_thm (e e_1 e_2 : IntW 32) :
 
 theorem test11f_thm (e e_1 e_2 : IntW 32) :
   LLVM.and (LLVM.xor (mul e_2 e_1) (LLVM.xor e (const? 32 (-1)))) (LLVM.xor (mul e_2 e_1) e) ⊑
-    LLVM.and (LLVM.xor (mul e_2 e_1) e) (LLVM.xor (LLVM.xor e (mul e_2 e_1)) (const? 32 (-1))) := by 
+    LLVM.and (LLVM.xor (mul e_2 e_1) e) (LLVM.xor (LLVM.xor e (mul e_2 e_1)) (const? 32 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -176,7 +176,7 @@ theorem test11f_thm (e e_1 e_2 : IntW 32) :
 
 theorem test12_thm (e e_1 : IntW 32) :
   LLVM.xor (LLVM.and e_1 (LLVM.xor e (const? 32 (-1)))) (LLVM.xor e_1 (const? 32 (-1))) ⊑
-    LLVM.xor (LLVM.and e_1 e) (const? 32 (-1)) := by 
+    LLVM.xor (LLVM.and e_1 e) (const? 32 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -186,7 +186,7 @@ theorem test12_thm (e e_1 : IntW 32) :
 
 theorem test12commuted_thm (e e_1 : IntW 32) :
   LLVM.xor (LLVM.and (LLVM.xor e_1 (const? 32 (-1))) e) (LLVM.xor e (const? 32 (-1))) ⊑
-    LLVM.xor (LLVM.and e e_1) (const? 32 (-1)) := by 
+    LLVM.xor (LLVM.and e e_1) (const? 32 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -196,7 +196,7 @@ theorem test12commuted_thm (e e_1 : IntW 32) :
 
 theorem test13_thm (e e_1 : IntW 32) :
   LLVM.xor (LLVM.xor e_1 (const? 32 (-1))) (LLVM.and e_1 (LLVM.xor e (const? 32 (-1)))) ⊑
-    LLVM.xor (LLVM.and e_1 e) (const? 32 (-1)) := by 
+    LLVM.xor (LLVM.and e_1 e) (const? 32 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -206,7 +206,7 @@ theorem test13_thm (e e_1 : IntW 32) :
 
 theorem test13commuted_thm (e e_1 : IntW 32) :
   LLVM.xor (LLVM.xor e_1 (const? 32 (-1))) (LLVM.and (LLVM.xor e (const? 32 (-1))) e_1) ⊑
-    LLVM.xor (LLVM.and e_1 e) (const? 32 (-1)) := by 
+    LLVM.xor (LLVM.and e_1 e) (const? 32 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -215,7 +215,7 @@ theorem test13commuted_thm (e e_1 : IntW 32) :
 
 
 theorem xor_or_xor_common_op_commute1_thm (e e_1 e_2 : IntW 32) :
-  LLVM.xor (LLVM.xor e_2 e_1) (LLVM.or e_2 e) ⊑ LLVM.xor (LLVM.and e (LLVM.xor e_2 (const? 32 (-1)))) e_1 := by 
+  LLVM.xor (LLVM.xor e_2 e_1) (LLVM.or e_2 e) ⊑ LLVM.xor (LLVM.and e (LLVM.xor e_2 (const? 32 (-1)))) e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -224,7 +224,7 @@ theorem xor_or_xor_common_op_commute1_thm (e e_1 e_2 : IntW 32) :
 
 
 theorem xor_or_xor_common_op_commute2_thm (e e_1 e_2 : IntW 32) :
-  LLVM.xor (LLVM.xor e_2 e_1) (LLVM.or e_1 e) ⊑ LLVM.xor (LLVM.and e (LLVM.xor e_1 (const? 32 (-1)))) e_2 := by 
+  LLVM.xor (LLVM.xor e_2 e_1) (LLVM.or e_1 e) ⊑ LLVM.xor (LLVM.and e (LLVM.xor e_1 (const? 32 (-1)))) e_2 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -233,7 +233,7 @@ theorem xor_or_xor_common_op_commute2_thm (e e_1 e_2 : IntW 32) :
 
 
 theorem xor_or_xor_common_op_commute3_thm (e e_1 e_2 : IntW 32) :
-  LLVM.xor (LLVM.xor e_2 e_1) (LLVM.or e e_2) ⊑ LLVM.xor (LLVM.and e (LLVM.xor e_2 (const? 32 (-1)))) e_1 := by 
+  LLVM.xor (LLVM.xor e_2 e_1) (LLVM.or e e_2) ⊑ LLVM.xor (LLVM.and e (LLVM.xor e_2 (const? 32 (-1)))) e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -242,7 +242,7 @@ theorem xor_or_xor_common_op_commute3_thm (e e_1 e_2 : IntW 32) :
 
 
 theorem xor_or_xor_common_op_commute4_thm (e e_1 e_2 : IntW 32) :
-  LLVM.xor (LLVM.xor e_2 e_1) (LLVM.or e e_1) ⊑ LLVM.xor (LLVM.and e (LLVM.xor e_1 (const? 32 (-1)))) e_2 := by 
+  LLVM.xor (LLVM.xor e_2 e_1) (LLVM.or e e_1) ⊑ LLVM.xor (LLVM.and e (LLVM.xor e_1 (const? 32 (-1)))) e_2 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -251,7 +251,7 @@ theorem xor_or_xor_common_op_commute4_thm (e e_1 e_2 : IntW 32) :
 
 
 theorem xor_or_xor_common_op_commute5_thm (e e_1 e_2 : IntW 32) :
-  LLVM.xor (LLVM.or e_2 e_1) (LLVM.xor e_2 e) ⊑ LLVM.xor (LLVM.and e_1 (LLVM.xor e_2 (const? 32 (-1)))) e := by 
+  LLVM.xor (LLVM.or e_2 e_1) (LLVM.xor e_2 e) ⊑ LLVM.xor (LLVM.and e_1 (LLVM.xor e_2 (const? 32 (-1)))) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -260,7 +260,7 @@ theorem xor_or_xor_common_op_commute5_thm (e e_1 e_2 : IntW 32) :
 
 
 theorem xor_or_xor_common_op_commute6_thm (e e_1 e_2 : IntW 32) :
-  LLVM.xor (LLVM.or e_2 e_1) (LLVM.xor e e_2) ⊑ LLVM.xor (LLVM.and e_1 (LLVM.xor e_2 (const? 32 (-1)))) e := by 
+  LLVM.xor (LLVM.or e_2 e_1) (LLVM.xor e e_2) ⊑ LLVM.xor (LLVM.and e_1 (LLVM.xor e_2 (const? 32 (-1)))) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -269,7 +269,7 @@ theorem xor_or_xor_common_op_commute6_thm (e e_1 e_2 : IntW 32) :
 
 
 theorem xor_or_xor_common_op_commute7_thm (e e_1 e_2 : IntW 32) :
-  LLVM.xor (LLVM.or e_2 e_1) (LLVM.xor e_1 e) ⊑ LLVM.xor (LLVM.and e_2 (LLVM.xor e_1 (const? 32 (-1)))) e := by 
+  LLVM.xor (LLVM.or e_2 e_1) (LLVM.xor e_1 e) ⊑ LLVM.xor (LLVM.and e_2 (LLVM.xor e_1 (const? 32 (-1)))) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -278,7 +278,7 @@ theorem xor_or_xor_common_op_commute7_thm (e e_1 e_2 : IntW 32) :
 
 
 theorem xor_or_xor_common_op_commute8_thm (e e_1 e_2 : IntW 32) :
-  LLVM.xor (LLVM.or e_2 e_1) (LLVM.xor e e_1) ⊑ LLVM.xor (LLVM.and e_2 (LLVM.xor e_1 (const? 32 (-1)))) e := by 
+  LLVM.xor (LLVM.or e_2 e_1) (LLVM.xor e e_1) ⊑ LLVM.xor (LLVM.and e_2 (LLVM.xor e_1 (const? 32 (-1)))) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -289,7 +289,7 @@ theorem xor_or_xor_common_op_commute8_thm (e e_1 e_2 : IntW 32) :
 theorem test15_thm (e e_1 : IntW 8) :
   mul (LLVM.and (LLVM.xor e_1 e) (LLVM.xor (LLVM.xor e (const? 8 33)) e_1)) (LLVM.xor (LLVM.xor e (const? 8 33)) e_1) ⊑
     mul (LLVM.and (LLVM.xor e_1 e) (LLVM.xor (LLVM.xor e e_1) (const? 8 33)))
-      (LLVM.xor (LLVM.xor e e_1) (const? 8 33)) := by 
+      (LLVM.xor (LLVM.xor e e_1) (const? 8 33)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -300,7 +300,7 @@ theorem test15_thm (e e_1 : IntW 8) :
 theorem test16_thm (e e_1 : IntW 8) :
   mul (LLVM.and (LLVM.xor (LLVM.xor e_1 (const? 8 33)) e) (LLVM.xor e e_1)) (LLVM.xor (LLVM.xor e_1 (const? 8 33)) e) ⊑
     mul (LLVM.and (LLVM.xor (LLVM.xor e_1 e) (const? 8 33)) (LLVM.xor e e_1))
-      (LLVM.xor (LLVM.xor e_1 e) (const? 8 33)) := by 
+      (LLVM.xor (LLVM.xor e_1 e) (const? 8 33)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -310,7 +310,7 @@ theorem test16_thm (e e_1 : IntW 8) :
 
 theorem not_xor_to_or_not1_thm (e e_1 e_2 : IntW 3) :
   LLVM.xor (LLVM.xor (LLVM.and e_2 e_1) (LLVM.or e e_1)) (const? 3 (-1)) ⊑
-    LLVM.or (LLVM.and e_2 e_1) (LLVM.xor (LLVM.or e e_1) (const? 3 (-1))) := by 
+    LLVM.or (LLVM.and e_2 e_1) (LLVM.xor (LLVM.or e e_1) (const? 3 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -320,7 +320,7 @@ theorem not_xor_to_or_not1_thm (e e_1 e_2 : IntW 3) :
 
 theorem not_xor_to_or_not2_thm (e e_1 e_2 : IntW 3) :
   LLVM.xor (LLVM.xor (LLVM.and e_2 e_1) (LLVM.or e_1 e)) (const? 3 (-1)) ⊑
-    LLVM.or (LLVM.and e_2 e_1) (LLVM.xor (LLVM.or e_1 e) (const? 3 (-1))) := by 
+    LLVM.or (LLVM.and e_2 e_1) (LLVM.xor (LLVM.or e_1 e) (const? 3 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -330,7 +330,7 @@ theorem not_xor_to_or_not2_thm (e e_1 e_2 : IntW 3) :
 
 theorem not_xor_to_or_not3_thm (e e_1 e_2 : IntW 3) :
   LLVM.xor (LLVM.xor (LLVM.and e_2 e_1) (LLVM.or e_2 e)) (const? 3 (-1)) ⊑
-    LLVM.or (LLVM.and e_2 e_1) (LLVM.xor (LLVM.or e_2 e) (const? 3 (-1))) := by 
+    LLVM.or (LLVM.and e_2 e_1) (LLVM.xor (LLVM.or e_2 e) (const? 3 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -340,7 +340,7 @@ theorem not_xor_to_or_not3_thm (e e_1 e_2 : IntW 3) :
 
 theorem not_xor_to_or_not4_thm (e e_1 e_2 : IntW 3) :
   LLVM.xor (LLVM.xor (LLVM.and e_2 e_1) (LLVM.or e e_2)) (const? 3 (-1)) ⊑
-    LLVM.or (LLVM.and e_2 e_1) (LLVM.xor (LLVM.or e e_2) (const? 3 (-1))) := by 
+    LLVM.or (LLVM.and e_2 e_1) (LLVM.xor (LLVM.or e e_2) (const? 3 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -350,7 +350,7 @@ theorem not_xor_to_or_not4_thm (e e_1 e_2 : IntW 3) :
 
 theorem xor_notand_to_or_not1_thm (e e_1 e_2 : IntW 3) :
   LLVM.xor (LLVM.xor (LLVM.and e_2 e_1) (const? 3 (-1))) (LLVM.or e e_1) ⊑
-    LLVM.or (LLVM.and e_2 e_1) (LLVM.xor (LLVM.or e e_1) (const? 3 (-1))) := by 
+    LLVM.or (LLVM.and e_2 e_1) (LLVM.xor (LLVM.or e e_1) (const? 3 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -360,7 +360,7 @@ theorem xor_notand_to_or_not1_thm (e e_1 e_2 : IntW 3) :
 
 theorem xor_notand_to_or_not2_thm (e e_1 e_2 : IntW 3) :
   LLVM.xor (LLVM.xor (LLVM.and e_2 e_1) (const? 3 (-1))) (LLVM.or e_1 e) ⊑
-    LLVM.or (LLVM.and e_2 e_1) (LLVM.xor (LLVM.or e_1 e) (const? 3 (-1))) := by 
+    LLVM.or (LLVM.and e_2 e_1) (LLVM.xor (LLVM.or e_1 e) (const? 3 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -370,7 +370,7 @@ theorem xor_notand_to_or_not2_thm (e e_1 e_2 : IntW 3) :
 
 theorem xor_notand_to_or_not3_thm (e e_1 e_2 : IntW 3) :
   LLVM.xor (LLVM.xor (LLVM.and e_2 e_1) (const? 3 (-1))) (LLVM.or e_2 e) ⊑
-    LLVM.or (LLVM.and e_2 e_1) (LLVM.xor (LLVM.or e_2 e) (const? 3 (-1))) := by 
+    LLVM.or (LLVM.and e_2 e_1) (LLVM.xor (LLVM.or e_2 e) (const? 3 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -380,11 +380,9 @@ theorem xor_notand_to_or_not3_thm (e e_1 e_2 : IntW 3) :
 
 theorem xor_notand_to_or_not4_thm (e e_1 e_2 : IntW 3) :
   LLVM.xor (LLVM.xor (LLVM.and e_2 e_1) (const? 3 (-1))) (LLVM.or e e_2) ⊑
-    LLVM.or (LLVM.and e_2 e_1) (LLVM.xor (LLVM.or e e_2) (const? 3 (-1))) := by 
+    LLVM.or (LLVM.and e_2 e_1) (LLVM.xor (LLVM.or e e_2) (const? 3 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
     try alive_auto
     all_goals sorry
-
-


### PR DESCRIPTION
Add support for eliminating the conditions for undef-tracking as well as support for folding over `Option.bind_some'`. While at it, update the LLVM semantics to use symbols such as `^^^` instead of `BitVec.xor`.

This change should make `simp_alive_case_bash` trigger more often, as the conditions previously prevented it from working.

Before this change we got:

```lean
e : IntW 32
⊢ (do
    let x ← e
    let x_1 ← some (BitVec.ofInt 32 32)
    let x ← some (x.and x_1)
    let x_2 ← some (BitVec.ofInt 32 145)
    let x' ←
      if false = true ∧ x.msb = x_2.msb ∧ (x + x_2).msb ≠ x.msb then none
        else if false = true ∧ (x + x_2 < x ∨ x + x_2 < x_2) then none else some (x.add x_2)
    let y' ← some (BitVec.ofInt 32 153)
    some (x'.xor y')) ⊑
  do
  let x ← e
  let x_1 ← some (BitVec.ofInt 32 32)
  let x' ← some (x.and x_1)
  let y' ← some (BitVec.ofInt 32 8)
  if false = true ∧ (x' &&& y' != 0) = true then none else some (x'.or y')
```

After this change we get the following output:

```lean
e : IntW 32
⊢ (do
    let x ← e
    some ((x &&& 32#32) + 145#32 ^^^ 153#32)) ⊑
  do
  let x ← e
  some (x &&& 32#32 ||| 8#32)
```