### PR TITLE
feat: Proofs for Bits/Fast/FiniteStateMachine, Bits/Fast/Reflect

### DIFF
--- a/SSA/Experimental/Bits/Fast/BitStream.lean
+++ b/SSA/Experimental/Bits/Fast/BitStream.lean
@@ -319,7 +319,6 @@ section Scan
 /-- Scan the bitwise or operation on bitstreams -/
 def scanOr (s : BitStream) : BitStream := scanl false Bool.or s
 
-
 @[simp]
 theorem scanOr_zero (s : BitStream) : scanOr s 0 = s 0 := rfl
 

--- a/SSA/Experimental/Bits/Fast/BitStream.lean
+++ b/SSA/Experimental/Bits/Fast/BitStream.lean
@@ -479,36 +479,6 @@ def addAux (x y : BitStream) (i : Nat) :  Bool × Bool :=
 def add (x y : BitStream) : BitStream :=
   fun n => (addAux x y n).1
 
-
-/-!
-Use `add_eq_addAux` to reason about `add`'s behaviour.
--/
-
-
--- /-- The stream of carries -/
--- def carryOut (x y : BitStream) : BitStream :=
---   fun n => (addAux x y n).2
---
--- @[simp] theorem carryOutOut_zero (x y : BitStream) : (x.carryOut y 0) = ((x 0) && (y 0)) := by
---   simp [carryOut, addAux,BitVec.adcb]
---
--- @[simp] theorem carryOut_succ (x y : BitStream) : (x.carryOut y (i+1)) =
---     let carryOut := carryOut x y i
---     let a := x (i + 1)
---     let b := y (i + 1)
---     Bool.atLeastTwo a  b carryOut := by
---   simp [carryOut, addAux, BitVec.adcb, Bool.atLeastTwo]
---
--- @[simp] theorem add_zero (x y : BitStream) : (x.add y 0) = ((x 0) ^^ (y 0)) := by
---   simp [add, addAux, BitVec.adcb]
---
--- @[simp] theorem add_succ (x y : BitStream) : (x.add y (i+1)) =
---     let carryIn := carryOut x y i
---     let a := x (i + 1)
---     let b := y (i + 1)
---     a ^^ b ^^ carryIn := by
---   simp [addAux, add, BitVec.adcb, carryOut]
---
 def subAux (x y : BitStream) : Nat → Bool × Bool
   | 0 => (xor (x 0) (y 0), !(x 0) && y 0)
   | n+1 =>

--- a/SSA/Experimental/Bits/Fast/BitStream.lean
+++ b/SSA/Experimental/Bits/Fast/BitStream.lean
@@ -212,6 +212,7 @@ def toBitVec (w : Nat) (x : BitStream) : BitVec w :=
         apply BitVec.getLsbD_ge
         omega
 
+
 /-- `EqualUpTo w x y` holds iff `x` and `y` are equal in the first `w` bits -/
 def EqualUpTo (w : Nat) (x y : BitStream) : Prop :=
   ∀ i < w, x i = y i

--- a/SSA/Experimental/Bits/Fast/BitStream.lean
+++ b/SSA/Experimental/Bits/Fast/BitStream.lean
@@ -194,17 +194,17 @@ def toBitVec (w : Nat) (x : BitStream) : BitVec w :=
   | 0   => 0#0
   | w+1 => (x.toBitVec w).cons (x w)
 
-@[simp] theorem getLsbD_toBitVec (w : Nat) (x : BitStream) : 
-    (x.toBitVec w).getLsbD i = ((decide (i < w)) && x i) := by 
-  induction w generalizing x 
+@[simp] theorem getLsbD_toBitVec (w : Nat) (x : BitStream) :
+    (x.toBitVec w).getLsbD i = ((decide (i < w)) && x i) := by
+  induction w generalizing x
   case zero => simp [toBitVec]
-  case succ w ih => 
+  case succ w ih =>
     simp [toBitVec]
     rw [BitVec.getLsbD_cons]
     by_cases hi : i = w
     · simp [hi]
     · simp [hi]
-      by_cases hw : i < w + 1 
+      by_cases hw : i < w + 1
       · simp [hw]
         rw [ih]
         simp; omega
@@ -468,7 +468,7 @@ def addAux (x y : BitStream) (i : Nat) :  Bool × Bool :=
 @[simp] theorem addAux_zero (x y : BitStream) : (x.addAux y 0) = ((x 0) ^^ (y 0), (x 0) && (y 0)) := by
   simp [addAux, addAux,BitVec.adcb]
 
-@[simp] theorem addAux_succ (x y : BitStream) : (x.addAux y (i+1)) = 
+@[simp] theorem addAux_succ (x y : BitStream) : (x.addAux y (i+1)) =
     let addAux := (addAux x y i)
     let a := x (i + 1)
     let b := y (i + 1)
@@ -488,27 +488,27 @@ Use `add_eq_addAux` to reason about `add`'s behaviour.
 -- /-- The stream of carries -/
 -- def carryOut (x y : BitStream) : BitStream :=
 --   fun n => (addAux x y n).2
--- 
+--
 -- @[simp] theorem carryOutOut_zero (x y : BitStream) : (x.carryOut y 0) = ((x 0) && (y 0)) := by
 --   simp [carryOut, addAux,BitVec.adcb]
--- 
--- @[simp] theorem carryOut_succ (x y : BitStream) : (x.carryOut y (i+1)) = 
+--
+-- @[simp] theorem carryOut_succ (x y : BitStream) : (x.carryOut y (i+1)) =
 --     let carryOut := carryOut x y i
 --     let a := x (i + 1)
 --     let b := y (i + 1)
 --     Bool.atLeastTwo a  b carryOut := by
 --   simp [carryOut, addAux, BitVec.adcb, Bool.atLeastTwo]
--- 
+--
 -- @[simp] theorem add_zero (x y : BitStream) : (x.add y 0) = ((x 0) ^^ (y 0)) := by
 --   simp [add, addAux, BitVec.adcb]
--- 
--- @[simp] theorem add_succ (x y : BitStream) : (x.add y (i+1)) = 
+--
+-- @[simp] theorem add_succ (x y : BitStream) : (x.add y (i+1)) =
 --     let carryIn := carryOut x y i
 --     let a := x (i + 1)
 --     let b := y (i + 1)
 --     a ^^ b ^^ carryIn := by
 --   simp [addAux, add, BitVec.adcb, carryOut]
--- 
+--
 def subAux (x y : BitStream) : Nat → Bool × Bool
   | 0 => (xor (x 0) (y 0), !(x 0) && y 0)
   | n+1 =>
@@ -525,9 +525,10 @@ def sub (x y : BitStream) : BitStream :=
 def borrow (x y : BitStream) : BitStream :=
   fun n => (subAux x y n).2
 
+
 @[simp] theorem borrow_zero (x y : BitStream) : (x.borrow y 0) = (!(x 0) && y 0) := rfl
 
-@[simp] theorem borrow_succ (x y : BitStream) : (x.borrow y (i+1)) = 
+@[simp] theorem borrow_succ (x y : BitStream) : (x.borrow y (i+1)) =
   let borrow := borrow x y i
   let a := x (i + 1)
   let b := y (i + 1)
@@ -542,7 +543,7 @@ def negAux (x : BitStream) : Nat → Bool × Bool
 
 @[simp] theorem negAux_zero (x : BitStream) : x.negAux 0 = (x 0, ! (x 0)) := rfl
 
-@[simp] theorem negAux_succ (x : BitStream) (n : Nat) : x.negAux (n + 1) = 
+@[simp] theorem negAux_succ (x : BitStream) (n : Nat) : x.negAux (n + 1) =
     let borrow := (negAux x n).2
     let a := x (n + 1)
     (xor (!a) borrow, !a && borrow) := rfl
@@ -591,13 +592,13 @@ abbrev negOne : BitStream := fun _ => true
 @[simp] theorem one_ext_zero : one 0 = true := rfl
 @[simp] theorem one_ext_succ : one (i + 1) = false := rfl
 
-theorem negAux_eq_addAux (x : BitStream) (i : Nat) : 
-    (negAux x i).1 =  (addAux (~~~ x) one i).1 ∧ 
+theorem negAux_eq_addAux (x : BitStream) (i : Nat) :
+    (negAux x i).1 =  (addAux (~~~ x) one i).1 ∧
     (negAux x i).2 =  (addAux (~~~ x) one i).2 := by
   induction i
   case zero => simp
   case succ ih => simp [ih]
-  
+
 theorem neg_eq_not_add_one (x : BitStream) : - x = (~~~ x) + one := by
   ext i
   rw [neg_eq_negAux, add_eq_addAux]
@@ -952,7 +953,7 @@ variable (i : Nat)
     simp [negAux, ih]
 
 /-- The stream from `- (ofNat 1)` has all output bits `1`, and is thus equal to `negOne`. -/
-@[simp] theorem neg_ofNat_one_eq : - (BitStream.ofNat 1) = negOne := by 
+@[simp] theorem neg_ofNat_one_eq : - (BitStream.ofNat 1) = negOne := by
   rw [← neg_eq]
   unfold BitStream.neg
   simp
@@ -960,4 +961,3 @@ variable (i : Nat)
 end Lemmas
 
 end OfInt
-

--- a/SSA/Experimental/Bits/Fast/BitStream.lean
+++ b/SSA/Experimental/Bits/Fast/BitStream.lean
@@ -448,11 +448,29 @@ end Scan
 /-! # Addition, Subtraction, Negation -/
 section Arith
 
+def adcb (x y c : BitStream) (i : Nat) :  Bool × Bool :=
+  Prod.swap (BitVec.adcb (x i) (y i) (c i))
+
 def addAux (x y : BitStream) (i : Nat) :  Bool × Bool :=
   let carry : Bool := match i with
     | 0 => false
     | i + 1 => (addAux x y i).2
   Prod.swap (BitVec.adcb (x i) (y i) carry)
+
+/-- The stream of carries -/
+def carry (x y : BitStream) : BitStream :=
+  fun n => (addAux x y n).2
+
+@[simp] theorem carry_zero (x y : BitStream) : (x.carry y 0) = ((x 0) && (y 0)) := by
+  simp [carry, addAux,BitVec.adcb]
+
+@[simp] theorem carry_succ (x y : BitStream) : (x.carry y (i+1)) = 
+    let carry := carry x y i
+    let a := x (i + 1)
+    let b := y (i + 1)
+    Bool.atLeastTwo a  b carry := by
+  simp [carry, addAux, BitVec.adcb, Bool.atLeastTwo]
+
 
 def add (x y : BitStream) : BitStream :=
   fun n => (addAux x y n).1
@@ -522,6 +540,10 @@ instance : Sub BitStream := ⟨sub⟩
 theorem add_eq (a b : BitStream) : a.add b = a + b := rfl
 theorem sub_eq (a b : BitStream) : a.sub b = a - b := rfl
 theorem neg_eq (a : BitStream) : a.neg  = - a := rfl
+
+theorem add_eq_addAux (x y : BitStream) : (x + y) i = (addAux x y i).1 := rfl
+theorem sub_eq_subAux (x y : BitStream) : (x - y) i = (subAux x y i).1 := rfl
+theorem neg_eq_negAux (x : BitStream) : (- x) i = (negAux x i).1 := rfl
 
 /-- `repeatBit xs` will repeat the first bit of `xs` which is `true`.
 That is, it will be all-zeros iff `xs` is all-zeroes,

--- a/SSA/Experimental/Bits/Fast/BitStream.lean
+++ b/SSA/Experimental/Bits/Fast/BitStream.lean
@@ -329,6 +329,14 @@ variable (x y : BitVec (w+1))
     zero_lt_one, or_true, decide_true, Bool.true_and, not_eq]
   split <;> simp_all
 
+theorem and_comm (x y : BitStream) : x &&& y = y &&& x := by
+  funext i
+  simp [Bool.and_comm]
+
+theorem or_comm (x y : BitStream) : x ||| y = y ||| x := by
+  funext i
+  simp [Bool.or_comm]
+
 end Lemmas
 
 end BitwiseOps

--- a/SSA/Experimental/Bits/Fast/BitStream.lean
+++ b/SSA/Experimental/Bits/Fast/BitStream.lean
@@ -194,6 +194,24 @@ def toBitVec (w : Nat) (x : BitStream) : BitVec w :=
   | 0   => 0#0
   | w+1 => (x.toBitVec w).cons (x w)
 
+@[simp] theorem getLsbD_toBitVec (w : Nat) (x : BitStream) : 
+    (x.toBitVec w).getLsbD i = ((decide (i < w)) && x i) := by 
+  induction w generalizing x 
+  case zero => simp [toBitVec]
+  case succ w ih => 
+    simp [toBitVec]
+    rw [BitVec.getLsbD_cons]
+    by_cases hi : i = w
+    · simp [hi]
+    · simp [hi]
+      by_cases hw : i < w + 1 
+      · simp [hw]
+        rw [ih]
+        simp; omega
+      · simp [hw]
+        apply BitVec.getLsbD_ge
+        omega
+
 /-- `EqualUpTo w x y` holds iff `x` and `y` are equal in the first `w` bits -/
 def EqualUpTo (w : Nat) (x y : BitStream) : Prop :=
   ∀ i < w, x i = y i

--- a/SSA/Experimental/Bits/Fast/BitStream.lean
+++ b/SSA/Experimental/Bits/Fast/BitStream.lean
@@ -454,6 +454,14 @@ def sub (x y : BitStream) : BitStream :=
 def borrow (x y : BitStream) : BitStream :=
   fun n => (subAux x y n).2
 
+@[simp] theorem borrow_zero (x y : BitStream) : (x.borrow y 0) = (!(x 0) && y 0) := rfl
+
+@[simp] theorem borrow_succ (x y : BitStream) : (x.borrow y (i+1)) = 
+  let borrow := borrow x y i
+  let a := x (i + 1)
+  let b := y (i + 1)
+  !a && b || ((!(xor a b)) && borrow) := rfl
+
 def negAux (x : BitStream) : Nat → Bool × Bool
   | 0 => (x 0, !(x 0))
   | n+1 =>

--- a/SSA/Experimental/Bits/Fast/Decide.lean
+++ b/SSA/Experimental/Bits/Fast/Decide.lean
@@ -13,34 +13,41 @@ instance (p : Predicate) :
 We can decide that the evaluation of a predicate is forever false,
 which is to say, that it is true for all bitwidths.
 -/
-instance (p : Predicate) :
+instance DecidableForallPredicateEvalEqFalse (p : Predicate) :
     Decidable (∀ (n : ℕ) (x : List BitStream) , p.eval x n = false) :=
   decidable_of_iff
     (decideIfZeros (predicateEvalEqFSM p).toFSM) $ by
-  rw [decideIfZeros_correct]
-  simp only [FSM.eval_simplify]
-  rw [← (predicateEvalEqFSM p).good]
+  rw [decideIfZeros_correct] -- correct
+  simp only [FSM.eval_simplify] -- correct
+  rw [← (predicateEvalEqFSM p).good] -- correct:
   constructor
-  · intros h  n x
-    sorry
-  · sorry
-    -- specialize h n (fun i => x[i])
-    -- rw [← Predicate.evalFin_eq_eval] at h
+  · intros h n xs
+    rw [← Predicate.evalFin_eq_eval p xs]
+    · apply h
+    · exact fun i => if hi : i < xs.length then xs[i] else default
+    · intros i
+      simp
+      by_cases hi : i < xs.length
+      · simp [hi]
+      · simp only [hi, ↓reduceDIte]
+        rw [List.getElem?_eq_none (by omega)]
+        simp
+  · intros h n xs
+    specialize h n 
+    rw [Predicate.evalFin_eq_eval p  (List.ofFn xs) xs]
+    · apply h
+    · simp
+
+/--
+info: 'DecidableForallPredicateEvalEqFalse' depends on axioms: [axEvalFinEqEval, propext, Classical.choice, Quot.sound]
+-/
+#guard_msgs in #print axioms DecidableForallPredicateEvalEqFalse 
 
 instance DecideFixedWidthPredicateEvalFin  (p : Predicate) (n : ℕ) : 
     Decidable (∀ (x : Fin p.arity → BitStream) , p.evalFin x n = false) :=
   decidable_of_iff
     (decideIfZerosAtIx (predicateEvalEqFSM p).toFSM n) $ by
   rw [decideIfZeroesAtIx_correct, ← (predicateEvalEqFSM p).good]
-
-/-
-instance DecideFixedWidthPredicateEval (p : Predicate) (n : ℕ) : 
-    Decidable (∀ (x : List BitStream) , p.eval x n = false) :=
-  decidable_of_iff
-    (decideIfZerosAtIx (predicateEvalEqFSM p).toFSM n) $ by
-  rw [decideIfZeroesAtIx_correct, ← (predicateEvalEqFSM p).good]
-  constructor <;> sorry
--/
 
 open Term
 

--- a/SSA/Experimental/Bits/Fast/Decide.lean
+++ b/SSA/Experimental/Bits/Fast/Decide.lean
@@ -1,7 +1,7 @@
 import SSA.Experimental.Bits.Fast.FiniteStateMachine
 import SSA.Experimental.Bits.Fast.Lemmas
 
-instance (p : Predicate) : 
+instance (p : Predicate) :
     Decidable (∀ (n : ℕ) (x : Fin p.arity → BitStream) , p.evalFin x n = false) :=
   decidable_of_iff
     (decideIfZeros (predicateEvalEqFSM p).toFSM) $ by
@@ -33,21 +33,20 @@ instance DecidableForallPredicateEvalEqFalse (p : Predicate) :
         rw [List.getElem?_eq_none (by omega)]
         simp
   · intros h n xs
-    specialize h n 
+    specialize h n
     rw [Predicate.evalFin_eq_eval p  (List.ofFn xs) xs]
     · apply h
     · simp
 
 /--
-info: 'DecidableForallPredicateEvalEqFalse' depends on axioms: [propext, Classical.choice, Quot.sound]
+info: 'DecidableForallPredicateEvalEqFalse' depends on axioms: [propext, sorryAx, Classical.choice, Quot.sound]
 -/
-#guard_msgs in #print axioms DecidableForallPredicateEvalEqFalse 
+#guard_msgs in #print axioms DecidableForallPredicateEvalEqFalse
 
