### PR TITLE
feat: Add user-facing tactic bail out based on circuit complexity

### DIFF
--- a/SSA/Experimental/Bits/Fast/Circuit.lean
+++ b/SSA/Experimental/Bits/Fast/Circuit.lean
@@ -24,6 +24,14 @@ namespace Circuit
 
 variable {α : Type u} {β : Type v}
 
+/--
+Compute the size of the circuit.
+Leaf nodes take 1 size, and internal nodes take 1 + size of children.
+-/
+def size (α : Type u) : Circuit α → Nat
+| tru | fals | var .. => 1
+| and l r | or l r | xor l r => 1 + l.size  + r.size
+
 def vars [DecidableEq α] : Circuit α → List α
   | tru => []
   | fals => []

--- a/SSA/Experimental/Bits/Fast/FiniteStateMachine.lean
+++ b/SSA/Experimental/Bits/Fast/FiniteStateMachine.lean
@@ -44,6 +44,23 @@ namespace FSM
 
 variable {arity : Type} (p : FSM arity)
 
+instance : Std.Commutative Nat.add where
+  comm := fun a b => by simp only [Nat.add_eq]; omega
+
+instance : Std.Associative Nat.add where
+  assoc := fun a b => by simp only [Nat.add_eq]; omega
+
+/--
+Return the total size of the FSM as a function of all of its circuits.
+Note that this implicitly counts the size of the state space of the FSM,
+and consequently, is the natural notion of complexity of the FSM.
+-/
+def circuitSize : Nat := Id.run do
+  let outCircSize := p.nextBitCirc none |>.size
+  let states := @Finset.univ p.α inferInstance
+  let stateCircSize := Finset.fold Nat.add  0 (fun a => p.nextBitCirc (.some a) |>.size) states
+  return outCircSize + stateCircSize
+
 /-- The state of FSM `p` is given by a function from `p.α` to `Bool`.
 
 Note that `p.α` is assumed to be a finite type, so `p.State` is morally

--- a/SSA/Experimental/Bits/Fast/Reflect.lean
+++ b/SSA/Experimental/Bits/Fast/Reflect.lean
@@ -47,6 +47,49 @@ def BitStream.denote (s : BitStream) (w : Nat) : BitVec w := s.toBitVec w
   simp [denote, toBitVec]
   sorry
 
+open Lean in
+def mkBoolLit (b : Bool) : Expr :=
+  match b with
+  | true => mkConst ``true
+  | false => mkConst ``false
+
+open Lean in
+def Term.quote (t : _root_.Term) : Expr :=
+  match t with
+  | ofNat n => mkApp (mkConst ``Term.ofNat) (mkNatLit n)
+  | var n => mkApp (mkConst ``Term.var) (mkNatLit n)
+  | zero => mkConst ``Term.zero
+  | one => mkConst ``Term.one
+  | negOne => mkConst ``Term.negOne
+  | decr t => mkApp (mkConst ``Term.decr) (t.quote)
+  | incr t => mkApp (mkConst ``Term.incr) (t.quote)
+  | neg t => mkApp (mkConst ``Term.neg) (t.quote)
+  | not t => mkApp (mkConst ``Term.not) (t.quote)
+  | ls b t => mkApp2 (mkConst ``Term.ls) (mkBoolLit b) (t.quote)
+  | sub t₁ t₂ => mkApp2 (mkConst ``Term.sub) (t₁.quote) (t₂.quote)
+  | add t₁ t₂ => mkApp2 (mkConst ``Term.add) (t₁.quote) (t₂.quote)
+  | xor t₁ t₂ => mkApp2 (mkConst ``Term.xor) (t₁.quote) (t₂.quote)
+  | or t₁ t₂ => mkApp2 (mkConst ``Term.or) (t₁.quote) (t₂.quote)
+  | and t₁ t₂ => mkApp2 (mkConst ``Term.and) (t₁.quote) (t₂.quote)
+
+open Lean in
+def Predicate.quote (p : _root_.Predicate) : Expr :=
+  match p with
+  | widthEq n => mkApp (mkConst ``Predicate.widthEq) (mkNatLit n)
+  | widthNeq n => mkApp (mkConst ``Predicate.widthNeq) (mkNatLit n)
+  | widthLt n => mkApp (mkConst ``Predicate.widthLt) (mkNatLit n)
+  | widthLe n => mkApp (mkConst ``Predicate.widthLe) (mkNatLit n)
+  | widthGt n => mkApp (mkConst ``Predicate.widthGt) (mkNatLit n)
+  | widthGe n => mkApp (mkConst ``Predicate.widthGe) (mkNatLit n)
+  | eq a b => mkApp2 (mkConst ``Predicate.eq) (_root_.Term.quote a) (_root_.Term.quote b)
+  | neq a b => mkApp2 (mkConst ``Predicate.neq) (_root_.Term.quote a) (_root_.Term.quote b)
+  | ult a b => mkApp2 (mkConst ``Predicate.ult) (_root_.Term.quote a) (_root_.Term.quote b)
+  | ule a b => mkApp2 (mkConst ``Predicate.ule) (_root_.Term.quote a) (_root_.Term.quote b)
+  | slt a b => mkApp2 (mkConst ``Predicate.slt) (_root_.Term.quote a) (_root_.Term.quote b)
+  | sle a b => mkApp2 (mkConst ``Predicate.sle) (_root_.Term.quote a) (_root_.Term.quote b)
+  | land p q => mkApp2 (mkConst ``Predicate.land) (Predicate.quote p) (Predicate.quote q)
+  | lor p q => mkApp2 (mkConst ``Predicate.lor) (Predicate.quote p) (Predicate.quote q)
+
 /-- Denote a Term into its underlying bitvector -/
 def Term.denote (w : Nat) (t : Term) (vars : List (BitVec w)) : BitVec w :=
   match t with
