### PR TITLE
feat: update hash of Lean extension in shell.nix

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -20,7 +20,7 @@ mkShell {
         name = "lean4";
         publisher = "leanprover";
         version = "latest";
-        sha256 = "sha256-V2ZjimjLdWjy2ARQY9d5bASOxImVQcSVY/sqMIogiDw=";
+        sha256 = "sha256-9i/cYAvdGDGnw8o0HZtVWYKF6FSuaoiHPGg7w3Xz3n8=";
       }
     ];
     })


### PR DESCRIPTION
We've pinned the version of the Lean extension in `shell.nix` to the latest, so this PR updates the SHA hash to match what is currently being served as the latest version of the extension.