-instance DecideFixedWidthPredicateEvalFin  (p : Predicate) (n : ℕ) : 
+instance DecideFixedWidthPredicateEvalFin  (p : Predicate) (n : ℕ) :
     Decidable (∀ (x : Fin p.arity → BitStream) , p.evalFin x n = false) :=
   decidable_of_iff
     (decideIfZerosAtIx (predicateEvalEqFSM p).toFSM n) $ by
   rw [decideIfZeroesAtIx_correct, ← (predicateEvalEqFSM p).good]
 
 open Term
-

--- a/SSA/Experimental/Bits/Fast/Decide.lean
+++ b/SSA/Experimental/Bits/Fast/Decide.lean
@@ -39,7 +39,7 @@ instance DecidableForallPredicateEvalEqFalse (p : Predicate) :
     · simp
 
 /--
-info: 'DecidableForallPredicateEvalEqFalse' depends on axioms: [axEvalFinEqEval, propext, Classical.choice, Quot.sound]
+info: 'DecidableForallPredicateEvalEqFalse' depends on axioms: [propext, Classical.choice, Quot.sound]
 -/
 #guard_msgs in #print axioms DecidableForallPredicateEvalEqFalse 
 

--- a/SSA/Experimental/Bits/Fast/Decide.lean
+++ b/SSA/Experimental/Bits/Fast/Decide.lean
@@ -1,16 +1,6 @@
 import SSA.Experimental.Bits.Fast.FiniteStateMachine
 import SSA.Experimental.Bits.Fast.Lemmas
 
-instance (t₁ t₂ : Term) : Decidable (t₁.eval = t₂.eval) :=
-  decidable_of_iff
-    (decideIfZeros (termEvalEqFSM (t₁.xor t₂)).toFSM) $ by
-  rw [decideIfZeros_correct]
-  simp only [FSM.eval_simplify]
-  rw [← (termEvalEqFSM (t₁.xor t₂)).good]
-  simp only [eval_eq_iff_xor_eq_zero]
-  rw [forall_swap]
-  simp only [← funext_iff]
-
 instance (p : Predicate) : 
     Decidable (∀ (n : ℕ) (x : Fin p.arity → BitStream) , p.evalFin x n = false) :=
   decidable_of_iff
@@ -30,7 +20,12 @@ instance (p : Predicate) :
   rw [decideIfZeros_correct]
   simp only [FSM.eval_simplify]
   rw [← (predicateEvalEqFSM p).good]
-  constructor <;> sorry
+  constructor
+  · intros h  n x
+    sorry
+  · sorry
+    -- specialize h n (fun i => x[i])
+    -- rw [← Predicate.evalFin_eq_eval] at h
 
 instance DecideFixedWidthPredicateEvalFin  (p : Predicate) (n : ℕ) : 
     Decidable (∀ (x : Fin p.arity → BitStream) , p.evalFin x n = false) :=
@@ -38,139 +33,14 @@ instance DecideFixedWidthPredicateEvalFin  (p : Predicate) (n : ℕ) :
     (decideIfZerosAtIx (predicateEvalEqFSM p).toFSM n) $ by
   rw [decideIfZeroesAtIx_correct, ← (predicateEvalEqFSM p).good]
 
+/-
 instance DecideFixedWidthPredicateEval (p : Predicate) (n : ℕ) : 
     Decidable (∀ (x : List BitStream) , p.eval x n = false) :=
   decidable_of_iff
     (decideIfZerosAtIx (predicateEvalEqFSM p).toFSM n) $ by
   rw [decideIfZeroesAtIx_correct, ← (predicateEvalEqFSM p).good]
   constructor <;> sorry
+-/
 
 open Term
 
-def run_decide (t₁ t₂ : Term) : IO Bool := do
-  pure (t₁.eval = t₂.eval)
-
-def decide (t₁ t₂ : Term) : IO Bool :=
-  --timeit "" (run_decide t₁ t₂)
-  (run_decide t₁ t₂)
-
-section testDecide
-
-def x := Term.var 0
-def y := Term.var 1
-def z := Term.var 2
-
-example : ((and x y) + (or x y)).eval = (x + y).eval := by
-  native_decide
-
-example : ((or x y) - (xor x y)).eval = (and x y).eval := by
-  native_decide
-
-
-/-
-Note that we use `#eval!` instead of `#eval`, since our
-proof of `decide` currently contains a `sorry`. We should elminate the `sorry`,
-and then switch to `#eval`.
--/
-
-/--
-info: 'Decidable.decide' does not depend on any axioms
----
-info: 'decide' depends on axioms: [propext, sorryAx, Classical.choice, Quot.sound]
--/
-#guard_msgs in #print axioms decide
-
-/-- info: true -/
-#guard_msgs in #eval! decide (x + -x) 0
-
--- /-- info: true -/
--- #guard_msgs in #eval! decide (incr x) (x + 1)
-
--- /-- info: true -/
--- #guard_msgs in #eval! decide (decr x) (x - 1)
-
-/-- info: true -/
-#guard_msgs in #eval! decide (x + -y) (x - y)
-
-/-- info: true -/
-#guard_msgs in #eval! decide (x + 0) (var 0)
-
-/-- info: true -/
-#guard_msgs in #eval! decide (x + y) (y + x)
-
-/-- info: true -/
-#guard_msgs in #eval! decide (x + (y + z)) (x + y + z)
-
-/-- info: true -/
-#guard_msgs in #eval! decide (x - x) 0
-
-/-- info: true -/
-#guard_msgs in #eval! decide (x + 0) x
-
-/-- info: true -/
-#guard_msgs in #eval! decide (0 + x) x
-
--- /-- info: true -/
--- #guard_msgs in #eval! decide (-x) (not x).incr
-
--- /-- info: true -/
--- #guard_msgs in #eval! decide (-x) (not x.decr)
-
--- /-- info: true -/
--- #guard_msgs in #eval! decide (not x) (-x).decr
-
-/-- info: true -/
-#guard_msgs in #eval! decide (-not x) (x + 1)
-
-/-- info: true -/
-#guard_msgs in #eval! decide (x + y) (x - not y - 1)
-
-/-- info: true -/
-#guard_msgs in #eval! decide (x + y) ((xor x y) + (and x y).ls false)
-
-/-- info: true -/
-#guard_msgs in #eval! decide (x + y) (or x y + and x y)
-
-/-- info: true -/
-#guard_msgs in #eval! decide (x + y) ((or x y).ls false - (xor x y))
-
--- /-- info: true -/
--- #guard_msgs in #eval! decide (x - y) (x + not y).incr
-
-/-- info: true -/
-#guard_msgs in #eval! decide (x - y) (xor x y - (and (not x) y).ls false)
-
-/-- info: true -/
-#guard_msgs in #eval! decide (x - y) (and x (not y) - (and (not x) y))
-
-/-- info: true -/
-#guard_msgs in #eval! decide (x - y) ((and x (not y)).ls false - (xor x y))
-
-/-- info: true -/
-#guard_msgs in #eval! decide (xor x y) ((or x y) - (and x y))
-
-/-- info: true -/
-#guard_msgs in #eval! decide (and x (not y)) (or x y - y)
-
-/-- info: true -/
-#guard_msgs in #eval! decide (and x (not y)) (x - and x y)
-
--- /-- info: true -/
--- #guard_msgs in #eval! decide (not (x - y)) (y - x).decr
-
-/-- info: true -/
-#guard_msgs in #eval! decide (not (x - y)) (not x + y)
-
--- /-- info: true -/
--- #guard_msgs in #eval! decide (not (xor x y)) (and x y - (or x y)).decr
-
-/-- info: true -/
-#guard_msgs in #eval! decide (not (xor x y)) (and x y + not (or x y))
-
-/-- info: true -/
-#guard_msgs in #eval! decide (or x y) (and x (not y) + y)
-
-/-- info: true -/
-#guard_msgs in #eval! decide (and x y) (or (not x) y - not x)
-
-end testDecide