@@ -87,6 +130,14 @@ def Predicate.denote (p : Predicate) (w : Nat) (vars : List (BitVec w)) : Prop :
   | .slt  t₁ t₂ => ((t₁.denote w vars).slt (t₂.denote w vars)) = true
   | .ule  t₁ t₂ => ((t₁.denote w vars) ≤ (t₂.denote w vars))
   | .ult  t₁ t₂ => (t₁.denote w vars) < (t₂.denote w vars)
+
+/--
+The cost model of the predicate, which is based on the cardinality of the state space,
+and the size of the circuits.
+-/
+def Predicate.cost (p : Predicate) : Nat :=
+  let fsm := predicateEvalEqFSM p
+  fsm.circuitSize
 
 /--
 The semantics of a predicate:
@@ -233,14 +284,14 @@ abbrev ReflectedExpr := Expr
 Insert expression 'e' into the reflection map. This returns the map,
 as well as the denoted term.
 -/
-def ReflectMap.findOrInsertExpr (m : ReflectMap) (e : Expr) : ReflectedExpr × ReflectMap :=
+def ReflectMap.findOrInsertExpr (m : ReflectMap) (e : Expr) : _root_.Term × ReflectMap :=
   let (ix, m) := match m.exprs.get? e with
     | some ix =>  (ix, m)
     | none =>
       let ix := m.exprs.size
       (ix, { m with exprs := m.exprs.insert e ix })
-  let e :=  mkApp (mkConst ``Term.var) (mkNatLit ix)
-  (e, m)
+  -- let e :=  mkApp (mkConst ``Term.var) (mkNatLit ix)
+  (Term.var ix, m)
 
 
 /--
@@ -266,14 +317,14 @@ instance : ToMessageData ReflectMap where
 Result of reflection, where we have a collection of bitvector variables,
 along with the bitwidth and the final term.
 -/
-structure ReflectResult where
+structure ReflectResult (α : Type) where
   /-- Map of 'free variables' in the bitvector expression,
   which are indexed as Term.var. This array is used to build the environment for decide.
   -/
   bvToIxMap : ReflectMap
-  e : ReflectedExpr
+  e : α
 
-instance : ToMessageData ReflectResult where
+instance [ToMessageData α] : ToMessageData (ReflectResult α) where
   toMessageData result := m!"{result.e} {result.bvToIxMap}"
 
 
@@ -317,7 +368,7 @@ info: ∀ {w : Nat} (a : BitVec w),
 #check ∀ {w : Nat} (a : BitVec w),  a.slt 0#w
 
 
-def reflectAtomUnchecked (map : ReflectMap) (_w : Expr) (e : Expr) : MetaM ReflectResult := do
+def reflectAtomUnchecked (map : ReflectMap) (_w : Expr) (e : Expr) : MetaM (ReflectResult _root_.Term) := do
   let (e, map) := map.findOrInsertExpr e
   return { bvToIxMap := map, e := e }
 
