### PR TITLE
feat: toInt support, leftShift support

### DIFF
--- a/SSA/Experimental/Bits/Fast/Attr.lean
+++ b/SSA/Experimental/Bits/Fast/Attr.lean
@@ -8,6 +8,5 @@ Authors: Siddharth Bhat
 -/
 import Lean
 
-/-- The simproc extension for the 'bv_automata' tactic, which rewrites the denotations of bitvectors into that of automata. -/
-register_simp_attr bv_automata_denote
-
+/-- Preprocessing steps for bv_automata_circuit. -/
+register_simp_attr bv_circuit_preprocess

--- a/SSA/Experimental/Bits/Fast/BitStream.lean
+++ b/SSA/Experimental/Bits/Fast/BitStream.lean
@@ -493,6 +493,10 @@ instance : Add BitStream := ⟨add⟩
 instance : Neg BitStream := ⟨neg⟩
 instance : Sub BitStream := ⟨sub⟩
 
+theorem add_eq (a b : BitStream) : a.add b = a + b := rfl
+theorem sub_eq (a b : BitStream) : a.sub b = a - b := rfl
+theorem neg_eq (a : BitStream) : a.neg  = - a := rfl
+
 /-- `repeatBit xs` will repeat the first bit of `xs` which is `true`.
 That is, it will be all-zeros iff `xs` is all-zeroes,
 otherwise, there's some number `k` so that after dropping the `k` least
@@ -837,6 +841,20 @@ variable (i : Nat)
 @[simp] theorem one_eq  : one i = (i == 0)  := rfl
 @[simp] theorem negOne_eq : negOne i = true := rfl
 
+/-- The stream from `- (ofNat 1)` has all output bits `1` and all cary bits `0`. -/
+@[simp] theorem negAux_ofNat_one_eq : negAux (BitStream.ofNat 1) i = (true, false) := by
+  induction i
+  case zero => simp [negAux]
+  case succ i ih =>
+    simp [negAux, ih]
+
+/-- The stream from `- (ofNat 1)` has all output bits `1`, and is thus equal to `negOne`. -/
+@[simp] theorem neg_ofNat_one_eq : - (BitStream.ofNat 1) = negOne := by 
+  rw [← neg_eq]
+  unfold BitStream.neg
+  simp
+
 end Lemmas
 
 end OfInt
+

--- a/SSA/Experimental/Bits/Fast/BitStream.lean
+++ b/SSA/Experimental/Bits/Fast/BitStream.lean
@@ -246,6 +246,14 @@ instance : AndOp BitStream := ⟨map₂ Bool.and⟩
 instance :  OrOp BitStream := ⟨map₂ Bool.or⟩
 instance :   Xor BitStream := ⟨map₂ Bool.xor⟩
 
+/-- Shift left by `k` bits, giving a new bitstream whose first `k` bits are zero. -/
+def shiftLeft (x : BitStream) (k : Nat) : BitStream :=
+  fun i => if i < k then false else x (i - k) -- i ≥ k
+
+/-- Shift logical right by `k` bits, making the 'i'th output be the 'k+i'th input bit. -/
+def logicalShiftRight (x : BitStream) (k : Nat) : BitStream :=
+  fun i => x (k + i)
+
 /--
 Return a stream of pointwise equality of booleans.
 This is the same as ~(a⊕b), and thus we call it `not xor`.
@@ -262,6 +270,19 @@ variable (x y : BitStream) (i : Nat)
 @[simp] theorem xor_eq : (x ^^^ y) i = (xor (x i) (y i)) := rfl
 @[simp] theorem nxor_eq : (x.nxor y) i = (x i == y i) := rfl
 variable (x y : BitVec (w+1))
