### PR TITLE
Revert "chore: move back to default arguments for bv_automat_circuit"

### DIFF
--- a/SSA/Projects/InstCombine/TacticAuto.lean
+++ b/SSA/Projects/InstCombine/TacticAuto.lean
@@ -300,8 +300,8 @@ macro "bv_bench": tactic =>
             "bv_normalize" : (bv_normalize; done),
             "bv_decide" : (bv_decide; done),
             "bv_auto" : (bv_auto; done),
-            "bv_automata_circuit" : (bv_automata_circuit; done),
-            "bv_normalize_automata_circuit" : ((try (solve | bv_normalize)); (try bv_automata_circuit); done)
+            "bv_automata_circuit" : (bv_automata_circuit (config := { circuitSizeThreshold := 30 } ); done),
+            "bv_normalize_automata_circuit" : ((try (solve | bv_normalize)); (try bv_automata_circuit (config := { circuitSizeThreshold := 30 } )); done)
           ]
           try bv_auto
           try sorry


### PR DESCRIPTION
This reverts commit af9384352b23be74d5116cdf0e6c45f03c63a043.

This causes the upcoming CI to hang for a very long time.