@@ -329,15 +380,14 @@ and furthermore, it will reflect all terms as variables.
 
 Precondition: we assume that this is called on bitvectors.
 -/
-partial def reflectTermUnchecked (map : ReflectMap) (w : Expr) (e : Expr) : MetaM ReflectResult := do
+partial def reflectTermUnchecked (map : ReflectMap) (w : Expr) (e : Expr) : MetaM (ReflectResult _root_.Term) := do
   -- TODO: bitvector contants.
   match_expr e with
   | BitVec.ofInt _wExpr iExpr =>
     let i ← getIntValue? iExpr
     match i with
     | .some (-1) =>
-      let e := (mkConst ``Term.negOne)
-      return {bvToIxMap := map, e := e}
+      return {bvToIxMap := map, e := Term.negOne }
     | _ =>
       let (e, map) := map.findOrInsertExpr e
       return { bvToIxMap := map, e := e }
@@ -345,46 +395,48 @@ partial def reflectTermUnchecked (map : ReflectMap) (w : Expr) (e : Expr) : Meta
     let n ← getNatValue? nExpr
     match n with
     | .some 0 =>
-      let e := (mkConst ``Term.zero)
-      return {bvToIxMap := map, e := e}
+      return {bvToIxMap := map, e := Term.zero }
     | .some 1 =>
       let e := (mkConst ``Term.one)
-      return {bvToIxMap := map, e := e}
-    | _ =>
-      let e := mkApp (mkConst ``Term.ofNat) nExpr
-      return { bvToIxMap := map, e := e }
+      return {bvToIxMap := map, e := Term.one }
+    | .some n =>
+      return { bvToIxMap := map, e := Term.ofNat n }
+    | none =>
+      logWarning "expected concrete BitVec.ofNat, found symbol '{n}', creating free variable"
+      reflectAtomUnchecked map w e
+
   | HAnd.hAnd _bv _bv _bv _inst a b =>
       let a ← reflectTermUnchecked map w a
       let b ← reflectTermUnchecked a.bvToIxMap w b
-      let out := mkApp2 (mkConst ``Term.and) a.e b.e
+      let out := Term.and a.e b.e
       return { b with e := out }
   | HOr.hOr _bv _bv _bv _inst a b =>
       let a ← reflectTermUnchecked map w a
       let b ← reflectTermUnchecked a.bvToIxMap w b
-      let out := mkApp2 (mkConst ``Term.or) a.e b.e
+      let out := Term.or a.e b.e
       return { b with e := out }
   | HXor.hXor _bv _bv _bv _inst a b =>
       let a ← reflectTermUnchecked map w a
       let b ← reflectTermUnchecked a.bvToIxMap w b
-      let out := mkApp2 (mkConst ``Term.xor) a.e b.e
+      let out := Term.xor a.e b.e
       return { b with e := out }
   | Complement.complement _bv _inst a =>
       let a ← reflectTermUnchecked map w a
-      let out := mkApp (mkConst ``Term.not) a.e
+      let out := Term.not a.e
       return { a with e := out }
   | HAdd.hAdd _bv _bv _bv _inst a b =>
       let a ← reflectTermUnchecked map w a
       let b ← reflectTermUnchecked a.bvToIxMap w b
-      let out := mkApp2 (mkConst ``Term.add) a.e b.e
+      let out := Term.add a.e b.e
       return { b with e := out }
   | HSub.hSub _bv _bv _bv _inst a b =>
       let a ← reflectTermUnchecked map w a
       let b ← reflectTermUnchecked a.bvToIxMap w b
-      let out := mkApp2 (mkConst ``Term.sub) a.e b.e
+      let out := Term.sub a.e b.e
       return { b with e := out }
   | Neg.neg _bv _inst a =>
       let a ← reflectTermUnchecked map w a
-      let out := mkApp (mkConst ``Term.neg) a.e
+      let out := Term.neg a.e
       return { a with e := out }
   -- incr
   -- decr
