### PR TITLE
chore: unhide 'IntW' and hoist 'ifs'

### DIFF
--- a/SSA/Projects/InstCombine/AliveHandwrittenLargeExamples.lean
+++ b/SSA/Projects/InstCombine/AliveHandwrittenLargeExamples.lean
@@ -361,6 +361,7 @@ def alive_simplifyMulDivRem290 (w : Nat) :
   simp_alive_ssa
   simp_alive_undef
   simp_alive_ops
+  simp_alive_case_bash
   alive_auto
 
 /-- info: 'AliveHandwritten.MulDivRem.alive_simplifyMulDivRem290' depends on axioms: [propext, Classical.choice, Quot.sound] -/
@@ -412,6 +413,7 @@ def alive_simplifyAndOrXor2515 (w : Nat) :
   simp only [simp_llvm_wrap]
   simp_alive_ssa
   simp_alive_undef
+  simp_alive_case_bash
   alive_auto
 
 /-- info: 'AliveHandwritten.AndOrXor.alive_simplifyAndOrXor2515' depends on axioms:

--- a/SSA/Projects/InstCombine/ForLean.lean
+++ b/SSA/Projects/InstCombine/ForLean.lean
@@ -528,3 +528,13 @@ end Bool
 
 theorem Option.some_bind'' (x : α) (f : α → Option β) : some x >>= f = f x := by
   simp
+
+@[simp]
+theorem bind_if_then_none_eq_if_bind (h : Prop) [Decidable h] (x : Option α) :
+    (if h then none else x) >>= f = if h then none else x >>= f := by
+  split <;> simp
+
+@[simp]
+theorem bind_if_else_none_eq_if_bind (h : Prop) [Decidable h] (x : Option α) :
+    (if h then x else none) >>= f = if h then x >>= f else none := by
+  split <;> simp

--- a/SSA/Projects/InstCombine/LLVM/Semantics.lean
+++ b/SSA/Projects/InstCombine/LLVM/Semantics.lean
@@ -12,7 +12,7 @@ import SSA.Projects.InstCombine.LLVM.SimpSet
 namespace LLVM
 
 
-def IntW w := Option <| BitVec w
+abbrev IntW w := Option <| BitVec w
 
 /--
 The ‘and’ instruction returns the bitwise logical and of its two operands.

--- a/SSA/Projects/InstCombine/PaperExamples.lean
+++ b/SSA/Projects/InstCombine/PaperExamples.lean
@@ -30,18 +30,9 @@ theorem shift_mul:
   simp_alive_peephole
   simp_alive_undef
   simp_alive_ops
-  intros A B
-  rcases A with rfl | A  <;>
-  rcases B with rfl | B  <;> (try (simp only [Bool.false_eq_true, shiftLeft_eq', false_and, ↓reduceIte, ushiftRight_eq', natCast_eq_ofNat,
-  ge_iff_le, EffectKind.return_impure_toMonad_eq, Option.pure_def, truncate_eq_setWidth, ofNat_eq_ofNat, toNat_ofNat,
-  mul_eq, Option.bind_eq_bind, Option.some_bind, Option.none_bind, Option.bind_none, Refinement.refl]; done)) ;
-  by_cases h : (BitVec.ofNat w w) ≤ B <;>
-    simp only [Bool.false_eq_true, shiftLeft_eq', false_and, ↓reduceIte, ushiftRight_eq',
-      natCast_eq_ofNat, ge_iff_le, EffectKind.return_impure_toMonad_eq, Option.pure_def,
-      truncate_eq_setWidth, ofNat_eq_ofNat, toNat_ofNat, mul_eq, Option.bind_eq_bind,
-      Option.some_bind, Refinement.refl, h]
-  simp
-  simp
+  simp_alive_case_bash
+  · simp
+  · simp
 
 /--
 info: 'AlivePaperExamples.shift_mul' depends on axioms: [propext, Classical.choice, Quot.sound]

--- a/SSA/Projects/InstCombine/TacticAuto.lean
+++ b/SSA/Projects/InstCombine/TacticAuto.lean
@@ -109,7 +109,8 @@ macro "simp_alive_ops" : tactic =>
             simp_llvm,
             BitVec.ofInt_neg_one,
             (BitVec.ofInt_ofNat),
-            pure_bind
+            pure_bind,
+            bind_if_then_none_eq_if_bind, bind_if_else_none_eq_if_bind
           ]
       )
   )


### PR DESCRIPTION
This is required to hoist monadic ifs (via  bind_if_then_none_eq_if_bind, bind_if_else_none_eq_if_bind), which subsquently will allow us to eliminate the option monad more reliably.