### PR TITLE
llvm: add BitVec.mul_add to bv_normalize

### DIFF
--- a/SSA/Projects/InstCombine/ForLean.lean
+++ b/SSA/Projects/InstCombine/ForLean.lean
@@ -459,6 +459,8 @@ theorem sdiv_allOnes {w : ℕ} {x : BitVec w} :
     simp [BitVec.eq_nil x]
   · rw [BitVec.msb_allOnes (by omega)]
     by_cases h : x.msb <;> simp [h, BitVec.neg_allOnes]
+
+attribute [bv_normalize] BitVec.mul_add
 end BitVec
 
 namespace Bool


### PR DESCRIPTION
This change solves for more theorems (instead of timing out):

leanSAT and Bitwuzla solved: 6812
leanSAT and Bitwuzla provided 0 counterexamples
leanSAT and Bitwuzla both failed on 61 theorems
leanSAT failed and Bitwuzla succeeded on 22 theorems
leanSAT succeeded and Bitwuzla failed on 0 theorems
There were 0 inconsistencies
Errors raised: 999
error (deterministic) timeout at `whnf`, maximum number of heartbeats (200000) has been reached was raised 32 times
error (kernel) deep recursion detected was raised 3 times
error (kernel) deterministic timeout was raised 377 times
error None of the hypotheses are in the supported BitVec fragment. was raised 6 times
error The SAT solver timed out while solving the problem. was raised 80 times
error The SMT solver timed out while solving the problem. was raised 58 times
error application type mismatch was raised 2 times
error error evaluating configuration was raised 360 times
error maximum recursion depth has been reached was raised 7 times
error tactic 'simp' failed, nested error: was raised 74 times