### PR TITLE
feat: goodies for circuit automata tactic

### DIFF
--- a/SSA/Experimental/Bits/Fast/FiniteStateMachine.lean
+++ b/SSA/Experimental/Bits/Fast/FiniteStateMachine.lean
@@ -50,6 +50,10 @@ instance : Std.Commutative Nat.add where
 instance : Std.Associative Nat.add where
   assoc := fun a b => by simp only [Nat.add_eq]; omega
 
+/-- The size of the state space of the finite state machine. -/
+def stateSpaceSize : Nat := @Finset.univ p.α inferInstance |>.card
+
+
 /--
 Return the total size of the FSM as a function of all of its circuits.
 Note that this implicitly counts the size of the state space of the FSM,


### PR DESCRIPTION
- Added a warning when we get uninterpreted symbols like `(f x)`. This will help end-users to understand that we don't yet support e.g. `x * 3`, and is overall an important quality of life feature.
- Log number of states in the automata, and add an option to bail out based on the number of states. This number will be proportional to the size of the constants we have in the formula, so @tobiasgrosser should use the new option based on this metric to threshold problems.
