### PR TITLE
chore: clear results folders before running tests

### DIFF
--- a/bv-evaluation/compare-leansat-vs-bitwuzla-hdel.py
+++ b/bv-evaluation/compare-leansat-vs-bitwuzla-hdel.py
@@ -11,6 +11,16 @@ reps = 1
 
 bv_width = [4, 8, 16, 32, 64]
 
+for file in os.listdir(results_dir):
+    file_path = os.path.join(results_dir, file)
+    try:
+        if os.path.isfile(file_path) or os.path.islink(file_path):
+            os.unlink(file_path)
+        elif os.path.isdir(file_path):
+            shutil.rmtree(file_path)
+    except Exception as e:
+        print('Failed to delete %s. Reason: %s' % (file_path, e))
+
 for file in os.listdir(benchmark_dir_list):
     print(file)
     for bvw in bv_width:

--- a/bv-evaluation/compare-leansat-vs-bitwuzla-hdel.py
+++ b/bv-evaluation/compare-leansat-vs-bitwuzla-hdel.py
@@ -1,5 +1,6 @@
 import subprocess
 import os 
+import shutil 
 
 results_dir = "bv-evaluation/results/HackersDelight/"
 

--- a/bv-evaluation/compare-leansat-vs-bitwuzla-llvm.py
+++ b/bv-evaluation/compare-leansat-vs-bitwuzla-llvm.py
@@ -2,6 +2,7 @@ import subprocess
 import os
 import concurrent.futures
 import argparse
+import shutil
 
 ROOT_DIR = subprocess.check_output(['git', 'rev-parse', '--show-toplevel']).decode('utf-8').strip()
 
@@ -10,6 +11,17 @@ RESULTS_DIR = ROOT_DIR + '/bv-evaluation/results/llvm/'
 BENCHMARK_DIR = ROOT_DIR + '/SSA/Projects/InstCombine/tests/proofs/'
 
 REPS = 1
+
+def clear_folder():
+    for file in os.listdir(RESULTS_DIR):
+        file_path = os.path.join(RESULTS_DIR, file)
+        try:
+            if os.path.isfile(file_path) or os.path.islink(file_path):
+                os.unlink(file_path)
+            elif os.path.isdir(file_path):
+                shutil.rmtree(file_path)
+        except Exception as e:
+            print('Failed to delete %s. Reason: %s' % (file_path, e))
 
 def run_file(file: str):
     file_path = BENCHMARK_DIR + file
@@ -44,4 +56,5 @@ def process(jobs: int):
 parser = argparse.ArgumentParser(prog='compare-leansat-vs-bitwuzla-llvm')
 parser.add_argument('-j', '--jobs', type=int, default=1)
 args = parser.parse_args()
+clear_folder()
 process(args.jobs)


### PR DESCRIPTION
changed `compare-leansat-vs-bitwuzla` scripts to clear the results directories before running the tests.