@@ -400,14 +452,14 @@ info: ∀ {w : Nat} (a b : BitVec w), Or (@Eq (BitVec w) a b) (And (@Ne (BitVec 
 #check ∀ {w : Nat} (a b : BitVec w), a = b ∨ (a ≠ b) ∧ a = b
 
 /-- Return a new expression that this is defeq to, along with the expression of the environment that this needs, under which it will be defeq. -/
-partial def reflectPredicateAux (bvToIxMap : ReflectMap) (e : Expr) (wExpected : Expr) : MetaM ReflectResult := do
+partial def reflectPredicateAux (bvToIxMap : ReflectMap) (e : Expr) (wExpected : Expr) : MetaM (ReflectResult Predicate) := do
   match_expr e with
   | Eq α a b =>
     match_expr α with
     | BitVec w =>
       let a ←  reflectTermUnchecked bvToIxMap w a
       let b ← reflectTermUnchecked a.bvToIxMap w b
-      return { bvToIxMap := b.bvToIxMap, e := mkAppN (mkConst ``Predicate.eq) #[a.e, b.e] }
+      return { bvToIxMap := b.bvToIxMap, e := Predicate.eq a.e b.e }
     | Bool =>
       -- Sadly, recall that slt, sle are of type 'BitVec w → BitVec w → Bool',
       -- so we get goal states of them form 'a <ₛb = true'.
@@ -419,11 +471,11 @@ partial def reflectPredicateAux (bvToIxMap : ReflectMap) (e : Expr) (wExpected :
       | BitVec.slt w a b =>
         let a ← reflectTermUnchecked bvToIxMap w a
         let b ← reflectTermUnchecked a.bvToIxMap w b
-        return { bvToIxMap := b.bvToIxMap, e := mkAppN (mkConst ``Predicate.slt) #[a.e, b.e] }
+        return { bvToIxMap := b.bvToIxMap, e := Predicate.slt a.e b.e }
       | BitVec.sle w a b =>
         let a ← reflectTermUnchecked bvToIxMap w a
         let b ← reflectTermUnchecked a.bvToIxMap w b
-        return { bvToIxMap := b.bvToIxMap, e := mkAppN (mkConst ``Predicate.sle) #[a.e, b.e] }
+        return { bvToIxMap := b.bvToIxMap, e := Predicate.sle a.e b.e }
       | _ =>
         throwError "unknown boolean conditional, expected 'bv.slt bv = true' or 'bv.sle bv = true'. Found {indentD e}"
     | _ =>
@@ -437,33 +489,33 @@ partial def reflectPredicateAux (bvToIxMap : ReflectMap) (e : Expr) (wExpected :
         throwError "Only Nat expressions allowed are '{wExpected} ≠ <concrete value>'. Found {indentD e}."
       let some natVal ← Lean.Meta.getNatValue? b
         | throwError "Expected '{wExpected} ≠ <concrete width>', found symbolic width {indentD b}."
-      let out := mkApp (mkConst ``Predicate.widthNeq) (Lean.mkNatLit natVal)
+      let out := Predicate.widthNeq natVal
       return { bvToIxMap := bvToIxMap, e := out }
     | BitVec w =>
       let a ← reflectTermUnchecked bvToIxMap w a
       let b ← reflectTermUnchecked a.bvToIxMap w b
-      return { bvToIxMap := b.bvToIxMap, e := mkAppN (mkConst ``Predicate.neq) #[a.e, b.e] }
+      return { bvToIxMap := b.bvToIxMap, e := Predicate.neq a.e b.e }
     | _ =>
       throwError "Expected typeclass to be 'BitVec w' / 'Nat', found '{indentD α}' in {e} when matching against 'Ne'"
   | LT.lt α _inst a b =>
     let_expr BitVec w := α | throwError "Expected typeclass to be BitVec w, found '{indentD α}' in {indentD e} when matching against 'LT.lt'"
     let a ← reflectTermUnchecked bvToIxMap w a
     let b ← reflectTermUnchecked a.bvToIxMap w b
-    return { bvToIxMap := b.bvToIxMap, e := mkAppN (mkConst ``Predicate.ult) #[a.e, b.e] }
+    return { bvToIxMap := b.bvToIxMap, e := Predicate.ult a.e b.e }
   | LE.le α _inst a b =>
     let_expr BitVec w := α | throwError "Expected typeclass to be BitVec w, found '{indentD α}' in {indentD e} when matching against 'LE.le'"
     let a ← reflectTermUnchecked bvToIxMap w a
     let b ← reflectTermUnchecked a.bvToIxMap w b
-    return { bvToIxMap := b.bvToIxMap, e := mkAppN (mkConst ``Predicate.ule) #[a.e, b.e] }
+    return { bvToIxMap := b.bvToIxMap, e := Predicate.ule a.e b.e }
   | Or p q =>
     let p ← reflectPredicateAux bvToIxMap p wExpected
     let q ← reflectPredicateAux p.bvToIxMap q wExpected
-    let out := mkApp2 (mkConst ``Predicate.lor) p.e q.e
+    let out := Predicate.lor p.e q.e
     return { q with e := out }
   | And p q =>
     let p ← reflectPredicateAux bvToIxMap p wExpected
     let q ← reflectPredicateAux p.bvToIxMap q wExpected
-    let out := mkApp2 (mkConst ``Predicate.land) p.e q.e
+    let out := Predicate.land p.e q.e
     return { q with e := out }
   | _ =>
      throwError "expected predicate over bitvectors (no quantification), found:  {indentD e}"
@@ -521,9 +573,6 @@ def generalizeMap (g : MVarId) (e : Expr) : MetaM (FVarId × MVarId) :=  do
     return (fvars[0], g)
   throwError"expected a single free variable from generalizing map {e}, found multiple..."
 
-#check reduceBool
-#check ofReduceBool
-
 /--
 Revert all hypotheses that have to do with bitvectors, so that we can use them.
 
@@ -539,6 +588,7 @@ For now, we use a sound overapproximation and revert everything.
 def revertBvHyps (g : MVarId) : MetaM MVarId := do
   let (_, g) ← g.revert (← g.getNondepPropHyps)
   return g
+
 
 /--
 Reflect an expression of the form:
@@ -592,8 +642,16 @@ def reflectUniversalWidthBVs (g : MVarId) : MetaM (List MVarId) := do
     logInfo m!"goal after NNF: {indentD g}"
     -- finally, we perform reflection.
     let result ← reflectPredicateAux ∅ (← g.getType) w
+    let circuitSizeThreshold : Nat := 100
+    let fsm := predicateEvalEqFSM result.e |>.toFSM
+    logInfo m!"Circuit size of FSM: '{toMessageData fsm.circuitSize}'"
+    if fsm.circuitSize > circuitSizeThreshold then
+      throwError "Not running on goal: since circuit size ('{fsm.circuitSize}') is larger than threshold ('{circuitSizeThreshold}')"
+
     let bvToIxMapVal ← result.bvToIxMap.toExpr w
-    let target := (mkAppN (mkConst ``Predicate.denote) #[result.e, w, bvToIxMapVal])
+
+    let cost := result.e.cost
+    let target := (mkAppN (mkConst ``Predicate.denote) #[result.e.quote, w, bvToIxMapVal])
     let g ← g.replaceTargetDefEq target
     logInfo m!"goal after reflection: {indentD g}"
     let (mapFv, g) ← generalizeMap g bvToIxMapVal;
@@ -775,6 +833,8 @@ info: goal after NNF: ⏎
   a b : BitVec 10
   ⊢ a = b
 ---
+info: Circuit size of FSM: '3'
+---
 info: goal after reflection: ⏎
   a b : BitVec 10
   ⊢ (Predicate.eq (Term.var 0) (Term.var 1)).denote 10 (Map.append 10 b (Map.append 10 a Map.empty))
@@ -890,8 +950,8 @@ example : ∀ (w : Nat) (x : BitVec w), (BitVec.ofInt w (-1)) &&& x = x := by
   intros
   bv_automata_circuit
 
-/-- Can solve width-constraints problems -/
-def test29 (x y : BitVec w) : w = 64 → x &&& x &&& x &&& x &&& x &&& x = x := by
+/-- Can solve width-constraints problems, but this takes a while. -/
+def test29 (x y : BitVec w) : w = 32 → x &&& x &&& x &&& x &&& x &&& x = x := by
   bv_automata_circuit
 
 /-- Can solve width-constraints problems -/
@@ -929,6 +989,8 @@ To perform width-specific reasoning, rewrite goal with a width constraint, e.g. 
 info: goal after NNF: ⏎
   x : BitVec 1
   ⊢ x + x + x + x = 0#1
+---
+info: Circuit size of FSM: '70'
 ---
 info: goal after reflection: ⏎
   x : BitVec 1

--- a/SSA/Experimental/Bits/Fast/Reflect.lean
+++ b/SSA/Experimental/Bits/Fast/Reflect.lean
@@ -21,6 +21,19 @@ import Lean.Meta.Tactic.Simp.BuiltinSimprocs.BitVec
 
 import Lean
 
+/-
+TODO:
+- [ ] BitVec.ofInt
+- [ ] leftShift
+- [ ] Break down numeral multiplication into left shift:
+       10 * z
+     = z <<< 1 + 5 * z
+     = z <<< 1 + (z + 4 * z)
+     = z <<< 1 + (z + z <<< 2).
+
+     Needs O(log |N|) terms.
+-/
+
 /--
 Denote a bitstream into the underlying bitvector.
 -/

--- a/SSA/Projects/InstCombine/TacticAuto.lean
+++ b/SSA/Projects/InstCombine/TacticAuto.lean
@@ -296,7 +296,7 @@ macro "bv_bench": tactic =>
             "bv_normalize" : (bv_normalize; done),
             "bv_decide" : (bv_decide; done),
             "bv_auto" : (bv_auto; done),
-            "bv_automata_circuit" : (bv_automata_circuit (config := { circuitSizeThreshold := 30 } ); done)
+            "bv_automata_circuit" : (bv_automata_circuit (config := { circuitSizeThreshold := 30 } ); done),
             "bv_normalize_automata_circuit" : (bv_normalize; bv_automata_circuit (config := { circuitSizeThreshold := 30 } ); done)
           ]
           try bv_auto

--- a/SSA/Projects/InstCombine/TacticAuto.lean
+++ b/SSA/Projects/InstCombine/TacticAuto.lean
@@ -296,7 +296,7 @@ macro "bv_bench": tactic =>
             "bv_normalize" : (bv_normalize; done),
             "bv_decide" : (bv_decide; done),
             "bv_auto" : (bv_auto; done),
-            "bv_automata_circuit" : (bv_automata_circuit; done)
+            "bv_automata_circuit" : (bv_automata_circuit (config := { circuitSizeThreshold := 30 } ); done)
           ]
           try bv_auto
           try sorry

--- a/SSA/Projects/InstCombine/TacticAuto.lean
+++ b/SSA/Projects/InstCombine/TacticAuto.lean
@@ -297,6 +297,7 @@ macro "bv_bench": tactic =>
             "bv_decide" : (bv_decide; done),
             "bv_auto" : (bv_auto; done),
             "bv_automata_circuit" : (bv_automata_circuit (config := { circuitSizeThreshold := 30 } ); done)
+            "bv_normalize_automata_circuit" : (bv_normalize; bv_automata_circuit (config := { circuitSizeThreshold := 30 } ); done)
           ]
           try bv_auto
           try sorry

--- a/SSA/Projects/InstCombine/TacticAuto.lean
+++ b/SSA/Projects/InstCombine/TacticAuto.lean
@@ -297,7 +297,7 @@ macro "bv_bench": tactic =>
             "bv_decide" : (bv_decide; done),
             "bv_auto" : (bv_auto; done),
             "bv_automata_circuit" : (bv_automata_circuit (config := { circuitSizeThreshold := 30 } ); done),
-            "bv_normalize_automata_circuit" : (bv_normalize; bv_automata_circuit (config := { circuitSizeThreshold := 30 } ); done)
+            "bv_normalize_automata_circuit" : ((try (solve | bv_normalize)); (bv_automata_circuit (config := { circuitSizeThreshold := 30 } )); done)
           ]
           try bv_auto
           try sorry


### PR DESCRIPTION
To implement this, we measure the total size of the circuit that is built for the FSM. This automatically includes the state space of the FSM, since there is one circuit to compute each bit of the FSM state, and is thus the natural measure of complexity.

The user-facing API is:

```lean
theorem add_eq_xor_add_mul_and' (x y : BitVec w) :
    x + y = (x ^^^ y) + (x &&& y) + (x &&& y) := by
  bv_automata_circuit
  bv_automata_circuit (config := { circuitSizeThreshold := 100 } )
```

Furthermore, in implementing this, we cleanup our implementation of reflection. We were previously working directly with raw `Expr`s at the tactic level. Now, we switch to parsing the current goal state (which is a raw `Expr`) into a well-typed and well-denoted term of type `Predicate`, so that we can `Predicate.toFSM.circuitComplexity` easily. Finally, we convert the predicate back into an expression with `Predicate.quote`. 

This process not also helps clean up the code, but made me realize a programming error in the implementation of `BitVec.ofNat` in the corner case where one calls `BitVec.ofNat w <symbolic-natural>`. The previous version, when building raw expressions, would try to reflect this into a `Term`, but such a `Term` would not be a closed term (i.e. it would depend on a free variable, the `<symbolic-natural>`, and would in fact cause a Lean error). This has now been fixed, where we now correctly abstract the entire `BitVec.ofNat w <symbolic-natural>` into an uninterpreted expression.