### PR TITLE
chore: fold a bit more after splitting the theorem

### DIFF
--- a/SSA/Projects/InstCombine/TacticAuto.lean
+++ b/SSA/Projects/InstCombine/TacticAuto.lean
@@ -237,14 +237,14 @@ macro "simp_alive_split": tactic =>
       (
         all_goals try intros
         repeat(
-          all_goals try simp only [BitVec.Refinement.some_some, BitVec.Refinement.refl,
+          all_goals try simp only [BitVec.Refinement.some_some, BitVec.Refinement.refl, Option.some_bind'',
             BitVec.Refinement.none_left, Option.some_bind, Option.bind_none, Option.none_bind, Option.some.injEq]
-          all_goals try simp only [BitVec.Refinement.some_some, BitVec.Refinement.refl,
+          all_goals try simp only [BitVec.Refinement.some_some, BitVec.Refinement.refl, Option.some_bind'',
             BitVec.Refinement.none_left, Option, some_bind, Option.bind_none, Option.none_bind, Option.some.injEq] at *
           any_goals split
-          all_goals try simp only [BitVec.Refinement.some_some, BitVec.Refinement.refl,
+          all_goals try simp only [BitVec.Refinement.some_some, BitVec.Refinement.refl, Option.some_bind'',
             BitVec.Refinement.none_left, Option.some_bind, Option.bind_none, Option.none_bind, Option.some.injEq]
-          all_goals try simp only [BitVec.Refinement.some_some, BitVec.Refinement.refl,
+          all_goals try simp only [BitVec.Refinement.some_some, BitVec.Refinement.refl, Option.some_bind'',
             BitVec.Refinement.none_left, Option.some_bind, Option.bind_none, Option.none_bind, Option.some.injEq] at *
         )
       )


### PR DESCRIPTION
This will avoid at least one more "None of the hypotheses are in the supported BitVec fragment."