### PR TITLE
chore: force bv_compare

### DIFF
--- a/SSA/Projects/InstCombine/TacticAuto.lean
+++ b/SSA/Projects/InstCombine/TacticAuto.lean
@@ -219,9 +219,7 @@ macro "alive_auto": tactic =>
 macro "bv_compare'": tactic =>
   `(tactic|
       (
-        first
-        | bv_compare
-        | bv_decide
+        bv_decide
       )
    )
 
@@ -242,6 +240,6 @@ macro "simp_alive_split": tactic =>
 macro "simp_alive_benchmark": tactic =>
   `(tactic|
       (
-        all_goals bv_compare'
+        all_goals bv_compare
       )
    )


### PR DESCRIPTION
It seems I broke something last minute:

```lean
section gxor2_proof
theorem test0_thm (e : IntW 32) :
  icmp IntPredicate.sgt (LLVM.xor e (const? 32 (-2147483648))) (const? 32 (-1)) ⊑
    icmp IntPredicate.slt e (const? 32 0) := by 
    simp_alive_undef
    simp_alive_ops
    simp_alive_case_bash
    simp_alive_split
    /-
    tactic 'apply' failed, failed to unify
      ?p
    with
      ofBool (_fvar.1399 ^^^ 2147483648#32 >ₛ -1#32) = ofBool (0#32 >ₛ _fvar.1399)
    
    e : IntW 32
    ⊢ ofBool (_fvar.1399 ^^^ 2147483648#32 >ₛ -1#32) = ofBool (0#32 >ₛ _fvar.1399)
    -/
    bv_compare
    all_goals sorry
```