--- a/SSA/Experimental/Bits/Fast/Decide.lean
+++ b/SSA/Experimental/Bits/Fast/Decide.lean
@@ -83,11 +83,11 @@ info: 'decide' depends on axioms: [propext, sorryAx, Classical.choice, Quot.soun
 /-- info: true -/
 #guard_msgs in #eval! decide (x + -x) 0
 
-/-- info: true -/
-#guard_msgs in #eval! decide (incr x) (x + 1)
+-- /-- info: true -/
+-- #guard_msgs in #eval! decide (incr x) (x + 1)
 
-/-- info: true -/
-#guard_msgs in #eval! decide (decr x) (x - 1)
+-- /-- info: true -/
+-- #guard_msgs in #eval! decide (decr x) (x - 1)
 
 /-- info: true -/
 #guard_msgs in #eval! decide (x + -y) (x - y)
@@ -110,14 +110,14 @@ info: 'decide' depends on axioms: [propext, sorryAx, Classical.choice, Quot.soun
 /-- info: true -/
 #guard_msgs in #eval! decide (0 + x) x
 
-/-- info: true -/
-#guard_msgs in #eval! decide (-x) (not x).incr
+-- /-- info: true -/
+-- #guard_msgs in #eval! decide (-x) (not x).incr
 
-/-- info: true -/
-#guard_msgs in #eval! decide (-x) (not x.decr)
+-- /-- info: true -/
+-- #guard_msgs in #eval! decide (-x) (not x.decr)
 
-/-- info: true -/
-#guard_msgs in #eval! decide (not x) (-x).decr
+-- /-- info: true -/
+-- #guard_msgs in #eval! decide (not x) (-x).decr
 
 /-- info: true -/
 #guard_msgs in #eval! decide (-not x) (x + 1)
@@ -134,8 +134,8 @@ info: 'decide' depends on axioms: [propext, sorryAx, Classical.choice, Quot.soun
 /-- info: true -/
 #guard_msgs in #eval! decide (x + y) ((or x y).ls false - (xor x y))
 
-/-- info: true -/
-#guard_msgs in #eval! decide (x - y) (x + not y).incr
+-- /-- info: true -/
+-- #guard_msgs in #eval! decide (x - y) (x + not y).incr
 
 /-- info: true -/
 #guard_msgs in #eval! decide (x - y) (xor x y - (and (not x) y).ls false)
@@ -155,14 +155,14 @@ info: 'decide' depends on axioms: [propext, sorryAx, Classical.choice, Quot.soun
 /-- info: true -/
 #guard_msgs in #eval! decide (and x (not y)) (x - and x y)
 
-/-- info: true -/
-#guard_msgs in #eval! decide (not (x - y)) (y - x).decr
+-- /-- info: true -/
+-- #guard_msgs in #eval! decide (not (x - y)) (y - x).decr
 
 /-- info: true -/
 #guard_msgs in #eval! decide (not (x - y)) (not x + y)
 
-/-- info: true -/
-#guard_msgs in #eval! decide (not (xor x y)) (and x y - (or x y)).decr
+-- /-- info: true -/
+-- #guard_msgs in #eval! decide (not (xor x y)) (and x y - (or x y)).decr
 
 /-- info: true -/
 #guard_msgs in #eval! decide (not (xor x y)) (and x y + not (or x y))

--- a/SSA/Experimental/Bits/Fast/Decide.lean
+++ b/SSA/Experimental/Bits/Fast/Decide.lean
@@ -39,7 +39,7 @@ instance DecidableForallPredicateEvalEqFalse (p : Predicate) :
     · simp
 
 /--
-info: 'DecidableForallPredicateEvalEqFalse' depends on axioms: [propext, sorryAx, Classical.choice, Quot.sound]
+info: 'DecidableForallPredicateEvalEqFalse' depends on axioms: [propext, Classical.choice, Quot.sound]
 -/
 #guard_msgs in #print axioms DecidableForallPredicateEvalEqFalse
 

--- a/SSA/Experimental/Bits/Fast/Defs.lean
+++ b/SSA/Experimental/Bits/Fast/Defs.lean
@@ -199,10 +199,7 @@ Start by assuming that they are not (not equal) i.e. that they are equal, and th
 If their values ever differ, then we know that we will have `a[i] == b[i]` to be `false`.
 From this point onward, they will always disagree, and thus the predicate should become `0`.
 -/
--- def Predicate.evalNeq (t₁ t₂ : BitStream) : BitStream := (BitStream.nxor t₁ t₂).scanAnd
-def Predicate.evalNeq (t₁ t₂ : BitStream) : BitStream := 
-  let bs : BitStream := fun i => if t₁ i != t₂ i then false else true
-  bs.scanAnd
+def Predicate.evalNeq (t₁ t₂ : BitStream) : BitStream := (t₁.nxor t₂).concat true |>.scanAnd
 
 /-
 If they have been `0` so far, then `t1 &&& t2 |>.scanOr` will be `1`.
@@ -306,6 +303,11 @@ def Predicate.evalFinEq (x₁ x₂ : BitStream) : BitStream :=
     BitStream.concat false (x₁ ^^^ x₂) |>.scanOr
 
 @[simp]
+def Predicate.evalFinNeq (x₁ x₂ : BitStream) : BitStream := 
+    -- width 0, stuff is always equal
+    BitStream.concat true (x₁.nxor x₂) |>.scanAnd
+
+@[simp]
 def Predicate.evalFinSlt (x₁ x₂ : BitStream) : BitStream := 
   -- width 0, nothing is less than
   BitStream.concat true (~~~ (x₁ - x₂))
@@ -331,7 +333,7 @@ match p with
 | .neq t₁ t₂  =>
     let x₁ := t₁.evalFin (fun i => vars (Fin.castLE (by simp [arity]) i))
     let x₂ := t₂.evalFin (fun i => vars (Fin.castLE (by simp [arity]) i))
-    (x₁.nxor x₂)
+    Predicate.evalFinNeq x₁ x₂
 | .land p q =>
   -- if both `p` and `q` are logically true (i.e. the predicate is `false`),
   -- only then should we return a `false`.

--- a/SSA/Experimental/Bits/Fast/Defs.lean
+++ b/SSA/Experimental/Bits/Fast/Defs.lean
@@ -191,7 +191,7 @@ inductive Predicate : Type where
 /--
 If they are equal so far, then `t1 ^^^ t2`.scanOr will be 0.
 -/
-def Predicate.evalEq (t₁ t₂ : BitStream) : BitStream := (t₁ ^^^ t₂).scanOr
+def Predicate.evalEq (t₁ t₂ : BitStream) : BitStream := (t₁ ^^^ t₂).concat false |>.scanOr
 /--
 If they have been equal so far, then `BitStream.nxor t₁ t₂`.scanAnd will be 1.
 Start by assuming that they are not (not equal) i.e. that they are equal, and the 

--- a/SSA/Experimental/Bits/Fast/Defs.lean
+++ b/SSA/Experimental/Bits/Fast/Defs.lean
@@ -38,10 +38,10 @@ inductive Term : Type
 | sub : Term → Term → Term
 /-- Negation -/
 | neg : Term → Term
-/-- Increment (i.e., add one) -/
-| incr : Term → Term
-/-- Decrement (i.e., subtract one) -/
-| decr : Term → Term
+-- /-- Increment (i.e., add one) -/
+-- | incr : Term → Term
+-- /-- Decrement (i.e., subtract one) -/
+-- | decr : Term → Term
 /-- shift left by `k` bits. -/
 | shiftL : Term → Nat → Term 
 -- /-- logical shift right by `k` bits. -/
@@ -74,8 +74,8 @@ def Term.eval (t : Term) (vars : List BitStream) : BitStream :=
   | add t₁ t₂   => (Term.eval t₁ vars) + (Term.eval t₂ vars)
   | sub t₁ t₂   => (Term.eval t₁ vars) - (Term.eval t₂ vars)
   | neg t       => -(Term.eval t vars)
-  | incr t      => BitStream.incr (Term.eval t vars)
-  | decr t      => BitStream.decr (Term.eval t vars)
+--   | incr t      => BitStream.incr (Term.eval t vars)
+--   | decr t      => BitStream.decr (Term.eval t vars)
   | shiftL t n  => BitStream.shiftLeft (Term.eval t vars) n
  -- | repeatBit t => BitStream.repeatBit (Term.eval t vars)
 
@@ -104,8 +104,8 @@ a term like `var 10` only has a single free variable, but its arity will be `11`
 | add t₁ t₂ => max (arity t₁) (arity t₂)
 | sub t₁ t₂ => max (arity t₁) (arity t₂)
 | neg t => arity t
-| incr t => arity t
-| decr t => arity t
+-- | incr t => arity t
+-- | decr t => arity t
 | shiftL t .. => arity t
 -- | repeatBit t => arity t
 
@@ -146,8 +146,8 @@ and only require that many bitstream values to be given in `vars`.
       let x₂ := t₂.evalFin (fun i => vars (Fin.castLE (by simp [arity]) i))
       x₁ - x₂
   | neg t       => -(Term.evalFin t vars)
-  | incr t      => BitStream.incr (Term.evalFin t vars)
-  | decr t      => BitStream.decr (Term.evalFin t vars)
+ --  | incr t      => BitStream.incr (Term.evalFin t vars)
+ --  | decr t      => BitStream.decr (Term.evalFin t vars)
   | shiftL t n  => BitStream.shiftLeft (Term.evalFin t vars) n
   -- | repeatBit t => BitStream.repeatBit (Term.evalFin t vars)
 

--- a/SSA/Experimental/Bits/Fast/Defs.lean
+++ b/SSA/Experimental/Bits/Fast/Defs.lean
@@ -216,14 +216,14 @@ This is defined by computing the borrow bit of 't₁ - t₂'.
 If the borrow bit is `1`, then we know that `t₁ < t₂', so we return a `0`.
 Otherwise, we know that 't₁ ≥ t₂'.
 -/
-def Predicate.evalUlt (t₁ t₂ : BitStream) : BitStream := ~~~ (t₁.borrow t₂)
+def Predicate.evalUlt (t₁ t₂ : BitStream) : BitStream := (~~~ (t₁.borrow t₂)).concat true
 
 /-- 
 Evaluate whether 't₁ <s t₂'.
 This is defined by computing the most significant bit of 't₁ - t₂'.
 IF the `msb is 1`, then `t₁ - t₂ <s 0`, and thus `t₁ <s t₂'.
 -/
-def Predicate.evalSlt (t₁ t₂ : BitStream) : BitStream := ~~~ (t₁ - t₂)
+def Predicate.evalSlt (t₁ t₂ : BitStream) : BitStream := (~~~ (t₁ - t₂)).concat true
 
 -- | leq (t₁ t₂ : Term) : Predicate -> simulate in terms of lt and eq
 open BitStream in

--- a/SSA/Experimental/Bits/Fast/Defs.lean
+++ b/SSA/Experimental/Bits/Fast/Defs.lean
@@ -297,16 +297,23 @@ def Predicate.evalFinLor (x₁ x₂ : BitStream) : BitStream :=
     (x₁ &&& x₂)
 
 @[simp]
+def Predicate.evalFinLand (x₁ x₂ : BitStream) : BitStream := 
+  (x₁ ||| x₂)
+
+@[simp]
 def Predicate.evalFinEq (x₁ x₂ : BitStream) : BitStream := 
-    (x₁ ^^^ x₂)
+    -- width 0, stuff is always equal
+    BitStream.concat false (x₁ ^^^ x₂) |>.scanOr
 
 @[simp]
 def Predicate.evalFinSlt (x₁ x₂ : BitStream) : BitStream := 
-  ~~~ (x₁ - x₂)
+  -- width 0, nothing is less than
+  BitStream.concat true (~~~ (x₁ - x₂))
 
 @[simp]
 def Predicate.evalFinUlt (x₁ x₂ : BitStream) : BitStream := 
-  ~~~ (x₁.borrow x₂)
+  -- width 0, nothing is less than
+  BitStream.concat true (~~~ (x₁.borrow x₂))
 
 /-- Denote a predicate into a bitstream, where the ith bit tells us if it is true in the ith state -/
 @[simp] def Predicate.evalFin (p : Predicate) (vars : Fin (arity p) → BitStream) : BitStream :=
@@ -330,7 +337,7 @@ match p with
   -- only then should we return a `false`.
   let x₁ := p.evalFin (fun i => vars (Fin.castLE (by simp [arity]) i))
   let x₂ := q.evalFin (fun i => vars (Fin.castLE (by simp [arity]) i))
-  (x₁ ||| x₂)
+  Predicate.evalFinLand x₁ x₂
 | .lor p q =>
   -- If either of the predicates are `false`, then result is `false`.
   let x₁ := p.evalFin (fun i => vars (Fin.castLE (by simp [arity]) i))

--- a/SSA/Experimental/Bits/Fast/Defs.lean
+++ b/SSA/Experimental/Bits/Fast/Defs.lean
@@ -218,21 +218,36 @@ Otherwise, we know that 't₁ ≥ t₂'.
 -/
 def Predicate.evalUlt (t₁ t₂ : BitStream) : BitStream := (~~~ (t₁.borrow t₂)).concat true
 
+
 /--
-Evaluate whether the MSB is uneqal at this bit.
+Returns false if the MSBs are equal.
 -/
-def Predicate.evalMsbNeq (t₁ t₂ : BitStream) : BitStream :=
+def Predicate.evalMsbEq (t₁ t₂ : BitStream) : BitStream :=
   (t₁ ^^^ t₂).concat false
+
+
+private theorem not_not_xor_not (a b : Bool) : ! ((!a).xor (!b)) = (a == b) := by
+  revert a b
+  decide
+
+/--
+info: BitVec.slt_eq_not_carry {w : ℕ} (x y : BitVec w) : (x <ₛ y) = (x.msb == y.msb ^^ BitVec.carry w x (~~~y) true)
+-/
+#guard_msgs in #check BitVec.slt_eq_not_carry
 
 /--
 Evaluate whether `t₁ <ₛ t₂`.
 This is defined by computing the most significant bit of `t₁ - t₂`.
 IF the `msb is 1`, then `t₁ - t₂ <s 0`, and thus `t₁ <s t₂`.
+
+consider the cases:
+  evalMsbEq | evalUlt |
+  F         | F       | F (it's correct. MSBs are equal, and they are ULT)
+
 -/
 def Predicate.evalSlt (t₁ t₂ : BitStream) : BitStream :=
-  (Predicate.evalUlt t₁ t₂) ^^^ (Predicate.evalMsbNeq t₁ t₂)
+    (((Predicate.evalUlt t₁ t₂)) ^^^ (Predicate.evalMsbEq t₁ t₂))
 
--- | leq (t₁ t₂ : Term) : Predicate -> simulate in terms of lt and eq
 open BitStream in
 /--
 Evaluate a term predicate `p` to the BitStream it represents,

--- a/SSA/Experimental/Bits/Fast/Defs.lean
+++ b/SSA/Experimental/Bits/Fast/Defs.lean
@@ -61,7 +61,7 @@ so eval requires us to give a value for each possible variable.
 -/
 def Term.eval (t : Term) (vars : List BitStream) : BitStream :=
   match t with
-  | var n       => vars[n]!
+  | var n       => vars.getD n default
   | zero        => BitStream.zero
   | one         => BitStream.one
   | negOne      => BitStream.negOne

--- a/SSA/Experimental/Bits/Fast/Defs.lean
+++ b/SSA/Experimental/Bits/Fast/Defs.lean
@@ -43,7 +43,7 @@ inductive Term : Type
 -- /-- Decrement (i.e., subtract one) -/
 -- | decr : Term → Term
 /-- shift left by `k` bits. -/
-| shiftL : Term → Nat → Term 
+| shiftL : Term → Nat → Term
 -- /-- logical shift right by `k` bits. -/
 -- | lshiftR : Term → Nat → Term
 -- bollu: I don't think we can do ashiftr, because it's output is 'irregular',
@@ -194,7 +194,7 @@ If they are equal so far, then `t1 ^^^ t2`.scanOr will be 0.
 def Predicate.evalEq (t₁ t₂ : BitStream) : BitStream := (t₁ ^^^ t₂).concat false |>.scanOr
 /--
 If they have been equal so far, then `BitStream.nxor t₁ t₂`.scanAnd will be 1.
-Start by assuming that they are not (not equal) i.e. that they are equal, and the 
+Start by assuming that they are not (not equal) i.e. that they are equal, and the
    initial value of the preciate is false / `1`.
 If their values ever differ, then we know that we will have `a[i] == b[i]` to be `false`.
 From this point onward, they will always disagree, and thus the predicate should become `0`.
@@ -210,7 +210,7 @@ def Predicate.evalLor (t₁ t₂ : BitStream) : BitStream := (t₁ &&& t₂)
 def Predicate.evalLand (t₁ t₂ : BitStream) : BitStream := (t₁ ||| t₂)
 
 
-/-- 
+/--
 Evaluate whether 't₁ <ᵤ t₂'.
 This is defined by computing the borrow bit of 't₁ - t₂'.
 If the borrow bit is `1`, then we know that `t₁ < t₂', so we return a `0`.
@@ -218,12 +218,19 @@ Otherwise, we know that 't₁ ≥ t₂'.
 -/
 def Predicate.evalUlt (t₁ t₂ : BitStream) : BitStream := (~~~ (t₁.borrow t₂)).concat true
 
-/-- 
-Evaluate whether 't₁ <s t₂'.
-This is defined by computing the most significant bit of 't₁ - t₂'.
-IF the `msb is 1`, then `t₁ - t₂ <s 0`, and thus `t₁ <s t₂'.
+/--
+Evaluate whether the MSB is uneqal at this bit.
 -/
-def Predicate.evalSlt (t₁ t₂ : BitStream) : BitStream := (~~~ (t₁ - t₂)).concat true
+def Predicate.evalMsbNeq (t₁ t₂ : BitStream) : BitStream :=
+  (t₁ ^^^ t₂).concat false
+
+/--
+Evaluate whether `t₁ <ₛ t₂`.
+This is defined by computing the most significant bit of `t₁ - t₂`.
+IF the `msb is 1`, then `t₁ - t₂ <s 0`, and thus `t₁ <s t₂`.
+-/
+def Predicate.evalSlt (t₁ t₂ : BitStream) : BitStream :=
+  (Predicate.evalUlt t₁ t₂) ^^^ (Predicate.evalMsbNeq t₁ t₂)
 
 -- | leq (t₁ t₂ : Term) : Predicate -> simulate in terms of lt and eq
 open BitStream in
@@ -250,12 +257,12 @@ def Predicate.eval (p : Predicate) (vars : List BitStream) : BitStream :=
   | lor p q => Predicate.evalLor (p.eval vars) (q.eval vars)
   | land p q => Predicate.evalLand (p.eval vars) (q.eval vars)
   | ult t₁ t₂ => Predicate.evalUlt (t₁.eval vars) (t₂.eval vars)
-  | ule t₁ t₂ => 
-     Predicate.evalLor 
+  | ule t₁ t₂ =>
+     Predicate.evalLor
        (Predicate.evalEq (t₁.eval vars) (t₂.eval vars))
        (Predicate.evalUlt (t₁.eval vars) (t₂.eval vars))
   | slt t₁ t₂ => Predicate.evalSlt (t₁.eval vars) (t₂.eval vars)
-  | sle t₁ t₂ => Predicate.evalLor 
+  | sle t₁ t₂ => Predicate.evalLor
        (Predicate.evalEq (t₁.eval vars) (t₂.eval vars))
        (Predicate.evalSlt (t₁.eval vars) (t₂.eval vars))
 
@@ -286,36 +293,8 @@ end Predicate
 | .neq t₁ t₂ => max t₁.arity t₂.arity
 | .ult t₁ t₂ => max t₁.arity t₂.arity
 | .ule t₁ t₂ => t₁.arity ⊔ t₂.arity ⊔ (t₁.arity ⊔ t₂.arity)
-| .slt t₁ t₂ => max t₁.arity t₂.arity
-| .sle t₁ t₂ => t₁.arity ⊔ t₂.arity ⊔ (t₁.arity ⊔ t₂.arity)
-
-@[simp]
-def Predicate.evalFinLor (x₁ x₂ : BitStream) : BitStream := 
-    (x₁ &&& x₂)
-
-@[simp]
-def Predicate.evalFinLand (x₁ x₂ : BitStream) : BitStream := 
-  (x₁ ||| x₂)
-
-@[simp]
-def Predicate.evalFinEq (x₁ x₂ : BitStream) : BitStream := 
-    -- width 0, stuff is always equal
-    BitStream.concat false (x₁ ^^^ x₂) |>.scanOr
-
-@[simp]
-def Predicate.evalFinNeq (x₁ x₂ : BitStream) : BitStream := 
-    -- width 0, stuff is always equal
-    BitStream.concat true (x₁.nxor x₂) |>.scanAnd
-
-@[simp]
-def Predicate.evalFinSlt (x₁ x₂ : BitStream) : BitStream := 
-  -- width 0, nothing is less than
-  BitStream.concat true (~~~ (x₁ - x₂))
-
-@[simp]
-def Predicate.evalFinUlt (x₁ x₂ : BitStream) : BitStream := 
-  -- width 0, nothing is less than
-  BitStream.concat true (~~~ (x₁.borrow x₂))
+| .slt t₁ t₂ => (t₁.arity ⊔ t₂.arity ⊔ (t₁.arity ⊔ t₂.arity))
+| .sle t₁ t₂ => (t₁.arity ⊔ t₂.arity ⊔ (t₁.arity ⊔ t₂.arity) ⊔ (t₁.arity ⊔ t₂.arity))
 
 /-- Denote a predicate into a bitstream, where the ith bit tells us if it is true in the ith state -/
 @[simp] def Predicate.evalFin (p : Predicate) (vars : Fin (arity p) → BitStream) : BitStream :=
@@ -329,36 +308,35 @@ match p with
 | .eq t₁ t₂ =>
     let x₁ := t₁.evalFin (fun i => vars (Fin.castLE (by simp [arity]) i))
     let x₂ := t₂.evalFin (fun i => vars (Fin.castLE (by simp [arity]) i))
-    Predicate.evalFinEq x₁ x₂
+    Predicate.evalEq x₁ x₂
 | .neq t₁ t₂  =>
     let x₁ := t₁.evalFin (fun i => vars (Fin.castLE (by simp [arity]) i))
     let x₂ := t₂.evalFin (fun i => vars (Fin.castLE (by simp [arity]) i))
-    Predicate.evalFinNeq x₁ x₂
+    Predicate.evalNeq x₁ x₂
 | .land p q =>
   -- if both `p` and `q` are logically true (i.e. the predicate is `false`),
   -- only then should we return a `false`.
   let x₁ := p.evalFin (fun i => vars (Fin.castLE (by simp [arity]) i))
   let x₂ := q.evalFin (fun i => vars (Fin.castLE (by simp [arity]) i))
-  Predicate.evalFinLand x₁ x₂
+  Predicate.evalLand x₁ x₂
 | .lor p q =>
   -- If either of the predicates are `false`, then result is `false`.
   let x₁ := p.evalFin (fun i => vars (Fin.castLE (by simp [arity]) i))
   let x₂ := q.evalFin (fun i => vars (Fin.castLE (by simp [arity]) i))
-  Predicate.evalFinLor x₁ x₂
-| .slt p q => 
+  Predicate.evalLor x₁ x₂
+| .slt p q =>
   let x₁ := p.evalFin (fun i => vars (Fin.castLE (by simp [arity]) i))
   let x₂ := q.evalFin (fun i => vars (Fin.castLE (by simp [arity]) i))
-  Predicate.evalFinSlt x₁ x₂
-| .sle p q => 
+  Predicate.evalSlt x₁ x₂
+| .sle p q =>
   let x₁ := p.evalFin (fun i => vars (Fin.castLE (by simp [arity]) i))
   let x₂ := q.evalFin (fun i => vars (Fin.castLE (by simp [arity]) i))
-  Predicate.evalFinLor (Predicate.evalFinSlt x₁ x₂) (Predicate.evalFinEq x₁ x₂)
-| .ult p q => 
+  Predicate.evalLor (Predicate.evalSlt x₁ x₂) (Predicate.evalEq x₁ x₂)
+| .ult p q =>
   let x₁ := p.evalFin (fun i => vars (Fin.castLE (by simp [arity]) i))
   let x₂ := q.evalFin (fun i => vars (Fin.castLE (by simp [arity]) i))
-  (Predicate.evalFinUlt x₁ x₂)
-| .ule p q => 
+  (Predicate.evalUlt x₁ x₂)
+| .ule p q =>
   let x₁ := p.evalFin (fun i => vars (Fin.castLE (by simp [arity]) i))
   let x₂ := q.evalFin (fun i => vars (Fin.castLE (by simp [arity]) i))
-  Predicate.evalFinLor (Predicate.evalFinUlt x₁ x₂) (Predicate.evalFinEq x₁ x₂)
-
+  Predicate.evalLor (Predicate.evalUlt x₁ x₂) (Predicate.evalEq x₁ x₂)

--- a/SSA/Experimental/Bits/Fast/Defs.lean
+++ b/SSA/Experimental/Bits/Fast/Defs.lean
@@ -297,6 +297,7 @@ end Predicate
 | .sle t₁ t₂ => (t₁.arity ⊔ t₂.arity ⊔ (t₁.arity ⊔ t₂.arity) ⊔ (t₁.arity ⊔ t₂.arity))
 
 /-- Denote a predicate into a bitstream, where the ith bit tells us if it is true in the ith state -/
+-- TODO: remove this from the @[simp] set.
 @[simp] def Predicate.evalFin (p : Predicate) (vars : Fin (arity p) → BitStream) : BitStream :=
 match p with
 | widthEq n => BitStream.falseIffEq n

--- a/SSA/Experimental/Bits/Fast/Defs.lean
+++ b/SSA/Experimental/Bits/Fast/Defs.lean
@@ -285,9 +285,9 @@ end Predicate
 | .land p q => max p.arity q.arity
 | .neq t₁ t₂ => max t₁.arity t₂.arity
 | .ult t₁ t₂ => max t₁.arity t₂.arity
-| .ule t₁ t₂ => max (max t₁.arity t₂.arity) (max t₁.arity t₂.arity)
+| .ule t₁ t₂ => t₁.arity ⊔ t₂.arity ⊔ (t₁.arity ⊔ t₂.arity)
 | .slt t₁ t₂ => max t₁.arity t₂.arity
-| .sle t₁ t₂ => max (max t₁.arity t₂.arity) (max t₁.arity t₂.arity)
+| .sle t₁ t₂ => t₁.arity ⊔ t₂.arity ⊔ (t₁.arity ⊔ t₂.arity)
 
 @[simp]
 def Predicate.evalFinLor (x₁ x₂ : BitStream) : BitStream := 

--- a/SSA/Experimental/Bits/Fast/FiniteStateMachine.lean
+++ b/SSA/Experimental/Bits/Fast/FiniteStateMachine.lean
@@ -926,7 +926,11 @@ theorem eval_ofInt (x : Int) (i : Nat) {env : Fin 0 → BitStream} :
   rcases x with x | x
   · simp [ofInt, BitStream.ofInt]
   · simp only [ofInt, composeUnaryAux_eval, eval_neg, BitStream.ofInt]
-    sorry
+    -- TODO: why does 'congr' not work here?
+    apply congrFun
+    apply congrArg
+    ext i
+    simp
 
 
 /-- Identity finite state machine -/

--- a/SSA/Experimental/Bits/Fast/FiniteStateMachine.lean
+++ b/SSA/Experimental/Bits/Fast/FiniteStateMachine.lean
@@ -1254,16 +1254,16 @@ def fsmUle (a : FSM (Fin k)) (b : FSM (Fin l)) : FSM (Fin (k ⊔ l ⊔ (k ⊔ l)
   fsmLor ult eq
 
 
-def fsmMsbNeq (a : FSM (Fin k)) (b : FSM (Fin l)) : FSM (Fin (k ⊔ l)) :=
-  composeUnaryAux (FSM.ls (!false)) <| composeBinaryAux FSM.xor a b
+def fsmMsbEq (a : FSM (Fin k)) (b : FSM (Fin l)) : FSM (Fin (k ⊔ l)) :=
+  composeUnaryAux (FSM.ls false) <| composeBinaryAux FSM.xor a b
 
 -- theorem fsmMsbNeq_eq_Predicate_MsbNeq (t₁ t₂ : Term) :
 --   (Predicate.msbNeq t₁ t₂).evalFin = (fsmMsbNeq (termEvalEqFSM t₁).toFSM (termEvalEqFSM t₂).toFSM).eval := sorry
 
 def fsmSlt (a : FSM (Fin k)) (b : FSM (Fin l)) : FSM (Fin (k ⊔ l ⊔ (k ⊔ l))) :=
-  let msbCheck := fsmMsbNeq a b
+  let msbCheck := fsmMsbEq a b
   let ult := fsmUlt a b
-  composeUnaryAux FSM.not <| composeBinaryAux FSM.xor ult msbCheck
+  composeBinaryAux FSM.xor ult msbCheck
 
 /--
 TODO: implement FSM.cast so we don't need to accumulate `max`s in this godforsaken fashion.
@@ -1363,9 +1363,8 @@ def predicateEvalEqFSM : ∀ (p : Predicate), FSMPredicateSolution p
      { toFSM := fsmSlt a.toFSM b.toFSM
        good := by
         ext;
-        sorry
-        -- simp [Predicate.evalSlt, fsmSlt,
-        --   Predicate.evalUlt, fsmUlt, a.good, b.good, Predicate.evalMsbNeq, fsmMsbNeq, a.good, b.good]
+        simp [Predicate.evalSlt, fsmSlt,
+          Predicate.evalUlt, fsmUlt, a.good, b.good, Predicate.evalMsbEq, fsmMsbEq, a.good, b.good]
      }
    | .sle t₁ t₂ =>
       let a := termEvalEqFSM t₁
@@ -1374,12 +1373,11 @@ def predicateEvalEqFSM : ∀ (p : Predicate), FSMPredicateSolution p
         toFSM := fsmSle a.toFSM b.toFSM
         good := by
           ext x i
-          sorry
-          -- simp [fsmSle,
-          --   Predicate.evalLor, fsmLor,
-          --   Predicate.evalSlt, fsmSlt, Predicate.evalUlt,
-          --   fsmUlt, a.good, b.good, Predicate.evalMsbNeq, fsmMsbNeq,
-          --   Predicate.evalEq, fsmEq, a.good, b.good]
+          simp [fsmSle,
+            Predicate.evalLor, fsmLor,
+            Predicate.evalSlt, fsmSlt, Predicate.evalUlt,
+            fsmUlt, a.good, b.good, Predicate.evalMsbEq, fsmMsbEq,
+            Predicate.evalEq, fsmEq, a.good, b.good]
       }
    | .ult t₁ t₂ =>
       let a := termEvalEqFSM t₁
@@ -1402,9 +1400,7 @@ def predicateEvalEqFSM : ∀ (p : Predicate), FSMPredicateSolution p
           simp [fsmUle, fsmUlt, fsmEq, fsmLor, a.good, b.good, Predicate.evalLor, Predicate.evalUlt, Predicate.evalEq]
       }
 
-/--
-info: 'predicateEvalEqFSM' depends on axioms: [propext, sorryAx, Classical.choice, Quot.sound]
--/
+/-- info: 'predicateEvalEqFSM' depends on axioms: [propext, Classical.choice, Quot.sound] -/
 #guard_msgs in #print axioms predicateEvalEqFSM
 
 def card_compl [Fintype α] [DecidableEq α] (c : Circuit α) : ℕ :=

--- a/SSA/Experimental/Bits/Fast/FiniteStateMachine.lean
+++ b/SSA/Experimental/Bits/Fast/FiniteStateMachine.lean
@@ -1458,7 +1458,7 @@ def decideIfZerosAtIxAux {arity : Type _} [DecidableEq arity]
       | nItersLeft' + 1 => 
         -- accumulate one iteration
         have c' := (c.bind (fsm.nextBitCirc ∘ some)).fst
-        if h : c' ≤ c 
+        if _ : c' ≤ c 
         then true
         else decideIfZerosAtIxAux fsm (c' ||| c) nItersLeft'
 

--- a/SSA/Experimental/Bits/Fast/FiniteStateMachine.lean
+++ b/SSA/Experimental/Bits/Fast/FiniteStateMachine.lean
@@ -1464,10 +1464,11 @@ def decideIfZerosAtIx {arity : Type _} [DecidableEq arity]
 /--
 The correctness statement of decideIfZeroesAtIx.
 This tells us that decideIfZeroesAtIx is correct iff the FSM 'p' when evaluated returns false
-for all inputs at the index 'w' of the bitstream
+for all inputs at the index 'w' of the bitstream.
+
+We file this as a separate axiom
 -/
-theorem decideIfZeroesAtIx_correct {arity : Type _} [DecidableEq arity]
-    (p : FSM arity) (w : Nat) : decideIfZerosAtIx p w = true ↔ ∀ (x : arity → BitStream), p.eval x w = false := by
-  sorry
+axiom decideIfZeroesAtIx_correct {arity : Type _} [DecidableEq arity]
+    (p : FSM arity) (w : Nat) : decideIfZerosAtIx p w = true ↔ ∀ (x : arity → BitStream), p.eval x w = false 
 
 end FSM

--- a/SSA/Experimental/Bits/Fast/FiniteStateMachine.lean
+++ b/SSA/Experimental/Bits/Fast/FiniteStateMachine.lean
@@ -1255,7 +1255,7 @@ def fsmUle (a : FSM (Fin k)) (b : FSM (Fin l)) : FSM (Fin (k ⊔ l ⊔ (k ⊔ l)
 
 
 def fsmMsbNeq (a : FSM (Fin k)) (b : FSM (Fin l)) : FSM (Fin (k ⊔ l)) :=
-  composeUnaryAux (FSM.ls false) <| composeBinaryAux FSM.xor a b
+  composeUnaryAux (FSM.ls (!false)) <| composeBinaryAux FSM.xor a b
 
 -- theorem fsmMsbNeq_eq_Predicate_MsbNeq (t₁ t₂ : Term) :
 --   (Predicate.msbNeq t₁ t₂).evalFin = (fsmMsbNeq (termEvalEqFSM t₁).toFSM (termEvalEqFSM t₂).toFSM).eval := sorry
@@ -1263,7 +1263,7 @@ def fsmMsbNeq (a : FSM (Fin k)) (b : FSM (Fin l)) : FSM (Fin (k ⊔ l)) :=
 def fsmSlt (a : FSM (Fin k)) (b : FSM (Fin l)) : FSM (Fin (k ⊔ l ⊔ (k ⊔ l))) :=
   let msbCheck := fsmMsbNeq a b
   let ult := fsmUlt a b
-  composeBinaryAux FSM.xor ult msbCheck
+  composeUnaryAux FSM.not <| composeBinaryAux FSM.xor ult msbCheck
 
 /--
 TODO: implement FSM.cast so we don't need to accumulate `max`s in this godforsaken fashion.
@@ -1363,11 +1363,9 @@ def predicateEvalEqFSM : ∀ (p : Predicate), FSMPredicateSolution p
      { toFSM := fsmSlt a.toFSM b.toFSM
        good := by
         ext;
-        simp
-        simp [Predicate.evalSlt, fsmSlt]
-        congr
-        · simp [Predicate.evalUlt, fsmUlt, a.good, b.good]
-        · simp [Predicate.evalMsbNeq, fsmMsbNeq, a.good, b.good]
+        sorry
+        -- simp [Predicate.evalSlt, fsmSlt,
+        --   Predicate.evalUlt, fsmUlt, a.good, b.good, Predicate.evalMsbNeq, fsmMsbNeq, a.good, b.good]
      }
    | .sle t₁ t₂ =>
       let a := termEvalEqFSM t₁
@@ -1376,12 +1374,12 @@ def predicateEvalEqFSM : ∀ (p : Predicate), FSMPredicateSolution p
         toFSM := fsmSle a.toFSM b.toFSM
         good := by
           ext x i
-          simp [fsmSle]
-          simp [Predicate.evalLor, fsmLor]
-          congr
-          · simp [Predicate.evalSlt, fsmSlt, Predicate.evalUlt, fsmUlt, a.good, b.good, Predicate.evalMsbNeq, fsmMsbNeq]
-            -- TODO: this should follow from a theorem we have proven.
-          · simp [Predicate.evalEq, fsmEq, a.good, b.good]
+          sorry
+          -- simp [fsmSle,
+          --   Predicate.evalLor, fsmLor,
+          --   Predicate.evalSlt, fsmSlt, Predicate.evalUlt,
+          --   fsmUlt, a.good, b.good, Predicate.evalMsbNeq, fsmMsbNeq,
+          --   Predicate.evalEq, fsmEq, a.good, b.good]
       }
    | .ult t₁ t₂ =>
       let a := termEvalEqFSM t₁
@@ -1404,7 +1402,9 @@ def predicateEvalEqFSM : ∀ (p : Predicate), FSMPredicateSolution p
           simp [fsmUle, fsmUlt, fsmEq, fsmLor, a.good, b.good, Predicate.evalLor, Predicate.evalUlt, Predicate.evalEq]
       }
 
-/-- info: 'predicateEvalEqFSM' depends on axioms: [propext, Classical.choice, Quot.sound] -/
+/--
+info: 'predicateEvalEqFSM' depends on axioms: [propext, sorryAx, Classical.choice, Quot.sound]
+-/
 #guard_msgs in #print axioms predicateEvalEqFSM
 
 def card_compl [Fintype α] [DecidableEq α] (c : Circuit α) : ℕ :=

--- a/SSA/Experimental/Bits/Fast/FiniteStateMachine.lean
+++ b/SSA/Experimental/Bits/Fast/FiniteStateMachine.lean
@@ -1426,6 +1426,9 @@ theorem decideIfZeros_correct {arity : Type _} [DecidableEq arity]
     use x
     exact h
 
+/-- info: 'decideIfZeros_correct' depends on axioms: [propext, Classical.choice, Quot.sound] -/
+#guard_msgs in #print axioms decideIfZeros_correct
+
 /-- Iterate the next bit circuit 'n' times, while universally quantifying over all inputs
 that are possible at each step. -/
 def FSM.nextBitCircIterate {arity : Type _ } [DecidableEq arity]

--- a/SSA/Experimental/Bits/Fast/FiniteStateMachine.lean
+++ b/SSA/Experimental/Bits/Fast/FiniteStateMachine.lean
@@ -1139,14 +1139,6 @@ def termEvalEqFSM : ∀ (t : Term), FSMTermSolution t
     let q := termEvalEqFSM t
     { toFSM := by dsimp [arity]; exact composeUnary FSM.neg q,
       good := by ext; simp }
---   | incr t =>
---     let q := termEvalEqFSM t
---     { toFSM := by dsimp [arity]; exact composeUnary FSM.incr q,
---       good := by ext; simp }
---   | decr t =>
---     let q := termEvalEqFSM t
---     { toFSM := by dsimp [arity]; exact composeUnary FSM.decr q,
---       good := by ext; simp }
   | shiftL t k =>
      let q := termEvalEqFSM t
      {

--- a/SSA/Experimental/Bits/Fast/FiniteStateMachine.lean
+++ b/SSA/Experimental/Bits/Fast/FiniteStateMachine.lean
@@ -1139,21 +1139,21 @@ def termEvalEqFSM : ∀ (t : Term), FSMTermSolution t
     let q := termEvalEqFSM t
     { toFSM := by dsimp [arity]; exact composeUnary FSM.neg q,
       good := by ext; simp }
-  | incr t =>
-    let q := termEvalEqFSM t
-    { toFSM := by dsimp [arity]; exact composeUnary FSM.incr q,
-      good := by ext; simp }
-  | decr t =>
-    let q := termEvalEqFSM t
-    { toFSM := by dsimp [arity]; exact composeUnary FSM.decr q,
-      good := by ext; simp }
+--   | incr t =>
+--     let q := termEvalEqFSM t
+--     { toFSM := by dsimp [arity]; exact composeUnary FSM.incr q,
+--       good := by ext; simp }
+--   | decr t =>
+--     let q := termEvalEqFSM t
+--     { toFSM := by dsimp [arity]; exact composeUnary FSM.decr q,
+--       good := by ext; simp }
   | shiftL t k =>
      let q := termEvalEqFSM t
      {
        toFSM := by dsimp [arity]; exact composeUnary (FSM.shiftLeft k) q,
        good := by 
          ext x i
-         simp only [evalFin, BitStream.eval_shiftLeft, Bool.if_false_left, arity.eq_16, id_eq,
+         simp only [evalFin, BitStream.eval_shiftLeft, Bool.if_false_left, arity.eq_14, id_eq,
            composeUnary_eval, FSM.eval_shiftLeft]
          by_cases hi : i < k
          · simp [hi]

--- a/SSA/Experimental/Bits/Fast/FiniteStateMachine.lean
+++ b/SSA/Experimental/Bits/Fast/FiniteStateMachine.lean
@@ -1225,8 +1225,8 @@ def predicateEvalEqFSM : ∀ (p : Predicate), FSMPredicateSolution p
     let t₂' := termEvalEqFSM t₂
     {
      -- At width 0, all things are equal.
-     toFSM := composeUnaryAux (FSM.ls false) <| (composeUnaryAux FSM.scanOr <| composeBinary FSM.xor t₁' t₂')
-     good := by ext; simp; sorry
+     toFSM := (composeUnaryAux FSM.scanOr <| composeUnaryAux (FSM.ls false) <|  composeBinary FSM.xor t₁' t₂')
+     good := by ext; simp
     }
   | .neq t₁ t₂ =>
     let t₁' := termEvalEqFSM t₁
@@ -1235,8 +1235,11 @@ def predicateEvalEqFSM : ∀ (p : Predicate), FSMPredicateSolution p
      -- At width 0, all things are equal, so the predicate is untrue.
      -- If it ever becomes `0`, it should stay `0` forever, because once
      -- two bitstreams become disequal, they stay disequal!
-     toFSM := composeUnaryAux (FSM.ls true) <| (composeUnaryAux FSM.scanAnd <| composeBinary FSM.nxor t₁' t₂')
-     good := by sorry -- ext; simp;
+     toFSM := (composeUnaryAux FSM.scanAnd <| composeUnaryAux (FSM.ls true) <| composeBinary FSM.nxor t₁' t₂')
+     good := by
+       ext x i
+       simp
+       sorry
     }
    | .land p q =>
      let x₁ := predicateEvalEqFSM p
@@ -1245,7 +1248,7 @@ def predicateEvalEqFSM : ∀ (p : Predicate), FSMPredicateSolution p
        -- If this ever becomes `1`, it should stay `1`,
        -- since once it's falsified, it should stay falsified!
        toFSM := composeBinaryAux FSM.or x₁.toFSM x₂.toFSM
-       good := by sorry -- ext; simp [x₁.good, x₂.good]
+       good := by ext x i; simp [x₁.good, x₂.good]
      }
    | .lor p q =>
      let x₁ := predicateEvalEqFSM p
@@ -1254,7 +1257,7 @@ def predicateEvalEqFSM : ∀ (p : Predicate), FSMPredicateSolution p
        -- If it ever becomes `1`, it should stay `1`,
        -- since one it's falsified, it should stay falsified!
        toFSM := composeBinaryAux FSM.and x₁.toFSM x₂.toFSM
-       good := by sorry -- ext; simp [x₁.good, x₂.good]
+       good := by ext x i; simp [x₁.good, x₂.good]
      }
    | .slt t₁ t₂ =>
      let q₁ := termEvalEqFSM t₁
@@ -1278,7 +1281,7 @@ def predicateEvalEqFSM : ∀ (p : Predicate), FSMPredicateSolution p
       let out := composeBinaryAux FSM.and slt eq
       {
        toFSM := hsz ▸ out
-       good := by sorry -- TODO: show that it's good 'ext; simp';
+       good := by ext x i; simp; sorry
       }
    | .ult t₁ t₂ =>
       let t₁' := termEvalEqFSM t₁
@@ -1286,7 +1289,10 @@ def predicateEvalEqFSM : ∀ (p : Predicate), FSMPredicateSolution p
       {
        -- a <u b if when we compute (a - b), we must borrow a value.
        toFSM := composeUnaryAux (FSM.ls true) <| (composeUnaryAux FSM.not $ composeBinary FSM.borrow t₁' t₂')
-       good := by sorry -- TODO: show that it's good 'ext; simp';
+       good := by 
+         ext x i; 
+         simp
+         sorry
       }
    | .ule t₁ t₂ =>
       let t₁' := termEvalEqFSM t₁
@@ -1301,7 +1307,10 @@ def predicateEvalEqFSM : ∀ (p : Predicate), FSMPredicateSolution p
       let out := composeBinaryAux FSM.and ult eq
       {
        toFSM := hsz ▸ out
-       good := by sorry -- TODO: show that it's good 'ext; simp';
+       good := by 
+         ext x i
+         simp
+         sorry
       }
 
 def card_compl [Fintype α] [DecidableEq α] (c : Circuit α) : ℕ :=

--- a/SSA/Experimental/Bits/Fast/FiniteStateMachine.lean
+++ b/SSA/Experimental/Bits/Fast/FiniteStateMachine.lean
@@ -998,6 +998,9 @@ def trueUptoExcluding (n : Nat) : FSM (Fin 0) :=
 def falseAfterIncluding (n : Nat) : FSM (Fin 0) := trueUptoExcluding n
 private theorem falseAfterIncluding_false_iff (n i : Nat) {env : Fin 0 → BitStream} :
   (falseAfterIncluding n).eval env i = false ↔ i ≥ n := by simp [falseAfterIncluding];
+@[simp] theorem eval_falseAfterIncluding (n : Nat) (i : Nat) {env : Fin 0 → BitStream} :
+    (falseAfterIncluding n).eval env i = decide (i < n) := by
+  simp [falseAfterIncluding]
 
 /--
 Build an FSM whose value is 'true' for states [0, 1, ... n] (including the endpoint),
@@ -1010,6 +1013,8 @@ def trueUptoIncluding (n : Nat) : FSM (Fin 0) := ofNat (BitVec.allOnes (n+1)).to
 def falseAfterExcluding (n : Nat) : FSM (Fin 0) := trueUptoIncluding n
 private theorem falseAfterExcluding_false_iff (n i : Nat) {env : Fin 0 → BitStream} :
   (falseAfterExcluding n).eval env i = false ↔ i > n := by simp [falseAfterExcluding]
+@[simp] theorem eval_falseAfterExcluding (n : Nat) (i : Nat) {env : Fin 0 → BitStream} :
+    (falseAfterExcluding n).eval env i = decide (i ≤ n) := by simp [falseAfterExcluding]
 
 /--
 Build an FSM whose value is and 'false' for the first [0, 1, ... n), and 'true' for [n, n + 1, ...).
@@ -1180,32 +1185,40 @@ def predicateEvalEqFSM : ∀ (p : Predicate), FSMPredicateSolution p
   | .widthEq n =>
     {
       toFSM := FSM.falseOnlyAt n
-      good := by sorry
+      good := by 
+        ext i x
+        simp only [Predicate.evalFin, Bool.decide_eq_true, Predicate.arity.eq_1,
+          FSM.eval_falseOnlyAt]
+        by_cases h : x = n  <;> simp [h]
     }
   | .widthNeq n =>
      {
       toFSM := FSM.trueOnlyAt n
-      good := by sorry
+      good := by
+        ext i x 
+        simp only [Predicate.evalFin, Bool.decide_eq_true, Predicate.arity.eq_2,
+          FSM.eval_trueOnlyAt]
+        by_cases h : x = n <;> simp [h]
      }
   | .widthGe n =>
      {
       toFSM := FSM.falseAfterIncluding n
-      good := by sorry
+      good := by ext; simp
      }
   | .widthGt n =>
      {
       toFSM := FSM.falseAfterExcluding n
-      good := by sorry
+      good := by ext; simp
      }
   | .widthLt n =>
      {
       toFSM := FSM.falseUptoExcluding n
-      good := by sorry
+      good := by ext; simp
      }
   | .widthLe n =>
      {
       toFSM := FSM.falseUptoIncluding n
-      good := by sorry
+      good := by ext; simp
      }
   | .eq t₁ t₂ =>
     let t₁' := termEvalEqFSM t₁

--- a/SSA/Experimental/Bits/Fast/Lemmas.lean
+++ b/SSA/Experimental/Bits/Fast/Lemmas.lean
@@ -10,6 +10,7 @@ import Mathlib.Tactic.Ring
 import SSA.Experimental.Bits.Fast.Defs
 import SSA.Experimental.Bits.Fast.BitStream
 
+
 open Term
 
 /--
@@ -95,7 +96,6 @@ lemma Term.evalFin_eq_eval (t : Term)
 
 axiom axEvalFinEqEval {p : Prop} : p
 
-
 lemma Predicate.evalFin_eq_eval (p : Predicate)
    (varsList : List BitStream) (varsFin : Fin p.arity → BitStream)
    (hvars : ∀ (i : Fin p.arity), varsList.getD i default = (varsFin i)) :
@@ -146,10 +146,9 @@ lemma Predicate.evalFin_eq_eval (p : Predicate)
     simp [evalUlt]
     rw [Term.evalFin_eq_eval _ varsList]
     · rw [Term.evalFin_eq_eval _ varsList]
-      · exact axEvalFinEqEval  -- discrepancy
-      · intros i
-        rw [hvars ⟨i, by omega⟩]
-        rfl
+      intros i 
+      rw [hvars ⟨i, by omega⟩]
+      rfl
     · intros i
       rw [hvars ⟨i, by omega⟩]
       rfl
@@ -157,10 +156,9 @@ lemma Predicate.evalFin_eq_eval (p : Predicate)
     simp [evalSlt]
     rw [Term.evalFin_eq_eval _ varsList]
     · rw [Term.evalFin_eq_eval _ varsList]
-      · exact axEvalFinEqEval  -- discrepancy
-      · intros i
-        rw [hvars ⟨i, by omega⟩]
-        rfl
+      intros i 
+      rw [hvars ⟨i, by omega⟩]
+      rfl
     · intros i
       rw [hvars ⟨i, by omega⟩]
       rfl
@@ -168,7 +166,8 @@ lemma Predicate.evalFin_eq_eval (p : Predicate)
     simp [evalUlt, evalEq]
     rw [Term.evalFin_eq_eval _ varsList]
     · rw [Term.evalFin_eq_eval _ varsList]
-      · exact axEvalFinEqEval  -- discrepancy
+      · simp [evalLor]
+        rw [BitStream.and_comm]
       · intros i
         rw [hvars ⟨i, by omega⟩]
         rfl
@@ -179,7 +178,8 @@ lemma Predicate.evalFin_eq_eval (p : Predicate)
     simp [evalUlt, evalEq]
     rw [Term.evalFin_eq_eval _ varsList]
     · rw [Term.evalFin_eq_eval _ varsList]
-      · exact axEvalFinEqEval  -- discrepancy
+      · simp [evalSlt, evalLor]
+        rw [BitStream.and_comm]
       · intros i
         rw [hvars ⟨i, by omega⟩]
         rfl
@@ -187,7 +187,7 @@ lemma Predicate.evalFin_eq_eval (p : Predicate)
       rw [hvars ⟨i, by omega⟩]
       rfl
 
-/-- info: 'Predicate.evalFin_eq_eval' depends on axioms: [axEvalFinEqEval, propext, Quot.sound] -/
+/-- info: 'Predicate.evalFin_eq_eval' depends on axioms: [propext, Quot.sound] -/
 #guard_msgs in #print axioms Predicate.evalFin_eq_eval
 
 

--- a/SSA/Experimental/Bits/Fast/Lemmas.lean
+++ b/SSA/Experimental/Bits/Fast/Lemmas.lean
@@ -94,8 +94,6 @@ lemma Term.evalFin_eq_eval (t : Term)
 /-- info: 'Term.evalFin_eq_eval' depends on axioms: [propext, Quot.sound] -/
 #guard_msgs in #print axioms Term.evalFin_eq_eval 
 
-axiom axEvalFinEqEval {p : Prop} : p
-
 lemma Predicate.evalFin_eq_eval (p : Predicate)
    (varsList : List BitStream) (varsFin : Fin p.arity → BitStream)
    (hvars : ∀ (i : Fin p.arity), varsList.getD i default = (varsFin i)) :

--- a/SSA/Experimental/Bits/Fast/Lemmas.lean
+++ b/SSA/Experimental/Bits/Fast/Lemmas.lean
@@ -18,20 +18,178 @@ Build a list `[f 0, f 1, ... ]`  of length `size`.
 abbrev List.ofFn' (f : Nat → α) (size : Nat) : List α :=
   List.ofFn (n := size) (fun i => f i)
 
+
+lemma Term.evalFin_eq_eval (t : Term) 
+   (varsList : List BitStream) (varsFin : Fin t.arity → BitStream)
+   (hvars : ∀ (i : Fin t.arity), varsList.getD i default = (varsFin i)) :
+    Term.evalFin t varsFin = Term.eval t varsList := by
+  induction t generalizing varsList <;>
+    dsimp [Term.evalFin, Term.eval, arity] at *
+  case var i => rw [← hvars]; simp
+  case and a b ha hb => 
+    rw [ha varsList]
+    · rw [hb varsList]
+      intros i
+      have := hvars ⟨i, by omega⟩
+      rw [this]
+      rfl
+    · intros i
+      have := hvars ⟨i, by omega⟩
+      rw [this]
+      rfl
+  case or a b ha hb =>
+    rw [ha varsList]
+    · rw [hb varsList]
+      intros i
+      have := hvars ⟨i, by omega⟩
+      rw [this]
+      rfl
+    · intros i
+      have := hvars ⟨i, by omega⟩
+      rw [this]
+      rfl
+  case xor a b ha hb =>
+    rw [ha varsList]
+    · rw [hb varsList]
+      intros i
+      have := hvars ⟨i, by omega⟩
+      rw [this]
+      rfl
+    · intros i
+      have := hvars ⟨i, by omega⟩
+      rw [this]
+      rfl
+  case not a ha => rw [ha varsList _ hvars]
+  case neg a ha => rw [ha varsList _ hvars]
+  case shiftL k a ha => rw [ha varsList _ hvars]
+  case ls a b ha =>
+    rw [ha varsList]
+    intros i
+    -- TODO: make this into simp normal form
+    rw [hvars]
+  case add a b ha hb =>
+    rw [ha varsList]
+    · rw [hb varsList]
+      intros i
+      have := hvars ⟨i, by omega⟩
+      rw [this]
+      rfl
+    · intros i
+      have := hvars ⟨i, by omega⟩
+      rw [this]
+      rfl
+  case sub a b ha hb =>
+    rw [ha varsList]
+    · rw [hb varsList]
+      intros i
+      have := hvars ⟨i, by omega⟩
+      rw [this]
+      rfl
+    · intros i
+      have := hvars ⟨i, by omega⟩
+      rw [this]
+      rfl
+
+/-- info: 'Term.evalFin_eq_eval' depends on axioms: [propext, Quot.sound] -/
+#guard_msgs in #print axioms Term.evalFin_eq_eval 
+
 axiom axEvalFinEqEval {p : Prop} : p
-
-
-lemma Term.evalFin_eq_eval (t : Term) (vars : Nat → BitStream) :
-    Term.evalFin t (fun i => vars i) = Term.eval t (List.ofFn' vars t.arity) := by
-  induction t <;>
-    dsimp [Term.evalFin, Term.eval, arity] at * <;> exact axEvalFinEqEval
 
 
 lemma Predicate.evalFin_eq_eval (p : Predicate)
    (varsList : List BitStream) (varsFin : Fin p.arity → BitStream)
    (hvars : ∀ (i : Fin p.arity), varsList.getD i default = (varsFin i)) :
     Predicate.evalFin p varsFin  = Predicate.eval p varsList := by
-  induction p <;> exact axEvalFinEqEval
+  induction p generalizing varsList <;>
+    dsimp [Predicate.evalFin, Predicate.eval, Predicate.arity] at *
+  case eq =>
+    simp [evalEq]
+    rw [Term.evalFin_eq_eval _ varsList]
+    · rw [Term.evalFin_eq_eval _ varsList]
+      · intros i
+        rw [hvars ⟨i, by omega⟩]
+        rfl
+    · intros i
+      rw [hvars ⟨i, by omega⟩]
+      rfl
+  case neq =>
+    simp [evalNeq]
+    rw [Term.evalFin_eq_eval _ varsList]
+    · rw [Term.evalFin_eq_eval _ varsList]
+      · intros i
+        rw [hvars ⟨i, by omega⟩]
+        rfl
+    · intros i
+      rw [hvars ⟨i, by omega⟩]
+      rfl
+  case land p q hp hq =>
+    simp [evalLand]
+    rw [hp varsList]
+    · rw [hq varsList]
+      · intros i
+        rw [hvars ⟨i, by omega⟩]
+        rfl
+    · intros i
+      rw [hvars ⟨i, by omega⟩]
+      rfl
+  case lor p q hp hq =>
+    simp [evalLor]
+    rw [hp varsList]
+    · rw [hq varsList]
+      · intros i
+        rw [hvars ⟨i, by omega⟩]
+        rfl
+    · intros i
+      rw [hvars ⟨i, by omega⟩]
+      rfl
+  case ult =>
+    simp [evalUlt]
+    rw [Term.evalFin_eq_eval _ varsList]
+    · rw [Term.evalFin_eq_eval _ varsList]
+      · exact axEvalFinEqEval  -- discrepancy
+      · intros i
+        rw [hvars ⟨i, by omega⟩]
+        rfl
+    · intros i
+      rw [hvars ⟨i, by omega⟩]
+      rfl
+  case slt =>
+    simp [evalSlt]
+    rw [Term.evalFin_eq_eval _ varsList]
+    · rw [Term.evalFin_eq_eval _ varsList]
+      · exact axEvalFinEqEval  -- discrepancy
+      · intros i
+        rw [hvars ⟨i, by omega⟩]
+        rfl
+    · intros i
+      rw [hvars ⟨i, by omega⟩]
+      rfl
+  case ule =>
+    simp [evalUlt, evalEq]
+    rw [Term.evalFin_eq_eval _ varsList]
+    · rw [Term.evalFin_eq_eval _ varsList]
+      · exact axEvalFinEqEval  -- discrepancy
+      · intros i
+        rw [hvars ⟨i, by omega⟩]
+        rfl
+    · intros i
+      rw [hvars ⟨i, by omega⟩]
+      rfl
+  case sle =>
+    simp [evalUlt, evalEq]
+    rw [Term.evalFin_eq_eval _ varsList]
+    · rw [Term.evalFin_eq_eval _ varsList]
+      · exact axEvalFinEqEval  -- discrepancy
+      · intros i
+        rw [hvars ⟨i, by omega⟩]
+        rfl
+    · intros i
+      rw [hvars ⟨i, by omega⟩]
+      rfl
+
+/-- info: 'Predicate.evalFin_eq_eval' depends on axioms: [axEvalFinEqEval, propext, Quot.sound] -/
+#guard_msgs in #print axioms Predicate.evalFin_eq_eval
+
 
 lemma eq_iff_xor_eq_zero (seq₁ seq₂ : BitStream) :
     (∀ i, seq₁ i = seq₂ i) ↔ (∀ i, (seq₁ ^^^ seq₂) i = BitStream.zero i) := by

--- a/SSA/Experimental/Bits/Fast/Lemmas.lean
+++ b/SSA/Experimental/Bits/Fast/Lemmas.lean
@@ -15,24 +15,24 @@ open Term
 /--
 Build a list `[f 0, f 1, ... ]`  of length `size`.
 -/
-def List.ofFn' (f : Nat → α) (size : Nat) : List α :=
+abbrev List.ofFn' (f : Nat → α) (size : Nat) : List α :=
   List.ofFn (n := size) (fun i => f i)
+
+axiom axEvalFinEqEval {p : Prop} : p
+
 
 lemma Term.evalFin_eq_eval (t : Term) (vars : Nat → BitStream) :
     Term.evalFin t (fun i => vars i) = Term.eval t (List.ofFn' vars t.arity) := by
   induction t <;>
-    dsimp [Term.evalFin, Term.eval, arity] at * <;> sorry
+    dsimp [Term.evalFin, Term.eval, arity] at * <;> exact axEvalFinEqEval
 
-lemma Predicate.evalFin_eq_eval (p : Predicate) (vars : Nat → BitStream) :
-    Predicate.evalFin p (fun i => vars i) = Predicate.eval p (List.ofFn' vars p.arity) := by
-  induction p <;> sorry
+
+lemma Predicate.evalFin_eq_eval (p : Predicate)
+   (varsList : List BitStream) (varsFin : Fin p.arity → BitStream)
+   (hvars : ∀ (i : Fin p.arity), varsList.getD i default = (varsFin i)) :
+    Predicate.evalFin p varsFin  = Predicate.eval p varsList := by
+  induction p <;> exact axEvalFinEqEval
 
 lemma eq_iff_xor_eq_zero (seq₁ seq₂ : BitStream) :
     (∀ i, seq₁ i = seq₂ i) ↔ (∀ i, (seq₁ ^^^ seq₂) i = BitStream.zero i) := by
   simp [funext_iff]
-
-lemma eval_eq_iff_xor_eq_zero (t₁ t₂ : Term) :
-    t₁.eval = t₂.eval ↔ (t₁.xor t₂).evalFin = fun _ => BitStream.zero := by
-  simp only [funext_iff, Term.eval, Term.evalFin,
-    ← eq_iff_xor_eq_zero, ← evalFin_eq_eval]
-  constructor <;> sorry

--- a/SSA/Experimental/Bits/Fast/Reflect.lean
+++ b/SSA/Experimental/Bits/Fast/Reflect.lean
@@ -321,13 +321,18 @@ def Predicate.cost (p : Predicate) : Nat :=
   let fsm := predicateEvalEqFSM p
   fsm.circuitSize
 
-@[simp] theorem Predicate.eval_land_iff (p q : Predicate) (vars : List (BitVec w)) :
-    evalLand (p.eval (List.map BitStream.ofBitVec vars)) (q.eval (List.map BitStream.ofBitVec vars)) w = false ↔
-    p.denote w vars ∧ q.denote w vars := by sorry
-
-@[simp] theorem Predicate.eval_lor_iff (p q : Predicate) (vars : List (BitVec w)) :
-    evalLor (p.eval (List.map BitStream.ofBitVec vars)) (q.eval (List.map BitStream.ofBitVec vars)) w = false ↔
-    p.denote w vars ∨ q.denote w vars := by sorry
+-- @[simp] theorem Predicate.eval_land_iff (p q : Predicate) (vars : List (BitVec w)) :
+--     evalLand (p.eval (List.map BitStream.ofBitVec vars)) (q.eval (List.map BitStream.ofBitVec vars)) w = false ↔
+--     p.denote w vars ∧ q.denote w vars := by
+--   constructor
+--   · simp [evalLand];
+--     intros hp hq
+-- 
+--   · simp; sorry
+-- 
+-- @[simp] theorem Predicate.eval_lor_iff (p q : Predicate) (vars : List (BitVec w)) :
+--     evalLor (p.eval (List.map BitStream.ofBitVec vars)) (q.eval (List.map BitStream.ofBitVec vars)) w = false ↔
+--     p.denote w vars ∨ q.denote w vars := by sorry
  
 
 /--
@@ -349,8 +354,26 @@ theorem Predicate.eval_eq_denote (w : Nat) (p : Predicate) (vars : List (BitVec 
   case ule a b => simp [eval, denote]; sorry
   case slt a b => simp [eval, denote]; sorry
   case sle a b => simp [eval, denote]; sorry
-  case land p q hp hq => simp [eval, denote, hp, hq]
-  case lor p q hp hq => simp [eval, denote, hp, hq]
+  case land p q hp hq => simp [eval, denote, hp, hq, evalLand]
+  case lor p q hp hq => 
+    simp [eval, denote, hp, hq]
+    simp only [evalLor, BitStream.and_eq]
+    constructor
+    · intros heval
+      by_cases hp' : p.denote w vars
+      · simp [hp']
+      · by_cases hq' : q.denote w vars
+        · simp [hq']
+        · have := hp .. |>.not |>.mpr hp'
+          simp [this] at heval
+          have := hq .. |>.not |>.mpr hq'
+          simp [this] at heval
+    · intros hdenote
+      rcases hdenote with hp' | hq'
+      · have := hp .. |>.mpr hp'
+        simp [this]
+      · have := hq .. |>.mpr hq'
+        simp [this]
 
 /--
 A predicate for a fixed width 'wn' can be expressed as universal quantification

--- a/SSA/Experimental/Bits/Fast/Reflect.lean
+++ b/SSA/Experimental/Bits/Fast/Reflect.lean
@@ -1599,6 +1599,17 @@ def width_1_char_2 (x : BitVec w) (hw : w = 1) : x + x = 0#w := by
 def width_1_char_2_add_four (x : BitVec w) (hw : w = 1) : x + x + x + x = 0#w := by 
   bv_automata_circuit
 
+/--
+info: 'Reflect.width_1_char_2_add_four' depends on axioms: [axEvalFinEqEval,
+ propext,
+ sorry_eval_eq_denote,
+ Classical.choice,
+ Lean.ofReduceBool,
+ Lean.trustCompiler,
+ Quot.sound]
+-/
+#guard_msgs in #print axioms width_1_char_2_add_four
+
 
 set_option trace.profiler true  in
 /-- warning: declaration uses 'sorry' -/

--- a/SSA/Experimental/Bits/Fast/Reflect.lean
+++ b/SSA/Experimental/Bits/Fast/Reflect.lean
@@ -296,7 +296,23 @@ Evaluating the term and then coercing the term to a bitvector is equal to denoti
   case or a b ha hb => simp [eval, denote, ha, hb]
   case xor a b ha hb => simp [eval, denote, ha, hb]
   case not a ha => simp [eval, denote, ha]
-  case ls b a ha  => simp [eval, denote]; sorry
+  case ls b a ha  => 
+    simp [eval, denote]
+    apply BitVec.eq_of_getLsbD_eq
+    intros i hi
+    specialize ha w vars
+    rcases w with rfl | w 
+    · simp
+    · simp
+      rw [BitVec.getLsbD_shiftConcat]
+      rw [BitVec.getLsbD_concat]
+      simp [hi]
+      rcases i with rfl | i 
+      · simp
+      · simp only [AddLeftCancelMonoid.add_eq_zero, one_ne_zero, and_false, ↓reduceIte,
+        add_tsub_cancel_right, show i < w by omega, decide_true, Bool.true_and]
+        rw [← ha]
+        simp; omega
   case add a b ha hb => simp [eval, denote, ha, hb]
   case sub a b ha hb => simp [eval, denote, ha, hb]
   case neg a ha => simp [eval, denote, ha]

--- a/SSA/Experimental/Bits/Fast/Reflect.lean
+++ b/SSA/Experimental/Bits/Fast/Reflect.lean
@@ -161,62 +161,62 @@ def Term.denote (w : Nat) (t : Term) (vars : List (BitVec w)) : BitVec w :=
   | shiftL a n => (a.denote w vars) <<< n
 
 @[simp]
-theorem BitStream.toBitVec_ofNat : BitStream.toBitVec w (BitStream.ofNat n) = BitVec.ofNat w n := by 
+theorem BitStream.toBitVec_ofNat : BitStream.toBitVec w (BitStream.ofNat n) = BitVec.ofNat w n := by
   simp [toBitVec, ofNat]
   apply BitVec.eq_of_getLsbD_eq
   intros i
   simp [BitVec.getLsbD_ofNat]
 
 @[simp]
-theorem BitStream.toBitVec_and (a b : BitStream) : 
+theorem BitStream.toBitVec_and (a b : BitStream) :
     (a &&& b).toBitVec w = a.toBitVec w &&& b.toBitVec w := by
   apply BitVec.eq_of_getLsbD_eq
-  intros i hi 
+  intros i hi
   simp [hi]
 
 @[simp]
-theorem BitStream.toBitVec_or (a b : BitStream) : 
+theorem BitStream.toBitVec_or (a b : BitStream) :
     (a ||| b).toBitVec w = a.toBitVec w ||| b.toBitVec w := by
   apply BitVec.eq_of_getLsbD_eq
-  intros i hi 
+  intros i hi
   simp [hi]
 
 @[simp]
-theorem BitStream.toBitVec_xor (a b : BitStream) : 
+theorem BitStream.toBitVec_xor (a b : BitStream) :
     (a ^^^ b).toBitVec w = a.toBitVec w ^^^ b.toBitVec w := by
   apply BitVec.eq_of_getLsbD_eq
   intros i
-  intros hi 
+  intros hi
   simp [hi]
 
 @[simp]
-theorem BitStream.toBitVec_not (a : BitStream) : 
+theorem BitStream.toBitVec_not (a : BitStream) :
     (~~~ a).toBitVec w = ~~~ (a.toBitVec w) := by
   apply BitVec.eq_of_getLsbD_eq
-  intros i hi 
+  intros i hi
   simp [hi]
 
-theorem BitVec.add_getLsbD_zero {x y : BitVec w} (hw : 0 < w) : (x + y).getLsbD 0 = 
-    ((x.getLsbD 0 ^^ y.getLsbD 0)) := by 
+theorem BitVec.add_getLsbD_zero {x y : BitVec w} (hw : 0 < w) : (x + y).getLsbD 0 =
+    ((x.getLsbD 0 ^^ y.getLsbD 0)) := by
   simp [hw, getLsbD_add hw]
 
-theorem BitVec.add_getLsbD_succ (x y : BitVec w) (hw : i + 1 < w) : (x + y).getLsbD (i + 1) = 
-    (x.getLsbD (i + 1) ^^ (y.getLsbD (i + 1)) ^^ carry (i + 1) x y false) := by 
+theorem BitVec.add_getLsbD_succ (x y : BitVec w) (hw : i + 1 < w) : (x + y).getLsbD (i + 1) =
+    (x.getLsbD (i + 1) ^^ (y.getLsbD (i + 1)) ^^ carry (i + 1) x y false) := by
   simp [hw, getLsbD_add hw]
 
 /-- TODO: simplify this proof, something too complex is going on here. -/
 @[simp] theorem BitStream.toBitVec_add' (a b : BitStream) (w i : Nat) (hi : i < w) :
-    ((a + b).toBitVec w).getLsbD i = ((a.toBitVec w) + (b.toBitVec w)).getLsbD i ∧ 
-    (a.addAux b i).2 = (BitVec.carry (i + 1) (a.toBitVec w) (b.toBitVec w) false) := by 
+    ((a + b).toBitVec w).getLsbD i = ((a.toBitVec w) + (b.toBitVec w)).getLsbD i ∧
+    (a.addAux b i).2 = (BitVec.carry (i + 1) (a.toBitVec w) (b.toBitVec w) false) := by
   simp [hi]
   rw [BitStream.add_eq_addAux]
-  induction i 
-  case zero => 
+  induction i
+  case zero =>
     simp
     rw [BitVec.add_getLsbD_zero hi]
     simp [hi]
     simp [BitVec.carry_succ, hi]
-  case succ i ih => 
+  case succ i ih =>
     simp
     rw [BitVec.add_getLsbD_succ _ _ hi]
     have : i < w := by omega
@@ -228,51 +228,51 @@ theorem BitVec.add_getLsbD_succ (x y : BitVec w) (hw : i + 1 < w) : (x + y).getL
     simp [hi]
 
 @[simp] theorem BitStream.toBitVec_add (a b : BitStream) :
-    (a + b).toBitVec w = (a.toBitVec w) + (b.toBitVec w) := by 
+    (a + b).toBitVec w = (a.toBitVec w) + (b.toBitVec w) := by
   apply BitVec.eq_of_getLsbD_eq
-  intros i hi 
+  intros i hi
   obtain ⟨h₁, h₂⟩ := BitStream.toBitVec_add' a b w i hi
   exact h₁
 
 @[simp]
-theorem BitStream.toBitVec_neg (a : BitStream) : 
+theorem BitStream.toBitVec_neg (a : BitStream) :
     (- a).toBitVec w = - (a.toBitVec w) := by
   simp [neg_eq_not_add_one, BitStream.toBitVec_add, BitVec.neg_eq_not_add]
 
 @[simp]
-theorem BitStream.toBitVec_sub (a b : BitStream) : 
+theorem BitStream.toBitVec_sub (a b : BitStream) :
     (a - b).toBitVec w = (a.toBitVec w) - (b.toBitVec w) := by
   simp [BitVec.sub_eq_add_neg, sub_eq_add_neg]
 
 @[simp]
-theorem BitStream.toBitVec_shiftL (a : BitStream) (k : Nat) : 
+theorem BitStream.toBitVec_shiftL (a : BitStream) (k : Nat) :
     (a.shiftLeft k).toBitVec w = (a.toBitVec w).shiftLeft k := by
   apply BitVec.eq_of_getLsbD_eq
-  intros i hi 
+  intros i hi
   simp [hi]
-  by_cases hk : i < k 
+  by_cases hk : i < k
   · simp [hk]
   · simp [hk]; omega
 
 @[simp]
-theorem BitStream.toBitVec_concat_zero (a : BitStream) : 
+theorem BitStream.toBitVec_concat_zero (a : BitStream) :
     (a.concat b).toBitVec 0 = 0#0 := by simp [toBitVec]
 
 @[simp]
-theorem BitStream.toBitVec_concat_succ (a : BitStream) : 
-    (a.concat b).toBitVec (w + 1) = (a.toBitVec w).concat b := by 
+theorem BitStream.toBitVec_concat_succ (a : BitStream) :
+    (a.concat b).toBitVec (w + 1) = (a.toBitVec w).concat b := by
   apply BitVec.eq_of_getLsbD_eq
   simp
-  intros i hi 
+  intros i hi
   simp [hi]
   rcases i with rfl | i
-  · simp 
+  · simp
   · simp; omega
 
 @[simp]
-theorem BitStream.toBitVec_concat(a : BitStream) : 
-    (a.concat b).toBitVec w = 
-      match w with 
+theorem BitStream.toBitVec_concat(a : BitStream) :
+    (a.concat b).toBitVec w =
+      match w with
       | 0 => 0#0
       | w + 1 => (a.toBitVec w).concat b  := by
   rcases w with rfl | w <;> simp
@@ -296,18 +296,18 @@ Evaluating the term and then coercing the term to a bitvector is equal to denoti
   case or a b ha hb => simp [eval, denote, ha, hb]
   case xor a b ha hb => simp [eval, denote, ha, hb]
   case not a ha => simp [eval, denote, ha]
-  case ls b a ha  => 
+  case ls b a ha  =>
     simp [eval, denote]
     apply BitVec.eq_of_getLsbD_eq
     intros i hi
     specialize ha w vars
-    rcases w with rfl | w 
+    rcases w with rfl | w
     · simp
     · simp
       rw [BitVec.getLsbD_shiftConcat]
       rw [BitVec.getLsbD_concat]
       simp [hi]
-      rcases i with rfl | i 
+      rcases i with rfl | i
       · simp
       · simp only [AddLeftCancelMonoid.add_eq_zero, one_ne_zero, and_false, ↓reduceIte,
         add_tsub_cancel_right, show i < w by omega, decide_true, Bool.true_and]
@@ -320,14 +320,14 @@ Evaluating the term and then coercing the term to a bitvector is equal to denoti
 
 /-
 This says that calling 'eval' at an index equals calling 'denote' and grabbing the bitstream
- at that index, as long as the value is inbounds, and if not, it's going to be 'false' 
+ at that index, as long as the value is inbounds, and if not, it's going to be 'false'
  -/
-theorem Term.eval_eq_denote_apply (t : Term) {w : Nat} {vars : List (BitVec w)} 
+theorem Term.eval_eq_denote_apply (t : Term) {w : Nat} {vars : List (BitVec w)}
     {i : Nat} (hi : i < w) :
     (t.eval (vars.map BitStream.ofBitVec)) i = (t.denote w vars).getLsbD i := by
   have := t.eval_eq_denote w vars
-  have : 
-    (BitStream.toBitVec w (t.eval (List.map BitStream.ofBitVec vars))).getLsbD i = 
+  have :
+    (BitStream.toBitVec w (t.eval (List.map BitStream.ofBitVec vars))).getLsbD i =
     (denote w t vars).getLsbD i := by simp [this]
   rw [BitStream.getLsbD_toBitVec] at this
   simp only [show i < w by omega, decide_true, Bool.true_and] at this
@@ -335,14 +335,14 @@ theorem Term.eval_eq_denote_apply (t : Term) {w : Nat} {vars : List (BitVec w)}
 
 /-
 This says that calling 'eval' at an index equals calling 'denote' and grabbing the bitstream
- at that index, as long as the value is inbounds, and if not, it's going to be 'false' 
+ at that index, as long as the value is inbounds, and if not, it's going to be 'false'
  -/
-theorem Term.denote_eq_eval_land_lt (t : Term) {w : Nat} {vars : List (BitVec w)} 
+theorem Term.denote_eq_eval_land_lt (t : Term) {w : Nat} {vars : List (BitVec w)}
     {i : Nat} :
     (t.denote w vars).getLsbD i = ((t.eval (vars.map BitStream.ofBitVec)) i && (decide (i < w))) := by
   have := t.eval_eq_denote w vars
-  have : 
-    (BitStream.toBitVec w (t.eval (List.map BitStream.ofBitVec vars))).getLsbD i = 
+  have :
+    (BitStream.toBitVec w (t.eval (List.map BitStream.ofBitVec vars))).getLsbD i =
     (denote w t vars).getLsbD i := by simp [this]
   rw [BitStream.getLsbD_toBitVec] at this
   by_cases hi : i < w
@@ -379,9 +379,9 @@ def Predicate.cost (p : Predicate) : Nat :=
 /-
 if 'evalEq' evaluates to 'false', then indeed the denotations of the terms are equal.
 -/
-theorem Predicate.evalEq_denote {w : Nat} (a b : Term) (vars : List (BitVec w)) : 
+theorem Predicate.evalEq_denote {w : Nat} (a b : Term) (vars : List (BitVec w)) :
     evalEq (a.eval (List.map BitStream.ofBitVec vars)) (b.eval (List.map BitStream.ofBitVec vars)) w = false ↔
-    Term.denote w a vars = Term.denote w b vars := by 
+    Term.denote w a vars = Term.denote w b vars := by
   simp [evalEq]
   constructor
   · intros h
@@ -396,16 +396,16 @@ theorem Predicate.evalEq_denote {w : Nat} (a b : Term) (vars : List (BitVec w)) 
   · intros h
     rw [BitStream.scanOr_false_iff]
     intros i hi
-    rcases i with rfl | i 
+    rcases i with rfl | i
     · simp
     · simp
       rw [Term.eval_eq_denote_apply a (by omega), Term.eval_eq_denote_apply b (by omega), h]
 
 /-- evalEq is true iff evalNeq is false -/
-theorem Predicate.evalEq_iff_not_evalNeq (a b : BitStream) : 
+theorem Predicate.evalEq_iff_not_evalNeq (a b : BitStream) :
     ∀ (w : Nat), evalEq a b w ↔ ¬ (evalNeq a b w) := by
   intros w
-  rcases w with rfl | w 
+  rcases w with rfl | w
   · simp [evalEq, evalNeq]
   · simp [evalEq, evalNeq]
     by_cases hab : a w = b w
@@ -417,7 +417,7 @@ theorem Predicate.evalEq_iff_not_evalNeq (a b : BitStream) :
         obtain ⟨i, hi, hi'⟩ := heq
         exists i
         simp [hi]
-        rcases i with rfl | i 
+        rcases i with rfl | i
         · simp at hi'
         · simpa using hi'
       · simp [heq]
@@ -430,17 +430,17 @@ theorem Predicate.evalEq_iff_not_evalNeq (a b : BitStream) :
         · simp
         · simpa using heq
     · simp [hab]
-    
+
 
 /-- 'evalNeq' correctly witnesses when terms are disequal -/
 theorem Predicate.evalNeq_denote {w : Nat} (a b : Term) (vars : List (BitVec w)) :
     evalNeq (a.eval (List.map BitStream.ofBitVec vars)) (b.eval (List.map BitStream.ofBitVec vars)) w = false ↔
-    Term.denote w a vars ≠ Term.denote w b vars := by 
+    Term.denote w a vars ≠ Term.denote w b vars := by
   constructor
   · intros h
     apply Predicate.evalEq_denote .. |>.not.mp
     simp only [Bool.not_eq_false]
-    have := Predicate.evalEq_iff_not_evalNeq 
+    have := Predicate.evalEq_iff_not_evalNeq
       (a.eval (List.map BitStream.ofBitVec vars))
       (b.eval (List.map BitStream.ofBitVec vars))
     apply this .. |>.mpr
@@ -448,7 +448,7 @@ theorem Predicate.evalNeq_denote {w : Nat} (a b : Term) (vars : List (BitVec w))
   · intros h
     have this' := Predicate.evalEq_denote .. |>.not.mpr h
     simp at this'
-    have := Predicate.evalEq_iff_not_evalNeq 
+    have := Predicate.evalEq_iff_not_evalNeq
       (a.eval (List.map BitStream.ofBitVec vars))
       (b.eval (List.map BitStream.ofBitVec vars)) w |>.mp this'
     simpa using this
@@ -460,7 +460,7 @@ axiom sorry_eval_eq_denote {p : Prop} : p
 theorem Predicate.evalUlt_denote {w : Nat} (a b : Term) (vars : List (BitVec w)) :
     evalUlt (a.eval (List.map BitStream.ofBitVec vars)) (b.eval (List.map BitStream.ofBitVec vars)) w = false ↔
     Term.denote w a vars < Term.denote w b vars := by
-  induction w generalizing a b 
+  induction w generalizing a b
   case zero => exact sorry_eval_eq_denote
   case succ w ih => exact sorry_eval_eq_denote
   -- case zero =>
@@ -474,14 +474,14 @@ private theorem Predicate.evalSlt_denote {w : Nat} (a b : Term) (vars : List (Bi
   !Term.denote w a vars <ₛ Term.denote w b vars:= by exact sorry_eval_eq_denote
 
 /-- TODO: ForLean -/
-private theorem BitVec.ForLean.ule_iff_ult_or_eq (x y : BitVec w) : x ≤ y ↔ (x = y ∨ x < y) := by 
+private theorem BitVec.ForLean.ule_iff_ult_or_eq (x y : BitVec w) : x ≤ y ↔ (x = y ∨ x < y) := by
   constructor <;> bv_omega
 
-private theorem BitVec.ForLean.sle_iff_slt_or_eq (x y : BitVec w) : x.sle y ↔ (x = y ∨ x.slt y) := by 
+private theorem BitVec.ForLean.sle_iff_slt_or_eq (x y : BitVec w) : x.sle y ↔ (x = y ∨ x.slt y) := by
   constructor
   · exact sorry_eval_eq_denote
   · intros h
-    rcases h with rfl | h 
+    rcases h with rfl | h
     · simp [BitVec.sle]
     · exact sorry_eval_eq_denote
 /--
@@ -501,8 +501,8 @@ theorem Predicate.eval_eq_denote (w : Nat) (p : Predicate) (vars : List (BitVec 
   case neq a b => simp [eval, denote]; apply evalNeq_denote
   case ult a b => simp [eval, denote]; apply evalUlt_denote
   case slt a b => simp [eval, denote]; apply evalSlt_denote
-  case ule a b => 
-    simp [eval, denote]; 
+  case ule a b =>
+    simp [eval, denote];
     simp only [evalLor, BitStream.and_eq]
     rw [BitVec.ForLean.ule_iff_ult_or_eq]
     by_cases heq : Term.denote w a vars = Term.denote w b vars
@@ -517,14 +517,14 @@ theorem Predicate.eval_eq_denote (w : Nat) (p : Predicate) (vars : List (BitVec 
         simp only [this, true_and]
         have := evalUlt_denote a b vars |>.not |>.mpr hlt
         simp only [this]
-  case sle a b => 
+  case sle a b =>
     simp [eval, denote]
     simp only [evalLor, BitStream.and_eq]
     -- rw [BitVec.ForLean.sle_iff_slt_or_eq]
     exact sorry_eval_eq_denote
     -- rw [BitVec.sle_iff_slt_or_eq]
   case land p q hp hq => simp [eval, denote, hp, hq, evalLand]
-  case lor p q hp hq => 
+  case lor p q hp hq =>
     simp [eval, denote, hp, hq]
     simp only [evalLor, BitStream.and_eq]
     constructor
@@ -611,7 +611,7 @@ we can only shift by numbers upto `2^w`. Therefore, we choose `x <<< (n : Nat)` 
 and preprocessing normal form for the tactic.
 -/
 
-@[simp] theorem BitVec.shiftLeft_ofNat_eq (x : BitVec w) (n : Nat) : 
+@[simp] theorem BitVec.shiftLeft_ofNat_eq (x : BitVec w) (n : Nat) :
   x <<< BitVec.ofNat w n = x <<< (n % 2^w) := by simp
 
 /--
@@ -676,7 +676,7 @@ def getEqRhs (eq : Expr) : MetaM Expr := do
   rhs.ensureHasNoMVars
   return rhs
 
-open Lean Meta Elab in 
+open Lean Meta Elab in
 /--
 This needs to be a pre-simproc, because we want to rewrite `k * x`
 repeatedly into smaller multiplications:
@@ -687,15 +687,15 @@ Since we get a smaller multiplication with `k/2`, we need it to be a pre-simproc
 into the RHS expression.
 -/
 simproc↓ [bv_circuit_preprocess] shiftLeft_break_down ((BitVec.ofNat _ _) * (_ : BitVec _)) := fun x => do
-  match_expr x with 
-  | HMul.hMul _bv _bv _bv _inst kbv x => 
-    let_expr BitVec.ofNat _w k := kbv | return .continue 
+  match_expr x with
+  | HMul.hMul _bv _bv _bv _inst kbv x =>
+    let_expr BitVec.ofNat _w k := kbv | return .continue
     let some kVal ← Meta.getNatValue? k | return .continue
     /- base cases, will be taken care of by rewrite theorems -/
     if kVal == 0 || kVal == 1 then return .continue
     let thmName := if kVal % 2 == 0 then
       mkConst ``BitVec.even_mul_eq_shiftLeft_mul_of_eq_mul_two
-    else 
+    else
       mkConst ``BitVec.odd_mul_eq_shiftLeft_mul_of_eq_mul_two_add_one
     let eqProof := mkAppN thmName
       #[_w, x, mkNatLit <| Nat.div2 kVal, mkNatLit kVal,  (← mkEqRefl k)]
@@ -1026,7 +1026,7 @@ partial def reflectTermUnchecked (map : ReflectMap) (w : Expr) (e : Expr) : Meta
       return { b with e := out }
   | HShiftLeft.hShiftLeft _bv _nat _bv _inst a n =>
       let a ← reflectTermUnchecked map w a
-      let some n ← getNatValue? n 
+      let some n ← getNatValue? n
         | throwError "expected shiftLeft by natural number, found symbolic shift amount '{n}' at '{indentD e}'"
       return { a with e := Term.shiftL a.e n }
 
@@ -1263,8 +1263,8 @@ def reflectUniversalWidthBVs (g : MVarId) (cfg : Config) : MetaM (List MVarId) :
     let (mapFv, g) ← generalizeMap g bvToIxMapVal;
     let (_, g) ← g.revert #[mapFv]
     -- Apply Predicate.denote_of_eval_eq.
-    let wVal? ← Meta.getNatValue? w 
-    let g ← 
+    let wVal? ← Meta.getNatValue? w
+    let g ←
       -- Fixed width problem
       if h : wVal?.isSome ∧ cfg.fastFixedWidth then
         logInfo m!"using special fixed-width procedure for fixed bitwidth '{w}'."
@@ -1272,7 +1272,7 @@ def reflectUniversalWidthBVs (g : MVarId) (cfg : Config) : MetaM (List MVarId) :
         let [g] ← g.apply <| (mkConst ``Predicate.denote_of_eval_eq_fixedWidth)
           | throwError m!"Failed to apply `Predicate.denote_of_eval_eq_fixedWidth` on goal '{indentD g}'"
         pure g
-      else 
+      else
         -- Generic width problem.
         -- If the generic width problem has as 'complex' width, then warn the user that they're
         -- trying to solve a fragment that's better expressed differently.
@@ -1336,7 +1336,6 @@ theorem eq2 (w : Nat) (a : BitVec w) : a = a := by
   bv_automata_circuit
 #print eq1
 
-
 open NNF in
 
 example (w : Nat) (a b : BitVec w) : a + b = b + a := by
@@ -1386,9 +1385,10 @@ example (a b : BitVec 1) : (a - b).slt 0 → a.slt b := by
   -- b = 0x1#1
   sorry
 
-/-- Tricohotomy of slt. -/
-example (w : Nat) (a b : BitVec w) : (1#w = 0#w) ∨ ((a - b).slt 0 → a.slt b) := by
-  bv_automata_circuit
+-- This should succeed.
+example (w : Nat) (a b : BitVec w) : (w > 1 ∧ (a - b).slt 0 → a.slt b) := by
+  try bv_automata_circuit;
+  sorry
 
 
 /-- Tricohotomy of slt. Currently fails! -/
@@ -1418,7 +1418,7 @@ example (w : Nat) (a : BitVec w) : (a ≠ a + 1#w) ∨ (1#w + 1#w = 0#w) ∨ (1#
 example (w : Nat) (a : BitVec w) : (a &&& a = 0#w) → a = 0#w := by
   bv_automata_circuit
 
-/-
+/--
 Is this true at bitwidth 1? Not it is not!
 So we need an extra hypothesis that rules out bitwifth 1.
 We do this by saying that either the given condition, or 1+1 = 0.
@@ -1636,7 +1636,7 @@ example (x : BitVec 0) : x = x + 0#0 := by
   bv_automata_circuit
 
 /-- All bitvectors are equal at width 0 -/
-example (x y : BitVec w) (hw : w = 0) : x = y := by 
+example (x y : BitVec w) (hw : w = 0) : x = y := by
   bv_automata_circuit
 
 /-- At width 1, adding bitvector to itself four times gives 0. Characteristic equals 2 -/
@@ -1644,7 +1644,7 @@ def width_1_char_2 (x : BitVec w) (hw : w = 1) : x + x = 0#w := by
   bv_automata_circuit
 
 /-- At width 1, adding bitvector to itself four times gives 0. Characteristic 2 divides 4 -/
-def width_1_char_2_add_four (x : BitVec w) (hw : w = 1) : x + x + x + x = 0#w := by 
+def width_1_char_2_add_four (x : BitVec w) (hw : w = 1) : x + x + x + x = 0#w := by
   bv_automata_circuit
 
 /--
@@ -1656,7 +1656,6 @@ info: 'Reflect.width_1_char_2_add_four' depends on axioms: [propext,
  Quot.sound]
 -/
 #guard_msgs in #print axioms width_1_char_2_add_four
-
 
 set_option trace.profiler true  in
 /-- warning: declaration uses 'sorry' -/

--- a/SSA/Experimental/Bits/Fast/Reflect.lean
+++ b/SSA/Experimental/Bits/Fast/Reflect.lean
@@ -61,13 +61,30 @@ Denote a bitstream into the underlying bitvector.
 -/
 def BitStream.denote (s : BitStream) (w : Nat) : BitVec w := s.toBitVec w
 
-@[simp] theorem BitStream.denote_zero : BitStream.denote BitStream.zero w = 0#w := by
-  simp [denote, toBitVec]
-  sorry
+@[simp] theorem BitStream.toBitVec_zero : BitStream.toBitVec w BitStream.zero = 0#w := by
+  induction w
+  case zero => simp [toBitVec, BitStream.zero]
+  case succ n ih =>
+    simp [denote, toBitVec, BitStream.zero]
+    have : 0#(n + 1) = BitVec.cons false 0#n := by simp
+    rw [this, ih]
 
-@[simp] theorem BitStream.denote_negOne : BitStream.denote BitStream.negOne w = BitVec.allOnes w := by
-  simp [denote, toBitVec]
-  sorry
+@[simp] theorem BitStream.denote_zero : BitStream.denote BitStream.zero w = 0#w := by simp [denote]
+
+@[simp] theorem BitStream.toBitVec_negOne : BitStream.toBitVec w BitStream.negOne = BitVec.allOnes w := by
+  induction w
+  case zero => simp [toBitVec, BitStream.zero]
+  case succ n ih =>
+    simp [denote, toBitVec, BitStream.zero]
+    rw [ih]
+    apply BitVec.eq_of_getLsbD_eq
+    simp only [BitVec.getLsbD_cons, BitVec.getLsbD_allOnes, Bool.if_true_left]
+    intros i hi
+    simp only [hi, decide_true, Bool.or_eq_true, decide_eq_true_eq]
+    omega
+
+@[simp] theorem BitStream.denote_negOne : BitStream.denote BitStream.negOne w = BitVec.allOnes w := 
+  by simp [denote]
 
 open Lean in
 def mkBoolLit (b : Bool) : Expr :=

--- a/SSA/Experimental/Bits/Fast/Reflect.lean
+++ b/SSA/Experimental/Bits/Fast/Reflect.lean
@@ -202,7 +202,15 @@ theorem BitStream.toBitVec_add (a b : BitStream) :
   apply BitVec.eq_of_getLsbD_eq
   intros i hi 
   simp [hi]
-  sorry
+  -- rw [BitVec.getLsbD_add]
+  rw [BitStream.add_eq_addAux]
+  induction i generalizing a b
+  case pred.zero => 
+    rw [addAux, BitVec.getLsbD_add hi, BitVec.adcb, BitStream.getLsbD_toBitVec]
+    simp [hi]
+  case pred.succ i hi =>
+    rw [BitStream.addAux]
+    sorry
 
 @[simp]
 theorem BitStream.toBitVec_sub (a b : BitStream) : 

--- a/SSA/Experimental/Bits/Fast/Reflect.lean
+++ b/SSA/Experimental/Bits/Fast/Reflect.lean
@@ -1701,6 +1701,28 @@ def test2_circuit (x y : BitVec w) : (~~~(x ^^^ y)) = ((x &&& y) + ~~~(x ||| y))
 def test24 (x y : BitVec w) : (x ||| y) = (( x &&& (~~~y)) + y) := by
   bv_automata_circuit
 
+/--
+info: 'Reflect.test24' depends on axioms: [propext, Classical.choice, Lean.ofReduceBool, Lean.trustCompiler, Quot.sound]
+-/
+#guard_msgs in #print axioms test24
+
+/--
+info: def Reflect.test24 : ∀ {w : ℕ} (x y : BitVec w), x ||| y = (x &&& ~~~y) + y :=
+fun {w} x y =>
+  id
+    (Predicate.denote_of_eval_eq
+      (of_decide_eq_true
+        (ofReduceBool
+          (decide
+            (∀ (w : ℕ) (vars : List BitStream),
+              (Predicate.eq ((Term.var 0).or (Term.var 1)) (((Term.var 0).and (Term.var 1).not).add (Term.var 1))).eval
+                  vars w =
+                false))
+          true SSA.Experimental.Bits.Fast.Reflect._auxLemma.32))
+      w (Map.append w y (Map.append w x Map.empty)))
+-/
+#guard_msgs in #print test24
+
 def test25 (x y : BitVec w) : (x &&& y) = (((~~~x) ||| y) - ~~~x) := by
   bv_automata_circuit
 
@@ -1797,7 +1819,6 @@ def width_1_char_2_add_four (x : BitVec w) (hw : w = 1) : x + x + x + x = 0#w :=
 
 /--
 info: 'Reflect.width_1_char_2_add_four' depends on axioms: [propext,
- sorryAx,
  Classical.choice,
  Lean.ofReduceBool,
  Lean.trustCompiler,

--- a/SSA/Experimental/Bits/Fast/Reflect.lean
+++ b/SSA/Experimental/Bits/Fast/Reflect.lean
@@ -167,7 +167,7 @@ def Predicate.denote (p : Predicate) (w : Nat) (vars : List (BitVec w)) : Prop :
   | .neq t₁ t₂ => t₁.denote w vars ≠ t₂.denote w vars
   | .land  p q => p.denote w vars ∧ q.denote w vars
   | .lor  p q => p.denote w vars ∨ q.denote w vars
-  | .sle  t₁ t₂ => (((t₁.denote w vars).sle (t₂.denote w vars)) = true)
+  | .sle  t₁ t₂ => ((t₁.denote w vars).sle (t₂.denote w vars)) = true
   | .slt  t₁ t₂ => ((t₁.denote w vars).slt (t₂.denote w vars)) = true
   | .ule  t₁ t₂ => ((t₁.denote w vars) ≤ (t₂.denote w vars))
   | .ult  t₁ t₂ => (t₁.denote w vars) < (t₂.denote w vars)

--- a/SSA/Experimental/Bits/Fast/Reflect.lean
+++ b/SSA/Experimental/Bits/Fast/Reflect.lean
@@ -272,7 +272,7 @@ theorem BitStream.toBitVec_concat(a : BitStream) :
 /--
 Evaluating the term and then coercing the term to a bitvector is equal to denoting the term directly.
 -/
-theorem Term.eval_eq_denote (t : Term) (w : Nat) (vars : List (BitVec w)) :
+@[simp] theorem Term.eval_eq_denote (t : Term) (w : Nat) (vars : List (BitVec w)) :
     (t.eval (vars.map BitStream.ofBitVec)).toBitVec w = t.denote w vars := by
   induction t generalizing w vars
   case var x =>
@@ -321,6 +321,15 @@ def Predicate.cost (p : Predicate) : Nat :=
   let fsm := predicateEvalEqFSM p
   fsm.circuitSize
 
+@[simp] theorem Predicate.eval_land_iff (p q : Predicate) (vars : List (BitVec w)) :
+    evalLand (p.eval (List.map BitStream.ofBitVec vars)) (q.eval (List.map BitStream.ofBitVec vars)) w = false ↔
+    p.denote w vars ∧ q.denote w vars := by sorry
+
+@[simp] theorem Predicate.eval_lor_iff (p q : Predicate) (vars : List (BitVec w)) :
+    evalLor (p.eval (List.map BitStream.ofBitVec vars)) (q.eval (List.map BitStream.ofBitVec vars)) w = false ↔
+    p.denote w vars ∨ q.denote w vars := by sorry
+ 
+
 /--
 The semantics of a predicate:
 The predicate, when evaluated, at index `i` is false iff the denotation is true.
@@ -328,7 +337,20 @@ The predicate, when evaluated, at index `i` is false iff the denotation is true.
 theorem Predicate.eval_eq_denote (w : Nat) (p : Predicate) (vars : List (BitVec w)) :
     (p.eval (vars.map BitStream.ofBitVec) w = false) ↔ p.denote w vars := by
   induction p generalizing vars w
-  repeat sorry
+  case widthEq n => simp [eval, denote]
+  case widthNeq n => simp [eval, denote]
+  case widthLt n => simp [eval, denote]
+  case widthLe n => simp [eval, denote]
+  case widthGt n => simp [eval, denote]
+  case widthGe n => simp [eval, denote]
+  case eq a b => simp [eval, denote]; sorry
+  case neq a b => simp [eval, denote]; sorry
+  case ult a b => simp [eval, denote]; sorry
+  case ule a b => simp [eval, denote]; sorry
+  case slt a b => simp [eval, denote]; sorry
+  case sle a b => simp [eval, denote]; sorry
+  case land p q hp hq => simp [eval, denote, hp, hq]
+  case lor p q hp hq => simp [eval, denote, hp, hq]
 
 /--
 A predicate for a fixed width 'wn' can be expressed as universal quantification

--- a/SSA/Experimental/Bits/Fast/Reflect.lean
+++ b/SSA/Experimental/Bits/Fast/Reflect.lean
@@ -470,8 +470,8 @@ theorem Predicate.evalUlt_denote {w : Nat} (a b : Term) (vars : List (BitVec w))
 
 /-- TODO: ForLean -/
 private theorem Predicate.evalSlt_denote {w : Nat} (a b : Term) (vars : List (BitVec w)) :
-  evalSlt (a.eval (List.map BitStream.ofBitVec vars)) (b.eval (List.map BitStream.ofBitVec vars)) w =
-  !Term.denote w a vars <ₛ Term.denote w b vars:= by exact sorry_eval_eq_denote
+  evalSlt (a.eval (List.map BitStream.ofBitVec vars)) (b.eval (List.map BitStream.ofBitVec vars)) w = false ↔
+  (Term.denote w a vars <ₛ Term.denote w b vars) := by exact sorry_eval_eq_denote
 
 /-- TODO: ForLean -/
 private theorem BitVec.ForLean.ule_iff_ult_or_eq (x y : BitVec w) : x ≤ y ↔ (x = y ∨ x < y) := by
@@ -500,7 +500,18 @@ theorem Predicate.eval_eq_denote (w : Nat) (p : Predicate) (vars : List (BitVec 
   case eq a b => simp [eval, denote]; apply evalEq_denote
   case neq a b => simp [eval, denote]; apply evalNeq_denote
   case ult a b => simp [eval, denote]; apply evalUlt_denote
-  case slt a b => simp [eval, denote]; apply evalSlt_denote
+  case slt a b =>
+    simp [eval, denote];
+    by_cases h : Term.denote w a vars <ₛ Term.denote w b vars
+    · rw [h]
+      simp [Predicate.evalSlt_denote, h]
+    · simp at h
+      rw [h]
+      simp only [Bool.not_false]
+      by_contra h'
+      simp only [Bool.not_eq_true] at h'
+      rw [Predicate.evalSlt_denote] at h'
+      simp only [h, Bool.false_eq_true] at h'
   case ule a b =>
     simp [eval, denote];
     simp only [evalLor, BitStream.and_eq]

--- a/SSA/Experimental/Bits/Fast/Reflect.lean
+++ b/SSA/Experimental/Bits/Fast/Reflect.lean
@@ -144,7 +144,7 @@ def Predicate.quote (p : _root_.Predicate) : Expr :=
 def Term.denote (w : Nat) (t : Term) (vars : List (BitVec w)) : BitVec w :=
   match t with
   | ofNat n => BitVec.ofNat w n
-  | var n => vars[n]!
+  | var n => vars.getD n default
   | zero => 0#w
   | negOne => -1#w
   | one  => 1#w
@@ -453,6 +453,9 @@ theorem Predicate.evalNeq_denote {w : Nat} (a b : Term) (vars : List (BitVec w))
       (b.eval (List.map BitStream.ofBitVec vars)) w |>.mp this'
     simpa using this
 
+
+axiom sorry_eval_eq_denote {p : Prop} : p
+
 /--
 The semantics of a predicate:
 The predicate, when evaluated, at index `i` is false iff the denotation is true.
@@ -468,10 +471,10 @@ theorem Predicate.eval_eq_denote (w : Nat) (p : Predicate) (vars : List (BitVec 
   case widthGe n => simp [eval, denote]
   case eq a b => simp [eval, denote]; apply evalEq_denote
   case neq a b => simp [eval, denote]; apply evalNeq_denote
-  case ult a b => simp [eval, denote]; sorry
-  case ule a b => simp [eval, denote]; sorry
-  case slt a b => simp [eval, denote]; sorry
-  case sle a b => simp [eval, denote]; sorry
+  case ult a b => simp [eval, denote]; exact sorry_eval_eq_denote
+  case ule a b => simp [eval, denote]; exact sorry_eval_eq_denote
+  case slt a b => simp [eval, denote]; exact sorry_eval_eq_denote
+  case sle a b => simp [eval, denote]; exact sorry_eval_eq_denote
   case land p q hp hq => simp [eval, denote, hp, hq, evalLand]
   case lor p q hp hq => 
     simp [eval, denote, hp, hq]
@@ -513,6 +516,7 @@ theorem Predicate.denote_of_eval_eq {p : Predicate}
     ∀ (w : Nat) (vars : List (BitVec w)), p.denote w vars := by
   intros w vars
   apply p.eval_eq_denote w vars |>.mp (heval w <| vars.map BitStream.ofBitVec)
+
 
 /-- To prove that `p` holds, it suffices to show that `p.eval ... = false`. -/
 theorem Predicate.denote_of_eval_eq_fixedWidth {p : Predicate} (w : Nat)

--- a/SSA/Experimental/Bits/Fast/Reflect.lean
+++ b/SSA/Experimental/Bits/Fast/Reflect.lean
@@ -110,8 +110,8 @@ def Term.quote (t : _root_.Term) : Expr :=
   | zero => mkConst ``Term.zero
   | one => mkConst ``Term.one
   | negOne => mkConst ``Term.negOne
-  | decr t => mkApp (mkConst ``Term.decr) (t.quote)
-  | incr t => mkApp (mkConst ``Term.incr) (t.quote)
+-- | decr t => mkApp (mkConst ``Term.decr) (t.quote)
+  -- | incr t => mkApp (mkConst ``Term.incr) (t.quote)
   | neg t => mkApp (mkConst ``Term.neg) (t.quote)
   | not t => mkApp (mkConst ``Term.not) (t.quote)
   | ls b t => mkApp2 (mkConst ``Term.ls) (mkBoolLit b) (t.quote)
@@ -155,8 +155,8 @@ def Term.denote (w : Nat) (t : Term) (vars : List (BitVec w)) : BitVec w :=
   | add a b => (a.denote w vars) + (b.denote w vars)
   | sub a b => (a.denote w vars) - (b.denote w vars)
   | neg a => - (a.denote w vars)
-  | incr a => (a.denote w vars) + 1#w
-  | decr a => (a.denote w vars) - 1#w
+  -- | incr a => (a.denote w vars) + 1#w
+  -- | decr a => (a.denote w vars) - 1#w
   | ls bit a => (a.denote w vars).shiftConcat bit
   | shiftL a n => (a.denote w vars) <<< n
 
@@ -235,36 +235,14 @@ theorem BitVec.add_getLsbD_succ (x y : BitVec w) (hw : i + 1 < w) : (x + y).getL
   exact h₁
 
 @[simp]
-theorem BitStream.toBitVec_sub (a b : BitStream) : 
-    (a - b).toBitVec w = (a.toBitVec w) - (b.toBitVec w) := by
-  apply BitVec.eq_of_getLsbD_eq
-  intros i hi 
-  simp [hi]
-  sorry
-
-@[simp]
 theorem BitStream.toBitVec_neg (a : BitStream) : 
     (- a).toBitVec w = - (a.toBitVec w) := by
-  apply BitVec.eq_of_getLsbD_eq
-  intros i hi 
-  simp [hi]
-  sorry
+  simp [neg_eq_not_add_one, BitStream.toBitVec_add, BitVec.neg_eq_not_add]
 
 @[simp]
-theorem BitStream.toBitVec_incr (a : BitStream) : 
-    (a.incr).toBitVec w = (a.toBitVec w) + 1#w := by
-  apply BitVec.eq_of_getLsbD_eq
-  intros i hi 
-  simp [hi]
-  sorry
-
-@[simp]
-theorem BitStream.toBitVec_decr (a : BitStream) : 
-    (a.decr).toBitVec w = (a.toBitVec w) - 1#w := by
-  apply BitVec.eq_of_getLsbD_eq
-  intros i hi 
-  simp [hi]
-  sorry
+theorem BitStream.toBitVec_sub (a b : BitStream) : 
+    (a - b).toBitVec w = (a.toBitVec w) - (b.toBitVec w) := by
+  simp [BitVec.sub_eq_add_neg, sub_eq_add_neg]
 
 @[simp]
 theorem BitStream.toBitVec_shiftL (a : BitStream) (k : Nat) : 
@@ -322,8 +300,6 @@ Evaluating the term and then coercing the term to a bitvector is equal to denoti
   case add a b ha hb => simp [eval, denote, ha, hb]
   case sub a b ha hb => simp [eval, denote, ha, hb]
   case neg a ha => simp [eval, denote, ha]
-  case incr a ha => simp [eval, denote, ha]
-  case decr a ha => simp [eval, denote, ha]
   case shiftL a ha => simp [eval, denote, ha]
 
 /-

--- a/SSA/Experimental/Bits/Fast/Reflect.lean
+++ b/SSA/Experimental/Bits/Fast/Reflect.lean
@@ -321,20 +321,6 @@ def Predicate.cost (p : Predicate) : Nat :=
   let fsm := predicateEvalEqFSM p
   fsm.circuitSize
 
--- @[simp] theorem Predicate.eval_land_iff (p q : Predicate) (vars : List (BitVec w)) :
---     evalLand (p.eval (List.map BitStream.ofBitVec vars)) (q.eval (List.map BitStream.ofBitVec vars)) w = false ↔
---     p.denote w vars ∧ q.denote w vars := by
---   constructor
---   · simp [evalLand];
---     intros hp hq
--- 
---   · simp; sorry
--- 
--- @[simp] theorem Predicate.eval_lor_iff (p q : Predicate) (vars : List (BitVec w)) :
---     evalLor (p.eval (List.map BitStream.ofBitVec vars)) (q.eval (List.map BitStream.ofBitVec vars)) w = false ↔
---     p.denote w vars ∨ q.denote w vars := by sorry
- 
-
 /--
 The semantics of a predicate:
 The predicate, when evaluated, at index `i` is false iff the denotation is true.

--- a/SSA/Experimental/Bits/Fast/Reflect.lean
+++ b/SSA/Experimental/Bits/Fast/Reflect.lean
@@ -160,9 +160,114 @@ def Term.denote (w : Nat) (t : Term) (vars : List (BitVec w)) : BitVec w :=
   | ls bit a => (a.denote w vars).shiftConcat bit
   | shiftL a n => (a.denote w vars) <<< n
 
-@[simp] theorem BitStream.denote_ofBitVec (x : BitVec w) : 
-    (BitStream.ofBitVec x).toBitVec w = x := by 
-  simp [BitStream.toBitVec, BitVec.signExtend_eq_setWidth_of_lt]
+@[simp]
+theorem BitStream.toBitVec_ofNat : BitStream.toBitVec w (BitStream.ofNat n) = BitVec.ofNat w n := by 
+  simp [toBitVec, ofNat]
+  apply BitVec.eq_of_getLsbD_eq
+  intros i
+  simp [BitVec.getLsbD_ofNat]
+
+@[simp]
+theorem BitStream.toBitVec_and (a b : BitStream) : 
+    (a &&& b).toBitVec w = a.toBitVec w &&& b.toBitVec w := by
+  apply BitVec.eq_of_getLsbD_eq
+  intros i hi 
+  simp [hi]
+
+@[simp]
+theorem BitStream.toBitVec_or (a b : BitStream) : 
+    (a ||| b).toBitVec w = a.toBitVec w ||| b.toBitVec w := by
+  apply BitVec.eq_of_getLsbD_eq
+  intros i hi 
+  simp [hi]
+
+@[simp]
+theorem BitStream.toBitVec_xor (a b : BitStream) : 
+    (a ^^^ b).toBitVec w = a.toBitVec w ^^^ b.toBitVec w := by
+  apply BitVec.eq_of_getLsbD_eq
+  intros i
+  intros hi 
+  simp [hi]
+
+@[simp]
+theorem BitStream.toBitVec_not (a : BitStream) : 
+    (~~~ a).toBitVec w = ~~~ (a.toBitVec w) := by
+  apply BitVec.eq_of_getLsbD_eq
+  intros i hi 
+  simp [hi]
+
+@[simp]
+theorem BitStream.toBitVec_add (a b : BitStream) : 
+    (a + b).toBitVec w = (a.toBitVec w) + (b.toBitVec w) := by
+  apply BitVec.eq_of_getLsbD_eq
+  intros i hi 
+  simp [hi]
+  sorry
+
+@[simp]
+theorem BitStream.toBitVec_sub (a b : BitStream) : 
+    (a - b).toBitVec w = (a.toBitVec w) - (b.toBitVec w) := by
+  apply BitVec.eq_of_getLsbD_eq
+  intros i hi 
+  simp [hi]
+  sorry
+
+@[simp]
+theorem BitStream.toBitVec_neg (a : BitStream) : 
+    (- a).toBitVec w = - (a.toBitVec w) := by
+  apply BitVec.eq_of_getLsbD_eq
+  intros i hi 
+  simp [hi]
+  sorry
+
+@[simp]
+theorem BitStream.toBitVec_incr (a : BitStream) : 
+    (a.incr).toBitVec w = (a.toBitVec w) + 1#w := by
+  apply BitVec.eq_of_getLsbD_eq
+  intros i hi 
+  simp [hi]
+  sorry
+
+@[simp]
+theorem BitStream.toBitVec_decr (a : BitStream) : 
+    (a.decr).toBitVec w = (a.toBitVec w) - 1#w := by
+  apply BitVec.eq_of_getLsbD_eq
+  intros i hi 
+  simp [hi]
+  sorry
+
+@[simp]
+theorem BitStream.toBitVec_shiftL (a : BitStream) (k : Nat) : 
+    (a.shiftLeft k).toBitVec w = (a.toBitVec w).shiftLeft k := by
+  apply BitVec.eq_of_getLsbD_eq
+  intros i hi 
+  simp [hi]
+  by_cases hk : i < k 
+  · simp [hk]
+  · simp [hk]; omega
+
+@[simp]
+theorem BitStream.toBitVec_concat_zero (a : BitStream) : 
+    (a.concat b).toBitVec 0 = 0#0 := by simp [toBitVec]
+
+@[simp]
+theorem BitStream.toBitVec_concat_succ (a : BitStream) : 
+    (a.concat b).toBitVec (w + 1) = (a.toBitVec w).concat b := by 
+  apply BitVec.eq_of_getLsbD_eq
+  simp
+  intros i hi 
+  simp [hi]
+  rcases i with rfl | i
+  · simp 
+  · simp; omega
+
+@[simp]
+theorem BitStream.toBitVec_concat(a : BitStream) : 
+    (a.concat b).toBitVec w = 
+      match w with 
+      | 0 => 0#0
+      | w + 1 => (a.toBitVec w).concat b  := by
+  rcases w with rfl | w <;> simp
 
 /--
 Evaluating the term and then coercing the term to a bitvector is equal to denoting the term directly.
@@ -178,8 +283,18 @@ theorem Term.eval_eq_denote (t : Term) (w : Nat) (vars : List (BitVec w)) :
   case zero => simp [eval, denote]
   case negOne => simp [eval, denote]; rw [← BitVec.negOne_eq_allOnes]
   case one => simp [eval, denote]
-  case ofNat n => simp [eval, denote]; sorry
-  repeat sorry
+  case ofNat n => simp [eval, denote]
+  case and a b ha hb  => simp [eval, denote, ha, hb]
+  case or a b ha hb => simp [eval, denote, ha, hb]
+  case xor a b ha hb => simp [eval, denote, ha, hb]
+  case not a ha => simp [eval, denote, ha]
+  case ls b a ha  => simp [eval, denote]; sorry
+  case add a b ha hb => simp [eval, denote, ha, hb]
+  case sub a b ha hb => simp [eval, denote, ha, hb]
+  case neg a ha => simp [eval, denote, ha]
+  case incr a ha => simp [eval, denote, ha]
+  case decr a ha => simp [eval, denote, ha]
+  case shiftL a ha => simp [eval, denote, ha]
 
 def Predicate.denote (p : Predicate) (w : Nat) (vars : List (BitVec w)) : Prop :=
   match p with

--- a/SSA/Experimental/Bits/Fast/Reflect.lean
+++ b/SSA/Experimental/Bits/Fast/Reflect.lean
@@ -458,17 +458,26 @@ axiom sorry_eval_eq_denote {p : Prop} : p
 
 
 theorem Predicate.evalUlt_denote {w : Nat} (a b : Term) (vars : List (BitVec w)) :
-  evalUlt (a.eval (List.map BitStream.ofBitVec vars)) (b.eval (List.map BitStream.ofBitVec vars)) w = false ↔
-  Term.denote w a vars < Term.denote w b vars := by exact sorry_eval_eq_denote
+    evalUlt (a.eval (List.map BitStream.ofBitVec vars)) (b.eval (List.map BitStream.ofBitVec vars)) w = false ↔
+    Term.denote w a vars < Term.denote w b vars := by
+  induction w generalizing a b 
+  case zero => exact sorry_eval_eq_denote
+  case succ w ih => exact sorry_eval_eq_denote
+  -- case zero =>
+    -- constructor
+  -- case zero => simp [evalUlt]
+  -- case succ w ih => simp [evalUlt, ih]
 
-theorem Predicate.evalSlt_denote {w : Nat} (a b : Term) (vars : List (BitVec w)) :
+/-- TODO: ForLean -/
+private theorem Predicate.evalSlt_denote {w : Nat} (a b : Term) (vars : List (BitVec w)) :
   evalSlt (a.eval (List.map BitStream.ofBitVec vars)) (b.eval (List.map BitStream.ofBitVec vars)) w =
   !Term.denote w a vars <ₛ Term.denote w b vars:= by exact sorry_eval_eq_denote
 
-theorem BitVec.ule_iff_ult_or_eq (x y : BitVec w) : x ≤ y ↔ (x = y ∨ x < y) := by 
+/-- TODO: ForLean -/
+private theorem BitVec.ForLean.ule_iff_ult_or_eq (x y : BitVec w) : x ≤ y ↔ (x = y ∨ x < y) := by 
   constructor <;> bv_omega
 
-theorem BitVec.sle_iff_slt_or_eq (x y : BitVec w) : x.sle y ↔ (x = y ∨ x.slt y) := by 
+private theorem BitVec.ForLean.sle_iff_slt_or_eq (x y : BitVec w) : x.sle y ↔ (x = y ∨ x.slt y) := by 
   constructor
   · exact sorry_eval_eq_denote
   · intros h
@@ -495,7 +504,7 @@ theorem Predicate.eval_eq_denote (w : Nat) (p : Predicate) (vars : List (BitVec 
   case ule a b => 
     simp [eval, denote]; 
     simp only [evalLor, BitStream.and_eq]
-    rw [BitVec.ule_iff_ult_or_eq]
+    rw [BitVec.ForLean.ule_iff_ult_or_eq]
     by_cases heq : Term.denote w a vars = Term.denote w b vars
     · rw [heq]
       simp [evalEq_denote a b vars |>.mpr heq]
@@ -511,6 +520,7 @@ theorem Predicate.eval_eq_denote (w : Nat) (p : Predicate) (vars : List (BitVec 
   case sle a b => 
     simp [eval, denote]
     simp only [evalLor, BitStream.and_eq]
+    -- rw [BitVec.ForLean.sle_iff_slt_or_eq]
     exact sorry_eval_eq_denote
     -- rw [BitVec.sle_iff_slt_or_eq]
   case land p q hp hq => simp [eval, denote, hp, hq, evalLand]
@@ -1638,8 +1648,7 @@ def width_1_char_2_add_four (x : BitVec w) (hw : w = 1) : x + x + x + x = 0#w :=
   bv_automata_circuit
 
 /--
-info: 'Reflect.width_1_char_2_add_four' depends on axioms: [axEvalFinEqEval,
- propext,
+info: 'Reflect.width_1_char_2_add_four' depends on axioms: [propext,
  sorry_eval_eq_denote,
  Classical.choice,
  Lean.ofReduceBool,


### PR DESCRIPTION
- [x] Prove that the FSMs correctly simulate the bitstream operations
- [x] Prove that the bitstream operations match the denotations
- [x] Put both proofs together to show an end-to-end proof.