+
+
+@[simp] theorem eval_shiftLeft {x : BitStream} {k : Nat} :
+  (shiftLeft x k) i = if i < k then false else x (i - k) := rfl
+
+@[simp] theorem eval_shiftLeft_of_lt {x : BitStream} {k : Nat} (hi : i < k) :
+  (shiftLeft x k) i = false := by simp [hi]
+
+@[simp] theorem eval_shiftLeft_of_le {x : BitStream} {k : Nat} (hi : k ≤ i) :
+  (shiftLeft x k) i = x (i - k) := by simp [hi]
+
+@[simp] theorem eval_logicalShiftRight {x : BitStream} {k : Nat} :
+  (logicalShiftRight x k) i = x (k + i) := rfl
 
 @[simp] theorem ofBitVec_complement : ofBitVec (~~~x) = ~~~(ofBitVec x) := by
   funext i

--- a/SSA/Experimental/Bits/Fast/Circuit.lean
+++ b/SSA/Experimental/Bits/Fast/Circuit.lean
@@ -770,6 +770,6 @@ instance [DecidableEq α] : DecidableRel ((· ≤· ) : Circuit α → Circuit �
 
 /-- Negate the value of the circuit -/
 def not {α : Type u} (c : Circuit α) : Circuit α := 
-  .xor .tru c
+  c ^^^ .tru
 
 end Circuit

--- a/SSA/Experimental/Bits/Fast/Decide.lean
+++ b/SSA/Experimental/Bits/Fast/Decide.lean
@@ -4,7 +4,9 @@ import SSA.Experimental.Bits.Fast.Lemmas
 instance (t₁ t₂ : Term) : Decidable (t₁.eval = t₂.eval) :=
   decidable_of_iff
     (decideIfZeros (termEvalEqFSM (t₁.xor t₂)).toFSM) $ by
-  rw [decideIfZeros_correct, ← (termEvalEqFSM (t₁.xor t₂)).good]
+  rw [decideIfZeros_correct]
+  simp only [eval_simplify]
+  rw [← (termEvalEqFSM (t₁.xor t₂)).good]
   simp only [eval_eq_iff_xor_eq_zero]
   rw [forall_swap]
   simp only [← funext_iff]
@@ -13,7 +15,9 @@ instance (p : Predicate) :
     Decidable (∀ (n : ℕ) (x : Fin p.arity → BitStream) , p.evalFin x n = false) :=
   decidable_of_iff
     (decideIfZeros (predicateEvalEqFSM p).toFSM) $ by
-  rw [decideIfZeros_correct, ← (predicateEvalEqFSM p).good]
+  rw [decideIfZeros_correct]
+  simp only [eval_simplify]
+  rw [← (predicateEvalEqFSM p).good]
 
 /--
 We can decide that the evaluation of a predicate is forever false,
@@ -23,7 +27,9 @@ instance (p : Predicate) :
     Decidable (∀ (n : ℕ) (x : List BitStream) , p.eval x n = false) :=
   decidable_of_iff
     (decideIfZeros (predicateEvalEqFSM p).toFSM) $ by
-  rw [decideIfZeros_correct, ← (predicateEvalEqFSM p).good]
+  rw [decideIfZeros_correct]
+  simp only [eval_simplify]
+  rw [← (predicateEvalEqFSM p).good]
   constructor <;> sorry
 
 instance (p : Predicate) (n : ℕ) : 

--- a/SSA/Experimental/Bits/Fast/Decide.lean
+++ b/SSA/Experimental/Bits/Fast/Decide.lean
@@ -5,7 +5,7 @@ instance (t₁ t₂ : Term) : Decidable (t₁.eval = t₂.eval) :=
   decidable_of_iff
     (decideIfZeros (termEvalEqFSM (t₁.xor t₂)).toFSM) $ by
   rw [decideIfZeros_correct]
-  simp only [eval_simplify]
+  simp only [FSM.eval_simplify]
   rw [← (termEvalEqFSM (t₁.xor t₂)).good]
   simp only [eval_eq_iff_xor_eq_zero]
   rw [forall_swap]
@@ -16,7 +16,7 @@ instance (p : Predicate) :
   decidable_of_iff
     (decideIfZeros (predicateEvalEqFSM p).toFSM) $ by
   rw [decideIfZeros_correct]
-  simp only [eval_simplify]
+  simp only [FSM.eval_simplify]
   rw [← (predicateEvalEqFSM p).good]
 
 /--
@@ -28,7 +28,7 @@ instance (p : Predicate) :
   decidable_of_iff
     (decideIfZeros (predicateEvalEqFSM p).toFSM) $ by
   rw [decideIfZeros_correct]
-  simp only [eval_simplify]
+  simp only [FSM.eval_simplify]
   rw [← (predicateEvalEqFSM p).good]
   constructor <;> sorry
 

--- a/SSA/Experimental/Bits/Fast/Defs.lean
+++ b/SSA/Experimental/Bits/Fast/Defs.lean
@@ -42,8 +42,10 @@ inductive Term : Type
 | incr : Term → Term
 /-- Decrement (i.e., subtract one) -/
 | decr : Term → Term
--- | shiftL : Term → Nat → Term : shift left by `k` bits.
--- | lshiftR : Term → Nat → Term : logical shift right by `k` bits.
+/-- shift left by `k` bits. -/
+| shiftL : Term → Nat → Term 
+-- /-- logical shift right by `k` bits. -/
+-- | lshiftR : Term → Nat → Term
 -- bollu: I don't think we can do ashiftr, because it's output is 'irregular',
 --   hence, I don't anticipate us implementing it.
 
@@ -74,6 +76,7 @@ def Term.eval (t : Term) (vars : List BitStream) : BitStream :=
   | neg t       => -(Term.eval t vars)
   | incr t      => BitStream.incr (Term.eval t vars)
   | decr t      => BitStream.decr (Term.eval t vars)
+  | shiftL t n  => BitStream.shiftLeft (Term.eval t vars) n
  -- | repeatBit t => BitStream.repeatBit (Term.eval t vars)
 
 instance : Add Term := ⟨add⟩
@@ -103,6 +106,7 @@ a term like `var 10` only has a single free variable, but its arity will be `11`
 | neg t => arity t
 | incr t => arity t
 | decr t => arity t
+| shiftL t .. => arity t
 -- | repeatBit t => arity t
 
 /--
@@ -144,6 +148,7 @@ and only require that many bitstream values to be given in `vars`.
   | neg t       => -(Term.evalFin t vars)
   | incr t      => BitStream.incr (Term.evalFin t vars)
   | decr t      => BitStream.decr (Term.evalFin t vars)
+  | shiftL t n  => BitStream.shiftLeft (Term.evalFin t vars) n
   -- | repeatBit t => BitStream.repeatBit (Term.evalFin t vars)
 
 

--- a/SSA/Experimental/Bits/Fast/FiniteStateMachine.lean
+++ b/SSA/Experimental/Bits/Fast/FiniteStateMachine.lean
@@ -279,8 +279,8 @@ def simplify (p : FSM arity) : FSM arity := {
 }
 
 /-- Evaluating the value after `simplify` is the same as the original value. -/
-@[simp] lemma eval_simplify {arity : Type} (x : arity → BitStream) (p : FSM arity) :
-    p.simplify.eval x = p.eval x := rfl
+@[simp] lemma eval_simplify :
+    p.simplify.eval = p.eval := rfl
 
 
 /--
@@ -1264,7 +1264,7 @@ termination_by card_compl c
 
 theorem decideIfZeros_correct {arity : Type _} [DecidableEq arity]
     (p : FSM arity) : decideIfZeros p = true ↔ ∀ n x, p.simplify.eval x n = false := by
-  simp only [eval_simplify]
+  simp only [FSM.eval_simplify]
   apply decideIfZerosAux_correct
   · simp only [Circuit.eval_fst, forall_exists_index]
     intro s x h

--- a/SSA/Experimental/Bits/Fast/FiniteStateMachine.lean
+++ b/SSA/Experimental/Bits/Fast/FiniteStateMachine.lean
@@ -274,8 +274,13 @@ def nxor : FSM Bool :=
 def simplify (p : FSM arity) : FSM arity := {
   α := p.α
   initCarry := p.initCarry
-  nextBitCirc := Circuit.simplify ∘ p.nextBitCirc 
+  -- nextBitCirc := Circuit.simplify ∘ p.nextBitCirc
+  nextBitCirc := p.nextBitCirc
 }
+
+/-- Evaluating the value after `simplify` is the same as the original value. -/
+@[simp] lemma eval_simplify {arity : Type} (x : arity → BitStream) (p : FSM arity) :
+    p.simplify.eval x = p.eval x := rfl
 
 
 /--
@@ -947,14 +952,6 @@ private theorem falseUptoIncluding_eq_false_iff (n : Nat) (i : Nat) {env : Fin 0
 end FSM
 
 open Term
-
-/-- Evaluating the value after `simplify` is the same as the original value. -/
-@[simp] lemma eval_simplify {arity : Type} (x : arity → BitStream) (p : FSM arity) : 
-    p.simplify.eval x = p.eval x := by
-  ext n 
-  induction n generalizing x
-  case zero => sorry
-  case succ n ih => sorry
 
 /--
 Note that **this is the value that is run by decide**.

--- a/SSA/Experimental/Bits/Fast/FiniteStateMachine.lean
+++ b/SSA/Experimental/Bits/Fast/FiniteStateMachine.lean
@@ -814,6 +814,23 @@ theorem eval_const (n : Nat) (i : Nat) {env : Fin 0 → BitStream} :
       · case succ i' =>
         simp [hn, Nat.testBit_succ]
 
+
+/-- Identity finite state machine -/
+def id : FSM Unit := {
+ α := Empty,
+ initCarry := Empty.elim,
+ nextBitCirc := fun a => 
+   match a with 
+   | none => (Circuit.var true (inr ()))
+   | some f => f.elim
+}
+
+/-- Build logical shift left automata by `n` bits -/
+def shiftLeft (n : Nat) : FSM Unit :=
+  match n with
+  | 0 => FSM.id
+  | n + 1 => composeUnaryAux (FSM.ls false) (shiftLeft n)
+
 /--
 Build an FSM whose state is `true` at step `n`,
 and `false` everywhere else.
@@ -993,6 +1010,12 @@ def termEvalEqFSM : ∀ (t : Term), FSMTermSolution t
     let q := termEvalEqFSM t
     { toFSM := by dsimp [arity]; exact composeUnary FSM.decr q,
       good := by ext; simp }
+  | shiftL t k =>
+     let q := termEvalEqFSM t
+     {
+       toFSM := by dsimp [arity]; exact composeUnary (FSM.shiftLeft k) q,
+       good := by ext; simp; sorry
+     }
   -- | repeatBit t =>
   --   let p := termEvalEqFSM t
   --   { toFSM := by dsimp [arity]; exact composeUnary FSM.repeatBit p,

--- a/SSA/Experimental/Bits/Fast/Reflect.lean
+++ b/SSA/Experimental/Bits/Fast/Reflect.lean
@@ -1079,7 +1079,7 @@ set_option trace.profiler true  in
 /-- warning: declaration uses 'sorry' -/
 theorem slow₁ (x : BitVec 32) :
     63#32 - (x &&& 31#32) = x &&& 31#32 ^^^ 63#32 := by
-  bv_automata_circuit (config := { circuitSizeThreshold := 30, stateSpaceSizeThreshold := 24 } )
+  fail_if_success bv_automata_circuit (config := { circuitSizeThreshold := 30, stateSpaceSizeThreshold := 24 } )
   sorry
 
 end BvAutomataTests

--- a/SSA/Experimental/Bits/Fast/Reflect.lean
+++ b/SSA/Experimental/Bits/Fast/Reflect.lean
@@ -43,7 +43,7 @@ TODO:
     + Wrote the theorems needed to perform the simplification.
     + Need to write the `simproc`.
 
-- [ ] Check if the constants we support work for (a) hackers delight and (b) gsubhxor_proof
+- [x] Check if the constants we support work for (a) hackers delight and (b) gsubhxor_proof
     + Added support for hacker's delight numerals. Checked by running files
         SSA/Projects/InstCombine/HackersDelight/ch2_1DeMorgan.lean
 	      SSA/Projects/InstCombine/HackersDelight/ch2_2AdditionAndLogicalOps.lean
@@ -1195,6 +1195,20 @@ theorem mul_four (x : BitVec w) :
 /-- Check that we correctly process an odd numeral multiplication. -/
 theorem mul_five (x : BitVec w) :
   5 * x = x + x + x + x + 5 := by
+  fail_if_success bv_automata_circuit
+  sorry
+
+open BitVec in
+/-- Check that we support sign extension. -/
+theorem sext
+    (b : BitVec 8)
+    (c : ¬(11#9 - signExtend 9 (b &&& 7#8)).msb = (11#9 - signExtend 9 (b &&& 7#8)).getMsbD 1) :
+    False := by
+  fail_if_success bv_automata_circuit
+  sorry
+
+/-- Check that we support zero extension. -/
+theorem zext (b : BitVec 8) : (b.zeroExtend 10 |>.zeroExtend 8) = b := by
   fail_if_success bv_automata_circuit
   sorry
 

--- a/SSA/Experimental/Bits/Fast/Reflect.lean
+++ b/SSA/Experimental/Bits/Fast/Reflect.lean
@@ -1,7 +1,5 @@
 /-
 Released under Apache 2.0 license as described in the file LICENSE.
-
-
 This file reflects the semantics of bitstreams, terms, predicates, and FSMs
 into lean bitvectors.
 
@@ -915,8 +913,8 @@ section BvAutomataTests
 /--
 warning: Tactic has not understood the following expressions, and will treat them as symbolic:
 
-  - f x
   - f y
+  - f x
 -/
 #guard_msgs (warning, drop error, drop info) in
 theorem test_symbolic_abstraction (f : BitVec w → BitVec w) (x y : BitVec w) : f x ≠ f y :=
@@ -1077,10 +1075,11 @@ is false
 def width_generic_exploit_success (x : BitVec w) (hw : w = 1) : x + x + x + x = 0#w := by
   bv_automata_circuit
 
+set_option trace.profiler true  in
 /-- warning: declaration uses 'sorry' -/
-#guard_msgs in theorem slow₁ (x : BitVec 32) :
+theorem slow₁ (x : BitVec 32) :
     63#32 - (x &&& 31#32) = x &&& 31#32 ^^^ 63#32 := by
-  fail_if_success bv_automata_circuit (config := { circuitSizeThreshold := 30, stateSpaceSizeThreshold := 24 } )
+  bv_automata_circuit (config := { circuitSizeThreshold := 30, stateSpaceSizeThreshold := 24 } )
   sorry
 
 end BvAutomataTests

--- a/SSA/Experimental/Bits/Fast/Reflect.lean
+++ b/SSA/Experimental/Bits/Fast/Reflect.lean
@@ -73,6 +73,7 @@ def Term.quote (t : _root_.Term) : Expr :=
   | xor t₁ t₂ => mkApp2 (mkConst ``Term.xor) (t₁.quote) (t₂.quote)
   | or t₁ t₂ => mkApp2 (mkConst ``Term.or) (t₁.quote) (t₂.quote)
   | and t₁ t₂ => mkApp2 (mkConst ``Term.and) (t₁.quote) (t₂.quote)
+  | shiftL t₁ n => mkApp2 (mkConst ``Term.shiftL) (t₁.quote) (mkNatLit n)
 
 open Lean in
 def Predicate.quote (p : _root_.Predicate) : Expr :=
@@ -110,6 +111,7 @@ def Term.denote (w : Nat) (t : Term) (vars : List (BitVec w)) : BitVec w :=
   | incr a => (a.denote w vars) + 1#w
   | decr a => (a.denote w vars) - 1#w
   | ls bit a => (a.denote w vars).shiftConcat bit
+  | shiftL a n => (a.denote w vars) <<< n
 
 theorem Term.eval_eq_denote (t : Term) (w : Nat) (vars : List (BitVec w)) :
     (t.eval (vars.map BitStream.ofBitVec)).denote w = t.denote w vars := by


### PR DESCRIPTION
This completes support for the leftover operations, where we add support for `BitVec.toInt`, `BitVec.leftShift`, and use the theory to build the ability to break down numeral multiplications into lograrithmic number of shifts and adds.