### PR TITLE
chore: run bv_compare unconditionally in LLVM tests

### DIFF
--- a/SSA/Projects/InstCombine/TacticAuto.lean
+++ b/SSA/Projects/InstCombine/TacticAuto.lean
@@ -226,9 +226,8 @@ macro "alive_auto": tactic =>
 macro "bv_compare'": tactic =>
   `(tactic|
       (
-        first
-        | bv_compare
-        | bv_decide
+        try bv_compare
+        try bv_decide
       )
    )
 


### PR DESCRIPTION
This avoids 'declaration has metavariable' bug.