### PR TITLE
chore: update generate-proofs and avoid trailing whitespace after 'by'

### DIFF
--- a/SSA/Projects/InstCombine/scripts/proof-gen.py
+++ b/SSA/Projects/InstCombine/scripts/proof-gen.py
@@ -8,7 +8,7 @@ from cfg import *
 
 def get_lines(msg):
     # Define the regex pattern to match error messages with line numbers
-    pattern = re.compile(r"info: .+?:(\d+):\d+: (.+?)(?=warning)", flags=re.DOTALL)
+    pattern = re.compile(r"info: .+?:(\d+):\d+: (theorem extracted.+?)(?=warning)", flags=re.DOTALL)
     # Find all matches in the log
     matches = pattern.findall(msg)
     lines_thm = [(int(l), m) for (l, m) in matches if "no goals to be solved" not in m]
@@ -19,7 +19,7 @@ def get_lines(msg):
 def gen_proof(thm):
     return thm.replace(
         "sorry\n",
-        """by 
+        """by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/g2003h05h26hCastMiscompile_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/g2003h05h26hCastMiscompile_proof.lean
@@ -8,7 +8,7 @@ set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
 
 section g2003h05h26hCastMiscompile_proof
-theorem test_thm (e : IntW 64) : zext 64 (trunc 32 e) ⊑ LLVM.and e (const? 64 4294967295) := by 
+theorem test_thm (e : IntW 64) : zext 64 (trunc 32 e) ⊑ LLVM.and e (const? 64 4294967295) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/g2004h02h23hShiftShiftOverflow_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/g2004h02h23hShiftShiftOverflow_proof.lean
@@ -8,7 +8,7 @@ set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
 
 section g2004h02h23hShiftShiftOverflow_proof
-theorem test_thm (e : IntW 32) : ashr (ashr e (const? 32 17)) (const? 32 17) ⊑ ashr e (const? 32 31) := by 
+theorem test_thm (e : IntW 32) : ashr (ashr e (const? 32 17)) (const? 32 17) ⊑ ashr e (const? 32 31) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -17,7 +17,7 @@ theorem test_thm (e : IntW 32) : ashr (ashr e (const? 32 17)) (const? 32 17) ⊑
     all_goals sorry
 
 
-theorem test2_thm (e : IntW 32) : shl (shl e (const? 32 17)) (const? 32 17) ⊑ const? 32 0 := by 
+theorem test2_thm (e : IntW 32) : shl (shl e (const? 32 17)) (const? 32 17) ⊑ const? 32 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/g2004h08h10hBoolSetCC_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/g2004h08h10hBoolSetCC_proof.lean
@@ -8,7 +8,7 @@ set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
 
 section g2004h08h10hBoolSetCC_proof
-theorem test_thm (e : IntW 1) : icmp IntPredicate.ult e (const? 1 0) ⊑ const? 1 0 := by 
+theorem test_thm (e : IntW 1) : icmp IntPredicate.ult e (const? 1 0) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/g2004h09h28hBadShiftAndSetCC_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/g2004h09h28hBadShiftAndSetCC_proof.lean
@@ -10,7 +10,7 @@ set_option linter.unreachableTactic false
 section g2004h09h28hBadShiftAndSetCC_proof
 theorem test_thm (e : IntW 32) :
   icmp IntPredicate.eq (LLVM.and (shl e (const? 32 8)) (const? 32 (-16777216))) (const? 32 167772160) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 32 16711680)) (const? 32 655360) := by 
+    icmp IntPredicate.eq (LLVM.and e (const? 32 16711680)) (const? 32 655360) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/g2004h11h22hMissedhandhfold_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/g2004h11h22hMissedhandhfold_proof.lean
@@ -8,7 +8,7 @@ set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
 
 section g2004h11h22hMissedhandhfold_proof
-theorem test21_thm (e : IntW 8) : LLVM.and (ashr e (const? 8 7)) (const? 8 1) ⊑ lshr e (const? 8 7) := by 
+theorem test21_thm (e : IntW 8) : LLVM.and (ashr e (const? 8 7)) (const? 8 1) ⊑ lshr e (const? 8 7) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/g2004h11h27hSetCCForCastLargerAndConstant_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/g2004h11h27hSetCCForCastLargerAndConstant_proof.lean
@@ -9,7 +9,7 @@ set_option linter.unreachableTactic false
 
 section g2004h11h27hSetCCForCastLargerAndConstant_proof
 theorem lt_signed_to_large_unsigned_thm (e : IntW 8) :
-  icmp IntPredicate.ult (sext 32 e) (const? 32 1024) ⊑ icmp IntPredicate.sgt e (const? 8 (-1)) := by 
+  icmp IntPredicate.ult (sext 32 e) (const? 32 1024) ⊑ icmp IntPredicate.sgt e (const? 8 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -18,7 +18,7 @@ theorem lt_signed_to_large_unsigned_thm (e : IntW 8) :
     all_goals sorry
 
 
-theorem lt_signed_to_large_signed_thm (e : IntW 8) : icmp IntPredicate.slt (sext 32 e) (const? 32 1024) ⊑ const? 1 1 := by 
+theorem lt_signed_to_large_signed_thm (e : IntW 8) : icmp IntPredicate.slt (sext 32 e) (const? 32 1024) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -27,7 +27,7 @@ theorem lt_signed_to_large_signed_thm (e : IntW 8) : icmp IntPredicate.slt (sext
     all_goals sorry
 
 
-theorem lt_signed_to_large_negative_thm (e : IntW 8) : icmp IntPredicate.slt (sext 32 e) (const? 32 (-1024)) ⊑ const? 1 0 := by 
+theorem lt_signed_to_large_negative_thm (e : IntW 8) : icmp IntPredicate.slt (sext 32 e) (const? 32 (-1024)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -37,7 +37,7 @@ theorem lt_signed_to_large_negative_thm (e : IntW 8) : icmp IntPredicate.slt (se
 
 
 theorem lt_signed_to_small_unsigned_thm (e : IntW 8) :
-  icmp IntPredicate.ult (sext 32 e) (const? 32 17) ⊑ icmp IntPredicate.ult e (const? 8 17) := by 
+  icmp IntPredicate.ult (sext 32 e) (const? 32 17) ⊑ icmp IntPredicate.ult e (const? 8 17) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -47,7 +47,7 @@ theorem lt_signed_to_small_unsigned_thm (e : IntW 8) :
 
 
 theorem lt_signed_to_small_signed_thm (e : IntW 8) :
-  icmp IntPredicate.slt (sext 32 e) (const? 32 17) ⊑ icmp IntPredicate.slt e (const? 8 17) := by 
+  icmp IntPredicate.slt (sext 32 e) (const? 32 17) ⊑ icmp IntPredicate.slt e (const? 8 17) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -57,7 +57,7 @@ theorem lt_signed_to_small_signed_thm (e : IntW 8) :
 
 
 theorem lt_signed_to_small_negative_thm (e : IntW 8) :
-  icmp IntPredicate.slt (sext 32 e) (const? 32 (-17)) ⊑ icmp IntPredicate.slt e (const? 8 (-17)) := by 
+  icmp IntPredicate.slt (sext 32 e) (const? 32 (-17)) ⊑ icmp IntPredicate.slt e (const? 8 (-17)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -66,7 +66,7 @@ theorem lt_signed_to_small_negative_thm (e : IntW 8) :
     all_goals sorry
 
 
-theorem lt_unsigned_to_large_unsigned_thm (e : IntW 8) : icmp IntPredicate.ult (zext 32 e) (const? 32 1024) ⊑ const? 1 1 := by 
+theorem lt_unsigned_to_large_unsigned_thm (e : IntW 8) : icmp IntPredicate.ult (zext 32 e) (const? 32 1024) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -75,7 +75,7 @@ theorem lt_unsigned_to_large_unsigned_thm (e : IntW 8) : icmp IntPredicate.ult (
     all_goals sorry
 
 
-theorem lt_unsigned_to_large_signed_thm (e : IntW 8) : icmp IntPredicate.slt (zext 32 e) (const? 32 1024) ⊑ const? 1 1 := by 
+theorem lt_unsigned_to_large_signed_thm (e : IntW 8) : icmp IntPredicate.slt (zext 32 e) (const? 32 1024) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -84,7 +84,7 @@ theorem lt_unsigned_to_large_signed_thm (e : IntW 8) : icmp IntPredicate.slt (ze
     all_goals sorry
 
 
-theorem lt_unsigned_to_large_negative_thm (e : IntW 8) : icmp IntPredicate.slt (zext 32 e) (const? 32 (-1024)) ⊑ const? 1 0 := by 
+theorem lt_unsigned_to_large_negative_thm (e : IntW 8) : icmp IntPredicate.slt (zext 32 e) (const? 32 (-1024)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -94,7 +94,7 @@ theorem lt_unsigned_to_large_negative_thm (e : IntW 8) : icmp IntPredicate.slt (
 
 
 theorem lt_unsigned_to_small_unsigned_thm (e : IntW 8) :
-  icmp IntPredicate.ult (zext 32 e) (const? 32 17) ⊑ icmp IntPredicate.ult e (const? 8 17) := by 
+  icmp IntPredicate.ult (zext 32 e) (const? 32 17) ⊑ icmp IntPredicate.ult e (const? 8 17) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -104,7 +104,7 @@ theorem lt_unsigned_to_small_unsigned_thm (e : IntW 8) :
 
 
 theorem lt_unsigned_to_small_signed_thm (e : IntW 8) :
-  icmp IntPredicate.slt (zext 32 e) (const? 32 17) ⊑ icmp IntPredicate.ult e (const? 8 17) := by 
+  icmp IntPredicate.slt (zext 32 e) (const? 32 17) ⊑ icmp IntPredicate.ult e (const? 8 17) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -113,7 +113,7 @@ theorem lt_unsigned_to_small_signed_thm (e : IntW 8) :
     all_goals sorry
 
 
-theorem lt_unsigned_to_small_negative_thm (e : IntW 8) : icmp IntPredicate.slt (zext 32 e) (const? 32 (-17)) ⊑ const? 1 0 := by 
+theorem lt_unsigned_to_small_negative_thm (e : IntW 8) : icmp IntPredicate.slt (zext 32 e) (const? 32 (-17)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -123,7 +123,7 @@ theorem lt_unsigned_to_small_negative_thm (e : IntW 8) : icmp IntPredicate.slt (
 
 
 theorem gt_signed_to_large_unsigned_thm (e : IntW 8) :
-  icmp IntPredicate.ugt (sext 32 e) (const? 32 1024) ⊑ icmp IntPredicate.slt e (const? 8 0) := by 
+  icmp IntPredicate.ugt (sext 32 e) (const? 32 1024) ⊑ icmp IntPredicate.slt e (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -132,7 +132,7 @@ theorem gt_signed_to_large_unsigned_thm (e : IntW 8) :
     all_goals sorry
 
 
-theorem gt_signed_to_large_signed_thm (e : IntW 8) : icmp IntPredicate.sgt (sext 32 e) (const? 32 1024) ⊑ const? 1 0 := by 
+theorem gt_signed_to_large_signed_thm (e : IntW 8) : icmp IntPredicate.sgt (sext 32 e) (const? 32 1024) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -141,7 +141,7 @@ theorem gt_signed_to_large_signed_thm (e : IntW 8) : icmp IntPredicate.sgt (sext
     all_goals sorry
 
 
-theorem gt_signed_to_large_negative_thm (e : IntW 8) : icmp IntPredicate.sgt (sext 32 e) (const? 32 (-1024)) ⊑ const? 1 1 := by 
+theorem gt_signed_to_large_negative_thm (e : IntW 8) : icmp IntPredicate.sgt (sext 32 e) (const? 32 (-1024)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -151,7 +151,7 @@ theorem gt_signed_to_large_negative_thm (e : IntW 8) : icmp IntPredicate.sgt (se
 
 
 theorem gt_signed_to_small_unsigned_thm (e : IntW 8) :
-  icmp IntPredicate.ugt (sext 32 e) (const? 32 17) ⊑ icmp IntPredicate.ugt e (const? 8 17) := by 
+  icmp IntPredicate.ugt (sext 32 e) (const? 32 17) ⊑ icmp IntPredicate.ugt e (const? 8 17) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -161,7 +161,7 @@ theorem gt_signed_to_small_unsigned_thm (e : IntW 8) :
 
 
 theorem gt_signed_to_small_signed_thm (e : IntW 8) :
-  icmp IntPredicate.sgt (sext 32 e) (const? 32 17) ⊑ icmp IntPredicate.sgt e (const? 8 17) := by 
+  icmp IntPredicate.sgt (sext 32 e) (const? 32 17) ⊑ icmp IntPredicate.sgt e (const? 8 17) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -171,7 +171,7 @@ theorem gt_signed_to_small_signed_thm (e : IntW 8) :
 
 
 theorem gt_signed_to_small_negative_thm (e : IntW 8) :
-  icmp IntPredicate.sgt (sext 32 e) (const? 32 (-17)) ⊑ icmp IntPredicate.sgt e (const? 8 (-17)) := by 
+  icmp IntPredicate.sgt (sext 32 e) (const? 32 (-17)) ⊑ icmp IntPredicate.sgt e (const? 8 (-17)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -180,7 +180,7 @@ theorem gt_signed_to_small_negative_thm (e : IntW 8) :
     all_goals sorry
 
 
-theorem gt_unsigned_to_large_unsigned_thm (e : IntW 8) : icmp IntPredicate.ugt (zext 32 e) (const? 32 1024) ⊑ const? 1 0 := by 
+theorem gt_unsigned_to_large_unsigned_thm (e : IntW 8) : icmp IntPredicate.ugt (zext 32 e) (const? 32 1024) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -189,7 +189,7 @@ theorem gt_unsigned_to_large_unsigned_thm (e : IntW 8) : icmp IntPredicate.ugt (
     all_goals sorry
 
 
-theorem gt_unsigned_to_large_signed_thm (e : IntW 8) : icmp IntPredicate.sgt (zext 32 e) (const? 32 1024) ⊑ const? 1 0 := by 
+theorem gt_unsigned_to_large_signed_thm (e : IntW 8) : icmp IntPredicate.sgt (zext 32 e) (const? 32 1024) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -198,7 +198,7 @@ theorem gt_unsigned_to_large_signed_thm (e : IntW 8) : icmp IntPredicate.sgt (ze
     all_goals sorry
 
 
-theorem gt_unsigned_to_large_negative_thm (e : IntW 8) : icmp IntPredicate.sgt (zext 32 e) (const? 32 (-1024)) ⊑ const? 1 1 := by 
+theorem gt_unsigned_to_large_negative_thm (e : IntW 8) : icmp IntPredicate.sgt (zext 32 e) (const? 32 (-1024)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -208,7 +208,7 @@ theorem gt_unsigned_to_large_negative_thm (e : IntW 8) : icmp IntPredicate.sgt (
 
 
 theorem gt_unsigned_to_small_unsigned_thm (e : IntW 8) :
-  icmp IntPredicate.ugt (zext 32 e) (const? 32 17) ⊑ icmp IntPredicate.ugt e (const? 8 17) := by 
+  icmp IntPredicate.ugt (zext 32 e) (const? 32 17) ⊑ icmp IntPredicate.ugt e (const? 8 17) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -218,7 +218,7 @@ theorem gt_unsigned_to_small_unsigned_thm (e : IntW 8) :
 
 
 theorem gt_unsigned_to_small_signed_thm (e : IntW 8) :
-  icmp IntPredicate.sgt (zext 32 e) (const? 32 17) ⊑ icmp IntPredicate.ugt e (const? 8 17) := by 
+  icmp IntPredicate.sgt (zext 32 e) (const? 32 17) ⊑ icmp IntPredicate.ugt e (const? 8 17) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -227,7 +227,7 @@ theorem gt_unsigned_to_small_signed_thm (e : IntW 8) :
     all_goals sorry
 
 
-theorem gt_unsigned_to_small_negative_thm (e : IntW 8) : icmp IntPredicate.sgt (zext 32 e) (const? 32 (-17)) ⊑ const? 1 1 := by 
+theorem gt_unsigned_to_small_negative_thm (e : IntW 8) : icmp IntPredicate.sgt (zext 32 e) (const? 32 (-17)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -237,7 +237,7 @@ theorem gt_unsigned_to_small_negative_thm (e : IntW 8) : icmp IntPredicate.sgt (
 
 
 theorem different_size_zext_zext_ugt_thm (e : IntW 4) (e_1 : IntW 7) :
-  icmp IntPredicate.ugt (zext 25 e_1) (zext 25 e) ⊑ icmp IntPredicate.ugt e_1 (zext 7 e) := by 
+  icmp IntPredicate.ugt (zext 25 e_1) (zext 25 e) ⊑ icmp IntPredicate.ugt e_1 (zext 7 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -247,7 +247,7 @@ theorem different_size_zext_zext_ugt_thm (e : IntW 4) (e_1 : IntW 7) :
 
 
 theorem different_size_zext_zext_ult_thm (e : IntW 7) (e_1 : IntW 4) :
-  icmp IntPredicate.ult (zext 25 e_1) (zext 25 e) ⊑ icmp IntPredicate.ugt e (zext 7 e_1) := by 
+  icmp IntPredicate.ult (zext 25 e_1) (zext 25 e) ⊑ icmp IntPredicate.ugt e (zext 7 e_1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -257,7 +257,7 @@ theorem different_size_zext_zext_ult_thm (e : IntW 7) (e_1 : IntW 4) :
 
 
 theorem different_size_zext_zext_eq_thm (e : IntW 7) (e_1 : IntW 4) :
-  icmp IntPredicate.eq (zext 25 e_1) (zext 25 e) ⊑ icmp IntPredicate.eq e (zext 7 e_1) := by 
+  icmp IntPredicate.eq (zext 25 e_1) (zext 25 e) ⊑ icmp IntPredicate.eq e (zext 7 e_1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -267,7 +267,7 @@ theorem different_size_zext_zext_eq_thm (e : IntW 7) (e_1 : IntW 4) :
 
 
 theorem different_size_zext_zext_ne_commute_thm (e : IntW 4) (e_1 : IntW 7) :
-  icmp IntPredicate.ne (zext 25 e_1) (zext 25 e) ⊑ icmp IntPredicate.ne e_1 (zext 7 e) := by 
+  icmp IntPredicate.ne (zext 25 e_1) (zext 25 e) ⊑ icmp IntPredicate.ne e_1 (zext 7 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -277,7 +277,7 @@ theorem different_size_zext_zext_ne_commute_thm (e : IntW 4) (e_1 : IntW 7) :
 
 
 theorem different_size_zext_zext_slt_thm (e : IntW 4) (e_1 : IntW 7) :
-  icmp IntPredicate.slt (zext 25 e_1) (zext 25 e) ⊑ icmp IntPredicate.ult e_1 (zext 7 e) := by 
+  icmp IntPredicate.slt (zext 25 e_1) (zext 25 e) ⊑ icmp IntPredicate.ult e_1 (zext 7 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -287,7 +287,7 @@ theorem different_size_zext_zext_slt_thm (e : IntW 4) (e_1 : IntW 7) :
 
 
 theorem different_size_zext_zext_sgt_thm (e : IntW 4) (e_1 : IntW 7) :
-  icmp IntPredicate.sgt (zext 25 e_1) (zext 25 e) ⊑ icmp IntPredicate.ugt e_1 (zext 7 e) := by 
+  icmp IntPredicate.sgt (zext 25 e_1) (zext 25 e) ⊑ icmp IntPredicate.ugt e_1 (zext 7 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -297,7 +297,7 @@ theorem different_size_zext_zext_sgt_thm (e : IntW 4) (e_1 : IntW 7) :
 
 
 theorem different_size_sext_sext_sgt_thm (e : IntW 4) (e_1 : IntW 7) :
-  icmp IntPredicate.sgt (sext 25 e_1) (sext 25 e) ⊑ icmp IntPredicate.sgt e_1 (sext 7 e) := by 
+  icmp IntPredicate.sgt (sext 25 e_1) (sext 25 e) ⊑ icmp IntPredicate.sgt e_1 (sext 7 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -307,7 +307,7 @@ theorem different_size_sext_sext_sgt_thm (e : IntW 4) (e_1 : IntW 7) :
 
 
 theorem different_size_sext_sext_sle_thm (e : IntW 4) (e_1 : IntW 7) :
-  icmp IntPredicate.sle (sext 25 e_1) (sext 25 e) ⊑ icmp IntPredicate.sle e_1 (sext 7 e) := by 
+  icmp IntPredicate.sle (sext 25 e_1) (sext 25 e) ⊑ icmp IntPredicate.sle e_1 (sext 7 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -317,7 +317,7 @@ theorem different_size_sext_sext_sle_thm (e : IntW 4) (e_1 : IntW 7) :
 
 
 theorem different_size_sext_sext_eq_thm (e : IntW 4) (e_1 : IntW 7) :
-  icmp IntPredicate.eq (sext 25 e_1) (sext 25 e) ⊑ icmp IntPredicate.eq e_1 (sext 7 e) := by 
+  icmp IntPredicate.eq (sext 25 e_1) (sext 25 e) ⊑ icmp IntPredicate.eq e_1 (sext 7 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -327,7 +327,7 @@ theorem different_size_sext_sext_eq_thm (e : IntW 4) (e_1 : IntW 7) :
 
 
 theorem different_size_sext_sext_ule_thm (e : IntW 4) (e_1 : IntW 7) :
-  icmp IntPredicate.ule (sext 25 e_1) (sext 25 e) ⊑ icmp IntPredicate.ule e_1 (sext 7 e) := by 
+  icmp IntPredicate.ule (sext 25 e_1) (sext 25 e) ⊑ icmp IntPredicate.ule e_1 (sext 7 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/g2005h03h04hShiftOverflow_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/g2005h03h04hShiftOverflow_proof.lean
@@ -9,7 +9,7 @@ set_option linter.unreachableTactic false
 
 section g2005h03h04hShiftOverflow_proof
 theorem test_thm (e : IntW 64) :
-  icmp IntPredicate.ugt (lshr e (const? 64 1)) (const? 64 0) ⊑ icmp IntPredicate.ugt e (const? 64 1) := by 
+  icmp IntPredicate.ugt (lshr e (const? 64 1)) (const? 64 0) ⊑ icmp IntPredicate.ugt e (const? 64 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/g2005h04h07hUDivSelectCrash_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/g2005h04h07hUDivSelectCrash_proof.lean
@@ -9,7 +9,7 @@ set_option linter.unreachableTactic false
 
 section g2005h04h07hUDivSelectCrash_proof
 theorem test_thm (e : IntW 1) (e_1 : IntW 32) :
-  LLVM.udiv e_1 (select e (const? 32 8) (const? 32 1)) ⊑ lshr e_1 (select e (const? 32 3) (const? 32 0)) := by 
+  LLVM.udiv e_1 (select e (const? 32 8) (const? 32 1)) ⊑ lshr e_1 (select e (const? 32 3) (const? 32 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/g2005h06h16hRangeCrash_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/g2005h06h16hRangeCrash_proof.lean
@@ -9,7 +9,7 @@ set_option linter.unreachableTactic false
 
 section g2005h06h16hRangeCrash_proof
 theorem test_thm :
-  icmp IntPredicate.eq (LLVM.sdiv (const? 32 0) (const? 32 (-2147483648))) (const? 32 0) ⊑ const? 1 1 := by 
+  icmp IntPredicate.eq (LLVM.sdiv (const? 32 0) (const? 32 (-2147483648))) (const? 32 0) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/g2006h02h13hDemandedMiscompile_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/g2006h02h13hDemandedMiscompile_proof.lean
@@ -8,7 +8,7 @@ set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
 
 section g2006h02h13hDemandedMiscompile_proof
-theorem test_thm (e : IntW 8) : ashr (sext 32 e) (const? 32 8) ⊑ sext 32 (ashr e (const? 8 7)) := by 
+theorem test_thm (e : IntW 8) : ashr (sext 32 e) (const? 32 8) ⊑ sext 32 (ashr e (const? 8 7)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/g2006h02h28hCrash_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/g2006h02h28hCrash_proof.lean
@@ -8,7 +8,7 @@ set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
 
 section g2006h02h28hCrash_proof
-theorem test_thm : zext 32 (icmp IntPredicate.eq (const? 32 1) (const? 32 2)) ⊑ const? 32 0 := by 
+theorem test_thm : zext 32 (icmp IntPredicate.eq (const? 32 1) (const? 32 2)) ⊑ const? 32 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/g2006h04h28hShiftShiftLongLong_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/g2006h04h28hShiftShiftLongLong_proof.lean
@@ -9,7 +9,7 @@ set_option linter.unreachableTactic false
 
 section g2006h04h28hShiftShiftLongLong_proof
 theorem test_thm (e : IntW 64) :
-  ashr (shl e (const? 64 16)) (const? 64 16) ⊑ ashr (shl e (const? 64 16)) (const? 64 16) { «exact» := true } := by 
+  ashr (shl e (const? 64 16)) (const? 64 16) ⊑ ashr (shl e (const? 64 16)) (const? 64 16) { «exact» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/g2006h10h19hSignedToUnsignedCastAndConsth2_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/g2006h10h19hSignedToUnsignedCastAndConsth2_proof.lean
@@ -9,7 +9,7 @@ set_option linter.unreachableTactic false
 
 section g2006h10h19hSignedToUnsignedCastAndConsth2_proof
 theorem eq_signed_to_small_unsigned_thm (e : IntW 8) :
-  icmp IntPredicate.eq (sext 32 e) (const? 32 17) ⊑ icmp IntPredicate.eq e (const? 8 17) := by 
+  icmp IntPredicate.eq (sext 32 e) (const? 32 17) ⊑ icmp IntPredicate.eq e (const? 8 17) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/g2006h10h20hmask_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/g2006h10h20hmask_proof.lean
@@ -9,7 +9,7 @@ set_option linter.unreachableTactic false
 
 section g2006h10h20hmask_proof
 theorem foo_thm (e e_1 : IntW 64) :
-  zext 64 (LLVM.and (trunc 32 e_1) (trunc 32 e)) ⊑ LLVM.and (LLVM.and e_1 e) (const? 64 4294967295) := by 
+  zext 64 (LLVM.and (trunc 32 e_1) (trunc 32 e)) ⊑ LLVM.and (LLVM.and e_1 e) (const? 64 4294967295) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/g2006h11h10hashrhmiscompile_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/g2006h11h10hashrhmiscompile_proof.lean
@@ -9,7 +9,7 @@ set_option linter.unreachableTactic false
 
 section g2006h11h10hashrhmiscompile_proof
 theorem test_thm (e : IntW 8) :
-  lshr (const? 32 (-1)) (zext 32 e) ⊑ lshr (const? 32 (-1)) (zext 32 e { «nneg» := true }) := by 
+  lshr (const? 32 (-1)) (zext 32 e) ⊑ lshr (const? 32 (-1)) (zext 32 e { «nneg» := true }) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/g2007h01h13hExtCompareMiscompile_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/g2007h01h13hExtCompareMiscompile_proof.lean
@@ -9,7 +9,7 @@ set_option linter.unreachableTactic false
 
 section g2007h01h13hExtCompareMiscompile_proof
 theorem test_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.sgt (zext 32 e_1) (zext 32 e) ⊑ icmp IntPredicate.ugt e_1 e := by 
+  icmp IntPredicate.sgt (zext 32 e_1) (zext 32 e) ⊑ icmp IntPredicate.ugt e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/g2007h03h13hCompareMerge_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/g2007h03h13hCompareMerge_proof.lean
@@ -9,7 +9,7 @@ set_option linter.unreachableTactic false
 
 section g2007h03h13hCompareMerge_proof
 theorem test_thm (e e_1 : IntW 32) :
-  LLVM.or (icmp IntPredicate.slt e_1 e) (icmp IntPredicate.eq e_1 e) ⊑ icmp IntPredicate.sle e_1 e := by 
+  LLVM.or (icmp IntPredicate.slt e_1 e) (icmp IntPredicate.eq e_1 e) ⊑ icmp IntPredicate.sle e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -19,7 +19,7 @@ theorem test_thm (e e_1 : IntW 32) :
 
 
 theorem test_logical_thm (e e_1 : IntW 32) :
-  select (icmp IntPredicate.slt e_1 e) (const? 1 1) (icmp IntPredicate.eq e_1 e) ⊑ icmp IntPredicate.sle e_1 e := by 
+  select (icmp IntPredicate.slt e_1 e) (const? 1 1) (icmp IntPredicate.eq e_1 e) ⊑ icmp IntPredicate.sle e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/g2007h03h19hBadTruncChangePR1261_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/g2007h03h19hBadTruncChangePR1261_proof.lean
@@ -10,7 +10,7 @@ set_option linter.unreachableTactic false
 section g2007h03h19hBadTruncChangePR1261_proof
 theorem test_thm (e : IntW 31) :
   trunc 16 (lshr (add (sext 32 e) (const? 32 16384)) (const? 32 15)) ⊑
-    trunc 16 (lshr (add (zext 32 e) (const? 32 16384) { «nsw» := false, «nuw» := true }) (const? 32 15)) := by 
+    trunc 16 (lshr (add (zext 32 e) (const? 32 16384) { «nsw» := false, «nuw» := true }) (const? 32 15)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/g2007h03h21hSignedRangeTest_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/g2007h03h21hSignedRangeTest_proof.lean
@@ -10,7 +10,7 @@ set_option linter.unreachableTactic false
 section g2007h03h21hSignedRangeTest_proof
 theorem test_thm (e : IntW 32) :
   icmp IntPredicate.ne (LLVM.sdiv e (const? 32 12)) (const? 32 (-6)) ⊑
-    icmp IntPredicate.ult (add e (const? 32 71)) (const? 32 (-12)) := by 
+    icmp IntPredicate.ult (add e (const? 32 71)) (const? 32 (-12)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/g2007h03h25hDoubleShift_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/g2007h03h25hDoubleShift_proof.lean
@@ -10,7 +10,7 @@ set_option linter.unreachableTactic false
 section g2007h03h25hDoubleShift_proof
 theorem test_thm (e : IntW 32) :
   icmp IntPredicate.ne (lshr (shl e (const? 32 12)) (const? 32 12)) (const? 32 0) ⊑
-    icmp IntPredicate.ne (LLVM.and e (const? 32 1048575)) (const? 32 0) := by 
+    icmp IntPredicate.ne (LLVM.and e (const? 32 1048575)) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/g2007h05h10hicmphor_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/g2007h05h10hicmphor_proof.lean
@@ -10,7 +10,7 @@ set_option linter.unreachableTactic false
 section g2007h05h10hicmphor_proof
 theorem test_thm (e : IntW 32) :
   LLVM.or (icmp IntPredicate.ugt e (const? 32 255)) (icmp IntPredicate.sgt e (const? 32 255)) ⊑
-    icmp IntPredicate.ugt e (const? 32 255) := by 
+    icmp IntPredicate.ugt e (const? 32 255) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -21,7 +21,7 @@ theorem test_thm (e : IntW 32) :
 
 theorem test_logical_thm (e : IntW 32) :
   select (icmp IntPredicate.ugt e (const? 32 255)) (const? 1 1) (icmp IntPredicate.sgt e (const? 32 255)) ⊑
-    icmp IntPredicate.ugt e (const? 32 255) := by 
+    icmp IntPredicate.ugt e (const? 32 255) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/g2007h06h21hDivCompareMiscomp_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/g2007h06h21hDivCompareMiscomp_proof.lean
@@ -9,7 +9,7 @@ set_option linter.unreachableTactic false
 
 section g2007h06h21hDivCompareMiscomp_proof
 theorem test_thm (e : IntW 32) :
-  icmp IntPredicate.ult (LLVM.udiv e (const? 32 4)) (const? 32 1073741824) ⊑ const? 1 1 := by 
+  icmp IntPredicate.ult (LLVM.udiv e (const? 32 4)) (const? 32 1073741824) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/g2007h08h02hInfiniteLoop_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/g2007h08h02hInfiniteLoop_proof.lean
@@ -10,7 +10,7 @@ set_option linter.unreachableTactic false
 section g2007h08h02hInfiniteLoop_proof
 theorem test_thm (e e_1 : IntW 16) :
   sext 64 (add (sext 32 e_1) (sext 32 e)) ⊑
-    sext 64 (add (sext 32 e_1) (sext 32 e) { «nsw» := true, «nuw» := false }) := by 
+    sext 64 (add (sext 32 e_1) (sext 32 e) { «nsw» := true, «nuw» := false }) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/g2007h11h15hCompareMiscomp_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/g2007h11h15hCompareMiscomp_proof.lean
@@ -10,7 +10,7 @@ set_option linter.unreachableTactic false
 section g2007h11h15hCompareMiscomp_proof
 theorem test_thm (e : IntW 32) :
   LLVM.and (icmp IntPredicate.sgt e (const? 32 (-1))) (icmp IntPredicate.eq e (const? 32 1)) ⊑
-    icmp IntPredicate.eq e (const? 32 1) := by 
+    icmp IntPredicate.eq e (const? 32 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -21,7 +21,7 @@ theorem test_thm (e : IntW 32) :
 
 theorem test_logical_thm (e : IntW 32) :
   select (icmp IntPredicate.sgt e (const? 32 (-1))) (icmp IntPredicate.eq e (const? 32 1)) (const? 1 0) ⊑
-    icmp IntPredicate.eq e (const? 32 1) := by 
+    icmp IntPredicate.eq e (const? 32 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/g2008h01h13hAndCmpCmp_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/g2008h01h13hAndCmpCmp_proof.lean
@@ -10,7 +10,7 @@ set_option linter.unreachableTactic false
 section g2008h01h13hAndCmpCmp_proof
 theorem test_logical_thm (e : IntW 32) :
   select (icmp IntPredicate.ne e (const? 32 34)) (icmp IntPredicate.sgt e (const? 32 (-1))) (const? 1 0) ⊑
-    LLVM.and (icmp IntPredicate.ne e (const? 32 34)) (icmp IntPredicate.sgt e (const? 32 (-1))) := by 
+    LLVM.and (icmp IntPredicate.ne e (const? 32 34)) (icmp IntPredicate.sgt e (const? 32 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/g2008h01h21hMulTrunc_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/g2008h01h21hMulTrunc_proof.lean
@@ -10,7 +10,7 @@ set_option linter.unreachableTactic false
 section g2008h01h21hMulTrunc_proof
 theorem test1_thm (e : IntW 16) :
   trunc 16 (LLVM.or (lshr (zext 32 e) (const? 32 8)) (mul (zext 32 e) (const? 32 5))) ⊑
-    LLVM.or (lshr e (const? 16 8)) (mul e (const? 16 5)) := by 
+    LLVM.or (lshr e (const? 16 8)) (mul e (const? 16 5)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/g2008h02h16hSDivOverflow2_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/g2008h02h16hSDivOverflow2_proof.lean
@@ -9,7 +9,7 @@ set_option linter.unreachableTactic false
 
 section g2008h02h16hSDivOverflow2_proof
 theorem i_thm (e : IntW 8) :
-  LLVM.sdiv (LLVM.sdiv e (const? 8 (-3))) (const? 8 (-3)) ⊑ LLVM.sdiv e (const? 8 9) := by 
+  LLVM.sdiv (LLVM.sdiv e (const? 8 (-3))) (const? 8 (-3)) ⊑ LLVM.sdiv e (const? 8 9) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/g2008h02h23hMulSub_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/g2008h02h23hMulSub_proof.lean
@@ -8,7 +8,7 @@ set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
 
 section g2008h02h23hMulSub_proof
-theorem test_thm (e : IntW 26) : sub (mul e (const? 26 2885)) (mul e (const? 26 2884)) ⊑ e := by 
+theorem test_thm (e : IntW 26) : sub (mul e (const? 26 2885)) (mul e (const? 26 2884)) ⊑ e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/g2008h05h31hAddBool_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/g2008h05h31hAddBool_proof.lean
@@ -8,7 +8,7 @@ set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
 
 section g2008h05h31hAddBool_proof
-theorem test_thm (e e_1 : IntW 1) : add e_1 e ⊑ LLVM.xor e_1 e := by 
+theorem test_thm (e e_1 : IntW 1) : add e_1 e ⊑ LLVM.xor e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/g2008h05h31hBools_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/g2008h05h31hBools_proof.lean
@@ -8,7 +8,7 @@ set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
 
 section g2008h05h31hBools_proof
-theorem foo1_thm (e e_1 : IntW 1) : sub e_1 e ⊑ LLVM.xor e e_1 := by 
+theorem foo1_thm (e e_1 : IntW 1) : sub e_1 e ⊑ LLVM.xor e e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -17,7 +17,7 @@ theorem foo1_thm (e e_1 : IntW 1) : sub e_1 e ⊑ LLVM.xor e e_1 := by
     all_goals sorry
 
 
-theorem foo2_thm (e e_1 : IntW 1) : mul e_1 e ⊑ LLVM.and e_1 e := by 
+theorem foo2_thm (e e_1 : IntW 1) : mul e_1 e ⊑ LLVM.and e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -26,7 +26,7 @@ theorem foo2_thm (e e_1 : IntW 1) : mul e_1 e ⊑ LLVM.and e_1 e := by
     all_goals sorry
 
 
-theorem foo3_thm (e e_1 : IntW 1) : LLVM.udiv e_1 e ⊑ e_1 := by 
+theorem foo3_thm (e e_1 : IntW 1) : LLVM.udiv e_1 e ⊑ e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -35,7 +35,7 @@ theorem foo3_thm (e e_1 : IntW 1) : LLVM.udiv e_1 e ⊑ e_1 := by
     all_goals sorry
 
 
-theorem foo4_thm (e e_1 : IntW 1) : LLVM.sdiv e_1 e ⊑ e_1 := by 
+theorem foo4_thm (e e_1 : IntW 1) : LLVM.sdiv e_1 e ⊑ e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/g2008h06h21hCompareMiscomp_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/g2008h06h21hCompareMiscomp_proof.lean
@@ -10,7 +10,7 @@ set_option linter.unreachableTactic false
 section g2008h06h21hCompareMiscomp_proof
 theorem test_thm (e : IntW 32) :
   LLVM.and (icmp IntPredicate.ugt e (const? 32 13)) (icmp IntPredicate.eq e (const? 32 15)) ⊑
-    icmp IntPredicate.eq e (const? 32 15) := by 
+    icmp IntPredicate.eq e (const? 32 15) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -21,7 +21,7 @@ theorem test_thm (e : IntW 32) :
 
 theorem test_logical_thm (e : IntW 32) :
   select (icmp IntPredicate.ugt e (const? 32 13)) (icmp IntPredicate.eq e (const? 32 15)) (const? 1 0) ⊑
-    icmp IntPredicate.eq e (const? 32 15) := by 
+    icmp IntPredicate.eq e (const? 32 15) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/g2008h07h08hShiftOneAndOne_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/g2008h07h08hShiftOneAndOne_proof.lean
@@ -10,7 +10,7 @@ set_option linter.unreachableTactic false
 section g2008h07h08hShiftOneAndOne_proof
 theorem PR2330_thm (e : IntW 32) :
   icmp IntPredicate.eq (LLVM.and (shl (const? 32 1) e) (const? 32 1)) (const? 32 0) ⊑
-    icmp IntPredicate.ne e (const? 32 0) := by 
+    icmp IntPredicate.ne e (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/g2008h07h08hSubAnd_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/g2008h07h08hSubAnd_proof.lean
@@ -9,7 +9,7 @@ set_option linter.unreachableTactic false
 
 section g2008h07h08hSubAnd_proof
 theorem a_thm (e : IntW 32) :
-  LLVM.and (sub (const? 32 8) e) (const? 32 7) ⊑ LLVM.and (sub (const? 32 0) e) (const? 32 7) := by 
+  LLVM.and (sub (const? 32 8) e) (const? 32 7) ⊑ LLVM.and (sub (const? 32 0) e) (const? 32 7) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/g2008h07h09hSubAndError_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/g2008h07h09hSubAndError_proof.lean
@@ -9,7 +9,7 @@ set_option linter.unreachableTactic false
 
 section g2008h07h09hSubAndError_proof
 theorem foo_thm (e : IntW 32) :
-  LLVM.and (sub (const? 32 5) e) (const? 32 2) ⊑ LLVM.and (sub (const? 32 1) e) (const? 32 2) := by 
+  LLVM.and (sub (const? 32 5) e) (const? 32 2) ⊑ LLVM.and (sub (const? 32 1) e) (const? 32 2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/g2008h07h10hCastSextBool_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/g2008h07h10hCastSextBool_proof.lean
@@ -8,7 +8,7 @@ set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
 
 section g2008h07h10hCastSextBool_proof
-theorem PR2539_A_thm (e : IntW 1) : icmp IntPredicate.slt (zext 32 e) (const? 32 1) ⊑ LLVM.xor e (const? 1 1) := by 
+theorem PR2539_A_thm (e : IntW 1) : icmp IntPredicate.slt (zext 32 e) (const? 32 1) ⊑ LLVM.xor e (const? 1 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -17,7 +17,7 @@ theorem PR2539_A_thm (e : IntW 1) : icmp IntPredicate.slt (zext 32 e) (const? 32
     all_goals sorry
 
 
-theorem PR2539_B_thm (e : IntW 1) : icmp IntPredicate.slt e (const? 1 1) ⊑ const? 1 0 := by 
+theorem PR2539_B_thm (e : IntW 1) : icmp IntPredicate.slt e (const? 1 1) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/g2008h07h11hRemAnd_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/g2008h07h11hRemAnd_proof.lean
@@ -9,7 +9,7 @@ set_option linter.unreachableTactic false
 
 section g2008h07h11hRemAnd_proof
 theorem a_thm (e : IntW 32) :
-  LLVM.and (LLVM.srem e (const? 32 8)) (const? 32 1) ⊑ LLVM.and e (const? 32 1) := by 
+  LLVM.and (LLVM.srem e (const? 32 8)) (const? 32 1) ⊑ LLVM.and e (const? 32 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/g2008h10h11hDivCompareFold_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/g2008h10h11hDivCompareFold_proof.lean
@@ -9,7 +9,7 @@ set_option linter.unreachableTactic false
 
 section g2008h10h11hDivCompareFold_proof
 theorem x_thm (e : IntW 32) :
-  icmp IntPredicate.slt (LLVM.sdiv e (const? 32 65536)) (const? 32 (-65536)) ⊑ const? 1 0 := by 
+  icmp IntPredicate.slt (LLVM.sdiv e (const? 32 65536)) (const? 32 (-65536)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/g2008h11h01hSRemDemandedBits_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/g2008h11h01hSRemDemandedBits_proof.lean
@@ -9,7 +9,7 @@ set_option linter.unreachableTactic false
 
 section g2008h11h01hSRemDemandedBits_proof
 theorem foo_thm (e : IntW 32) :
-  icmp IntPredicate.eq (LLVM.srem e (const? 32 (-1))) (const? 32 0) ⊑ const? 1 1 := by 
+  icmp IntPredicate.eq (LLVM.srem e (const? 32 (-1))) (const? 32 0) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/g2009h03h24hInfLoop_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/g2009h03h24hInfLoop_proof.lean
@@ -11,7 +11,7 @@ section g2009h03h24hInfLoop_proof
 theorem test_thm (e : IntW 32) :
   icmp IntPredicate.eq (LLVM.and (lshr (const? 32 3968) e) (const? 32 1)) (const? 32 0) ⊑
     icmp IntPredicate.eq (LLVM.and (shl (const? 32 1) e { «nsw» := false, «nuw» := true }) (const? 32 3968))
-      (const? 32 0) := by 
+      (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/g2010h11h01hlshrhmask_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/g2010h11h01hlshrhmask_proof.lean
@@ -18,7 +18,7 @@ theorem main_thm (e : IntW 32) :
           (const? 8 7))
         (const? 8 64)) ⊑
     zext 32 (LLVM.and (shl (LLVM.xor (trunc 8 e) (const? 8 (-1))) (const? 8 5)) (const? 8 64))
-      { «nneg» := true } := by 
+      { «nneg» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -38,7 +38,7 @@ theorem foo_thm (e e_1 : IntW 8) :
         (LLVM.or (LLVM.and e (const? 8 33))
           (LLVM.and (sub (const? 8 40) (LLVM.and e (const? 8 84)) { «nsw» := true, «nuw» := false }) (const? 8 84))
           { «disjoint» := true })
-        (LLVM.xor (shl e_1 (const? 8 7)) (LLVM.and e (const? 8 (-118)))) { «disjoint» := true }) := by 
+        (LLVM.xor (shl e_1 (const? 8 7)) (LLVM.and e (const? 8 (-118)))) { «disjoint» := true }) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/g2010h11h23hDistributed_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/g2010h11h23hDistributed_proof.lean
@@ -11,7 +11,7 @@ section g2010h11h23hDistributed_proof
 theorem foo_thm (e e_1 : IntW 32) :
   sub (mul (add e_1 e { «nsw» := true, «nuw» := false }) e_1 { «nsw» := true, «nuw» := false })
       (mul e_1 e_1 { «nsw» := true, «nuw» := false }) ⊑
-    mul e e_1 := by 
+    mul e e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -22,7 +22,7 @@ theorem foo_thm (e e_1 : IntW 32) :
 
 theorem bar_thm (e e_1 : IntW 64) :
   icmp IntPredicate.eq (LLVM.and e_1 (LLVM.xor (LLVM.and e_1 e) (const? 64 (-1)))) (const? 64 0) ⊑
-    icmp IntPredicate.eq (LLVM.and e_1 (LLVM.xor e (const? 64 (-1)))) (const? 64 0) := by 
+    icmp IntPredicate.eq (LLVM.and e_1 (LLVM.xor e (const? 64 (-1)))) (const? 64 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/g2011h03h08hSRemMinusOneBadOpt_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/g2011h03h08hSRemMinusOneBadOpt_proof.lean
@@ -9,7 +9,7 @@ set_option linter.unreachableTactic false
 
 section g2011h03h08hSRemMinusOneBadOpt_proof
 theorem test_thm (e : IntW 64) :
-  LLVM.srem (trunc 32 (LLVM.or e (const? 64 4294967294))) (const? 32 (-1)) ⊑ const? 32 0 := by 
+  LLVM.srem (trunc 32 (LLVM.or e (const? 64 4294967294))) (const? 32 (-1)) ⊑ const? 32 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/g2012h02h28hICmp_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/g2012h02h28hICmp_proof.lean
@@ -12,7 +12,7 @@ theorem f1_logical_thm (e : IntW 32) :
   select (icmp IntPredicate.ne (trunc 8 e) (const? 8 0))
       (icmp IntPredicate.ne (LLVM.and e (const? 32 16711680)) (const? 32 0)) (const? 1 0) ⊑
     LLVM.and (icmp IntPredicate.ne (trunc 8 e) (const? 8 0))
-      (icmp IntPredicate.ne (LLVM.and e (const? 32 16711680)) (const? 32 0)) := by 
+      (icmp IntPredicate.ne (LLVM.and e (const? 32 16711680)) (const? 32 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/g2012h08h28hudiv_ashl_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/g2012h08h28hudiv_ashl_proof.lean
@@ -9,7 +9,7 @@ set_option linter.unreachableTactic false
 
 section g2012h08h28hudiv_ashl_proof
 theorem udiv400_thm (e : IntW 32) :
-  LLVM.udiv (lshr e (const? 32 2)) (const? 32 100) ⊑ LLVM.udiv e (const? 32 400) := by 
+  LLVM.udiv (lshr e (const? 32 2)) (const? 32 100) ⊑ LLVM.udiv e (const? 32 400) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -19,7 +19,7 @@ theorem udiv400_thm (e : IntW 32) :
 
 
 theorem sdiv400_yes_thm (e : IntW 32) :
-  LLVM.sdiv (lshr e (const? 32 2)) (const? 32 100) ⊑ LLVM.udiv e (const? 32 400) := by 
+  LLVM.sdiv (lshr e (const? 32 2)) (const? 32 100) ⊑ LLVM.udiv e (const? 32 400) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -29,7 +29,7 @@ theorem sdiv400_yes_thm (e : IntW 32) :
 
 
 theorem udiv_i80_thm (e : IntW 80) :
-  LLVM.udiv (lshr e (const? 80 2)) (const? 80 100) ⊑ LLVM.udiv e (const? 80 400) := by 
+  LLVM.udiv (lshr e (const? 80 2)) (const? 80 100) ⊑ LLVM.udiv e (const? 80 400) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gAddOverFlow_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gAddOverFlow_proof.lean
@@ -10,7 +10,7 @@ set_option linter.unreachableTactic false
 section gAddOverFlow_proof
 theorem oppositesign_thm (e e_1 : IntW 16) :
   add (LLVM.or e_1 (const? 16 (-32768))) (LLVM.and e (const? 16 32767)) ⊑
-    add (LLVM.or e_1 (const? 16 (-32768))) (LLVM.and e (const? 16 32767)) { «nsw» := true, «nuw» := false } := by 
+    add (LLVM.or e_1 (const? 16 (-32768))) (LLVM.and e (const? 16 32767)) { «nsw» := true, «nuw» := false } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -21,7 +21,7 @@ theorem oppositesign_thm (e e_1 : IntW 16) :
 
 theorem zero_sign_bit_thm (e : IntW 16) :
   add (LLVM.and e (const? 16 32767)) (const? 16 512) ⊑
-    add (LLVM.and e (const? 16 32767)) (const? 16 512) { «nsw» := false, «nuw» := true } := by 
+    add (LLVM.and e (const? 16 32767)) (const? 16 512) { «nsw» := false, «nuw» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -32,7 +32,7 @@ theorem zero_sign_bit_thm (e : IntW 16) :
 
 theorem zero_sign_bit2_thm (e e_1 : IntW 16) :
   add (LLVM.and e_1 (const? 16 32767)) (LLVM.and e (const? 16 32767)) ⊑
-    add (LLVM.and e_1 (const? 16 32767)) (LLVM.and e (const? 16 32767)) { «nsw» := false, «nuw» := true } := by 
+    add (LLVM.and e_1 (const? 16 32767)) (LLVM.and e (const? 16 32767)) { «nsw» := false, «nuw» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -43,7 +43,7 @@ theorem zero_sign_bit2_thm (e e_1 : IntW 16) :
 
 theorem ripple_nsw1_thm (e e_1 : IntW 16) :
   add (LLVM.and e_1 (const? 16 1)) (LLVM.and e (const? 16 (-16385))) ⊑
-    add (LLVM.and e_1 (const? 16 1)) (LLVM.and e (const? 16 (-16385))) { «nsw» := true, «nuw» := true } := by 
+    add (LLVM.and e_1 (const? 16 1)) (LLVM.and e (const? 16 (-16385))) { «nsw» := true, «nuw» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -54,7 +54,7 @@ theorem ripple_nsw1_thm (e e_1 : IntW 16) :
 
 theorem ripple_nsw2_thm (e e_1 : IntW 16) :
   add (LLVM.and e_1 (const? 16 (-16385))) (LLVM.and e (const? 16 1)) ⊑
-    add (LLVM.and e_1 (const? 16 (-16385))) (LLVM.and e (const? 16 1)) { «nsw» := true, «nuw» := true } := by 
+    add (LLVM.and e_1 (const? 16 (-16385))) (LLVM.and e (const? 16 1)) { «nsw» := true, «nuw» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -65,7 +65,7 @@ theorem ripple_nsw2_thm (e e_1 : IntW 16) :
 
 theorem ripple_nsw3_thm (e e_1 : IntW 16) :
   add (LLVM.and e_1 (const? 16 (-21845))) (LLVM.and e (const? 16 21843)) ⊑
-    add (LLVM.and e_1 (const? 16 (-21845))) (LLVM.and e (const? 16 21843)) { «nsw» := true, «nuw» := true } := by 
+    add (LLVM.and e_1 (const? 16 (-21845))) (LLVM.and e (const? 16 21843)) { «nsw» := true, «nuw» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -76,7 +76,7 @@ theorem ripple_nsw3_thm (e e_1 : IntW 16) :
 
 theorem ripple_nsw4_thm (e e_1 : IntW 16) :
   add (LLVM.and e_1 (const? 16 21843)) (LLVM.and e (const? 16 (-21845))) ⊑
-    add (LLVM.and e_1 (const? 16 21843)) (LLVM.and e (const? 16 (-21845))) { «nsw» := true, «nuw» := true } := by 
+    add (LLVM.and e_1 (const? 16 21843)) (LLVM.and e (const? 16 (-21845))) { «nsw» := true, «nuw» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -87,7 +87,7 @@ theorem ripple_nsw4_thm (e e_1 : IntW 16) :
 
 theorem ripple_nsw5_thm (e e_1 : IntW 16) :
   add (LLVM.or e_1 (const? 16 (-21845))) (LLVM.or e (const? 16 (-10923))) ⊑
-    add (LLVM.or e_1 (const? 16 (-21845))) (LLVM.or e (const? 16 (-10923))) { «nsw» := true, «nuw» := false } := by 
+    add (LLVM.or e_1 (const? 16 (-21845))) (LLVM.or e (const? 16 (-10923))) { «nsw» := true, «nuw» := false } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -98,7 +98,7 @@ theorem ripple_nsw5_thm (e e_1 : IntW 16) :
 
 theorem ripple_nsw6_thm (e e_1 : IntW 16) :
   add (LLVM.or e_1 (const? 16 (-10923))) (LLVM.or e (const? 16 (-21845))) ⊑
-    add (LLVM.or e_1 (const? 16 (-10923))) (LLVM.or e (const? 16 (-21845))) { «nsw» := true, «nuw» := false } := by 
+    add (LLVM.or e_1 (const? 16 (-10923))) (LLVM.or e (const? 16 (-21845))) { «nsw» := true, «nuw» := false } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -109,7 +109,7 @@ theorem ripple_nsw6_thm (e e_1 : IntW 16) :
 
 theorem ripple_no_nsw2_thm (e e_1 : IntW 16) :
   add (LLVM.and e_1 (const? 16 1)) (LLVM.and e (const? 16 32767)) ⊑
-    add (LLVM.and e_1 (const? 16 1)) (LLVM.and e (const? 16 32767)) { «nsw» := false, «nuw» := true } := by 
+    add (LLVM.and e_1 (const? 16 1)) (LLVM.and e (const? 16 32767)) { «nsw» := false, «nuw» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -120,7 +120,7 @@ theorem ripple_no_nsw2_thm (e e_1 : IntW 16) :
 
 theorem PR38021_thm (e : IntW 8) :
   add (lshr e (const? 8 3)) (const? 8 (-63)) ⊑
-    add (lshr e (const? 8 3)) (const? 8 (-63)) { «nsw» := true, «nuw» := true } := by 
+    add (lshr e (const? 8 3)) (const? 8 (-63)) { «nsw» := true, «nuw» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gJavaCompare_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gJavaCompare_proof.lean
@@ -13,7 +13,7 @@ theorem le_thm (e e_1 : IntW 32) :
       (select (icmp IntPredicate.slt e_1 e) (const? 32 (-1))
         (select (icmp IntPredicate.sgt e_1 e) (const? 32 1) (const? 32 0)))
       (const? 32 0) ⊑
-    icmp IntPredicate.sle e_1 e := by 
+    icmp IntPredicate.sle e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gabsh1_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gabsh1_proof.lean
@@ -12,7 +12,7 @@ theorem abs_must_be_positive_thm (e : IntW 32) :
   icmp IntPredicate.sge
       (select (icmp IntPredicate.sge e (const? 32 0)) e (sub (const? 32 0) e { «nsw» := true, «nuw» := false }))
       (const? 32 0) ⊑
-    const? 1 1 := by 
+    const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -24,7 +24,7 @@ theorem abs_must_be_positive_thm (e : IntW 32) :
 theorem abs_diff_signed_slt_swap_wrong_pred1_thm (e e_1 : IntW 32) :
   select (icmp IntPredicate.eq e_1 e) (sub e e_1 { «nsw» := true, «nuw» := false })
       (sub e_1 e { «nsw» := true, «nuw» := false }) ⊑
-    sub e_1 e { «nsw» := true, «nuw» := false } := by 
+    sub e_1 e { «nsw» := true, «nuw» := false } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gadd2_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gadd2_proof.lean
@@ -9,7 +9,7 @@ set_option linter.unreachableTactic false
 
 section gadd2_proof
 theorem test1_thm (e : IntW 64) (e_1 : IntW 32) :
-  LLVM.and (add (shl (zext 64 e_1) (const? 64 32)) e) (const? 64 123) ⊑ LLVM.and e (const? 64 123) := by 
+  LLVM.and (add (shl (zext 64 e_1) (const? 64 32)) e) (const? 64 123) ⊑ LLVM.and e (const? 64 123) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -19,7 +19,7 @@ theorem test1_thm (e : IntW 64) (e_1 : IntW 32) :
 
 
 theorem test2_thm (e : IntW 32) :
-  add (LLVM.and e (const? 32 7)) (LLVM.and e (const? 32 32)) ⊑ LLVM.and e (const? 32 39) := by 
+  add (LLVM.and e (const? 32 7)) (LLVM.and e (const? 32 32)) ⊑ LLVM.and e (const? 32 39) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -30,7 +30,7 @@ theorem test2_thm (e : IntW 32) :
 
 theorem test3_thm (e : IntW 32) :
   add (LLVM.and e (const? 32 128)) (lshr e (const? 32 30)) ⊑
-    LLVM.or (LLVM.and e (const? 32 128)) (lshr e (const? 32 30)) { «disjoint» := true } := by 
+    LLVM.or (LLVM.and e (const? 32 128)) (lshr e (const? 32 30)) { «disjoint» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -40,7 +40,7 @@ theorem test3_thm (e : IntW 32) :
 
 
 theorem test4_thm (e : IntW 32) :
-  add e e { «nsw» := false, «nuw» := true } ⊑ shl e (const? 32 1) { «nsw» := false, «nuw» := true } := by 
+  add e e { «nsw» := false, «nuw» := true } ⊑ shl e (const? 32 1) { «nsw» := false, «nuw» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -50,7 +50,7 @@ theorem test4_thm (e : IntW 32) :
 
 
 theorem test9_thm (e : IntW 16) :
-  add (mul e (const? 16 2)) (mul e (const? 16 32767)) ⊑ mul e (const? 16 (-32767)) := by 
+  add (mul e (const? 16 2)) (mul e (const? 16 32767)) ⊑ mul e (const? 16 (-32767)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -62,7 +62,7 @@ theorem test9_thm (e : IntW 16) :
 theorem test10_thm (e e_1 : IntW 32) :
   add (add e_1 (const? 32 1))
       (LLVM.xor (LLVM.or (ashr e (const? 32 3)) (const? 32 (-1431655766))) (const? 32 1431655765)) ⊑
-    sub e_1 (LLVM.and (ashr e (const? 32 3)) (const? 32 1431655765)) := by 
+    sub e_1 (LLVM.and (ashr e (const? 32 3)) (const? 32 1431655765)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -73,7 +73,7 @@ theorem test10_thm (e e_1 : IntW 32) :
 
 theorem test11_thm (e e_1 : IntW 32) :
   add (add e_1 (const? 32 1)) (LLVM.xor (LLVM.or e (const? 32 (-1431655766))) (const? 32 1431655765)) ⊑
-    sub e_1 (LLVM.and e (const? 32 1431655765)) := by 
+    sub e_1 (LLVM.and e (const? 32 1431655765)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -85,7 +85,7 @@ theorem test11_thm (e e_1 : IntW 32) :
 theorem test12_thm (e e_1 : IntW 32) :
   add (add e_1 (const? 32 1) { «nsw» := true, «nuw» := false })
       (LLVM.xor (LLVM.or e (const? 32 (-1431655766))) (const? 32 1431655765)) { «nsw» := true, «nuw» := false } ⊑
-    sub e_1 (LLVM.and e (const? 32 1431655765)) := by 
+    sub e_1 (LLVM.and e (const? 32 1431655765)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -96,7 +96,7 @@ theorem test12_thm (e e_1 : IntW 32) :
 
 theorem test13_thm (e e_1 : IntW 32) :
   add (add e_1 (const? 32 1)) (LLVM.xor (LLVM.or e (const? 32 (-1431655767))) (const? 32 1431655766)) ⊑
-    sub e_1 (LLVM.and e (const? 32 1431655766)) := by 
+    sub e_1 (LLVM.and e (const? 32 1431655766)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -108,7 +108,7 @@ theorem test13_thm (e e_1 : IntW 32) :
 theorem test14_thm (e e_1 : IntW 32) :
   add (add e_1 (const? 32 1) { «nsw» := true, «nuw» := false })
       (LLVM.xor (LLVM.or e (const? 32 (-1431655767))) (const? 32 1431655766)) { «nsw» := true, «nuw» := false } ⊑
-    sub e_1 (LLVM.and e (const? 32 1431655766)) := by 
+    sub e_1 (LLVM.and e (const? 32 1431655766)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -119,7 +119,7 @@ theorem test14_thm (e e_1 : IntW 32) :
 
 theorem test15_thm (e e_1 : IntW 32) :
   add (add e_1 (const? 32 1)) (LLVM.xor (LLVM.and e (const? 32 (-1431655767))) (const? 32 (-1431655767))) ⊑
-    sub e_1 (LLVM.or e (const? 32 1431655766)) := by 
+    sub e_1 (LLVM.or e (const? 32 1431655766)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -131,7 +131,7 @@ theorem test15_thm (e e_1 : IntW 32) :
 theorem test16_thm (e e_1 : IntW 32) :
   add (add e_1 (const? 32 1) { «nsw» := true, «nuw» := false })
       (LLVM.xor (LLVM.and e (const? 32 (-1431655767))) (const? 32 (-1431655767))) { «nsw» := true, «nuw» := false } ⊑
-    sub e_1 (LLVM.or e (const? 32 1431655766)) := by 
+    sub e_1 (LLVM.or e (const? 32 1431655766)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -143,7 +143,7 @@ theorem test16_thm (e e_1 : IntW 32) :
 theorem test17_thm (e e_1 : IntW 32) :
   add (LLVM.xor (LLVM.and e_1 (const? 32 (-1431655766))) (const? 32 (-1431655765))) e
       { «nsw» := true, «nuw» := false } ⊑
-    sub e (LLVM.or e_1 (const? 32 1431655765)) := by 
+    sub e (LLVM.or e_1 (const? 32 1431655765)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -155,7 +155,7 @@ theorem test17_thm (e e_1 : IntW 32) :
 theorem test18_thm (e e_1 : IntW 32) :
   add (add e_1 (const? 32 1) { «nsw» := true, «nuw» := false })
       (LLVM.xor (LLVM.and e (const? 32 (-1431655766))) (const? 32 (-1431655766))) { «nsw» := true, «nuw» := false } ⊑
-    sub e_1 (LLVM.or e (const? 32 1431655765)) := by 
+    sub e_1 (LLVM.or e (const? 32 1431655765)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -166,7 +166,7 @@ theorem test18_thm (e e_1 : IntW 32) :
 
 theorem add_nsw_mul_nsw_thm (e : IntW 16) :
   add (add e e { «nsw» := true, «nuw» := false }) e { «nsw» := true, «nuw» := false } ⊑
-    mul e (const? 16 3) { «nsw» := true, «nuw» := false } := by 
+    mul e (const? 16 3) { «nsw» := true, «nuw» := false } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -177,7 +177,7 @@ theorem add_nsw_mul_nsw_thm (e : IntW 16) :
 
 theorem mul_add_to_mul_1_thm (e : IntW 16) :
   add e (mul e (const? 16 8) { «nsw» := true, «nuw» := false }) { «nsw» := true, «nuw» := false } ⊑
-    mul e (const? 16 9) { «nsw» := true, «nuw» := false } := by 
+    mul e (const? 16 9) { «nsw» := true, «nuw» := false } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -188,7 +188,7 @@ theorem mul_add_to_mul_1_thm (e : IntW 16) :
 
 theorem mul_add_to_mul_2_thm (e : IntW 16) :
   add (mul e (const? 16 8) { «nsw» := true, «nuw» := false }) e { «nsw» := true, «nuw» := false } ⊑
-    mul e (const? 16 9) { «nsw» := true, «nuw» := false } := by 
+    mul e (const? 16 9) { «nsw» := true, «nuw» := false } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -198,7 +198,7 @@ theorem mul_add_to_mul_2_thm (e : IntW 16) :
 
 
 theorem mul_add_to_mul_3_thm (e : IntW 16) :
-  add (mul e (const? 16 2)) (mul e (const? 16 3)) { «nsw» := true, «nuw» := false } ⊑ mul e (const? 16 5) := by 
+  add (mul e (const? 16 2)) (mul e (const? 16 3)) { «nsw» := true, «nuw» := false } ⊑ mul e (const? 16 5) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -210,7 +210,7 @@ theorem mul_add_to_mul_3_thm (e : IntW 16) :
 theorem mul_add_to_mul_4_thm (e : IntW 16) :
   add (mul e (const? 16 2) { «nsw» := true, «nuw» := false }) (mul e (const? 16 7) { «nsw» := true, «nuw» := false })
       { «nsw» := true, «nuw» := false } ⊑
-    mul e (const? 16 9) { «nsw» := true, «nuw» := false } := by 
+    mul e (const? 16 9) { «nsw» := true, «nuw» := false } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -222,7 +222,7 @@ theorem mul_add_to_mul_4_thm (e : IntW 16) :
 theorem mul_add_to_mul_5_thm (e : IntW 16) :
   add (mul e (const? 16 3) { «nsw» := true, «nuw» := false }) (mul e (const? 16 7) { «nsw» := true, «nuw» := false })
       { «nsw» := true, «nuw» := false } ⊑
-    mul e (const? 16 10) { «nsw» := true, «nuw» := false } := by 
+    mul e (const? 16 10) { «nsw» := true, «nuw» := false } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -235,7 +235,7 @@ theorem mul_add_to_mul_6_thm (e e_1 : IntW 32) :
   add (mul e_1 e { «nsw» := true, «nuw» := false })
       (mul (mul e_1 e { «nsw» := true, «nuw» := false }) (const? 32 5) { «nsw» := true, «nuw» := false })
       { «nsw» := true, «nuw» := false } ⊑
-    mul (mul e_1 e { «nsw» := true, «nuw» := false }) (const? 32 6) { «nsw» := true, «nuw» := false } := by 
+    mul (mul e_1 e { «nsw» := true, «nuw» := false }) (const? 32 6) { «nsw» := true, «nuw» := false } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -246,7 +246,7 @@ theorem mul_add_to_mul_6_thm (e e_1 : IntW 32) :
 
 theorem mul_add_to_mul_7_thm (e : IntW 16) :
   add e (mul e (const? 16 32767) { «nsw» := true, «nuw» := false }) { «nsw» := true, «nuw» := false } ⊑
-    shl e (const? 16 15) := by 
+    shl e (const? 16 15) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -258,7 +258,7 @@ theorem mul_add_to_mul_7_thm (e : IntW 16) :
 theorem mul_add_to_mul_8_thm (e : IntW 16) :
   add (mul e (const? 16 16383) { «nsw» := true, «nuw» := false })
       (mul e (const? 16 16384) { «nsw» := true, «nuw» := false }) { «nsw» := true, «nuw» := false } ⊑
-    mul e (const? 16 32767) { «nsw» := true, «nuw» := false } := by 
+    mul e (const? 16 32767) { «nsw» := true, «nuw» := false } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -270,7 +270,7 @@ theorem mul_add_to_mul_8_thm (e : IntW 16) :
 theorem mul_add_to_mul_9_thm (e : IntW 16) :
   add (mul e (const? 16 16384) { «nsw» := true, «nuw» := false })
       (mul e (const? 16 16384) { «nsw» := true, «nuw» := false }) { «nsw» := true, «nuw» := false } ⊑
-    shl e (const? 16 15) := by 
+    shl e (const? 16 15) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -279,7 +279,7 @@ theorem mul_add_to_mul_9_thm (e : IntW 16) :
     all_goals sorry
 
 
-theorem add_or_and_thm (e e_1 : IntW 32) : add (LLVM.or e_1 e) (LLVM.and e_1 e) ⊑ add e_1 e := by 
+theorem add_or_and_thm (e e_1 : IntW 32) : add (LLVM.or e_1 e) (LLVM.and e_1 e) ⊑ add e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -288,7 +288,7 @@ theorem add_or_and_thm (e e_1 : IntW 32) : add (LLVM.or e_1 e) (LLVM.and e_1 e) 
     all_goals sorry
 
 
-theorem add_or_and_commutative_thm (e e_1 : IntW 32) : add (LLVM.or e_1 e) (LLVM.and e e_1) ⊑ add e_1 e := by 
+theorem add_or_and_commutative_thm (e e_1 : IntW 32) : add (LLVM.or e_1 e) (LLVM.and e e_1) ⊑ add e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -297,7 +297,7 @@ theorem add_or_and_commutative_thm (e e_1 : IntW 32) : add (LLVM.or e_1 e) (LLVM
     all_goals sorry
 
 
-theorem add_and_or_thm (e e_1 : IntW 32) : add (LLVM.and e_1 e) (LLVM.or e_1 e) ⊑ add e_1 e := by 
+theorem add_and_or_thm (e e_1 : IntW 32) : add (LLVM.and e_1 e) (LLVM.or e_1 e) ⊑ add e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -306,7 +306,7 @@ theorem add_and_or_thm (e e_1 : IntW 32) : add (LLVM.and e_1 e) (LLVM.or e_1 e) 
     all_goals sorry
 
 
-theorem add_and_or_commutative_thm (e e_1 : IntW 32) : add (LLVM.and e_1 e) (LLVM.or e e_1) ⊑ add e e_1 := by 
+theorem add_and_or_commutative_thm (e e_1 : IntW 32) : add (LLVM.and e_1 e) (LLVM.or e e_1) ⊑ add e e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -317,7 +317,7 @@ theorem add_and_or_commutative_thm (e e_1 : IntW 32) : add (LLVM.and e_1 e) (LLV
 
 theorem add_nsw_or_and_thm (e e_1 : IntW 32) :
   add (LLVM.or e_1 e) (LLVM.and e_1 e) { «nsw» := true, «nuw» := false } ⊑
-    add e_1 e { «nsw» := true, «nuw» := false } := by 
+    add e_1 e { «nsw» := true, «nuw» := false } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -328,7 +328,7 @@ theorem add_nsw_or_and_thm (e e_1 : IntW 32) :
 
 theorem add_nuw_or_and_thm (e e_1 : IntW 32) :
   add (LLVM.or e_1 e) (LLVM.and e_1 e) { «nsw» := false, «nuw» := true } ⊑
-    add e_1 e { «nsw» := false, «nuw» := true } := by 
+    add e_1 e { «nsw» := false, «nuw» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -339,7 +339,7 @@ theorem add_nuw_or_and_thm (e e_1 : IntW 32) :
 
 theorem add_nuw_nsw_or_and_thm (e e_1 : IntW 32) :
   add (LLVM.or e_1 e) (LLVM.and e_1 e) { «nsw» := true, «nuw» := true } ⊑
-    add e_1 e { «nsw» := true, «nuw» := true } := by 
+    add e_1 e { «nsw» := true, «nuw» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -351,7 +351,7 @@ theorem add_nuw_nsw_or_and_thm (e e_1 : IntW 32) :
 theorem add_of_mul_thm (e e_1 e_2 : IntW 8) :
   add (mul e_2 e_1 { «nsw» := true, «nuw» := false }) (mul e_2 e { «nsw» := true, «nuw» := false })
       { «nsw» := true, «nuw» := false } ⊑
-    mul e_2 (add e_1 e) := by 
+    mul e_2 (add e_1 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -361,7 +361,7 @@ theorem add_of_mul_thm (e e_1 e_2 : IntW 8) :
 
 
 theorem add_of_selects_thm (e : IntW 32) (e_1 : IntW 1) :
-  add (select e_1 (const? 32 0) (const? 32 (-2))) (select e_1 e (const? 32 2)) ⊑ select e_1 e (const? 32 0) := by 
+  add (select e_1 (const? 32 0) (const? 32 (-2))) (select e_1 e (const? 32 2)) ⊑ select e_1 e (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -372,7 +372,7 @@ theorem add_of_selects_thm (e : IntW 32) (e_1 : IntW 1) :
 
 theorem add_undemanded_low_bits_thm (e : IntW 32) :
   lshr (add (LLVM.or e (const? 32 15)) (const? 32 1616)) (const? 32 4) ⊑
-    lshr (add e (const? 32 1616)) (const? 32 4) := by 
+    lshr (add e (const? 32 1616)) (const? 32 4) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -383,7 +383,7 @@ theorem add_undemanded_low_bits_thm (e : IntW 32) :
 
 theorem sub_undemanded_low_bits_thm (e : IntW 32) :
   lshr (sub (LLVM.or e (const? 32 15)) (const? 32 1616)) (const? 32 4) ⊑
-    lshr (add e (const? 32 (-1616))) (const? 32 4) := by 
+    lshr (add e (const? 32 (-1616))) (const? 32 4) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gadd4_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gadd4_proof.lean
@@ -10,7 +10,7 @@ set_option linter.unreachableTactic false
 section gadd4_proof
 theorem match_unsigned_thm (e : IntW 64) :
   add (urem e (const? 64 299)) (mul (urem (LLVM.udiv e (const? 64 299)) (const? 64 64)) (const? 64 299)) ⊑
-    urem e (const? 64 19136) := by 
+    urem e (const? 64 19136) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -21,7 +21,7 @@ theorem match_unsigned_thm (e : IntW 64) :
 
 theorem match_andAsRem_lshrAsDiv_shlAsMul_thm (e : IntW 64) :
   add (LLVM.and e (const? 64 63)) (shl (urem (lshr e (const? 64 6)) (const? 64 9)) (const? 64 6)) ⊑
-    urem e (const? 64 576) := by 
+    urem e (const? 64 576) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -33,7 +33,7 @@ theorem match_andAsRem_lshrAsDiv_shlAsMul_thm (e : IntW 64) :
 theorem match_signed_thm (e : IntW 64) :
   add (add (LLVM.srem e (const? 64 299)) (mul (LLVM.srem (LLVM.sdiv e (const? 64 299)) (const? 64 64)) (const? 64 299)))
       (mul (LLVM.srem (LLVM.sdiv e (const? 64 19136)) (const? 64 9)) (const? 64 19136)) ⊑
-    LLVM.srem e (const? 64 172224) := by 
+    LLVM.srem e (const? 64 172224) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -46,7 +46,7 @@ theorem not_match_inconsistent_signs_thm (e : IntW 64) :
   add (urem e (const? 64 299)) (mul (urem (LLVM.sdiv e (const? 64 299)) (const? 64 64)) (const? 64 299)) ⊑
     add (urem e (const? 64 299))
       (mul (LLVM.and (LLVM.sdiv e (const? 64 299)) (const? 64 63)) (const? 64 299) { «nsw» := true, «nuw» := true })
-      { «nsw» := true, «nuw» := true } := by 
+      { «nsw» := true, «nuw» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -59,7 +59,7 @@ theorem not_match_inconsistent_values_thm (e : IntW 64) :
   add (urem e (const? 64 299)) (mul (urem (LLVM.udiv e (const? 64 29)) (const? 64 64)) (const? 64 299)) ⊑
     add (urem e (const? 64 299))
       (mul (LLVM.and (LLVM.udiv e (const? 64 29)) (const? 64 63)) (const? 64 299) { «nsw» := true, «nuw» := true })
-      { «nsw» := true, «nuw» := true } := by 
+      { «nsw» := true, «nuw» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -70,7 +70,7 @@ theorem not_match_inconsistent_values_thm (e : IntW 64) :
 
 theorem fold_add_udiv_urem_thm (e : IntW 32) :
   add (shl (LLVM.udiv e (const? 32 10)) (const? 32 4)) (urem e (const? 32 10)) ⊑
-    add (mul (LLVM.udiv e (const? 32 10)) (const? 32 6) { «nsw» := false, «nuw» := true }) e := by 
+    add (mul (LLVM.udiv e (const? 32 10)) (const? 32 6) { «nsw» := false, «nuw» := true }) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -81,7 +81,7 @@ theorem fold_add_udiv_urem_thm (e : IntW 32) :
 
 theorem fold_add_sdiv_srem_thm (e : IntW 32) :
   add (shl (LLVM.sdiv e (const? 32 10)) (const? 32 4)) (LLVM.srem e (const? 32 10)) ⊑
-    add (mul (LLVM.sdiv e (const? 32 10)) (const? 32 6) { «nsw» := true, «nuw» := false }) e := by 
+    add (mul (LLVM.sdiv e (const? 32 10)) (const? 32 6) { «nsw» := true, «nuw» := false }) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -92,7 +92,7 @@ theorem fold_add_sdiv_srem_thm (e : IntW 32) :
 
 theorem fold_add_udiv_urem_to_mul_thm (e : IntW 32) :
   add (mul (LLVM.udiv e (const? 32 7)) (const? 32 21)) (mul (urem e (const? 32 7)) (const? 32 3)) ⊑
-    mul e (const? 32 3) := by 
+    mul e (const? 32 3) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -103,7 +103,7 @@ theorem fold_add_udiv_urem_to_mul_thm (e : IntW 32) :
 
 theorem fold_add_udiv_urem_commuted_thm (e : IntW 32) :
   add (urem e (const? 32 10)) (shl (LLVM.udiv e (const? 32 10)) (const? 32 4)) ⊑
-    add (mul (LLVM.udiv e (const? 32 10)) (const? 32 6) { «nsw» := false, «nuw» := true }) e := by 
+    add (mul (LLVM.udiv e (const? 32 10)) (const? 32 6) { «nsw» := false, «nuw» := true }) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -114,7 +114,7 @@ theorem fold_add_udiv_urem_commuted_thm (e : IntW 32) :
 
 theorem fold_add_udiv_urem_or_disjoint_thm (e : IntW 32) :
   LLVM.or (shl (LLVM.udiv e (const? 32 10)) (const? 32 4)) (urem e (const? 32 10)) { «disjoint» := true } ⊑
-    add (mul (LLVM.udiv e (const? 32 10)) (const? 32 6) { «nsw» := false, «nuw» := true }) e := by 
+    add (mul (LLVM.udiv e (const? 32 10)) (const? 32 6) { «nsw» := false, «nuw» := true }) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -125,7 +125,7 @@ theorem fold_add_udiv_urem_or_disjoint_thm (e : IntW 32) :
 
 theorem fold_add_udiv_urem_without_noundef_thm (e : IntW 32) :
   add (shl (LLVM.udiv e (const? 32 10)) (const? 32 4)) (urem e (const? 32 10)) ⊑
-    LLVM.or (shl (LLVM.udiv e (const? 32 10)) (const? 32 4)) (urem e (const? 32 10)) { «disjoint» := true } := by 
+    LLVM.or (shl (LLVM.udiv e (const? 32 10)) (const? 32 4)) (urem e (const? 32 10)) { «disjoint» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gadd_or_sub_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gadd_or_sub_proof.lean
@@ -9,7 +9,7 @@ set_option linter.unreachableTactic false
 
 section gadd_or_sub_proof
 theorem add_or_sub_comb_i32_commuted1_nuw_thm (e : IntW 32) :
-  add (LLVM.or (sub (const? 32 0) e) e) e { «nsw» := false, «nuw» := true } ⊑ e := by 
+  add (LLVM.or (sub (const? 32 0) e) e) e { «nsw» := false, «nuw» := true } ⊑ e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -20,7 +20,7 @@ theorem add_or_sub_comb_i32_commuted1_nuw_thm (e : IntW 32) :
 
 theorem add_or_sub_comb_i8_commuted2_nsw_thm (e : IntW 8) :
   add (mul e e) (LLVM.or (sub (const? 8 0) (mul e e)) (mul e e)) { «nsw» := true, «nuw» := false } ⊑
-    LLVM.and (add (mul e e) (const? 8 (-1)) { «nsw» := true, «nuw» := false }) (mul e e) := by 
+    LLVM.and (add (mul e e) (const? 8 (-1)) { «nsw» := true, «nuw» := false }) (mul e e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -30,7 +30,7 @@ theorem add_or_sub_comb_i8_commuted2_nsw_thm (e : IntW 8) :
 
 
 theorem add_or_sub_comb_i128_commuted3_nuw_nsw_thm (e : IntW 128) :
-  add (LLVM.or (mul e e) (sub (const? 128 0) (mul e e))) (mul e e) { «nsw» := true, «nuw» := true } ⊑ mul e e := by 
+  add (LLVM.or (mul e e) (sub (const? 128 0) (mul e e))) (mul e e) { «nsw» := true, «nuw» := true } ⊑ mul e e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -41,7 +41,7 @@ theorem add_or_sub_comb_i128_commuted3_nuw_nsw_thm (e : IntW 128) :
 
 theorem add_or_sub_comb_i64_commuted4_thm (e : IntW 64) :
   add (mul e e) (LLVM.or (mul e e) (sub (const? 64 0) (mul e e))) ⊑
-    LLVM.and (add (mul e e) (const? 64 (-1))) (mul e e) := by 
+    LLVM.and (add (mul e e) (const? 64 (-1))) (mul e e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -51,7 +51,7 @@ theorem add_or_sub_comb_i64_commuted4_thm (e : IntW 64) :
 
 
 theorem add_or_sub_comb_i8_negative_y_sub_thm (e e_1 : IntW 8) :
-  add (LLVM.or (sub (const? 8 0) e_1) e) e ⊑ add (LLVM.or e (sub (const? 8 0) e_1)) e := by 
+  add (LLVM.or (sub (const? 8 0) e_1) e) e ⊑ add (LLVM.or e (sub (const? 8 0) e_1)) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -61,7 +61,7 @@ theorem add_or_sub_comb_i8_negative_y_sub_thm (e e_1 : IntW 8) :
 
 
 theorem add_or_sub_comb_i8_negative_y_or_thm (e e_1 : IntW 8) :
-  add (LLVM.or (sub (const? 8 0) e_1) e) e_1 ⊑ add (LLVM.or e (sub (const? 8 0) e_1)) e_1 := by 
+  add (LLVM.or (sub (const? 8 0) e_1) e) e_1 ⊑ add (LLVM.or e (sub (const? 8 0) e_1)) e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -71,7 +71,7 @@ theorem add_or_sub_comb_i8_negative_y_or_thm (e e_1 : IntW 8) :
 
 
 theorem add_or_sub_comb_i8_negative_y_add_thm (e e_1 : IntW 8) :
-  add (LLVM.or (sub (const? 8 0) e_1) e_1) e ⊑ add (LLVM.or e_1 (sub (const? 8 0) e_1)) e := by 
+  add (LLVM.or (sub (const? 8 0) e_1) e_1) e ⊑ add (LLVM.or e_1 (sub (const? 8 0) e_1)) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -81,7 +81,7 @@ theorem add_or_sub_comb_i8_negative_y_add_thm (e e_1 : IntW 8) :
 
 
 theorem add_or_sub_comb_i8_negative_xor_instead_or_thm (e : IntW 8) :
-  add (LLVM.xor (sub (const? 8 0) e) e) e ⊑ add (LLVM.xor e (sub (const? 8 0) e)) e := by 
+  add (LLVM.xor (sub (const? 8 0) e) e) e ⊑ add (LLVM.xor e (sub (const? 8 0) e)) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gaddhmask_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gaddhmask_proof.lean
@@ -10,7 +10,7 @@ set_option linter.unreachableTactic false
 section gaddhmask_proof
 theorem add_mask_sign_i32_thm (e : IntW 32) :
   add (LLVM.and (ashr e (const? 32 31)) (const? 32 8)) (ashr e (const? 32 31)) ⊑
-    select (icmp IntPredicate.slt e (const? 32 0)) (const? 32 7) (const? 32 0) := by 
+    select (icmp IntPredicate.slt e (const? 32 0)) (const? 32 7) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -21,7 +21,7 @@ theorem add_mask_sign_i32_thm (e : IntW 32) :
 
 theorem add_mask_sign_commute_i32_thm (e : IntW 32) :
   add (ashr e (const? 32 31)) (LLVM.and (ashr e (const? 32 31)) (const? 32 8)) ⊑
-    select (icmp IntPredicate.slt e (const? 32 0)) (const? 32 7) (const? 32 0) := by 
+    select (icmp IntPredicate.slt e (const? 32 0)) (const? 32 7) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -32,7 +32,7 @@ theorem add_mask_sign_commute_i32_thm (e : IntW 32) :
 
 theorem add_mask_ashr28_i32_thm (e : IntW 32) :
   add (LLVM.and (ashr e (const? 32 28)) (const? 32 8)) (ashr e (const? 32 28)) ⊑
-    LLVM.and (lshr e (const? 32 28)) (const? 32 7) := by 
+    LLVM.and (lshr e (const? 32 28)) (const? 32 7) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -44,7 +44,7 @@ theorem add_mask_ashr28_i32_thm (e : IntW 32) :
 theorem add_mask_ashr28_non_pow2_i32_thm (e : IntW 32) :
   add (LLVM.and (ashr e (const? 32 28)) (const? 32 9)) (ashr e (const? 32 28)) ⊑
     add (LLVM.and (ashr e (const? 32 28)) (const? 32 9)) (ashr e (const? 32 28))
-      { «nsw» := true, «nuw» := false } := by 
+      { «nsw» := true, «nuw» := false } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -56,7 +56,7 @@ theorem add_mask_ashr28_non_pow2_i32_thm (e : IntW 32) :
 theorem add_mask_ashr27_i32_thm (e : IntW 32) :
   add (LLVM.and (ashr e (const? 32 27)) (const? 32 8)) (ashr e (const? 32 27)) ⊑
     add (LLVM.and (ashr e (const? 32 27)) (const? 32 8)) (ashr e (const? 32 27))
-      { «nsw» := true, «nuw» := false } := by 
+      { «nsw» := true, «nuw» := false } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gaddhmaskhneg_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gaddhmaskhneg_proof.lean
@@ -10,7 +10,7 @@ set_option linter.unreachableTactic false
 section gaddhmaskhneg_proof
 theorem dec_mask_neg_i32_thm (e : IntW 32) :
   add (LLVM.and (sub (const? 32 0) e) e) (const? 32 (-1)) ⊑
-    LLVM.and (add e (const? 32 (-1))) (LLVM.xor e (const? 32 (-1))) := by 
+    LLVM.and (add e (const? 32 (-1))) (LLVM.xor e (const? 32 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -22,7 +22,7 @@ theorem dec_mask_neg_i32_thm (e : IntW 32) :
 theorem dec_mask_commute_neg_i32_thm (e : IntW 32) :
   add (LLVM.and (LLVM.sdiv (const? 32 42) e) (sub (const? 32 0) (LLVM.sdiv (const? 32 42) e))) (const? 32 (-1)) ⊑
     LLVM.and (add (LLVM.sdiv (const? 32 42) e) (const? 32 (-1)) { «nsw» := true, «nuw» := false })
-      (LLVM.xor (LLVM.sdiv (const? 32 42) e) (const? 32 (-1))) := by 
+      (LLVM.xor (LLVM.sdiv (const? 32 42) e) (const? 32 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -33,7 +33,7 @@ theorem dec_mask_commute_neg_i32_thm (e : IntW 32) :
 
 theorem dec_commute_mask_neg_i32_thm (e : IntW 32) :
   add (const? 32 (-1)) (LLVM.and (sub (const? 32 0) e) e) ⊑
-    LLVM.and (add e (const? 32 (-1))) (LLVM.xor e (const? 32 (-1))) := by 
+    LLVM.and (add e (const? 32 (-1))) (LLVM.xor e (const? 32 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gaddhshift_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gaddhshift_proof.lean
@@ -9,7 +9,7 @@ set_option linter.unreachableTactic false
 
 section gaddhshift_proof
 theorem flip_add_of_shift_neg_thm (e e_1 e_2 : IntW 8) :
-  add (shl (sub (const? 8 0) e_2) e_1 { «nsw» := true, «nuw» := true }) e ⊑ sub e (shl e_2 e_1) := by 
+  add (shl (sub (const? 8 0) e_2) e_1 { «nsw» := true, «nuw» := true }) e ⊑ sub e (shl e_2 e_1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gaddhshlhsdivhtohsrem_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gaddhshlhsdivhtohsrem_proof.lean
@@ -9,7 +9,7 @@ set_option linter.unreachableTactic false
 
 section gaddhshlhsdivhtohsrem_proof
 theorem addhshlhsdivhscalar0_thm (e : IntW 8) :
-  add (shl (LLVM.sdiv e (const? 8 (-4))) (const? 8 2)) e ⊑ LLVM.srem e (const? 8 4) := by 
+  add (shl (LLVM.sdiv e (const? 8 (-4))) (const? 8 2)) e ⊑ LLVM.srem e (const? 8 4) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -19,7 +19,7 @@ theorem addhshlhsdivhscalar0_thm (e : IntW 8) :
 
 
 theorem addhshlhsdivhscalar1_thm (e : IntW 8) :
-  add (shl (LLVM.sdiv e (const? 8 (-64))) (const? 8 6)) e ⊑ LLVM.srem e (const? 8 64) := by 
+  add (shl (LLVM.sdiv e (const? 8 (-64))) (const? 8 6)) e ⊑ LLVM.srem e (const? 8 64) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -29,7 +29,7 @@ theorem addhshlhsdivhscalar1_thm (e : IntW 8) :
 
 
 theorem addhshlhsdivhscalar2_thm (e : IntW 32) :
-  add (shl (LLVM.sdiv e (const? 32 (-1073741824))) (const? 32 30)) e ⊑ LLVM.srem e (const? 32 1073741824) := by 
+  add (shl (LLVM.sdiv e (const? 32 (-1073741824))) (const? 32 30)) e ⊑ LLVM.srem e (const? 32 1073741824) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -40,7 +40,7 @@ theorem addhshlhsdivhscalar2_thm (e : IntW 32) :
 
 theorem addhshlhsdivhnegative0_thm (e : IntW 8) :
   add (shl (LLVM.sdiv e (const? 8 4)) (const? 8 2)) e ⊑
-    add (shl (LLVM.sdiv e (const? 8 4)) (const? 8 2) { «nsw» := true, «nuw» := false }) e := by 
+    add (shl (LLVM.sdiv e (const? 8 4)) (const? 8 2) { «nsw» := true, «nuw» := false }) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -50,7 +50,7 @@ theorem addhshlhsdivhnegative0_thm (e : IntW 8) :
 
 
 theorem addhshlhsdivhnegative1_thm (e : IntW 32) :
-  add (shl (LLVM.sdiv e (const? 32 (-1))) (const? 32 1)) e ⊑ sub (const? 32 0) e := by 
+  add (shl (LLVM.sdiv e (const? 32 (-1))) (const? 32 1)) e ⊑ sub (const? 32 0) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -61,7 +61,7 @@ theorem addhshlhsdivhnegative1_thm (e : IntW 32) :
 
 theorem addhshlhsdivhnegative2_thm (e : IntW 32) :
   add (shl (LLVM.sdiv e (const? 32 (-2147483648))) (const? 32 31)) e ⊑
-    add (select (icmp IntPredicate.eq e (const? 32 (-2147483648))) (const? 32 (-2147483648)) (const? 32 0)) e := by 
+    add (select (icmp IntPredicate.eq e (const? 32 (-2147483648))) (const? 32 (-2147483648)) (const? 32 0)) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gaddnegneg_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gaddnegneg_proof.lean
@@ -9,7 +9,7 @@ set_option linter.unreachableTactic false
 
 section gaddnegneg_proof
 theorem l_thm (e e_1 e_2 : IntW 32) :
-  add (add (sub (const? 32 0) e_2) (sub (const? 32 0) e_1)) e ⊑ sub e (add e_2 e_1) := by 
+  add (add (sub (const? 32 0) e_2) (sub (const? 32 0) e_1)) e ⊑ sub e (add e_2 e_1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gaddsubhconstanthfolding_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gaddsubhconstanthfolding_proof.lean
@@ -8,7 +8,7 @@ set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
 
 section gaddsubhconstanthfolding_proof
-theorem add_const_add_const_thm (e : IntW 32) : add (add e (const? 32 8)) (const? 32 2) ⊑ add e (const? 32 10) := by 
+theorem add_const_add_const_thm (e : IntW 32) : add (add e (const? 32 8)) (const? 32 2) ⊑ add e (const? 32 10) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -17,7 +17,7 @@ theorem add_const_add_const_thm (e : IntW 32) : add (add e (const? 32 8)) (const
     all_goals sorry
 
 
-theorem add_const_sub_const_thm (e : IntW 32) : sub (add e (const? 32 8)) (const? 32 2) ⊑ add e (const? 32 6) := by 
+theorem add_const_sub_const_thm (e : IntW 32) : sub (add e (const? 32 8)) (const? 32 2) ⊑ add e (const? 32 6) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -26,7 +26,7 @@ theorem add_const_sub_const_thm (e : IntW 32) : sub (add e (const? 32 8)) (const
     all_goals sorry
 
 
-theorem add_const_const_sub_thm (e : IntW 32) : sub (const? 32 2) (add e (const? 32 8)) ⊑ sub (const? 32 (-6)) e := by 
+theorem add_const_const_sub_thm (e : IntW 32) : sub (const? 32 2) (add e (const? 32 8)) ⊑ sub (const? 32 (-6)) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -37,7 +37,7 @@ theorem add_const_const_sub_thm (e : IntW 32) : sub (const? 32 2) (add e (const?
 
 theorem add_nsw_const_const_sub_nsw_thm (e : IntW 8) :
   sub (const? 8 (-127)) (add e (const? 8 1) { «nsw» := true, «nuw» := false }) { «nsw» := true, «nuw» := false } ⊑
-    sub (const? 8 (-128)) e { «nsw» := true, «nuw» := false } := by 
+    sub (const? 8 (-128)) e { «nsw» := true, «nuw» := false } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -47,7 +47,7 @@ theorem add_nsw_const_const_sub_nsw_thm (e : IntW 8) :
 
 
 theorem add_nsw_const_const_sub_thm (e : IntW 8) :
-  sub (const? 8 (-127)) (add e (const? 8 1) { «nsw» := true, «nuw» := false }) ⊑ sub (const? 8 (-128)) e := by 
+  sub (const? 8 (-127)) (add e (const? 8 1) { «nsw» := true, «nuw» := false }) ⊑ sub (const? 8 (-128)) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -57,7 +57,7 @@ theorem add_nsw_const_const_sub_thm (e : IntW 8) :
 
 
 theorem add_const_const_sub_nsw_thm (e : IntW 8) :
-  sub (const? 8 (-127)) (add e (const? 8 1)) { «nsw» := true, «nuw» := false } ⊑ sub (const? 8 (-128)) e := by 
+  sub (const? 8 (-127)) (add e (const? 8 1)) { «nsw» := true, «nuw» := false } ⊑ sub (const? 8 (-128)) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -68,7 +68,7 @@ theorem add_const_const_sub_nsw_thm (e : IntW 8) :
 
 theorem add_nsw_const_const_sub_nsw_ov_thm (e : IntW 8) :
   sub (const? 8 (-127)) (add e (const? 8 2) { «nsw» := true, «nuw» := false }) { «nsw» := true, «nuw» := false } ⊑
-    sub (const? 8 127) e := by 
+    sub (const? 8 127) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -79,7 +79,7 @@ theorem add_nsw_const_const_sub_nsw_ov_thm (e : IntW 8) :
 
 theorem add_nuw_const_const_sub_nuw_thm (e : IntW 8) :
   sub (const? 8 (-127)) (add e (const? 8 1) { «nsw» := false, «nuw» := true }) { «nsw» := false, «nuw» := true } ⊑
-    sub (const? 8 (-128)) e { «nsw» := false, «nuw» := true } := by 
+    sub (const? 8 (-128)) e { «nsw» := false, «nuw» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -89,7 +89,7 @@ theorem add_nuw_const_const_sub_nuw_thm (e : IntW 8) :
 
 
 theorem add_nuw_const_const_sub_thm (e : IntW 8) :
-  sub (const? 8 (-127)) (add e (const? 8 1) { «nsw» := false, «nuw» := true }) ⊑ sub (const? 8 (-128)) e := by 
+  sub (const? 8 (-127)) (add e (const? 8 1) { «nsw» := false, «nuw» := true }) ⊑ sub (const? 8 (-128)) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -99,7 +99,7 @@ theorem add_nuw_const_const_sub_thm (e : IntW 8) :
 
 
 theorem add_const_const_sub_nuw_thm (e : IntW 8) :
-  sub (const? 8 (-127)) (add e (const? 8 1)) { «nsw» := false, «nuw» := true } ⊑ sub (const? 8 (-128)) e := by 
+  sub (const? 8 (-127)) (add e (const? 8 1)) { «nsw» := false, «nuw» := true } ⊑ sub (const? 8 (-128)) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -108,7 +108,7 @@ theorem add_const_const_sub_nuw_thm (e : IntW 8) :
     all_goals sorry
 
 
-theorem sub_const_add_const_thm (e : IntW 32) : add (sub e (const? 32 8)) (const? 32 2) ⊑ add e (const? 32 (-6)) := by 
+theorem sub_const_add_const_thm (e : IntW 32) : add (sub e (const? 32 8)) (const? 32 2) ⊑ add e (const? 32 (-6)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -117,7 +117,7 @@ theorem sub_const_add_const_thm (e : IntW 32) : add (sub e (const? 32 8)) (const
     all_goals sorry
 
 
-theorem sub_const_sub_const_thm (e : IntW 32) : sub (sub e (const? 32 8)) (const? 32 2) ⊑ add e (const? 32 (-10)) := by 
+theorem sub_const_sub_const_thm (e : IntW 32) : sub (sub e (const? 32 8)) (const? 32 2) ⊑ add e (const? 32 (-10)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -126,7 +126,7 @@ theorem sub_const_sub_const_thm (e : IntW 32) : sub (sub e (const? 32 8)) (const
     all_goals sorry
 
 
-theorem sub_const_const_sub_thm (e : IntW 32) : sub (const? 32 2) (sub e (const? 32 8)) ⊑ sub (const? 32 10) e := by 
+theorem sub_const_const_sub_thm (e : IntW 32) : sub (const? 32 2) (sub e (const? 32 8)) ⊑ sub (const? 32 10) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -135,7 +135,7 @@ theorem sub_const_const_sub_thm (e : IntW 32) : sub (const? 32 2) (sub e (const?
     all_goals sorry
 
 
-theorem const_sub_add_const_thm (e : IntW 32) : add (sub (const? 32 8) e) (const? 32 2) ⊑ sub (const? 32 10) e := by 
+theorem const_sub_add_const_thm (e : IntW 32) : add (sub (const? 32 8) e) (const? 32 2) ⊑ sub (const? 32 10) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -144,7 +144,7 @@ theorem const_sub_add_const_thm (e : IntW 32) : add (sub (const? 32 8) e) (const
     all_goals sorry
 
 
-theorem const_sub_sub_const_thm (e : IntW 32) : sub (sub (const? 32 8) e) (const? 32 2) ⊑ sub (const? 32 6) e := by 
+theorem const_sub_sub_const_thm (e : IntW 32) : sub (sub (const? 32 8) e) (const? 32 2) ⊑ sub (const? 32 6) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -153,7 +153,7 @@ theorem const_sub_sub_const_thm (e : IntW 32) : sub (sub (const? 32 8) e) (const
     all_goals sorry
 
 
-theorem const_sub_const_sub_thm (e : IntW 32) : sub (const? 32 2) (sub (const? 32 8) e) ⊑ add e (const? 32 (-6)) := by 
+theorem const_sub_const_sub_thm (e : IntW 32) : sub (const? 32 2) (sub (const? 32 8) e) ⊑ add e (const? 32 (-6)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -164,7 +164,7 @@ theorem const_sub_const_sub_thm (e : IntW 32) : sub (const? 32 2) (sub (const? 3
 
 theorem addsub_combine_constants_thm (e e_1 : IntW 7) :
   add (add e_1 (const? 7 42)) (sub (const? 7 10) e) { «nsw» := true, «nuw» := false } ⊑
-    add (sub e_1 e) (const? 7 52) := by 
+    add (sub e_1 e) (const? 7 52) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -173,7 +173,7 @@ theorem addsub_combine_constants_thm (e e_1 : IntW 7) :
     all_goals sorry
 
 
-theorem sub_from_constant_thm (e e_1 : IntW 5) : add (sub (const? 5 10) e_1) e ⊑ add (sub e e_1) (const? 5 10) := by 
+theorem sub_from_constant_thm (e e_1 : IntW 5) : add (sub (const? 5 10) e_1) e ⊑ add (sub e e_1) (const? 5 10) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -184,7 +184,7 @@ theorem sub_from_constant_thm (e e_1 : IntW 5) : add (sub (const? 5 10) e_1) e �
 
 theorem sub_from_constant_commute_thm (e e_1 : IntW 5) :
   add (mul e_1 e_1) (sub (const? 5 10) e { «nsw» := true, «nuw» := false }) { «nsw» := true, «nuw» := false } ⊑
-    add (sub (mul e_1 e_1) e) (const? 5 10) := by 
+    add (sub (mul e_1 e_1) e) (const? 5 10) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gand2_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gand2_proof.lean
@@ -8,7 +8,7 @@ set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
 
 section gand2_proof
-theorem test2_thm (e e_1 : IntW 1) : LLVM.and (LLVM.and e_1 e) e_1 ⊑ LLVM.and e_1 e := by 
+theorem test2_thm (e e_1 : IntW 1) : LLVM.and (LLVM.and e_1 e) e_1 ⊑ LLVM.and e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -18,7 +18,7 @@ theorem test2_thm (e e_1 : IntW 1) : LLVM.and (LLVM.and e_1 e) e_1 ⊑ LLVM.and 
 
 
 theorem test2_logical_thm (e e_1 : IntW 1) :
-  select (select e_1 e (const? 1 0)) e_1 (const? 1 0) ⊑ select e_1 e (const? 1 0) := by 
+  select (select e_1 e (const? 1 0)) e_1 (const? 1 0) ⊑ select e_1 e (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -27,7 +27,7 @@ theorem test2_logical_thm (e e_1 : IntW 1) :
     all_goals sorry
 
 
-theorem test3_thm (e e_1 : IntW 32) : LLVM.and e_1 (LLVM.and e e_1) ⊑ LLVM.and e e_1 := by 
+theorem test3_thm (e e_1 : IntW 32) : LLVM.and e_1 (LLVM.and e e_1) ⊑ LLVM.and e e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -38,7 +38,7 @@ theorem test3_thm (e e_1 : IntW 32) : LLVM.and e_1 (LLVM.and e e_1) ⊑ LLVM.and
 
 theorem test7_thm (e : IntW 1) (e_1 : IntW 32) :
   LLVM.and (LLVM.and (icmp IntPredicate.slt e_1 (const? 32 1)) e) (icmp IntPredicate.sgt e_1 (const? 32 (-1))) ⊑
-    LLVM.and (icmp IntPredicate.eq e_1 (const? 32 0)) e := by 
+    LLVM.and (icmp IntPredicate.eq e_1 (const? 32 0)) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -50,7 +50,7 @@ theorem test7_thm (e : IntW 1) (e_1 : IntW 32) :
 theorem test7_logical_thm (e : IntW 1) (e_1 : IntW 32) :
   select (select (icmp IntPredicate.slt e_1 (const? 32 1)) e (const? 1 0)) (icmp IntPredicate.sgt e_1 (const? 32 (-1)))
       (const? 1 0) ⊑
-    select (icmp IntPredicate.eq e_1 (const? 32 0)) e (const? 1 0) := by 
+    select (icmp IntPredicate.eq e_1 (const? 32 0)) e (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -61,7 +61,7 @@ theorem test7_logical_thm (e : IntW 1) (e_1 : IntW 32) :
 
 theorem test8_thm (e : IntW 32) :
   LLVM.and (icmp IntPredicate.ne e (const? 32 0)) (icmp IntPredicate.ult e (const? 32 14)) ⊑
-    icmp IntPredicate.ult (add e (const? 32 (-1))) (const? 32 13) := by 
+    icmp IntPredicate.ult (add e (const? 32 (-1))) (const? 32 13) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -72,7 +72,7 @@ theorem test8_thm (e : IntW 32) :
 
 theorem test8_logical_thm (e : IntW 32) :
   select (icmp IntPredicate.ne e (const? 32 0)) (icmp IntPredicate.ult e (const? 32 14)) (const? 1 0) ⊑
-    icmp IntPredicate.ult (add e (const? 32 (-1))) (const? 32 13) := by 
+    icmp IntPredicate.ult (add e (const? 32 (-1))) (const? 32 13) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -82,7 +82,7 @@ theorem test8_logical_thm (e : IntW 32) :
 
 
 theorem test9_thm (e : IntW 64) :
-  LLVM.and (sub (const? 64 0) e { «nsw» := true, «nuw» := false }) (const? 64 1) ⊑ LLVM.and e (const? 64 1) := by 
+  LLVM.and (sub (const? 64 0) e { «nsw» := true, «nuw» := false }) (const? 64 1) ⊑ LLVM.and e (const? 64 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -94,7 +94,7 @@ theorem test9_thm (e : IntW 64) :
 theorem test10_thm (e : IntW 64) :
   add (sub (const? 64 0) e { «nsw» := true, «nuw» := false })
       (LLVM.and (sub (const? 64 0) e { «nsw» := true, «nuw» := false }) (const? 64 1)) ⊑
-    sub (const? 64 0) (LLVM.and e (const? 64 (-2))) := by 
+    sub (const? 64 0) (LLVM.and e (const? 64 (-2))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -104,7 +104,7 @@ theorem test10_thm (e : IntW 64) :
 
 
 theorem and1_shl1_is_cmp_eq_0_thm (e : IntW 8) :
-  LLVM.and (shl (const? 8 1) e) (const? 8 1) ⊑ zext 8 (icmp IntPredicate.eq e (const? 8 0)) := by 
+  LLVM.and (shl (const? 8 1) e) (const? 8 1) ⊑ zext 8 (icmp IntPredicate.eq e (const? 8 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -117,7 +117,7 @@ theorem and1_shl1_is_cmp_eq_0_multiuse_thm (e : IntW 8) :
   add (shl (const? 8 1) e) (LLVM.and (shl (const? 8 1) e) (const? 8 1)) ⊑
     add (shl (const? 8 1) e { «nsw» := false, «nuw» := true })
       (LLVM.and (shl (const? 8 1) e { «nsw» := false, «nuw» := true }) (const? 8 1))
-      { «nsw» := false, «nuw» := true } := by 
+      { «nsw» := false, «nuw» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -126,7 +126,7 @@ theorem and1_shl1_is_cmp_eq_0_multiuse_thm (e : IntW 8) :
     all_goals sorry
 
 
-theorem and1_lshr1_is_cmp_eq_0_thm (e : IntW 8) : LLVM.and (lshr (const? 8 1) e) (const? 8 1) ⊑ lshr (const? 8 1) e := by 
+theorem and1_lshr1_is_cmp_eq_0_thm (e : IntW 8) : LLVM.and (lshr (const? 8 1) e) (const? 8 1) ⊑ lshr (const? 8 1) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -137,7 +137,7 @@ theorem and1_lshr1_is_cmp_eq_0_thm (e : IntW 8) : LLVM.and (lshr (const? 8 1) e)
 
 theorem and1_lshr1_is_cmp_eq_0_multiuse_thm (e : IntW 8) :
   add (lshr (const? 8 1) e) (LLVM.and (lshr (const? 8 1) e) (const? 8 1)) ⊑
-    shl (lshr (const? 8 1) e) (const? 8 1) { «nsw» := true, «nuw» := true } := by 
+    shl (lshr (const? 8 1) e) (const? 8 1) { «nsw» := true, «nuw» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -148,7 +148,7 @@ theorem and1_lshr1_is_cmp_eq_0_multiuse_thm (e : IntW 8) :
 
 theorem test11_thm (e e_1 : IntW 32) :
   mul (LLVM.and (add (shl e_1 (const? 32 8)) e) (const? 32 128)) (shl e_1 (const? 32 8)) ⊑
-    mul (LLVM.and e (const? 32 128)) (shl e_1 (const? 32 8)) := by 
+    mul (LLVM.and e (const? 32 128)) (shl e_1 (const? 32 8)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -159,7 +159,7 @@ theorem test11_thm (e e_1 : IntW 32) :
 
 theorem test12_thm (e e_1 : IntW 32) :
   mul (LLVM.and (add e_1 (shl e (const? 32 8))) (const? 32 128)) (shl e (const? 32 8)) ⊑
-    mul (LLVM.and e_1 (const? 32 128)) (shl e (const? 32 8)) := by 
+    mul (LLVM.and e_1 (const? 32 128)) (shl e (const? 32 8)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -170,7 +170,7 @@ theorem test12_thm (e e_1 : IntW 32) :
 
 theorem test13_thm (e e_1 : IntW 32) :
   mul (LLVM.and (sub e_1 (shl e (const? 32 8))) (const? 32 128)) (shl e (const? 32 8)) ⊑
-    mul (LLVM.and e_1 (const? 32 128)) (shl e (const? 32 8)) := by 
+    mul (LLVM.and e_1 (const? 32 128)) (shl e (const? 32 8)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -181,7 +181,7 @@ theorem test13_thm (e e_1 : IntW 32) :
 
 theorem test14_thm (e e_1 : IntW 32) :
   mul (LLVM.and (sub (shl e_1 (const? 32 8)) e) (const? 32 128)) (shl e_1 (const? 32 8)) ⊑
-    mul (LLVM.and (sub (const? 32 0) e) (const? 32 128)) (shl e_1 (const? 32 8)) := by 
+    mul (LLVM.and (sub (const? 32 0) e) (const? 32 128)) (shl e_1 (const? 32 8)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gand_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gand_proof.lean
@@ -9,7 +9,7 @@ set_option linter.unreachableTactic false
 
 section gand_proof
 theorem test_with_1_thm (e : IntW 32) :
-  LLVM.and (shl (const? 32 1) e) (const? 32 1) ⊑ zext 32 (icmp IntPredicate.eq e (const? 32 0)) := by 
+  LLVM.and (shl (const? 32 1) e) (const? 32 1) ⊑ zext 32 (icmp IntPredicate.eq e (const? 32 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -19,7 +19,7 @@ theorem test_with_1_thm (e : IntW 32) :
 
 
 theorem test_with_3_thm (e : IntW 32) :
-  LLVM.and (shl (const? 32 3) e) (const? 32 1) ⊑ zext 32 (icmp IntPredicate.eq e (const? 32 0)) := by 
+  LLVM.and (shl (const? 32 3) e) (const? 32 1) ⊑ zext 32 (icmp IntPredicate.eq e (const? 32 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -29,7 +29,7 @@ theorem test_with_3_thm (e : IntW 32) :
 
 
 theorem test_with_5_thm (e : IntW 32) :
-  LLVM.and (shl (const? 32 5) e) (const? 32 1) ⊑ zext 32 (icmp IntPredicate.eq e (const? 32 0)) := by 
+  LLVM.and (shl (const? 32 5) e) (const? 32 1) ⊑ zext 32 (icmp IntPredicate.eq e (const? 32 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -39,7 +39,7 @@ theorem test_with_5_thm (e : IntW 32) :
 
 
 theorem test_with_neg_5_thm (e : IntW 32) :
-  LLVM.and (shl (const? 32 (-5)) e) (const? 32 1) ⊑ zext 32 (icmp IntPredicate.eq e (const? 32 0)) := by 
+  LLVM.and (shl (const? 32 (-5)) e) (const? 32 1) ⊑ zext 32 (icmp IntPredicate.eq e (const? 32 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -48,7 +48,7 @@ theorem test_with_neg_5_thm (e : IntW 32) :
     all_goals sorry
 
 
-theorem test_with_even_thm (e : IntW 32) : LLVM.and (shl (const? 32 4) e) (const? 32 1) ⊑ const? 32 0 := by 
+theorem test_with_even_thm (e : IntW 32) : LLVM.and (shl (const? 32 4) e) (const? 32 1) ⊑ const? 32 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -57,7 +57,7 @@ theorem test_with_even_thm (e : IntW 32) : LLVM.and (shl (const? 32 4) e) (const
     all_goals sorry
 
 
-theorem test_with_neg_even_thm (e : IntW 32) : LLVM.and (shl (const? 32 (-4)) e) (const? 32 1) ⊑ const? 32 0 := by 
+theorem test_with_neg_even_thm (e : IntW 32) : LLVM.and (shl (const? 32 (-4)) e) (const? 32 1) ⊑ const? 32 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -66,7 +66,7 @@ theorem test_with_neg_even_thm (e : IntW 32) : LLVM.and (shl (const? 32 (-4)) e)
     all_goals sorry
 
 
-theorem test1_thm (e : IntW 32) : LLVM.and e (const? 32 0) ⊑ const? 32 0 := by 
+theorem test1_thm (e : IntW 32) : LLVM.and e (const? 32 0) ⊑ const? 32 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -75,7 +75,7 @@ theorem test1_thm (e : IntW 32) : LLVM.and e (const? 32 0) ⊑ const? 32 0 := by
     all_goals sorry
 
 
-theorem test2_thm (e : IntW 32) : LLVM.and e (const? 32 (-1)) ⊑ e := by 
+theorem test2_thm (e : IntW 32) : LLVM.and e (const? 32 (-1)) ⊑ e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -84,7 +84,7 @@ theorem test2_thm (e : IntW 32) : LLVM.and e (const? 32 (-1)) ⊑ e := by
     all_goals sorry
 
 
-theorem test3_thm (e : IntW 1) : LLVM.and e (const? 1 0) ⊑ const? 1 0 := by 
+theorem test3_thm (e : IntW 1) : LLVM.and e (const? 1 0) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -93,7 +93,7 @@ theorem test3_thm (e : IntW 1) : LLVM.and e (const? 1 0) ⊑ const? 1 0 := by
     all_goals sorry
 
 
-theorem test3_logical_thm (e : IntW 1) : select e (const? 1 0) (const? 1 0) ⊑ const? 1 0 := by 
+theorem test3_logical_thm (e : IntW 1) : select e (const? 1 0) (const? 1 0) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -102,7 +102,7 @@ theorem test3_logical_thm (e : IntW 1) : select e (const? 1 0) (const? 1 0) ⊑ 
     all_goals sorry
 
 
-theorem test4_thm (e : IntW 1) : LLVM.and e (const? 1 1) ⊑ e := by 
+theorem test4_thm (e : IntW 1) : LLVM.and e (const? 1 1) ⊑ e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -111,7 +111,7 @@ theorem test4_thm (e : IntW 1) : LLVM.and e (const? 1 1) ⊑ e := by
     all_goals sorry
 
 
-theorem test4_logical_thm (e : IntW 1) : select e (const? 1 1) (const? 1 0) ⊑ e := by 
+theorem test4_logical_thm (e : IntW 1) : select e (const? 1 1) (const? 1 0) ⊑ e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -120,7 +120,7 @@ theorem test4_logical_thm (e : IntW 1) : select e (const? 1 1) (const? 1 0) ⊑ 
     all_goals sorry
 
 
-theorem test5_thm (e : IntW 32) : LLVM.and e e ⊑ e := by 
+theorem test5_thm (e : IntW 32) : LLVM.and e e ⊑ e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -129,7 +129,7 @@ theorem test5_thm (e : IntW 32) : LLVM.and e e ⊑ e := by
     all_goals sorry
 
 
-theorem test6_thm (e : IntW 1) : LLVM.and e e ⊑ e := by 
+theorem test6_thm (e : IntW 1) : LLVM.and e e ⊑ e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -138,7 +138,7 @@ theorem test6_thm (e : IntW 1) : LLVM.and e e ⊑ e := by
     all_goals sorry
 
 
-theorem test6_logical_thm (e : IntW 1) : select e e (const? 1 0) ⊑ e := by 
+theorem test6_logical_thm (e : IntW 1) : select e e (const? 1 0) ⊑ e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -147,7 +147,7 @@ theorem test6_logical_thm (e : IntW 1) : select e e (const? 1 0) ⊑ e := by
     all_goals sorry
 
 
-theorem test7_thm (e : IntW 32) : LLVM.and e (LLVM.xor e (const? 32 (-1))) ⊑ const? 32 0 := by 
+theorem test7_thm (e : IntW 32) : LLVM.and e (LLVM.xor e (const? 32 (-1))) ⊑ const? 32 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -156,7 +156,7 @@ theorem test7_thm (e : IntW 32) : LLVM.and e (LLVM.xor e (const? 32 (-1))) ⊑ c
     all_goals sorry
 
 
-theorem test8_thm (e : IntW 8) : LLVM.and (LLVM.and e (const? 8 3)) (const? 8 4) ⊑ const? 8 0 := by 
+theorem test8_thm (e : IntW 8) : LLVM.and (LLVM.and e (const? 8 3)) (const? 8 4) ⊑ const? 8 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -167,7 +167,7 @@ theorem test8_thm (e : IntW 8) : LLVM.and (LLVM.and e (const? 8 3)) (const? 8 4)
 
 theorem test9_thm (e : IntW 32) :
   icmp IntPredicate.ne (LLVM.and e (const? 32 (-2147483648))) (const? 32 0) ⊑
-    icmp IntPredicate.slt e (const? 32 0) := by 
+    icmp IntPredicate.slt e (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -178,7 +178,7 @@ theorem test9_thm (e : IntW 32) :
 
 theorem test9a_thm (e : IntW 32) :
   icmp IntPredicate.ne (LLVM.and e (const? 32 (-2147483648))) (const? 32 0) ⊑
-    icmp IntPredicate.slt e (const? 32 0) := by 
+    icmp IntPredicate.slt e (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -188,7 +188,7 @@ theorem test9a_thm (e : IntW 32) :
 
 
 theorem test10_thm (e : IntW 32) :
-  LLVM.and (LLVM.xor (LLVM.and e (const? 32 12)) (const? 32 15)) (const? 32 1) ⊑ const? 32 1 := by 
+  LLVM.and (LLVM.xor (LLVM.and e (const? 32 12)) (const? 32 15)) (const? 32 1) ⊑ const? 32 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -198,7 +198,7 @@ theorem test10_thm (e : IntW 32) :
 
 
 theorem test12_thm (e e_1 : IntW 32) :
-  LLVM.and (icmp IntPredicate.ult e_1 e) (icmp IntPredicate.ule e_1 e) ⊑ icmp IntPredicate.ult e_1 e := by 
+  LLVM.and (icmp IntPredicate.ult e_1 e) (icmp IntPredicate.ule e_1 e) ⊑ icmp IntPredicate.ult e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -208,7 +208,7 @@ theorem test12_thm (e e_1 : IntW 32) :
 
 
 theorem test12_logical_thm (e e_1 : IntW 32) :
-  select (icmp IntPredicate.ult e_1 e) (icmp IntPredicate.ule e_1 e) (const? 1 0) ⊑ icmp IntPredicate.ult e_1 e := by 
+  select (icmp IntPredicate.ult e_1 e) (icmp IntPredicate.ule e_1 e) (const? 1 0) ⊑ icmp IntPredicate.ult e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -218,7 +218,7 @@ theorem test12_logical_thm (e e_1 : IntW 32) :
 
 
 theorem test13_thm (e e_1 : IntW 32) :
-  LLVM.and (icmp IntPredicate.ult e_1 e) (icmp IntPredicate.ugt e_1 e) ⊑ const? 1 0 := by 
+  LLVM.and (icmp IntPredicate.ult e_1 e) (icmp IntPredicate.ugt e_1 e) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -228,7 +228,7 @@ theorem test13_thm (e e_1 : IntW 32) :
 
 
 theorem test13_logical_thm (e e_1 : IntW 32) :
-  select (icmp IntPredicate.ult e_1 e) (icmp IntPredicate.ugt e_1 e) (const? 1 0) ⊑ const? 1 0 := by 
+  select (icmp IntPredicate.ult e_1 e) (icmp IntPredicate.ugt e_1 e) (const? 1 0) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -238,7 +238,7 @@ theorem test13_logical_thm (e e_1 : IntW 32) :
 
 
 theorem test14_thm (e : IntW 8) :
-  icmp IntPredicate.ne (LLVM.and e (const? 8 (-128))) (const? 8 0) ⊑ icmp IntPredicate.slt e (const? 8 0) := by 
+  icmp IntPredicate.ne (LLVM.and e (const? 8 (-128))) (const? 8 0) ⊑ icmp IntPredicate.slt e (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -247,7 +247,7 @@ theorem test14_thm (e : IntW 8) :
     all_goals sorry
 
 
-theorem test15_thm (e : IntW 8) : LLVM.and (lshr e (const? 8 7)) (const? 8 2) ⊑ const? 8 0 := by 
+theorem test15_thm (e : IntW 8) : LLVM.and (lshr e (const? 8 7)) (const? 8 2) ⊑ const? 8 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -256,7 +256,7 @@ theorem test15_thm (e : IntW 8) : LLVM.and (lshr e (const? 8 7)) (const? 8 2) �
     all_goals sorry
 
 
-theorem test16_thm (e : IntW 8) : LLVM.and (shl e (const? 8 2)) (const? 8 3) ⊑ const? 8 0 := by 
+theorem test16_thm (e : IntW 8) : LLVM.and (shl e (const? 8 2)) (const? 8 3) ⊑ const? 8 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -266,7 +266,7 @@ theorem test16_thm (e : IntW 8) : LLVM.and (shl e (const? 8 2)) (const? 8 3) ⊑
 
 
 theorem test18_thm (e : IntW 32) :
-  icmp IntPredicate.ne (LLVM.and e (const? 32 (-128))) (const? 32 0) ⊑ icmp IntPredicate.ugt e (const? 32 127) := by 
+  icmp IntPredicate.ne (LLVM.and e (const? 32 (-128))) (const? 32 0) ⊑ icmp IntPredicate.ugt e (const? 32 127) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -276,7 +276,7 @@ theorem test18_thm (e : IntW 32) :
 
 
 theorem test18a_thm (e : IntW 8) :
-  icmp IntPredicate.eq (LLVM.and e (const? 8 (-2))) (const? 8 0) ⊑ icmp IntPredicate.ult e (const? 8 2) := by 
+  icmp IntPredicate.eq (LLVM.and e (const? 8 (-2))) (const? 8 0) ⊑ icmp IntPredicate.ult e (const? 8 2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -285,7 +285,7 @@ theorem test18a_thm (e : IntW 8) :
     all_goals sorry
 
 
-theorem test19_thm (e : IntW 32) : LLVM.and (shl e (const? 32 3)) (const? 32 (-2)) ⊑ shl e (const? 32 3) := by 
+theorem test19_thm (e : IntW 32) : LLVM.and (shl e (const? 32 3)) (const? 32 (-2)) ⊑ shl e (const? 32 3) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -294,7 +294,7 @@ theorem test19_thm (e : IntW 32) : LLVM.and (shl e (const? 32 3)) (const? 32 (-2
     all_goals sorry
 
 
-theorem test20_thm (e : IntW 8) : LLVM.and (lshr e (const? 8 7)) (const? 8 1) ⊑ lshr e (const? 8 7) := by 
+theorem test20_thm (e : IntW 8) : LLVM.and (lshr e (const? 8 7)) (const? 8 1) ⊑ lshr e (const? 8 7) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -305,7 +305,7 @@ theorem test20_thm (e : IntW 8) : LLVM.and (lshr e (const? 8 7)) (const? 8 1) �
 
 theorem test23_thm (e : IntW 32) :
   LLVM.and (icmp IntPredicate.sgt e (const? 32 1)) (icmp IntPredicate.sle e (const? 32 2)) ⊑
-    icmp IntPredicate.eq e (const? 32 2) := by 
+    icmp IntPredicate.eq e (const? 32 2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -316,7 +316,7 @@ theorem test23_thm (e : IntW 32) :
 
 theorem test23_logical_thm (e : IntW 32) :
   select (icmp IntPredicate.sgt e (const? 32 1)) (icmp IntPredicate.sle e (const? 32 2)) (const? 1 0) ⊑
-    icmp IntPredicate.eq e (const? 32 2) := by 
+    icmp IntPredicate.eq e (const? 32 2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -327,7 +327,7 @@ theorem test23_logical_thm (e : IntW 32) :
 
 theorem test24_thm (e : IntW 32) :
   LLVM.and (icmp IntPredicate.sgt e (const? 32 1)) (icmp IntPredicate.ne e (const? 32 2)) ⊑
-    icmp IntPredicate.sgt e (const? 32 2) := by 
+    icmp IntPredicate.sgt e (const? 32 2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -338,7 +338,7 @@ theorem test24_thm (e : IntW 32) :
 
 theorem test24_logical_thm (e : IntW 32) :
   select (icmp IntPredicate.sgt e (const? 32 1)) (icmp IntPredicate.ne e (const? 32 2)) (const? 1 0) ⊑
-    icmp IntPredicate.sgt e (const? 32 2) := by 
+    icmp IntPredicate.sgt e (const? 32 2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -349,7 +349,7 @@ theorem test24_logical_thm (e : IntW 32) :
 
 theorem test25_thm (e : IntW 32) :
   LLVM.and (icmp IntPredicate.sge e (const? 32 50)) (icmp IntPredicate.slt e (const? 32 100)) ⊑
-    icmp IntPredicate.ult (add e (const? 32 (-50))) (const? 32 50) := by 
+    icmp IntPredicate.ult (add e (const? 32 (-50))) (const? 32 50) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -360,7 +360,7 @@ theorem test25_thm (e : IntW 32) :
 
 theorem test25_logical_thm (e : IntW 32) :
   select (icmp IntPredicate.sge e (const? 32 50)) (icmp IntPredicate.slt e (const? 32 100)) (const? 1 0) ⊑
-    icmp IntPredicate.ult (add e (const? 32 (-50))) (const? 32 50) := by 
+    icmp IntPredicate.ult (add e (const? 32 (-50))) (const? 32 50) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -370,7 +370,7 @@ theorem test25_logical_thm (e : IntW 32) :
 
 
 theorem test27_thm (e : IntW 8) :
-  add (LLVM.and (sub (LLVM.and e (const? 8 4)) (const? 8 16)) (const? 8 (-16))) (const? 8 16) ⊑ const? 8 0 := by 
+  add (LLVM.and (sub (LLVM.and e (const? 8 4)) (const? 8 16)) (const? 8 (-16))) (const? 8 16) ⊑ const? 8 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -379,7 +379,7 @@ theorem test27_thm (e : IntW 8) :
     all_goals sorry
 
 
-theorem ashr_lowmask_thm (e : IntW 32) : LLVM.and (ashr e (const? 32 24)) (const? 32 255) ⊑ lshr e (const? 32 24) := by 
+theorem ashr_lowmask_thm (e : IntW 32) : LLVM.and (ashr e (const? 32 24)) (const? 32 255) ⊑ lshr e (const? 32 24) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -388,7 +388,7 @@ theorem ashr_lowmask_thm (e : IntW 32) : LLVM.and (ashr e (const? 32 24)) (const
     all_goals sorry
 
 
-theorem test29_thm (e : IntW 8) : LLVM.and (zext 32 e) (const? 32 255) ⊑ zext 32 e := by 
+theorem test29_thm (e : IntW 8) : LLVM.and (zext 32 e) (const? 32 255) ⊑ zext 32 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -397,7 +397,7 @@ theorem test29_thm (e : IntW 8) : LLVM.and (zext 32 e) (const? 32 255) ⊑ zext 
     all_goals sorry
 
 
-theorem test30_thm (e : IntW 1) : LLVM.and (zext 32 e) (const? 32 1) ⊑ zext 32 e := by 
+theorem test30_thm (e : IntW 1) : LLVM.and (zext 32 e) (const? 32 1) ⊑ zext 32 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -407,7 +407,7 @@ theorem test30_thm (e : IntW 1) : LLVM.and (zext 32 e) (const? 32 1) ⊑ zext 32
 
 
 theorem test31_thm (e : IntW 1) :
-  LLVM.and (shl (zext 32 e) (const? 32 4)) (const? 32 16) ⊑ select e (const? 32 16) (const? 32 0) := by 
+  LLVM.and (shl (zext 32 e) (const? 32 4)) (const? 32 16) ⊑ select e (const? 32 16) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -418,7 +418,7 @@ theorem test31_thm (e : IntW 1) :
 
 theorem and_zext_demanded_thm (e : IntW 16) (e_1 : IntW 32) :
   LLVM.and (LLVM.or e_1 (const? 32 255)) (zext 32 (lshr e (const? 16 8))) ⊑
-    zext 32 (lshr e (const? 16 8)) { «nneg» := true } := by 
+    zext 32 (lshr e (const? 16 8)) { «nneg» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -428,7 +428,7 @@ theorem and_zext_demanded_thm (e : IntW 16) (e_1 : IntW 32) :
 
 
 theorem test32_thm (e : IntW 32) :
-  LLVM.and (lshr (LLVM.and e (const? 32 16)) (const? 32 2)) (const? 32 1) ⊑ const? 32 0 := by 
+  LLVM.and (lshr (LLVM.and e (const? 32 16)) (const? 32 2)) (const? 32 1) ⊑ const? 32 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -439,7 +439,7 @@ theorem test32_thm (e : IntW 32) :
 
 theorem test33_thm (e : IntW 32) :
   LLVM.or (LLVM.and e (const? 32 (-2))) (LLVM.xor (LLVM.and e (const? 32 1)) (const? 32 1)) ⊑
-    LLVM.xor e (const? 32 1) := by 
+    LLVM.xor e (const? 32 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -450,7 +450,7 @@ theorem test33_thm (e : IntW 32) :
 
 theorem test33b_thm (e : IntW 32) :
   LLVM.or (LLVM.xor (LLVM.and e (const? 32 1)) (const? 32 1)) (LLVM.and e (const? 32 (-2))) ⊑
-    LLVM.xor e (const? 32 1) := by 
+    LLVM.xor e (const? 32 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -459,7 +459,7 @@ theorem test33b_thm (e : IntW 32) :
     all_goals sorry
 
 
-theorem test34_thm (e e_1 : IntW 32) : LLVM.and (LLVM.or e_1 e) e_1 ⊑ e_1 := by 
+theorem test34_thm (e e_1 : IntW 32) : LLVM.and (LLVM.or e_1 e) e_1 ⊑ e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -470,7 +470,7 @@ theorem test34_thm (e e_1 : IntW 32) : LLVM.and (LLVM.or e_1 e) e_1 ⊑ e_1 := b
 
 theorem test35_thm (e : IntW 32) :
   LLVM.and (sub (const? 64 0) (zext 64 e)) (const? 64 240) ⊑
-    zext 64 (LLVM.and (sub (const? 32 0) e) (const? 32 240)) { «nneg» := true } := by 
+    zext 64 (LLVM.and (sub (const? 32 0) e) (const? 32 240)) { «nneg» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -481,7 +481,7 @@ theorem test35_thm (e : IntW 32) :
 
 theorem test36_thm (e : IntW 32) :
   LLVM.and (add (zext 64 e) (const? 64 7)) (const? 64 240) ⊑
-    zext 64 (LLVM.and (add e (const? 32 7)) (const? 32 240)) { «nneg» := true } := by 
+    zext 64 (LLVM.and (add e (const? 32 7)) (const? 32 240)) { «nneg» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -492,7 +492,7 @@ theorem test36_thm (e : IntW 32) :
 
 theorem test37_thm (e : IntW 32) :
   LLVM.and (mul (zext 64 e) (const? 64 7)) (const? 64 240) ⊑
-    zext 64 (LLVM.and (mul e (const? 32 7)) (const? 32 240)) { «nneg» := true } := by 
+    zext 64 (LLVM.and (mul e (const? 32 7)) (const? 32 240)) { «nneg» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -503,7 +503,7 @@ theorem test37_thm (e : IntW 32) :
 
 theorem test38_thm (e : IntW 32) :
   LLVM.and (LLVM.xor (zext 64 e) (const? 64 7)) (const? 64 240) ⊑
-    zext 64 (LLVM.and e (const? 32 240)) { «nneg» := true } := by 
+    zext 64 (LLVM.and e (const? 32 240)) { «nneg» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -514,7 +514,7 @@ theorem test38_thm (e : IntW 32) :
 
 theorem test39_thm (e : IntW 32) :
   LLVM.and (LLVM.or (zext 64 e) (const? 64 7)) (const? 64 240) ⊑
-    zext 64 (LLVM.and e (const? 32 240)) { «nneg» := true } := by 
+    zext 64 (LLVM.and e (const? 32 240)) { «nneg» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -524,7 +524,7 @@ theorem test39_thm (e : IntW 32) :
 
 
 theorem lowmask_add_zext_thm (e : IntW 32) (e_1 : IntW 8) :
-  LLVM.and (add (zext 32 e_1) e) (const? 32 255) ⊑ zext 32 (add e_1 (trunc 8 e)) := by 
+  LLVM.and (add (zext 32 e_1) e) (const? 32 255) ⊑ zext 32 (add e_1 (trunc 8 e)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -534,7 +534,7 @@ theorem lowmask_add_zext_thm (e : IntW 32) (e_1 : IntW 8) :
 
 
 theorem lowmask_add_zext_commute_thm (e : IntW 16) (e_1 : IntW 32) :
-  LLVM.and (add (mul e_1 e_1) (zext 32 e)) (const? 32 65535) ⊑ zext 32 (add e (trunc 16 (mul e_1 e_1))) := by 
+  LLVM.and (add (mul e_1 e_1) (zext 32 e)) (const? 32 65535) ⊑ zext 32 (add e (trunc 16 (mul e_1 e_1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -544,7 +544,7 @@ theorem lowmask_add_zext_commute_thm (e : IntW 16) (e_1 : IntW 32) :
 
 
 theorem lowmask_add_zext_wrong_mask_thm (e : IntW 32) (e_1 : IntW 8) :
-  LLVM.and (add (zext 32 e_1) e) (const? 32 511) ⊑ LLVM.and (add e (zext 32 e_1)) (const? 32 511) := by 
+  LLVM.and (add (zext 32 e_1) e) (const? 32 511) ⊑ LLVM.and (add e (zext 32 e_1)) (const? 32 511) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -554,7 +554,7 @@ theorem lowmask_add_zext_wrong_mask_thm (e : IntW 32) (e_1 : IntW 8) :
 
 
 theorem lowmask_sub_zext_commute_thm (e : IntW 5) (e_1 : IntW 17) :
-  LLVM.and (sub e_1 (zext 17 e)) (const? 17 31) ⊑ zext 17 (sub (trunc 5 e_1) e) := by 
+  LLVM.and (sub e_1 (zext 17 e)) (const? 17 31) ⊑ zext 17 (sub (trunc 5 e_1) e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -564,7 +564,7 @@ theorem lowmask_sub_zext_commute_thm (e : IntW 5) (e_1 : IntW 17) :
 
 
 theorem lowmask_mul_zext_thm (e : IntW 32) (e_1 : IntW 8) :
-  LLVM.and (mul (zext 32 e_1) e) (const? 32 255) ⊑ zext 32 (mul e_1 (trunc 8 e)) := by 
+  LLVM.and (mul (zext 32 e_1) e) (const? 32 255) ⊑ zext 32 (mul e_1 (trunc 8 e)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -574,7 +574,7 @@ theorem lowmask_mul_zext_thm (e : IntW 32) (e_1 : IntW 8) :
 
 
 theorem lowmask_xor_zext_commute_thm (e : IntW 8) (e_1 : IntW 32) :
-  LLVM.and (LLVM.xor (mul e_1 e_1) (zext 32 e)) (const? 32 255) ⊑ zext 32 (LLVM.xor e (trunc 8 (mul e_1 e_1))) := by 
+  LLVM.and (LLVM.xor (mul e_1 e_1) (zext 32 e)) (const? 32 255) ⊑ zext 32 (LLVM.xor e (trunc 8 (mul e_1 e_1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -584,7 +584,7 @@ theorem lowmask_xor_zext_commute_thm (e : IntW 8) (e_1 : IntW 32) :
 
 
 theorem lowmask_or_zext_commute_thm (e : IntW 16) (e_1 : IntW 24) :
-  LLVM.and (LLVM.or e_1 (zext 24 e)) (const? 24 65535) ⊑ zext 24 (LLVM.or e (trunc 16 e_1)) := by 
+  LLVM.and (LLVM.or e_1 (zext 24 e)) (const? 24 65535) ⊑ zext 24 (LLVM.or e (trunc 16 e_1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -594,7 +594,7 @@ theorem lowmask_or_zext_commute_thm (e : IntW 16) (e_1 : IntW 24) :
 
 
 theorem test40_thm (e : IntW 1) :
-  LLVM.and (select e (const? 32 1000) (const? 32 10)) (const? 32 123) ⊑ select e (const? 32 104) (const? 32 10) := by 
+  LLVM.and (select e (const? 32 1000) (const? 32 10)) (const? 32 123) ⊑ select e (const? 32 104) (const? 32 10) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -605,7 +605,7 @@ theorem test40_thm (e : IntW 1) :
 
 theorem test42_thm (e e_1 e_2 : IntW 32) :
   LLVM.and (LLVM.xor (LLVM.xor e_2 (const? 32 (-1))) (mul e_1 e)) (LLVM.or e_2 (mul e_1 e)) ⊑
-    LLVM.and (mul e_1 e) e_2 := by 
+    LLVM.and (mul e_1 e) e_2 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -616,7 +616,7 @@ theorem test42_thm (e e_1 e_2 : IntW 32) :
 
 theorem test43_thm (e e_1 e_2 : IntW 32) :
   LLVM.and (LLVM.or e_2 (mul e_1 e)) (LLVM.xor (LLVM.xor e_2 (const? 32 (-1))) (mul e_1 e)) ⊑
-    LLVM.and (mul e_1 e) e_2 := by 
+    LLVM.and (mul e_1 e) e_2 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -626,7 +626,7 @@ theorem test43_thm (e e_1 e_2 : IntW 32) :
 
 
 theorem test44_thm (e e_1 : IntW 32) :
-  LLVM.and (LLVM.or (LLVM.xor e_1 (const? 32 (-1))) e) e_1 ⊑ LLVM.and e e_1 := by 
+  LLVM.and (LLVM.or (LLVM.xor e_1 (const? 32 (-1))) e) e_1 ⊑ LLVM.and e e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -635,7 +635,7 @@ theorem test44_thm (e e_1 : IntW 32) :
     all_goals sorry
 
 
-theorem test45_thm (e e_1 : IntW 32) : LLVM.and (LLVM.or e_1 (LLVM.xor e (const? 32 (-1)))) e ⊑ LLVM.and e_1 e := by 
+theorem test45_thm (e e_1 : IntW 32) : LLVM.and (LLVM.or e_1 (LLVM.xor e (const? 32 (-1)))) e ⊑ LLVM.and e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -645,7 +645,7 @@ theorem test45_thm (e e_1 : IntW 32) : LLVM.and (LLVM.or e_1 (LLVM.xor e (const?
 
 
 theorem test46_thm (e e_1 : IntW 32) :
-  LLVM.and e_1 (LLVM.or (LLVM.xor e_1 (const? 32 (-1))) e) ⊑ LLVM.and e_1 e := by 
+  LLVM.and e_1 (LLVM.or (LLVM.xor e_1 (const? 32 (-1))) e) ⊑ LLVM.and e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -655,7 +655,7 @@ theorem test46_thm (e e_1 : IntW 32) :
 
 
 theorem test47_thm (e e_1 : IntW 32) :
-  LLVM.and e_1 (LLVM.or e (LLVM.xor e_1 (const? 32 (-1)))) ⊑ LLVM.and e_1 e := by 
+  LLVM.and e_1 (LLVM.or e (LLVM.xor e_1 (const? 32 (-1)))) ⊑ LLVM.and e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -667,7 +667,7 @@ theorem test47_thm (e e_1 : IntW 32) :
 theorem and_orn_cmp_1_thm (e e_1 e_2 : IntW 32) :
   LLVM.and (icmp IntPredicate.sgt e_2 e_1)
       (LLVM.or (icmp IntPredicate.ugt e (const? 32 42)) (icmp IntPredicate.sle e_2 e_1)) ⊑
-    LLVM.and (icmp IntPredicate.sgt e_2 e_1) (icmp IntPredicate.ugt e (const? 32 42)) := by 
+    LLVM.and (icmp IntPredicate.sgt e_2 e_1) (icmp IntPredicate.ugt e (const? 32 42)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -679,7 +679,7 @@ theorem and_orn_cmp_1_thm (e e_1 e_2 : IntW 32) :
 theorem and_orn_cmp_1_logical_thm (e e_1 e_2 : IntW 32) :
   select (icmp IntPredicate.sgt e_2 e_1)
       (select (icmp IntPredicate.ugt e (const? 32 42)) (const? 1 1) (icmp IntPredicate.sle e_2 e_1)) (const? 1 0) ⊑
-    select (icmp IntPredicate.sgt e_2 e_1) (icmp IntPredicate.ugt e (const? 32 42)) (const? 1 0) := by 
+    select (icmp IntPredicate.sgt e_2 e_1) (icmp IntPredicate.ugt e (const? 32 42)) (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -691,7 +691,7 @@ theorem and_orn_cmp_1_logical_thm (e e_1 e_2 : IntW 32) :
 theorem and_orn_cmp_3_thm (e e_1 e_2 : IntW 72) :
   LLVM.and (icmp IntPredicate.ugt e_2 e_1)
       (LLVM.or (icmp IntPredicate.ule e_2 e_1) (icmp IntPredicate.ugt e (const? 72 42))) ⊑
-    LLVM.and (icmp IntPredicate.ugt e_2 e_1) (icmp IntPredicate.ugt e (const? 72 42)) := by 
+    LLVM.and (icmp IntPredicate.ugt e_2 e_1) (icmp IntPredicate.ugt e (const? 72 42)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -703,7 +703,7 @@ theorem and_orn_cmp_3_thm (e e_1 e_2 : IntW 72) :
 theorem and_orn_cmp_3_logical_thm (e e_1 e_2 : IntW 72) :
   select (icmp IntPredicate.ugt e_2 e_1)
       (select (icmp IntPredicate.ule e_2 e_1) (const? 1 1) (icmp IntPredicate.ugt e (const? 72 42))) (const? 1 0) ⊑
-    select (icmp IntPredicate.ugt e_2 e_1) (icmp IntPredicate.ugt e (const? 72 42)) (const? 1 0) := by 
+    select (icmp IntPredicate.ugt e_2 e_1) (icmp IntPredicate.ugt e (const? 72 42)) (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -715,7 +715,7 @@ theorem and_orn_cmp_3_logical_thm (e e_1 e_2 : IntW 72) :
 theorem andn_or_cmp_1_thm (e e_1 e_2 : IntW 37) :
   LLVM.and (icmp IntPredicate.sle e_2 e_1)
       (LLVM.or (icmp IntPredicate.ugt e (const? 37 42)) (icmp IntPredicate.sgt e_2 e_1)) ⊑
-    LLVM.and (icmp IntPredicate.sle e_2 e_1) (icmp IntPredicate.ugt e (const? 37 42)) := by 
+    LLVM.and (icmp IntPredicate.sle e_2 e_1) (icmp IntPredicate.ugt e (const? 37 42)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -727,7 +727,7 @@ theorem andn_or_cmp_1_thm (e e_1 e_2 : IntW 37) :
 theorem andn_or_cmp_1_logical_thm (e e_1 e_2 : IntW 37) :
   select (icmp IntPredicate.sle e_2 e_1)
       (select (icmp IntPredicate.ugt e (const? 37 42)) (const? 1 1) (icmp IntPredicate.sgt e_2 e_1)) (const? 1 0) ⊑
-    select (icmp IntPredicate.sle e_2 e_1) (icmp IntPredicate.ugt e (const? 37 42)) (const? 1 0) := by 
+    select (icmp IntPredicate.sle e_2 e_1) (icmp IntPredicate.ugt e (const? 37 42)) (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -739,7 +739,7 @@ theorem andn_or_cmp_1_logical_thm (e e_1 e_2 : IntW 37) :
 theorem andn_or_cmp_2_thm (e e_1 e_2 : IntW 16) :
   LLVM.and (LLVM.or (icmp IntPredicate.ugt e_2 (const? 16 42)) (icmp IntPredicate.sge e_1 e))
       (icmp IntPredicate.slt e_1 e) ⊑
-    LLVM.and (icmp IntPredicate.ugt e_2 (const? 16 42)) (icmp IntPredicate.slt e_1 e) := by 
+    LLVM.and (icmp IntPredicate.ugt e_2 (const? 16 42)) (icmp IntPredicate.slt e_1 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -751,7 +751,7 @@ theorem andn_or_cmp_2_thm (e e_1 e_2 : IntW 16) :
 theorem andn_or_cmp_2_logical_thm (e e_1 e_2 : IntW 16) :
   select (select (icmp IntPredicate.ugt e_2 (const? 16 42)) (const? 1 1) (icmp IntPredicate.sge e_1 e))
       (icmp IntPredicate.slt e_1 e) (const? 1 0) ⊑
-    select (icmp IntPredicate.ugt e_2 (const? 16 42)) (icmp IntPredicate.slt e_1 e) (const? 1 0) := by 
+    select (icmp IntPredicate.ugt e_2 (const? 16 42)) (icmp IntPredicate.slt e_1 e) (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -763,7 +763,7 @@ theorem andn_or_cmp_2_logical_thm (e e_1 e_2 : IntW 16) :
 theorem andn_or_cmp_4_thm (e e_1 e_2 : IntW 32) :
   LLVM.and (LLVM.or (icmp IntPredicate.eq e_2 e_1) (icmp IntPredicate.ugt e (const? 32 42)))
       (icmp IntPredicate.ne e_2 e_1) ⊑
-    LLVM.and (icmp IntPredicate.ugt e (const? 32 42)) (icmp IntPredicate.ne e_2 e_1) := by 
+    LLVM.and (icmp IntPredicate.ugt e (const? 32 42)) (icmp IntPredicate.ne e_2 e_1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -775,7 +775,7 @@ theorem andn_or_cmp_4_thm (e e_1 e_2 : IntW 32) :
 theorem andn_or_cmp_4_logical_thm (e e_1 e_2 : IntW 32) :
   select (select (icmp IntPredicate.eq e_2 e_1) (const? 1 1) (icmp IntPredicate.ugt e (const? 32 42)))
       (icmp IntPredicate.ne e_2 e_1) (const? 1 0) ⊑
-    select (icmp IntPredicate.ne e_2 e_1) (icmp IntPredicate.ugt e (const? 32 42)) (const? 1 0) := by 
+    select (icmp IntPredicate.ne e_2 e_1) (icmp IntPredicate.ugt e (const? 32 42)) (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -785,7 +785,7 @@ theorem andn_or_cmp_4_logical_thm (e e_1 e_2 : IntW 32) :
 
 
 theorem lowbitmask_casted_shift_thm (e : IntW 8) :
-  LLVM.and (sext 32 (ashr e (const? 8 1))) (const? 32 2147483647) ⊑ lshr (sext 32 e) (const? 32 1) := by 
+  LLVM.and (sext 32 (ashr e (const? 8 1))) (const? 32 2147483647) ⊑ lshr (sext 32 e) (const? 32 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -794,7 +794,7 @@ theorem lowbitmask_casted_shift_thm (e : IntW 8) :
     all_goals sorry
 
 
-theorem lowmask_add_2_thm (e : IntW 8) : LLVM.and (add e (const? 8 (-64))) (const? 8 63) ⊑ LLVM.and e (const? 8 63) := by 
+theorem lowmask_add_2_thm (e : IntW 8) : LLVM.and (add e (const? 8 (-64))) (const? 8 63) ⊑ LLVM.and e (const? 8 63) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -804,7 +804,7 @@ theorem lowmask_add_2_thm (e : IntW 8) : LLVM.and (add e (const? 8 (-64))) (cons
 
 
 theorem flip_masked_bit_thm (e : IntW 8) :
-  LLVM.and (add e (const? 8 16)) (const? 8 16) ⊑ LLVM.xor (LLVM.and e (const? 8 16)) (const? 8 16) := by 
+  LLVM.and (add e (const? 8 16)) (const? 8 16) ⊑ LLVM.xor (LLVM.and e (const? 8 16)) (const? 8 16) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -814,7 +814,7 @@ theorem flip_masked_bit_thm (e : IntW 8) :
 
 
 theorem ashr_bitwidth_mask_thm (e e_1 : IntW 8) :
-  LLVM.and (ashr e_1 (const? 8 7)) e ⊑ select (icmp IntPredicate.slt e_1 (const? 8 0)) e (const? 8 0) := by 
+  LLVM.and (ashr e_1 (const? 8 7)) e ⊑ select (icmp IntPredicate.slt e_1 (const? 8 0)) e (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -825,7 +825,7 @@ theorem ashr_bitwidth_mask_thm (e e_1 : IntW 8) :
 
 theorem signbit_splat_mask_thm (e : IntW 16) (e_1 : IntW 8) :
   LLVM.and (sext 16 (ashr e_1 (const? 8 7))) e ⊑
-    select (icmp IntPredicate.slt e_1 (const? 8 0)) e (const? 16 0) := by 
+    select (icmp IntPredicate.slt e_1 (const? 8 0)) e (const? 16 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -835,7 +835,7 @@ theorem signbit_splat_mask_thm (e : IntW 16) (e_1 : IntW 8) :
 
 
 theorem not_signbit_splat_mask1_thm (e : IntW 16) (e_1 : IntW 8) :
-  LLVM.and (zext 16 (ashr e_1 (const? 8 7))) e ⊑ LLVM.and e (zext 16 (ashr e_1 (const? 8 7))) := by 
+  LLVM.and (zext 16 (ashr e_1 (const? 8 7))) e ⊑ LLVM.and e (zext 16 (ashr e_1 (const? 8 7))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -845,7 +845,7 @@ theorem not_signbit_splat_mask1_thm (e : IntW 16) (e_1 : IntW 8) :
 
 
 theorem not_signbit_splat_mask2_thm (e : IntW 16) (e_1 : IntW 8) :
-  LLVM.and (sext 16 (ashr e_1 (const? 8 6))) e ⊑ LLVM.and e (sext 16 (ashr e_1 (const? 8 6))) := by 
+  LLVM.and (sext 16 (ashr e_1 (const? 8 6))) e ⊑ LLVM.and e (sext 16 (ashr e_1 (const? 8 6))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -856,7 +856,7 @@ theorem not_signbit_splat_mask2_thm (e : IntW 16) (e_1 : IntW 8) :
 
 theorem not_ashr_bitwidth_mask_thm (e e_1 : IntW 8) :
   LLVM.and (LLVM.xor (ashr e_1 (const? 8 7)) (const? 8 (-1))) e ⊑
-    select (icmp IntPredicate.slt e_1 (const? 8 0)) (const? 8 0) e := by 
+    select (icmp IntPredicate.slt e_1 (const? 8 0)) (const? 8 0) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -867,7 +867,7 @@ theorem not_ashr_bitwidth_mask_thm (e e_1 : IntW 8) :
 
 theorem not_ashr_not_bitwidth_mask_thm (e e_1 : IntW 8) :
   LLVM.and (LLVM.xor (ashr e_1 (const? 8 6)) (const? 8 (-1))) e ⊑
-    LLVM.and e (LLVM.xor (ashr e_1 (const? 8 6)) (const? 8 (-1))) := by 
+    LLVM.and e (LLVM.xor (ashr e_1 (const? 8 6)) (const? 8 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -878,7 +878,7 @@ theorem not_ashr_not_bitwidth_mask_thm (e e_1 : IntW 8) :
 
 theorem not_lshr_bitwidth_mask_thm (e e_1 : IntW 8) :
   LLVM.and (LLVM.xor (lshr e_1 (const? 8 7)) (const? 8 (-1))) e ⊑
-    LLVM.and e (LLVM.xor (lshr e_1 (const? 8 7)) (const? 8 (-1))) := by 
+    LLVM.and e (LLVM.xor (lshr e_1 (const? 8 7)) (const? 8 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -889,7 +889,7 @@ theorem not_lshr_bitwidth_mask_thm (e e_1 : IntW 8) :
 
 theorem invert_signbit_splat_mask_thm (e : IntW 16) (e_1 : IntW 8) :
   LLVM.and (sext 16 (LLVM.xor (ashr e_1 (const? 8 7)) (const? 8 (-1)))) e ⊑
-    select (icmp IntPredicate.sgt e_1 (const? 8 (-1))) e (const? 16 0) := by 
+    select (icmp IntPredicate.sgt e_1 (const? 8 (-1))) e (const? 16 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -900,7 +900,7 @@ theorem invert_signbit_splat_mask_thm (e : IntW 16) (e_1 : IntW 8) :
 
 theorem not_invert_signbit_splat_mask1_thm (e : IntW 16) (e_1 : IntW 8) :
   LLVM.and (zext 16 (LLVM.xor (ashr e_1 (const? 8 7)) (const? 8 (-1)))) e ⊑
-    LLVM.and e (zext 16 (sext 8 (icmp IntPredicate.sgt e_1 (const? 8 (-1))))) := by 
+    LLVM.and e (zext 16 (sext 8 (icmp IntPredicate.sgt e_1 (const? 8 (-1))))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -911,7 +911,7 @@ theorem not_invert_signbit_splat_mask1_thm (e : IntW 16) (e_1 : IntW 8) :
 
 theorem not_invert_signbit_splat_mask2_thm (e : IntW 16) (e_1 : IntW 8) :
   LLVM.and (sext 16 (LLVM.xor (ashr e_1 (const? 8 6)) (const? 8 (-1)))) e ⊑
-    LLVM.and e (sext 16 (LLVM.xor (ashr e_1 (const? 8 6)) (const? 8 (-1)))) := by 
+    LLVM.and e (sext 16 (LLVM.xor (ashr e_1 (const? 8 6)) (const? 8 (-1)))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -922,7 +922,7 @@ theorem not_invert_signbit_splat_mask2_thm (e : IntW 16) (e_1 : IntW 8) :
 
 theorem shl_lshr_pow2_const_case1_thm (e : IntW 16) :
   LLVM.and (lshr (shl (const? 16 4) e) (const? 16 6)) (const? 16 8) ⊑
-    select (icmp IntPredicate.eq e (const? 16 7)) (const? 16 8) (const? 16 0) := by 
+    select (icmp IntPredicate.eq e (const? 16 7)) (const? 16 8) (const? 16 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -933,7 +933,7 @@ theorem shl_lshr_pow2_const_case1_thm (e : IntW 16) :
 
 theorem shl_ashr_pow2_const_case1_thm (e : IntW 16) :
   LLVM.and (ashr (shl (const? 16 4) e) (const? 16 6)) (const? 16 8) ⊑
-    select (icmp IntPredicate.eq e (const? 16 7)) (const? 16 8) (const? 16 0) := by 
+    select (icmp IntPredicate.eq e (const? 16 7)) (const? 16 8) (const? 16 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -944,7 +944,7 @@ theorem shl_ashr_pow2_const_case1_thm (e : IntW 16) :
 
 theorem shl_lshr_pow2_const_case2_thm (e : IntW 16) :
   LLVM.and (lshr (shl (const? 16 16) e) (const? 16 3)) (const? 16 8) ⊑
-    select (icmp IntPredicate.eq e (const? 16 2)) (const? 16 8) (const? 16 0) := by 
+    select (icmp IntPredicate.eq e (const? 16 2)) (const? 16 8) (const? 16 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -955,7 +955,7 @@ theorem shl_lshr_pow2_const_case2_thm (e : IntW 16) :
 
 theorem shl_lshr_pow2_not_const_case2_thm (e : IntW 16) :
   LLVM.xor (LLVM.and (lshr (shl (const? 16 16) e) (const? 16 3)) (const? 16 8)) (const? 16 8) ⊑
-    select (icmp IntPredicate.eq e (const? 16 2)) (const? 16 0) (const? 16 8) := by 
+    select (icmp IntPredicate.eq e (const? 16 2)) (const? 16 0) (const? 16 8) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -965,7 +965,7 @@ theorem shl_lshr_pow2_not_const_case2_thm (e : IntW 16) :
 
 
 theorem shl_lshr_pow2_const_negative_overflow1_thm (e : IntW 16) :
-  LLVM.and (lshr (shl (const? 16 4096) e) (const? 16 6)) (const? 16 8) ⊑ const? 16 0 := by 
+  LLVM.and (lshr (shl (const? 16 4096) e) (const? 16 6)) (const? 16 8) ⊑ const? 16 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -975,7 +975,7 @@ theorem shl_lshr_pow2_const_negative_overflow1_thm (e : IntW 16) :
 
 
 theorem shl_lshr_pow2_const_negative_overflow2_thm (e : IntW 16) :
-  LLVM.and (lshr (shl (const? 16 8) e) (const? 16 6)) (const? 16 (-32768)) ⊑ const? 16 0 := by 
+  LLVM.and (lshr (shl (const? 16 8) e) (const? 16 6)) (const? 16 (-32768)) ⊑ const? 16 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -986,7 +986,7 @@ theorem shl_lshr_pow2_const_negative_overflow2_thm (e : IntW 16) :
 
 theorem lshr_lshr_pow2_const_thm (e : IntW 16) :
   LLVM.and (lshr (lshr (const? 16 2048) e) (const? 16 6)) (const? 16 4) ⊑
-    select (icmp IntPredicate.eq e (const? 16 3)) (const? 16 4) (const? 16 0) := by 
+    select (icmp IntPredicate.eq e (const? 16 3)) (const? 16 4) (const? 16 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -997,7 +997,7 @@ theorem lshr_lshr_pow2_const_thm (e : IntW 16) :
 
 theorem lshr_lshr_pow2_const_negative_nopow2_1_thm (e : IntW 16) :
   LLVM.and (lshr (lshr (const? 16 2047) e) (const? 16 6)) (const? 16 4) ⊑
-    LLVM.and (lshr (const? 16 31) e) (const? 16 4) := by 
+    LLVM.and (lshr (const? 16 31) e) (const? 16 4) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1008,7 +1008,7 @@ theorem lshr_lshr_pow2_const_negative_nopow2_1_thm (e : IntW 16) :
 
 theorem lshr_lshr_pow2_const_negative_nopow2_2_thm (e : IntW 16) :
   LLVM.and (lshr (lshr (const? 16 8192) e) (const? 16 6)) (const? 16 3) ⊑
-    LLVM.and (lshr (const? 16 128) e) (const? 16 3) := by 
+    LLVM.and (lshr (const? 16 128) e) (const? 16 3) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1018,7 +1018,7 @@ theorem lshr_lshr_pow2_const_negative_nopow2_2_thm (e : IntW 16) :
 
 
 theorem lshr_lshr_pow2_const_negative_overflow_thm (e : IntW 16) :
-  LLVM.and (lshr (lshr (const? 16 (-32768)) e) (const? 16 15)) (const? 16 4) ⊑ const? 16 0 := by 
+  LLVM.and (lshr (lshr (const? 16 (-32768)) e) (const? 16 15)) (const? 16 4) ⊑ const? 16 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1029,7 +1029,7 @@ theorem lshr_lshr_pow2_const_negative_overflow_thm (e : IntW 16) :
 
 theorem lshr_shl_pow2_const_case1_thm (e : IntW 16) :
   LLVM.and (shl (lshr (const? 16 256) e) (const? 16 2)) (const? 16 8) ⊑
-    select (icmp IntPredicate.eq e (const? 16 7)) (const? 16 8) (const? 16 0) := by 
+    select (icmp IntPredicate.eq e (const? 16 7)) (const? 16 8) (const? 16 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1040,7 +1040,7 @@ theorem lshr_shl_pow2_const_case1_thm (e : IntW 16) :
 
 theorem lshr_shl_pow2_const_xor_thm (e : IntW 16) :
   LLVM.xor (LLVM.and (shl (lshr (const? 16 256) e) (const? 16 2)) (const? 16 8)) (const? 16 8) ⊑
-    select (icmp IntPredicate.eq e (const? 16 7)) (const? 16 0) (const? 16 8) := by 
+    select (icmp IntPredicate.eq e (const? 16 7)) (const? 16 0) (const? 16 8) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1051,7 +1051,7 @@ theorem lshr_shl_pow2_const_xor_thm (e : IntW 16) :
 
 theorem lshr_shl_pow2_const_case2_thm (e : IntW 16) :
   LLVM.and (shl (lshr (const? 16 8192) e) (const? 16 4)) (const? 16 32) ⊑
-    select (icmp IntPredicate.eq e (const? 16 12)) (const? 16 32) (const? 16 0) := by 
+    select (icmp IntPredicate.eq e (const? 16 12)) (const? 16 32) (const? 16 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1061,7 +1061,7 @@ theorem lshr_shl_pow2_const_case2_thm (e : IntW 16) :
 
 
 theorem lshr_shl_pow2_const_overflow_thm (e : IntW 16) :
-  LLVM.and (shl (lshr (const? 16 8192) e) (const? 16 6)) (const? 16 32) ⊑ const? 16 0 := by 
+  LLVM.and (shl (lshr (const? 16 8192) e) (const? 16 6)) (const? 16 32) ⊑ const? 16 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1072,7 +1072,7 @@ theorem lshr_shl_pow2_const_overflow_thm (e : IntW 16) :
 
 theorem negate_lowbitmask_thm (e e_1 : IntW 8) :
   LLVM.and (sub (const? 8 0) (LLVM.and e_1 (const? 8 1))) e ⊑
-    select (icmp IntPredicate.eq (LLVM.and e_1 (const? 8 1)) (const? 8 0)) (const? 8 0) e := by 
+    select (icmp IntPredicate.eq (LLVM.and e_1 (const? 8 1)) (const? 8 0)) (const? 8 0) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1082,7 +1082,7 @@ theorem negate_lowbitmask_thm (e e_1 : IntW 8) :
 
 
 theorem and_zext_thm (e : IntW 1) (e_1 : IntW 32) :
-  LLVM.and e_1 (zext 32 e) ⊑ select e (LLVM.and e_1 (const? 32 1)) (const? 32 0) := by 
+  LLVM.and e_1 (zext 32 e) ⊑ select e (LLVM.and e_1 (const? 32 1)) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1092,7 +1092,7 @@ theorem and_zext_thm (e : IntW 1) (e_1 : IntW 32) :
 
 
 theorem and_zext_commuted_thm (e : IntW 32) (e_1 : IntW 1) :
-  LLVM.and (zext 32 e_1) e ⊑ select e_1 (LLVM.and e (const? 32 1)) (const? 32 0) := by 
+  LLVM.and (zext 32 e_1) e ⊑ select e_1 (LLVM.and e (const? 32 1)) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1101,7 +1101,7 @@ theorem and_zext_commuted_thm (e : IntW 32) (e_1 : IntW 1) :
     all_goals sorry
 
 
-theorem and_zext_eq_even_thm (e : IntW 32) : LLVM.and e (zext 32 (icmp IntPredicate.eq e (const? 32 2))) ⊑ const? 32 0 := by 
+theorem and_zext_eq_even_thm (e : IntW 32) : LLVM.and e (zext 32 (icmp IntPredicate.eq e (const? 32 2))) ⊑ const? 32 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1110,7 +1110,7 @@ theorem and_zext_eq_even_thm (e : IntW 32) : LLVM.and e (zext 32 (icmp IntPredic
     all_goals sorry
 
 
-theorem and_zext_eq_even_commuted_thm (e : IntW 32) : LLVM.and (zext 32 (icmp IntPredicate.eq e (const? 32 2))) e ⊑ const? 32 0 := by 
+theorem and_zext_eq_even_commuted_thm (e : IntW 32) : LLVM.and (zext 32 (icmp IntPredicate.eq e (const? 32 2))) e ⊑ const? 32 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1120,7 +1120,7 @@ theorem and_zext_eq_even_commuted_thm (e : IntW 32) : LLVM.and (zext 32 (icmp In
 
 
 theorem and_zext_eq_odd_thm (e : IntW 32) :
-  LLVM.and e (zext 32 (icmp IntPredicate.eq e (const? 32 3))) ⊑ zext 32 (icmp IntPredicate.eq e (const? 32 3)) := by 
+  LLVM.and e (zext 32 (icmp IntPredicate.eq e (const? 32 3))) ⊑ zext 32 (icmp IntPredicate.eq e (const? 32 3)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1130,7 +1130,7 @@ theorem and_zext_eq_odd_thm (e : IntW 32) :
 
 
 theorem and_zext_eq_odd_commuted_thm (e : IntW 32) :
-  LLVM.and (zext 32 (icmp IntPredicate.eq e (const? 32 3))) e ⊑ zext 32 (icmp IntPredicate.eq e (const? 32 3)) := by 
+  LLVM.and (zext 32 (icmp IntPredicate.eq e (const? 32 3))) e ⊑ zext 32 (icmp IntPredicate.eq e (const? 32 3)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1141,7 +1141,7 @@ theorem and_zext_eq_odd_commuted_thm (e : IntW 32) :
 
 theorem and_zext_eq_zero_thm (e e_1 : IntW 32) :
   LLVM.and (zext 32 (icmp IntPredicate.eq e_1 (const? 32 0))) (LLVM.xor (lshr e_1 e) (const? 32 (-1))) ⊑
-    zext 32 (icmp IntPredicate.eq e_1 (const? 32 0)) := by 
+    zext 32 (icmp IntPredicate.eq e_1 (const? 32 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1151,7 +1151,7 @@ theorem and_zext_eq_zero_thm (e e_1 : IntW 32) :
 
 
 theorem add_constant_equal_with_the_top_bit_of_demandedbits_pass_thm (e : IntW 32) :
-  LLVM.and (add e (const? 32 16)) (const? 32 24) ⊑ LLVM.xor (LLVM.and e (const? 32 24)) (const? 32 16) := by 
+  LLVM.and (add e (const? 32 16)) (const? 32 24) ⊑ LLVM.xor (LLVM.and e (const? 32 24)) (const? 32 16) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1162,7 +1162,7 @@ theorem add_constant_equal_with_the_top_bit_of_demandedbits_pass_thm (e : IntW 3
 
 theorem add_constant_equal_with_the_top_bit_of_demandedbits_insertpt_thm (e e_1 : IntW 32) :
   LLVM.and (LLVM.or (add e_1 (const? 32 16)) e) (const? 32 24) ⊑
-    LLVM.and (LLVM.or (LLVM.xor e_1 (const? 32 16)) e) (const? 32 24) := by 
+    LLVM.and (LLVM.or (LLVM.xor e_1 (const? 32 16)) e) (const? 32 24) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1173,7 +1173,7 @@ theorem add_constant_equal_with_the_top_bit_of_demandedbits_insertpt_thm (e e_1 
 
 theorem and_sext_multiuse_thm (e e_1 e_2 e_3 : IntW 32) :
   add (LLVM.and (sext 32 (icmp IntPredicate.sgt e_3 e_2)) e_1) (LLVM.and (sext 32 (icmp IntPredicate.sgt e_3 e_2)) e) ⊑
-    select (icmp IntPredicate.sgt e_3 e_2) (add e_1 e) (const? 32 0) := by 
+    select (icmp IntPredicate.sgt e_3 e_2) (add e_1 e) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gandhcompare_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gandhcompare_proof.lean
@@ -10,7 +10,7 @@ set_option linter.unreachableTactic false
 section gandhcompare_proof
 theorem test1_thm (e e_1 : IntW 32) :
   icmp IntPredicate.ne (LLVM.and e_1 (const? 32 65280)) (LLVM.and e (const? 32 65280)) ⊑
-    icmp IntPredicate.ne (LLVM.and (LLVM.xor e_1 e) (const? 32 65280)) (const? 32 0) := by 
+    icmp IntPredicate.ne (LLVM.and (LLVM.xor e_1 e) (const? 32 65280)) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -21,7 +21,7 @@ theorem test1_thm (e e_1 : IntW 32) :
 
 theorem test_eq_0_and_15_add_1_thm (e : IntW 8) :
   icmp IntPredicate.eq (LLVM.and (add e (const? 8 1)) (const? 8 15)) (const? 8 0) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 8 15)) (const? 8 15) := by 
+    icmp IntPredicate.eq (LLVM.and e (const? 8 15)) (const? 8 15) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -32,7 +32,7 @@ theorem test_eq_0_and_15_add_1_thm (e : IntW 8) :
 
 theorem test_ne_0_and_15_add_1_thm (e : IntW 8) :
   icmp IntPredicate.ne (LLVM.and (add e (const? 8 1)) (const? 8 15)) (const? 8 0) ⊑
-    icmp IntPredicate.ne (LLVM.and e (const? 8 15)) (const? 8 15) := by 
+    icmp IntPredicate.ne (LLVM.and e (const? 8 15)) (const? 8 15) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -43,7 +43,7 @@ theorem test_ne_0_and_15_add_1_thm (e : IntW 8) :
 
 theorem test_eq_0_and_15_add_3_thm (e : IntW 8) :
   icmp IntPredicate.eq (LLVM.and (add e (const? 8 3)) (const? 8 15)) (const? 8 0) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 8 15)) (const? 8 13) := by 
+    icmp IntPredicate.eq (LLVM.and e (const? 8 15)) (const? 8 13) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -54,7 +54,7 @@ theorem test_eq_0_and_15_add_3_thm (e : IntW 8) :
 
 theorem test_ne_0_and_15_add_3_thm (e : IntW 8) :
   icmp IntPredicate.ne (LLVM.and (add e (const? 8 3)) (const? 8 15)) (const? 8 0) ⊑
-    icmp IntPredicate.ne (LLVM.and e (const? 8 15)) (const? 8 13) := by 
+    icmp IntPredicate.ne (LLVM.and e (const? 8 15)) (const? 8 13) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -65,7 +65,7 @@ theorem test_ne_0_and_15_add_3_thm (e : IntW 8) :
 
 theorem test_eq_11_and_15_add_10_thm (e : IntW 8) :
   icmp IntPredicate.eq (LLVM.and (add e (const? 8 10)) (const? 8 15)) (const? 8 11) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 8 15)) (const? 8 1) := by 
+    icmp IntPredicate.eq (LLVM.and e (const? 8 15)) (const? 8 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -76,7 +76,7 @@ theorem test_eq_11_and_15_add_10_thm (e : IntW 8) :
 
 theorem test_ne_11_and_15_add_10_thm (e : IntW 8) :
   icmp IntPredicate.ne (LLVM.and (add e (const? 8 10)) (const? 8 15)) (const? 8 11) ⊑
-    icmp IntPredicate.ne (LLVM.and e (const? 8 15)) (const? 8 1) := by 
+    icmp IntPredicate.ne (LLVM.and e (const? 8 15)) (const? 8 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gandhnarrow_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gandhnarrow_proof.lean
@@ -9,7 +9,7 @@ set_option linter.unreachableTactic false
 
 section gandhnarrow_proof
 theorem zext_add_thm (e : IntW 8) :
-  LLVM.and (add (zext 16 e) (const? 16 44)) (zext 16 e) ⊑ zext 16 (LLVM.and (add e (const? 8 44)) e) := by 
+  LLVM.and (add (zext 16 e) (const? 16 44)) (zext 16 e) ⊑ zext 16 (LLVM.and (add e (const? 8 44)) e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -19,7 +19,7 @@ theorem zext_add_thm (e : IntW 8) :
 
 
 theorem zext_sub_thm (e : IntW 8) :
-  LLVM.and (sub (const? 16 (-5)) (zext 16 e)) (zext 16 e) ⊑ zext 16 (LLVM.and (sub (const? 8 (-5)) e) e) := by 
+  LLVM.and (sub (const? 16 (-5)) (zext 16 e)) (zext 16 e) ⊑ zext 16 (LLVM.and (sub (const? 8 (-5)) e) e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -29,7 +29,7 @@ theorem zext_sub_thm (e : IntW 8) :
 
 
 theorem zext_mul_thm (e : IntW 8) :
-  LLVM.and (mul (zext 16 e) (const? 16 3)) (zext 16 e) ⊑ zext 16 (LLVM.and (mul e (const? 8 3)) e) := by 
+  LLVM.and (mul (zext 16 e) (const? 16 3)) (zext 16 e) ⊑ zext 16 (LLVM.and (mul e (const? 8 3)) e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -40,7 +40,7 @@ theorem zext_mul_thm (e : IntW 8) :
 
 theorem zext_lshr_thm (e : IntW 8) :
   LLVM.and (lshr (zext 16 e) (const? 16 4)) (zext 16 e) ⊑
-    zext 16 (LLVM.and (lshr e (const? 8 4)) e) { «nneg» := true } := by 
+    zext 16 (LLVM.and (lshr e (const? 8 4)) e) { «nneg» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -51,7 +51,7 @@ theorem zext_lshr_thm (e : IntW 8) :
 
 theorem zext_ashr_thm (e : IntW 8) :
   LLVM.and (ashr (zext 16 e) (const? 16 2)) (zext 16 e) ⊑
-    zext 16 (LLVM.and (lshr e (const? 8 2)) e) { «nneg» := true } := by 
+    zext 16 (LLVM.and (lshr e (const? 8 2)) e) { «nneg» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -61,7 +61,7 @@ theorem zext_ashr_thm (e : IntW 8) :
 
 
 theorem zext_shl_thm (e : IntW 8) :
-  LLVM.and (shl (zext 16 e) (const? 16 3)) (zext 16 e) ⊑ zext 16 (LLVM.and (shl e (const? 8 3)) e) := by 
+  LLVM.and (shl (zext 16 e) (const? 16 3)) (zext 16 e) ⊑ zext 16 (LLVM.and (shl e (const? 8 3)) e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gandhorhand_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gandhorhand_proof.lean
@@ -10,7 +10,7 @@ set_option linter.unreachableTactic false
 section gandhorhand_proof
 theorem test1_thm (e e_1 : IntW 32) :
   LLVM.and (LLVM.or (LLVM.and e_1 (const? 32 7)) (LLVM.and e (const? 32 8))) (const? 32 7) ⊑
-    LLVM.and e_1 (const? 32 7) := by 
+    LLVM.and e_1 (const? 32 7) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -20,7 +20,7 @@ theorem test1_thm (e e_1 : IntW 32) :
 
 
 theorem test2_thm (e : IntW 8) (e_1 : IntW 32) :
-  LLVM.and (LLVM.or e_1 (zext 32 e)) (const? 32 65536) ⊑ LLVM.and e_1 (const? 32 65536) := by 
+  LLVM.and (LLVM.or e_1 (zext 32 e)) (const? 32 65536) ⊑ LLVM.and e_1 (const? 32 65536) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -30,7 +30,7 @@ theorem test2_thm (e : IntW 8) (e_1 : IntW 32) :
 
 
 theorem test3_thm (e e_1 : IntW 32) :
-  LLVM.and (LLVM.or e_1 (shl e (const? 32 1))) (const? 32 1) ⊑ LLVM.and e_1 (const? 32 1) := by 
+  LLVM.and (LLVM.or e_1 (shl e (const? 32 1))) (const? 32 1) ⊑ LLVM.and e_1 (const? 32 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -40,7 +40,7 @@ theorem test3_thm (e e_1 : IntW 32) :
 
 
 theorem test4_thm (e e_1 : IntW 32) :
-  LLVM.and (LLVM.or e_1 (lshr e (const? 32 31))) (const? 32 2) ⊑ LLVM.and e_1 (const? 32 2) := by 
+  LLVM.and (LLVM.or e_1 (lshr e (const? 32 31))) (const? 32 2) ⊑ LLVM.and e_1 (const? 32 2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -49,7 +49,7 @@ theorem test4_thm (e e_1 : IntW 32) :
     all_goals sorry
 
 
-theorem or_test1_thm (e : IntW 32) : LLVM.or (LLVM.and e (const? 32 1)) (const? 32 1) ⊑ const? 32 1 := by 
+theorem or_test1_thm (e : IntW 32) : LLVM.or (LLVM.and e (const? 32 1)) (const? 32 1) ⊑ const? 32 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -58,7 +58,7 @@ theorem or_test1_thm (e : IntW 32) : LLVM.or (LLVM.and e (const? 32 1)) (const? 
     all_goals sorry
 
 
-theorem or_test2_thm (e : IntW 8) : LLVM.or (shl e (const? 8 7)) (const? 8 (-128)) ⊑ const? 8 (-128) := by 
+theorem or_test2_thm (e : IntW 8) : LLVM.or (shl e (const? 8 7)) (const? 8 (-128)) ⊑ const? 8 (-128) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gandhorhicmphconsthicmp_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gandhorhicmphconsthicmp_proof.lean
@@ -10,7 +10,7 @@ set_option linter.unreachableTactic false
 section gandhorhicmphconsthicmp_proof
 theorem eq_basic_thm (e e_1 : IntW 8) :
   LLVM.or (icmp IntPredicate.eq e_1 (const? 8 0)) (icmp IntPredicate.ugt e_1 e) ⊑
-    icmp IntPredicate.uge (add e_1 (const? 8 (-1))) e := by 
+    icmp IntPredicate.uge (add e_1 (const? 8 (-1))) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -21,7 +21,7 @@ theorem eq_basic_thm (e e_1 : IntW 8) :
 
 theorem ne_basic_equal_5_thm (e e_1 : IntW 8) :
   LLVM.and (icmp IntPredicate.ne e_1 (const? 8 5)) (icmp IntPredicate.ule (add e_1 (const? 8 (-5))) e) ⊑
-    icmp IntPredicate.ult (add e_1 (const? 8 (-6))) e := by 
+    icmp IntPredicate.ult (add e_1 (const? 8 (-6))) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -32,7 +32,7 @@ theorem ne_basic_equal_5_thm (e e_1 : IntW 8) :
 
 theorem eq_basic_equal_minus_1_thm (e e_1 : IntW 8) :
   LLVM.or (icmp IntPredicate.eq e_1 (const? 8 (-1))) (icmp IntPredicate.ugt (add e_1 (const? 8 1)) e) ⊑
-    icmp IntPredicate.uge e_1 e := by 
+    icmp IntPredicate.uge e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -43,7 +43,7 @@ theorem eq_basic_equal_minus_1_thm (e e_1 : IntW 8) :
 
 theorem ne_basic_equal_minus_7_thm (e e_1 : IntW 8) :
   LLVM.and (icmp IntPredicate.ne e_1 (const? 8 (-7))) (icmp IntPredicate.ule (add e_1 (const? 8 7)) e) ⊑
-    icmp IntPredicate.ult (add e_1 (const? 8 6)) e := by 
+    icmp IntPredicate.ult (add e_1 (const? 8 6)) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -54,7 +54,7 @@ theorem ne_basic_equal_minus_7_thm (e e_1 : IntW 8) :
 
 theorem eq_commuted_thm (e e_1 : IntW 8) :
   LLVM.or (icmp IntPredicate.eq e_1 (const? 8 0)) (icmp IntPredicate.ult (LLVM.sdiv (const? 8 43) e) e_1) ⊑
-    icmp IntPredicate.uge (add e_1 (const? 8 (-1))) (LLVM.sdiv (const? 8 43) e) := by 
+    icmp IntPredicate.uge (add e_1 (const? 8 (-1))) (LLVM.sdiv (const? 8 43) e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -66,7 +66,7 @@ theorem eq_commuted_thm (e e_1 : IntW 8) :
 theorem ne_commuted_equal_minus_1_thm (e e_1 : IntW 8) :
   LLVM.and (icmp IntPredicate.ne e_1 (const? 8 (-1)))
       (icmp IntPredicate.uge (LLVM.sdiv (const? 8 42) e) (add e_1 (const? 8 1))) ⊑
-    icmp IntPredicate.ult e_1 (LLVM.sdiv (const? 8 42) e) := by 
+    icmp IntPredicate.ult e_1 (LLVM.sdiv (const? 8 42) e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gandhorhicmphminhmax_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gandhorhicmphminhmax_proof.lean
@@ -9,7 +9,7 @@ set_option linter.unreachableTactic false
 
 section gandhorhicmphminhmax_proof
 theorem slt_and_max_thm (e e_1 : IntW 8) :
-  LLVM.and (icmp IntPredicate.slt e_1 e) (icmp IntPredicate.eq e_1 (const? 8 127)) ⊑ const? 1 0 := by 
+  LLVM.and (icmp IntPredicate.slt e_1 e) (icmp IntPredicate.eq e_1 (const? 8 127)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -19,7 +19,7 @@ theorem slt_and_max_thm (e e_1 : IntW 8) :
 
 
 theorem slt_and_max_logical_thm (e e_1 : IntW 8) :
-  select (icmp IntPredicate.slt e_1 e) (icmp IntPredicate.eq e_1 (const? 8 127)) (const? 1 0) ⊑ const? 1 0 := by 
+  select (icmp IntPredicate.slt e_1 e) (icmp IntPredicate.eq e_1 (const? 8 127)) (const? 1 0) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -29,7 +29,7 @@ theorem slt_and_max_logical_thm (e e_1 : IntW 8) :
 
 
 theorem slt_swap_and_max_thm (e e_1 : IntW 8) :
-  LLVM.and (icmp IntPredicate.sgt e_1 e) (icmp IntPredicate.eq e (const? 8 127)) ⊑ const? 1 0 := by 
+  LLVM.and (icmp IntPredicate.sgt e_1 e) (icmp IntPredicate.eq e (const? 8 127)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -39,7 +39,7 @@ theorem slt_swap_and_max_thm (e e_1 : IntW 8) :
 
 
 theorem slt_swap_and_max_logical_thm (e e_1 : IntW 8) :
-  select (icmp IntPredicate.sgt e_1 e) (icmp IntPredicate.eq e (const? 8 127)) (const? 1 0) ⊑ const? 1 0 := by 
+  select (icmp IntPredicate.sgt e_1 e) (icmp IntPredicate.eq e (const? 8 127)) (const? 1 0) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -49,7 +49,7 @@ theorem slt_swap_and_max_logical_thm (e e_1 : IntW 8) :
 
 
 theorem slt_swap_and_max_commute_thm (e e_1 : IntW 8) :
-  LLVM.and (icmp IntPredicate.eq e_1 (const? 8 127)) (icmp IntPredicate.sgt e e_1) ⊑ const? 1 0 := by 
+  LLVM.and (icmp IntPredicate.eq e_1 (const? 8 127)) (icmp IntPredicate.sgt e e_1) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -59,7 +59,7 @@ theorem slt_swap_and_max_commute_thm (e e_1 : IntW 8) :
 
 
 theorem slt_swap_and_max_commute_logical_thm (e e_1 : IntW 8) :
-  select (icmp IntPredicate.eq e_1 (const? 8 127)) (icmp IntPredicate.sgt e e_1) (const? 1 0) ⊑ const? 1 0 := by 
+  select (icmp IntPredicate.eq e_1 (const? 8 127)) (icmp IntPredicate.sgt e e_1) (const? 1 0) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -69,7 +69,7 @@ theorem slt_swap_and_max_commute_logical_thm (e e_1 : IntW 8) :
 
 
 theorem ult_and_max_thm (e e_1 : IntW 8) :
-  LLVM.and (icmp IntPredicate.ult e_1 e) (icmp IntPredicate.eq e_1 (const? 8 (-1))) ⊑ const? 1 0 := by 
+  LLVM.and (icmp IntPredicate.ult e_1 e) (icmp IntPredicate.eq e_1 (const? 8 (-1))) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -79,7 +79,7 @@ theorem ult_and_max_thm (e e_1 : IntW 8) :
 
 
 theorem ult_and_max_logical_thm (e e_1 : IntW 8) :
-  select (icmp IntPredicate.ult e_1 e) (icmp IntPredicate.eq e_1 (const? 8 (-1))) (const? 1 0) ⊑ const? 1 0 := by 
+  select (icmp IntPredicate.ult e_1 e) (icmp IntPredicate.eq e_1 (const? 8 (-1))) (const? 1 0) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -89,7 +89,7 @@ theorem ult_and_max_logical_thm (e e_1 : IntW 8) :
 
 
 theorem ult_and_max_commute_thm (e e_1 : IntW 8) :
-  LLVM.and (icmp IntPredicate.eq e_1 (const? 8 (-1))) (icmp IntPredicate.ult e_1 e) ⊑ const? 1 0 := by 
+  LLVM.and (icmp IntPredicate.eq e_1 (const? 8 (-1))) (icmp IntPredicate.ult e_1 e) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -99,7 +99,7 @@ theorem ult_and_max_commute_thm (e e_1 : IntW 8) :
 
 
 theorem ult_and_max_commute_logical_thm (e e_1 : IntW 8) :
-  select (icmp IntPredicate.eq e_1 (const? 8 (-1))) (icmp IntPredicate.ult e_1 e) (const? 1 0) ⊑ const? 1 0 := by 
+  select (icmp IntPredicate.eq e_1 (const? 8 (-1))) (icmp IntPredicate.ult e_1 e) (const? 1 0) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -109,7 +109,7 @@ theorem ult_and_max_commute_logical_thm (e e_1 : IntW 8) :
 
 
 theorem ult_swap_and_max_thm (e e_1 : IntW 8) :
-  LLVM.and (icmp IntPredicate.ugt e_1 e) (icmp IntPredicate.eq e (const? 8 (-1))) ⊑ const? 1 0 := by 
+  LLVM.and (icmp IntPredicate.ugt e_1 e) (icmp IntPredicate.eq e (const? 8 (-1))) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -119,7 +119,7 @@ theorem ult_swap_and_max_thm (e e_1 : IntW 8) :
 
 
 theorem ult_swap_and_max_logical_thm (e e_1 : IntW 8) :
-  select (icmp IntPredicate.ugt e_1 e) (icmp IntPredicate.eq e (const? 8 (-1))) (const? 1 0) ⊑ const? 1 0 := by 
+  select (icmp IntPredicate.ugt e_1 e) (icmp IntPredicate.eq e (const? 8 (-1))) (const? 1 0) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -129,7 +129,7 @@ theorem ult_swap_and_max_logical_thm (e e_1 : IntW 8) :
 
 
 theorem ult_swap_and_max_commute_thm (e e_1 : IntW 8) :
-  LLVM.and (icmp IntPredicate.eq e_1 (const? 8 (-1))) (icmp IntPredicate.ugt e e_1) ⊑ const? 1 0 := by 
+  LLVM.and (icmp IntPredicate.eq e_1 (const? 8 (-1))) (icmp IntPredicate.ugt e e_1) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -139,7 +139,7 @@ theorem ult_swap_and_max_commute_thm (e e_1 : IntW 8) :
 
 
 theorem ult_swap_and_max_commute_logical_thm (e e_1 : IntW 8) :
-  select (icmp IntPredicate.eq e_1 (const? 8 (-1))) (icmp IntPredicate.ugt e e_1) (const? 1 0) ⊑ const? 1 0 := by 
+  select (icmp IntPredicate.eq e_1 (const? 8 (-1))) (icmp IntPredicate.ugt e e_1) (const? 1 0) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -149,7 +149,7 @@ theorem ult_swap_and_max_commute_logical_thm (e e_1 : IntW 8) :
 
 
 theorem sgt_and_min_thm (e e_1 : IntW 9) :
-  LLVM.and (icmp IntPredicate.sgt e_1 e) (icmp IntPredicate.eq e_1 (const? 9 (-256))) ⊑ const? 1 0 := by 
+  LLVM.and (icmp IntPredicate.sgt e_1 e) (icmp IntPredicate.eq e_1 (const? 9 (-256))) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -159,7 +159,7 @@ theorem sgt_and_min_thm (e e_1 : IntW 9) :
 
 
 theorem sgt_and_min_logical_thm (e e_1 : IntW 9) :
-  select (icmp IntPredicate.sgt e_1 e) (icmp IntPredicate.eq e_1 (const? 9 (-256))) (const? 1 0) ⊑ const? 1 0 := by 
+  select (icmp IntPredicate.sgt e_1 e) (icmp IntPredicate.eq e_1 (const? 9 (-256))) (const? 1 0) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -169,7 +169,7 @@ theorem sgt_and_min_logical_thm (e e_1 : IntW 9) :
 
 
 theorem sgt_and_min_commute_thm (e e_1 : IntW 8) :
-  LLVM.and (icmp IntPredicate.eq e_1 (const? 8 (-128))) (icmp IntPredicate.sgt e_1 e) ⊑ const? 1 0 := by 
+  LLVM.and (icmp IntPredicate.eq e_1 (const? 8 (-128))) (icmp IntPredicate.sgt e_1 e) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -179,7 +179,7 @@ theorem sgt_and_min_commute_thm (e e_1 : IntW 8) :
 
 
 theorem sgt_and_min_commute_logical_thm (e e_1 : IntW 8) :
-  select (icmp IntPredicate.eq e_1 (const? 8 (-128))) (icmp IntPredicate.sgt e_1 e) (const? 1 0) ⊑ const? 1 0 := by 
+  select (icmp IntPredicate.eq e_1 (const? 8 (-128))) (icmp IntPredicate.sgt e_1 e) (const? 1 0) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -189,7 +189,7 @@ theorem sgt_and_min_commute_logical_thm (e e_1 : IntW 8) :
 
 
 theorem sgt_swap_and_min_thm (e e_1 : IntW 8) :
-  LLVM.and (icmp IntPredicate.slt e_1 e) (icmp IntPredicate.eq e (const? 8 (-128))) ⊑ const? 1 0 := by 
+  LLVM.and (icmp IntPredicate.slt e_1 e) (icmp IntPredicate.eq e (const? 8 (-128))) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -199,7 +199,7 @@ theorem sgt_swap_and_min_thm (e e_1 : IntW 8) :
 
 
 theorem sgt_swap_and_min_logical_thm (e e_1 : IntW 8) :
-  select (icmp IntPredicate.slt e_1 e) (icmp IntPredicate.eq e (const? 8 (-128))) (const? 1 0) ⊑ const? 1 0 := by 
+  select (icmp IntPredicate.slt e_1 e) (icmp IntPredicate.eq e (const? 8 (-128))) (const? 1 0) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -209,7 +209,7 @@ theorem sgt_swap_and_min_logical_thm (e e_1 : IntW 8) :
 
 
 theorem sgt_swap_and_min_commute_thm (e e_1 : IntW 8) :
-  LLVM.and (icmp IntPredicate.eq e_1 (const? 8 (-128))) (icmp IntPredicate.slt e e_1) ⊑ const? 1 0 := by 
+  LLVM.and (icmp IntPredicate.eq e_1 (const? 8 (-128))) (icmp IntPredicate.slt e e_1) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -219,7 +219,7 @@ theorem sgt_swap_and_min_commute_thm (e e_1 : IntW 8) :
 
 
 theorem sgt_swap_and_min_commute_logical_thm (e e_1 : IntW 8) :
-  select (icmp IntPredicate.eq e_1 (const? 8 (-128))) (icmp IntPredicate.slt e e_1) (const? 1 0) ⊑ const? 1 0 := by 
+  select (icmp IntPredicate.eq e_1 (const? 8 (-128))) (icmp IntPredicate.slt e e_1) (const? 1 0) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -229,7 +229,7 @@ theorem sgt_swap_and_min_commute_logical_thm (e e_1 : IntW 8) :
 
 
 theorem ugt_and_min_thm (e e_1 : IntW 8) :
-  LLVM.and (icmp IntPredicate.ugt e_1 e) (icmp IntPredicate.eq e_1 (const? 8 0)) ⊑ const? 1 0 := by 
+  LLVM.and (icmp IntPredicate.ugt e_1 e) (icmp IntPredicate.eq e_1 (const? 8 0)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -239,7 +239,7 @@ theorem ugt_and_min_thm (e e_1 : IntW 8) :
 
 
 theorem ugt_and_min_logical_thm (e e_1 : IntW 8) :
-  select (icmp IntPredicate.ugt e_1 e) (icmp IntPredicate.eq e_1 (const? 8 0)) (const? 1 0) ⊑ const? 1 0 := by 
+  select (icmp IntPredicate.ugt e_1 e) (icmp IntPredicate.eq e_1 (const? 8 0)) (const? 1 0) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -249,7 +249,7 @@ theorem ugt_and_min_logical_thm (e e_1 : IntW 8) :
 
 
 theorem ugt_and_min_commute_thm (e e_1 : IntW 8) :
-  LLVM.and (icmp IntPredicate.eq e_1 (const? 8 0)) (icmp IntPredicate.ugt e_1 e) ⊑ const? 1 0 := by 
+  LLVM.and (icmp IntPredicate.eq e_1 (const? 8 0)) (icmp IntPredicate.ugt e_1 e) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -259,7 +259,7 @@ theorem ugt_and_min_commute_thm (e e_1 : IntW 8) :
 
 
 theorem ugt_and_min_commute_logical_thm (e e_1 : IntW 8) :
-  select (icmp IntPredicate.eq e_1 (const? 8 0)) (icmp IntPredicate.ugt e_1 e) (const? 1 0) ⊑ const? 1 0 := by 
+  select (icmp IntPredicate.eq e_1 (const? 8 0)) (icmp IntPredicate.ugt e_1 e) (const? 1 0) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -269,7 +269,7 @@ theorem ugt_and_min_commute_logical_thm (e e_1 : IntW 8) :
 
 
 theorem ugt_swap_and_min_thm (e e_1 : IntW 8) :
-  LLVM.and (icmp IntPredicate.ult e_1 e) (icmp IntPredicate.eq e (const? 8 0)) ⊑ const? 1 0 := by 
+  LLVM.and (icmp IntPredicate.ult e_1 e) (icmp IntPredicate.eq e (const? 8 0)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -279,7 +279,7 @@ theorem ugt_swap_and_min_thm (e e_1 : IntW 8) :
 
 
 theorem ugt_swap_and_min_logical_thm (e e_1 : IntW 8) :
-  select (icmp IntPredicate.ult e_1 e) (icmp IntPredicate.eq e (const? 8 0)) (const? 1 0) ⊑ const? 1 0 := by 
+  select (icmp IntPredicate.ult e_1 e) (icmp IntPredicate.eq e (const? 8 0)) (const? 1 0) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -289,7 +289,7 @@ theorem ugt_swap_and_min_logical_thm (e e_1 : IntW 8) :
 
 
 theorem ugt_swap_and_min_commute_thm (e e_1 : IntW 8) :
-  LLVM.and (icmp IntPredicate.eq e_1 (const? 8 0)) (icmp IntPredicate.ult e e_1) ⊑ const? 1 0 := by 
+  LLVM.and (icmp IntPredicate.eq e_1 (const? 8 0)) (icmp IntPredicate.ult e e_1) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -299,7 +299,7 @@ theorem ugt_swap_and_min_commute_thm (e e_1 : IntW 8) :
 
 
 theorem ugt_swap_and_min_commute_logical_thm (e e_1 : IntW 8) :
-  select (icmp IntPredicate.eq e_1 (const? 8 0)) (icmp IntPredicate.ult e e_1) (const? 1 0) ⊑ const? 1 0 := by 
+  select (icmp IntPredicate.eq e_1 (const? 8 0)) (icmp IntPredicate.ult e e_1) (const? 1 0) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -309,7 +309,7 @@ theorem ugt_swap_and_min_commute_logical_thm (e e_1 : IntW 8) :
 
 
 theorem sge_or_not_max_thm (e e_1 : IntW 8) :
-  LLVM.or (icmp IntPredicate.sge e_1 e) (icmp IntPredicate.ne e_1 (const? 8 127)) ⊑ const? 1 1 := by 
+  LLVM.or (icmp IntPredicate.sge e_1 e) (icmp IntPredicate.ne e_1 (const? 8 127)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -319,7 +319,7 @@ theorem sge_or_not_max_thm (e e_1 : IntW 8) :
 
 
 theorem sge_or_not_max_logical_thm (e e_1 : IntW 8) :
-  select (icmp IntPredicate.sge e_1 e) (const? 1 1) (icmp IntPredicate.ne e_1 (const? 8 127)) ⊑ const? 1 1 := by 
+  select (icmp IntPredicate.sge e_1 e) (const? 1 1) (icmp IntPredicate.ne e_1 (const? 8 127)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -329,7 +329,7 @@ theorem sge_or_not_max_logical_thm (e e_1 : IntW 8) :
 
 
 theorem sge_or_not_max_commute_thm (e e_1 : IntW 8) :
-  LLVM.or (icmp IntPredicate.ne e_1 (const? 8 127)) (icmp IntPredicate.sge e_1 e) ⊑ const? 1 1 := by 
+  LLVM.or (icmp IntPredicate.ne e_1 (const? 8 127)) (icmp IntPredicate.sge e_1 e) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -339,7 +339,7 @@ theorem sge_or_not_max_commute_thm (e e_1 : IntW 8) :
 
 
 theorem sge_or_not_max_commute_logical_thm (e e_1 : IntW 8) :
-  select (icmp IntPredicate.ne e_1 (const? 8 127)) (const? 1 1) (icmp IntPredicate.sge e_1 e) ⊑ const? 1 1 := by 
+  select (icmp IntPredicate.ne e_1 (const? 8 127)) (const? 1 1) (icmp IntPredicate.sge e_1 e) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -349,7 +349,7 @@ theorem sge_or_not_max_commute_logical_thm (e e_1 : IntW 8) :
 
 
 theorem sge_swap_or_not_max_thm (e e_1 : IntW 8) :
-  LLVM.or (icmp IntPredicate.sle e_1 e) (icmp IntPredicate.ne e (const? 8 127)) ⊑ const? 1 1 := by 
+  LLVM.or (icmp IntPredicate.sle e_1 e) (icmp IntPredicate.ne e (const? 8 127)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -359,7 +359,7 @@ theorem sge_swap_or_not_max_thm (e e_1 : IntW 8) :
 
 
 theorem sge_swap_or_not_max_logical_thm (e e_1 : IntW 8) :
-  select (icmp IntPredicate.sle e_1 e) (const? 1 1) (icmp IntPredicate.ne e (const? 8 127)) ⊑ const? 1 1 := by 
+  select (icmp IntPredicate.sle e_1 e) (const? 1 1) (icmp IntPredicate.ne e (const? 8 127)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -369,7 +369,7 @@ theorem sge_swap_or_not_max_logical_thm (e e_1 : IntW 8) :
 
 
 theorem sge_swap_or_not_max_commute_thm (e e_1 : IntW 8) :
-  LLVM.or (icmp IntPredicate.ne e_1 (const? 8 127)) (icmp IntPredicate.sle e e_1) ⊑ const? 1 1 := by 
+  LLVM.or (icmp IntPredicate.ne e_1 (const? 8 127)) (icmp IntPredicate.sle e e_1) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -379,7 +379,7 @@ theorem sge_swap_or_not_max_commute_thm (e e_1 : IntW 8) :
 
 
 theorem sge_swap_or_not_max_commute_logical_thm (e e_1 : IntW 8) :
-  select (icmp IntPredicate.ne e_1 (const? 8 127)) (const? 1 1) (icmp IntPredicate.sle e e_1) ⊑ const? 1 1 := by 
+  select (icmp IntPredicate.ne e_1 (const? 8 127)) (const? 1 1) (icmp IntPredicate.sle e e_1) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -389,7 +389,7 @@ theorem sge_swap_or_not_max_commute_logical_thm (e e_1 : IntW 8) :
 
 
 theorem uge_or_not_max_thm (e e_1 : IntW 8) :
-  LLVM.or (icmp IntPredicate.uge e_1 e) (icmp IntPredicate.ne e_1 (const? 8 (-1))) ⊑ const? 1 1 := by 
+  LLVM.or (icmp IntPredicate.uge e_1 e) (icmp IntPredicate.ne e_1 (const? 8 (-1))) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -399,7 +399,7 @@ theorem uge_or_not_max_thm (e e_1 : IntW 8) :
 
 
 theorem uge_or_not_max_logical_thm (e e_1 : IntW 8) :
-  select (icmp IntPredicate.uge e_1 e) (const? 1 1) (icmp IntPredicate.ne e_1 (const? 8 (-1))) ⊑ const? 1 1 := by 
+  select (icmp IntPredicate.uge e_1 e) (const? 1 1) (icmp IntPredicate.ne e_1 (const? 8 (-1))) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -409,7 +409,7 @@ theorem uge_or_not_max_logical_thm (e e_1 : IntW 8) :
 
 
 theorem uge_or_not_max_commute_thm (e e_1 : IntW 8) :
-  LLVM.or (icmp IntPredicate.ne e_1 (const? 8 (-1))) (icmp IntPredicate.uge e_1 e) ⊑ const? 1 1 := by 
+  LLVM.or (icmp IntPredicate.ne e_1 (const? 8 (-1))) (icmp IntPredicate.uge e_1 e) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -419,7 +419,7 @@ theorem uge_or_not_max_commute_thm (e e_1 : IntW 8) :
 
 
 theorem uge_or_not_max_commute_logical_thm (e e_1 : IntW 8) :
-  select (icmp IntPredicate.ne e_1 (const? 8 (-1))) (const? 1 1) (icmp IntPredicate.uge e_1 e) ⊑ const? 1 1 := by 
+  select (icmp IntPredicate.ne e_1 (const? 8 (-1))) (const? 1 1) (icmp IntPredicate.uge e_1 e) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -429,7 +429,7 @@ theorem uge_or_not_max_commute_logical_thm (e e_1 : IntW 8) :
 
 
 theorem uge_swap_or_not_max_thm (e e_1 : IntW 8) :
-  LLVM.or (icmp IntPredicate.ule e_1 e) (icmp IntPredicate.ne e (const? 8 (-1))) ⊑ const? 1 1 := by 
+  LLVM.or (icmp IntPredicate.ule e_1 e) (icmp IntPredicate.ne e (const? 8 (-1))) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -439,7 +439,7 @@ theorem uge_swap_or_not_max_thm (e e_1 : IntW 8) :
 
 
 theorem uge_swap_or_not_max_logical_thm (e e_1 : IntW 8) :
-  select (icmp IntPredicate.ule e_1 e) (const? 1 1) (icmp IntPredicate.ne e (const? 8 (-1))) ⊑ const? 1 1 := by 
+  select (icmp IntPredicate.ule e_1 e) (const? 1 1) (icmp IntPredicate.ne e (const? 8 (-1))) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -449,7 +449,7 @@ theorem uge_swap_or_not_max_logical_thm (e e_1 : IntW 8) :
 
 
 theorem uge_swap_or_not_max_commute_thm (e e_1 : IntW 8) :
-  LLVM.or (icmp IntPredicate.ne e_1 (const? 8 (-1))) (icmp IntPredicate.ule e e_1) ⊑ const? 1 1 := by 
+  LLVM.or (icmp IntPredicate.ne e_1 (const? 8 (-1))) (icmp IntPredicate.ule e e_1) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -459,7 +459,7 @@ theorem uge_swap_or_not_max_commute_thm (e e_1 : IntW 8) :
 
 
 theorem uge_swap_or_not_max_commute_logical_thm (e e_1 : IntW 8) :
-  select (icmp IntPredicate.ne e_1 (const? 8 (-1))) (const? 1 1) (icmp IntPredicate.ule e e_1) ⊑ const? 1 1 := by 
+  select (icmp IntPredicate.ne e_1 (const? 8 (-1))) (const? 1 1) (icmp IntPredicate.ule e e_1) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -469,7 +469,7 @@ theorem uge_swap_or_not_max_commute_logical_thm (e e_1 : IntW 8) :
 
 
 theorem sle_or_not_min_thm (e e_1 : IntW 8) :
-  LLVM.or (icmp IntPredicate.sle e_1 e) (icmp IntPredicate.ne e_1 (const? 8 (-128))) ⊑ const? 1 1 := by 
+  LLVM.or (icmp IntPredicate.sle e_1 e) (icmp IntPredicate.ne e_1 (const? 8 (-128))) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -479,7 +479,7 @@ theorem sle_or_not_min_thm (e e_1 : IntW 8) :
 
 
 theorem sle_or_not_min_logical_thm (e e_1 : IntW 8) :
-  select (icmp IntPredicate.sle e_1 e) (const? 1 1) (icmp IntPredicate.ne e_1 (const? 8 (-128))) ⊑ const? 1 1 := by 
+  select (icmp IntPredicate.sle e_1 e) (const? 1 1) (icmp IntPredicate.ne e_1 (const? 8 (-128))) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -489,7 +489,7 @@ theorem sle_or_not_min_logical_thm (e e_1 : IntW 8) :
 
 
 theorem sle_or_not_min_commute_thm (e e_1 : IntW 8) :
-  LLVM.or (icmp IntPredicate.ne e_1 (const? 8 (-128))) (icmp IntPredicate.sle e_1 e) ⊑ const? 1 1 := by 
+  LLVM.or (icmp IntPredicate.ne e_1 (const? 8 (-128))) (icmp IntPredicate.sle e_1 e) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -499,7 +499,7 @@ theorem sle_or_not_min_commute_thm (e e_1 : IntW 8) :
 
 
 theorem sle_or_not_min_commute_logical_thm (e e_1 : IntW 8) :
-  select (icmp IntPredicate.ne e_1 (const? 8 (-128))) (const? 1 1) (icmp IntPredicate.sle e_1 e) ⊑ const? 1 1 := by 
+  select (icmp IntPredicate.ne e_1 (const? 8 (-128))) (const? 1 1) (icmp IntPredicate.sle e_1 e) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -509,7 +509,7 @@ theorem sle_or_not_min_commute_logical_thm (e e_1 : IntW 8) :
 
 
 theorem sle_swap_or_not_min_thm (e e_1 : IntW 8) :
-  LLVM.or (icmp IntPredicate.sge e_1 e) (icmp IntPredicate.ne e (const? 8 (-128))) ⊑ const? 1 1 := by 
+  LLVM.or (icmp IntPredicate.sge e_1 e) (icmp IntPredicate.ne e (const? 8 (-128))) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -519,7 +519,7 @@ theorem sle_swap_or_not_min_thm (e e_1 : IntW 8) :
 
 
 theorem sle_swap_or_not_min_logical_thm (e e_1 : IntW 8) :
-  select (icmp IntPredicate.sge e_1 e) (const? 1 1) (icmp IntPredicate.ne e (const? 8 (-128))) ⊑ const? 1 1 := by 
+  select (icmp IntPredicate.sge e_1 e) (const? 1 1) (icmp IntPredicate.ne e (const? 8 (-128))) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -529,7 +529,7 @@ theorem sle_swap_or_not_min_logical_thm (e e_1 : IntW 8) :
 
 
 theorem sle_swap_or_not_min_commute_thm (e e_1 : IntW 8) :
-  LLVM.or (icmp IntPredicate.ne e_1 (const? 8 (-128))) (icmp IntPredicate.sge e e_1) ⊑ const? 1 1 := by 
+  LLVM.or (icmp IntPredicate.ne e_1 (const? 8 (-128))) (icmp IntPredicate.sge e e_1) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -539,7 +539,7 @@ theorem sle_swap_or_not_min_commute_thm (e e_1 : IntW 8) :
 
 
 theorem sle_swap_or_not_min_commute_logical_thm (e e_1 : IntW 8) :
-  select (icmp IntPredicate.ne e_1 (const? 8 (-128))) (const? 1 1) (icmp IntPredicate.sge e e_1) ⊑ const? 1 1 := by 
+  select (icmp IntPredicate.ne e_1 (const? 8 (-128))) (const? 1 1) (icmp IntPredicate.sge e e_1) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -549,7 +549,7 @@ theorem sle_swap_or_not_min_commute_logical_thm (e e_1 : IntW 8) :
 
 
 theorem ule_or_not_min_thm (e e_1 : IntW 427) :
-  LLVM.or (icmp IntPredicate.ule e_1 e) (icmp IntPredicate.ne e_1 (const? 427 0)) ⊑ const? 1 1 := by 
+  LLVM.or (icmp IntPredicate.ule e_1 e) (icmp IntPredicate.ne e_1 (const? 427 0)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -559,7 +559,7 @@ theorem ule_or_not_min_thm (e e_1 : IntW 427) :
 
 
 theorem ule_or_not_min_logical_thm (e e_1 : IntW 427) :
-  select (icmp IntPredicate.ule e_1 e) (const? 1 1) (icmp IntPredicate.ne e_1 (const? 427 0)) ⊑ const? 1 1 := by 
+  select (icmp IntPredicate.ule e_1 e) (const? 1 1) (icmp IntPredicate.ne e_1 (const? 427 0)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -569,7 +569,7 @@ theorem ule_or_not_min_logical_thm (e e_1 : IntW 427) :
 
 
 theorem ule_or_not_min_commute_thm (e e_1 : IntW 8) :
-  LLVM.or (icmp IntPredicate.ne e_1 (const? 8 0)) (icmp IntPredicate.ule e_1 e) ⊑ const? 1 1 := by 
+  LLVM.or (icmp IntPredicate.ne e_1 (const? 8 0)) (icmp IntPredicate.ule e_1 e) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -579,7 +579,7 @@ theorem ule_or_not_min_commute_thm (e e_1 : IntW 8) :
 
 
 theorem ule_or_not_min_commute_logical_thm (e e_1 : IntW 8) :
-  select (icmp IntPredicate.ne e_1 (const? 8 0)) (const? 1 1) (icmp IntPredicate.ule e_1 e) ⊑ const? 1 1 := by 
+  select (icmp IntPredicate.ne e_1 (const? 8 0)) (const? 1 1) (icmp IntPredicate.ule e_1 e) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -589,7 +589,7 @@ theorem ule_or_not_min_commute_logical_thm (e e_1 : IntW 8) :
 
 
 theorem ule_swap_or_not_min_thm (e e_1 : IntW 8) :
-  LLVM.or (icmp IntPredicate.uge e_1 e) (icmp IntPredicate.ne e (const? 8 0)) ⊑ const? 1 1 := by 
+  LLVM.or (icmp IntPredicate.uge e_1 e) (icmp IntPredicate.ne e (const? 8 0)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -599,7 +599,7 @@ theorem ule_swap_or_not_min_thm (e e_1 : IntW 8) :
 
 
 theorem ule_swap_or_not_min_logical_thm (e e_1 : IntW 8) :
-  select (icmp IntPredicate.uge e_1 e) (const? 1 1) (icmp IntPredicate.ne e (const? 8 0)) ⊑ const? 1 1 := by 
+  select (icmp IntPredicate.uge e_1 e) (const? 1 1) (icmp IntPredicate.ne e (const? 8 0)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -609,7 +609,7 @@ theorem ule_swap_or_not_min_logical_thm (e e_1 : IntW 8) :
 
 
 theorem ule_swap_or_not_min_commute_thm (e e_1 : IntW 8) :
-  LLVM.or (icmp IntPredicate.ne e_1 (const? 8 0)) (icmp IntPredicate.uge e e_1) ⊑ const? 1 1 := by 
+  LLVM.or (icmp IntPredicate.ne e_1 (const? 8 0)) (icmp IntPredicate.uge e e_1) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -619,7 +619,7 @@ theorem ule_swap_or_not_min_commute_thm (e e_1 : IntW 8) :
 
 
 theorem ule_swap_or_not_min_commute_logical_thm (e e_1 : IntW 8) :
-  select (icmp IntPredicate.ne e_1 (const? 8 0)) (const? 1 1) (icmp IntPredicate.uge e e_1) ⊑ const? 1 1 := by 
+  select (icmp IntPredicate.ne e_1 (const? 8 0)) (const? 1 1) (icmp IntPredicate.uge e e_1) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -630,7 +630,7 @@ theorem ule_swap_or_not_min_commute_logical_thm (e e_1 : IntW 8) :
 
 theorem sge_and_max_thm (e e_1 : IntW 8) :
   LLVM.and (icmp IntPredicate.sge e_1 e) (icmp IntPredicate.eq e_1 (const? 8 127)) ⊑
-    icmp IntPredicate.eq e_1 (const? 8 127) := by 
+    icmp IntPredicate.eq e_1 (const? 8 127) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -641,7 +641,7 @@ theorem sge_and_max_thm (e e_1 : IntW 8) :
 
 theorem sge_and_max_logical_thm (e e_1 : IntW 8) :
   select (icmp IntPredicate.sge e_1 e) (icmp IntPredicate.eq e_1 (const? 8 127)) (const? 1 0) ⊑
-    icmp IntPredicate.eq e_1 (const? 8 127) := by 
+    icmp IntPredicate.eq e_1 (const? 8 127) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -652,7 +652,7 @@ theorem sge_and_max_logical_thm (e e_1 : IntW 8) :
 
 theorem sge_and_max_logical_samesign_thm (e e_1 : IntW 8) :
   select (icmp IntPredicate.sge e_1 e) (icmp IntPredicate.eq e_1 (const? 8 127)) (const? 1 0) ⊑
-    icmp IntPredicate.eq e_1 (const? 8 127) := by 
+    icmp IntPredicate.eq e_1 (const? 8 127) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -663,7 +663,7 @@ theorem sge_and_max_logical_samesign_thm (e e_1 : IntW 8) :
 
 theorem sge_and_max_commute_thm (e e_1 : IntW 8) :
   LLVM.and (icmp IntPredicate.eq e_1 (const? 8 127)) (icmp IntPredicate.sge e_1 e) ⊑
-    icmp IntPredicate.eq e_1 (const? 8 127) := by 
+    icmp IntPredicate.eq e_1 (const? 8 127) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -674,7 +674,7 @@ theorem sge_and_max_commute_thm (e e_1 : IntW 8) :
 
 theorem sge_and_max_commute_logical_thm (e e_1 : IntW 8) :
   select (icmp IntPredicate.eq e_1 (const? 8 127)) (icmp IntPredicate.sge e_1 e) (const? 1 0) ⊑
-    icmp IntPredicate.eq e_1 (const? 8 127) := by 
+    icmp IntPredicate.eq e_1 (const? 8 127) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -685,7 +685,7 @@ theorem sge_and_max_commute_logical_thm (e e_1 : IntW 8) :
 
 theorem sge_swap_and_max_thm (e e_1 : IntW 8) :
   LLVM.and (icmp IntPredicate.sle e_1 e) (icmp IntPredicate.eq e (const? 8 127)) ⊑
-    icmp IntPredicate.eq e (const? 8 127) := by 
+    icmp IntPredicate.eq e (const? 8 127) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -696,7 +696,7 @@ theorem sge_swap_and_max_thm (e e_1 : IntW 8) :
 
 theorem sge_swap_and_max_logical_thm (e e_1 : IntW 8) :
   select (icmp IntPredicate.sle e_1 e) (icmp IntPredicate.eq e (const? 8 127)) (const? 1 0) ⊑
-    icmp IntPredicate.eq e (const? 8 127) := by 
+    icmp IntPredicate.eq e (const? 8 127) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -707,7 +707,7 @@ theorem sge_swap_and_max_logical_thm (e e_1 : IntW 8) :
 
 theorem sge_swap_and_max_commute_thm (e e_1 : IntW 8) :
   LLVM.and (icmp IntPredicate.eq e_1 (const? 8 127)) (icmp IntPredicate.sle e e_1) ⊑
-    icmp IntPredicate.eq e_1 (const? 8 127) := by 
+    icmp IntPredicate.eq e_1 (const? 8 127) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -718,7 +718,7 @@ theorem sge_swap_and_max_commute_thm (e e_1 : IntW 8) :
 
 theorem sge_swap_and_max_commute_logical_thm (e e_1 : IntW 8) :
   select (icmp IntPredicate.eq e_1 (const? 8 127)) (icmp IntPredicate.sle e e_1) (const? 1 0) ⊑
-    icmp IntPredicate.eq e_1 (const? 8 127) := by 
+    icmp IntPredicate.eq e_1 (const? 8 127) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -729,7 +729,7 @@ theorem sge_swap_and_max_commute_logical_thm (e e_1 : IntW 8) :
 
 theorem uge_and_max_thm (e e_1 : IntW 8) :
   LLVM.and (icmp IntPredicate.uge e_1 e) (icmp IntPredicate.eq e_1 (const? 8 (-1))) ⊑
-    icmp IntPredicate.eq e_1 (const? 8 (-1)) := by 
+    icmp IntPredicate.eq e_1 (const? 8 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -740,7 +740,7 @@ theorem uge_and_max_thm (e e_1 : IntW 8) :
 
 theorem uge_and_max_logical_thm (e e_1 : IntW 8) :
   select (icmp IntPredicate.uge e_1 e) (icmp IntPredicate.eq e_1 (const? 8 (-1))) (const? 1 0) ⊑
-    icmp IntPredicate.eq e_1 (const? 8 (-1)) := by 
+    icmp IntPredicate.eq e_1 (const? 8 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -751,7 +751,7 @@ theorem uge_and_max_logical_thm (e e_1 : IntW 8) :
 
 theorem uge_and_max_commute_thm (e e_1 : IntW 8) :
   LLVM.and (icmp IntPredicate.eq e_1 (const? 8 (-1))) (icmp IntPredicate.uge e_1 e) ⊑
-    icmp IntPredicate.eq e_1 (const? 8 (-1)) := by 
+    icmp IntPredicate.eq e_1 (const? 8 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -762,7 +762,7 @@ theorem uge_and_max_commute_thm (e e_1 : IntW 8) :
 
 theorem uge_and_max_commute_logical_thm (e e_1 : IntW 8) :
   select (icmp IntPredicate.eq e_1 (const? 8 (-1))) (icmp IntPredicate.uge e_1 e) (const? 1 0) ⊑
-    icmp IntPredicate.eq e_1 (const? 8 (-1)) := by 
+    icmp IntPredicate.eq e_1 (const? 8 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -773,7 +773,7 @@ theorem uge_and_max_commute_logical_thm (e e_1 : IntW 8) :
 
 theorem uge_swap_and_max_thm (e e_1 : IntW 8) :
   LLVM.and (icmp IntPredicate.ule e_1 e) (icmp IntPredicate.eq e (const? 8 (-1))) ⊑
-    icmp IntPredicate.eq e (const? 8 (-1)) := by 
+    icmp IntPredicate.eq e (const? 8 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -784,7 +784,7 @@ theorem uge_swap_and_max_thm (e e_1 : IntW 8) :
 
 theorem uge_swap_and_max_logical_thm (e e_1 : IntW 8) :
   select (icmp IntPredicate.ule e_1 e) (icmp IntPredicate.eq e (const? 8 (-1))) (const? 1 0) ⊑
-    icmp IntPredicate.eq e (const? 8 (-1)) := by 
+    icmp IntPredicate.eq e (const? 8 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -795,7 +795,7 @@ theorem uge_swap_and_max_logical_thm (e e_1 : IntW 8) :
 
 theorem uge_swap_and_max_commute_thm (e e_1 : IntW 8) :
   LLVM.and (icmp IntPredicate.eq e_1 (const? 8 (-1))) (icmp IntPredicate.ule e e_1) ⊑
-    icmp IntPredicate.eq e_1 (const? 8 (-1)) := by 
+    icmp IntPredicate.eq e_1 (const? 8 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -806,7 +806,7 @@ theorem uge_swap_and_max_commute_thm (e e_1 : IntW 8) :
 
 theorem uge_swap_and_max_commute_logical_thm (e e_1 : IntW 8) :
   select (icmp IntPredicate.eq e_1 (const? 8 (-1))) (icmp IntPredicate.ule e e_1) (const? 1 0) ⊑
-    icmp IntPredicate.eq e_1 (const? 8 (-1)) := by 
+    icmp IntPredicate.eq e_1 (const? 8 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -817,7 +817,7 @@ theorem uge_swap_and_max_commute_logical_thm (e e_1 : IntW 8) :
 
 theorem sle_and_min_thm (e e_1 : IntW 8) :
   LLVM.and (icmp IntPredicate.sle e_1 e) (icmp IntPredicate.eq e_1 (const? 8 (-128))) ⊑
-    icmp IntPredicate.eq e_1 (const? 8 (-128)) := by 
+    icmp IntPredicate.eq e_1 (const? 8 (-128)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -828,7 +828,7 @@ theorem sle_and_min_thm (e e_1 : IntW 8) :
 
 theorem sle_and_min_logical_thm (e e_1 : IntW 8) :
   select (icmp IntPredicate.sle e_1 e) (icmp IntPredicate.eq e_1 (const? 8 (-128))) (const? 1 0) ⊑
-    icmp IntPredicate.eq e_1 (const? 8 (-128)) := by 
+    icmp IntPredicate.eq e_1 (const? 8 (-128)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -839,7 +839,7 @@ theorem sle_and_min_logical_thm (e e_1 : IntW 8) :
 
 theorem sle_and_min_commute_thm (e e_1 : IntW 8) :
   LLVM.and (icmp IntPredicate.eq e_1 (const? 8 (-128))) (icmp IntPredicate.sle e_1 e) ⊑
-    icmp IntPredicate.eq e_1 (const? 8 (-128)) := by 
+    icmp IntPredicate.eq e_1 (const? 8 (-128)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -850,7 +850,7 @@ theorem sle_and_min_commute_thm (e e_1 : IntW 8) :
 
 theorem sle_and_min_commute_logical_thm (e e_1 : IntW 8) :
   select (icmp IntPredicate.eq e_1 (const? 8 (-128))) (icmp IntPredicate.sle e_1 e) (const? 1 0) ⊑
-    icmp IntPredicate.eq e_1 (const? 8 (-128)) := by 
+    icmp IntPredicate.eq e_1 (const? 8 (-128)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -861,7 +861,7 @@ theorem sle_and_min_commute_logical_thm (e e_1 : IntW 8) :
 
 theorem sle_swap_and_min_thm (e e_1 : IntW 8) :
   LLVM.and (icmp IntPredicate.sge e_1 e) (icmp IntPredicate.eq e (const? 8 (-128))) ⊑
-    icmp IntPredicate.eq e (const? 8 (-128)) := by 
+    icmp IntPredicate.eq e (const? 8 (-128)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -872,7 +872,7 @@ theorem sle_swap_and_min_thm (e e_1 : IntW 8) :
 
 theorem sle_swap_and_min_logical_thm (e e_1 : IntW 8) :
   select (icmp IntPredicate.sge e_1 e) (icmp IntPredicate.eq e (const? 8 (-128))) (const? 1 0) ⊑
-    icmp IntPredicate.eq e (const? 8 (-128)) := by 
+    icmp IntPredicate.eq e (const? 8 (-128)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -883,7 +883,7 @@ theorem sle_swap_and_min_logical_thm (e e_1 : IntW 8) :
 
 theorem sle_swap_and_min_commute_thm (e e_1 : IntW 8) :
   LLVM.and (icmp IntPredicate.eq e_1 (const? 8 (-128))) (icmp IntPredicate.sge e e_1) ⊑
-    icmp IntPredicate.eq e_1 (const? 8 (-128)) := by 
+    icmp IntPredicate.eq e_1 (const? 8 (-128)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -894,7 +894,7 @@ theorem sle_swap_and_min_commute_thm (e e_1 : IntW 8) :
 
 theorem sle_swap_and_min_commute_logical_thm (e e_1 : IntW 8) :
   select (icmp IntPredicate.eq e_1 (const? 8 (-128))) (icmp IntPredicate.sge e e_1) (const? 1 0) ⊑
-    icmp IntPredicate.eq e_1 (const? 8 (-128)) := by 
+    icmp IntPredicate.eq e_1 (const? 8 (-128)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -905,7 +905,7 @@ theorem sle_swap_and_min_commute_logical_thm (e e_1 : IntW 8) :
 
 theorem ule_and_min_thm (e e_1 : IntW 8) :
   LLVM.and (icmp IntPredicate.ule e_1 e) (icmp IntPredicate.eq e_1 (const? 8 0)) ⊑
-    icmp IntPredicate.eq e_1 (const? 8 0) := by 
+    icmp IntPredicate.eq e_1 (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -916,7 +916,7 @@ theorem ule_and_min_thm (e e_1 : IntW 8) :
 
 theorem ule_and_min_logical_thm (e e_1 : IntW 8) :
   select (icmp IntPredicate.ule e_1 e) (icmp IntPredicate.eq e_1 (const? 8 0)) (const? 1 0) ⊑
-    icmp IntPredicate.eq e_1 (const? 8 0) := by 
+    icmp IntPredicate.eq e_1 (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -927,7 +927,7 @@ theorem ule_and_min_logical_thm (e e_1 : IntW 8) :
 
 theorem ule_and_min_commute_thm (e e_1 : IntW 8) :
   LLVM.and (icmp IntPredicate.eq e_1 (const? 8 0)) (icmp IntPredicate.ule e_1 e) ⊑
-    icmp IntPredicate.eq e_1 (const? 8 0) := by 
+    icmp IntPredicate.eq e_1 (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -938,7 +938,7 @@ theorem ule_and_min_commute_thm (e e_1 : IntW 8) :
 
 theorem ule_and_min_commute_logical_thm (e e_1 : IntW 8) :
   select (icmp IntPredicate.eq e_1 (const? 8 0)) (icmp IntPredicate.ule e_1 e) (const? 1 0) ⊑
-    icmp IntPredicate.eq e_1 (const? 8 0) := by 
+    icmp IntPredicate.eq e_1 (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -949,7 +949,7 @@ theorem ule_and_min_commute_logical_thm (e e_1 : IntW 8) :
 
 theorem ule_swap_and_min_thm (e e_1 : IntW 8) :
   LLVM.and (icmp IntPredicate.uge e_1 e) (icmp IntPredicate.eq e (const? 8 0)) ⊑
-    icmp IntPredicate.eq e (const? 8 0) := by 
+    icmp IntPredicate.eq e (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -960,7 +960,7 @@ theorem ule_swap_and_min_thm (e e_1 : IntW 8) :
 
 theorem ule_swap_and_min_logical_thm (e e_1 : IntW 8) :
   select (icmp IntPredicate.uge e_1 e) (icmp IntPredicate.eq e (const? 8 0)) (const? 1 0) ⊑
-    icmp IntPredicate.eq e (const? 8 0) := by 
+    icmp IntPredicate.eq e (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -971,7 +971,7 @@ theorem ule_swap_and_min_logical_thm (e e_1 : IntW 8) :
 
 theorem ule_swap_and_min_commute_thm (e e_1 : IntW 8) :
   LLVM.and (icmp IntPredicate.eq e_1 (const? 8 0)) (icmp IntPredicate.uge e e_1) ⊑
-    icmp IntPredicate.eq e_1 (const? 8 0) := by 
+    icmp IntPredicate.eq e_1 (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -982,7 +982,7 @@ theorem ule_swap_and_min_commute_thm (e e_1 : IntW 8) :
 
 theorem ule_swap_and_min_commute_logical_thm (e e_1 : IntW 8) :
   select (icmp IntPredicate.eq e_1 (const? 8 0)) (icmp IntPredicate.uge e e_1) (const? 1 0) ⊑
-    icmp IntPredicate.eq e_1 (const? 8 0) := by 
+    icmp IntPredicate.eq e_1 (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -992,7 +992,7 @@ theorem ule_swap_and_min_commute_logical_thm (e e_1 : IntW 8) :
 
 
 theorem sge_or_max_thm (e e_1 : IntW 8) :
-  LLVM.or (icmp IntPredicate.sge e_1 e) (icmp IntPredicate.eq e_1 (const? 8 127)) ⊑ icmp IntPredicate.sge e_1 e := by 
+  LLVM.or (icmp IntPredicate.sge e_1 e) (icmp IntPredicate.eq e_1 (const? 8 127)) ⊑ icmp IntPredicate.sge e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1003,7 +1003,7 @@ theorem sge_or_max_thm (e e_1 : IntW 8) :
 
 theorem sge_or_max_logical_thm (e e_1 : IntW 8) :
   select (icmp IntPredicate.sge e_1 e) (const? 1 1) (icmp IntPredicate.eq e_1 (const? 8 127)) ⊑
-    icmp IntPredicate.sge e_1 e := by 
+    icmp IntPredicate.sge e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1013,7 +1013,7 @@ theorem sge_or_max_logical_thm (e e_1 : IntW 8) :
 
 
 theorem sge_or_max_commute_thm (e e_1 : IntW 8) :
-  LLVM.or (icmp IntPredicate.eq e_1 (const? 8 127)) (icmp IntPredicate.sge e_1 e) ⊑ icmp IntPredicate.sge e_1 e := by 
+  LLVM.or (icmp IntPredicate.eq e_1 (const? 8 127)) (icmp IntPredicate.sge e_1 e) ⊑ icmp IntPredicate.sge e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1023,7 +1023,7 @@ theorem sge_or_max_commute_thm (e e_1 : IntW 8) :
 
 
 theorem sge_swap_or_max_thm (e e_1 : IntW 8) :
-  LLVM.or (icmp IntPredicate.sle e_1 e) (icmp IntPredicate.eq e (const? 8 127)) ⊑ icmp IntPredicate.sle e_1 e := by 
+  LLVM.or (icmp IntPredicate.sle e_1 e) (icmp IntPredicate.eq e (const? 8 127)) ⊑ icmp IntPredicate.sle e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1034,7 +1034,7 @@ theorem sge_swap_or_max_thm (e e_1 : IntW 8) :
 
 theorem sge_swap_or_max_logical_thm (e e_1 : IntW 8) :
   select (icmp IntPredicate.sle e_1 e) (const? 1 1) (icmp IntPredicate.eq e (const? 8 127)) ⊑
-    icmp IntPredicate.sle e_1 e := by 
+    icmp IntPredicate.sle e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1044,7 +1044,7 @@ theorem sge_swap_or_max_logical_thm (e e_1 : IntW 8) :
 
 
 theorem sge_swap_or_max_commute_thm (e e_1 : IntW 8) :
-  LLVM.or (icmp IntPredicate.eq e_1 (const? 8 127)) (icmp IntPredicate.sle e e_1) ⊑ icmp IntPredicate.sle e e_1 := by 
+  LLVM.or (icmp IntPredicate.eq e_1 (const? 8 127)) (icmp IntPredicate.sle e e_1) ⊑ icmp IntPredicate.sle e e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1055,7 +1055,7 @@ theorem sge_swap_or_max_commute_thm (e e_1 : IntW 8) :
 
 theorem uge_or_max_thm (e e_1 : IntW 8) :
   LLVM.or (icmp IntPredicate.uge e_1 e) (icmp IntPredicate.eq e_1 (const? 8 (-1))) ⊑
-    icmp IntPredicate.uge e_1 e := by 
+    icmp IntPredicate.uge e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1066,7 +1066,7 @@ theorem uge_or_max_thm (e e_1 : IntW 8) :
 
 theorem uge_or_max_logical_thm (e e_1 : IntW 8) :
   select (icmp IntPredicate.uge e_1 e) (const? 1 1) (icmp IntPredicate.eq e_1 (const? 8 (-1))) ⊑
-    icmp IntPredicate.uge e_1 e := by 
+    icmp IntPredicate.uge e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1077,7 +1077,7 @@ theorem uge_or_max_logical_thm (e e_1 : IntW 8) :
 
 theorem uge_or_max_commute_thm (e e_1 : IntW 8) :
   LLVM.or (icmp IntPredicate.eq e_1 (const? 8 (-1))) (icmp IntPredicate.uge e_1 e) ⊑
-    icmp IntPredicate.uge e_1 e := by 
+    icmp IntPredicate.uge e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1087,7 +1087,7 @@ theorem uge_or_max_commute_thm (e e_1 : IntW 8) :
 
 
 theorem uge_swap_or_max_thm (e e_1 : IntW 8) :
-  LLVM.or (icmp IntPredicate.ule e_1 e) (icmp IntPredicate.eq e (const? 8 (-1))) ⊑ icmp IntPredicate.ule e_1 e := by 
+  LLVM.or (icmp IntPredicate.ule e_1 e) (icmp IntPredicate.eq e (const? 8 (-1))) ⊑ icmp IntPredicate.ule e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1098,7 +1098,7 @@ theorem uge_swap_or_max_thm (e e_1 : IntW 8) :
 
 theorem uge_swap_or_max_logical_thm (e e_1 : IntW 8) :
   select (icmp IntPredicate.ule e_1 e) (const? 1 1) (icmp IntPredicate.eq e (const? 8 (-1))) ⊑
-    icmp IntPredicate.ule e_1 e := by 
+    icmp IntPredicate.ule e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1109,7 +1109,7 @@ theorem uge_swap_or_max_logical_thm (e e_1 : IntW 8) :
 
 theorem uge_swap_or_max_commute_thm (e e_1 : IntW 8) :
   LLVM.or (icmp IntPredicate.eq e_1 (const? 8 (-1))) (icmp IntPredicate.ule e e_1) ⊑
-    icmp IntPredicate.ule e e_1 := by 
+    icmp IntPredicate.ule e e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1120,7 +1120,7 @@ theorem uge_swap_or_max_commute_thm (e e_1 : IntW 8) :
 
 theorem sle_or_min_thm (e e_1 : IntW 8) :
   LLVM.or (icmp IntPredicate.sle e_1 e) (icmp IntPredicate.eq e_1 (const? 8 (-128))) ⊑
-    icmp IntPredicate.sle e_1 e := by 
+    icmp IntPredicate.sle e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1131,7 +1131,7 @@ theorem sle_or_min_thm (e e_1 : IntW 8) :
 
 theorem sle_or_min_logical_thm (e e_1 : IntW 8) :
   select (icmp IntPredicate.sle e_1 e) (const? 1 1) (icmp IntPredicate.eq e_1 (const? 8 (-128))) ⊑
-    icmp IntPredicate.sle e_1 e := by 
+    icmp IntPredicate.sle e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1142,7 +1142,7 @@ theorem sle_or_min_logical_thm (e e_1 : IntW 8) :
 
 theorem sle_or_min_commute_thm (e e_1 : IntW 8) :
   LLVM.or (icmp IntPredicate.eq e_1 (const? 8 (-128))) (icmp IntPredicate.sle e_1 e) ⊑
-    icmp IntPredicate.sle e_1 e := by 
+    icmp IntPredicate.sle e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1153,7 +1153,7 @@ theorem sle_or_min_commute_thm (e e_1 : IntW 8) :
 
 theorem sle_swap_or_min_thm (e e_1 : IntW 8) :
   LLVM.or (icmp IntPredicate.sge e_1 e) (icmp IntPredicate.eq e (const? 8 (-128))) ⊑
-    icmp IntPredicate.sge e_1 e := by 
+    icmp IntPredicate.sge e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1164,7 +1164,7 @@ theorem sle_swap_or_min_thm (e e_1 : IntW 8) :
 
 theorem sle_swap_or_min_logical_thm (e e_1 : IntW 8) :
   select (icmp IntPredicate.sge e_1 e) (const? 1 1) (icmp IntPredicate.eq e (const? 8 (-128))) ⊑
-    icmp IntPredicate.sge e_1 e := by 
+    icmp IntPredicate.sge e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1175,7 +1175,7 @@ theorem sle_swap_or_min_logical_thm (e e_1 : IntW 8) :
 
 theorem sle_swap_or_min_commute_thm (e e_1 : IntW 8) :
   LLVM.or (icmp IntPredicate.eq e_1 (const? 8 (-128))) (icmp IntPredicate.sge e e_1) ⊑
-    icmp IntPredicate.sge e e_1 := by 
+    icmp IntPredicate.sge e e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1185,7 +1185,7 @@ theorem sle_swap_or_min_commute_thm (e e_1 : IntW 8) :
 
 
 theorem ule_or_min_thm (e e_1 : IntW 8) :
-  LLVM.or (icmp IntPredicate.ule e_1 e) (icmp IntPredicate.eq e_1 (const? 8 0)) ⊑ icmp IntPredicate.ule e_1 e := by 
+  LLVM.or (icmp IntPredicate.ule e_1 e) (icmp IntPredicate.eq e_1 (const? 8 0)) ⊑ icmp IntPredicate.ule e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1196,7 +1196,7 @@ theorem ule_or_min_thm (e e_1 : IntW 8) :
 
 theorem ule_or_min_logical_thm (e e_1 : IntW 8) :
   select (icmp IntPredicate.ule e_1 e) (const? 1 1) (icmp IntPredicate.eq e_1 (const? 8 0)) ⊑
-    icmp IntPredicate.ule e_1 e := by 
+    icmp IntPredicate.ule e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1206,7 +1206,7 @@ theorem ule_or_min_logical_thm (e e_1 : IntW 8) :
 
 
 theorem ule_or_min_commute_thm (e e_1 : IntW 8) :
-  LLVM.or (icmp IntPredicate.eq e_1 (const? 8 0)) (icmp IntPredicate.ule e_1 e) ⊑ icmp IntPredicate.ule e_1 e := by 
+  LLVM.or (icmp IntPredicate.eq e_1 (const? 8 0)) (icmp IntPredicate.ule e_1 e) ⊑ icmp IntPredicate.ule e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1216,7 +1216,7 @@ theorem ule_or_min_commute_thm (e e_1 : IntW 8) :
 
 
 theorem ule_swap_or_min_thm (e e_1 : IntW 8) :
-  LLVM.or (icmp IntPredicate.uge e_1 e) (icmp IntPredicate.eq e (const? 8 0)) ⊑ icmp IntPredicate.uge e_1 e := by 
+  LLVM.or (icmp IntPredicate.uge e_1 e) (icmp IntPredicate.eq e (const? 8 0)) ⊑ icmp IntPredicate.uge e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1227,7 +1227,7 @@ theorem ule_swap_or_min_thm (e e_1 : IntW 8) :
 
 theorem ule_swap_or_min_logical_thm (e e_1 : IntW 8) :
   select (icmp IntPredicate.uge e_1 e) (const? 1 1) (icmp IntPredicate.eq e (const? 8 0)) ⊑
-    icmp IntPredicate.uge e_1 e := by 
+    icmp IntPredicate.uge e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1237,7 +1237,7 @@ theorem ule_swap_or_min_logical_thm (e e_1 : IntW 8) :
 
 
 theorem ule_swap_or_min_commute_thm (e e_1 : IntW 8) :
-  LLVM.or (icmp IntPredicate.eq e_1 (const? 8 0)) (icmp IntPredicate.uge e e_1) ⊑ icmp IntPredicate.uge e e_1 := by 
+  LLVM.or (icmp IntPredicate.eq e_1 (const? 8 0)) (icmp IntPredicate.uge e e_1) ⊑ icmp IntPredicate.uge e e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1248,7 +1248,7 @@ theorem ule_swap_or_min_commute_thm (e e_1 : IntW 8) :
 
 theorem slt_and_not_max_thm (e e_1 : IntW 8) :
   LLVM.and (icmp IntPredicate.slt e_1 e) (icmp IntPredicate.ne e_1 (const? 8 127)) ⊑
-    icmp IntPredicate.slt e_1 e := by 
+    icmp IntPredicate.slt e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1259,7 +1259,7 @@ theorem slt_and_not_max_thm (e e_1 : IntW 8) :
 
 theorem slt_and_not_max_logical_thm (e e_1 : IntW 8) :
   select (icmp IntPredicate.slt e_1 e) (icmp IntPredicate.ne e_1 (const? 8 127)) (const? 1 0) ⊑
-    icmp IntPredicate.slt e_1 e := by 
+    icmp IntPredicate.slt e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1270,7 +1270,7 @@ theorem slt_and_not_max_logical_thm (e e_1 : IntW 8) :
 
 theorem slt_and_not_max_commute_thm (e e_1 : IntW 8) :
   LLVM.and (icmp IntPredicate.ne e_1 (const? 8 127)) (icmp IntPredicate.slt e_1 e) ⊑
-    icmp IntPredicate.slt e_1 e := by 
+    icmp IntPredicate.slt e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1280,7 +1280,7 @@ theorem slt_and_not_max_commute_thm (e e_1 : IntW 8) :
 
 
 theorem slt_swap_and_not_max_thm (e e_1 : IntW 8) :
-  LLVM.and (icmp IntPredicate.sgt e_1 e) (icmp IntPredicate.ne e (const? 8 127)) ⊑ icmp IntPredicate.sgt e_1 e := by 
+  LLVM.and (icmp IntPredicate.sgt e_1 e) (icmp IntPredicate.ne e (const? 8 127)) ⊑ icmp IntPredicate.sgt e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1291,7 +1291,7 @@ theorem slt_swap_and_not_max_thm (e e_1 : IntW 8) :
 
 theorem slt_swap_and_not_max_logical_thm (e e_1 : IntW 8) :
   select (icmp IntPredicate.sgt e_1 e) (icmp IntPredicate.ne e (const? 8 127)) (const? 1 0) ⊑
-    icmp IntPredicate.sgt e_1 e := by 
+    icmp IntPredicate.sgt e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1302,7 +1302,7 @@ theorem slt_swap_and_not_max_logical_thm (e e_1 : IntW 8) :
 
 theorem slt_swap_and_not_max_commute_thm (e e_1 : IntW 8) :
   LLVM.and (icmp IntPredicate.ne e_1 (const? 8 127)) (icmp IntPredicate.sgt e e_1) ⊑
-    icmp IntPredicate.sgt e e_1 := by 
+    icmp IntPredicate.sgt e e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1313,7 +1313,7 @@ theorem slt_swap_and_not_max_commute_thm (e e_1 : IntW 8) :
 
 theorem ult_and_not_max_thm (e e_1 : IntW 8) :
   LLVM.and (icmp IntPredicate.ult e_1 e) (icmp IntPredicate.ne e_1 (const? 8 (-1))) ⊑
-    icmp IntPredicate.ult e_1 e := by 
+    icmp IntPredicate.ult e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1324,7 +1324,7 @@ theorem ult_and_not_max_thm (e e_1 : IntW 8) :
 
 theorem ult_and_not_max_logical_thm (e e_1 : IntW 8) :
   select (icmp IntPredicate.ult e_1 e) (icmp IntPredicate.ne e_1 (const? 8 (-1))) (const? 1 0) ⊑
-    icmp IntPredicate.ult e_1 e := by 
+    icmp IntPredicate.ult e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1335,7 +1335,7 @@ theorem ult_and_not_max_logical_thm (e e_1 : IntW 8) :
 
 theorem ult_and_not_max_commute_thm (e e_1 : IntW 8) :
   LLVM.and (icmp IntPredicate.ne e_1 (const? 8 (-1))) (icmp IntPredicate.ult e_1 e) ⊑
-    icmp IntPredicate.ult e_1 e := by 
+    icmp IntPredicate.ult e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1345,7 +1345,7 @@ theorem ult_and_not_max_commute_thm (e e_1 : IntW 8) :
 
 
 theorem ult_swap_and_not_max_thm (e e_1 : IntW 8) :
-  LLVM.and (icmp IntPredicate.ugt e_1 e) (icmp IntPredicate.ne e (const? 8 (-1))) ⊑ icmp IntPredicate.ugt e_1 e := by 
+  LLVM.and (icmp IntPredicate.ugt e_1 e) (icmp IntPredicate.ne e (const? 8 (-1))) ⊑ icmp IntPredicate.ugt e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1356,7 +1356,7 @@ theorem ult_swap_and_not_max_thm (e e_1 : IntW 8) :
 
 theorem ult_swap_and_not_max_logical_thm (e e_1 : IntW 8) :
   select (icmp IntPredicate.ugt e_1 e) (icmp IntPredicate.ne e (const? 8 (-1))) (const? 1 0) ⊑
-    icmp IntPredicate.ugt e_1 e := by 
+    icmp IntPredicate.ugt e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1367,7 +1367,7 @@ theorem ult_swap_and_not_max_logical_thm (e e_1 : IntW 8) :
 
 theorem ult_swap_and_not_max_commute_thm (e e_1 : IntW 8) :
   LLVM.and (icmp IntPredicate.ne e_1 (const? 8 (-1))) (icmp IntPredicate.ugt e e_1) ⊑
-    icmp IntPredicate.ugt e e_1 := by 
+    icmp IntPredicate.ugt e e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1378,7 +1378,7 @@ theorem ult_swap_and_not_max_commute_thm (e e_1 : IntW 8) :
 
 theorem sgt_and_not_min_thm (e e_1 : IntW 8) :
   LLVM.and (icmp IntPredicate.sgt e_1 e) (icmp IntPredicate.ne e_1 (const? 8 (-128))) ⊑
-    icmp IntPredicate.sgt e_1 e := by 
+    icmp IntPredicate.sgt e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1389,7 +1389,7 @@ theorem sgt_and_not_min_thm (e e_1 : IntW 8) :
 
 theorem sgt_and_not_min_logical_thm (e e_1 : IntW 8) :
   select (icmp IntPredicate.sgt e_1 e) (icmp IntPredicate.ne e_1 (const? 8 (-128))) (const? 1 0) ⊑
-    icmp IntPredicate.sgt e_1 e := by 
+    icmp IntPredicate.sgt e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1400,7 +1400,7 @@ theorem sgt_and_not_min_logical_thm (e e_1 : IntW 8) :
 
 theorem sgt_and_not_min_commute_thm (e e_1 : IntW 8) :
   LLVM.and (icmp IntPredicate.ne e_1 (const? 8 (-128))) (icmp IntPredicate.sgt e_1 e) ⊑
-    icmp IntPredicate.sgt e_1 e := by 
+    icmp IntPredicate.sgt e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1411,7 +1411,7 @@ theorem sgt_and_not_min_commute_thm (e e_1 : IntW 8) :
 
 theorem sgt_swap_and_not_min_thm (e e_1 : IntW 8) :
   LLVM.and (icmp IntPredicate.slt e_1 e) (icmp IntPredicate.ne e (const? 8 (-128))) ⊑
-    icmp IntPredicate.slt e_1 e := by 
+    icmp IntPredicate.slt e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1422,7 +1422,7 @@ theorem sgt_swap_and_not_min_thm (e e_1 : IntW 8) :
 
 theorem sgt_swap_and_not_min_logical_thm (e e_1 : IntW 8) :
   select (icmp IntPredicate.slt e_1 e) (icmp IntPredicate.ne e (const? 8 (-128))) (const? 1 0) ⊑
-    icmp IntPredicate.slt e_1 e := by 
+    icmp IntPredicate.slt e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1433,7 +1433,7 @@ theorem sgt_swap_and_not_min_logical_thm (e e_1 : IntW 8) :
 
 theorem sgt_swap_and_not_min_commute_thm (e e_1 : IntW 8) :
   LLVM.and (icmp IntPredicate.ne e_1 (const? 8 (-128))) (icmp IntPredicate.slt e e_1) ⊑
-    icmp IntPredicate.slt e e_1 := by 
+    icmp IntPredicate.slt e e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1443,7 +1443,7 @@ theorem sgt_swap_and_not_min_commute_thm (e e_1 : IntW 8) :
 
 
 theorem ugt_and_not_min_thm (e e_1 : IntW 8) :
-  LLVM.and (icmp IntPredicate.ugt e_1 e) (icmp IntPredicate.ne e_1 (const? 8 0)) ⊑ icmp IntPredicate.ugt e_1 e := by 
+  LLVM.and (icmp IntPredicate.ugt e_1 e) (icmp IntPredicate.ne e_1 (const? 8 0)) ⊑ icmp IntPredicate.ugt e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1454,7 +1454,7 @@ theorem ugt_and_not_min_thm (e e_1 : IntW 8) :
 
 theorem ugt_and_not_min_logical_thm (e e_1 : IntW 8) :
   select (icmp IntPredicate.ugt e_1 e) (icmp IntPredicate.ne e_1 (const? 8 0)) (const? 1 0) ⊑
-    icmp IntPredicate.ugt e_1 e := by 
+    icmp IntPredicate.ugt e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1464,7 +1464,7 @@ theorem ugt_and_not_min_logical_thm (e e_1 : IntW 8) :
 
 
 theorem ugt_and_not_min_commute_thm (e e_1 : IntW 8) :
-  LLVM.and (icmp IntPredicate.ne e_1 (const? 8 0)) (icmp IntPredicate.ugt e_1 e) ⊑ icmp IntPredicate.ugt e_1 e := by 
+  LLVM.and (icmp IntPredicate.ne e_1 (const? 8 0)) (icmp IntPredicate.ugt e_1 e) ⊑ icmp IntPredicate.ugt e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1474,7 +1474,7 @@ theorem ugt_and_not_min_commute_thm (e e_1 : IntW 8) :
 
 
 theorem ugt_swap_and_not_min_thm (e e_1 : IntW 8) :
-  LLVM.and (icmp IntPredicate.ult e_1 e) (icmp IntPredicate.ne e (const? 8 0)) ⊑ icmp IntPredicate.ult e_1 e := by 
+  LLVM.and (icmp IntPredicate.ult e_1 e) (icmp IntPredicate.ne e (const? 8 0)) ⊑ icmp IntPredicate.ult e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1485,7 +1485,7 @@ theorem ugt_swap_and_not_min_thm (e e_1 : IntW 8) :
 
 theorem ugt_swap_and_not_min_logical_thm (e e_1 : IntW 8) :
   select (icmp IntPredicate.ult e_1 e) (icmp IntPredicate.ne e (const? 8 0)) (const? 1 0) ⊑
-    icmp IntPredicate.ult e_1 e := by 
+    icmp IntPredicate.ult e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1495,7 +1495,7 @@ theorem ugt_swap_and_not_min_logical_thm (e e_1 : IntW 8) :
 
 
 theorem ugt_swap_and_not_min_commute_thm (e e_1 : IntW 8) :
-  LLVM.and (icmp IntPredicate.ne e_1 (const? 8 0)) (icmp IntPredicate.ult e e_1) ⊑ icmp IntPredicate.ult e e_1 := by 
+  LLVM.and (icmp IntPredicate.ne e_1 (const? 8 0)) (icmp IntPredicate.ult e e_1) ⊑ icmp IntPredicate.ult e e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1506,7 +1506,7 @@ theorem ugt_swap_and_not_min_commute_thm (e e_1 : IntW 8) :
 
 theorem slt_or_not_max_thm (e e_1 : IntW 8) :
   LLVM.or (icmp IntPredicate.slt e_1 e) (icmp IntPredicate.ne e_1 (const? 8 127)) ⊑
-    icmp IntPredicate.ne e_1 (const? 8 127) := by 
+    icmp IntPredicate.ne e_1 (const? 8 127) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1517,7 +1517,7 @@ theorem slt_or_not_max_thm (e e_1 : IntW 8) :
 
 theorem slt_or_not_max_logical_thm (e e_1 : IntW 8) :
   select (icmp IntPredicate.slt e_1 e) (const? 1 1) (icmp IntPredicate.ne e_1 (const? 8 127)) ⊑
-    icmp IntPredicate.ne e_1 (const? 8 127) := by 
+    icmp IntPredicate.ne e_1 (const? 8 127) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1528,7 +1528,7 @@ theorem slt_or_not_max_logical_thm (e e_1 : IntW 8) :
 
 theorem slt_or_not_max_commute_thm (e e_1 : IntW 8) :
   LLVM.or (icmp IntPredicate.ne e_1 (const? 8 127)) (icmp IntPredicate.slt e_1 e) ⊑
-    icmp IntPredicate.ne e_1 (const? 8 127) := by 
+    icmp IntPredicate.ne e_1 (const? 8 127) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1539,7 +1539,7 @@ theorem slt_or_not_max_commute_thm (e e_1 : IntW 8) :
 
 theorem slt_or_not_max_commute_logical_thm (e e_1 : IntW 8) :
   select (icmp IntPredicate.ne e_1 (const? 8 127)) (const? 1 1) (icmp IntPredicate.slt e_1 e) ⊑
-    icmp IntPredicate.ne e_1 (const? 8 127) := by 
+    icmp IntPredicate.ne e_1 (const? 8 127) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1550,7 +1550,7 @@ theorem slt_or_not_max_commute_logical_thm (e e_1 : IntW 8) :
 
 theorem slt_swap_or_not_max_thm (e e_1 : IntW 8) :
   LLVM.or (icmp IntPredicate.sgt e_1 e) (icmp IntPredicate.ne e (const? 8 127)) ⊑
-    icmp IntPredicate.ne e (const? 8 127) := by 
+    icmp IntPredicate.ne e (const? 8 127) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1561,7 +1561,7 @@ theorem slt_swap_or_not_max_thm (e e_1 : IntW 8) :
 
 theorem slt_swap_or_not_max_logical_thm (e e_1 : IntW 8) :
   select (icmp IntPredicate.sgt e_1 e) (const? 1 1) (icmp IntPredicate.ne e (const? 8 127)) ⊑
-    icmp IntPredicate.ne e (const? 8 127) := by 
+    icmp IntPredicate.ne e (const? 8 127) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1572,7 +1572,7 @@ theorem slt_swap_or_not_max_logical_thm (e e_1 : IntW 8) :
 
 theorem slt_swap_or_not_max_commute_thm (e e_1 : IntW 8) :
   LLVM.or (icmp IntPredicate.ne e_1 (const? 8 127)) (icmp IntPredicate.sgt e e_1) ⊑
-    icmp IntPredicate.ne e_1 (const? 8 127) := by 
+    icmp IntPredicate.ne e_1 (const? 8 127) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1583,7 +1583,7 @@ theorem slt_swap_or_not_max_commute_thm (e e_1 : IntW 8) :
 
 theorem slt_swap_or_not_max_commute_logical_thm (e e_1 : IntW 8) :
   select (icmp IntPredicate.ne e_1 (const? 8 127)) (const? 1 1) (icmp IntPredicate.sgt e e_1) ⊑
-    icmp IntPredicate.ne e_1 (const? 8 127) := by 
+    icmp IntPredicate.ne e_1 (const? 8 127) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1594,7 +1594,7 @@ theorem slt_swap_or_not_max_commute_logical_thm (e e_1 : IntW 8) :
 
 theorem ult_or_not_max_thm (e e_1 : IntW 8) :
   LLVM.or (icmp IntPredicate.ult e_1 e) (icmp IntPredicate.ne e_1 (const? 8 (-1))) ⊑
-    icmp IntPredicate.ne e_1 (const? 8 (-1)) := by 
+    icmp IntPredicate.ne e_1 (const? 8 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1605,7 +1605,7 @@ theorem ult_or_not_max_thm (e e_1 : IntW 8) :
 
 theorem ult_or_not_max_logical_thm (e e_1 : IntW 8) :
   select (icmp IntPredicate.ult e_1 e) (const? 1 1) (icmp IntPredicate.ne e_1 (const? 8 (-1))) ⊑
-    icmp IntPredicate.ne e_1 (const? 8 (-1)) := by 
+    icmp IntPredicate.ne e_1 (const? 8 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1616,7 +1616,7 @@ theorem ult_or_not_max_logical_thm (e e_1 : IntW 8) :
 
 theorem ult_or_not_max_commute_thm (e e_1 : IntW 8) :
   LLVM.or (icmp IntPredicate.ne e_1 (const? 8 (-1))) (icmp IntPredicate.ult e_1 e) ⊑
-    icmp IntPredicate.ne e_1 (const? 8 (-1)) := by 
+    icmp IntPredicate.ne e_1 (const? 8 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1627,7 +1627,7 @@ theorem ult_or_not_max_commute_thm (e e_1 : IntW 8) :
 
 theorem ult_or_not_max_commute_logical_thm (e e_1 : IntW 8) :
   select (icmp IntPredicate.ne e_1 (const? 8 (-1))) (const? 1 1) (icmp IntPredicate.ult e_1 e) ⊑
-    icmp IntPredicate.ne e_1 (const? 8 (-1)) := by 
+    icmp IntPredicate.ne e_1 (const? 8 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1638,7 +1638,7 @@ theorem ult_or_not_max_commute_logical_thm (e e_1 : IntW 8) :
 
 theorem ult_swap_or_not_max_thm (e e_1 : IntW 8) :
   LLVM.or (icmp IntPredicate.ugt e_1 e) (icmp IntPredicate.ne e (const? 8 (-1))) ⊑
-    icmp IntPredicate.ne e (const? 8 (-1)) := by 
+    icmp IntPredicate.ne e (const? 8 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1649,7 +1649,7 @@ theorem ult_swap_or_not_max_thm (e e_1 : IntW 8) :
 
 theorem ult_swap_or_not_max_logical_thm (e e_1 : IntW 8) :
   select (icmp IntPredicate.ugt e_1 e) (const? 1 1) (icmp IntPredicate.ne e (const? 8 (-1))) ⊑
-    icmp IntPredicate.ne e (const? 8 (-1)) := by 
+    icmp IntPredicate.ne e (const? 8 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1660,7 +1660,7 @@ theorem ult_swap_or_not_max_logical_thm (e e_1 : IntW 8) :
 
 theorem ult_swap_or_not_max_commute_thm (e e_1 : IntW 8) :
   LLVM.or (icmp IntPredicate.ne e_1 (const? 8 (-1))) (icmp IntPredicate.ugt e e_1) ⊑
-    icmp IntPredicate.ne e_1 (const? 8 (-1)) := by 
+    icmp IntPredicate.ne e_1 (const? 8 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1671,7 +1671,7 @@ theorem ult_swap_or_not_max_commute_thm (e e_1 : IntW 8) :
 
 theorem ult_swap_or_not_max_commute_logical_thm (e e_1 : IntW 8) :
   select (icmp IntPredicate.ne e_1 (const? 8 (-1))) (const? 1 1) (icmp IntPredicate.ugt e e_1) ⊑
-    icmp IntPredicate.ne e_1 (const? 8 (-1)) := by 
+    icmp IntPredicate.ne e_1 (const? 8 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1682,7 +1682,7 @@ theorem ult_swap_or_not_max_commute_logical_thm (e e_1 : IntW 8) :
 
 theorem sgt_or_not_min_thm (e e_1 : IntW 8) :
   LLVM.or (icmp IntPredicate.sgt e_1 e) (icmp IntPredicate.ne e_1 (const? 8 (-128))) ⊑
-    icmp IntPredicate.ne e_1 (const? 8 (-128)) := by 
+    icmp IntPredicate.ne e_1 (const? 8 (-128)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1693,7 +1693,7 @@ theorem sgt_or_not_min_thm (e e_1 : IntW 8) :
 
 theorem sgt_or_not_min_logical_thm (e e_1 : IntW 8) :
   select (icmp IntPredicate.sgt e_1 e) (const? 1 1) (icmp IntPredicate.ne e_1 (const? 8 (-128))) ⊑
-    icmp IntPredicate.ne e_1 (const? 8 (-128)) := by 
+    icmp IntPredicate.ne e_1 (const? 8 (-128)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1704,7 +1704,7 @@ theorem sgt_or_not_min_logical_thm (e e_1 : IntW 8) :
 
 theorem sgt_or_not_min_commute_thm (e e_1 : IntW 8) :
   LLVM.or (icmp IntPredicate.ne e_1 (const? 8 (-128))) (icmp IntPredicate.sgt e_1 e) ⊑
-    icmp IntPredicate.ne e_1 (const? 8 (-128)) := by 
+    icmp IntPredicate.ne e_1 (const? 8 (-128)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1715,7 +1715,7 @@ theorem sgt_or_not_min_commute_thm (e e_1 : IntW 8) :
 
 theorem sgt_or_not_min_commute_logical_thm (e e_1 : IntW 8) :
   select (icmp IntPredicate.ne e_1 (const? 8 (-128))) (const? 1 1) (icmp IntPredicate.sgt e_1 e) ⊑
-    icmp IntPredicate.ne e_1 (const? 8 (-128)) := by 
+    icmp IntPredicate.ne e_1 (const? 8 (-128)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1726,7 +1726,7 @@ theorem sgt_or_not_min_commute_logical_thm (e e_1 : IntW 8) :
 
 theorem sgt_swap_or_not_min_thm (e e_1 : IntW 8) :
   LLVM.or (icmp IntPredicate.slt e_1 e) (icmp IntPredicate.ne e (const? 8 (-128))) ⊑
-    icmp IntPredicate.ne e (const? 8 (-128)) := by 
+    icmp IntPredicate.ne e (const? 8 (-128)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1737,7 +1737,7 @@ theorem sgt_swap_or_not_min_thm (e e_1 : IntW 8) :
 
 theorem sgt_swap_or_not_min_logical_thm (e e_1 : IntW 8) :
   select (icmp IntPredicate.slt e_1 e) (const? 1 1) (icmp IntPredicate.ne e (const? 8 (-128))) ⊑
-    icmp IntPredicate.ne e (const? 8 (-128)) := by 
+    icmp IntPredicate.ne e (const? 8 (-128)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1748,7 +1748,7 @@ theorem sgt_swap_or_not_min_logical_thm (e e_1 : IntW 8) :
 
 theorem sgt_swap_or_not_min_commute_thm (e e_1 : IntW 8) :
   LLVM.or (icmp IntPredicate.ne e_1 (const? 8 (-128))) (icmp IntPredicate.slt e e_1) ⊑
-    icmp IntPredicate.ne e_1 (const? 8 (-128)) := by 
+    icmp IntPredicate.ne e_1 (const? 8 (-128)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1759,7 +1759,7 @@ theorem sgt_swap_or_not_min_commute_thm (e e_1 : IntW 8) :
 
 theorem sgt_swap_or_not_min_commute_logical_thm (e e_1 : IntW 8) :
   select (icmp IntPredicate.ne e_1 (const? 8 (-128))) (const? 1 1) (icmp IntPredicate.slt e e_1) ⊑
-    icmp IntPredicate.ne e_1 (const? 8 (-128)) := by 
+    icmp IntPredicate.ne e_1 (const? 8 (-128)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1770,7 +1770,7 @@ theorem sgt_swap_or_not_min_commute_logical_thm (e e_1 : IntW 8) :
 
 theorem ugt_or_not_min_thm (e e_1 : IntW 8) :
   LLVM.or (icmp IntPredicate.ugt e_1 e) (icmp IntPredicate.ne e_1 (const? 8 0)) ⊑
-    icmp IntPredicate.ne e_1 (const? 8 0) := by 
+    icmp IntPredicate.ne e_1 (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1781,7 +1781,7 @@ theorem ugt_or_not_min_thm (e e_1 : IntW 8) :
 
 theorem ugt_or_not_min_logical_thm (e e_1 : IntW 8) :
   select (icmp IntPredicate.ugt e_1 e) (const? 1 1) (icmp IntPredicate.ne e_1 (const? 8 0)) ⊑
-    icmp IntPredicate.ne e_1 (const? 8 0) := by 
+    icmp IntPredicate.ne e_1 (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1792,7 +1792,7 @@ theorem ugt_or_not_min_logical_thm (e e_1 : IntW 8) :
 
 theorem ugt_or_not_min_commute_thm (e e_1 : IntW 8) :
   LLVM.or (icmp IntPredicate.ne e_1 (const? 8 0)) (icmp IntPredicate.ugt e_1 e) ⊑
-    icmp IntPredicate.ne e_1 (const? 8 0) := by 
+    icmp IntPredicate.ne e_1 (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1803,7 +1803,7 @@ theorem ugt_or_not_min_commute_thm (e e_1 : IntW 8) :
 
 theorem ugt_or_not_min_commute_logical_thm (e e_1 : IntW 8) :
   select (icmp IntPredicate.ne e_1 (const? 8 0)) (const? 1 1) (icmp IntPredicate.ugt e_1 e) ⊑
-    icmp IntPredicate.ne e_1 (const? 8 0) := by 
+    icmp IntPredicate.ne e_1 (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1814,7 +1814,7 @@ theorem ugt_or_not_min_commute_logical_thm (e e_1 : IntW 8) :
 
 theorem ugt_swap_or_not_min_thm (e e_1 : IntW 8) :
   LLVM.or (icmp IntPredicate.ult e_1 e) (icmp IntPredicate.ne e (const? 8 0)) ⊑
-    icmp IntPredicate.ne e (const? 8 0) := by 
+    icmp IntPredicate.ne e (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1825,7 +1825,7 @@ theorem ugt_swap_or_not_min_thm (e e_1 : IntW 8) :
 
 theorem ugt_swap_or_not_min_logical_thm (e e_1 : IntW 8) :
   select (icmp IntPredicate.ult e_1 e) (const? 1 1) (icmp IntPredicate.ne e (const? 8 0)) ⊑
-    icmp IntPredicate.ne e (const? 8 0) := by 
+    icmp IntPredicate.ne e (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1836,7 +1836,7 @@ theorem ugt_swap_or_not_min_logical_thm (e e_1 : IntW 8) :
 
 theorem ugt_swap_or_not_min_commute_thm (e e_1 : IntW 823) :
   LLVM.or (icmp IntPredicate.ne e_1 (const? 823 0)) (icmp IntPredicate.ult e e_1) ⊑
-    icmp IntPredicate.ne e_1 (const? 823 0) := by 
+    icmp IntPredicate.ne e_1 (const? 823 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1847,7 +1847,7 @@ theorem ugt_swap_or_not_min_commute_thm (e e_1 : IntW 823) :
 
 theorem ugt_swap_or_not_min_commute_logical_thm (e e_1 : IntW 823) :
   select (icmp IntPredicate.ne e_1 (const? 823 0)) (const? 1 1) (icmp IntPredicate.ult e e_1) ⊑
-    icmp IntPredicate.ne e_1 (const? 823 0) := by 
+    icmp IntPredicate.ne e_1 (const? 823 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gandhorhicmps_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gandhorhicmps_proof.lean
@@ -10,7 +10,7 @@ set_option linter.unreachableTactic false
 section gandhorhicmps_proof
 theorem PR1817_1_thm (e : IntW 32) :
   LLVM.and (icmp IntPredicate.slt e (const? 32 10)) (icmp IntPredicate.ult e (const? 32 10)) ⊑
-    icmp IntPredicate.ult e (const? 32 10) := by 
+    icmp IntPredicate.ult e (const? 32 10) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -21,7 +21,7 @@ theorem PR1817_1_thm (e : IntW 32) :
 
 theorem PR1817_1_logical_thm (e : IntW 32) :
   select (icmp IntPredicate.slt e (const? 32 10)) (icmp IntPredicate.ult e (const? 32 10)) (const? 1 0) ⊑
-    icmp IntPredicate.ult e (const? 32 10) := by 
+    icmp IntPredicate.ult e (const? 32 10) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -32,7 +32,7 @@ theorem PR1817_1_logical_thm (e : IntW 32) :
 
 theorem PR1817_2_thm (e : IntW 32) :
   LLVM.or (icmp IntPredicate.slt e (const? 32 10)) (icmp IntPredicate.ult e (const? 32 10)) ⊑
-    icmp IntPredicate.slt e (const? 32 10) := by 
+    icmp IntPredicate.slt e (const? 32 10) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -43,7 +43,7 @@ theorem PR1817_2_thm (e : IntW 32) :
 
 theorem PR1817_2_logical_thm (e : IntW 32) :
   select (icmp IntPredicate.slt e (const? 32 10)) (const? 1 1) (icmp IntPredicate.ult e (const? 32 10)) ⊑
-    icmp IntPredicate.slt e (const? 32 10) := by 
+    icmp IntPredicate.slt e (const? 32 10) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -54,7 +54,7 @@ theorem PR1817_2_logical_thm (e : IntW 32) :
 
 theorem PR2330_thm (e e_1 : IntW 32) :
   LLVM.and (icmp IntPredicate.ult e_1 (const? 32 8)) (icmp IntPredicate.ult e (const? 32 8)) ⊑
-    icmp IntPredicate.ult (LLVM.or e_1 e) (const? 32 8) := by 
+    icmp IntPredicate.ult (LLVM.or e_1 e) (const? 32 8) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -65,7 +65,7 @@ theorem PR2330_thm (e e_1 : IntW 32) :
 
 theorem or_eq_with_one_bit_diff_constants1_thm (e : IntW 32) :
   LLVM.or (icmp IntPredicate.eq e (const? 32 50)) (icmp IntPredicate.eq e (const? 32 51)) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 32 (-2))) (const? 32 50) := by 
+    icmp IntPredicate.eq (LLVM.and e (const? 32 (-2))) (const? 32 50) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -76,7 +76,7 @@ theorem or_eq_with_one_bit_diff_constants1_thm (e : IntW 32) :
 
 theorem or_eq_with_one_bit_diff_constants1_logical_thm (e : IntW 32) :
   select (icmp IntPredicate.eq e (const? 32 50)) (const? 1 1) (icmp IntPredicate.eq e (const? 32 51)) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 32 (-2))) (const? 32 50) := by 
+    icmp IntPredicate.eq (LLVM.and e (const? 32 (-2))) (const? 32 50) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -87,7 +87,7 @@ theorem or_eq_with_one_bit_diff_constants1_logical_thm (e : IntW 32) :
 
 theorem and_ne_with_one_bit_diff_constants1_thm (e : IntW 32) :
   LLVM.and (icmp IntPredicate.ne e (const? 32 51)) (icmp IntPredicate.ne e (const? 32 50)) ⊑
-    icmp IntPredicate.ult (add e (const? 32 (-52))) (const? 32 (-2)) := by 
+    icmp IntPredicate.ult (add e (const? 32 (-52))) (const? 32 (-2)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -98,7 +98,7 @@ theorem and_ne_with_one_bit_diff_constants1_thm (e : IntW 32) :
 
 theorem and_ne_with_one_bit_diff_constants1_logical_thm (e : IntW 32) :
   select (icmp IntPredicate.ne e (const? 32 51)) (icmp IntPredicate.ne e (const? 32 50)) (const? 1 0) ⊑
-    icmp IntPredicate.ult (add e (const? 32 (-52))) (const? 32 (-2)) := by 
+    icmp IntPredicate.ult (add e (const? 32 (-52))) (const? 32 (-2)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -109,7 +109,7 @@ theorem and_ne_with_one_bit_diff_constants1_logical_thm (e : IntW 32) :
 
 theorem or_eq_with_one_bit_diff_constants2_thm (e : IntW 32) :
   LLVM.or (icmp IntPredicate.eq e (const? 32 97)) (icmp IntPredicate.eq e (const? 32 65)) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 32 (-33))) (const? 32 65) := by 
+    icmp IntPredicate.eq (LLVM.and e (const? 32 (-33))) (const? 32 65) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -120,7 +120,7 @@ theorem or_eq_with_one_bit_diff_constants2_thm (e : IntW 32) :
 
 theorem or_eq_with_one_bit_diff_constants2_logical_thm (e : IntW 32) :
   select (icmp IntPredicate.eq e (const? 32 97)) (const? 1 1) (icmp IntPredicate.eq e (const? 32 65)) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 32 (-33))) (const? 32 65) := by 
+    icmp IntPredicate.eq (LLVM.and e (const? 32 (-33))) (const? 32 65) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -131,7 +131,7 @@ theorem or_eq_with_one_bit_diff_constants2_logical_thm (e : IntW 32) :
 
 theorem and_ne_with_one_bit_diff_constants2_thm (e : IntW 19) :
   LLVM.and (icmp IntPredicate.ne e (const? 19 65)) (icmp IntPredicate.ne e (const? 19 193)) ⊑
-    icmp IntPredicate.ne (LLVM.and e (const? 19 (-129))) (const? 19 65) := by 
+    icmp IntPredicate.ne (LLVM.and e (const? 19 (-129))) (const? 19 65) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -142,7 +142,7 @@ theorem and_ne_with_one_bit_diff_constants2_thm (e : IntW 19) :
 
 theorem and_ne_with_one_bit_diff_constants2_logical_thm (e : IntW 19) :
   select (icmp IntPredicate.ne e (const? 19 65)) (icmp IntPredicate.ne e (const? 19 193)) (const? 1 0) ⊑
-    icmp IntPredicate.ne (LLVM.and e (const? 19 (-129))) (const? 19 65) := by 
+    icmp IntPredicate.ne (LLVM.and e (const? 19 (-129))) (const? 19 65) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -153,7 +153,7 @@ theorem and_ne_with_one_bit_diff_constants2_logical_thm (e : IntW 19) :
 
 theorem or_eq_with_one_bit_diff_constants3_thm (e : IntW 8) :
   LLVM.or (icmp IntPredicate.eq e (const? 8 (-2))) (icmp IntPredicate.eq e (const? 8 126)) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 8 127)) (const? 8 126) := by 
+    icmp IntPredicate.eq (LLVM.and e (const? 8 127)) (const? 8 126) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -164,7 +164,7 @@ theorem or_eq_with_one_bit_diff_constants3_thm (e : IntW 8) :
 
 theorem or_eq_with_one_bit_diff_constants3_logical_thm (e : IntW 8) :
   select (icmp IntPredicate.eq e (const? 8 (-2))) (const? 1 1) (icmp IntPredicate.eq e (const? 8 126)) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 8 127)) (const? 8 126) := by 
+    icmp IntPredicate.eq (LLVM.and e (const? 8 127)) (const? 8 126) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -175,7 +175,7 @@ theorem or_eq_with_one_bit_diff_constants3_logical_thm (e : IntW 8) :
 
 theorem and_ne_with_one_bit_diff_constants3_thm (e : IntW 8) :
   LLVM.and (icmp IntPredicate.ne e (const? 8 65)) (icmp IntPredicate.ne e (const? 8 (-63))) ⊑
-    icmp IntPredicate.ne (LLVM.and e (const? 8 127)) (const? 8 65) := by 
+    icmp IntPredicate.ne (LLVM.and e (const? 8 127)) (const? 8 65) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -186,7 +186,7 @@ theorem and_ne_with_one_bit_diff_constants3_thm (e : IntW 8) :
 
 theorem and_ne_with_one_bit_diff_constants3_logical_thm (e : IntW 8) :
   select (icmp IntPredicate.ne e (const? 8 65)) (icmp IntPredicate.ne e (const? 8 (-63))) (const? 1 0) ⊑
-    icmp IntPredicate.ne (LLVM.and e (const? 8 127)) (const? 8 65) := by 
+    icmp IntPredicate.ne (LLVM.and e (const? 8 127)) (const? 8 65) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -197,7 +197,7 @@ theorem and_ne_with_one_bit_diff_constants3_logical_thm (e : IntW 8) :
 
 theorem or_eq_with_diff_one_thm (e : IntW 8) :
   LLVM.or (icmp IntPredicate.eq e (const? 8 13)) (icmp IntPredicate.eq e (const? 8 14)) ⊑
-    icmp IntPredicate.ult (add e (const? 8 (-13))) (const? 8 2) := by 
+    icmp IntPredicate.ult (add e (const? 8 (-13))) (const? 8 2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -208,7 +208,7 @@ theorem or_eq_with_diff_one_thm (e : IntW 8) :
 
 theorem or_eq_with_diff_one_logical_thm (e : IntW 8) :
   select (icmp IntPredicate.eq e (const? 8 13)) (const? 1 1) (icmp IntPredicate.eq e (const? 8 14)) ⊑
-    icmp IntPredicate.ult (add e (const? 8 (-13))) (const? 8 2) := by 
+    icmp IntPredicate.ult (add e (const? 8 (-13))) (const? 8 2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -219,7 +219,7 @@ theorem or_eq_with_diff_one_logical_thm (e : IntW 8) :
 
 theorem and_ne_with_diff_one_thm (e : IntW 32) :
   LLVM.and (icmp IntPredicate.ne e (const? 32 40)) (icmp IntPredicate.ne e (const? 32 39)) ⊑
-    icmp IntPredicate.ult (add e (const? 32 (-41))) (const? 32 (-2)) := by 
+    icmp IntPredicate.ult (add e (const? 32 (-41))) (const? 32 (-2)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -230,7 +230,7 @@ theorem and_ne_with_diff_one_thm (e : IntW 32) :
 
 theorem and_ne_with_diff_one_logical_thm (e : IntW 32) :
   select (icmp IntPredicate.ne e (const? 32 40)) (icmp IntPredicate.ne e (const? 32 39)) (const? 1 0) ⊑
-    icmp IntPredicate.ult (add e (const? 32 (-41))) (const? 32 (-2)) := by 
+    icmp IntPredicate.ult (add e (const? 32 (-41))) (const? 32 (-2)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -241,7 +241,7 @@ theorem and_ne_with_diff_one_logical_thm (e : IntW 32) :
 
 theorem or_eq_with_diff_one_signed_thm (e : IntW 32) :
   LLVM.or (icmp IntPredicate.eq e (const? 32 0)) (icmp IntPredicate.eq e (const? 32 (-1))) ⊑
-    icmp IntPredicate.ult (add e (const? 32 1)) (const? 32 2) := by 
+    icmp IntPredicate.ult (add e (const? 32 1)) (const? 32 2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -252,7 +252,7 @@ theorem or_eq_with_diff_one_signed_thm (e : IntW 32) :
 
 theorem or_eq_with_diff_one_signed_logical_thm (e : IntW 32) :
   select (icmp IntPredicate.eq e (const? 32 0)) (const? 1 1) (icmp IntPredicate.eq e (const? 32 (-1))) ⊑
-    icmp IntPredicate.ult (add e (const? 32 1)) (const? 32 2) := by 
+    icmp IntPredicate.ult (add e (const? 32 1)) (const? 32 2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -263,7 +263,7 @@ theorem or_eq_with_diff_one_signed_logical_thm (e : IntW 32) :
 
 theorem and_ne_with_diff_one_signed_thm (e : IntW 64) :
   LLVM.and (icmp IntPredicate.ne e (const? 64 (-1))) (icmp IntPredicate.ne e (const? 64 0)) ⊑
-    icmp IntPredicate.ult (add e (const? 64 (-1))) (const? 64 (-2)) := by 
+    icmp IntPredicate.ult (add e (const? 64 (-1))) (const? 64 (-2)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -274,7 +274,7 @@ theorem and_ne_with_diff_one_signed_thm (e : IntW 64) :
 
 theorem and_ne_with_diff_one_signed_logical_thm (e : IntW 64) :
   select (icmp IntPredicate.ne e (const? 64 (-1))) (icmp IntPredicate.ne e (const? 64 0)) (const? 1 0) ⊑
-    icmp IntPredicate.ult (add e (const? 64 (-1))) (const? 64 (-2)) := by 
+    icmp IntPredicate.ult (add e (const? 64 (-1))) (const? 64 (-2)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -285,7 +285,7 @@ theorem and_ne_with_diff_one_signed_logical_thm (e : IntW 64) :
 
 theorem PR42691_1_thm (e : IntW 32) :
   LLVM.or (icmp IntPredicate.slt e (const? 32 0)) (icmp IntPredicate.eq e (const? 32 2147483647)) ⊑
-    icmp IntPredicate.ugt e (const? 32 2147483646) := by 
+    icmp IntPredicate.ugt e (const? 32 2147483646) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -296,7 +296,7 @@ theorem PR42691_1_thm (e : IntW 32) :
 
 theorem PR42691_1_logical_thm (e : IntW 32) :
   select (icmp IntPredicate.slt e (const? 32 0)) (const? 1 1) (icmp IntPredicate.eq e (const? 32 2147483647)) ⊑
-    icmp IntPredicate.ugt e (const? 32 2147483646) := by 
+    icmp IntPredicate.ugt e (const? 32 2147483646) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -307,7 +307,7 @@ theorem PR42691_1_logical_thm (e : IntW 32) :
 
 theorem PR42691_2_thm (e : IntW 32) :
   LLVM.or (icmp IntPredicate.ult e (const? 32 (-2147483648))) (icmp IntPredicate.eq e (const? 32 (-1))) ⊑
-    icmp IntPredicate.sgt e (const? 32 (-2)) := by 
+    icmp IntPredicate.sgt e (const? 32 (-2)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -318,7 +318,7 @@ theorem PR42691_2_thm (e : IntW 32) :
 
 theorem PR42691_2_logical_thm (e : IntW 32) :
   select (icmp IntPredicate.ult e (const? 32 (-2147483648))) (const? 1 1) (icmp IntPredicate.eq e (const? 32 (-1))) ⊑
-    icmp IntPredicate.sgt e (const? 32 (-2)) := by 
+    icmp IntPredicate.sgt e (const? 32 (-2)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -329,7 +329,7 @@ theorem PR42691_2_logical_thm (e : IntW 32) :
 
 theorem PR42691_3_thm (e : IntW 32) :
   LLVM.or (icmp IntPredicate.sge e (const? 32 0)) (icmp IntPredicate.eq e (const? 32 (-2147483648))) ⊑
-    icmp IntPredicate.ult e (const? 32 (-2147483647)) := by 
+    icmp IntPredicate.ult e (const? 32 (-2147483647)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -340,7 +340,7 @@ theorem PR42691_3_thm (e : IntW 32) :
 
 theorem PR42691_3_logical_thm (e : IntW 32) :
   select (icmp IntPredicate.sge e (const? 32 0)) (const? 1 1) (icmp IntPredicate.eq e (const? 32 (-2147483648))) ⊑
-    icmp IntPredicate.ult e (const? 32 (-2147483647)) := by 
+    icmp IntPredicate.ult e (const? 32 (-2147483647)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -351,7 +351,7 @@ theorem PR42691_3_logical_thm (e : IntW 32) :
 
 theorem PR42691_4_thm (e : IntW 32) :
   LLVM.or (icmp IntPredicate.uge e (const? 32 (-2147483648))) (icmp IntPredicate.eq e (const? 32 0)) ⊑
-    icmp IntPredicate.slt e (const? 32 1) := by 
+    icmp IntPredicate.slt e (const? 32 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -362,7 +362,7 @@ theorem PR42691_4_thm (e : IntW 32) :
 
 theorem PR42691_4_logical_thm (e : IntW 32) :
   select (icmp IntPredicate.uge e (const? 32 (-2147483648))) (const? 1 1) (icmp IntPredicate.eq e (const? 32 0)) ⊑
-    icmp IntPredicate.slt e (const? 32 1) := by 
+    icmp IntPredicate.slt e (const? 32 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -373,7 +373,7 @@ theorem PR42691_4_logical_thm (e : IntW 32) :
 
 theorem PR42691_5_thm (e : IntW 32) :
   LLVM.or (icmp IntPredicate.slt e (const? 32 1)) (icmp IntPredicate.eq e (const? 32 2147483647)) ⊑
-    icmp IntPredicate.ult (add e (const? 32 (-2147483647))) (const? 32 (-2147483646)) := by 
+    icmp IntPredicate.ult (add e (const? 32 (-2147483647))) (const? 32 (-2147483646)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -384,7 +384,7 @@ theorem PR42691_5_thm (e : IntW 32) :
 
 theorem PR42691_5_logical_thm (e : IntW 32) :
   select (icmp IntPredicate.slt e (const? 32 1)) (const? 1 1) (icmp IntPredicate.eq e (const? 32 2147483647)) ⊑
-    icmp IntPredicate.ult (add e (const? 32 (-2147483647))) (const? 32 (-2147483646)) := by 
+    icmp IntPredicate.ult (add e (const? 32 (-2147483647))) (const? 32 (-2147483646)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -395,7 +395,7 @@ theorem PR42691_5_logical_thm (e : IntW 32) :
 
 theorem PR42691_6_thm (e : IntW 32) :
   LLVM.or (icmp IntPredicate.ult e (const? 32 (-2147483647))) (icmp IntPredicate.eq e (const? 32 (-1))) ⊑
-    icmp IntPredicate.ult (add e (const? 32 1)) (const? 32 (-2147483646)) := by 
+    icmp IntPredicate.ult (add e (const? 32 1)) (const? 32 (-2147483646)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -406,7 +406,7 @@ theorem PR42691_6_thm (e : IntW 32) :
 
 theorem PR42691_6_logical_thm (e : IntW 32) :
   select (icmp IntPredicate.ult e (const? 32 (-2147483647))) (const? 1 1) (icmp IntPredicate.eq e (const? 32 (-1))) ⊑
-    icmp IntPredicate.ult (add e (const? 32 1)) (const? 32 (-2147483646)) := by 
+    icmp IntPredicate.ult (add e (const? 32 1)) (const? 32 (-2147483646)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -417,7 +417,7 @@ theorem PR42691_6_logical_thm (e : IntW 32) :
 
 theorem PR42691_7_thm (e : IntW 32) :
   LLVM.or (icmp IntPredicate.uge e (const? 32 (-2147483647))) (icmp IntPredicate.eq e (const? 32 0)) ⊑
-    icmp IntPredicate.slt (add e (const? 32 (-1))) (const? 32 0) := by 
+    icmp IntPredicate.slt (add e (const? 32 (-1))) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -428,7 +428,7 @@ theorem PR42691_7_thm (e : IntW 32) :
 
 theorem PR42691_7_logical_thm (e : IntW 32) :
   select (icmp IntPredicate.uge e (const? 32 (-2147483647))) (const? 1 1) (icmp IntPredicate.eq e (const? 32 0)) ⊑
-    icmp IntPredicate.slt (add e (const? 32 (-1))) (const? 32 0) := by 
+    icmp IntPredicate.slt (add e (const? 32 (-1))) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -439,7 +439,7 @@ theorem PR42691_7_logical_thm (e : IntW 32) :
 
 theorem PR42691_8_thm (e : IntW 32) :
   LLVM.and (icmp IntPredicate.slt e (const? 32 14)) (icmp IntPredicate.ne e (const? 32 (-2147483648))) ⊑
-    icmp IntPredicate.ult (add e (const? 32 2147483647)) (const? 32 (-2147483635)) := by 
+    icmp IntPredicate.ult (add e (const? 32 2147483647)) (const? 32 (-2147483635)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -450,7 +450,7 @@ theorem PR42691_8_thm (e : IntW 32) :
 
 theorem PR42691_8_logical_thm (e : IntW 32) :
   select (icmp IntPredicate.slt e (const? 32 14)) (icmp IntPredicate.ne e (const? 32 (-2147483648))) (const? 1 0) ⊑
-    icmp IntPredicate.ult (add e (const? 32 2147483647)) (const? 32 (-2147483635)) := by 
+    icmp IntPredicate.ult (add e (const? 32 2147483647)) (const? 32 (-2147483635)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -461,7 +461,7 @@ theorem PR42691_8_logical_thm (e : IntW 32) :
 
 theorem PR42691_9_thm (e : IntW 32) :
   LLVM.and (icmp IntPredicate.sgt e (const? 32 13)) (icmp IntPredicate.ne e (const? 32 2147483647)) ⊑
-    icmp IntPredicate.ult (add e (const? 32 (-14))) (const? 32 2147483633) := by 
+    icmp IntPredicate.ult (add e (const? 32 (-14))) (const? 32 2147483633) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -472,7 +472,7 @@ theorem PR42691_9_thm (e : IntW 32) :
 
 theorem PR42691_9_logical_thm (e : IntW 32) :
   select (icmp IntPredicate.sgt e (const? 32 13)) (icmp IntPredicate.ne e (const? 32 2147483647)) (const? 1 0) ⊑
-    icmp IntPredicate.ult (add e (const? 32 (-14))) (const? 32 2147483633) := by 
+    icmp IntPredicate.ult (add e (const? 32 (-14))) (const? 32 2147483633) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -483,7 +483,7 @@ theorem PR42691_9_logical_thm (e : IntW 32) :
 
 theorem PR42691_10_thm (e : IntW 32) :
   LLVM.and (icmp IntPredicate.ugt e (const? 32 13)) (icmp IntPredicate.ne e (const? 32 (-1))) ⊑
-    icmp IntPredicate.ult (add e (const? 32 (-14))) (const? 32 (-15)) := by 
+    icmp IntPredicate.ult (add e (const? 32 (-14))) (const? 32 (-15)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -494,7 +494,7 @@ theorem PR42691_10_thm (e : IntW 32) :
 
 theorem PR42691_10_logical_thm (e : IntW 32) :
   select (icmp IntPredicate.ugt e (const? 32 13)) (icmp IntPredicate.ne e (const? 32 (-1))) (const? 1 0) ⊑
-    icmp IntPredicate.ult (add e (const? 32 (-14))) (const? 32 (-15)) := by 
+    icmp IntPredicate.ult (add e (const? 32 (-14))) (const? 32 (-15)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -505,7 +505,7 @@ theorem PR42691_10_logical_thm (e : IntW 32) :
 
 theorem substitute_constant_and_eq_eq_thm (e e_1 : IntW 8) :
   LLVM.and (icmp IntPredicate.eq e_1 (const? 8 42)) (icmp IntPredicate.eq e_1 e) ⊑
-    LLVM.and (icmp IntPredicate.eq e_1 (const? 8 42)) (icmp IntPredicate.eq e (const? 8 42)) := by 
+    LLVM.and (icmp IntPredicate.eq e_1 (const? 8 42)) (icmp IntPredicate.eq e (const? 8 42)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -516,7 +516,7 @@ theorem substitute_constant_and_eq_eq_thm (e e_1 : IntW 8) :
 
 theorem substitute_constant_and_eq_eq_logical_thm (e e_1 : IntW 8) :
   select (icmp IntPredicate.eq e_1 (const? 8 42)) (icmp IntPredicate.eq e_1 e) (const? 1 0) ⊑
-    select (icmp IntPredicate.eq e_1 (const? 8 42)) (icmp IntPredicate.eq e (const? 8 42)) (const? 1 0) := by 
+    select (icmp IntPredicate.eq e_1 (const? 8 42)) (icmp IntPredicate.eq e (const? 8 42)) (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -527,7 +527,7 @@ theorem substitute_constant_and_eq_eq_logical_thm (e e_1 : IntW 8) :
 
 theorem substitute_constant_and_eq_eq_commute_thm (e e_1 : IntW 8) :
   LLVM.and (icmp IntPredicate.eq e_1 e) (icmp IntPredicate.eq e_1 (const? 8 42)) ⊑
-    LLVM.and (icmp IntPredicate.eq e_1 (const? 8 42)) (icmp IntPredicate.eq e (const? 8 42)) := by 
+    LLVM.and (icmp IntPredicate.eq e_1 (const? 8 42)) (icmp IntPredicate.eq e (const? 8 42)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -538,7 +538,7 @@ theorem substitute_constant_and_eq_eq_commute_thm (e e_1 : IntW 8) :
 
 theorem substitute_constant_and_eq_eq_commute_logical_thm (e e_1 : IntW 8) :
   select (icmp IntPredicate.eq e_1 e) (icmp IntPredicate.eq e_1 (const? 8 42)) (const? 1 0) ⊑
-    LLVM.and (icmp IntPredicate.eq e_1 (const? 8 42)) (icmp IntPredicate.eq e (const? 8 42)) := by 
+    LLVM.and (icmp IntPredicate.eq e_1 (const? 8 42)) (icmp IntPredicate.eq e (const? 8 42)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -549,7 +549,7 @@ theorem substitute_constant_and_eq_eq_commute_logical_thm (e e_1 : IntW 8) :
 
 theorem substitute_constant_and_eq_ugt_swap_thm (e e_1 : IntW 8) :
   LLVM.and (icmp IntPredicate.ugt e_1 e) (icmp IntPredicate.eq e (const? 8 42)) ⊑
-    LLVM.and (icmp IntPredicate.eq e (const? 8 42)) (icmp IntPredicate.ugt e_1 (const? 8 42)) := by 
+    LLVM.and (icmp IntPredicate.eq e (const? 8 42)) (icmp IntPredicate.ugt e_1 (const? 8 42)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -560,7 +560,7 @@ theorem substitute_constant_and_eq_ugt_swap_thm (e e_1 : IntW 8) :
 
 theorem substitute_constant_and_eq_ugt_swap_logical_thm (e e_1 : IntW 8) :
   select (icmp IntPredicate.ugt e_1 e) (icmp IntPredicate.eq e (const? 8 42)) (const? 1 0) ⊑
-    LLVM.and (icmp IntPredicate.eq e (const? 8 42)) (icmp IntPredicate.ugt e_1 (const? 8 42)) := by 
+    LLVM.and (icmp IntPredicate.eq e (const? 8 42)) (icmp IntPredicate.ugt e_1 (const? 8 42)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -571,7 +571,7 @@ theorem substitute_constant_and_eq_ugt_swap_logical_thm (e e_1 : IntW 8) :
 
 theorem substitute_constant_and_ne_ugt_swap_logical_thm (e e_1 : IntW 8) :
   select (icmp IntPredicate.ugt e_1 e) (icmp IntPredicate.ne e (const? 8 42)) (const? 1 0) ⊑
-    LLVM.and (icmp IntPredicate.ugt e_1 e) (icmp IntPredicate.ne e (const? 8 42)) := by 
+    LLVM.and (icmp IntPredicate.ugt e_1 e) (icmp IntPredicate.ne e (const? 8 42)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -582,7 +582,7 @@ theorem substitute_constant_and_ne_ugt_swap_logical_thm (e e_1 : IntW 8) :
 
 theorem substitute_constant_or_ne_swap_sle_thm (e e_1 : IntW 8) :
   LLVM.or (icmp IntPredicate.ne e_1 (const? 8 42)) (icmp IntPredicate.sle e e_1) ⊑
-    LLVM.or (icmp IntPredicate.ne e_1 (const? 8 42)) (icmp IntPredicate.slt e (const? 8 43)) := by 
+    LLVM.or (icmp IntPredicate.ne e_1 (const? 8 42)) (icmp IntPredicate.slt e (const? 8 43)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -593,7 +593,7 @@ theorem substitute_constant_or_ne_swap_sle_thm (e e_1 : IntW 8) :
 
 theorem substitute_constant_or_ne_swap_sle_logical_thm (e e_1 : IntW 8) :
   select (icmp IntPredicate.ne e_1 (const? 8 42)) (const? 1 1) (icmp IntPredicate.sle e e_1) ⊑
-    select (icmp IntPredicate.ne e_1 (const? 8 42)) (const? 1 1) (icmp IntPredicate.slt e (const? 8 43)) := by 
+    select (icmp IntPredicate.ne e_1 (const? 8 42)) (const? 1 1) (icmp IntPredicate.slt e (const? 8 43)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -604,7 +604,7 @@ theorem substitute_constant_or_ne_swap_sle_logical_thm (e e_1 : IntW 8) :
 
 theorem substitute_constant_or_ne_uge_commute_thm (e e_1 : IntW 8) :
   LLVM.or (icmp IntPredicate.uge e_1 e) (icmp IntPredicate.ne e_1 (const? 8 42)) ⊑
-    LLVM.or (icmp IntPredicate.ne e_1 (const? 8 42)) (icmp IntPredicate.ult e (const? 8 43)) := by 
+    LLVM.or (icmp IntPredicate.ne e_1 (const? 8 42)) (icmp IntPredicate.ult e (const? 8 43)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -615,7 +615,7 @@ theorem substitute_constant_or_ne_uge_commute_thm (e e_1 : IntW 8) :
 
 theorem substitute_constant_or_ne_uge_commute_logical_thm (e e_1 : IntW 8) :
   select (icmp IntPredicate.uge e_1 e) (const? 1 1) (icmp IntPredicate.ne e_1 (const? 8 42)) ⊑
-    LLVM.or (icmp IntPredicate.ne e_1 (const? 8 42)) (icmp IntPredicate.ult e (const? 8 43)) := by 
+    LLVM.or (icmp IntPredicate.ne e_1 (const? 8 42)) (icmp IntPredicate.ult e (const? 8 43)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -627,7 +627,7 @@ theorem substitute_constant_or_ne_uge_commute_logical_thm (e e_1 : IntW 8) :
 theorem or_ranges_overlap_thm (e : IntW 8) :
   LLVM.or (LLVM.and (icmp IntPredicate.uge e (const? 8 5)) (icmp IntPredicate.ule e (const? 8 10)))
       (LLVM.and (icmp IntPredicate.uge e (const? 8 10)) (icmp IntPredicate.ule e (const? 8 20))) ⊑
-    icmp IntPredicate.ult (add e (const? 8 (-5))) (const? 8 16) := by 
+    icmp IntPredicate.ult (add e (const? 8 (-5))) (const? 8 16) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -639,7 +639,7 @@ theorem or_ranges_overlap_thm (e : IntW 8) :
 theorem or_ranges_adjacent_thm (e : IntW 8) :
   LLVM.or (LLVM.and (icmp IntPredicate.uge e (const? 8 5)) (icmp IntPredicate.ule e (const? 8 10)))
       (LLVM.and (icmp IntPredicate.uge e (const? 8 11)) (icmp IntPredicate.ule e (const? 8 20))) ⊑
-    icmp IntPredicate.ult (add e (const? 8 (-5))) (const? 8 16) := by 
+    icmp IntPredicate.ult (add e (const? 8 (-5))) (const? 8 16) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -652,7 +652,7 @@ theorem or_ranges_separated_thm (e : IntW 8) :
   LLVM.or (LLVM.and (icmp IntPredicate.uge e (const? 8 5)) (icmp IntPredicate.ule e (const? 8 10)))
       (LLVM.and (icmp IntPredicate.uge e (const? 8 12)) (icmp IntPredicate.ule e (const? 8 20))) ⊑
     LLVM.or (icmp IntPredicate.ult (add e (const? 8 (-5))) (const? 8 6))
-      (icmp IntPredicate.ult (add e (const? 8 (-12))) (const? 8 9)) := by 
+      (icmp IntPredicate.ult (add e (const? 8 (-12))) (const? 8 9)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -664,7 +664,7 @@ theorem or_ranges_separated_thm (e : IntW 8) :
 theorem or_ranges_single_elem_right_thm (e : IntW 8) :
   LLVM.or (LLVM.and (icmp IntPredicate.uge e (const? 8 5)) (icmp IntPredicate.ule e (const? 8 10)))
       (icmp IntPredicate.eq e (const? 8 11)) ⊑
-    icmp IntPredicate.ult (add e (const? 8 (-5))) (const? 8 7) := by 
+    icmp IntPredicate.ult (add e (const? 8 (-5))) (const? 8 7) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -676,7 +676,7 @@ theorem or_ranges_single_elem_right_thm (e : IntW 8) :
 theorem or_ranges_single_elem_left_thm (e : IntW 8) :
   LLVM.or (LLVM.and (icmp IntPredicate.uge e (const? 8 5)) (icmp IntPredicate.ule e (const? 8 10)))
       (icmp IntPredicate.eq e (const? 8 4)) ⊑
-    icmp IntPredicate.ult (add e (const? 8 (-4))) (const? 8 7) := by 
+    icmp IntPredicate.ult (add e (const? 8 (-4))) (const? 8 7) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -688,7 +688,7 @@ theorem or_ranges_single_elem_left_thm (e : IntW 8) :
 theorem and_ranges_overlap_thm (e : IntW 8) :
   LLVM.and (LLVM.and (icmp IntPredicate.uge e (const? 8 5)) (icmp IntPredicate.ule e (const? 8 10)))
       (LLVM.and (icmp IntPredicate.uge e (const? 8 7)) (icmp IntPredicate.ule e (const? 8 20))) ⊑
-    icmp IntPredicate.ult (add e (const? 8 (-7))) (const? 8 4) := by 
+    icmp IntPredicate.ult (add e (const? 8 (-7))) (const? 8 4) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -700,7 +700,7 @@ theorem and_ranges_overlap_thm (e : IntW 8) :
 theorem and_ranges_overlap_single_thm (e : IntW 8) :
   LLVM.and (LLVM.and (icmp IntPredicate.uge e (const? 8 5)) (icmp IntPredicate.ule e (const? 8 10)))
       (LLVM.and (icmp IntPredicate.uge e (const? 8 10)) (icmp IntPredicate.ule e (const? 8 20))) ⊑
-    icmp IntPredicate.eq e (const? 8 10) := by 
+    icmp IntPredicate.eq e (const? 8 10) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -712,7 +712,7 @@ theorem and_ranges_overlap_single_thm (e : IntW 8) :
 theorem and_ranges_no_overlap_thm (e : IntW 8) :
   LLVM.and (LLVM.and (icmp IntPredicate.uge e (const? 8 5)) (icmp IntPredicate.ule e (const? 8 10)))
       (LLVM.and (icmp IntPredicate.uge e (const? 8 11)) (icmp IntPredicate.ule e (const? 8 20))) ⊑
-    const? 1 0 := by 
+    const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -724,7 +724,7 @@ theorem and_ranges_no_overlap_thm (e : IntW 8) :
 theorem and_ranges_signed_pred_thm (e : IntW 64) :
   LLVM.and (icmp IntPredicate.slt (add e (const? 64 127)) (const? 64 1024))
       (icmp IntPredicate.slt (add e (const? 64 128)) (const? 64 256)) ⊑
-    icmp IntPredicate.ult (add e (const? 64 (-9223372036854775681))) (const? 64 (-9223372036854775553)) := by 
+    icmp IntPredicate.ult (add e (const? 64 (-9223372036854775681))) (const? 64 (-9223372036854775553)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -736,7 +736,7 @@ theorem and_ranges_signed_pred_thm (e : IntW 64) :
 theorem and_two_ranges_to_mask_and_range_thm (e : IntW 8) :
   LLVM.and (icmp IntPredicate.ugt (add e (const? 8 (-97))) (const? 8 25))
       (icmp IntPredicate.ugt (add e (const? 8 (-65))) (const? 8 25)) ⊑
-    icmp IntPredicate.ult (add (LLVM.and e (const? 8 (-33))) (const? 8 (-91))) (const? 8 (-26)) := by 
+    icmp IntPredicate.ult (add (LLVM.and e (const? 8 (-33))) (const? 8 (-91))) (const? 8 (-26)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -749,7 +749,7 @@ theorem and_two_ranges_to_mask_and_range_not_pow2_diff_thm (e : IntW 8) :
   LLVM.and (icmp IntPredicate.ugt (add e (const? 8 (-97))) (const? 8 25))
       (icmp IntPredicate.ugt (add e (const? 8 (-64))) (const? 8 25)) ⊑
     LLVM.and (icmp IntPredicate.ult (add e (const? 8 (-123))) (const? 8 (-26)))
-      (icmp IntPredicate.ult (add e (const? 8 (-90))) (const? 8 (-26))) := by 
+      (icmp IntPredicate.ult (add e (const? 8 (-90))) (const? 8 (-26))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -762,7 +762,7 @@ theorem and_two_ranges_to_mask_and_range_different_sizes_thm (e : IntW 8) :
   LLVM.and (icmp IntPredicate.ugt (add e (const? 8 (-97))) (const? 8 25))
       (icmp IntPredicate.ugt (add e (const? 8 (-65))) (const? 8 24)) ⊑
     LLVM.and (icmp IntPredicate.ult (add e (const? 8 (-123))) (const? 8 (-26)))
-      (icmp IntPredicate.ult (add e (const? 8 (-90))) (const? 8 (-25))) := by 
+      (icmp IntPredicate.ult (add e (const? 8 (-90))) (const? 8 (-25))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -774,7 +774,7 @@ theorem and_two_ranges_to_mask_and_range_different_sizes_thm (e : IntW 8) :
 theorem and_two_ranges_to_mask_and_range_no_add_on_one_range_thm (e : IntW 16) :
   LLVM.and (icmp IntPredicate.uge e (const? 16 12))
       (LLVM.or (icmp IntPredicate.ult e (const? 16 16)) (icmp IntPredicate.uge e (const? 16 28))) ⊑
-    icmp IntPredicate.ugt (LLVM.and e (const? 16 (-20))) (const? 16 11) := by 
+    icmp IntPredicate.ugt (LLVM.and e (const? 16 (-20))) (const? 16 11) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -786,7 +786,7 @@ theorem and_two_ranges_to_mask_and_range_no_add_on_one_range_thm (e : IntW 16) :
 theorem is_ascii_alphabetic_thm (e : IntW 32) :
   select (icmp IntPredicate.ult (add e (const? 32 (-65)) { «nsw» := true, «nuw» := false }) (const? 32 26)) (const? 1 1)
       (icmp IntPredicate.ult (add e (const? 32 (-97)) { «nsw» := true, «nuw» := false }) (const? 32 26)) ⊑
-    icmp IntPredicate.ult (add (LLVM.and e (const? 32 (-33))) (const? 32 (-65))) (const? 32 26) := by 
+    icmp IntPredicate.ult (add (LLVM.and e (const? 32 (-33))) (const? 32 (-65))) (const? 32 26) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -799,7 +799,7 @@ theorem is_ascii_alphabetic_inverted_thm (e : IntW 32) :
   select (icmp IntPredicate.ult (add e (const? 32 (-91)) { «nsw» := true, «nuw» := false }) (const? 32 (-26)))
       (icmp IntPredicate.ult (add e (const? 32 (-123)) { «nsw» := true, «nuw» := false }) (const? 32 (-26)))
       (const? 1 0) ⊑
-    icmp IntPredicate.ult (add (LLVM.and e (const? 32 (-33))) (const? 32 (-91))) (const? 32 (-26)) := by 
+    icmp IntPredicate.ult (add (LLVM.and e (const? 32 (-33))) (const? 32 (-91))) (const? 32 (-26)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -815,7 +815,7 @@ theorem bitwise_and_bitwise_and_icmps_thm (e e_1 e_2 : IntW 8) :
       (icmp IntPredicate.ne (LLVM.and e_1 (shl (const? 8 1) e)) (const? 8 0)) ⊑
     LLVM.and (icmp IntPredicate.eq e_2 (const? 8 42))
       (icmp IntPredicate.eq (LLVM.and e_1 (LLVM.or (shl (const? 8 1) e { «nsw» := false, «nuw» := true }) (const? 8 1)))
-        (LLVM.or (shl (const? 8 1) e { «nsw» := false, «nuw» := true }) (const? 8 1))) := by 
+        (LLVM.or (shl (const? 8 1) e { «nsw» := false, «nuw» := true }) (const? 8 1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -831,7 +831,7 @@ theorem bitwise_and_bitwise_and_icmps_comm1_thm (e e_1 e_2 : IntW 8) :
     LLVM.and (icmp IntPredicate.eq e (const? 8 42))
       (icmp IntPredicate.eq
         (LLVM.and e_2 (LLVM.or (shl (const? 8 1) e_1 { «nsw» := false, «nuw» := true }) (const? 8 1)))
-        (LLVM.or (shl (const? 8 1) e_1 { «nsw» := false, «nuw» := true }) (const? 8 1))) := by 
+        (LLVM.or (shl (const? 8 1) e_1 { «nsw» := false, «nuw» := true }) (const? 8 1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -848,7 +848,7 @@ theorem bitwise_and_bitwise_and_icmps_comm2_thm (e e_1 e_2 : IntW 8) :
     LLVM.and
       (icmp IntPredicate.eq (LLVM.and e_2 (LLVM.or (shl (const? 8 1) e { «nsw» := false, «nuw» := true }) (const? 8 1)))
         (LLVM.or (shl (const? 8 1) e { «nsw» := false, «nuw» := true }) (const? 8 1)))
-      (icmp IntPredicate.eq e_1 (const? 8 42)) := by 
+      (icmp IntPredicate.eq e_1 (const? 8 42)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -865,7 +865,7 @@ theorem bitwise_and_bitwise_and_icmps_comm3_thm (e e_1 e_2 : IntW 8) :
       (icmp IntPredicate.eq
         (LLVM.and e_2 (LLVM.or (shl (const? 8 1) e_1 { «nsw» := false, «nuw» := true }) (const? 8 1)))
         (LLVM.or (shl (const? 8 1) e_1 { «nsw» := false, «nuw» := true }) (const? 8 1)))
-      (icmp IntPredicate.eq e (const? 8 42)) := by 
+      (icmp IntPredicate.eq e (const? 8 42)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -882,7 +882,7 @@ theorem bitwise_and_logical_and_icmps_thm (e e_1 e_2 : IntW 8) :
     select (icmp IntPredicate.eq e_2 (const? 8 42))
       (icmp IntPredicate.eq (LLVM.and e_1 (LLVM.or (shl (const? 8 1) e { «nsw» := false, «nuw» := true }) (const? 8 1)))
         (LLVM.or (shl (const? 8 1) e { «nsw» := false, «nuw» := true }) (const? 8 1)))
-      (const? 1 0) := by 
+      (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -899,7 +899,7 @@ theorem bitwise_and_logical_and_icmps_comm1_thm (e e_1 e_2 : IntW 8) :
       (icmp IntPredicate.eq
         (LLVM.and e_2 (LLVM.or (shl (const? 8 1) e_1 { «nsw» := false, «nuw» := true }) (const? 8 1)))
         (LLVM.or (shl (const? 8 1) e_1 { «nsw» := false, «nuw» := true }) (const? 8 1)))
-      (const? 1 0) := by 
+      (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -916,7 +916,7 @@ theorem bitwise_and_logical_and_icmps_comm3_thm (e e_1 e_2 : IntW 8) :
       (icmp IntPredicate.eq
         (LLVM.and e_2 (LLVM.or (shl (const? 8 1) e_1 { «nsw» := false, «nuw» := true }) (const? 8 1)))
         (LLVM.or (shl (const? 8 1) e_1 { «nsw» := false, «nuw» := true }) (const? 8 1)))
-      (icmp IntPredicate.eq e (const? 8 42)) (const? 1 0) := by 
+      (icmp IntPredicate.eq e (const? 8 42)) (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -934,7 +934,7 @@ theorem logical_and_bitwise_and_icmps_thm (e e_1 e_2 : IntW 8) :
       (LLVM.and (icmp IntPredicate.eq e_2 (const? 8 42))
         (icmp IntPredicate.ne (LLVM.and e_1 (const? 8 1)) (const? 8 0)))
       (icmp IntPredicate.ne (LLVM.and e_1 (shl (const? 8 1) e { «nsw» := false, «nuw» := true })) (const? 8 0))
-      (const? 1 0) := by 
+      (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -949,7 +949,7 @@ theorem logical_and_bitwise_and_icmps_comm1_thm (e e_1 e_2 : IntW 8) :
       (const? 1 0) ⊑
     select (icmp IntPredicate.ne (LLVM.and e_2 (shl (const? 8 1) e_1 { «nsw» := false, «nuw» := true })) (const? 8 0))
       (LLVM.and (icmp IntPredicate.eq e (const? 8 42)) (icmp IntPredicate.ne (LLVM.and e_2 (const? 8 1)) (const? 8 0)))
-      (const? 1 0) := by 
+      (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -967,7 +967,7 @@ theorem logical_and_bitwise_and_icmps_comm2_thm (e e_1 e_2 : IntW 8) :
       (LLVM.and (icmp IntPredicate.ne (LLVM.and e_2 (const? 8 1)) (const? 8 0))
         (icmp IntPredicate.eq e_1 (const? 8 42)))
       (icmp IntPredicate.ne (LLVM.and e_2 (shl (const? 8 1) e { «nsw» := false, «nuw» := true })) (const? 8 0))
-      (const? 1 0) := by 
+      (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -982,7 +982,7 @@ theorem logical_and_bitwise_and_icmps_comm3_thm (e e_1 e_2 : IntW 8) :
       (const? 1 0) ⊑
     select (icmp IntPredicate.ne (LLVM.and e_2 (shl (const? 8 1) e_1 { «nsw» := false, «nuw» := true })) (const? 8 0))
       (LLVM.and (icmp IntPredicate.ne (LLVM.and e_2 (const? 8 1)) (const? 8 0)) (icmp IntPredicate.eq e (const? 8 42)))
-      (const? 1 0) := by 
+      (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1000,7 +1000,7 @@ theorem logical_and_logical_and_icmps_thm (e e_1 e_2 : IntW 8) :
       (select (icmp IntPredicate.eq e_2 (const? 8 42)) (icmp IntPredicate.ne (LLVM.and e_1 (const? 8 1)) (const? 8 0))
         (const? 1 0))
       (icmp IntPredicate.ne (LLVM.and e_1 (shl (const? 8 1) e { «nsw» := false, «nuw» := true })) (const? 8 0))
-      (const? 1 0) := by 
+      (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1018,7 +1018,7 @@ theorem logical_and_logical_and_icmps_comm1_thm (e e_1 e_2 : IntW 8) :
       (select
         (icmp IntPredicate.ne (LLVM.and e_2 (shl (const? 8 1) e_1 { «nsw» := false, «nuw» := true })) (const? 8 0))
         (icmp IntPredicate.eq e (const? 8 42)) (const? 1 0))
-      (icmp IntPredicate.ne (LLVM.and e_2 (const? 8 1)) (const? 8 0)) (const? 1 0) := by 
+      (icmp IntPredicate.ne (LLVM.and e_2 (const? 8 1)) (const? 8 0)) (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1036,7 +1036,7 @@ theorem logical_and_logical_and_icmps_comm2_thm (e e_1 e_2 : IntW 8) :
       (select (icmp IntPredicate.ne (LLVM.and e_2 (const? 8 1)) (const? 8 0)) (icmp IntPredicate.eq e_1 (const? 8 42))
         (const? 1 0))
       (icmp IntPredicate.ne (LLVM.and e_2 (shl (const? 8 1) e { «nsw» := false, «nuw» := true })) (const? 8 0))
-      (const? 1 0) := by 
+      (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1054,7 +1054,7 @@ theorem logical_and_logical_and_icmps_comm3_thm (e e_1 e_2 : IntW 8) :
       (icmp IntPredicate.eq
         (LLVM.and e_2 (LLVM.or (shl (const? 8 1) e_1 { «nsw» := false, «nuw» := true }) (const? 8 1)))
         (LLVM.or (shl (const? 8 1) e_1 { «nsw» := false, «nuw» := true }) (const? 8 1)))
-      (icmp IntPredicate.eq e (const? 8 42)) (const? 1 0) := by 
+      (icmp IntPredicate.eq e (const? 8 42)) (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1069,7 +1069,7 @@ theorem bitwise_or_bitwise_or_icmps_thm (e e_1 e_2 : IntW 8) :
       (icmp IntPredicate.eq (LLVM.and e_1 (shl (const? 8 1) e)) (const? 8 0)) ⊑
     LLVM.or (icmp IntPredicate.eq e_2 (const? 8 42))
       (icmp IntPredicate.ne (LLVM.and e_1 (LLVM.or (shl (const? 8 1) e { «nsw» := false, «nuw» := true }) (const? 8 1)))
-        (LLVM.or (shl (const? 8 1) e { «nsw» := false, «nuw» := true }) (const? 8 1))) := by 
+        (LLVM.or (shl (const? 8 1) e { «nsw» := false, «nuw» := true }) (const? 8 1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1084,7 +1084,7 @@ theorem bitwise_or_bitwise_or_icmps_comm1_thm (e e_1 e_2 : IntW 8) :
     LLVM.or (icmp IntPredicate.eq e (const? 8 42))
       (icmp IntPredicate.ne
         (LLVM.and e_2 (LLVM.or (shl (const? 8 1) e_1 { «nsw» := false, «nuw» := true }) (const? 8 1)))
-        (LLVM.or (shl (const? 8 1) e_1 { «nsw» := false, «nuw» := true }) (const? 8 1))) := by 
+        (LLVM.or (shl (const? 8 1) e_1 { «nsw» := false, «nuw» := true }) (const? 8 1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1100,7 +1100,7 @@ theorem bitwise_or_bitwise_or_icmps_comm2_thm (e e_1 e_2 : IntW 8) :
     LLVM.or
       (icmp IntPredicate.ne (LLVM.and e_2 (LLVM.or (shl (const? 8 1) e { «nsw» := false, «nuw» := true }) (const? 8 1)))
         (LLVM.or (shl (const? 8 1) e { «nsw» := false, «nuw» := true }) (const? 8 1)))
-      (icmp IntPredicate.eq e_1 (const? 8 42)) := by 
+      (icmp IntPredicate.eq e_1 (const? 8 42)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1116,7 +1116,7 @@ theorem bitwise_or_bitwise_or_icmps_comm3_thm (e e_1 e_2 : IntW 8) :
       (icmp IntPredicate.ne
         (LLVM.and e_2 (LLVM.or (shl (const? 8 1) e_1 { «nsw» := false, «nuw» := true }) (const? 8 1)))
         (LLVM.or (shl (const? 8 1) e_1 { «nsw» := false, «nuw» := true }) (const? 8 1)))
-      (icmp IntPredicate.eq e (const? 8 42)) := by 
+      (icmp IntPredicate.eq e (const? 8 42)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1132,7 +1132,7 @@ theorem bitwise_or_logical_or_icmps_thm (e e_1 e_2 : IntW 8) :
       (icmp IntPredicate.eq (LLVM.and e_1 (shl (const? 8 1) e)) (const? 8 0)) ⊑
     select (icmp IntPredicate.eq e_2 (const? 8 42)) (const? 1 1)
       (icmp IntPredicate.ne (LLVM.and e_1 (LLVM.or (shl (const? 8 1) e { «nsw» := false, «nuw» := true }) (const? 8 1)))
-        (LLVM.or (shl (const? 8 1) e { «nsw» := false, «nuw» := true }) (const? 8 1))) := by 
+        (LLVM.or (shl (const? 8 1) e { «nsw» := false, «nuw» := true }) (const? 8 1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1148,7 +1148,7 @@ theorem bitwise_or_logical_or_icmps_comm1_thm (e e_1 e_2 : IntW 8) :
     select (icmp IntPredicate.eq e (const? 8 42)) (const? 1 1)
       (icmp IntPredicate.ne
         (LLVM.and e_2 (LLVM.or (shl (const? 8 1) e_1 { «nsw» := false, «nuw» := true }) (const? 8 1)))
-        (LLVM.or (shl (const? 8 1) e_1 { «nsw» := false, «nuw» := true }) (const? 8 1))) := by 
+        (LLVM.or (shl (const? 8 1) e_1 { «nsw» := false, «nuw» := true }) (const? 8 1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1165,7 +1165,7 @@ theorem bitwise_or_logical_or_icmps_comm3_thm (e e_1 e_2 : IntW 8) :
       (icmp IntPredicate.ne
         (LLVM.and e_2 (LLVM.or (shl (const? 8 1) e_1 { «nsw» := false, «nuw» := true }) (const? 8 1)))
         (LLVM.or (shl (const? 8 1) e_1 { «nsw» := false, «nuw» := true }) (const? 8 1)))
-      (const? 1 1) (icmp IntPredicate.eq e (const? 8 42)) := by 
+      (const? 1 1) (icmp IntPredicate.eq e (const? 8 42)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1181,7 +1181,7 @@ theorem logical_or_bitwise_or_icmps_thm (e e_1 e_2 : IntW 8) :
     select
       (LLVM.or (icmp IntPredicate.eq e_2 (const? 8 42)) (icmp IntPredicate.eq (LLVM.and e_1 (const? 8 1)) (const? 8 0)))
       (const? 1 1)
-      (icmp IntPredicate.eq (LLVM.and e_1 (shl (const? 8 1) e { «nsw» := false, «nuw» := true })) (const? 8 0)) := by 
+      (icmp IntPredicate.eq (LLVM.and e_1 (shl (const? 8 1) e { «nsw» := false, «nuw» := true })) (const? 8 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1196,7 +1196,7 @@ theorem logical_or_bitwise_or_icmps_comm1_thm (e e_1 e_2 : IntW 8) :
     select (icmp IntPredicate.eq (LLVM.and e_2 (shl (const? 8 1) e_1 { «nsw» := false, «nuw» := true })) (const? 8 0))
       (const? 1 1)
       (LLVM.or (icmp IntPredicate.eq e (const? 8 42))
-        (icmp IntPredicate.eq (LLVM.and e_2 (const? 8 1)) (const? 8 0))) := by 
+        (icmp IntPredicate.eq (LLVM.and e_2 (const? 8 1)) (const? 8 0))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1212,7 +1212,7 @@ theorem logical_or_bitwise_or_icmps_comm2_thm (e e_1 e_2 : IntW 8) :
     select
       (LLVM.or (icmp IntPredicate.eq (LLVM.and e_2 (const? 8 1)) (const? 8 0)) (icmp IntPredicate.eq e_1 (const? 8 42)))
       (const? 1 1)
-      (icmp IntPredicate.eq (LLVM.and e_2 (shl (const? 8 1) e { «nsw» := false, «nuw» := true })) (const? 8 0)) := by 
+      (icmp IntPredicate.eq (LLVM.and e_2 (shl (const? 8 1) e { «nsw» := false, «nuw» := true })) (const? 8 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1227,7 +1227,7 @@ theorem logical_or_bitwise_or_icmps_comm3_thm (e e_1 e_2 : IntW 8) :
     select (icmp IntPredicate.eq (LLVM.and e_2 (shl (const? 8 1) e_1 { «nsw» := false, «nuw» := true })) (const? 8 0))
       (const? 1 1)
       (LLVM.or (icmp IntPredicate.eq (LLVM.and e_2 (const? 8 1)) (const? 8 0))
-        (icmp IntPredicate.eq e (const? 8 42))) := by 
+        (icmp IntPredicate.eq e (const? 8 42))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1245,7 +1245,7 @@ theorem logical_or_logical_or_icmps_thm (e e_1 e_2 : IntW 8) :
       (select (icmp IntPredicate.eq e_2 (const? 8 42)) (const? 1 1)
         (icmp IntPredicate.eq (LLVM.and e_1 (const? 8 1)) (const? 8 0)))
       (const? 1 1)
-      (icmp IntPredicate.eq (LLVM.and e_1 (shl (const? 8 1) e { «nsw» := false, «nuw» := true })) (const? 8 0)) := by 
+      (icmp IntPredicate.eq (LLVM.and e_1 (shl (const? 8 1) e { «nsw» := false, «nuw» := true })) (const? 8 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1262,7 +1262,7 @@ theorem logical_or_logical_or_icmps_comm1_thm (e e_1 e_2 : IntW 8) :
       (select
         (icmp IntPredicate.eq (LLVM.and e_2 (shl (const? 8 1) e_1 { «nsw» := false, «nuw» := true })) (const? 8 0))
         (const? 1 1) (icmp IntPredicate.eq e (const? 8 42)))
-      (const? 1 1) (icmp IntPredicate.eq (LLVM.and e_2 (const? 8 1)) (const? 8 0)) := by 
+      (const? 1 1) (icmp IntPredicate.eq (LLVM.and e_2 (const? 8 1)) (const? 8 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1280,7 +1280,7 @@ theorem logical_or_logical_or_icmps_comm2_thm (e e_1 e_2 : IntW 8) :
       (select (icmp IntPredicate.eq (LLVM.and e_2 (const? 8 1)) (const? 8 0)) (const? 1 1)
         (icmp IntPredicate.eq e_1 (const? 8 42)))
       (const? 1 1)
-      (icmp IntPredicate.eq (LLVM.and e_2 (shl (const? 8 1) e { «nsw» := false, «nuw» := true })) (const? 8 0)) := by 
+      (icmp IntPredicate.eq (LLVM.and e_2 (shl (const? 8 1) e { «nsw» := false, «nuw» := true })) (const? 8 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1297,7 +1297,7 @@ theorem logical_or_logical_or_icmps_comm3_thm (e e_1 e_2 : IntW 8) :
       (icmp IntPredicate.ne
         (LLVM.and e_2 (LLVM.or (shl (const? 8 1) e_1 { «nsw» := false, «nuw» := true }) (const? 8 1)))
         (LLVM.or (shl (const? 8 1) e_1 { «nsw» := false, «nuw» := true }) (const? 8 1)))
-      (const? 1 1) (icmp IntPredicate.eq e (const? 8 42)) := by 
+      (const? 1 1) (icmp IntPredicate.eq e (const? 8 42)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1309,7 +1309,7 @@ theorem logical_or_logical_or_icmps_comm3_thm (e e_1 e_2 : IntW 8) :
 theorem bitwise_and_logical_and_masked_icmp_asymmetric_thm (e : IntW 1) (e_1 : IntW 32) :
   LLVM.and (select (icmp IntPredicate.ne (LLVM.and e_1 (const? 32 255)) (const? 32 0)) e (const? 1 0))
       (icmp IntPredicate.eq (LLVM.and e_1 (const? 32 11)) (const? 32 11)) ⊑
-    select (icmp IntPredicate.eq (LLVM.and e_1 (const? 32 11)) (const? 32 11)) e (const? 1 0) := by 
+    select (icmp IntPredicate.eq (LLVM.and e_1 (const? 32 11)) (const? 32 11)) e (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1321,7 +1321,7 @@ theorem bitwise_and_logical_and_masked_icmp_asymmetric_thm (e : IntW 1) (e_1 : I
 theorem bitwise_and_logical_and_masked_icmp_allzeros_thm (e : IntW 1) (e_1 : IntW 32) :
   LLVM.and (select (icmp IntPredicate.eq (LLVM.and e_1 (const? 32 8)) (const? 32 0)) e (const? 1 0))
       (icmp IntPredicate.eq (LLVM.and e_1 (const? 32 7)) (const? 32 0)) ⊑
-    select (icmp IntPredicate.eq (LLVM.and e_1 (const? 32 15)) (const? 32 0)) e (const? 1 0) := by 
+    select (icmp IntPredicate.eq (LLVM.and e_1 (const? 32 15)) (const? 32 0)) e (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1333,7 +1333,7 @@ theorem bitwise_and_logical_and_masked_icmp_allzeros_thm (e : IntW 1) (e_1 : Int
 theorem bitwise_and_logical_and_masked_icmp_allzeros_poison1_thm (e : IntW 1) (e_1 e_2 : IntW 32) :
   LLVM.and (select (icmp IntPredicate.eq (LLVM.and e_2 e_1) (const? 32 0)) e (const? 1 0))
       (icmp IntPredicate.eq (LLVM.and e_2 (const? 32 7)) (const? 32 0)) ⊑
-    select (icmp IntPredicate.eq (LLVM.and e_2 (LLVM.or e_1 (const? 32 7))) (const? 32 0)) e (const? 1 0) := by 
+    select (icmp IntPredicate.eq (LLVM.and e_2 (LLVM.or e_1 (const? 32 7))) (const? 32 0)) e (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1345,7 +1345,7 @@ theorem bitwise_and_logical_and_masked_icmp_allzeros_poison1_thm (e : IntW 1) (e
 theorem bitwise_and_logical_and_masked_icmp_allones_thm (e : IntW 1) (e_1 : IntW 32) :
   LLVM.and (select (icmp IntPredicate.eq (LLVM.and e_1 (const? 32 8)) (const? 32 8)) e (const? 1 0))
       (icmp IntPredicate.eq (LLVM.and e_1 (const? 32 7)) (const? 32 7)) ⊑
-    select (icmp IntPredicate.eq (LLVM.and e_1 (const? 32 15)) (const? 32 15)) e (const? 1 0) := by 
+    select (icmp IntPredicate.eq (LLVM.and e_1 (const? 32 15)) (const? 32 15)) e (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1358,7 +1358,7 @@ theorem bitwise_and_logical_and_masked_icmp_allones_poison1_thm (e : IntW 1) (e_
   LLVM.and (select (icmp IntPredicate.eq (LLVM.and e_2 e_1) e_1) e (const? 1 0))
       (icmp IntPredicate.eq (LLVM.and e_2 (const? 32 7)) (const? 32 7)) ⊑
     select (icmp IntPredicate.eq (LLVM.and e_2 (LLVM.or e_1 (const? 32 7))) (LLVM.or e_1 (const? 32 7))) e
-      (const? 1 0) := by 
+      (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1371,7 +1371,7 @@ theorem bitwise_and_logical_and_masked_icmp_allones_poison2_thm (e : IntW 32) (e
   LLVM.and (select (icmp IntPredicate.eq (LLVM.and e_2 (const? 32 8)) (const? 32 8)) e_1 (const? 1 0))
       (icmp IntPredicate.eq (LLVM.and e_2 e) e) ⊑
     LLVM.and (select (icmp IntPredicate.ne (LLVM.and e_2 (const? 32 8)) (const? 32 0)) e_1 (const? 1 0))
-      (icmp IntPredicate.eq (LLVM.and e_2 e) e) := by 
+      (icmp IntPredicate.eq (LLVM.and e_2 e) e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1383,7 +1383,7 @@ theorem bitwise_and_logical_and_masked_icmp_allones_poison2_thm (e : IntW 32) (e
 theorem samesign_thm (e e_1 : IntW 32) :
   LLVM.or (icmp IntPredicate.slt (LLVM.and e_1 e) (const? 32 0))
       (icmp IntPredicate.sgt (LLVM.or e_1 e) (const? 32 (-1))) ⊑
-    icmp IntPredicate.sgt (LLVM.xor e_1 e) (const? 32 (-1)) := by 
+    icmp IntPredicate.sgt (LLVM.xor e_1 e) (const? 32 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1394,7 +1394,7 @@ theorem samesign_thm (e e_1 : IntW 32) :
 
 theorem samesign_different_sign_bittest2_thm (e e_1 : IntW 32) :
   LLVM.or (icmp IntPredicate.slt (LLVM.and e_1 e) (const? 32 0)) (icmp IntPredicate.sge (LLVM.or e_1 e) (const? 32 0)) ⊑
-    icmp IntPredicate.sgt (LLVM.xor e_1 e) (const? 32 (-1)) := by 
+    icmp IntPredicate.sgt (LLVM.xor e_1 e) (const? 32 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1406,7 +1406,7 @@ theorem samesign_different_sign_bittest2_thm (e e_1 : IntW 32) :
 theorem samesign_commute1_thm (e e_1 : IntW 32) :
   LLVM.or (icmp IntPredicate.sgt (LLVM.or e_1 e) (const? 32 (-1)))
       (icmp IntPredicate.slt (LLVM.and e_1 e) (const? 32 0)) ⊑
-    icmp IntPredicate.sgt (LLVM.xor e_1 e) (const? 32 (-1)) := by 
+    icmp IntPredicate.sgt (LLVM.xor e_1 e) (const? 32 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1418,7 +1418,7 @@ theorem samesign_commute1_thm (e e_1 : IntW 32) :
 theorem samesign_commute2_thm (e e_1 : IntW 32) :
   LLVM.or (icmp IntPredicate.slt (LLVM.and e_1 e) (const? 32 0))
       (icmp IntPredicate.sgt (LLVM.or e e_1) (const? 32 (-1))) ⊑
-    icmp IntPredicate.sgt (LLVM.xor e_1 e) (const? 32 (-1)) := by 
+    icmp IntPredicate.sgt (LLVM.xor e_1 e) (const? 32 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1430,7 +1430,7 @@ theorem samesign_commute2_thm (e e_1 : IntW 32) :
 theorem samesign_commute3_thm (e e_1 : IntW 32) :
   LLVM.or (icmp IntPredicate.sgt (LLVM.or e_1 e) (const? 32 (-1)))
       (icmp IntPredicate.slt (LLVM.and e e_1) (const? 32 0)) ⊑
-    icmp IntPredicate.sgt (LLVM.xor e_1 e) (const? 32 (-1)) := by 
+    icmp IntPredicate.sgt (LLVM.xor e_1 e) (const? 32 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1442,7 +1442,7 @@ theorem samesign_commute3_thm (e e_1 : IntW 32) :
 theorem samesign_inverted_thm (e e_1 : IntW 32) :
   LLVM.and (icmp IntPredicate.sgt (LLVM.and e_1 e) (const? 32 (-1)))
       (icmp IntPredicate.slt (LLVM.or e_1 e) (const? 32 0)) ⊑
-    icmp IntPredicate.slt (LLVM.xor e_1 e) (const? 32 0) := by 
+    icmp IntPredicate.slt (LLVM.xor e_1 e) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1454,7 +1454,7 @@ theorem samesign_inverted_thm (e e_1 : IntW 32) :
 theorem samesign_inverted_different_sign_bittest1_thm (e e_1 : IntW 32) :
   LLVM.and (icmp IntPredicate.sge (LLVM.and e_1 e) (const? 32 0))
       (icmp IntPredicate.slt (LLVM.or e_1 e) (const? 32 0)) ⊑
-    icmp IntPredicate.slt (LLVM.xor e_1 e) (const? 32 0) := by 
+    icmp IntPredicate.slt (LLVM.xor e_1 e) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1466,7 +1466,7 @@ theorem samesign_inverted_different_sign_bittest1_thm (e e_1 : IntW 32) :
 theorem samesign_inverted_different_sign_bittest2_thm (e e_1 : IntW 32) :
   LLVM.and (icmp IntPredicate.sgt (LLVM.and e_1 e) (const? 32 (-1)))
       (icmp IntPredicate.sle (LLVM.or e_1 e) (const? 32 (-1))) ⊑
-    icmp IntPredicate.slt (LLVM.xor e_1 e) (const? 32 0) := by 
+    icmp IntPredicate.slt (LLVM.xor e_1 e) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1478,7 +1478,7 @@ theorem samesign_inverted_different_sign_bittest2_thm (e e_1 : IntW 32) :
 theorem samesign_inverted_commute1_thm (e e_1 : IntW 32) :
   LLVM.and (icmp IntPredicate.slt (LLVM.or e_1 e) (const? 32 0))
       (icmp IntPredicate.sgt (LLVM.and e_1 e) (const? 32 (-1))) ⊑
-    icmp IntPredicate.slt (LLVM.xor e_1 e) (const? 32 0) := by 
+    icmp IntPredicate.slt (LLVM.xor e_1 e) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1490,7 +1490,7 @@ theorem samesign_inverted_commute1_thm (e e_1 : IntW 32) :
 theorem samesign_inverted_commute2_thm (e e_1 : IntW 32) :
   LLVM.and (icmp IntPredicate.sgt (LLVM.and e_1 e) (const? 32 (-1)))
       (icmp IntPredicate.slt (LLVM.or e e_1) (const? 32 0)) ⊑
-    icmp IntPredicate.slt (LLVM.xor e_1 e) (const? 32 0) := by 
+    icmp IntPredicate.slt (LLVM.xor e_1 e) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1502,7 +1502,7 @@ theorem samesign_inverted_commute2_thm (e e_1 : IntW 32) :
 theorem samesign_inverted_commute3_thm (e e_1 : IntW 32) :
   LLVM.and (icmp IntPredicate.slt (LLVM.or e_1 e) (const? 32 0))
       (icmp IntPredicate.sgt (LLVM.and e e_1) (const? 32 (-1))) ⊑
-    icmp IntPredicate.slt (LLVM.xor e_1 e) (const? 32 0) := by 
+    icmp IntPredicate.slt (LLVM.xor e_1 e) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1513,7 +1513,7 @@ theorem samesign_inverted_commute3_thm (e e_1 : IntW 32) :
 
 theorem icmp_slt_0_or_icmp_sgt_0_i32_thm (e : IntW 32) :
   LLVM.or (zext 32 (icmp IntPredicate.slt e (const? 32 0))) (zext 32 (icmp IntPredicate.sgt e (const? 32 0))) ⊑
-    zext 32 (icmp IntPredicate.ne e (const? 32 0)) := by 
+    zext 32 (icmp IntPredicate.ne e (const? 32 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1524,7 +1524,7 @@ theorem icmp_slt_0_or_icmp_sgt_0_i32_thm (e : IntW 32) :
 
 theorem icmp_slt_0_or_icmp_sgt_0_i64_thm (e : IntW 64) :
   LLVM.or (zext 64 (icmp IntPredicate.slt e (const? 64 0))) (zext 64 (icmp IntPredicate.sgt e (const? 64 0))) ⊑
-    zext 64 (icmp IntPredicate.ne e (const? 64 0)) := by 
+    zext 64 (icmp IntPredicate.ne e (const? 64 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1534,7 +1534,7 @@ theorem icmp_slt_0_or_icmp_sgt_0_i64_thm (e : IntW 64) :
 
 
 theorem icmp_slt_0_or_icmp_sgt_0_i64_fail0_thm (e : IntW 64) :
-  LLVM.or (lshr e (const? 64 63)) (zext 64 (icmp IntPredicate.slt e (const? 64 0))) ⊑ lshr e (const? 64 63) := by 
+  LLVM.or (lshr e (const? 64 63)) (zext 64 (icmp IntPredicate.slt e (const? 64 0))) ⊑ lshr e (const? 64 63) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1545,7 +1545,7 @@ theorem icmp_slt_0_or_icmp_sgt_0_i64_fail0_thm (e : IntW 64) :
 
 theorem icmp_slt_0_or_icmp_sgt_0_i64_fail3_thm (e : IntW 64) :
   LLVM.or (ashr e (const? 64 62)) (zext 64 (icmp IntPredicate.slt e (const? 64 0))) ⊑
-    LLVM.or (ashr e (const? 64 62)) (lshr e (const? 64 63)) := by 
+    LLVM.or (ashr e (const? 64 62)) (lshr e (const? 64 63)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1555,7 +1555,7 @@ theorem icmp_slt_0_or_icmp_sgt_0_i64_fail3_thm (e : IntW 64) :
 
 
 theorem icmp_slt_0_and_icmp_sge_neg1_i32_thm (e : IntW 32) :
-  LLVM.and (lshr e (const? 32 31)) (zext 32 (icmp IntPredicate.sgt e (const? 32 (-1)))) ⊑ const? 32 0 := by 
+  LLVM.and (lshr e (const? 32 31)) (zext 32 (icmp IntPredicate.sgt e (const? 32 (-1)))) ⊑ const? 32 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1565,7 +1565,7 @@ theorem icmp_slt_0_and_icmp_sge_neg1_i32_thm (e : IntW 32) :
 
 
 theorem icmp_slt_0_or_icmp_sge_neg1_i32_thm (e : IntW 32) :
-  LLVM.or (lshr e (const? 32 31)) (zext 32 (icmp IntPredicate.sge e (const? 32 (-1)))) ⊑ const? 32 1 := by 
+  LLVM.or (lshr e (const? 32 31)) (zext 32 (icmp IntPredicate.sge e (const? 32 (-1)))) ⊑ const? 32 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1576,7 +1576,7 @@ theorem icmp_slt_0_or_icmp_sge_neg1_i32_thm (e : IntW 32) :
 
 theorem icmp_slt_0_or_icmp_sge_100_i32_thm (e : IntW 32) :
   LLVM.or (lshr e (const? 32 31)) (zext 32 (icmp IntPredicate.sge e (const? 32 100))) ⊑
-    zext 32 (icmp IntPredicate.ugt e (const? 32 99)) := by 
+    zext 32 (icmp IntPredicate.ugt e (const? 32 99)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1587,7 +1587,7 @@ theorem icmp_slt_0_or_icmp_sge_100_i32_thm (e : IntW 32) :
 
 theorem icmp_slt_0_and_icmp_sge_neg1_i64_thm (e : IntW 64) :
   LLVM.and (lshr e (const? 64 63)) (zext 64 (icmp IntPredicate.sge e (const? 64 (-1)))) ⊑
-    zext 64 (icmp IntPredicate.eq e (const? 64 (-1))) := by 
+    zext 64 (icmp IntPredicate.eq e (const? 64 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1598,7 +1598,7 @@ theorem icmp_slt_0_and_icmp_sge_neg1_i64_thm (e : IntW 64) :
 
 theorem icmp_slt_0_and_icmp_sge_neg2_i64_thm (e : IntW 64) :
   LLVM.and (lshr e (const? 64 63)) (zext 64 (icmp IntPredicate.sge e (const? 64 (-2)))) ⊑
-    zext 64 (icmp IntPredicate.ugt e (const? 64 (-3))) := by 
+    zext 64 (icmp IntPredicate.ugt e (const? 64 (-3))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1609,7 +1609,7 @@ theorem icmp_slt_0_and_icmp_sge_neg2_i64_thm (e : IntW 64) :
 
 theorem ashr_and_icmp_sge_neg1_i64_thm (e : IntW 64) :
   LLVM.and (ashr e (const? 64 63)) (zext 64 (icmp IntPredicate.sge e (const? 64 (-1)))) ⊑
-    zext 64 (icmp IntPredicate.eq e (const? 64 (-1))) := by 
+    zext 64 (icmp IntPredicate.eq e (const? 64 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1619,7 +1619,7 @@ theorem ashr_and_icmp_sge_neg1_i64_thm (e : IntW 64) :
 
 
 theorem icmp_slt_0_and_icmp_sgt_neg1_i64_thm (e : IntW 64) :
-  LLVM.and (lshr e (const? 64 63)) (zext 64 (icmp IntPredicate.sgt e (const? 64 (-1)))) ⊑ const? 64 0 := by 
+  LLVM.and (lshr e (const? 64 63)) (zext 64 (icmp IntPredicate.sgt e (const? 64 (-1)))) ⊑ const? 64 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1631,7 +1631,7 @@ theorem icmp_slt_0_and_icmp_sgt_neg1_i64_thm (e : IntW 64) :
 theorem icmp_slt_0_and_icmp_sge_neg1_i64_fail_thm (e : IntW 64) :
   LLVM.and (lshr e (const? 64 62)) (zext 64 (icmp IntPredicate.sge e (const? 64 (-1)))) ⊑
     select (icmp IntPredicate.sgt e (const? 64 (-2))) (LLVM.and (lshr e (const? 64 62)) (const? 64 1))
-      (const? 64 0) := by 
+      (const? 64 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1642,7 +1642,7 @@ theorem icmp_slt_0_and_icmp_sge_neg1_i64_fail_thm (e : IntW 64) :
 
 theorem icmp_x_slt_0_xor_icmp_y_sgt_neg1_i32_thm (e e_1 : IntW 32) :
   LLVM.xor (lshr e_1 (const? 32 31)) (zext 32 (icmp IntPredicate.sgt e (const? 32 (-1)))) ⊑
-    zext 32 (icmp IntPredicate.sgt (LLVM.xor e_1 e) (const? 32 (-1))) := by 
+    zext 32 (icmp IntPredicate.sgt (LLVM.xor e_1 e) (const? 32 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1653,7 +1653,7 @@ theorem icmp_x_slt_0_xor_icmp_y_sgt_neg1_i32_thm (e e_1 : IntW 32) :
 
 theorem icmp_slt_0_xor_icmp_sgt_neg2_i32_thm (e : IntW 32) :
   LLVM.xor (lshr e (const? 32 31)) (zext 32 (icmp IntPredicate.sgt e (const? 32 (-2)))) ⊑
-    zext 32 (icmp IntPredicate.ne e (const? 32 (-1))) := by 
+    zext 32 (icmp IntPredicate.ne e (const? 32 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1664,7 +1664,7 @@ theorem icmp_slt_0_xor_icmp_sgt_neg2_i32_thm (e : IntW 32) :
 
 theorem icmp_slt_0_or_icmp_eq_100_i32_fail_thm (e : IntW 32) :
   LLVM.or (lshr e (const? 32 31)) (zext 32 (icmp IntPredicate.eq e (const? 32 100))) ⊑
-    zext 32 (LLVM.or (icmp IntPredicate.slt e (const? 32 0)) (icmp IntPredicate.eq e (const? 32 100))) := by 
+    zext 32 (LLVM.or (icmp IntPredicate.slt e (const? 32 0)) (icmp IntPredicate.eq e (const? 32 100))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1675,7 +1675,7 @@ theorem icmp_slt_0_or_icmp_eq_100_i32_fail_thm (e : IntW 32) :
 
 theorem icmp_slt_0_and_icmp_ne_neg2_i32_fail_thm (e : IntW 32) :
   LLVM.and (lshr e (const? 32 31)) (zext 32 (icmp IntPredicate.ne e (const? 32 (-2)))) ⊑
-    zext 32 (LLVM.and (icmp IntPredicate.slt e (const? 32 0)) (icmp IntPredicate.ne e (const? 32 (-2)))) := by 
+    zext 32 (LLVM.and (icmp IntPredicate.slt e (const? 32 0)) (icmp IntPredicate.ne e (const? 32 (-2)))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1686,7 +1686,7 @@ theorem icmp_slt_0_and_icmp_ne_neg2_i32_fail_thm (e : IntW 32) :
 
 theorem icmp_x_slt_0_and_icmp_y_ne_neg2_i32_fail_thm (e e_1 : IntW 32) :
   LLVM.and (lshr e_1 (const? 32 31)) (zext 32 (icmp IntPredicate.ne e (const? 32 (-2)))) ⊑
-    zext 32 (LLVM.and (icmp IntPredicate.slt e_1 (const? 32 0)) (icmp IntPredicate.ne e (const? 32 (-2)))) := by 
+    zext 32 (LLVM.and (icmp IntPredicate.slt e_1 (const? 32 0)) (icmp IntPredicate.ne e (const? 32 (-2)))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1697,7 +1697,7 @@ theorem icmp_x_slt_0_and_icmp_y_ne_neg2_i32_fail_thm (e e_1 : IntW 32) :
 
 theorem icmp_x_slt_0_and_icmp_y_sgt_neg1_i32_fail_thm (e e_1 : IntW 32) :
   LLVM.and (lshr e_1 (const? 32 31)) (zext 32 (icmp IntPredicate.sgt e (const? 32 (-1)))) ⊑
-    zext 32 (LLVM.and (icmp IntPredicate.slt e_1 (const? 32 0)) (icmp IntPredicate.sgt e (const? 32 (-1)))) := by 
+    zext 32 (LLVM.and (icmp IntPredicate.slt e_1 (const? 32 0)) (icmp IntPredicate.sgt e (const? 32 (-1)))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1708,7 +1708,7 @@ theorem icmp_x_slt_0_and_icmp_y_sgt_neg1_i32_fail_thm (e e_1 : IntW 32) :
 
 theorem icmp_slt_0_xor_icmp_sge_neg2_i32_fail_thm (e : IntW 32) :
   LLVM.xor (lshr e (const? 32 31)) (zext 32 (icmp IntPredicate.sge e (const? 32 (-2)))) ⊑
-    zext 32 (icmp IntPredicate.ult e (const? 32 (-2))) := by 
+    zext 32 (icmp IntPredicate.ult e (const? 32 (-2))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1721,7 +1721,7 @@ theorem icmp_slt_0_or_icmp_add_1_sge_100_i32_fail_thm (e : IntW 32) :
   LLVM.or (lshr e (const? 32 31)) (zext 32 (icmp IntPredicate.sge (add e (const? 32 1)) (const? 32 100))) ⊑
     zext 32
       (LLVM.or (icmp IntPredicate.slt e (const? 32 0))
-        (icmp IntPredicate.sgt (add e (const? 32 1)) (const? 32 99))) := by 
+        (icmp IntPredicate.sgt (add e (const? 32 1)) (const? 32 99))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1733,7 +1733,7 @@ theorem icmp_slt_0_or_icmp_add_1_sge_100_i32_fail_thm (e : IntW 32) :
 theorem logical_and_icmps1_thm (e : IntW 32) (e_1 : IntW 1) :
   select (select e_1 (icmp IntPredicate.sgt e (const? 32 (-1))) (const? 1 0))
       (icmp IntPredicate.slt e (const? 32 10086)) (const? 1 0) ⊑
-    select e_1 (icmp IntPredicate.ult e (const? 32 10086)) (const? 1 0) := by 
+    select e_1 (icmp IntPredicate.ult e (const? 32 10086)) (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1745,7 +1745,7 @@ theorem logical_and_icmps1_thm (e : IntW 32) (e_1 : IntW 1) :
 theorem logical_and_icmps2_thm (e : IntW 32) (e_1 : IntW 1) :
   select (select e_1 (icmp IntPredicate.slt e (const? 32 (-1))) (const? 1 0)) (icmp IntPredicate.eq e (const? 32 10086))
       (const? 1 0) ⊑
-    const? 1 0 := by 
+    const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1756,7 +1756,7 @@ theorem logical_and_icmps2_thm (e : IntW 32) (e_1 : IntW 1) :
 
 theorem icmp_eq_or_z_or_pow2orz_thm (e e_1 : IntW 8) :
   LLVM.or (icmp IntPredicate.eq e_1 (LLVM.and (sub (const? 8 0) e) e)) (icmp IntPredicate.eq e_1 (const? 8 0)) ⊑
-    icmp IntPredicate.eq (LLVM.and e_1 (LLVM.and e (sub (const? 8 0) e))) e_1 := by 
+    icmp IntPredicate.eq (LLVM.and e_1 (LLVM.and e (sub (const? 8 0) e))) e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1768,7 +1768,7 @@ theorem icmp_eq_or_z_or_pow2orz_thm (e e_1 : IntW 8) :
 theorem icmp_eq_or_z_or_pow2orz_logical_thm (e e_1 : IntW 8) :
   select (icmp IntPredicate.eq e_1 (LLVM.and (sub (const? 8 0) e) e)) (const? 1 1)
       (icmp IntPredicate.eq e_1 (const? 8 0)) ⊑
-    icmp IntPredicate.eq (LLVM.and e_1 (LLVM.and e (sub (const? 8 0) e))) e_1 := by 
+    icmp IntPredicate.eq (LLVM.and e_1 (LLVM.and e (sub (const? 8 0) e))) e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1781,7 +1781,7 @@ theorem icmp_eq_or_z_or_pow2orz_fail_logic_or_thm (e e_1 : IntW 8) :
   select (icmp IntPredicate.eq e_1 (const? 8 0)) (const? 1 1)
       (icmp IntPredicate.eq e_1 (LLVM.and (sub (const? 8 0) e) e)) ⊑
     select (icmp IntPredicate.eq e_1 (const? 8 0)) (const? 1 1)
-      (icmp IntPredicate.eq e_1 (LLVM.and e (sub (const? 8 0) e))) := by 
+      (icmp IntPredicate.eq e_1 (LLVM.and e (sub (const? 8 0) e))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1793,7 +1793,7 @@ theorem icmp_eq_or_z_or_pow2orz_fail_logic_or_thm (e e_1 : IntW 8) :
 theorem icmp_ne_and_z_and_onefail_thm (e : IntW 8) :
   LLVM.and (LLVM.and (icmp IntPredicate.ne e (const? 8 0)) (icmp IntPredicate.ne e (const? 8 1)))
       (icmp IntPredicate.ne e (const? 8 2)) ⊑
-    icmp IntPredicate.ugt e (const? 8 2) := by 
+    icmp IntPredicate.ugt e (const? 8 2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1805,7 +1805,7 @@ theorem icmp_ne_and_z_and_onefail_thm (e : IntW 8) :
 theorem icmp_eq_or_z_or_pow2orz_fail_nonzero_const_thm (e e_1 : IntW 8) :
   LLVM.or (icmp IntPredicate.eq e_1 (const? 8 1)) (icmp IntPredicate.eq e_1 (LLVM.and (sub (const? 8 0) e) e)) ⊑
     LLVM.or (icmp IntPredicate.eq e_1 (const? 8 1))
-      (icmp IntPredicate.eq e_1 (LLVM.and e (sub (const? 8 0) e))) := by 
+      (icmp IntPredicate.eq e_1 (LLVM.and e (sub (const? 8 0) e))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1817,7 +1817,7 @@ theorem icmp_eq_or_z_or_pow2orz_fail_nonzero_const_thm (e e_1 : IntW 8) :
 theorem icmp_eq_or_z_or_pow2orz_fail_bad_pred2_thm (e e_1 : IntW 8) :
   LLVM.or (icmp IntPredicate.sle e_1 (const? 8 0)) (icmp IntPredicate.sle e_1 (LLVM.and (sub (const? 8 0) e) e)) ⊑
     LLVM.or (icmp IntPredicate.slt e_1 (const? 8 1))
-      (icmp IntPredicate.sle e_1 (LLVM.and e (sub (const? 8 0) e))) := by 
+      (icmp IntPredicate.sle e_1 (LLVM.and e (sub (const? 8 0) e))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1828,7 +1828,7 @@ theorem icmp_eq_or_z_or_pow2orz_fail_bad_pred2_thm (e e_1 : IntW 8) :
 
 theorem and_slt_to_mask_thm (e : IntW 8) :
   LLVM.and (icmp IntPredicate.slt e (const? 8 (-124))) (icmp IntPredicate.eq (LLVM.and e (const? 8 2)) (const? 8 0)) ⊑
-    icmp IntPredicate.slt e (const? 8 (-126)) := by 
+    icmp IntPredicate.slt e (const? 8 (-126)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1839,7 +1839,7 @@ theorem and_slt_to_mask_thm (e : IntW 8) :
 
 theorem and_sgt_to_mask_thm (e : IntW 8) :
   LLVM.and (icmp IntPredicate.sgt e (const? 8 123)) (icmp IntPredicate.eq (LLVM.and e (const? 8 2)) (const? 8 0)) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 8 (-2))) (const? 8 124) := by 
+    icmp IntPredicate.eq (LLVM.and e (const? 8 (-2))) (const? 8 124) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1850,7 +1850,7 @@ theorem and_sgt_to_mask_thm (e : IntW 8) :
 
 theorem and_ugt_to_mask_thm (e : IntW 8) :
   LLVM.and (icmp IntPredicate.ugt e (const? 8 (-5))) (icmp IntPredicate.eq (LLVM.and e (const? 8 2)) (const? 8 0)) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 8 (-2))) (const? 8 (-4)) := by 
+    icmp IntPredicate.eq (LLVM.and e (const? 8 (-2))) (const? 8 (-4)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gandhorhimpliedhcondhnot_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gandhorhimpliedhcondhnot_proof.lean
@@ -11,7 +11,7 @@ section gandhorhimpliedhcondhnot_proof
 theorem test_imply_not2_thm (e : IntW 1) (e_1 : IntW 32) :
   LLVM.or (select (icmp IntPredicate.eq e_1 (const? 32 0)) e (const? 1 0))
       (LLVM.xor (icmp IntPredicate.eq e_1 (const? 32 0)) (const? 1 1)) ⊑
-    select (icmp IntPredicate.ne e_1 (const? 32 0)) (const? 1 1) e := by 
+    select (icmp IntPredicate.ne e_1 (const? 32 0)) (const? 1 1) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gandhorhnot_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gandhorhnot_proof.lean
@@ -9,7 +9,7 @@ set_option linter.unreachableTactic false
 
 section gandhorhnot_proof
 theorem and_to_xor1_thm (e e_1 : IntW 32) :
-  LLVM.and (LLVM.or e_1 e) (LLVM.xor (LLVM.and e_1 e) (const? 32 (-1))) ⊑ LLVM.xor e_1 e := by 
+  LLVM.and (LLVM.or e_1 e) (LLVM.xor (LLVM.and e_1 e) (const? 32 (-1))) ⊑ LLVM.xor e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -19,7 +19,7 @@ theorem and_to_xor1_thm (e e_1 : IntW 32) :
 
 
 theorem and_to_xor2_thm (e e_1 : IntW 32) :
-  LLVM.and (LLVM.xor (LLVM.and e_1 e) (const? 32 (-1))) (LLVM.or e_1 e) ⊑ LLVM.xor e_1 e := by 
+  LLVM.and (LLVM.xor (LLVM.and e_1 e) (const? 32 (-1))) (LLVM.or e_1 e) ⊑ LLVM.xor e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -29,7 +29,7 @@ theorem and_to_xor2_thm (e e_1 : IntW 32) :
 
 
 theorem and_to_xor3_thm (e e_1 : IntW 32) :
-  LLVM.and (LLVM.or e_1 e) (LLVM.xor (LLVM.and e e_1) (const? 32 (-1))) ⊑ LLVM.xor e_1 e := by 
+  LLVM.and (LLVM.or e_1 e) (LLVM.xor (LLVM.and e e_1) (const? 32 (-1))) ⊑ LLVM.xor e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -39,7 +39,7 @@ theorem and_to_xor3_thm (e e_1 : IntW 32) :
 
 
 theorem and_to_xor4_thm (e e_1 : IntW 32) :
-  LLVM.and (LLVM.xor (LLVM.and e_1 e) (const? 32 (-1))) (LLVM.or e e_1) ⊑ LLVM.xor e e_1 := by 
+  LLVM.and (LLVM.xor (LLVM.and e_1 e) (const? 32 (-1))) (LLVM.or e e_1) ⊑ LLVM.xor e e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -50,7 +50,7 @@ theorem and_to_xor4_thm (e e_1 : IntW 32) :
 
 theorem or_to_nxor1_thm (e e_1 : IntW 32) :
   LLVM.or (LLVM.and e_1 e) (LLVM.xor (LLVM.or e_1 e) (const? 32 (-1))) ⊑
-    LLVM.xor (LLVM.xor e_1 e) (const? 32 (-1)) := by 
+    LLVM.xor (LLVM.xor e_1 e) (const? 32 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -61,7 +61,7 @@ theorem or_to_nxor1_thm (e e_1 : IntW 32) :
 
 theorem or_to_nxor2_thm (e e_1 : IntW 32) :
   LLVM.or (LLVM.and e_1 e) (LLVM.xor (LLVM.or e e_1) (const? 32 (-1))) ⊑
-    LLVM.xor (LLVM.xor e_1 e) (const? 32 (-1)) := by 
+    LLVM.xor (LLVM.xor e_1 e) (const? 32 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -72,7 +72,7 @@ theorem or_to_nxor2_thm (e e_1 : IntW 32) :
 
 theorem or_to_nxor3_thm (e e_1 : IntW 32) :
   LLVM.or (LLVM.xor (LLVM.or e_1 e) (const? 32 (-1))) (LLVM.and e_1 e) ⊑
-    LLVM.xor (LLVM.xor e_1 e) (const? 32 (-1)) := by 
+    LLVM.xor (LLVM.xor e_1 e) (const? 32 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -83,7 +83,7 @@ theorem or_to_nxor3_thm (e e_1 : IntW 32) :
 
 theorem or_to_nxor4_thm (e e_1 : IntW 32) :
   LLVM.or (LLVM.xor (LLVM.or e_1 e) (const? 32 (-1))) (LLVM.and e e_1) ⊑
-    LLVM.xor (LLVM.xor e e_1) (const? 32 (-1)) := by 
+    LLVM.xor (LLVM.xor e e_1) (const? 32 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -92,7 +92,7 @@ theorem or_to_nxor4_thm (e e_1 : IntW 32) :
     all_goals sorry
 
 
-theorem xor_to_xor1_thm (e e_1 : IntW 32) : LLVM.xor (LLVM.and e_1 e) (LLVM.or e_1 e) ⊑ LLVM.xor e_1 e := by 
+theorem xor_to_xor1_thm (e e_1 : IntW 32) : LLVM.xor (LLVM.and e_1 e) (LLVM.or e_1 e) ⊑ LLVM.xor e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -101,7 +101,7 @@ theorem xor_to_xor1_thm (e e_1 : IntW 32) : LLVM.xor (LLVM.and e_1 e) (LLVM.or e
     all_goals sorry
 
 
-theorem xor_to_xor2_thm (e e_1 : IntW 32) : LLVM.xor (LLVM.and e_1 e) (LLVM.or e e_1) ⊑ LLVM.xor e_1 e := by 
+theorem xor_to_xor2_thm (e e_1 : IntW 32) : LLVM.xor (LLVM.and e_1 e) (LLVM.or e e_1) ⊑ LLVM.xor e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -110,7 +110,7 @@ theorem xor_to_xor2_thm (e e_1 : IntW 32) : LLVM.xor (LLVM.and e_1 e) (LLVM.or e
     all_goals sorry
 
 
-theorem xor_to_xor3_thm (e e_1 : IntW 32) : LLVM.xor (LLVM.or e_1 e) (LLVM.and e_1 e) ⊑ LLVM.xor e_1 e := by 
+theorem xor_to_xor3_thm (e e_1 : IntW 32) : LLVM.xor (LLVM.or e_1 e) (LLVM.and e_1 e) ⊑ LLVM.xor e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -119,7 +119,7 @@ theorem xor_to_xor3_thm (e e_1 : IntW 32) : LLVM.xor (LLVM.or e_1 e) (LLVM.and e
     all_goals sorry
 
 
-theorem xor_to_xor4_thm (e e_1 : IntW 32) : LLVM.xor (LLVM.or e_1 e) (LLVM.and e e_1) ⊑ LLVM.xor e e_1 := by 
+theorem xor_to_xor4_thm (e e_1 : IntW 32) : LLVM.xor (LLVM.or e_1 e) (LLVM.and e e_1) ⊑ LLVM.xor e e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -130,7 +130,7 @@ theorem xor_to_xor4_thm (e e_1 : IntW 32) : LLVM.xor (LLVM.or e_1 e) (LLVM.and e
 
 theorem PR32830_thm (e e_1 e_2 : IntW 64) :
   LLVM.and (LLVM.or (LLVM.xor e_2 (const? 64 (-1))) e_1) (LLVM.or (LLVM.xor e_1 (const? 64 (-1))) e) ⊑
-    LLVM.and (LLVM.or e_1 (LLVM.xor e_2 (const? 64 (-1)))) (LLVM.or e (LLVM.xor e_1 (const? 64 (-1)))) := by 
+    LLVM.and (LLVM.or e_1 (LLVM.xor e_2 (const? 64 (-1)))) (LLVM.or e (LLVM.xor e_1 (const? 64 (-1)))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -143,7 +143,7 @@ theorem or_to_nxor_multiuse_thm (e e_1 : IntW 32) :
   mul (mul (LLVM.and e_1 e) (LLVM.xor (LLVM.or e_1 e) (const? 32 (-1))))
       (LLVM.or (LLVM.and e_1 e) (LLVM.xor (LLVM.or e_1 e) (const? 32 (-1)))) ⊑
     mul (mul (LLVM.and e_1 e) (LLVM.xor (LLVM.or e_1 e) (const? 32 (-1))))
-      (LLVM.or (LLVM.and e_1 e) (LLVM.xor (LLVM.or e_1 e) (const? 32 (-1))) { «disjoint» := true }) := by 
+      (LLVM.or (LLVM.and e_1 e) (LLVM.xor (LLVM.or e_1 e) (const? 32 (-1))) { «disjoint» := true }) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -153,7 +153,7 @@ theorem or_to_nxor_multiuse_thm (e e_1 : IntW 32) :
 
 
 theorem simplify_or_common_op_commute0_thm (e e_1 e_2 : IntW 4) :
-  LLVM.or (LLVM.xor (LLVM.and (LLVM.and e_2 e_1) e) (const? 4 (-1))) e_2 ⊑ const? 4 (-1) := by 
+  LLVM.or (LLVM.xor (LLVM.and (LLVM.and e_2 e_1) e) (const? 4 (-1))) e_2 ⊑ const? 4 (-1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -163,7 +163,7 @@ theorem simplify_or_common_op_commute0_thm (e e_1 e_2 : IntW 4) :
 
 
 theorem simplify_or_common_op_commute1_thm (e e_1 e_2 : IntW 4) :
-  LLVM.or (LLVM.xor (LLVM.and (LLVM.and e_2 e_1) e) (const? 4 (-1))) e_1 ⊑ const? 4 (-1) := by 
+  LLVM.or (LLVM.xor (LLVM.and (LLVM.and e_2 e_1) e) (const? 4 (-1))) e_1 ⊑ const? 4 (-1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -174,7 +174,7 @@ theorem simplify_or_common_op_commute1_thm (e e_1 e_2 : IntW 4) :
 
 theorem simplify_or_common_op_commute2_thm (e e_1 e_2 e_3 : IntW 4) :
   LLVM.or (LLVM.xor (LLVM.and (LLVM.and (mul e_3 e_3) (LLVM.and e_2 e_1)) e) (const? 4 (-1))) e_2 ⊑
-    const? 4 (-1) := by 
+    const? 4 (-1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -184,7 +184,7 @@ theorem simplify_or_common_op_commute2_thm (e e_1 e_2 e_3 : IntW 4) :
 
 
 theorem simplify_and_common_op_commute1_thm (e e_1 e_2 : IntW 4) :
-  LLVM.and (LLVM.xor (LLVM.or (LLVM.or e_2 e_1) e) (const? 4 (-1))) e_1 ⊑ const? 4 0 := by 
+  LLVM.and (LLVM.xor (LLVM.or (LLVM.or e_2 e_1) e) (const? 4 (-1))) e_1 ⊑ const? 4 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -194,7 +194,7 @@ theorem simplify_and_common_op_commute1_thm (e e_1 e_2 : IntW 4) :
 
 
 theorem simplify_and_common_op_commute2_thm (e e_1 e_2 e_3 : IntW 4) :
-  LLVM.and (LLVM.xor (LLVM.or (LLVM.or (mul e_3 e_3) (LLVM.or e_2 e_1)) e) (const? 4 (-1))) e_2 ⊑ const? 4 0 := by 
+  LLVM.and (LLVM.xor (LLVM.or (LLVM.or (mul e_3 e_3) (LLVM.or e_2 e_1)) e) (const? 4 (-1))) e_2 ⊑ const? 4 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -204,7 +204,7 @@ theorem simplify_and_common_op_commute2_thm (e e_1 e_2 e_3 : IntW 4) :
 
 
 theorem reduce_xor_common_op_commute0_thm (e e_1 e_2 : IntW 4) :
-  LLVM.or (LLVM.xor (LLVM.xor e_2 e_1) e) e_2 ⊑ LLVM.or (LLVM.xor e_1 e) e_2 := by 
+  LLVM.or (LLVM.xor (LLVM.xor e_2 e_1) e) e_2 ⊑ LLVM.or (LLVM.xor e_1 e) e_2 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -214,7 +214,7 @@ theorem reduce_xor_common_op_commute0_thm (e e_1 e_2 : IntW 4) :
 
 
 theorem reduce_xor_common_op_commute1_thm (e e_1 e_2 : IntW 4) :
-  LLVM.or (LLVM.xor (LLVM.xor e_2 e_1) e) e_1 ⊑ LLVM.or (LLVM.xor e_2 e) e_1 := by 
+  LLVM.or (LLVM.xor (LLVM.xor e_2 e_1) e) e_1 ⊑ LLVM.or (LLVM.xor e_2 e) e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -225,7 +225,7 @@ theorem reduce_xor_common_op_commute1_thm (e e_1 e_2 : IntW 4) :
 
 theorem annihilate_xor_common_op_commute2_thm (e e_1 e_2 e_3 : IntW 4) :
   LLVM.xor (LLVM.xor (LLVM.xor (mul e_3 e_3) (LLVM.xor e_2 e_1)) e) e_2 ⊑
-    LLVM.xor (LLVM.xor e_1 (mul e_3 e_3)) e := by 
+    LLVM.xor (LLVM.xor e_1 (mul e_3 e_3)) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gandhxorhmerge_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gandhxorhmerge_proof.lean
@@ -9,7 +9,7 @@ set_option linter.unreachableTactic false
 
 section gandhxorhmerge_proof
 theorem test1_thm (e e_1 e_2 : IntW 32) :
-  LLVM.xor (LLVM.and e_2 e_1) (LLVM.and e_2 e) ⊑ LLVM.and e_2 (LLVM.xor e_1 e) := by 
+  LLVM.xor (LLVM.and e_2 e_1) (LLVM.and e_2 e) ⊑ LLVM.and e_2 (LLVM.xor e_1 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -18,7 +18,7 @@ theorem test1_thm (e e_1 e_2 : IntW 32) :
     all_goals sorry
 
 
-theorem test2_thm (e e_1 : IntW 32) : LLVM.xor (LLVM.and e_1 e) (LLVM.or e_1 e) ⊑ LLVM.xor e_1 e := by 
+theorem test2_thm (e e_1 : IntW 32) : LLVM.xor (LLVM.and e_1 e) (LLVM.or e_1 e) ⊑ LLVM.xor e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -29,7 +29,7 @@ theorem test2_thm (e e_1 : IntW 32) : LLVM.xor (LLVM.and e_1 e) (LLVM.or e_1 e) 
 
 theorem PR38781_thm (e e_1 : IntW 32) :
   LLVM.and (LLVM.xor (lshr e_1 (const? 32 31)) (const? 32 1)) (LLVM.xor (lshr e (const? 32 31)) (const? 32 1)) ⊑
-    zext 32 (icmp IntPredicate.sgt (LLVM.or e_1 e) (const? 32 (-1))) := by 
+    zext 32 (icmp IntPredicate.sgt (LLVM.or e_1 e) (const? 32 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -39,7 +39,7 @@ theorem PR38781_thm (e e_1 : IntW 32) :
 
 
 theorem PR75692_1_thm (e : IntW 32) :
-  LLVM.and (LLVM.xor e (const? 32 4)) (LLVM.xor e (const? 32 (-5))) ⊑ const? 32 0 := by 
+  LLVM.and (LLVM.xor e (const? 32 4)) (LLVM.xor e (const? 32 (-5))) ⊑ const? 32 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gandhxorhor_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gandhxorhor_proof.lean
@@ -10,7 +10,7 @@ set_option linter.unreachableTactic false
 section gandhxorhor_proof
 theorem and_xor_common_op_thm (e e_1 : IntW 32) :
   LLVM.and (LLVM.udiv (const? 32 42) e_1) (LLVM.xor (LLVM.udiv (const? 32 42) e_1) (LLVM.udiv (const? 32 43) e)) ⊑
-    LLVM.and (LLVM.udiv (const? 32 42) e_1) (LLVM.xor (LLVM.udiv (const? 32 43) e) (const? 32 (-1))) := by 
+    LLVM.and (LLVM.udiv (const? 32 42) e_1) (LLVM.xor (LLVM.udiv (const? 32 43) e) (const? 32 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -21,7 +21,7 @@ theorem and_xor_common_op_thm (e e_1 : IntW 32) :
 
 theorem and_xor_common_op_commute1_thm (e e_1 : IntW 32) :
   LLVM.and (LLVM.udiv (const? 32 42) e_1) (LLVM.xor (LLVM.udiv (const? 32 43) e) (LLVM.udiv (const? 32 42) e_1)) ⊑
-    LLVM.and (LLVM.udiv (const? 32 42) e_1) (LLVM.xor (LLVM.udiv (const? 32 43) e) (const? 32 (-1))) := by 
+    LLVM.and (LLVM.udiv (const? 32 42) e_1) (LLVM.xor (LLVM.udiv (const? 32 43) e) (const? 32 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -32,7 +32,7 @@ theorem and_xor_common_op_commute1_thm (e e_1 : IntW 32) :
 
 theorem and_xor_common_op_commute2_thm (e e_1 : IntW 32) :
   LLVM.and (LLVM.xor (LLVM.udiv (const? 32 43) e_1) (LLVM.udiv (const? 32 42) e)) (LLVM.udiv (const? 32 42) e) ⊑
-    LLVM.and (LLVM.udiv (const? 32 42) e) (LLVM.xor (LLVM.udiv (const? 32 43) e_1) (const? 32 (-1))) := by 
+    LLVM.and (LLVM.udiv (const? 32 42) e) (LLVM.xor (LLVM.udiv (const? 32 43) e_1) (const? 32 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -42,7 +42,7 @@ theorem and_xor_common_op_commute2_thm (e e_1 : IntW 32) :
 
 
 theorem and_xor_not_common_op_thm (e e_1 : IntW 32) :
-  LLVM.and (LLVM.xor e_1 (LLVM.xor e (const? 32 (-1)))) e_1 ⊑ LLVM.and e_1 e := by 
+  LLVM.and (LLVM.xor e_1 (LLVM.xor e (const? 32 (-1)))) e_1 ⊑ LLVM.and e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -52,7 +52,7 @@ theorem and_xor_not_common_op_thm (e e_1 : IntW 32) :
 
 
 theorem and_not_xor_common_op_thm (e e_1 : IntW 32) :
-  LLVM.and (LLVM.xor (LLVM.xor e_1 e) (const? 32 (-1))) e ⊑ LLVM.and e e_1 := by 
+  LLVM.and (LLVM.xor (LLVM.xor e_1 e) (const? 32 (-1))) e ⊑ LLVM.and e e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -61,7 +61,7 @@ theorem and_not_xor_common_op_thm (e e_1 : IntW 32) :
     all_goals sorry
 
 
-theorem or_thm (e e_1 : IntW 64) : add (LLVM.and e_1 e) (LLVM.xor e_1 e) ⊑ LLVM.or e_1 e := by 
+theorem or_thm (e e_1 : IntW 64) : add (LLVM.and e_1 e) (LLVM.xor e_1 e) ⊑ LLVM.or e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -70,7 +70,7 @@ theorem or_thm (e e_1 : IntW 64) : add (LLVM.and e_1 e) (LLVM.xor e_1 e) ⊑ LLV
     all_goals sorry
 
 
-theorem or2_thm (e e_1 : IntW 64) : LLVM.or (LLVM.and e_1 e) (LLVM.xor e_1 e) ⊑ LLVM.or e_1 e := by 
+theorem or2_thm (e e_1 : IntW 64) : LLVM.or (LLVM.and e_1 e) (LLVM.xor e_1 e) ⊑ LLVM.or e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -83,7 +83,7 @@ theorem and_xor_or1_thm (e e_1 e_2 : IntW 64) :
   LLVM.or
       (LLVM.xor (LLVM.and (LLVM.udiv (const? 64 42) e_2) (LLVM.udiv (const? 64 42) e_1)) (LLVM.udiv (const? 64 42) e))
       (LLVM.udiv (const? 64 42) e_1) ⊑
-    LLVM.or (LLVM.udiv (const? 64 42) e) (LLVM.udiv (const? 64 42) e_1) := by 
+    LLVM.or (LLVM.udiv (const? 64 42) e) (LLVM.udiv (const? 64 42) e_1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -96,7 +96,7 @@ theorem and_xor_or2_thm (e e_1 e_2 : IntW 64) :
   LLVM.or
       (LLVM.xor (LLVM.and (LLVM.udiv (const? 64 42) e_2) (LLVM.udiv (const? 64 42) e_1)) (LLVM.udiv (const? 64 42) e))
       (LLVM.udiv (const? 64 42) e_2) ⊑
-    LLVM.or (LLVM.udiv (const? 64 42) e) (LLVM.udiv (const? 64 42) e_2) := by 
+    LLVM.or (LLVM.udiv (const? 64 42) e) (LLVM.udiv (const? 64 42) e_2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -109,7 +109,7 @@ theorem and_xor_or3_thm (e e_1 e_2 : IntW 64) :
   LLVM.or
       (LLVM.xor (LLVM.udiv (const? 64 42) e_2) (LLVM.and (LLVM.udiv (const? 64 42) e_1) (LLVM.udiv (const? 64 42) e)))
       (LLVM.udiv (const? 64 42) e) ⊑
-    LLVM.or (LLVM.udiv (const? 64 42) e_2) (LLVM.udiv (const? 64 42) e) := by 
+    LLVM.or (LLVM.udiv (const? 64 42) e_2) (LLVM.udiv (const? 64 42) e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -122,7 +122,7 @@ theorem and_xor_or4_thm (e e_1 e_2 : IntW 64) :
   LLVM.or
       (LLVM.xor (LLVM.udiv (const? 64 42) e_2) (LLVM.and (LLVM.udiv (const? 64 42) e_1) (LLVM.udiv (const? 64 42) e)))
       (LLVM.udiv (const? 64 42) e_1) ⊑
-    LLVM.or (LLVM.udiv (const? 64 42) e_2) (LLVM.udiv (const? 64 42) e_1) := by 
+    LLVM.or (LLVM.udiv (const? 64 42) e_2) (LLVM.udiv (const? 64 42) e_1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -134,7 +134,7 @@ theorem and_xor_or4_thm (e e_1 e_2 : IntW 64) :
 theorem and_xor_or5_thm (e e_1 e_2 : IntW 64) :
   LLVM.or (LLVM.udiv (const? 64 42) e_2)
       (LLVM.xor (LLVM.and (LLVM.udiv (const? 64 42) e_1) (LLVM.udiv (const? 64 42) e_2)) (LLVM.udiv (const? 64 42) e)) ⊑
-    LLVM.or (LLVM.udiv (const? 64 42) e_2) (LLVM.udiv (const? 64 42) e) := by 
+    LLVM.or (LLVM.udiv (const? 64 42) e_2) (LLVM.udiv (const? 64 42) e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -146,7 +146,7 @@ theorem and_xor_or5_thm (e e_1 e_2 : IntW 64) :
 theorem and_xor_or6_thm (e e_1 e_2 : IntW 64) :
   LLVM.or (LLVM.udiv (const? 64 42) e_2)
       (LLVM.xor (LLVM.and (LLVM.udiv (const? 64 42) e_2) (LLVM.udiv (const? 64 42) e_1)) (LLVM.udiv (const? 64 42) e)) ⊑
-    LLVM.or (LLVM.udiv (const? 64 42) e_2) (LLVM.udiv (const? 64 42) e) := by 
+    LLVM.or (LLVM.udiv (const? 64 42) e_2) (LLVM.udiv (const? 64 42) e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -158,7 +158,7 @@ theorem and_xor_or6_thm (e e_1 e_2 : IntW 64) :
 theorem and_xor_or7_thm (e e_1 e_2 : IntW 64) :
   LLVM.or (LLVM.udiv (const? 64 42) e_2)
       (LLVM.xor (LLVM.udiv (const? 64 42) e_1) (LLVM.and (LLVM.udiv (const? 64 42) e) (LLVM.udiv (const? 64 42) e_2))) ⊑
-    LLVM.or (LLVM.udiv (const? 64 42) e_2) (LLVM.udiv (const? 64 42) e_1) := by 
+    LLVM.or (LLVM.udiv (const? 64 42) e_2) (LLVM.udiv (const? 64 42) e_1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -170,7 +170,7 @@ theorem and_xor_or7_thm (e e_1 e_2 : IntW 64) :
 theorem and_xor_or8_thm (e e_1 e_2 : IntW 64) :
   LLVM.or (LLVM.udiv (const? 64 42) e_2)
       (LLVM.xor (LLVM.udiv (const? 64 42) e_1) (LLVM.and (LLVM.udiv (const? 64 42) e_2) (LLVM.udiv (const? 64 42) e))) ⊑
-    LLVM.or (LLVM.udiv (const? 64 42) e_2) (LLVM.udiv (const? 64 42) e_1) := by 
+    LLVM.or (LLVM.udiv (const? 64 42) e_2) (LLVM.udiv (const? 64 42) e_1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -180,7 +180,7 @@ theorem and_xor_or8_thm (e e_1 e_2 : IntW 64) :
 
 
 theorem and_shl_thm (e e_1 e_2 e_3 : IntW 8) :
-  LLVM.and (shl e_3 e_2) (LLVM.and (shl e_1 e_2) e) ⊑ LLVM.and (shl (LLVM.and e_1 e_3) e_2) e := by 
+  LLVM.and (shl e_3 e_2) (LLVM.and (shl e_1 e_2) e) ⊑ LLVM.and (shl (LLVM.and e_1 e_3) e_2) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -190,7 +190,7 @@ theorem and_shl_thm (e e_1 e_2 e_3 : IntW 8) :
 
 
 theorem or_shl_thm (e e_1 e_2 e_3 : IntW 8) :
-  LLVM.or (LLVM.or (shl e_3 e_2) e_1) (shl e e_2) ⊑ LLVM.or (shl (LLVM.or e_3 e) e_2) e_1 := by 
+  LLVM.or (LLVM.or (shl e_3 e_2) e_1) (shl e e_2) ⊑ LLVM.or (shl (LLVM.or e_3 e) e_2) e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -200,7 +200,7 @@ theorem or_shl_thm (e e_1 e_2 e_3 : IntW 8) :
 
 
 theorem or_lshr_thm (e e_1 e_2 e_3 : IntW 8) :
-  LLVM.or (lshr e_3 e_2) (LLVM.or (lshr e_1 e_2) e) ⊑ LLVM.or (lshr (LLVM.or e_1 e_3) e_2) e := by 
+  LLVM.or (lshr e_3 e_2) (LLVM.or (lshr e_1 e_2) e) ⊑ LLVM.or (lshr (LLVM.or e_1 e_3) e_2) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -210,7 +210,7 @@ theorem or_lshr_thm (e e_1 e_2 e_3 : IntW 8) :
 
 
 theorem xor_lshr_thm (e e_1 e_2 e_3 : IntW 8) :
-  LLVM.xor (LLVM.xor (lshr e_3 e_2) e_1) (lshr e e_2) ⊑ LLVM.xor (lshr (LLVM.xor e_3 e) e_2) e_1 := by 
+  LLVM.xor (LLVM.xor (lshr e_3 e_2) e_1) (lshr e e_2) ⊑ LLVM.xor (lshr (LLVM.xor e_3 e) e_2) e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -221,7 +221,7 @@ theorem xor_lshr_thm (e e_1 e_2 e_3 : IntW 8) :
 
 theorem xor_lshr_multiuse_thm (e e_1 e_2 e_3 : IntW 8) :
   LLVM.sdiv (LLVM.xor (lshr e_3 e_2) e_1) (LLVM.xor (LLVM.xor (lshr e_3 e_2) e_1) (lshr e e_2)) ⊑
-    LLVM.sdiv (LLVM.xor (lshr e_3 e_2) e_1) (LLVM.xor (lshr (LLVM.xor e_3 e) e_2) e_1) := by 
+    LLVM.sdiv (LLVM.xor (lshr e_3 e_2) e_1) (LLVM.xor (lshr (LLVM.xor e_3 e) e_2) e_1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -232,7 +232,7 @@ theorem xor_lshr_multiuse_thm (e e_1 e_2 e_3 : IntW 8) :
 
 theorem not_and_and_not_thm (e e_1 e_2 : IntW 32) :
   LLVM.and (LLVM.and (LLVM.sdiv (const? 32 42) e_2) (LLVM.xor e_1 (const? 32 (-1)))) (LLVM.xor e (const? 32 (-1))) ⊑
-    LLVM.and (LLVM.sdiv (const? 32 42) e_2) (LLVM.xor (LLVM.or e_1 e) (const? 32 (-1))) := by 
+    LLVM.and (LLVM.sdiv (const? 32 42) e_2) (LLVM.xor (LLVM.or e_1 e) (const? 32 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -243,7 +243,7 @@ theorem not_and_and_not_thm (e e_1 e_2 : IntW 32) :
 
 theorem not_and_and_not_commute1_thm (e e_1 e_2 : IntW 32) :
   LLVM.and (LLVM.and (LLVM.xor e_2 (const? 32 (-1))) e_1) (LLVM.xor e (const? 32 (-1))) ⊑
-    LLVM.and e_1 (LLVM.xor (LLVM.or e_2 e) (const? 32 (-1))) := by 
+    LLVM.and e_1 (LLVM.xor (LLVM.or e_2 e) (const? 32 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -254,7 +254,7 @@ theorem not_and_and_not_commute1_thm (e e_1 e_2 : IntW 32) :
 
 theorem not_or_or_not_thm (e e_1 e_2 : IntW 32) :
   LLVM.or (LLVM.or (LLVM.sdiv (const? 32 42) e_2) (LLVM.xor e_1 (const? 32 (-1)))) (LLVM.xor e (const? 32 (-1))) ⊑
-    LLVM.or (LLVM.sdiv (const? 32 42) e_2) (LLVM.xor (LLVM.and e_1 e) (const? 32 (-1))) := by 
+    LLVM.or (LLVM.sdiv (const? 32 42) e_2) (LLVM.xor (LLVM.and e_1 e) (const? 32 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -265,7 +265,7 @@ theorem not_or_or_not_thm (e e_1 e_2 : IntW 32) :
 
 theorem not_or_or_not_commute1_thm (e e_1 e_2 : IntW 32) :
   LLVM.or (LLVM.or (LLVM.xor e_2 (const? 32 (-1))) e_1) (LLVM.xor e (const? 32 (-1))) ⊑
-    LLVM.or e_1 (LLVM.xor (LLVM.and e_2 e) (const? 32 (-1))) := by 
+    LLVM.or e_1 (LLVM.xor (LLVM.and e_2 e) (const? 32 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -277,7 +277,7 @@ theorem not_or_or_not_commute1_thm (e e_1 e_2 : IntW 32) :
 theorem or_not_and_thm (e e_1 e_2 : IntW 32) :
   LLVM.or (LLVM.and (LLVM.xor (LLVM.or e_2 e_1) (const? 32 (-1))) e)
       (LLVM.and (LLVM.xor (LLVM.or e_2 e) (const? 32 (-1))) e_1) ⊑
-    LLVM.and (LLVM.xor e_1 e) (LLVM.xor e_2 (const? 32 (-1))) := by 
+    LLVM.and (LLVM.xor e_1 e) (LLVM.xor e_2 (const? 32 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -289,7 +289,7 @@ theorem or_not_and_thm (e e_1 e_2 : IntW 32) :
 theorem or_not_and_commute1_thm (e e_1 e_2 : IntW 32) :
   LLVM.or (LLVM.and (LLVM.xor (LLVM.or e_2 (LLVM.sdiv (const? 32 42) e_1)) (const? 32 (-1))) e)
       (LLVM.and (LLVM.sdiv (const? 32 42) e_1) (LLVM.xor (LLVM.or e_2 e) (const? 32 (-1)))) ⊑
-    LLVM.and (LLVM.xor (LLVM.sdiv (const? 32 42) e_1) e) (LLVM.xor e_2 (const? 32 (-1))) := by 
+    LLVM.and (LLVM.xor (LLVM.sdiv (const? 32 42) e_1) e) (LLVM.xor e_2 (const? 32 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -301,7 +301,7 @@ theorem or_not_and_commute1_thm (e e_1 e_2 : IntW 32) :
 theorem or_not_and_commute2_thm (e e_1 e_2 : IntW 32) :
   LLVM.or (LLVM.and (LLVM.sdiv (const? 32 42) e_2) (LLVM.xor (LLVM.or e_1 e) (const? 32 (-1))))
       (LLVM.and (LLVM.xor (LLVM.or e_1 (LLVM.sdiv (const? 32 42) e_2)) (const? 32 (-1))) e) ⊑
-    LLVM.and (LLVM.xor e (LLVM.sdiv (const? 32 42) e_2)) (LLVM.xor e_1 (const? 32 (-1))) := by 
+    LLVM.and (LLVM.xor e (LLVM.sdiv (const? 32 42) e_2)) (LLVM.xor e_1 (const? 32 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -313,7 +313,7 @@ theorem or_not_and_commute2_thm (e e_1 e_2 : IntW 32) :
 theorem or_not_and_commute3_thm (e e_1 e_2 : IntW 32) :
   LLVM.or (LLVM.and (LLVM.xor (LLVM.or e_2 e_1) (const? 32 (-1))) e)
       (LLVM.and (LLVM.xor (LLVM.or e e_1) (const? 32 (-1))) e_2) ⊑
-    LLVM.and (LLVM.xor e_2 e) (LLVM.xor e_1 (const? 32 (-1))) := by 
+    LLVM.and (LLVM.xor e_2 e) (LLVM.xor e_1 (const? 32 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -325,7 +325,7 @@ theorem or_not_and_commute3_thm (e e_1 e_2 : IntW 32) :
 theorem or_not_and_commute4_thm (e e_1 e_2 : IntW 32) :
   LLVM.or (LLVM.and (LLVM.sdiv (const? 32 42) e_2) (LLVM.xor (LLVM.or e_1 e) (const? 32 (-1))))
       (LLVM.and (LLVM.xor (LLVM.or e_1 (LLVM.sdiv (const? 32 42) e_2)) (const? 32 (-1))) e) ⊑
-    LLVM.and (LLVM.xor e (LLVM.sdiv (const? 32 42) e_2)) (LLVM.xor e_1 (const? 32 (-1))) := by 
+    LLVM.and (LLVM.xor e (LLVM.sdiv (const? 32 42) e_2)) (LLVM.xor e_1 (const? 32 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -339,7 +339,7 @@ theorem or_not_and_commute5_thm (e e_1 e_2 : IntW 32) :
       (LLVM.and (LLVM.sdiv (const? 32 42) e_2) (LLVM.xor (LLVM.or (LLVM.sdiv (const? 32 42) e_1) e) (const? 32 (-1))))
       (LLVM.and (LLVM.xor (LLVM.or (LLVM.sdiv (const? 32 42) e_1) (LLVM.sdiv (const? 32 42) e_2)) (const? 32 (-1))) e) ⊑
     LLVM.and (LLVM.xor e (LLVM.sdiv (const? 32 42) e_2))
-      (LLVM.xor (LLVM.sdiv (const? 32 42) e_1) (const? 32 (-1))) := by 
+      (LLVM.xor (LLVM.sdiv (const? 32 42) e_1) (const? 32 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -351,7 +351,7 @@ theorem or_not_and_commute5_thm (e e_1 e_2 : IntW 32) :
 theorem or_not_and_commute6_thm (e e_1 e_2 : IntW 32) :
   LLVM.or (LLVM.and (LLVM.xor (LLVM.or e_2 e_1) (const? 32 (-1))) e)
       (LLVM.and (LLVM.xor (LLVM.or e e_2) (const? 32 (-1))) e_1) ⊑
-    LLVM.and (LLVM.xor e_1 e) (LLVM.xor e_2 (const? 32 (-1))) := by 
+    LLVM.and (LLVM.xor e_1 e) (LLVM.xor e_2 (const? 32 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -363,7 +363,7 @@ theorem or_not_and_commute6_thm (e e_1 e_2 : IntW 32) :
 theorem or_not_and_commute7_thm (e e_1 e_2 : IntW 32) :
   LLVM.or (LLVM.and (LLVM.xor (LLVM.or e_2 e_1) (const? 32 (-1))) e)
       (LLVM.and (LLVM.xor (LLVM.or e_1 e) (const? 32 (-1))) e_2) ⊑
-    LLVM.and (LLVM.xor e_2 e) (LLVM.xor e_1 (const? 32 (-1))) := by 
+    LLVM.and (LLVM.xor e_2 e) (LLVM.xor e_1 (const? 32 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -377,7 +377,7 @@ theorem or_not_and_commute8_thm (e e_1 e_2 : IntW 32) :
       (LLVM.and (LLVM.xor (LLVM.or (LLVM.sdiv (const? 32 42) e_2) (LLVM.sdiv (const? 32 42) e_1)) (const? 32 (-1))) e)
       (LLVM.and (LLVM.sdiv (const? 32 42) e_1) (LLVM.xor (LLVM.or e (LLVM.sdiv (const? 32 42) e_2)) (const? 32 (-1)))) ⊑
     LLVM.and (LLVM.xor (LLVM.sdiv (const? 32 42) e_1) e)
-      (LLVM.xor (LLVM.sdiv (const? 32 42) e_2) (const? 32 (-1))) := by 
+      (LLVM.xor (LLVM.sdiv (const? 32 42) e_2) (const? 32 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -393,7 +393,7 @@ theorem or_not_and_commute9_thm (e e_1 e_2 : IntW 32) :
       (LLVM.and (LLVM.sdiv (const? 32 42) e_1)
         (LLVM.xor (LLVM.or (LLVM.sdiv (const? 32 42) e_2) (LLVM.sdiv (const? 32 42) e)) (const? 32 (-1)))) ⊑
     LLVM.and (LLVM.xor (LLVM.sdiv (const? 32 42) e_1) (LLVM.sdiv (const? 32 42) e))
-      (LLVM.xor (LLVM.sdiv (const? 32 42) e_2) (const? 32 (-1))) := by 
+      (LLVM.xor (LLVM.sdiv (const? 32 42) e_2) (const? 32 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -406,7 +406,7 @@ theorem or_not_and_wrong_c_thm (e e_1 e_2 e_3 : IntW 32) :
   LLVM.or (LLVM.and (LLVM.xor (LLVM.or e_3 e_2) (const? 32 (-1))) e_1)
       (LLVM.and (LLVM.xor (LLVM.or e_3 e) (const? 32 (-1))) e_2) ⊑
     LLVM.or (LLVM.and e_1 (LLVM.xor (LLVM.or e_3 e_2) (const? 32 (-1))))
-      (LLVM.and e_2 (LLVM.xor (LLVM.or e_3 e) (const? 32 (-1)))) := by 
+      (LLVM.and e_2 (LLVM.xor (LLVM.or e_3 e) (const? 32 (-1)))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -419,7 +419,7 @@ theorem or_not_and_wrong_b_thm (e e_1 e_2 e_3 : IntW 32) :
   LLVM.or (LLVM.and (LLVM.xor (LLVM.or e_3 e_2) (const? 32 (-1))) e_1)
       (LLVM.and (LLVM.xor (LLVM.or e_3 e_1) (const? 32 (-1))) e) ⊑
     LLVM.or (LLVM.and e_1 (LLVM.xor (LLVM.or e_3 e_2) (const? 32 (-1))))
-      (LLVM.and e (LLVM.xor (LLVM.or e_3 e_1) (const? 32 (-1)))) := by 
+      (LLVM.and e (LLVM.xor (LLVM.or e_3 e_1) (const? 32 (-1)))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -431,7 +431,7 @@ theorem or_not_and_wrong_b_thm (e e_1 e_2 e_3 : IntW 32) :
 theorem and_not_or_thm (e e_1 e_2 : IntW 32) :
   LLVM.and (LLVM.or (LLVM.xor (LLVM.and e_2 e_1) (const? 32 (-1))) e)
       (LLVM.or (LLVM.xor (LLVM.and e_2 e) (const? 32 (-1))) e_1) ⊑
-    LLVM.xor (LLVM.and (LLVM.xor e_1 e) e_2) (const? 32 (-1)) := by 
+    LLVM.xor (LLVM.and (LLVM.xor e_1 e) e_2) (const? 32 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -443,7 +443,7 @@ theorem and_not_or_thm (e e_1 e_2 : IntW 32) :
 theorem and_not_or_commute1_thm (e e_1 e_2 : IntW 32) :
   LLVM.and (LLVM.or (LLVM.xor (LLVM.and e_2 (LLVM.sdiv (const? 32 42) e_1)) (const? 32 (-1))) e)
       (LLVM.or (LLVM.sdiv (const? 32 42) e_1) (LLVM.xor (LLVM.and e_2 e) (const? 32 (-1)))) ⊑
-    LLVM.xor (LLVM.and (LLVM.xor (LLVM.sdiv (const? 32 42) e_1) e) e_2) (const? 32 (-1)) := by 
+    LLVM.xor (LLVM.and (LLVM.xor (LLVM.sdiv (const? 32 42) e_1) e) e_2) (const? 32 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -455,7 +455,7 @@ theorem and_not_or_commute1_thm (e e_1 e_2 : IntW 32) :
 theorem and_not_or_commute2_thm (e e_1 e_2 : IntW 32) :
   LLVM.and (LLVM.or (LLVM.sdiv (const? 32 42) e_2) (LLVM.xor (LLVM.and e_1 e) (const? 32 (-1))))
       (LLVM.or (LLVM.xor (LLVM.and e_1 (LLVM.sdiv (const? 32 42) e_2)) (const? 32 (-1))) e) ⊑
-    LLVM.xor (LLVM.and (LLVM.xor e (LLVM.sdiv (const? 32 42) e_2)) e_1) (const? 32 (-1)) := by 
+    LLVM.xor (LLVM.and (LLVM.xor e (LLVM.sdiv (const? 32 42) e_2)) e_1) (const? 32 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -467,7 +467,7 @@ theorem and_not_or_commute2_thm (e e_1 e_2 : IntW 32) :
 theorem and_not_or_commute3_thm (e e_1 e_2 : IntW 32) :
   LLVM.and (LLVM.or (LLVM.xor (LLVM.and e_2 e_1) (const? 32 (-1))) e)
       (LLVM.or (LLVM.xor (LLVM.and e e_1) (const? 32 (-1))) e_2) ⊑
-    LLVM.xor (LLVM.and (LLVM.xor e_2 e) e_1) (const? 32 (-1)) := by 
+    LLVM.xor (LLVM.and (LLVM.xor e_2 e) e_1) (const? 32 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -479,7 +479,7 @@ theorem and_not_or_commute3_thm (e e_1 e_2 : IntW 32) :
 theorem and_not_or_commute4_thm (e e_1 e_2 : IntW 32) :
   LLVM.and (LLVM.or (LLVM.sdiv (const? 32 42) e_2) (LLVM.xor (LLVM.and e_1 e) (const? 32 (-1))))
       (LLVM.or (LLVM.xor (LLVM.and e_1 (LLVM.sdiv (const? 32 42) e_2)) (const? 32 (-1))) e) ⊑
-    LLVM.xor (LLVM.and (LLVM.xor e (LLVM.sdiv (const? 32 42) e_2)) e_1) (const? 32 (-1)) := by 
+    LLVM.xor (LLVM.and (LLVM.xor e (LLVM.sdiv (const? 32 42) e_2)) e_1) (const? 32 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -493,7 +493,7 @@ theorem and_not_or_commute5_thm (e e_1 e_2 : IntW 32) :
       (LLVM.or (LLVM.sdiv (const? 32 42) e_2) (LLVM.xor (LLVM.and (LLVM.sdiv (const? 32 42) e_1) e) (const? 32 (-1))))
       (LLVM.or (LLVM.xor (LLVM.and (LLVM.sdiv (const? 32 42) e_1) (LLVM.sdiv (const? 32 42) e_2)) (const? 32 (-1))) e) ⊑
     LLVM.xor (LLVM.and (LLVM.xor e (LLVM.sdiv (const? 32 42) e_2)) (LLVM.sdiv (const? 32 42) e_1))
-      (const? 32 (-1)) := by 
+      (const? 32 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -505,7 +505,7 @@ theorem and_not_or_commute5_thm (e e_1 e_2 : IntW 32) :
 theorem and_not_or_commute6_thm (e e_1 e_2 : IntW 32) :
   LLVM.and (LLVM.or (LLVM.xor (LLVM.and e_2 e_1) (const? 32 (-1))) e)
       (LLVM.or (LLVM.xor (LLVM.and e e_2) (const? 32 (-1))) e_1) ⊑
-    LLVM.xor (LLVM.and (LLVM.xor e_1 e) e_2) (const? 32 (-1)) := by 
+    LLVM.xor (LLVM.and (LLVM.xor e_1 e) e_2) (const? 32 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -517,7 +517,7 @@ theorem and_not_or_commute6_thm (e e_1 e_2 : IntW 32) :
 theorem and_not_or_commute7_thm (e e_1 e_2 : IntW 32) :
   LLVM.and (LLVM.or (LLVM.xor (LLVM.and e_2 e_1) (const? 32 (-1))) e)
       (LLVM.or (LLVM.xor (LLVM.and e_1 e) (const? 32 (-1))) e_2) ⊑
-    LLVM.xor (LLVM.and (LLVM.xor e_2 e) e_1) (const? 32 (-1)) := by 
+    LLVM.xor (LLVM.and (LLVM.xor e_2 e) e_1) (const? 32 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -531,7 +531,7 @@ theorem and_not_or_commute8_thm (e e_1 e_2 : IntW 32) :
       (LLVM.or (LLVM.xor (LLVM.and (LLVM.sdiv (const? 32 42) e_2) (LLVM.sdiv (const? 32 42) e_1)) (const? 32 (-1))) e)
       (LLVM.or (LLVM.sdiv (const? 32 42) e_1) (LLVM.xor (LLVM.and e (LLVM.sdiv (const? 32 42) e_2)) (const? 32 (-1)))) ⊑
     LLVM.xor (LLVM.and (LLVM.xor (LLVM.sdiv (const? 32 42) e_1) e) (LLVM.sdiv (const? 32 42) e_2))
-      (const? 32 (-1)) := by 
+      (const? 32 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -548,7 +548,7 @@ theorem and_not_or_commute9_thm (e e_1 e_2 : IntW 32) :
         (LLVM.xor (LLVM.and (LLVM.sdiv (const? 32 42) e_2) (LLVM.sdiv (const? 32 42) e)) (const? 32 (-1)))) ⊑
     LLVM.xor
       (LLVM.and (LLVM.xor (LLVM.sdiv (const? 32 42) e_1) (LLVM.sdiv (const? 32 42) e)) (LLVM.sdiv (const? 32 42) e_2))
-      (const? 32 (-1)) := by 
+      (const? 32 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -561,7 +561,7 @@ theorem and_not_or_wrong_c_thm (e e_1 e_2 e_3 : IntW 32) :
   LLVM.and (LLVM.or (LLVM.xor (LLVM.and e_3 e_2) (const? 32 (-1))) e_1)
       (LLVM.or (LLVM.xor (LLVM.and e_3 e) (const? 32 (-1))) e_2) ⊑
     LLVM.and (LLVM.or e_1 (LLVM.xor (LLVM.and e_3 e_2) (const? 32 (-1))))
-      (LLVM.or e_2 (LLVM.xor (LLVM.and e_3 e) (const? 32 (-1)))) := by 
+      (LLVM.or e_2 (LLVM.xor (LLVM.and e_3 e) (const? 32 (-1)))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -574,7 +574,7 @@ theorem and_not_or_wrong_b_thm (e e_1 e_2 e_3 : IntW 32) :
   LLVM.and (LLVM.or (LLVM.xor (LLVM.and e_3 e_2) (const? 32 (-1))) e_1)
       (LLVM.or (LLVM.xor (LLVM.and e_3 e_1) (const? 32 (-1))) e) ⊑
     LLVM.and (LLVM.or e_1 (LLVM.xor (LLVM.and e_3 e_2) (const? 32 (-1))))
-      (LLVM.or e (LLVM.xor (LLVM.and e_3 e_1) (const? 32 (-1)))) := by 
+      (LLVM.or e (LLVM.xor (LLVM.and e_3 e_1) (const? 32 (-1)))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -585,7 +585,7 @@ theorem and_not_or_wrong_b_thm (e e_1 e_2 e_3 : IntW 32) :
 
 theorem or_and_not_not_thm (e e_1 e_2 : IntW 32) :
   LLVM.or (LLVM.and (LLVM.xor (LLVM.or e_2 e_1) (const? 32 (-1))) e) (LLVM.xor (LLVM.or e e_2) (const? 32 (-1))) ⊑
-    LLVM.xor (LLVM.or (LLVM.and e_1 e) e_2) (const? 32 (-1)) := by 
+    LLVM.xor (LLVM.or (LLVM.and e_1 e) e_2) (const? 32 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -597,7 +597,7 @@ theorem or_and_not_not_thm (e e_1 e_2 : IntW 32) :
 theorem or_and_not_not_commute1_thm (e e_1 e_2 : IntW 32) :
   LLVM.or (LLVM.and (LLVM.sdiv (const? 32 42) e_2) (LLVM.xor (LLVM.or e_1 e) (const? 32 (-1))))
       (LLVM.xor (LLVM.or (LLVM.sdiv (const? 32 42) e_2) e_1) (const? 32 (-1))) ⊑
-    LLVM.xor (LLVM.or (LLVM.and e (LLVM.sdiv (const? 32 42) e_2)) e_1) (const? 32 (-1)) := by 
+    LLVM.xor (LLVM.or (LLVM.and e (LLVM.sdiv (const? 32 42) e_2)) e_1) (const? 32 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -608,7 +608,7 @@ theorem or_and_not_not_commute1_thm (e e_1 e_2 : IntW 32) :
 
 theorem or_and_not_not_commute2_thm (e e_1 e_2 : IntW 32) :
   LLVM.or (LLVM.and (LLVM.xor (LLVM.or e_2 e_1) (const? 32 (-1))) e) (LLVM.xor (LLVM.or e e_2) (const? 32 (-1))) ⊑
-    LLVM.xor (LLVM.or (LLVM.and e_1 e) e_2) (const? 32 (-1)) := by 
+    LLVM.xor (LLVM.or (LLVM.and e_1 e) e_2) (const? 32 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -619,7 +619,7 @@ theorem or_and_not_not_commute2_thm (e e_1 e_2 : IntW 32) :
 
 theorem or_and_not_not_commute3_thm (e e_1 e_2 : IntW 32) :
   LLVM.or (LLVM.and (LLVM.xor (LLVM.or e_2 e_1) (const? 32 (-1))) e) (LLVM.xor (LLVM.or e e_1) (const? 32 (-1))) ⊑
-    LLVM.xor (LLVM.or (LLVM.and e_2 e) e_1) (const? 32 (-1)) := by 
+    LLVM.xor (LLVM.or (LLVM.and e_2 e) e_1) (const? 32 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -630,7 +630,7 @@ theorem or_and_not_not_commute3_thm (e e_1 e_2 : IntW 32) :
 
 theorem or_and_not_not_commute4_thm (e e_1 e_2 : IntW 32) :
   LLVM.or (LLVM.and (LLVM.xor (LLVM.or e_2 e_1) (const? 32 (-1))) e) (LLVM.xor (LLVM.or e_2 e) (const? 32 (-1))) ⊑
-    LLVM.xor (LLVM.or (LLVM.and e_1 e) e_2) (const? 32 (-1)) := by 
+    LLVM.xor (LLVM.or (LLVM.and e_1 e) e_2) (const? 32 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -641,7 +641,7 @@ theorem or_and_not_not_commute4_thm (e e_1 e_2 : IntW 32) :
 
 theorem or_and_not_not_commute5_thm (e e_1 e_2 : IntW 32) :
   LLVM.or (LLVM.xor (LLVM.or e_2 e_1) (const? 32 (-1))) (LLVM.and (LLVM.xor (LLVM.or e_1 e) (const? 32 (-1))) e_2) ⊑
-    LLVM.xor (LLVM.or (LLVM.and e e_2) e_1) (const? 32 (-1)) := by 
+    LLVM.xor (LLVM.or (LLVM.and e e_2) e_1) (const? 32 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -653,7 +653,7 @@ theorem or_and_not_not_commute5_thm (e e_1 e_2 : IntW 32) :
 theorem or_and_not_not_commute6_thm (e e_1 e_2 : IntW 32) :
   LLVM.or (LLVM.and (LLVM.sdiv (const? 32 42) e_2) (LLVM.xor (LLVM.or e_1 e) (const? 32 (-1))))
       (LLVM.xor (LLVM.or (LLVM.sdiv (const? 32 42) e_2) e) (const? 32 (-1))) ⊑
-    LLVM.xor (LLVM.or (LLVM.and e_1 (LLVM.sdiv (const? 32 42) e_2)) e) (const? 32 (-1)) := by 
+    LLVM.xor (LLVM.or (LLVM.and e_1 (LLVM.sdiv (const? 32 42) e_2)) e) (const? 32 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -664,7 +664,7 @@ theorem or_and_not_not_commute6_thm (e e_1 e_2 : IntW 32) :
 
 theorem or_and_not_not_commute7_thm (e e_1 e_2 : IntW 32) :
   LLVM.or (LLVM.and (LLVM.xor (LLVM.or e_2 e_1) (const? 32 (-1))) e) (LLVM.xor (LLVM.or e_1 e) (const? 32 (-1))) ⊑
-    LLVM.xor (LLVM.or (LLVM.and e_2 e) e_1) (const? 32 (-1)) := by 
+    LLVM.xor (LLVM.or (LLVM.and e_2 e) e_1) (const? 32 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -676,7 +676,7 @@ theorem or_and_not_not_commute7_thm (e e_1 e_2 : IntW 32) :
 theorem or_and_not_not_wrong_a_thm (e e_1 e_2 e_3 : IntW 32) :
   LLVM.or (LLVM.and (LLVM.xor (LLVM.or e_3 e_2) (const? 32 (-1))) e_1) (LLVM.xor (LLVM.or e_1 e) (const? 32 (-1))) ⊑
     LLVM.or (LLVM.and e_1 (LLVM.xor (LLVM.or e_3 e_2) (const? 32 (-1))))
-      (LLVM.xor (LLVM.or e_1 e) (const? 32 (-1))) := by 
+      (LLVM.xor (LLVM.or e_1 e) (const? 32 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -688,7 +688,7 @@ theorem or_and_not_not_wrong_a_thm (e e_1 e_2 e_3 : IntW 32) :
 theorem or_and_not_not_wrong_b_thm (e e_1 e_2 e_3 : IntW 32) :
   LLVM.or (LLVM.and (LLVM.xor (LLVM.or e_3 e_2) (const? 32 (-1))) e_1) (LLVM.xor (LLVM.or e e_3) (const? 32 (-1))) ⊑
     LLVM.or (LLVM.and e_1 (LLVM.xor (LLVM.or e_3 e_2) (const? 32 (-1))))
-      (LLVM.xor (LLVM.or e e_3) (const? 32 (-1))) := by 
+      (LLVM.xor (LLVM.or e e_3) (const? 32 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -699,7 +699,7 @@ theorem or_and_not_not_wrong_b_thm (e e_1 e_2 e_3 : IntW 32) :
 
 theorem and_or_not_not_thm (e e_1 e_2 : IntW 32) :
   LLVM.and (LLVM.or (LLVM.xor (LLVM.and e_2 e_1) (const? 32 (-1))) e) (LLVM.xor (LLVM.and e e_2) (const? 32 (-1))) ⊑
-    LLVM.xor (LLVM.and (LLVM.or e_1 e) e_2) (const? 32 (-1)) := by 
+    LLVM.xor (LLVM.and (LLVM.or e_1 e) e_2) (const? 32 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -711,7 +711,7 @@ theorem and_or_not_not_thm (e e_1 e_2 : IntW 32) :
 theorem and_or_not_not_commute1_thm (e e_1 e_2 : IntW 32) :
   LLVM.and (LLVM.or (LLVM.sdiv (const? 32 42) e_2) (LLVM.xor (LLVM.and e_1 e) (const? 32 (-1))))
       (LLVM.xor (LLVM.and (LLVM.sdiv (const? 32 42) e_2) e_1) (const? 32 (-1))) ⊑
-    LLVM.xor (LLVM.and (LLVM.or e (LLVM.sdiv (const? 32 42) e_2)) e_1) (const? 32 (-1)) := by 
+    LLVM.xor (LLVM.and (LLVM.or e (LLVM.sdiv (const? 32 42) e_2)) e_1) (const? 32 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -722,7 +722,7 @@ theorem and_or_not_not_commute1_thm (e e_1 e_2 : IntW 32) :
 
 theorem and_or_not_not_commute2_thm (e e_1 e_2 : IntW 32) :
   LLVM.and (LLVM.or (LLVM.xor (LLVM.and e_2 e_1) (const? 32 (-1))) e) (LLVM.xor (LLVM.and e e_2) (const? 32 (-1))) ⊑
-    LLVM.xor (LLVM.and (LLVM.or e_1 e) e_2) (const? 32 (-1)) := by 
+    LLVM.xor (LLVM.and (LLVM.or e_1 e) e_2) (const? 32 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -733,7 +733,7 @@ theorem and_or_not_not_commute2_thm (e e_1 e_2 : IntW 32) :
 
 theorem and_or_not_not_commute3_thm (e e_1 e_2 : IntW 32) :
   LLVM.and (LLVM.or (LLVM.xor (LLVM.and e_2 e_1) (const? 32 (-1))) e) (LLVM.xor (LLVM.and e e_1) (const? 32 (-1))) ⊑
-    LLVM.xor (LLVM.and (LLVM.or e_2 e) e_1) (const? 32 (-1)) := by 
+    LLVM.xor (LLVM.and (LLVM.or e_2 e) e_1) (const? 32 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -744,7 +744,7 @@ theorem and_or_not_not_commute3_thm (e e_1 e_2 : IntW 32) :
 
 theorem and_or_not_not_commute4_thm (e e_1 e_2 : IntW 32) :
   LLVM.and (LLVM.or (LLVM.xor (LLVM.and e_2 e_1) (const? 32 (-1))) e) (LLVM.xor (LLVM.and e_2 e) (const? 32 (-1))) ⊑
-    LLVM.xor (LLVM.and (LLVM.or e_1 e) e_2) (const? 32 (-1)) := by 
+    LLVM.xor (LLVM.and (LLVM.or e_1 e) e_2) (const? 32 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -755,7 +755,7 @@ theorem and_or_not_not_commute4_thm (e e_1 e_2 : IntW 32) :
 
 theorem and_or_not_not_commute5_thm (e e_1 e_2 : IntW 32) :
   LLVM.and (LLVM.xor (LLVM.and e_2 e_1) (const? 32 (-1))) (LLVM.or (LLVM.xor (LLVM.and e_1 e) (const? 32 (-1))) e_2) ⊑
-    LLVM.xor (LLVM.and (LLVM.or e e_2) e_1) (const? 32 (-1)) := by 
+    LLVM.xor (LLVM.and (LLVM.or e e_2) e_1) (const? 32 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -767,7 +767,7 @@ theorem and_or_not_not_commute5_thm (e e_1 e_2 : IntW 32) :
 theorem and_or_not_not_commute6_thm (e e_1 e_2 : IntW 32) :
   LLVM.and (LLVM.or (LLVM.sdiv (const? 32 42) e_2) (LLVM.xor (LLVM.and e_1 e) (const? 32 (-1))))
       (LLVM.xor (LLVM.and (LLVM.sdiv (const? 32 42) e_2) e) (const? 32 (-1))) ⊑
-    LLVM.xor (LLVM.and (LLVM.or e_1 (LLVM.sdiv (const? 32 42) e_2)) e) (const? 32 (-1)) := by 
+    LLVM.xor (LLVM.and (LLVM.or e_1 (LLVM.sdiv (const? 32 42) e_2)) e) (const? 32 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -778,7 +778,7 @@ theorem and_or_not_not_commute6_thm (e e_1 e_2 : IntW 32) :
 
 theorem and_or_not_not_commute7_thm (e e_1 e_2 : IntW 32) :
   LLVM.and (LLVM.or (LLVM.xor (LLVM.and e_2 e_1) (const? 32 (-1))) e) (LLVM.xor (LLVM.and e_1 e) (const? 32 (-1))) ⊑
-    LLVM.xor (LLVM.and (LLVM.or e_2 e) e_1) (const? 32 (-1)) := by 
+    LLVM.xor (LLVM.and (LLVM.or e_2 e) e_1) (const? 32 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -789,7 +789,7 @@ theorem and_or_not_not_commute7_thm (e e_1 e_2 : IntW 32) :
 
 theorem and_or_not_not_wrong_a_thm (e e_1 e_2 e_3 : IntW 32) :
   LLVM.and (LLVM.or (LLVM.xor (LLVM.and e_3 e_2) (const? 32 (-1))) e_1) (LLVM.xor (LLVM.and e_1 e) (const? 32 (-1))) ⊑
-    LLVM.xor (LLVM.and e_1 e) (LLVM.or e_1 (LLVM.xor (LLVM.and e_3 e_2) (const? 32 (-1)))) := by 
+    LLVM.xor (LLVM.and e_1 e) (LLVM.or e_1 (LLVM.xor (LLVM.and e_3 e_2) (const? 32 (-1)))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -801,7 +801,7 @@ theorem and_or_not_not_wrong_a_thm (e e_1 e_2 e_3 : IntW 32) :
 theorem and_or_not_not_wrong_b_thm (e e_1 e_2 e_3 : IntW 32) :
   LLVM.and (LLVM.or (LLVM.xor (LLVM.and e_3 e_2) (const? 32 (-1))) e_1) (LLVM.xor (LLVM.and e e_3) (const? 32 (-1))) ⊑
     LLVM.and (LLVM.or e_1 (LLVM.xor (LLVM.and e_3 e_2) (const? 32 (-1))))
-      (LLVM.xor (LLVM.and e e_3) (const? 32 (-1))) := by 
+      (LLVM.xor (LLVM.and e e_3) (const? 32 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -813,7 +813,7 @@ theorem and_or_not_not_wrong_b_thm (e e_1 e_2 e_3 : IntW 32) :
 theorem and_not_or_or_not_or_xor_thm (e e_1 e_2 : IntW 32) :
   LLVM.or (LLVM.and (LLVM.xor (LLVM.or e_2 e_1) (const? 32 (-1))) e)
       (LLVM.xor (LLVM.or (LLVM.xor e_2 e_1) e) (const? 32 (-1))) ⊑
-    LLVM.xor (LLVM.and (LLVM.or e_2 e_1) (LLVM.or (LLVM.xor e_2 e_1) e)) (const? 32 (-1)) := by 
+    LLVM.xor (LLVM.and (LLVM.or e_2 e_1) (LLVM.or (LLVM.xor e_2 e_1) e)) (const? 32 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -825,7 +825,7 @@ theorem and_not_or_or_not_or_xor_thm (e e_1 e_2 : IntW 32) :
 theorem and_not_or_or_not_or_xor_commute1_thm (e e_1 e_2 : IntW 32) :
   LLVM.or (LLVM.and (LLVM.xor (LLVM.or e_2 e_1) (const? 32 (-1))) e)
       (LLVM.xor (LLVM.or (LLVM.xor e_1 e_2) e) (const? 32 (-1))) ⊑
-    LLVM.xor (LLVM.and (LLVM.or e_2 e_1) (LLVM.or (LLVM.xor e_1 e_2) e)) (const? 32 (-1)) := by 
+    LLVM.xor (LLVM.and (LLVM.or e_2 e_1) (LLVM.or (LLVM.xor e_1 e_2) e)) (const? 32 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -838,7 +838,7 @@ theorem and_not_or_or_not_or_xor_commute2_thm (e e_1 e_2 : IntW 32) :
   LLVM.or (LLVM.and (LLVM.sdiv (const? 32 42) e_2) (LLVM.xor (LLVM.or e_1 e) (const? 32 (-1))))
       (LLVM.xor (LLVM.or (LLVM.xor e_1 e) (LLVM.sdiv (const? 32 42) e_2)) (const? 32 (-1))) ⊑
     LLVM.xor (LLVM.and (LLVM.or e_1 e) (LLVM.or (LLVM.xor e_1 e) (LLVM.sdiv (const? 32 42) e_2)))
-      (const? 32 (-1)) := by 
+      (const? 32 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -850,7 +850,7 @@ theorem and_not_or_or_not_or_xor_commute2_thm (e e_1 e_2 : IntW 32) :
 theorem and_not_or_or_not_or_xor_commute3_thm (e e_1 e_2 : IntW 32) :
   LLVM.or (LLVM.and (LLVM.xor (LLVM.or e_2 e_1) (const? 32 (-1))) e)
       (LLVM.xor (LLVM.or (LLVM.xor e_1 e_2) e) (const? 32 (-1))) ⊑
-    LLVM.xor (LLVM.and (LLVM.or e_2 e_1) (LLVM.or (LLVM.xor e_1 e_2) e)) (const? 32 (-1)) := by 
+    LLVM.xor (LLVM.and (LLVM.or e_2 e_1) (LLVM.or (LLVM.xor e_1 e_2) e)) (const? 32 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -863,7 +863,7 @@ theorem and_not_or_or_not_or_xor_commute4_thm (e e_1 e_2 : IntW 32) :
   LLVM.or (LLVM.and (LLVM.sdiv (const? 32 42) e_2) (LLVM.xor (LLVM.or e_1 e) (const? 32 (-1))))
       (LLVM.xor (LLVM.or (LLVM.sdiv (const? 32 42) e_2) (LLVM.xor e_1 e)) (const? 32 (-1))) ⊑
     LLVM.xor (LLVM.and (LLVM.or e_1 e) (LLVM.or (LLVM.sdiv (const? 32 42) e_2) (LLVM.xor e_1 e)))
-      (const? 32 (-1)) := by 
+      (const? 32 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -875,7 +875,7 @@ theorem and_not_or_or_not_or_xor_commute4_thm (e e_1 e_2 : IntW 32) :
 theorem and_not_or_or_not_or_xor_commute5_thm (e e_1 e_2 : IntW 32) :
   LLVM.or (LLVM.xor (LLVM.or (LLVM.xor e_2 e_1) e) (const? 32 (-1)))
       (LLVM.and (LLVM.xor (LLVM.or e_2 e_1) (const? 32 (-1))) e) ⊑
-    LLVM.xor (LLVM.and (LLVM.or e_2 e_1) (LLVM.or (LLVM.xor e_2 e_1) e)) (const? 32 (-1)) := by 
+    LLVM.xor (LLVM.and (LLVM.or e_2 e_1) (LLVM.or (LLVM.xor e_2 e_1) e)) (const? 32 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -887,7 +887,7 @@ theorem and_not_or_or_not_or_xor_commute5_thm (e e_1 e_2 : IntW 32) :
 theorem or_not_and_and_not_and_xor_thm (e e_1 e_2 : IntW 32) :
   LLVM.and (LLVM.or (LLVM.xor (LLVM.and e_2 e_1) (const? 32 (-1))) e)
       (LLVM.xor (LLVM.and (LLVM.xor e_2 e_1) e) (const? 32 (-1))) ⊑
-    LLVM.xor (LLVM.and (LLVM.xor e_2 e_1) e) (LLVM.or e (LLVM.xor (LLVM.and e_2 e_1) (const? 32 (-1)))) := by 
+    LLVM.xor (LLVM.and (LLVM.xor e_2 e_1) e) (LLVM.or e (LLVM.xor (LLVM.and e_2 e_1) (const? 32 (-1)))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -899,7 +899,7 @@ theorem or_not_and_and_not_and_xor_thm (e e_1 e_2 : IntW 32) :
 theorem or_not_and_and_not_and_xor_commute1_thm (e e_1 e_2 : IntW 32) :
   LLVM.and (LLVM.or (LLVM.xor (LLVM.and e_2 e_1) (const? 32 (-1))) e)
       (LLVM.xor (LLVM.and (LLVM.xor e_1 e_2) e) (const? 32 (-1))) ⊑
-    LLVM.xor (LLVM.and (LLVM.xor e_1 e_2) e) (LLVM.or e (LLVM.xor (LLVM.and e_2 e_1) (const? 32 (-1)))) := by 
+    LLVM.xor (LLVM.and (LLVM.xor e_1 e_2) e) (LLVM.or e (LLVM.xor (LLVM.and e_2 e_1) (const? 32 (-1)))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -912,7 +912,7 @@ theorem or_not_and_and_not_and_xor_commute2_thm (e e_1 e_2 : IntW 32) :
   LLVM.and (LLVM.or (LLVM.sdiv (const? 32 42) e_2) (LLVM.xor (LLVM.and e_1 e) (const? 32 (-1))))
       (LLVM.xor (LLVM.and (LLVM.xor e_1 e) (LLVM.sdiv (const? 32 42) e_2)) (const? 32 (-1))) ⊑
     LLVM.xor (LLVM.and (LLVM.xor e_1 e) (LLVM.sdiv (const? 32 42) e_2))
-      (LLVM.or (LLVM.sdiv (const? 32 42) e_2) (LLVM.xor (LLVM.and e_1 e) (const? 32 (-1)))) := by 
+      (LLVM.or (LLVM.sdiv (const? 32 42) e_2) (LLVM.xor (LLVM.and e_1 e) (const? 32 (-1)))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -924,7 +924,7 @@ theorem or_not_and_and_not_and_xor_commute2_thm (e e_1 e_2 : IntW 32) :
 theorem or_not_and_and_not_and_xor_commute3_thm (e e_1 e_2 : IntW 32) :
   LLVM.and (LLVM.or (LLVM.xor (LLVM.and e_2 e_1) (const? 32 (-1))) e)
       (LLVM.xor (LLVM.and (LLVM.xor e_1 e_2) e) (const? 32 (-1))) ⊑
-    LLVM.xor (LLVM.and (LLVM.xor e_1 e_2) e) (LLVM.or e (LLVM.xor (LLVM.and e_2 e_1) (const? 32 (-1)))) := by 
+    LLVM.xor (LLVM.and (LLVM.xor e_1 e_2) e) (LLVM.or e (LLVM.xor (LLVM.and e_2 e_1) (const? 32 (-1)))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -937,7 +937,7 @@ theorem or_not_and_and_not_and_xor_commute4_thm (e e_1 e_2 : IntW 32) :
   LLVM.and (LLVM.or (LLVM.sdiv (const? 32 42) e_2) (LLVM.xor (LLVM.and e_1 e) (const? 32 (-1))))
       (LLVM.xor (LLVM.and (LLVM.sdiv (const? 32 42) e_2) (LLVM.xor e_1 e)) (const? 32 (-1))) ⊑
     LLVM.xor (LLVM.and (LLVM.sdiv (const? 32 42) e_2) (LLVM.xor e_1 e))
-      (LLVM.or (LLVM.sdiv (const? 32 42) e_2) (LLVM.xor (LLVM.and e_1 e) (const? 32 (-1)))) := by 
+      (LLVM.or (LLVM.sdiv (const? 32 42) e_2) (LLVM.xor (LLVM.and e_1 e) (const? 32 (-1)))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -949,7 +949,7 @@ theorem or_not_and_and_not_and_xor_commute4_thm (e e_1 e_2 : IntW 32) :
 theorem or_not_and_and_not_and_xor_commute5_thm (e e_1 e_2 : IntW 32) :
   LLVM.and (LLVM.xor (LLVM.and (LLVM.xor e_2 e_1) e) (const? 32 (-1)))
       (LLVM.or (LLVM.xor (LLVM.and e_2 e_1) (const? 32 (-1))) e) ⊑
-    LLVM.xor (LLVM.and (LLVM.xor e_2 e_1) e) (LLVM.or e (LLVM.xor (LLVM.and e_2 e_1) (const? 32 (-1)))) := by 
+    LLVM.xor (LLVM.and (LLVM.xor e_2 e_1) e) (LLVM.or e (LLVM.xor (LLVM.and e_2 e_1) (const? 32 (-1)))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -961,7 +961,7 @@ theorem or_not_and_and_not_and_xor_commute5_thm (e e_1 e_2 : IntW 32) :
 theorem not_and_and_or_not_or_or_thm (e e_1 e_2 : IntW 32) :
   LLVM.or (LLVM.and (LLVM.and (LLVM.xor e_2 (const? 32 (-1))) e_1) e)
       (LLVM.xor (LLVM.or (LLVM.or e_1 e_2) e) (const? 32 (-1))) ⊑
-    LLVM.xor (LLVM.or (LLVM.xor e e_1) e_2) (const? 32 (-1)) := by 
+    LLVM.xor (LLVM.or (LLVM.xor e e_1) e_2) (const? 32 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -973,7 +973,7 @@ theorem not_and_and_or_not_or_or_thm (e e_1 e_2 : IntW 32) :
 theorem not_and_and_or_not_or_or_commute1_or_thm (e e_1 e_2 : IntW 32) :
   LLVM.or (LLVM.and (LLVM.and (LLVM.xor e_2 (const? 32 (-1))) e_1) e)
       (LLVM.xor (LLVM.or (LLVM.or e e_2) e_1) (const? 32 (-1))) ⊑
-    LLVM.xor (LLVM.or (LLVM.xor e e_1) e_2) (const? 32 (-1)) := by 
+    LLVM.xor (LLVM.or (LLVM.xor e e_1) e_2) (const? 32 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -985,7 +985,7 @@ theorem not_and_and_or_not_or_or_commute1_or_thm (e e_1 e_2 : IntW 32) :
 theorem not_and_and_or_not_or_or_commute2_or_thm (e e_1 e_2 : IntW 32) :
   LLVM.or (LLVM.and (LLVM.and (LLVM.xor e_2 (const? 32 (-1))) e_1) e)
       (LLVM.xor (LLVM.or (LLVM.or e_1 e) e_2) (const? 32 (-1))) ⊑
-    LLVM.xor (LLVM.or (LLVM.xor e e_1) e_2) (const? 32 (-1)) := by 
+    LLVM.xor (LLVM.or (LLVM.xor e e_1) e_2) (const? 32 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -997,7 +997,7 @@ theorem not_and_and_or_not_or_or_commute2_or_thm (e e_1 e_2 : IntW 32) :
 theorem not_and_and_or_not_or_or_commute1_and_thm (e e_1 e_2 : IntW 32) :
   LLVM.or (LLVM.and (LLVM.and (LLVM.xor e_2 (const? 32 (-1))) e_1) e)
       (LLVM.xor (LLVM.or (LLVM.or e e_2) e_1) (const? 32 (-1))) ⊑
-    LLVM.xor (LLVM.or (LLVM.xor e e_1) e_2) (const? 32 (-1)) := by 
+    LLVM.xor (LLVM.or (LLVM.xor e e_1) e_2) (const? 32 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1009,7 +1009,7 @@ theorem not_and_and_or_not_or_or_commute1_and_thm (e e_1 e_2 : IntW 32) :
 theorem not_and_and_or_not_or_or_commute2_and_thm (e e_1 e_2 : IntW 32) :
   LLVM.or (LLVM.and (LLVM.and e_2 e_1) (LLVM.xor e (const? 32 (-1))))
       (LLVM.xor (LLVM.or (LLVM.or e_2 e) e_1) (const? 32 (-1))) ⊑
-    LLVM.xor (LLVM.or (LLVM.xor e_2 e_1) e) (const? 32 (-1)) := by 
+    LLVM.xor (LLVM.or (LLVM.xor e_2 e_1) e) (const? 32 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1021,7 +1021,7 @@ theorem not_and_and_or_not_or_or_commute2_and_thm (e e_1 e_2 : IntW 32) :
 theorem not_and_and_or_not_or_or_commute1_thm (e e_1 e_2 : IntW 32) :
   LLVM.or (LLVM.and (LLVM.and (LLVM.xor e_2 (const? 32 (-1))) e_1) e)
       (LLVM.xor (LLVM.or (LLVM.or e_2 e_1) e) (const? 32 (-1))) ⊑
-    LLVM.xor (LLVM.or (LLVM.xor e e_1) e_2) (const? 32 (-1)) := by 
+    LLVM.xor (LLVM.or (LLVM.xor e e_1) e_2) (const? 32 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1033,7 +1033,7 @@ theorem not_and_and_or_not_or_or_commute1_thm (e e_1 e_2 : IntW 32) :
 theorem not_and_and_or_not_or_or_commute2_thm (e e_1 e_2 : IntW 32) :
   LLVM.or (LLVM.and (LLVM.and (LLVM.xor e_2 (const? 32 (-1))) e_1) (LLVM.sdiv (const? 32 42) e))
       (LLVM.xor (LLVM.or (LLVM.sdiv (const? 32 42) e) (LLVM.or e_1 e_2)) (const? 32 (-1))) ⊑
-    LLVM.xor (LLVM.or (LLVM.xor (LLVM.sdiv (const? 32 42) e) e_1) e_2) (const? 32 (-1)) := by 
+    LLVM.xor (LLVM.or (LLVM.xor (LLVM.sdiv (const? 32 42) e) e_1) e_2) (const? 32 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1045,7 +1045,7 @@ theorem not_and_and_or_not_or_or_commute2_thm (e e_1 e_2 : IntW 32) :
 theorem not_and_and_or_not_or_or_commute3_thm (e e_1 e_2 : IntW 32) :
   LLVM.or (LLVM.and (LLVM.and (LLVM.sdiv (const? 32 42) e_2) (LLVM.xor e_1 (const? 32 (-1)))) e)
       (LLVM.xor (LLVM.or (LLVM.or (LLVM.sdiv (const? 32 42) e_2) e_1) e) (const? 32 (-1))) ⊑
-    LLVM.xor (LLVM.or (LLVM.xor e (LLVM.sdiv (const? 32 42) e_2)) e_1) (const? 32 (-1)) := by 
+    LLVM.xor (LLVM.or (LLVM.xor e (LLVM.sdiv (const? 32 42) e_2)) e_1) (const? 32 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1057,7 +1057,7 @@ theorem not_and_and_or_not_or_or_commute3_thm (e e_1 e_2 : IntW 32) :
 theorem not_and_and_or_not_or_or_commute4_thm (e e_1 e_2 : IntW 32) :
   LLVM.or (LLVM.and (LLVM.sdiv (const? 32 42) e_2) (LLVM.and (LLVM.xor e_1 (const? 32 (-1))) e))
       (LLVM.xor (LLVM.or (LLVM.or e e_1) (LLVM.sdiv (const? 32 42) e_2)) (const? 32 (-1))) ⊑
-    LLVM.xor (LLVM.or (LLVM.xor (LLVM.sdiv (const? 32 42) e_2) e) e_1) (const? 32 (-1)) := by 
+    LLVM.xor (LLVM.or (LLVM.xor (LLVM.sdiv (const? 32 42) e_2) e) e_1) (const? 32 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1069,7 +1069,7 @@ theorem not_and_and_or_not_or_or_commute4_thm (e e_1 e_2 : IntW 32) :
 theorem not_or_or_and_not_and_and_thm (e e_1 e_2 : IntW 32) :
   LLVM.and (LLVM.or (LLVM.or (LLVM.xor e_2 (const? 32 (-1))) e_1) e)
       (LLVM.xor (LLVM.and (LLVM.and e_1 e_2) e) (const? 32 (-1))) ⊑
-    LLVM.or (LLVM.xor e e_1) (LLVM.xor e_2 (const? 32 (-1))) := by 
+    LLVM.or (LLVM.xor e e_1) (LLVM.xor e_2 (const? 32 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1081,7 +1081,7 @@ theorem not_or_or_and_not_and_and_thm (e e_1 e_2 : IntW 32) :
 theorem not_or_or_and_not_and_and_commute1_and_thm (e e_1 e_2 : IntW 32) :
   LLVM.and (LLVM.or (LLVM.or (LLVM.xor e_2 (const? 32 (-1))) e_1) e)
       (LLVM.xor (LLVM.and (LLVM.and e e_2) e_1) (const? 32 (-1))) ⊑
-    LLVM.or (LLVM.xor e e_1) (LLVM.xor e_2 (const? 32 (-1))) := by 
+    LLVM.or (LLVM.xor e e_1) (LLVM.xor e_2 (const? 32 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1093,7 +1093,7 @@ theorem not_or_or_and_not_and_and_commute1_and_thm (e e_1 e_2 : IntW 32) :
 theorem not_or_or_and_not_and_and_commute2_and_thm (e e_1 e_2 : IntW 32) :
   LLVM.and (LLVM.or (LLVM.or (LLVM.xor e_2 (const? 32 (-1))) e_1) e)
       (LLVM.xor (LLVM.and (LLVM.and e_1 e) e_2) (const? 32 (-1))) ⊑
-    LLVM.or (LLVM.xor e e_1) (LLVM.xor e_2 (const? 32 (-1))) := by 
+    LLVM.or (LLVM.xor e e_1) (LLVM.xor e_2 (const? 32 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1105,7 +1105,7 @@ theorem not_or_or_and_not_and_and_commute2_and_thm (e e_1 e_2 : IntW 32) :
 theorem not_or_or_and_not_and_and_commute1_or_thm (e e_1 e_2 : IntW 32) :
   LLVM.and (LLVM.or (LLVM.or (LLVM.xor e_2 (const? 32 (-1))) e_1) e)
       (LLVM.xor (LLVM.and (LLVM.and e e_2) e_1) (const? 32 (-1))) ⊑
-    LLVM.or (LLVM.xor e e_1) (LLVM.xor e_2 (const? 32 (-1))) := by 
+    LLVM.or (LLVM.xor e e_1) (LLVM.xor e_2 (const? 32 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1117,7 +1117,7 @@ theorem not_or_or_and_not_and_and_commute1_or_thm (e e_1 e_2 : IntW 32) :
 theorem not_or_or_and_not_and_and_commute2_or_thm (e e_1 e_2 : IntW 32) :
   LLVM.and (LLVM.or (LLVM.or e_2 e_1) (LLVM.xor e (const? 32 (-1))))
       (LLVM.xor (LLVM.and (LLVM.and e_2 e) e_1) (const? 32 (-1))) ⊑
-    LLVM.or (LLVM.xor e_2 e_1) (LLVM.xor e (const? 32 (-1))) := by 
+    LLVM.or (LLVM.xor e_2 e_1) (LLVM.xor e (const? 32 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1129,7 +1129,7 @@ theorem not_or_or_and_not_and_and_commute2_or_thm (e e_1 e_2 : IntW 32) :
 theorem not_or_or_and_not_and_and_commute1_thm (e e_1 e_2 : IntW 32) :
   LLVM.and (LLVM.or (LLVM.or (LLVM.xor e_2 (const? 32 (-1))) e_1) e)
       (LLVM.xor (LLVM.and (LLVM.and e_2 e_1) e) (const? 32 (-1))) ⊑
-    LLVM.or (LLVM.xor e e_1) (LLVM.xor e_2 (const? 32 (-1))) := by 
+    LLVM.or (LLVM.xor e e_1) (LLVM.xor e_2 (const? 32 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1141,7 +1141,7 @@ theorem not_or_or_and_not_and_and_commute1_thm (e e_1 e_2 : IntW 32) :
 theorem not_or_or_and_not_and_and_commute2_thm (e e_1 e_2 : IntW 32) :
   LLVM.and (LLVM.or (LLVM.or (LLVM.xor e_2 (const? 32 (-1))) e_1) (LLVM.sdiv (const? 32 42) e))
       (LLVM.xor (LLVM.and (LLVM.sdiv (const? 32 42) e) (LLVM.and e_1 e_2)) (const? 32 (-1))) ⊑
-    LLVM.or (LLVM.xor (LLVM.sdiv (const? 32 42) e) e_1) (LLVM.xor e_2 (const? 32 (-1))) := by 
+    LLVM.or (LLVM.xor (LLVM.sdiv (const? 32 42) e) e_1) (LLVM.xor e_2 (const? 32 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1153,7 +1153,7 @@ theorem not_or_or_and_not_and_and_commute2_thm (e e_1 e_2 : IntW 32) :
 theorem not_or_or_and_not_and_and_commute3_thm (e e_1 e_2 : IntW 32) :
   LLVM.and (LLVM.or (LLVM.or (LLVM.sdiv (const? 32 42) e_2) (LLVM.xor e_1 (const? 32 (-1)))) e)
       (LLVM.xor (LLVM.and (LLVM.and (LLVM.sdiv (const? 32 42) e_2) e_1) e) (const? 32 (-1))) ⊑
-    LLVM.or (LLVM.xor e (LLVM.sdiv (const? 32 42) e_2)) (LLVM.xor e_1 (const? 32 (-1))) := by 
+    LLVM.or (LLVM.xor e (LLVM.sdiv (const? 32 42) e_2)) (LLVM.xor e_1 (const? 32 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1165,7 +1165,7 @@ theorem not_or_or_and_not_and_and_commute3_thm (e e_1 e_2 : IntW 32) :
 theorem not_or_or_and_not_and_and_commute4_thm (e e_1 e_2 : IntW 32) :
   LLVM.and (LLVM.or (LLVM.sdiv (const? 32 42) e_2) (LLVM.or (LLVM.xor e_1 (const? 32 (-1))) e))
       (LLVM.xor (LLVM.and (LLVM.and e e_1) (LLVM.sdiv (const? 32 42) e_2)) (const? 32 (-1))) ⊑
-    LLVM.or (LLVM.xor (LLVM.sdiv (const? 32 42) e_2) e) (LLVM.xor e_1 (const? 32 (-1))) := by 
+    LLVM.or (LLVM.xor (LLVM.sdiv (const? 32 42) e_2) e) (LLVM.xor e_1 (const? 32 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1176,7 +1176,7 @@ theorem not_or_or_and_not_and_and_commute4_thm (e e_1 e_2 : IntW 32) :
 
 theorem not_and_and_or_no_or_thm (e e_1 e_2 : IntW 32) :
   LLVM.or (LLVM.and (LLVM.and (LLVM.xor e_2 (const? 32 (-1))) e_1) e) (LLVM.xor (LLVM.or e_1 e_2) (const? 32 (-1))) ⊑
-    LLVM.and (LLVM.or e (LLVM.xor e_1 (const? 32 (-1)))) (LLVM.xor e_2 (const? 32 (-1))) := by 
+    LLVM.and (LLVM.or e (LLVM.xor e_1 (const? 32 (-1)))) (LLVM.xor e_2 (const? 32 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1187,7 +1187,7 @@ theorem not_and_and_or_no_or_thm (e e_1 e_2 : IntW 32) :
 
 theorem not_and_and_or_no_or_commute1_and_thm (e e_1 e_2 : IntW 32) :
   LLVM.or (LLVM.and (LLVM.and e_2 e_1) (LLVM.xor e (const? 32 (-1)))) (LLVM.xor (LLVM.or e_1 e) (const? 32 (-1))) ⊑
-    LLVM.and (LLVM.or e_2 (LLVM.xor e_1 (const? 32 (-1)))) (LLVM.xor e (const? 32 (-1))) := by 
+    LLVM.and (LLVM.or e_2 (LLVM.xor e_1 (const? 32 (-1)))) (LLVM.xor e (const? 32 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1198,7 +1198,7 @@ theorem not_and_and_or_no_or_commute1_and_thm (e e_1 e_2 : IntW 32) :
 
 theorem not_and_and_or_no_or_commute2_and_thm (e e_1 e_2 : IntW 32) :
   LLVM.or (LLVM.and (LLVM.and (LLVM.xor e_2 (const? 32 (-1))) e_1) e) (LLVM.xor (LLVM.or e e_2) (const? 32 (-1))) ⊑
-    LLVM.and (LLVM.or e_1 (LLVM.xor e (const? 32 (-1)))) (LLVM.xor e_2 (const? 32 (-1))) := by 
+    LLVM.and (LLVM.or e_1 (LLVM.xor e (const? 32 (-1)))) (LLVM.xor e_2 (const? 32 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1209,7 +1209,7 @@ theorem not_and_and_or_no_or_commute2_and_thm (e e_1 e_2 : IntW 32) :
 
 theorem not_and_and_or_no_or_commute1_thm (e e_1 e_2 : IntW 32) :
   LLVM.or (LLVM.and (LLVM.and (LLVM.xor e_2 (const? 32 (-1))) e_1) e) (LLVM.xor (LLVM.or e_2 e_1) (const? 32 (-1))) ⊑
-    LLVM.and (LLVM.or e (LLVM.xor e_1 (const? 32 (-1)))) (LLVM.xor e_2 (const? 32 (-1))) := by 
+    LLVM.and (LLVM.or e (LLVM.xor e_1 (const? 32 (-1)))) (LLVM.xor e_2 (const? 32 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1222,7 +1222,7 @@ theorem not_and_and_or_no_or_commute2_thm (e e_1 e_2 : IntW 32) :
   LLVM.or (LLVM.and (LLVM.and (LLVM.sdiv (const? 32 42) e_2) (LLVM.xor e_1 (const? 32 (-1)))) e)
       (LLVM.xor (LLVM.or (LLVM.sdiv (const? 32 42) e_2) e_1) (const? 32 (-1))) ⊑
     LLVM.and (LLVM.or e (LLVM.xor (LLVM.sdiv (const? 32 42) e_2) (const? 32 (-1))))
-      (LLVM.xor e_1 (const? 32 (-1))) := by 
+      (LLVM.xor e_1 (const? 32 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1235,7 +1235,7 @@ theorem not_and_and_or_no_or_commute3_thm (e e_1 e_2 : IntW 32) :
   LLVM.or (LLVM.and (LLVM.sdiv (const? 32 42) e_2) (LLVM.and (LLVM.xor e_1 (const? 32 (-1))) e))
       (LLVM.xor (LLVM.or e e_1) (const? 32 (-1))) ⊑
     LLVM.and (LLVM.or (LLVM.sdiv (const? 32 42) e_2) (LLVM.xor e (const? 32 (-1))))
-      (LLVM.xor e_1 (const? 32 (-1))) := by 
+      (LLVM.xor e_1 (const? 32 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1246,7 +1246,7 @@ theorem not_and_and_or_no_or_commute3_thm (e e_1 e_2 : IntW 32) :
 
 theorem not_or_or_and_no_and_thm (e e_1 e_2 : IntW 32) :
   LLVM.and (LLVM.or (LLVM.or (LLVM.xor e_2 (const? 32 (-1))) e_1) e) (LLVM.xor (LLVM.and e_1 e_2) (const? 32 (-1))) ⊑
-    LLVM.or (LLVM.and e (LLVM.xor e_1 (const? 32 (-1)))) (LLVM.xor e_2 (const? 32 (-1))) := by 
+    LLVM.or (LLVM.and e (LLVM.xor e_1 (const? 32 (-1)))) (LLVM.xor e_2 (const? 32 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1257,7 +1257,7 @@ theorem not_or_or_and_no_and_thm (e e_1 e_2 : IntW 32) :
 
 theorem not_or_or_and_no_and_commute1_or_thm (e e_1 e_2 : IntW 32) :
   LLVM.and (LLVM.or (LLVM.or e_2 e_1) (LLVM.xor e (const? 32 (-1)))) (LLVM.xor (LLVM.and e_1 e) (const? 32 (-1))) ⊑
-    LLVM.or (LLVM.and e_2 (LLVM.xor e_1 (const? 32 (-1)))) (LLVM.xor e (const? 32 (-1))) := by 
+    LLVM.or (LLVM.and e_2 (LLVM.xor e_1 (const? 32 (-1)))) (LLVM.xor e (const? 32 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1268,7 +1268,7 @@ theorem not_or_or_and_no_and_commute1_or_thm (e e_1 e_2 : IntW 32) :
 
 theorem not_or_or_and_no_and_commute2_or_thm (e e_1 e_2 : IntW 32) :
   LLVM.and (LLVM.or (LLVM.or (LLVM.xor e_2 (const? 32 (-1))) e_1) e) (LLVM.xor (LLVM.and e e_2) (const? 32 (-1))) ⊑
-    LLVM.or (LLVM.and e_1 (LLVM.xor e (const? 32 (-1)))) (LLVM.xor e_2 (const? 32 (-1))) := by 
+    LLVM.or (LLVM.and e_1 (LLVM.xor e (const? 32 (-1)))) (LLVM.xor e_2 (const? 32 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1279,7 +1279,7 @@ theorem not_or_or_and_no_and_commute2_or_thm (e e_1 e_2 : IntW 32) :
 
 theorem not_or_or_and_no_and_commute1_thm (e e_1 e_2 : IntW 32) :
   LLVM.and (LLVM.or (LLVM.or (LLVM.xor e_2 (const? 32 (-1))) e_1) e) (LLVM.xor (LLVM.and e_2 e_1) (const? 32 (-1))) ⊑
-    LLVM.or (LLVM.and e (LLVM.xor e_1 (const? 32 (-1)))) (LLVM.xor e_2 (const? 32 (-1))) := by 
+    LLVM.or (LLVM.and e (LLVM.xor e_1 (const? 32 (-1)))) (LLVM.xor e_2 (const? 32 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1292,7 +1292,7 @@ theorem not_or_or_and_no_and_commute2_thm (e e_1 e_2 : IntW 32) :
   LLVM.and (LLVM.or (LLVM.or (LLVM.sdiv (const? 32 42) e_2) (LLVM.xor e_1 (const? 32 (-1)))) e)
       (LLVM.xor (LLVM.and (LLVM.sdiv (const? 32 42) e_2) e_1) (const? 32 (-1))) ⊑
     LLVM.or (LLVM.and e (LLVM.xor (LLVM.sdiv (const? 32 42) e_2) (const? 32 (-1))))
-      (LLVM.xor e_1 (const? 32 (-1))) := by 
+      (LLVM.xor e_1 (const? 32 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1305,7 +1305,7 @@ theorem not_or_or_and_no_and_commute3_thm (e e_1 e_2 : IntW 32) :
   LLVM.and (LLVM.or (LLVM.sdiv (const? 32 42) e_2) (LLVM.or (LLVM.xor e_1 (const? 32 (-1))) e))
       (LLVM.xor (LLVM.and e e_1) (const? 32 (-1))) ⊑
     LLVM.or (LLVM.and (LLVM.sdiv (const? 32 42) e_2) (LLVM.xor e (const? 32 (-1))))
-      (LLVM.xor e_1 (const? 32 (-1))) := by 
+      (LLVM.xor e_1 (const? 32 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1316,7 +1316,7 @@ theorem not_or_or_and_no_and_commute3_thm (e e_1 e_2 : IntW 32) :
 
 theorem and_orn_xor_thm (e e_1 : IntW 4) :
   LLVM.and (LLVM.or (LLVM.xor e_1 (const? 4 (-1))) e) (LLVM.xor e_1 e) ⊑
-    LLVM.and e (LLVM.xor e_1 (const? 4 (-1))) := by 
+    LLVM.and e (LLVM.xor e_1 (const? 4 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1327,7 +1327,7 @@ theorem and_orn_xor_thm (e e_1 : IntW 4) :
 
 theorem and_orn_xor_commute8_thm (e e_1 : IntW 32) :
   LLVM.and (LLVM.xor (mul e_1 e_1) (mul e e)) (LLVM.or (mul e_1 e_1) (LLVM.xor (mul e e) (const? 32 (-1)))) ⊑
-    LLVM.and (mul e_1 e_1) (LLVM.xor (mul e e) (const? 32 (-1))) := by 
+    LLVM.and (mul e_1 e_1) (LLVM.xor (mul e e) (const? 32 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1337,7 +1337,7 @@ theorem and_orn_xor_commute8_thm (e e_1 : IntW 32) :
 
 
 theorem and_zext_zext_thm (e : IntW 4) (e_1 : IntW 8) :
-  LLVM.and (zext 16 e_1) (zext 16 e) ⊑ zext 16 (LLVM.and e_1 (zext 8 e)) { «nneg» := true } := by 
+  LLVM.and (zext 16 e_1) (zext 16 e) ⊑ zext 16 (LLVM.and e_1 (zext 8 e)) { «nneg» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1347,7 +1347,7 @@ theorem and_zext_zext_thm (e : IntW 4) (e_1 : IntW 8) :
 
 
 theorem or_zext_zext_thm (e : IntW 8) (e_1 : IntW 4) :
-  LLVM.or (zext 16 e_1) (zext 16 e) ⊑ zext 16 (LLVM.or e (zext 8 e_1)) := by 
+  LLVM.or (zext 16 e_1) (zext 16 e) ⊑ zext 16 (LLVM.or e (zext 8 e_1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1357,7 +1357,7 @@ theorem or_zext_zext_thm (e : IntW 8) (e_1 : IntW 4) :
 
 
 theorem and_sext_sext_thm (e : IntW 8) (e_1 : IntW 4) :
-  LLVM.and (sext 16 e_1) (sext 16 e) ⊑ sext 16 (LLVM.and e (sext 8 e_1)) := by 
+  LLVM.and (sext 16 e_1) (sext 16 e) ⊑ sext 16 (LLVM.and e (sext 8 e_1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1367,7 +1367,7 @@ theorem and_sext_sext_thm (e : IntW 8) (e_1 : IntW 4) :
 
 
 theorem or_sext_sext_thm (e : IntW 4) (e_1 : IntW 8) :
-  LLVM.or (sext 16 e_1) (sext 16 e) ⊑ sext 16 (LLVM.or e_1 (sext 8 e)) := by 
+  LLVM.or (sext 16 e_1) (sext 16 e) ⊑ sext 16 (LLVM.or e_1 (sext 8 e)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1377,7 +1377,7 @@ theorem or_sext_sext_thm (e : IntW 4) (e_1 : IntW 8) :
 
 
 theorem xor_sext_sext_thm (e : IntW 4) (e_1 : IntW 8) :
-  LLVM.xor (sext 16 e_1) (sext 16 e) ⊑ sext 16 (LLVM.xor e_1 (sext 8 e)) := by 
+  LLVM.xor (sext 16 e_1) (sext 16 e) ⊑ sext 16 (LLVM.xor e_1 (sext 8 e)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1389,7 +1389,7 @@ theorem xor_sext_sext_thm (e : IntW 4) (e_1 : IntW 8) :
 theorem PR56294_thm (e : IntW 8) :
   icmp IntPredicate.ne (LLVM.and (zext 32 (icmp IntPredicate.eq e (const? 8 2))) (zext 32 (LLVM.and e (const? 8 1))))
       (const? 32 0) ⊑
-    const? 1 0 := by 
+    const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1399,7 +1399,7 @@ theorem PR56294_thm (e : IntW 8) :
 
 
 theorem canonicalize_logic_first_or0_thm (e : IntW 32) :
-  LLVM.or (add e (const? 32 112)) (const? 32 15) ⊑ add (LLVM.or e (const? 32 15)) (const? 32 112) := by 
+  LLVM.or (add e (const? 32 112)) (const? 32 15) ⊑ add (LLVM.or e (const? 32 15)) (const? 32 112) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1410,7 +1410,7 @@ theorem canonicalize_logic_first_or0_thm (e : IntW 32) :
 
 theorem canonicalize_logic_first_or0_nsw_thm (e : IntW 32) :
   LLVM.or (add e (const? 32 112) { «nsw» := true, «nuw» := false }) (const? 32 15) ⊑
-    add (LLVM.or e (const? 32 15)) (const? 32 112) { «nsw» := true, «nuw» := false } := by 
+    add (LLVM.or e (const? 32 15)) (const? 32 112) { «nsw» := true, «nuw» := false } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1421,7 +1421,7 @@ theorem canonicalize_logic_first_or0_nsw_thm (e : IntW 32) :
 
 theorem canonicalize_logic_first_or0_nswnuw_thm (e : IntW 32) :
   LLVM.or (add e (const? 32 112) { «nsw» := true, «nuw» := true }) (const? 32 15) ⊑
-    add (LLVM.or e (const? 32 15)) (const? 32 112) { «nsw» := true, «nuw» := true } := by 
+    add (LLVM.or e (const? 32 15)) (const? 32 112) { «nsw» := true, «nuw» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1431,7 +1431,7 @@ theorem canonicalize_logic_first_or0_nswnuw_thm (e : IntW 32) :
 
 
 theorem canonicalize_logic_first_and0_thm (e : IntW 8) :
-  LLVM.and (add e (const? 8 48)) (const? 8 (-10)) ⊑ add (LLVM.and e (const? 8 (-10))) (const? 8 48) := by 
+  LLVM.and (add e (const? 8 48)) (const? 8 (-10)) ⊑ add (LLVM.and e (const? 8 (-10))) (const? 8 48) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1442,7 +1442,7 @@ theorem canonicalize_logic_first_and0_thm (e : IntW 8) :
 
 theorem canonicalize_logic_first_and0_nsw_thm (e : IntW 8) :
   LLVM.and (add e (const? 8 48) { «nsw» := true, «nuw» := false }) (const? 8 (-10)) ⊑
-    add (LLVM.and e (const? 8 (-10))) (const? 8 48) { «nsw» := true, «nuw» := false } := by 
+    add (LLVM.and e (const? 8 (-10))) (const? 8 48) { «nsw» := true, «nuw» := false } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1453,7 +1453,7 @@ theorem canonicalize_logic_first_and0_nsw_thm (e : IntW 8) :
 
 theorem canonicalize_logic_first_and0_nswnuw_thm (e : IntW 8) :
   LLVM.and (add e (const? 8 48) { «nsw» := true, «nuw» := true }) (const? 8 (-10)) ⊑
-    add (LLVM.and e (const? 8 (-10))) (const? 8 48) { «nsw» := true, «nuw» := true } := by 
+    add (LLVM.and e (const? 8 (-10))) (const? 8 48) { «nsw» := true, «nuw» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1463,7 +1463,7 @@ theorem canonicalize_logic_first_and0_nswnuw_thm (e : IntW 8) :
 
 
 theorem canonicalize_logic_first_xor_0_thm (e : IntW 8) :
-  LLVM.xor (add e (const? 8 96)) (const? 8 31) ⊑ add (LLVM.xor e (const? 8 31)) (const? 8 96) := by 
+  LLVM.xor (add e (const? 8 96)) (const? 8 31) ⊑ add (LLVM.xor e (const? 8 31)) (const? 8 96) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1474,7 +1474,7 @@ theorem canonicalize_logic_first_xor_0_thm (e : IntW 8) :
 
 theorem canonicalize_logic_first_xor_0_nsw_thm (e : IntW 8) :
   LLVM.xor (add e (const? 8 96) { «nsw» := true, «nuw» := false }) (const? 8 31) ⊑
-    add (LLVM.xor e (const? 8 31)) (const? 8 96) { «nsw» := true, «nuw» := false } := by 
+    add (LLVM.xor e (const? 8 31)) (const? 8 96) { «nsw» := true, «nuw» := false } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1485,7 +1485,7 @@ theorem canonicalize_logic_first_xor_0_nsw_thm (e : IntW 8) :
 
 theorem canonicalize_logic_first_xor_0_nswnuw_thm (e : IntW 8) :
   LLVM.xor (add e (const? 8 96) { «nsw» := true, «nuw» := true }) (const? 8 31) ⊑
-    add (LLVM.xor e (const? 8 31)) (const? 8 96) { «nsw» := true, «nuw» := true } := by 
+    add (LLVM.xor e (const? 8 31)) (const? 8 96) { «nsw» := true, «nuw» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1495,7 +1495,7 @@ theorem canonicalize_logic_first_xor_0_nswnuw_thm (e : IntW 8) :
 
 
 theorem test_and_xor_freely_invertable_thm (e : IntW 1) (e_1 e_2 : IntW 32) :
-  LLVM.and (LLVM.xor (icmp IntPredicate.sgt e_2 e_1) e) e ⊑ LLVM.and (icmp IntPredicate.sle e_2 e_1) e := by 
+  LLVM.and (LLVM.xor (icmp IntPredicate.sgt e_2 e_1) e) e ⊑ LLVM.and (icmp IntPredicate.sle e_2 e_1) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gannotations_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gannotations_proof.lean
@@ -8,7 +8,7 @@ set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
 
 section gannotations_proof
-theorem do_not_add_annotation_to_existing_instr_thm (e e_1 : IntW 32) : add (const? 32 0) (add e_1 e) ⊑ add e_1 e := by 
+theorem do_not_add_annotation_to_existing_instr_thm (e e_1 : IntW 32) : add (const? 32 0) (add e_1 e) ⊑ add e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gapinthadd_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gapinthadd_proof.lean
@@ -8,7 +8,7 @@ set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
 
 section gapinthadd_proof
-theorem test1_thm (e : IntW 1) : add (LLVM.xor e (const? 1 1)) (const? 1 1) ⊑ e := by 
+theorem test1_thm (e : IntW 1) : add (LLVM.xor e (const? 1 1)) (const? 1 1) ⊑ e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -18,7 +18,7 @@ theorem test1_thm (e : IntW 1) : add (LLVM.xor e (const? 1 1)) (const? 1 1) ⊑ 
 
 
 theorem test2_thm (e : IntW 47) :
-  add (LLVM.xor e (const? 47 (-70368744177664))) (const? 47 (-70368744177664)) ⊑ e := by 
+  add (LLVM.xor e (const? 47 (-70368744177664))) (const? 47 (-70368744177664)) ⊑ e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -27,7 +27,7 @@ theorem test2_thm (e : IntW 47) :
     all_goals sorry
 
 
-theorem test3_thm (e : IntW 15) : add (LLVM.xor e (const? 15 (-16384))) (const? 15 (-16384)) ⊑ e := by 
+theorem test3_thm (e : IntW 15) : add (LLVM.xor e (const? 15 (-16384))) (const? 15 (-16384)) ⊑ e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -36,7 +36,7 @@ theorem test3_thm (e : IntW 15) : add (LLVM.xor e (const? 15 (-16384))) (const? 
     all_goals sorry
 
 
-theorem test4_thm (e : IntW 49) : add (LLVM.and e (const? 49 (-2))) (const? 49 1) ⊑ LLVM.or e (const? 49 1) := by 
+theorem test4_thm (e : IntW 49) : add (LLVM.and e (const? 49 (-2))) (const? 49 1) ⊑ LLVM.or e (const? 49 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -46,7 +46,7 @@ theorem test4_thm (e : IntW 49) : add (LLVM.and e (const? 49 (-2))) (const? 49 1
 
 
 theorem sext_thm (e : IntW 4) :
-  add (zext 7 (LLVM.xor e (const? 4 (-8)))) (const? 7 (-8)) { «nsw» := true, «nuw» := false } ⊑ sext 7 e := by 
+  add (zext 7 (LLVM.xor e (const? 4 (-8)))) (const? 7 (-8)) { «nsw» := true, «nuw» := false } ⊑ sext 7 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -62,7 +62,7 @@ theorem sext_multiuse_thm (e : IntW 4) :
           (add (zext 7 (LLVM.xor e (const? 4 (-8)))) (const? 7 (-8)) { «nsw» := true, «nuw» := false })))
       (LLVM.xor e (const? 4 (-8))) ⊑
     LLVM.sdiv (trunc 4 (LLVM.sdiv (zext 7 (LLVM.xor e (const? 4 (-8)))) (sext 7 e)))
-      (LLVM.xor e (const? 4 (-8))) := by 
+      (LLVM.xor e (const? 4 (-8))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -72,7 +72,7 @@ theorem sext_multiuse_thm (e : IntW 4) :
 
 
 theorem test5_thm (e : IntW 111) :
-  add (LLVM.xor e (shl (const? 111 1) (const? 111 110))) (shl (const? 111 1) (const? 111 110)) ⊑ e := by 
+  add (LLVM.xor e (shl (const? 111 1) (const? 111 110))) (shl (const? 111 1) (const? 111 110)) ⊑ e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -82,7 +82,7 @@ theorem test5_thm (e : IntW 111) :
 
 
 theorem test6_thm (e : IntW 65) :
-  add (LLVM.xor e (shl (const? 65 1) (const? 65 64))) (shl (const? 65 1) (const? 65 64)) ⊑ e := by 
+  add (LLVM.xor e (shl (const? 65 1) (const? 65 64))) (shl (const? 65 1) (const? 65 64)) ⊑ e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -92,7 +92,7 @@ theorem test6_thm (e : IntW 65) :
 
 
 theorem test7_thm (e : IntW 1024) :
-  add (LLVM.xor e (shl (const? 1024 1) (const? 1024 1023))) (shl (const? 1024 1) (const? 1024 1023)) ⊑ e := by 
+  add (LLVM.xor e (shl (const? 1024 1) (const? 1024 1023))) (shl (const? 1024 1) (const? 1024 1023)) ⊑ e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -103,7 +103,7 @@ theorem test7_thm (e : IntW 1024) :
 
 theorem test8_thm (e : IntW 128) :
   add (LLVM.xor e (ashr (shl (const? 128 1) (const? 128 127)) (const? 128 120))) (shl (const? 128 1) (const? 128 127)) ⊑
-    LLVM.xor e (const? 128 170141183460469231731687303715884105600) := by 
+    LLVM.xor e (const? 128 170141183460469231731687303715884105600) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -114,7 +114,7 @@ theorem test8_thm (e : IntW 128) :
 
 theorem test9_thm (e : IntW 77) :
   add (LLVM.and e (const? 77 562949953421310)) (const? 77 1) ⊑
-    LLVM.or (LLVM.and e (const? 77 562949953421310)) (const? 77 1) { «disjoint» := true } := by 
+    LLVM.or (LLVM.and e (const? 77 562949953421310)) (const? 77 1) { «disjoint» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gapinthand_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gapinthand_proof.lean
@@ -8,7 +8,7 @@ set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
 
 section gapinthand_proof
-theorem test0_thm (e : IntW 39) : LLVM.and e (const? 39 0) ⊑ const? 39 0 := by 
+theorem test0_thm (e : IntW 39) : LLVM.and e (const? 39 0) ⊑ const? 39 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -17,7 +17,7 @@ theorem test0_thm (e : IntW 39) : LLVM.and e (const? 39 0) ⊑ const? 39 0 := by
     all_goals sorry
 
 
-theorem test2_thm (e : IntW 15) : LLVM.and e (const? 15 (-1)) ⊑ e := by 
+theorem test2_thm (e : IntW 15) : LLVM.and e (const? 15 (-1)) ⊑ e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -26,7 +26,7 @@ theorem test2_thm (e : IntW 15) : LLVM.and e (const? 15 (-1)) ⊑ e := by
     all_goals sorry
 
 
-theorem test3_thm (e : IntW 23) : LLVM.and (LLVM.and e (const? 23 127)) (const? 23 128) ⊑ const? 23 0 := by 
+theorem test3_thm (e : IntW 23) : LLVM.and (LLVM.and e (const? 23 127)) (const? 23 128) ⊑ const? 23 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -37,7 +37,7 @@ theorem test3_thm (e : IntW 23) : LLVM.and (LLVM.and e (const? 23 127)) (const? 
 
 theorem test4_thm (e : IntW 37) :
   icmp IntPredicate.ne (LLVM.and e (const? 37 (-2147483648))) (const? 37 0) ⊑
-    icmp IntPredicate.ugt e (const? 37 2147483647) := by 
+    icmp IntPredicate.ugt e (const? 37 2147483647) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -46,7 +46,7 @@ theorem test4_thm (e : IntW 37) :
     all_goals sorry
 
 
-theorem test7_thm (e : IntW 47) : LLVM.and (ashr e (const? 47 39)) (const? 47 255) ⊑ lshr e (const? 47 39) := by 
+theorem test7_thm (e : IntW 47) : LLVM.and (ashr e (const? 47 39)) (const? 47 255) ⊑ lshr e (const? 47 39) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -55,7 +55,7 @@ theorem test7_thm (e : IntW 47) : LLVM.and (ashr e (const? 47 39)) (const? 47 25
     all_goals sorry
 
 
-theorem test8_thm (e : IntW 999) : LLVM.and e (const? 999 0) ⊑ const? 999 0 := by 
+theorem test8_thm (e : IntW 999) : LLVM.and e (const? 999 0) ⊑ const? 999 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -64,7 +64,7 @@ theorem test8_thm (e : IntW 999) : LLVM.and e (const? 999 0) ⊑ const? 999 0 :=
     all_goals sorry
 
 
-theorem test9_thm (e : IntW 1005) : LLVM.and e (const? 1005 (-1)) ⊑ e := by 
+theorem test9_thm (e : IntW 1005) : LLVM.and e (const? 1005 (-1)) ⊑ e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -73,7 +73,7 @@ theorem test9_thm (e : IntW 1005) : LLVM.and e (const? 1005 (-1)) ⊑ e := by
     all_goals sorry
 
 
-theorem test10_thm (e : IntW 123) : LLVM.and (LLVM.and e (const? 123 127)) (const? 123 128) ⊑ const? 123 0 := by 
+theorem test10_thm (e : IntW 123) : LLVM.and (LLVM.and e (const? 123 127)) (const? 123 128) ⊑ const? 123 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -84,7 +84,7 @@ theorem test10_thm (e : IntW 123) : LLVM.and (LLVM.and e (const? 123 127)) (cons
 
 theorem test11_thm (e : IntW 737) :
   icmp IntPredicate.ne (LLVM.and e (const? 737 (-2147483648))) (const? 737 0) ⊑
-    icmp IntPredicate.ugt e (const? 737 2147483647) := by 
+    icmp IntPredicate.ugt e (const? 737 2147483647) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -94,7 +94,7 @@ theorem test11_thm (e : IntW 737) :
 
 
 theorem test13_thm (e : IntW 1024) :
-  LLVM.and (ashr e (const? 1024 1016)) (const? 1024 255) ⊑ lshr e (const? 1024 1016) := by 
+  LLVM.and (ashr e (const? 1024 1016)) (const? 1024 255) ⊑ lshr e (const? 1024 1016) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gapinthandhcompare_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gapinthandhcompare_proof.lean
@@ -10,7 +10,7 @@ set_option linter.unreachableTactic false
 section gapinthandhcompare_proof
 theorem test1_thm (e e_1 : IntW 33) :
   icmp IntPredicate.ne (LLVM.and e_1 (const? 33 65280)) (LLVM.and e (const? 33 65280)) ⊑
-    icmp IntPredicate.ne (LLVM.and (LLVM.xor e_1 e) (const? 33 65280)) (const? 33 0) := by 
+    icmp IntPredicate.ne (LLVM.and (LLVM.xor e_1 e) (const? 33 65280)) (const? 33 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -21,7 +21,7 @@ theorem test1_thm (e e_1 : IntW 33) :
 
 theorem test2_thm (e e_1 : IntW 999) :
   icmp IntPredicate.ne (LLVM.and e_1 (const? 999 65280)) (LLVM.and e (const? 999 65280)) ⊑
-    icmp IntPredicate.ne (LLVM.and (LLVM.xor e_1 e) (const? 999 65280)) (const? 999 0) := by 
+    icmp IntPredicate.ne (LLVM.and (LLVM.xor e_1 e) (const? 999 65280)) (const? 999 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gapinthandhorhand_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gapinthandhorhand_proof.lean
@@ -10,7 +10,7 @@ set_option linter.unreachableTactic false
 section gapinthandhorhand_proof
 theorem test1_thm (e e_1 : IntW 17) :
   LLVM.and (LLVM.or (LLVM.and e_1 (const? 17 7)) (LLVM.and e (const? 17 8))) (const? 17 7) ⊑
-    LLVM.and e_1 (const? 17 7) := by 
+    LLVM.and e_1 (const? 17 7) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -20,7 +20,7 @@ theorem test1_thm (e e_1 : IntW 17) :
 
 
 theorem test3_thm (e e_1 : IntW 49) :
-  LLVM.and (LLVM.or e_1 (shl e (const? 49 1))) (const? 49 1) ⊑ LLVM.and e_1 (const? 49 1) := by 
+  LLVM.and (LLVM.or e_1 (shl e (const? 49 1))) (const? 49 1) ⊑ LLVM.and e_1 (const? 49 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -30,7 +30,7 @@ theorem test3_thm (e e_1 : IntW 49) :
 
 
 theorem test4_thm (e e_1 : IntW 67) :
-  LLVM.and (LLVM.or e_1 (lshr e (const? 67 66))) (const? 67 2) ⊑ LLVM.and e_1 (const? 67 2) := by 
+  LLVM.and (LLVM.or e_1 (lshr e (const? 67 66))) (const? 67 2) ⊑ LLVM.and e_1 (const? 67 2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -39,7 +39,7 @@ theorem test4_thm (e e_1 : IntW 67) :
     all_goals sorry
 
 
-theorem or_test1_thm (e : IntW 231) : LLVM.or (LLVM.and e (const? 231 1)) (const? 231 1) ⊑ const? 231 1 := by 
+theorem or_test1_thm (e : IntW 231) : LLVM.or (LLVM.and e (const? 231 1)) (const? 231 1) ⊑ const? 231 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -48,7 +48,7 @@ theorem or_test1_thm (e : IntW 231) : LLVM.or (LLVM.and e (const? 231 1)) (const
     all_goals sorry
 
 
-theorem or_test2_thm (e : IntW 7) : LLVM.or (shl e (const? 7 6)) (const? 7 (-64)) ⊑ const? 7 (-64) := by 
+theorem or_test2_thm (e : IntW 7) : LLVM.or (shl e (const? 7 6)) (const? 7 (-64)) ⊑ const? 7 (-64) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gapinthandhxorhmerge_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gapinthandhxorhmerge_proof.lean
@@ -9,7 +9,7 @@ set_option linter.unreachableTactic false
 
 section gapinthandhxorhmerge_proof
 theorem test1_thm (e e_1 e_2 : IntW 57) :
-  LLVM.xor (LLVM.and e_2 e_1) (LLVM.and e_2 e) ⊑ LLVM.and e_2 (LLVM.xor e_1 e) := by 
+  LLVM.xor (LLVM.and e_2 e_1) (LLVM.and e_2 e) ⊑ LLVM.and e_2 (LLVM.xor e_1 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -18,7 +18,7 @@ theorem test1_thm (e e_1 e_2 : IntW 57) :
     all_goals sorry
 
 
-theorem test2_thm (e e_1 : IntW 23) : LLVM.xor (LLVM.and e_1 e) (LLVM.or e_1 e) ⊑ LLVM.xor e_1 e := by 
+theorem test2_thm (e e_1 : IntW 23) : LLVM.xor (LLVM.and e_1 e) (LLVM.or e_1 e) ⊑ LLVM.xor e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gapinthcast_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gapinthcast_proof.lean
@@ -10,7 +10,7 @@ set_option linter.unreachableTactic false
 section gapinthcast_proof
 theorem test1_thm (e : IntW 17) :
   trunc 17 (LLVM.or (lshr (zext 37 e) (const? 37 8)) (shl (zext 37 e) (const? 37 8))) ⊑
-    LLVM.or (lshr e (const? 17 8)) (shl e (const? 17 8)) := by 
+    LLVM.or (lshr e (const? 17 8)) (shl e (const? 17 8)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -21,7 +21,7 @@ theorem test1_thm (e : IntW 17) :
 
 theorem test2_thm (e : IntW 167) :
   trunc 167 (LLVM.or (lshr (zext 577 e) (const? 577 9)) (shl (zext 577 e) (const? 577 8))) ⊑
-    LLVM.or (lshr e (const? 167 9)) (shl e (const? 167 8)) := by 
+    LLVM.or (lshr e (const? 167 9)) (shl e (const? 167 8)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gapinthcasthcasthtohand_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gapinthcasthcasthtohand_proof.lean
@@ -8,7 +8,7 @@ set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
 
 section gapinthcasthcasthtohand_proof
-theorem test1_thm (e : IntW 61) : zext 61 (trunc 41 e) ⊑ LLVM.and e (const? 61 2199023255551) := by 
+theorem test1_thm (e : IntW 61) : zext 61 (trunc 41 e) ⊑ LLVM.and e (const? 61 2199023255551) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gapinthdiv1_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gapinthdiv1_proof.lean
@@ -8,7 +8,7 @@ set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
 
 section gapinthdiv1_proof
-theorem test1_thm (e : IntW 33) : LLVM.udiv e (const? 33 4096) ⊑ lshr e (const? 33 12) := by 
+theorem test1_thm (e : IntW 33) : LLVM.udiv e (const? 33 4096) ⊑ lshr e (const? 33 12) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -17,7 +17,7 @@ theorem test1_thm (e : IntW 33) : LLVM.udiv e (const? 33 4096) ⊑ lshr e (const
     all_goals sorry
 
 
-theorem test2_thm (e : IntW 49) : LLVM.udiv e (shl (const? 49 4096) (const? 49 17)) ⊑ lshr e (const? 49 29) := by 
+theorem test2_thm (e : IntW 49) : LLVM.udiv e (shl (const? 49 4096) (const? 49 17)) ⊑ lshr e (const? 49 29) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -28,7 +28,7 @@ theorem test2_thm (e : IntW 49) : LLVM.udiv e (shl (const? 49 4096) (const? 49 1
 
 theorem test3_thm (e : IntW 1) (e_1 : IntW 59) :
   LLVM.udiv e_1 (select e (const? 59 1024) (const? 59 4096)) ⊑
-    lshr e_1 (select e (const? 59 10) (const? 59 12)) := by 
+    lshr e_1 (select e (const? 59 10) (const? 59 12)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gapinthdiv2_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gapinthdiv2_proof.lean
@@ -8,7 +8,7 @@ set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
 
 section gapinthdiv2_proof
-theorem test1_thm (e : IntW 333) : LLVM.udiv e (const? 333 70368744177664) ⊑ lshr e (const? 333 46) := by 
+theorem test1_thm (e : IntW 333) : LLVM.udiv e (const? 333 70368744177664) ⊑ lshr e (const? 333 46) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -18,7 +18,7 @@ theorem test1_thm (e : IntW 333) : LLVM.udiv e (const? 333 70368744177664) ⊑ l
 
 
 theorem test2_thm (e : IntW 499) :
-  LLVM.udiv e (shl (const? 499 4096) (const? 499 197)) ⊑ lshr e (const? 499 209) := by 
+  LLVM.udiv e (shl (const? 499 4096) (const? 499 197)) ⊑ lshr e (const? 499 209) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -29,7 +29,7 @@ theorem test2_thm (e : IntW 499) :
 
 theorem test3_thm (e : IntW 1) (e_1 : IntW 599) :
   LLVM.udiv e_1 (select e (const? 599 70368744177664) (const? 599 4096)) ⊑
-    lshr e_1 (select e (const? 599 46) (const? 599 12)) := by 
+    lshr e_1 (select e (const? 599 46) (const? 599 12)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gapinthmul1_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gapinthmul1_proof.lean
@@ -8,7 +8,7 @@ set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
 
 section gapinthmul1_proof
-theorem test1_thm (e : IntW 17) : mul e (const? 17 1024) ⊑ shl e (const? 17 10) := by 
+theorem test1_thm (e : IntW 17) : mul e (const? 17 1024) ⊑ shl e (const? 17 10) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gapinthmul2_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gapinthmul2_proof.lean
@@ -8,7 +8,7 @@ set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
 
 section gapinthmul2_proof
-theorem test1_thm (e : IntW 177) : mul e (shl (const? 177 1) (const? 177 155)) ⊑ shl e (const? 177 155) := by 
+theorem test1_thm (e : IntW 177) : mul e (shl (const? 177 1) (const? 177 155)) ⊑ shl e (const? 177 155) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gapinthnot_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gapinthnot_proof.lean
@@ -8,7 +8,7 @@ set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
 
 section gapinthnot_proof
-theorem test1_thm (e : IntW 33) : LLVM.xor (LLVM.xor e (const? 33 (-1))) (const? 33 (-1)) ⊑ e := by 
+theorem test1_thm (e : IntW 33) : LLVM.xor (LLVM.xor e (const? 33 (-1))) (const? 33 (-1)) ⊑ e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -18,7 +18,7 @@ theorem test1_thm (e : IntW 33) : LLVM.xor (LLVM.xor e (const? 33 (-1))) (const?
 
 
 theorem test2_thm (e e_1 : IntW 52) :
-  LLVM.xor (icmp IntPredicate.ule e_1 e) (const? 1 1) ⊑ icmp IntPredicate.ugt e_1 e := by 
+  LLVM.xor (icmp IntPredicate.ule e_1 e) (const? 1 1) ⊑ icmp IntPredicate.ugt e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gapinthor_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gapinthor_proof.lean
@@ -8,7 +8,7 @@ set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
 
 section gapinthor_proof
-theorem test1_thm (e : IntW 23) : LLVM.or e (LLVM.xor (const? 23 (-1)) e) ⊑ const? 23 (-1) := by 
+theorem test1_thm (e : IntW 23) : LLVM.or e (LLVM.xor (const? 23 (-1)) e) ⊑ const? 23 (-1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -21,7 +21,7 @@ theorem test2_thm (e e_1 : IntW 39) :
   LLVM.or
       (LLVM.and (add e_1 (LLVM.and e (const? 39 (-274877906944)))) (LLVM.xor (const? 39 274877906943) (const? 39 (-1))))
       (LLVM.and e_1 (const? 39 274877906943)) ⊑
-    add e_1 (LLVM.and e (const? 39 (-274877906944))) := by 
+    add e_1 (LLVM.and e (const? 39 (-274877906944))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -30,7 +30,7 @@ theorem test2_thm (e e_1 : IntW 39) :
     all_goals sorry
 
 
-theorem test4_thm (e : IntW 1023) : LLVM.or e (LLVM.xor (const? 1023 (-1)) e) ⊑ const? 1023 (-1) := by 
+theorem test4_thm (e : IntW 1023) : LLVM.or e (LLVM.xor (const? 1023 (-1)) e) ⊑ const? 1023 (-1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -44,7 +44,7 @@ theorem test5_thm (e e_1 : IntW 399) :
       (LLVM.and (add e_1 (LLVM.and e (const? 399 18446742974197923840)))
         (LLVM.xor (const? 399 274877906943) (const? 399 (-1))))
       (LLVM.and e_1 (const? 399 274877906943)) ⊑
-    add e_1 (LLVM.and e (const? 399 18446742974197923840)) := by 
+    add e_1 (LLVM.and e (const? 399 18446742974197923840)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gapinthrem1_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gapinthrem1_proof.lean
@@ -8,7 +8,7 @@ set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
 
 section gapinthrem1_proof
-theorem test1_thm (e : IntW 33) : urem e (const? 33 4096) ⊑ LLVM.and e (const? 33 4095) := by 
+theorem test1_thm (e : IntW 33) : urem e (const? 33 4096) ⊑ LLVM.and e (const? 33 4095) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -18,7 +18,7 @@ theorem test1_thm (e : IntW 33) : urem e (const? 33 4096) ⊑ LLVM.and e (const?
 
 
 theorem test2_thm (e : IntW 49) :
-  urem e (shl (const? 49 4096) (const? 49 11)) ⊑ LLVM.and e (const? 49 8388607) := by 
+  urem e (shl (const? 49 4096) (const? 49 11)) ⊑ LLVM.and e (const? 49 8388607) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -29,7 +29,7 @@ theorem test2_thm (e : IntW 49) :
 
 theorem test3_thm (e : IntW 1) (e_1 : IntW 59) :
   urem e_1 (select e (const? 59 70368744177664) (const? 59 4096)) ⊑
-    LLVM.and e_1 (select e (const? 59 70368744177663) (const? 59 4095)) := by 
+    LLVM.and e_1 (select e (const? 59 70368744177663) (const? 59 4095)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gapinthrem2_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gapinthrem2_proof.lean
@@ -9,7 +9,7 @@ set_option linter.unreachableTactic false
 
 section gapinthrem2_proof
 theorem test1_thm (e : IntW 333) :
-  urem e (const? 333 70368744177664) ⊑ LLVM.and e (const? 333 70368744177663) := by 
+  urem e (const? 333 70368744177664) ⊑ LLVM.and e (const? 333 70368744177663) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -20,7 +20,7 @@ theorem test1_thm (e : IntW 333) :
 
 theorem test2_thm (e : IntW 499) :
   urem e (shl (const? 499 4096) (const? 499 111)) ⊑
-    LLVM.and e (const? 499 10633823966279326983230456482242756607) := by 
+    LLVM.and e (const? 499 10633823966279326983230456482242756607) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -31,7 +31,7 @@ theorem test2_thm (e : IntW 499) :
 
 theorem test3_thm (e : IntW 1) (e_1 : IntW 599) :
   urem e_1 (select e (const? 599 70368744177664) (const? 599 4096)) ⊑
-    LLVM.and e_1 (select e (const? 599 70368744177663) (const? 599 4095)) := by 
+    LLVM.and e_1 (select e (const? 599 70368744177663) (const? 599 4095)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gapinthselect_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gapinthselect_proof.lean
@@ -8,7 +8,7 @@ set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
 
 section gapinthselect_proof
-theorem zext_thm (e : IntW 1) : select e (const? 41 1) (const? 41 0) ⊑ zext 41 e := by 
+theorem zext_thm (e : IntW 1) : select e (const? 41 1) (const? 41 0) ⊑ zext 41 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -17,7 +17,7 @@ theorem zext_thm (e : IntW 1) : select e (const? 41 1) (const? 41 0) ⊑ zext 41
     all_goals sorry
 
 
-theorem sext_thm (e : IntW 1) : select e (const? 41 (-1)) (const? 41 0) ⊑ sext 41 e := by 
+theorem sext_thm (e : IntW 1) : select e (const? 41 (-1)) (const? 41 0) ⊑ sext 41 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -26,7 +26,7 @@ theorem sext_thm (e : IntW 1) : select e (const? 41 (-1)) (const? 41 0) ⊑ sext
     all_goals sorry
 
 
-theorem not_zext_thm (e : IntW 1) : select e (const? 999 0) (const? 999 1) ⊑ zext 999 (LLVM.xor e (const? 1 1)) := by 
+theorem not_zext_thm (e : IntW 1) : select e (const? 999 0) (const? 999 1) ⊑ zext 999 (LLVM.xor e (const? 1 1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -36,7 +36,7 @@ theorem not_zext_thm (e : IntW 1) : select e (const? 999 0) (const? 999 1) ⊑ z
 
 
 theorem not_sext_thm (e : IntW 1) :
-  select e (const? 999 0) (const? 999 (-1)) ⊑ sext 999 (LLVM.xor e (const? 1 1)) := by 
+  select e (const? 999 0) (const? 999 (-1)) ⊑ sext 999 (LLVM.xor e (const? 1 1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -46,7 +46,7 @@ theorem not_sext_thm (e : IntW 1) :
 
 
 theorem test3_thm (e : IntW 41) :
-  select (icmp IntPredicate.slt e (const? 41 0)) (const? 41 (-1)) (const? 41 0) ⊑ ashr e (const? 41 40) := by 
+  select (icmp IntPredicate.slt e (const? 41 0)) (const? 41 (-1)) (const? 41 0) ⊑ ashr e (const? 41 40) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -57,7 +57,7 @@ theorem test3_thm (e : IntW 41) :
 
 theorem test4_thm (e : IntW 1023) :
   select (icmp IntPredicate.slt e (const? 1023 0)) (const? 1023 (-1)) (const? 1023 0) ⊑
-    ashr e (const? 1023 1022) := by 
+    ashr e (const? 1023 1022) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gapinthshift_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gapinthshift_proof.lean
@@ -8,7 +8,7 @@ set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
 
 section gapinthshift_proof
-theorem test6_thm (e : IntW 55) : mul (shl e (const? 55 1)) (const? 55 3) ⊑ mul e (const? 55 6) := by 
+theorem test6_thm (e : IntW 55) : mul (shl e (const? 55 1)) (const? 55 3) ⊑ mul e (const? 55 6) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -17,7 +17,7 @@ theorem test6_thm (e : IntW 55) : mul (shl e (const? 55 1)) (const? 55 3) ⊑ mu
     all_goals sorry
 
 
-theorem test6a_thm (e : IntW 55) : shl (mul e (const? 55 3)) (const? 55 1) ⊑ mul e (const? 55 6) := by 
+theorem test6a_thm (e : IntW 55) : shl (mul e (const? 55 3)) (const? 55 1) ⊑ mul e (const? 55 6) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -26,7 +26,7 @@ theorem test6a_thm (e : IntW 55) : shl (mul e (const? 55 3)) (const? 55 1) ⊑ m
     all_goals sorry
 
 
-theorem test7_thm (e : IntW 8) : ashr (const? 29 (-1)) (zext 29 e) ⊑ const? 29 (-1) := by 
+theorem test7_thm (e : IntW 8) : ashr (const? 29 (-1)) (zext 29 e) ⊑ const? 29 (-1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -35,7 +35,7 @@ theorem test7_thm (e : IntW 8) : ashr (const? 29 (-1)) (zext 29 e) ⊑ const? 29
     all_goals sorry
 
 
-theorem test8_thm (e : IntW 7) : shl (shl e (const? 7 4)) (const? 7 3) ⊑ const? 7 0 := by 
+theorem test8_thm (e : IntW 7) : shl (shl e (const? 7 4)) (const? 7 3) ⊑ const? 7 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -44,7 +44,7 @@ theorem test8_thm (e : IntW 7) : shl (shl e (const? 7 4)) (const? 7 3) ⊑ const
     all_goals sorry
 
 
-theorem test9_thm (e : IntW 17) : lshr (shl e (const? 17 16)) (const? 17 16) ⊑ LLVM.and e (const? 17 1) := by 
+theorem test9_thm (e : IntW 17) : lshr (shl e (const? 17 16)) (const? 17 16) ⊑ LLVM.and e (const? 17 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -54,7 +54,7 @@ theorem test9_thm (e : IntW 17) : lshr (shl e (const? 17 16)) (const? 17 16) ⊑
 
 
 theorem test10_thm (e : IntW 19) :
-  shl (lshr e (const? 19 18)) (const? 19 18) ⊑ LLVM.and e (const? 19 (-262144)) := by 
+  shl (lshr e (const? 19 18)) (const? 19 18) ⊑ LLVM.and e (const? 19 (-262144)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -65,7 +65,7 @@ theorem test10_thm (e : IntW 19) :
 
 theorem multiuse_lshr_lshr_thm (e : IntW 9) :
   mul (lshr e (const? 9 2)) (lshr (lshr e (const? 9 2)) (const? 9 3)) ⊑
-    mul (lshr e (const? 9 2)) (lshr e (const? 9 5)) := by 
+    mul (lshr e (const? 9 2)) (lshr e (const? 9 5)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -76,7 +76,7 @@ theorem multiuse_lshr_lshr_thm (e : IntW 9) :
 
 theorem multiuse_shl_shl_thm (e : IntW 42) :
   mul (shl e (const? 42 8)) (shl (shl e (const? 42 8)) (const? 42 9)) ⊑
-    mul (shl e (const? 42 8)) (shl e (const? 42 17)) := by 
+    mul (shl e (const? 42 8)) (shl e (const? 42 17)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -87,7 +87,7 @@ theorem multiuse_shl_shl_thm (e : IntW 42) :
 
 theorem test11_thm (e : IntW 23) :
   shl (lshr (mul e (const? 23 3)) (const? 23 11)) (const? 23 12) ⊑
-    LLVM.and (mul e (const? 23 6)) (const? 23 (-4096)) := by 
+    LLVM.and (mul e (const? 23 6)) (const? 23 (-4096)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -96,7 +96,7 @@ theorem test11_thm (e : IntW 23) :
     all_goals sorry
 
 
-theorem test12_thm (e : IntW 47) : shl (ashr e (const? 47 8)) (const? 47 8) ⊑ LLVM.and e (const? 47 (-256)) := by 
+theorem test12_thm (e : IntW 47) : shl (ashr e (const? 47 8)) (const? 47 8) ⊑ LLVM.and e (const? 47 (-256)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -107,7 +107,7 @@ theorem test12_thm (e : IntW 47) : shl (ashr e (const? 47 8)) (const? 47 8) ⊑ 
 
 theorem test13_thm (e : IntW 18) :
   shl (ashr (mul e (const? 18 3)) (const? 18 8)) (const? 18 9) ⊑
-    LLVM.and (mul e (const? 18 6)) (const? 18 (-512)) := by 
+    LLVM.and (mul e (const? 18 6)) (const? 18 (-512)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -118,7 +118,7 @@ theorem test13_thm (e : IntW 18) :
 
 theorem test14_thm (e : IntW 35) :
   shl (LLVM.or (lshr e (const? 35 4)) (const? 35 1234)) (const? 35 4) ⊑
-    LLVM.or (LLVM.and e (const? 35 (-19760))) (const? 35 19744) { «disjoint» := true } := by 
+    LLVM.or (LLVM.and e (const? 35 (-19760))) (const? 35 19744) { «disjoint» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -128,7 +128,7 @@ theorem test14_thm (e : IntW 35) :
 
 
 theorem test14a_thm (e : IntW 79) :
-  lshr (LLVM.and (shl e (const? 79 4)) (const? 79 1234)) (const? 79 4) ⊑ LLVM.and e (const? 79 77) := by 
+  lshr (LLVM.and (shl e (const? 79 4)) (const? 79 1234)) (const? 79 4) ⊑ LLVM.and e (const? 79 77) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -138,7 +138,7 @@ theorem test14a_thm (e : IntW 79) :
 
 
 theorem test15_thm (e : IntW 1) :
-  shl (select e (const? 45 3) (const? 45 1)) (const? 45 2) ⊑ select e (const? 45 12) (const? 45 4) := by 
+  shl (select e (const? 45 3) (const? 45 1)) (const? 45 2) ⊑ select e (const? 45 12) (const? 45 4) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -148,7 +148,7 @@ theorem test15_thm (e : IntW 1) :
 
 
 theorem test15a_thm (e : IntW 1) :
-  shl (const? 53 64) (zext 53 (select e (const? 8 3) (const? 8 1))) ⊑ select e (const? 53 512) (const? 53 128) := by 
+  shl (const? 53 64) (zext 53 (select e (const? 8 3) (const? 8 1))) ⊑ select e (const? 53 512) (const? 53 128) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -159,7 +159,7 @@ theorem test15a_thm (e : IntW 1) :
 
 theorem test16_thm (e : IntW 84) :
   icmp IntPredicate.ne (LLVM.and (ashr e (const? 84 4)) (const? 84 1)) (const? 84 0) ⊑
-    icmp IntPredicate.ne (LLVM.and e (const? 84 16)) (const? 84 0) := by 
+    icmp IntPredicate.ne (LLVM.and e (const? 84 16)) (const? 84 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -170,7 +170,7 @@ theorem test16_thm (e : IntW 84) :
 
 theorem test17_thm (e : IntW 106) :
   icmp IntPredicate.eq (lshr e (const? 106 3)) (const? 106 1234) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 106 (-8))) (const? 106 9872) := by 
+    icmp IntPredicate.eq (LLVM.and e (const? 106 (-8))) (const? 106 9872) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -179,7 +179,7 @@ theorem test17_thm (e : IntW 106) :
     all_goals sorry
 
 
-theorem test18_thm (e : IntW 11) : icmp IntPredicate.eq (lshr e (const? 11 10)) (const? 11 123) ⊑ const? 1 0 := by 
+theorem test18_thm (e : IntW 11) : icmp IntPredicate.eq (lshr e (const? 11 10)) (const? 11 123) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -189,7 +189,7 @@ theorem test18_thm (e : IntW 11) : icmp IntPredicate.eq (lshr e (const? 11 10)) 
 
 
 theorem test19_thm (e : IntW 37) :
-  icmp IntPredicate.eq (ashr e (const? 37 2)) (const? 37 0) ⊑ icmp IntPredicate.ult e (const? 37 4) := by 
+  icmp IntPredicate.eq (ashr e (const? 37 2)) (const? 37 0) ⊑ icmp IntPredicate.ult e (const? 37 4) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -199,7 +199,7 @@ theorem test19_thm (e : IntW 37) :
 
 
 theorem test19a_thm (e : IntW 39) :
-  icmp IntPredicate.eq (ashr e (const? 39 2)) (const? 39 (-1)) ⊑ icmp IntPredicate.ugt e (const? 39 (-5)) := by 
+  icmp IntPredicate.eq (ashr e (const? 39 2)) (const? 39 (-1)) ⊑ icmp IntPredicate.ugt e (const? 39 (-5)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -208,7 +208,7 @@ theorem test19a_thm (e : IntW 39) :
     all_goals sorry
 
 
-theorem test20_thm (e : IntW 13) : icmp IntPredicate.eq (ashr e (const? 13 12)) (const? 13 123) ⊑ const? 1 0 := by 
+theorem test20_thm (e : IntW 13) : icmp IntPredicate.eq (ashr e (const? 13 12)) (const? 13 123) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -219,7 +219,7 @@ theorem test20_thm (e : IntW 13) : icmp IntPredicate.eq (ashr e (const? 13 12)) 
 
 theorem test21_thm (e : IntW 12) :
   icmp IntPredicate.eq (shl e (const? 12 6)) (const? 12 (-128)) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 12 63)) (const? 12 62) := by 
+    icmp IntPredicate.eq (LLVM.and e (const? 12 63)) (const? 12 62) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -230,7 +230,7 @@ theorem test21_thm (e : IntW 12) :
 
 theorem test22_thm (e : IntW 14) :
   icmp IntPredicate.eq (shl e (const? 14 7)) (const? 14 0) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 14 127)) (const? 14 0) := by 
+    icmp IntPredicate.eq (LLVM.and e (const? 14 127)) (const? 14 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -239,7 +239,7 @@ theorem test22_thm (e : IntW 14) :
     all_goals sorry
 
 
-theorem test23_thm (e : IntW 44) : trunc 11 (ashr (shl e (const? 44 33)) (const? 44 33)) ⊑ trunc 11 e := by 
+theorem test23_thm (e : IntW 44) : trunc 11 (ashr (shl e (const? 44 33)) (const? 44 33)) ⊑ trunc 11 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -250,7 +250,7 @@ theorem test23_thm (e : IntW 44) : trunc 11 (ashr (shl e (const? 44 33)) (const?
 
 theorem shl_lshr_eq_amt_multi_use_thm (e : IntW 44) :
   add (shl e (const? 44 33)) (lshr (shl e (const? 44 33)) (const? 44 33)) ⊑
-    LLVM.or (shl e (const? 44 33)) (LLVM.and e (const? 44 2047)) { «disjoint» := true } := by 
+    LLVM.or (shl e (const? 44 33)) (LLVM.and e (const? 44 2047)) { «disjoint» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -261,7 +261,7 @@ theorem shl_lshr_eq_amt_multi_use_thm (e : IntW 44) :
 
 theorem lshr_shl_eq_amt_multi_use_thm (e : IntW 43) :
   mul (lshr e (const? 43 23)) (shl (lshr e (const? 43 23)) (const? 43 23)) ⊑
-    mul (lshr e (const? 43 23)) (LLVM.and e (const? 43 (-8388608))) := by 
+    mul (lshr e (const? 43 23)) (LLVM.and e (const? 43 (-8388608))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -272,7 +272,7 @@ theorem lshr_shl_eq_amt_multi_use_thm (e : IntW 43) :
 
 theorem test25_thm (e e_1 : IntW 37) :
   shl (add (lshr e_1 (const? 37 17)) (lshr e (const? 37 17))) (const? 37 17) ⊑
-    LLVM.and (add e (LLVM.and e_1 (const? 37 (-131072)))) (const? 37 (-131072)) := by 
+    LLVM.and (add e (LLVM.and e_1 (const? 37 (-131072)))) (const? 37 (-131072)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gapinthshifthsimplify_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gapinthshifthsimplify_proof.lean
@@ -8,7 +8,7 @@ set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
 
 section gapinthshifthsimplify_proof
-theorem test0_thm (e e_1 e_2 : IntW 41) : LLVM.and (shl e_2 e_1) (shl e e_1) ⊑ shl (LLVM.and e_2 e) e_1 := by 
+theorem test0_thm (e e_1 e_2 : IntW 41) : LLVM.and (shl e_2 e_1) (shl e e_1) ⊑ shl (LLVM.and e_2 e) e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -17,7 +17,7 @@ theorem test0_thm (e e_1 e_2 : IntW 41) : LLVM.and (shl e_2 e_1) (shl e e_1) ⊑
     all_goals sorry
 
 
-theorem test1_thm (e e_1 e_2 : IntW 57) : LLVM.or (lshr e_2 e_1) (lshr e e_1) ⊑ lshr (LLVM.or e_2 e) e_1 := by 
+theorem test1_thm (e e_1 e_2 : IntW 57) : LLVM.or (lshr e_2 e_1) (lshr e e_1) ⊑ lshr (LLVM.or e_2 e) e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -26,7 +26,7 @@ theorem test1_thm (e e_1 e_2 : IntW 57) : LLVM.or (lshr e_2 e_1) (lshr e e_1) �
     all_goals sorry
 
 
-theorem test2_thm (e e_1 e_2 : IntW 49) : LLVM.xor (ashr e_2 e_1) (ashr e e_1) ⊑ ashr (LLVM.xor e_2 e) e_1 := by 
+theorem test2_thm (e e_1 e_2 : IntW 49) : LLVM.xor (ashr e_2 e_1) (ashr e e_1) ⊑ ashr (LLVM.xor e_2 e) e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gapinthsub_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gapinthsub_proof.lean
@@ -8,7 +8,7 @@ set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
 
 section gapinthsub_proof
-theorem test1_thm (e : IntW 23) : sub e e ⊑ const? 23 0 := by 
+theorem test1_thm (e : IntW 23) : sub e e ⊑ const? 23 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -17,7 +17,7 @@ theorem test1_thm (e : IntW 23) : sub e e ⊑ const? 23 0 := by
     all_goals sorry
 
 
-theorem test2_thm (e : IntW 47) : sub e (const? 47 0) ⊑ e := by 
+theorem test2_thm (e : IntW 47) : sub e (const? 47 0) ⊑ e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -26,7 +26,7 @@ theorem test2_thm (e : IntW 47) : sub e (const? 47 0) ⊑ e := by
     all_goals sorry
 
 
-theorem test3_thm (e : IntW 97) : sub (const? 97 0) (sub (const? 97 0) e) ⊑ e := by 
+theorem test3_thm (e : IntW 97) : sub (const? 97 0) (sub (const? 97 0) e) ⊑ e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -35,7 +35,7 @@ theorem test3_thm (e : IntW 97) : sub (const? 97 0) (sub (const? 97 0) e) ⊑ e 
     all_goals sorry
 
 
-theorem test4_thm (e e_1 : IntW 108) : sub e_1 (sub (const? 108 0) e) ⊑ add e_1 e := by 
+theorem test4_thm (e e_1 : IntW 108) : sub e_1 (sub (const? 108 0) e) ⊑ add e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -44,7 +44,7 @@ theorem test4_thm (e e_1 : IntW 108) : sub e_1 (sub (const? 108 0) e) ⊑ add e_
     all_goals sorry
 
 
-theorem test5_thm (e e_1 e_2 : IntW 19) : sub e_2 (sub e_1 e) ⊑ add (sub e e_1) e_2 := by 
+theorem test5_thm (e e_1 e_2 : IntW 19) : sub e_2 (sub e_1 e) ⊑ add (sub e e_1) e_2 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -53,7 +53,7 @@ theorem test5_thm (e e_1 e_2 : IntW 19) : sub e_2 (sub e_1 e) ⊑ add (sub e e_1
     all_goals sorry
 
 
-theorem test6_thm (e e_1 : IntW 57) : sub e_1 (LLVM.and e_1 e) ⊑ LLVM.and e_1 (LLVM.xor e (const? 57 (-1))) := by 
+theorem test6_thm (e e_1 : IntW 57) : sub e_1 (LLVM.and e_1 e) ⊑ LLVM.and e_1 (LLVM.xor e (const? 57 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -62,7 +62,7 @@ theorem test6_thm (e e_1 : IntW 57) : sub e_1 (LLVM.and e_1 e) ⊑ LLVM.and e_1 
     all_goals sorry
 
 
-theorem test7_thm (e : IntW 77) : sub (const? 77 (-1)) e ⊑ LLVM.xor e (const? 77 (-1)) := by 
+theorem test7_thm (e : IntW 77) : sub (const? 77 (-1)) e ⊑ LLVM.xor e (const? 77 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -71,7 +71,7 @@ theorem test7_thm (e : IntW 77) : sub (const? 77 (-1)) e ⊑ LLVM.xor e (const? 
     all_goals sorry
 
 
-theorem test8_thm (e : IntW 27) : sub (mul (const? 27 9) e) e ⊑ shl e (const? 27 3) := by 
+theorem test8_thm (e : IntW 27) : sub (mul (const? 27 9) e) e ⊑ shl e (const? 27 3) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -80,7 +80,7 @@ theorem test8_thm (e : IntW 27) : sub (mul (const? 27 9) e) e ⊑ shl e (const? 
     all_goals sorry
 
 
-theorem test9_thm (e : IntW 42) : sub e (mul (const? 42 3) e) ⊑ mul e (const? 42 (-2)) := by 
+theorem test9_thm (e : IntW 42) : sub e (mul (const? 42 3) e) ⊑ mul e (const? 42 (-2)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -90,7 +90,7 @@ theorem test9_thm (e : IntW 42) : sub e (mul (const? 42 3) e) ⊑ mul e (const? 
 
 
 theorem test11_thm (e e_1 : IntW 9) :
-  icmp IntPredicate.ne (sub e_1 e) (const? 9 0) ⊑ icmp IntPredicate.ne e_1 e := by 
+  icmp IntPredicate.ne (sub e_1 e) (const? 9 0) ⊑ icmp IntPredicate.ne e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -99,7 +99,7 @@ theorem test11_thm (e e_1 : IntW 9) :
     all_goals sorry
 
 
-theorem test12_thm (e : IntW 43) : sub (const? 43 0) (ashr e (const? 43 42)) ⊑ lshr e (const? 43 42) := by 
+theorem test12_thm (e : IntW 43) : sub (const? 43 0) (ashr e (const? 43 42)) ⊑ lshr e (const? 43 42) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -108,7 +108,7 @@ theorem test12_thm (e : IntW 43) : sub (const? 43 0) (ashr e (const? 43 42)) ⊑
     all_goals sorry
 
 
-theorem test13_thm (e : IntW 79) : sub (const? 79 0) (lshr e (const? 79 78)) ⊑ ashr e (const? 79 78) := by 
+theorem test13_thm (e : IntW 79) : sub (const? 79 0) (lshr e (const? 79 78)) ⊑ ashr e (const? 79 78) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -118,7 +118,7 @@ theorem test13_thm (e : IntW 79) : sub (const? 79 0) (lshr e (const? 79 78)) ⊑
 
 
 theorem test16_thm (e : IntW 51) :
-  sub (const? 51 0) (LLVM.sdiv e (const? 51 1123)) ⊑ LLVM.sdiv e (const? 51 (-1123)) := by 
+  sub (const? 51 0) (LLVM.sdiv e (const? 51 1123)) ⊑ LLVM.sdiv e (const? 51 (-1123)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -127,7 +127,7 @@ theorem test16_thm (e : IntW 51) :
     all_goals sorry
 
 
-theorem test18_thm (e : IntW 128) : sub (shl e (const? 128 2)) (shl e (const? 128 2)) ⊑ const? 128 0 := by 
+theorem test18_thm (e : IntW 128) : sub (shl e (const? 128 2)) (shl e (const? 128 2)) ⊑ const? 128 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -136,7 +136,7 @@ theorem test18_thm (e : IntW 128) : sub (shl e (const? 128 2)) (shl e (const? 12
     all_goals sorry
 
 
-theorem test19_thm (e e_1 : IntW 39) : add (sub e_1 e) e ⊑ e_1 := by 
+theorem test19_thm (e e_1 : IntW 39) : add (sub e_1 e) e ⊑ e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -146,7 +146,7 @@ theorem test19_thm (e e_1 : IntW 39) : add (sub e_1 e) e ⊑ e_1 := by
 
 
 theorem test20_thm (e e_1 : IntW 33) :
-  icmp IntPredicate.ne (sub e_1 e) e_1 ⊑ icmp IntPredicate.ne e (const? 33 0) := by 
+  icmp IntPredicate.ne (sub e_1 e) e_1 ⊑ icmp IntPredicate.ne e (const? 33 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -156,7 +156,7 @@ theorem test20_thm (e e_1 : IntW 33) :
 
 
 theorem test21_thm (e e_1 : IntW 256) :
-  icmp IntPredicate.ne (sub e_1 e) e_1 ⊑ icmp IntPredicate.ne e (const? 256 0) := by 
+  icmp IntPredicate.ne (sub e_1 e) e_1 ⊑ icmp IntPredicate.ne e (const? 256 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gapinthxor1_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gapinthxor1_proof.lean
@@ -11,7 +11,7 @@ section gapinthxor1_proof
 theorem test1_thm (e e_1 : IntW 47) :
   LLVM.xor (LLVM.and e_1 (const? 47 (-70368744177664))) (LLVM.and e (const? 47 70368744177661)) ⊑
     LLVM.or (LLVM.and e_1 (const? 47 (-70368744177664))) (LLVM.and e (const? 47 70368744177661))
-      { «disjoint» := true } := by 
+      { «disjoint» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -20,7 +20,7 @@ theorem test1_thm (e e_1 : IntW 47) :
     all_goals sorry
 
 
-theorem test2_thm (e : IntW 15) : LLVM.xor e (const? 15 0) ⊑ e := by 
+theorem test2_thm (e : IntW 15) : LLVM.xor e (const? 15 0) ⊑ e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -29,7 +29,7 @@ theorem test2_thm (e : IntW 15) : LLVM.xor e (const? 15 0) ⊑ e := by
     all_goals sorry
 
 
-theorem test3_thm (e : IntW 23) : LLVM.xor e e ⊑ const? 23 0 := by 
+theorem test3_thm (e : IntW 23) : LLVM.xor e e ⊑ const? 23 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -38,7 +38,7 @@ theorem test3_thm (e : IntW 23) : LLVM.xor e e ⊑ const? 23 0 := by
     all_goals sorry
 
 
-theorem test4_thm (e : IntW 37) : LLVM.xor e (LLVM.xor (const? 37 (-1)) e) ⊑ const? 37 (-1) := by 
+theorem test4_thm (e : IntW 37) : LLVM.xor e (LLVM.xor (const? 37 (-1)) e) ⊑ const? 37 (-1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -48,7 +48,7 @@ theorem test4_thm (e : IntW 37) : LLVM.xor e (LLVM.xor (const? 37 (-1)) e) ⊑ c
 
 
 theorem test5_thm (e : IntW 7) :
-  LLVM.xor (LLVM.or e (const? 7 23)) (const? 7 23) ⊑ LLVM.and e (const? 7 (-24)) := by 
+  LLVM.xor (LLVM.or e (const? 7 23)) (const? 7 23) ⊑ LLVM.and e (const? 7 (-24)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -57,7 +57,7 @@ theorem test5_thm (e : IntW 7) :
     all_goals sorry
 
 
-theorem test6_thm (e : IntW 7) : LLVM.xor (LLVM.xor e (const? 7 23)) (const? 7 23) ⊑ e := by 
+theorem test6_thm (e : IntW 7) : LLVM.xor (LLVM.xor e (const? 7 23)) (const? 7 23) ⊑ e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -68,7 +68,7 @@ theorem test6_thm (e : IntW 7) : LLVM.xor (LLVM.xor e (const? 7 23)) (const? 7 2
 
 theorem test7_thm (e : IntW 47) :
   LLVM.xor (LLVM.or e (const? 47 70368744177663)) (const? 47 703687463) ⊑
-    LLVM.or (LLVM.and e (const? 47 (-70368744177664))) (const? 47 70368040490200) { «disjoint» := true } := by 
+    LLVM.or (LLVM.and e (const? 47 (-70368744177664))) (const? 47 70368040490200) { «disjoint» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gapinthxor2_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gapinthxor2_proof.lean
@@ -11,7 +11,7 @@ section gapinthxor2_proof
 theorem test1_thm (e e_1 : IntW 447) :
   LLVM.xor (LLVM.and e_1 (const? 447 70368744177664)) (LLVM.and e (const? 447 70368744177663)) ⊑
     LLVM.or (LLVM.and e_1 (const? 447 70368744177664)) (LLVM.and e (const? 447 70368744177663))
-      { «disjoint» := true } := by 
+      { «disjoint» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -20,7 +20,7 @@ theorem test1_thm (e e_1 : IntW 447) :
     all_goals sorry
 
 
-theorem test2_thm (e : IntW 1005) : LLVM.xor e (const? 1005 0) ⊑ e := by 
+theorem test2_thm (e : IntW 1005) : LLVM.xor e (const? 1005 0) ⊑ e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -29,7 +29,7 @@ theorem test2_thm (e : IntW 1005) : LLVM.xor e (const? 1005 0) ⊑ e := by
     all_goals sorry
 
 
-theorem test3_thm (e : IntW 123) : LLVM.xor e e ⊑ const? 123 0 := by 
+theorem test3_thm (e : IntW 123) : LLVM.xor e e ⊑ const? 123 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -38,7 +38,7 @@ theorem test3_thm (e : IntW 123) : LLVM.xor e e ⊑ const? 123 0 := by
     all_goals sorry
 
 
-theorem test4_thm (e : IntW 737) : LLVM.xor e (LLVM.xor (const? 737 (-1)) e) ⊑ const? 737 (-1) := by 
+theorem test4_thm (e : IntW 737) : LLVM.xor e (LLVM.xor (const? 737 (-1)) e) ⊑ const? 737 (-1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -49,7 +49,7 @@ theorem test4_thm (e : IntW 737) : LLVM.xor e (LLVM.xor (const? 737 (-1)) e) ⊑
 
 theorem test5_thm (e : IntW 700) :
   LLVM.xor (LLVM.or e (const? 700 288230376151711743)) (const? 700 288230376151711743) ⊑
-    LLVM.and e (const? 700 (-288230376151711744)) := by 
+    LLVM.and e (const? 700 (-288230376151711744)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -58,7 +58,7 @@ theorem test5_thm (e : IntW 700) :
     all_goals sorry
 
 
-theorem test6_thm (e : IntW 77) : LLVM.xor (LLVM.xor e (const? 77 23)) (const? 77 23) ⊑ e := by 
+theorem test6_thm (e : IntW 77) : LLVM.xor (LLVM.xor e (const? 77 23)) (const? 77 23) ⊑ e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -69,7 +69,7 @@ theorem test6_thm (e : IntW 77) : LLVM.xor (LLVM.xor e (const? 77 23)) (const? 7
 
 theorem test7_thm (e : IntW 1023) :
   LLVM.xor (LLVM.or e (const? 1023 70368744177663)) (const? 1023 703687463) ⊑
-    LLVM.or (LLVM.and e (const? 1023 (-70368744177664))) (const? 1023 70368040490200) { «disjoint» := true } := by 
+    LLVM.or (LLVM.and e (const? 1023 (-70368744177664))) (const? 1023 70368040490200) { «disjoint» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gashrhdemand_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gashrhdemand_proof.lean
@@ -10,7 +10,7 @@ set_option linter.unreachableTactic false
 section gashrhdemand_proof
 theorem srem2_ashr_mask_thm (e : IntW 32) :
   LLVM.and (ashr (LLVM.srem e (const? 32 2)) (const? 32 31)) (const? 32 2) ⊑
-    LLVM.and (LLVM.srem e (const? 32 2)) (const? 32 2) := by 
+    LLVM.and (LLVM.srem e (const? 32 2)) (const? 32 2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -22,7 +22,7 @@ theorem srem2_ashr_mask_thm (e : IntW 32) :
 theorem srem8_ashr_mask_thm (e : IntW 32) :
   LLVM.and (ashr (LLVM.srem e (const? 32 8)) (const? 32 31)) (const? 32 2) ⊑
     select (icmp IntPredicate.ugt (LLVM.and e (const? 32 (-2147483641))) (const? 32 (-2147483648))) (const? 32 2)
-      (const? 32 0) := by 
+      (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -33,7 +33,7 @@ theorem srem8_ashr_mask_thm (e : IntW 32) :
 
 theorem ashr_can_be_lshr_thm (e : IntW 32) :
   trunc 16 (ashr e (const? 32 16) { «exact» := true }) { «nsw» := true, «nuw» := false } ⊑
-    trunc 16 (lshr e (const? 32 16) { «exact» := true }) { «nsw» := false, «nuw» := true } := by 
+    trunc 16 (lshr e (const? 32 16) { «exact» := true }) { «nsw» := false, «nuw» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -45,7 +45,7 @@ theorem ashr_can_be_lshr_thm (e : IntW 32) :
 theorem ashr_can_be_lshr_2_thm (e : IntW 32) :
   trunc 32 (ashr (shl (LLVM.or (zext 64 e) (const? 64 4278190080)) (const? 64 34)) (const? 64 32) { «exact» := true })
       { «nsw» := true, «nuw» := false } ⊑
-    LLVM.or (shl e (const? 32 2)) (const? 32 (-67108864)) := by 
+    LLVM.or (shl e (const? 32 2)) (const? 32 (-67108864)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gashrhlshr_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gashrhlshr_proof.lean
@@ -10,7 +10,7 @@ set_option linter.unreachableTactic false
 section gashrhlshr_proof
 theorem ashr_lshr_exact_ashr_only_thm (e e_1 : IntW 32) :
   select (icmp IntPredicate.sgt e_1 (const? 32 (-1))) (lshr e_1 e) (ashr e_1 e { «exact» := true }) ⊑
-    ashr e_1 e := by 
+    ashr e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -20,7 +20,7 @@ theorem ashr_lshr_exact_ashr_only_thm (e e_1 : IntW 32) :
 
 
 theorem ashr_lshr_no_exact_thm (e e_1 : IntW 32) :
-  select (icmp IntPredicate.sgt e_1 (const? 32 (-1))) (lshr e_1 e) (ashr e_1 e) ⊑ ashr e_1 e := by 
+  select (icmp IntPredicate.sgt e_1 (const? 32 (-1))) (lshr e_1 e) (ashr e_1 e) ⊑ ashr e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -32,7 +32,7 @@ theorem ashr_lshr_no_exact_thm (e e_1 : IntW 32) :
 theorem ashr_lshr_exact_both_thm (e e_1 : IntW 32) :
   select (icmp IntPredicate.sgt e_1 (const? 32 (-1))) (lshr e_1 e { «exact» := true })
       (ashr e_1 e { «exact» := true }) ⊑
-    ashr e_1 e { «exact» := true } := by 
+    ashr e_1 e { «exact» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -43,7 +43,7 @@ theorem ashr_lshr_exact_both_thm (e e_1 : IntW 32) :
 
 theorem ashr_lshr_exact_lshr_only_thm (e e_1 : IntW 32) :
   select (icmp IntPredicate.sgt e_1 (const? 32 (-1))) (lshr e_1 e { «exact» := true }) (ashr e_1 e) ⊑
-    ashr e_1 e := by 
+    ashr e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -53,7 +53,7 @@ theorem ashr_lshr_exact_lshr_only_thm (e e_1 : IntW 32) :
 
 
 theorem ashr_lshr2_thm (e e_1 : IntW 32) :
-  select (icmp IntPredicate.sgt e_1 (const? 32 5)) (lshr e_1 e) (ashr e_1 e { «exact» := true }) ⊑ ashr e_1 e := by 
+  select (icmp IntPredicate.sgt e_1 (const? 32 5)) (lshr e_1 e) (ashr e_1 e { «exact» := true }) ⊑ ashr e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -63,7 +63,7 @@ theorem ashr_lshr2_thm (e e_1 : IntW 32) :
 
 
 theorem ashr_lshr2_i128_thm (e e_1 : IntW 128) :
-  select (icmp IntPredicate.sgt e_1 (const? 128 5)) (lshr e_1 e) (ashr e_1 e { «exact» := true }) ⊑ ashr e_1 e := by 
+  select (icmp IntPredicate.sgt e_1 (const? 128 5)) (lshr e_1 e) (ashr e_1 e { «exact» := true }) ⊑ ashr e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -74,7 +74,7 @@ theorem ashr_lshr2_i128_thm (e e_1 : IntW 128) :
 
 theorem ashr_lshr_cst_thm (e : IntW 32) :
   select (icmp IntPredicate.slt e (const? 32 1)) (ashr e (const? 32 8) { «exact» := true }) (lshr e (const? 32 8)) ⊑
-    ashr e (const? 32 8) := by 
+    ashr e (const? 32 8) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -85,7 +85,7 @@ theorem ashr_lshr_cst_thm (e : IntW 32) :
 
 theorem ashr_lshr_cst2_thm (e : IntW 32) :
   select (icmp IntPredicate.sgt e (const? 32 (-1))) (lshr e (const? 32 8)) (ashr e (const? 32 8) { «exact» := true }) ⊑
-    ashr e (const? 32 8) := by 
+    ashr e (const? 32 8) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -95,7 +95,7 @@ theorem ashr_lshr_cst2_thm (e : IntW 32) :
 
 
 theorem ashr_lshr_inv_thm (e e_1 : IntW 32) :
-  select (icmp IntPredicate.slt e_1 (const? 32 1)) (ashr e_1 e { «exact» := true }) (lshr e_1 e) ⊑ ashr e_1 e := by 
+  select (icmp IntPredicate.slt e_1 (const? 32 1)) (ashr e_1 e { «exact» := true }) (lshr e_1 e) ⊑ ashr e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -105,7 +105,7 @@ theorem ashr_lshr_inv_thm (e e_1 : IntW 32) :
 
 
 theorem ashr_lshr_inv2_thm (e e_1 : IntW 32) :
-  select (icmp IntPredicate.slt e_1 (const? 32 7)) (ashr e_1 e { «exact» := true }) (lshr e_1 e) ⊑ ashr e_1 e := by 
+  select (icmp IntPredicate.slt e_1 (const? 32 7)) (ashr e_1 e { «exact» := true }) (lshr e_1 e) ⊑ ashr e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -116,7 +116,7 @@ theorem ashr_lshr_inv2_thm (e e_1 : IntW 32) :
 
 theorem ashr_lshr_wrong_cond_thm (e e_1 : IntW 32) :
   select (icmp IntPredicate.sge e_1 (const? 32 (-1))) (lshr e_1 e) (ashr e_1 e) ⊑
-    select (icmp IntPredicate.sgt e_1 (const? 32 (-2))) (lshr e_1 e) (ashr e_1 e) := by 
+    select (icmp IntPredicate.sgt e_1 (const? 32 (-2))) (lshr e_1 e) (ashr e_1 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -127,7 +127,7 @@ theorem ashr_lshr_wrong_cond_thm (e e_1 : IntW 32) :
 
 theorem ashr_lshr_shift_wrong_pred_thm (e e_1 : IntW 32) :
   select (icmp IntPredicate.sle e_1 (const? 32 0)) (lshr e_1 e) (ashr e_1 e) ⊑
-    select (icmp IntPredicate.slt e_1 (const? 32 1)) (lshr e_1 e) (ashr e_1 e) := by 
+    select (icmp IntPredicate.slt e_1 (const? 32 1)) (lshr e_1 e) (ashr e_1 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -138,7 +138,7 @@ theorem ashr_lshr_shift_wrong_pred_thm (e e_1 : IntW 32) :
 
 theorem ashr_lshr_shift_wrong_pred2_thm (e e_1 e_2 : IntW 32) :
   select (icmp IntPredicate.sge e_2 (const? 32 0)) (lshr e_1 e) (ashr e_1 e) ⊑
-    select (icmp IntPredicate.slt e_2 (const? 32 0)) (ashr e_1 e) (lshr e_1 e) := by 
+    select (icmp IntPredicate.slt e_2 (const? 32 0)) (ashr e_1 e) (lshr e_1 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -149,7 +149,7 @@ theorem ashr_lshr_shift_wrong_pred2_thm (e e_1 e_2 : IntW 32) :
 
 theorem ashr_lshr_wrong_operands_thm (e e_1 : IntW 32) :
   select (icmp IntPredicate.sge e_1 (const? 32 0)) (ashr e_1 e) (lshr e_1 e) ⊑
-    select (icmp IntPredicate.slt e_1 (const? 32 0)) (lshr e_1 e) (ashr e_1 e) := by 
+    select (icmp IntPredicate.slt e_1 (const? 32 0)) (lshr e_1 e) (ashr e_1 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -160,7 +160,7 @@ theorem ashr_lshr_wrong_operands_thm (e e_1 : IntW 32) :
 
 theorem ashr_lshr_no_ashr_thm (e e_1 : IntW 32) :
   select (icmp IntPredicate.sge e_1 (const? 32 0)) (lshr e_1 e) (LLVM.xor e_1 e) ⊑
-    select (icmp IntPredicate.slt e_1 (const? 32 0)) (LLVM.xor e_1 e) (lshr e_1 e) := by 
+    select (icmp IntPredicate.slt e_1 (const? 32 0)) (LLVM.xor e_1 e) (lshr e_1 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -171,7 +171,7 @@ theorem ashr_lshr_no_ashr_thm (e e_1 : IntW 32) :
 
 theorem ashr_lshr_shift_amt_mismatch_thm (e e_1 e_2 : IntW 32) :
   select (icmp IntPredicate.sge e_2 (const? 32 0)) (lshr e_2 e_1) (ashr e_2 e) ⊑
-    select (icmp IntPredicate.slt e_2 (const? 32 0)) (ashr e_2 e) (lshr e_2 e_1) := by 
+    select (icmp IntPredicate.slt e_2 (const? 32 0)) (ashr e_2 e) (lshr e_2 e_1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -182,7 +182,7 @@ theorem ashr_lshr_shift_amt_mismatch_thm (e e_1 e_2 : IntW 32) :
 
 theorem ashr_lshr_shift_base_mismatch_thm (e e_1 e_2 : IntW 32) :
   select (icmp IntPredicate.sge e_2 (const? 32 0)) (lshr e_2 e_1) (ashr e e_1) ⊑
-    select (icmp IntPredicate.slt e_2 (const? 32 0)) (ashr e e_1) (lshr e_2 e_1) := by 
+    select (icmp IntPredicate.slt e_2 (const? 32 0)) (ashr e e_1) (lshr e_2 e_1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -193,7 +193,7 @@ theorem ashr_lshr_shift_base_mismatch_thm (e e_1 e_2 : IntW 32) :
 
 theorem ashr_lshr_no_lshr_thm (e e_1 : IntW 32) :
   select (icmp IntPredicate.sge e_1 (const? 32 0)) (add e_1 e) (ashr e_1 e) ⊑
-    select (icmp IntPredicate.slt e_1 (const? 32 0)) (ashr e_1 e) (add e_1 e) := by 
+    select (icmp IntPredicate.slt e_1 (const? 32 0)) (ashr e_1 e) (add e_1 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -203,7 +203,7 @@ theorem ashr_lshr_no_lshr_thm (e e_1 : IntW 32) :
 
 
 theorem lshr_sub_nsw_thm (e e_1 : IntW 32) :
-  lshr (sub e_1 e { «nsw» := true, «nuw» := false }) (const? 32 31) ⊑ zext 32 (icmp IntPredicate.slt e_1 e) := by 
+  lshr (sub e_1 e { «nsw» := true, «nuw» := false }) (const? 32 31) ⊑ zext 32 (icmp IntPredicate.slt e_1 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -213,7 +213,7 @@ theorem lshr_sub_nsw_thm (e e_1 : IntW 32) :
 
 
 theorem ashr_sub_nsw_thm (e e_1 : IntW 17) :
-  ashr (sub e_1 e { «nsw» := true, «nuw» := false }) (const? 17 16) ⊑ sext 17 (icmp IntPredicate.slt e_1 e) := by 
+  ashr (sub e_1 e { «nsw» := true, «nuw» := false }) (const? 17 16) ⊑ sext 17 (icmp IntPredicate.slt e_1 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -224,7 +224,7 @@ theorem ashr_sub_nsw_thm (e e_1 : IntW 17) :
 
 theorem ashr_known_pos_exact_thm (e e_1 : IntW 8) :
   ashr (LLVM.and e_1 (const? 8 127)) e { «exact» := true } ⊑
-    lshr (LLVM.and e_1 (const? 8 127)) e { «exact» := true } := by 
+    lshr (LLVM.and e_1 (const? 8 127)) e { «exact» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -235,7 +235,7 @@ theorem ashr_known_pos_exact_thm (e e_1 : IntW 8) :
 
 theorem lshr_mul_times_3_div_2_thm (e : IntW 32) :
   lshr (mul e (const? 32 3) { «nsw» := true, «nuw» := true }) (const? 32 1) ⊑
-    add e (lshr e (const? 32 1)) { «nsw» := true, «nuw» := true } := by 
+    add e (lshr e (const? 32 1)) { «nsw» := true, «nuw» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -246,7 +246,7 @@ theorem lshr_mul_times_3_div_2_thm (e : IntW 32) :
 
 theorem lshr_mul_times_3_div_2_exact_thm (e : IntW 32) :
   lshr (mul e (const? 32 3) { «nsw» := true, «nuw» := false }) (const? 32 1) { «exact» := true } ⊑
-    add e (lshr e (const? 32 1) { «exact» := true }) { «nsw» := true, «nuw» := false } := by 
+    add e (lshr e (const? 32 1) { «exact» := true }) { «nsw» := true, «nuw» := false } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -257,7 +257,7 @@ theorem lshr_mul_times_3_div_2_exact_thm (e : IntW 32) :
 
 theorem lshr_mul_times_3_div_2_exact_2_thm (e : IntW 32) :
   lshr (mul e (const? 32 3) { «nsw» := false, «nuw» := true }) (const? 32 1) { «exact» := true } ⊑
-    add e (lshr e (const? 32 1) { «exact» := true }) { «nsw» := false, «nuw» := true } := by 
+    add e (lshr e (const? 32 1) { «exact» := true }) { «nsw» := false, «nuw» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -268,7 +268,7 @@ theorem lshr_mul_times_3_div_2_exact_2_thm (e : IntW 32) :
 
 theorem lshr_mul_times_5_div_4_thm (e : IntW 32) :
   lshr (mul e (const? 32 5) { «nsw» := true, «nuw» := true }) (const? 32 2) ⊑
-    add e (lshr e (const? 32 2)) { «nsw» := true, «nuw» := true } := by 
+    add e (lshr e (const? 32 2)) { «nsw» := true, «nuw» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -279,7 +279,7 @@ theorem lshr_mul_times_5_div_4_thm (e : IntW 32) :
 
 theorem lshr_mul_times_5_div_4_exact_thm (e : IntW 32) :
   lshr (mul e (const? 32 5) { «nsw» := true, «nuw» := false }) (const? 32 2) { «exact» := true } ⊑
-    add e (lshr e (const? 32 2) { «exact» := true }) { «nsw» := true, «nuw» := false } := by 
+    add e (lshr e (const? 32 2) { «exact» := true }) { «nsw» := true, «nuw» := false } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -290,7 +290,7 @@ theorem lshr_mul_times_5_div_4_exact_thm (e : IntW 32) :
 
 theorem lshr_mul_times_5_div_4_exact_2_thm (e : IntW 32) :
   lshr (mul e (const? 32 5) { «nsw» := false, «nuw» := true }) (const? 32 2) { «exact» := true } ⊑
-    add e (lshr e (const? 32 2) { «exact» := true }) { «nsw» := false, «nuw» := true } := by 
+    add e (lshr e (const? 32 2) { «exact» := true }) { «nsw» := false, «nuw» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -301,7 +301,7 @@ theorem lshr_mul_times_5_div_4_exact_2_thm (e : IntW 32) :
 
 theorem ashr_mul_times_3_div_2_thm (e : IntW 32) :
   ashr (mul e (const? 32 3) { «nsw» := true, «nuw» := true }) (const? 32 1) ⊑
-    add e (lshr e (const? 32 1)) { «nsw» := true, «nuw» := true } := by 
+    add e (lshr e (const? 32 1)) { «nsw» := true, «nuw» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -312,7 +312,7 @@ theorem ashr_mul_times_3_div_2_thm (e : IntW 32) :
 
 theorem ashr_mul_times_3_div_2_exact_thm (e : IntW 32) :
   ashr (mul e (const? 32 3) { «nsw» := true, «nuw» := false }) (const? 32 1) { «exact» := true } ⊑
-    add e (ashr e (const? 32 1) { «exact» := true }) { «nsw» := true, «nuw» := false } := by 
+    add e (ashr e (const? 32 1) { «exact» := true }) { «nsw» := true, «nuw» := false } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -323,7 +323,7 @@ theorem ashr_mul_times_3_div_2_exact_thm (e : IntW 32) :
 
 theorem ashr_mul_times_3_div_2_exact_2_thm (e : IntW 32) :
   ashr (mul e (const? 32 3) { «nsw» := true, «nuw» := false }) (const? 32 1) { «exact» := true } ⊑
-    add e (ashr e (const? 32 1) { «exact» := true }) { «nsw» := true, «nuw» := false } := by 
+    add e (ashr e (const? 32 1) { «exact» := true }) { «nsw» := true, «nuw» := false } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -334,7 +334,7 @@ theorem ashr_mul_times_3_div_2_exact_2_thm (e : IntW 32) :
 
 theorem ashr_mul_times_5_div_4_thm (e : IntW 32) :
   ashr (mul e (const? 32 5) { «nsw» := true, «nuw» := true }) (const? 32 2) ⊑
-    add e (lshr e (const? 32 2)) { «nsw» := true, «nuw» := true } := by 
+    add e (lshr e (const? 32 2)) { «nsw» := true, «nuw» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -345,7 +345,7 @@ theorem ashr_mul_times_5_div_4_thm (e : IntW 32) :
 
 theorem ashr_mul_times_5_div_4_exact_thm (e : IntW 32) :
   ashr (mul e (const? 32 5) { «nsw» := true, «nuw» := false }) (const? 32 2) { «exact» := true } ⊑
-    add e (ashr e (const? 32 2) { «exact» := true }) { «nsw» := true, «nuw» := false } := by 
+    add e (ashr e (const? 32 2) { «exact» := true }) { «nsw» := true, «nuw» := false } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -356,7 +356,7 @@ theorem ashr_mul_times_5_div_4_exact_thm (e : IntW 32) :
 
 theorem ashr_mul_times_5_div_4_exact_2_thm (e : IntW 32) :
   ashr (mul e (const? 32 5) { «nsw» := true, «nuw» := false }) (const? 32 2) { «exact» := true } ⊑
-    add e (ashr e (const? 32 2) { «exact» := true }) { «nsw» := true, «nuw» := false } := by 
+    add e (ashr e (const? 32 2) { «exact» := true }) { «nsw» := true, «nuw» := false } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -367,7 +367,7 @@ theorem ashr_mul_times_5_div_4_exact_2_thm (e : IntW 32) :
 
 theorem lsb_mask_sign_zext_thm (e : IntW 32) :
   lshr (LLVM.and (add e (const? 32 (-1))) (LLVM.xor e (const? 32 (-1)))) (const? 32 31) ⊑
-    zext 32 (icmp IntPredicate.eq e (const? 32 0)) := by 
+    zext 32 (icmp IntPredicate.eq e (const? 32 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -378,7 +378,7 @@ theorem lsb_mask_sign_zext_thm (e : IntW 32) :
 
 theorem lsb_mask_sign_zext_commuted_thm (e : IntW 32) :
   lshr (LLVM.and (LLVM.xor e (const? 32 (-1))) (add e (const? 32 (-1)))) (const? 32 31) ⊑
-    zext 32 (icmp IntPredicate.eq e (const? 32 0)) := by 
+    zext 32 (icmp IntPredicate.eq e (const? 32 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -389,7 +389,7 @@ theorem lsb_mask_sign_zext_commuted_thm (e : IntW 32) :
 
 theorem lsb_mask_sign_zext_wrong_cst2_thm (e : IntW 32) :
   lshr (LLVM.and (add e (const? 32 (-1))) (LLVM.xor e (const? 32 2))) (const? 32 31) ⊑
-    lshr (LLVM.and (add e (const? 32 (-1))) e) (const? 32 31) := by 
+    lshr (LLVM.and (add e (const? 32 (-1))) e) (const? 32 31) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -400,7 +400,7 @@ theorem lsb_mask_sign_zext_wrong_cst2_thm (e : IntW 32) :
 
 theorem lsb_mask_sign_sext_thm (e : IntW 32) :
   ashr (LLVM.and (add e (const? 32 (-1))) (LLVM.xor e (const? 32 (-1)))) (const? 32 31) ⊑
-    sext 32 (icmp IntPredicate.eq e (const? 32 0)) := by 
+    sext 32 (icmp IntPredicate.eq e (const? 32 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -411,7 +411,7 @@ theorem lsb_mask_sign_sext_thm (e : IntW 32) :
 
 theorem lsb_mask_sign_sext_commuted_thm (e : IntW 32) :
   ashr (LLVM.and (LLVM.xor e (const? 32 (-1))) (add e (const? 32 (-1)))) (const? 32 31) ⊑
-    sext 32 (icmp IntPredicate.eq e (const? 32 0)) := by 
+    sext 32 (icmp IntPredicate.eq e (const? 32 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -422,7 +422,7 @@ theorem lsb_mask_sign_sext_commuted_thm (e : IntW 32) :
 
 theorem lsb_mask_sign_sext_wrong_cst2_thm (e : IntW 32) :
   ashr (LLVM.and (add e (const? 32 (-1))) (LLVM.xor e (const? 32 2))) (const? 32 31) ⊑
-    ashr (LLVM.and (add e (const? 32 (-1))) e) (const? 32 31) := by 
+    ashr (LLVM.and (add e (const? 32 (-1))) e) (const? 32 31) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gassochcasthassoc_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gassochcasthassoc_proof.lean
@@ -9,7 +9,7 @@ set_option linter.unreachableTactic false
 
 section gassochcasthassoc_proof
 theorem XorZextXor_thm (e : IntW 3) :
-  LLVM.xor (zext 5 (LLVM.xor e (const? 3 3))) (const? 5 12) ⊑ LLVM.xor (zext 5 e) (const? 5 15) := by 
+  LLVM.xor (zext 5 (LLVM.xor e (const? 3 3))) (const? 5 12) ⊑ LLVM.xor (zext 5 e) (const? 5 15) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -19,7 +19,7 @@ theorem XorZextXor_thm (e : IntW 3) :
 
 
 theorem OrZextOr_thm (e : IntW 3) :
-  LLVM.or (zext 5 (LLVM.or e (const? 3 3))) (const? 5 8) ⊑ LLVM.or (zext 5 e) (const? 5 11) := by 
+  LLVM.or (zext 5 (LLVM.or e (const? 3 3))) (const? 5 8) ⊑ LLVM.or (zext 5 e) (const? 5 11) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -30,7 +30,7 @@ theorem OrZextOr_thm (e : IntW 3) :
 
 theorem AndZextAnd_thm (e : IntW 3) :
   LLVM.and (zext 5 (LLVM.and e (const? 3 3))) (const? 5 14) ⊑
-    zext 5 (LLVM.and e (const? 3 2)) { «nneg» := true } := by 
+    zext 5 (LLVM.and e (const? 3 2)) { «nneg» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -41,7 +41,7 @@ theorem AndZextAnd_thm (e : IntW 3) :
 
 theorem zext_nneg_thm (e : IntW 16) :
   LLVM.and (zext 24 (LLVM.and e (const? 16 32767)) { «nneg» := true }) (const? 24 8388607) ⊑
-    zext 24 (LLVM.and e (const? 16 32767)) { «nneg» := true } := by 
+    zext 24 (LLVM.and e (const? 16 32767)) { «nneg» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gavghlsb_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gavghlsb_proof.lean
@@ -10,7 +10,7 @@ set_option linter.unreachableTactic false
 section gavghlsb_proof
 theorem avg_lsb_thm (e e_1 : IntW 8) :
   lshr (add (LLVM.and e_1 (const? 8 1)) (LLVM.and e (const? 8 1)) { «nsw» := true, «nuw» := true }) (const? 8 1) ⊑
-    LLVM.and e_1 (LLVM.and e (const? 8 1)) := by 
+    LLVM.and e_1 (LLVM.and e (const? 8 1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gbinophandhshifts_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gbinophandhshifts_proof.lean
@@ -10,7 +10,7 @@ set_option linter.unreachableTactic false
 section gbinophandhshifts_proof
 theorem shl_and_and_thm (e e_1 : IntW 8) :
   LLVM.and (shl e_1 (const? 8 4)) (LLVM.and (shl e (const? 8 4)) (const? 8 88)) ⊑
-    LLVM.and (shl (LLVM.and e e_1) (const? 8 4)) (const? 8 80) := by 
+    LLVM.and (shl (LLVM.and e e_1) (const? 8 4)) (const? 8 80) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -21,7 +21,7 @@ theorem shl_and_and_thm (e e_1 : IntW 8) :
 
 theorem shl_and_and_fail_thm (e e_1 : IntW 8) :
   LLVM.and (shl e_1 (const? 8 4)) (LLVM.and (shl e (const? 8 5)) (const? 8 88)) ⊑
-    LLVM.and (shl e_1 (const? 8 4)) (LLVM.and (shl e (const? 8 5)) (const? 8 64)) := by 
+    LLVM.and (shl e_1 (const? 8 4)) (LLVM.and (shl e (const? 8 5)) (const? 8 64)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -32,7 +32,7 @@ theorem shl_and_and_fail_thm (e e_1 : IntW 8) :
 
 theorem shl_add_add_thm (e e_1 : IntW 8) :
   add (shl e_1 (const? 8 2)) (add (shl e (const? 8 2)) (const? 8 48)) ⊑
-    add (shl (add e e_1) (const? 8 2)) (const? 8 48) := by 
+    add (shl (add e e_1) (const? 8 2)) (const? 8 48) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -44,7 +44,7 @@ theorem shl_add_add_thm (e e_1 : IntW 8) :
 theorem shl_add_add_fail_thm (e e_1 : IntW 8) :
   add (lshr e_1 (const? 8 2)) (add (lshr e (const? 8 2)) (const? 8 48)) ⊑
     add (lshr e_1 (const? 8 2)) (add (lshr e (const? 8 2)) (const? 8 48) { «nsw» := true, «nuw» := true })
-      { «nsw» := false, «nuw» := true } := by 
+      { «nsw» := false, «nuw» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -55,7 +55,7 @@ theorem shl_add_add_fail_thm (e e_1 : IntW 8) :
 
 theorem shl_and_xor_thm (e e_1 : IntW 8) :
   LLVM.xor (shl e_1 (const? 8 1)) (LLVM.and (shl e (const? 8 1)) (const? 8 20)) ⊑
-    shl (LLVM.xor e_1 (LLVM.and e (const? 8 10))) (const? 8 1) := by 
+    shl (LLVM.xor e_1 (LLVM.and e (const? 8 10))) (const? 8 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -66,7 +66,7 @@ theorem shl_and_xor_thm (e e_1 : IntW 8) :
 
 theorem shl_and_add_thm (e e_1 : IntW 8) :
   add (shl e_1 (const? 8 1)) (LLVM.and (shl e (const? 8 1)) (const? 8 119)) ⊑
-    shl (add e_1 (LLVM.and e (const? 8 59))) (const? 8 1) := by 
+    shl (add e_1 (LLVM.and e (const? 8 59))) (const? 8 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -77,7 +77,7 @@ theorem shl_and_add_thm (e e_1 : IntW 8) :
 
 theorem lshr_or_and_thm (e e_1 : IntW 8) :
   LLVM.and (LLVM.or (lshr e_1 (const? 8 5)) (const? 8 (-58))) (lshr e (const? 8 5)) ⊑
-    lshr (LLVM.and e (LLVM.or e_1 (const? 8 (-64)))) (const? 8 5) := by 
+    lshr (LLVM.and e (LLVM.or e_1 (const? 8 (-64)))) (const? 8 5) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -88,7 +88,7 @@ theorem lshr_or_and_thm (e e_1 : IntW 8) :
 
 theorem lshr_or_or_fail_thm (e e_1 : IntW 8) :
   LLVM.or (lshr e_1 (const? 8 5)) (LLVM.or (lshr e (const? 8 5)) (const? 8 (-58))) ⊑
-    LLVM.or (lshr (LLVM.or e e_1) (const? 8 5)) (const? 8 (-58)) := by 
+    LLVM.or (lshr (LLVM.or e e_1) (const? 8 5)) (const? 8 (-58)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -98,7 +98,7 @@ theorem lshr_or_or_fail_thm (e e_1 : IntW 8) :
 
 
 theorem lshr_or_or_no_const_thm (e e_1 e_2 e_3 : IntW 8) :
-  LLVM.or (lshr e_3 e_2) (LLVM.or (lshr e_1 e_2) e) ⊑ LLVM.or (lshr (LLVM.or e_1 e_3) e_2) e := by 
+  LLVM.or (lshr e_3 e_2) (LLVM.or (lshr e_1 e_2) e) ⊑ LLVM.or (lshr (LLVM.or e_1 e_3) e_2) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -108,7 +108,7 @@ theorem lshr_or_or_no_const_thm (e e_1 e_2 e_3 : IntW 8) :
 
 
 theorem shl_xor_xor_no_const_thm (e e_1 e_2 e_3 : IntW 8) :
-  LLVM.xor (shl e_3 e_2) (LLVM.xor (shl e_1 e_2) e) ⊑ LLVM.xor (shl (LLVM.xor e_1 e_3) e_2) e := by 
+  LLVM.xor (shl e_3 e_2) (LLVM.xor (shl e_1 e_2) e) ⊑ LLVM.xor (shl (LLVM.xor e_1 e_3) e_2) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -118,7 +118,7 @@ theorem shl_xor_xor_no_const_thm (e e_1 e_2 e_3 : IntW 8) :
 
 
 theorem shl_add_add_no_const_thm (e e_1 e_2 e_3 : IntW 8) :
-  add (shl e_3 e_2) (add (shl e_1 e_2) e) ⊑ add (shl (add e_1 e_3) e_2) e := by 
+  add (shl e_3 e_2) (add (shl e_1 e_2) e) ⊑ add (shl (add e_1 e_3) e_2) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -129,7 +129,7 @@ theorem shl_add_add_no_const_thm (e e_1 e_2 e_3 : IntW 8) :
 
 theorem lshr_xor_or_good_mask_thm (e e_1 : IntW 8) :
   LLVM.or (lshr e_1 (const? 8 4)) (LLVM.xor (lshr e (const? 8 4)) (const? 8 48)) ⊑
-    LLVM.or (lshr (LLVM.or e e_1) (const? 8 4)) (const? 8 48) { «disjoint» := true } := by 
+    LLVM.or (lshr (LLVM.or e e_1) (const? 8 4)) (const? 8 48) { «disjoint» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -140,7 +140,7 @@ theorem lshr_xor_or_good_mask_thm (e e_1 : IntW 8) :
 
 theorem shl_xor_xor_good_mask_thm (e e_1 : IntW 8) :
   LLVM.xor (shl e_1 (const? 8 1)) (LLVM.xor (shl e (const? 8 1)) (const? 8 88)) ⊑
-    LLVM.xor (shl (LLVM.xor e e_1) (const? 8 1)) (const? 8 88) := by 
+    LLVM.xor (shl (LLVM.xor e e_1) (const? 8 1)) (const? 8 88) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -151,7 +151,7 @@ theorem shl_xor_xor_good_mask_thm (e e_1 : IntW 8) :
 
 theorem shl_xor_xor_bad_mask_distribute_thm (e e_1 : IntW 8) :
   LLVM.xor (shl e_1 (const? 8 1)) (LLVM.xor (shl e (const? 8 1)) (const? 8 (-68))) ⊑
-    LLVM.xor (shl (LLVM.xor e e_1) (const? 8 1)) (const? 8 (-68)) := by 
+    LLVM.xor (shl (LLVM.xor e e_1) (const? 8 1)) (const? 8 (-68)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -162,7 +162,7 @@ theorem shl_xor_xor_bad_mask_distribute_thm (e e_1 : IntW 8) :
 
 theorem shl_add_and_thm (e e_1 : IntW 8) :
   LLVM.and (shl e_1 (const? 8 1)) (add (shl e (const? 8 1)) (const? 8 123)) ⊑
-    shl (LLVM.and e_1 (add e (const? 8 61))) (const? 8 1) := by 
+    shl (LLVM.and e_1 (add e (const? 8 61))) (const? 8 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -174,7 +174,7 @@ theorem shl_add_and_thm (e e_1 : IntW 8) :
 theorem lshr_and_add_fail_thm (e e_1 : IntW 8) :
   add (lshr e_1 (const? 8 1)) (LLVM.and (lshr e (const? 8 1)) (const? 8 123)) ⊑
     add (lshr e_1 (const? 8 1)) (LLVM.and (lshr e (const? 8 1)) (const? 8 123))
-      { «nsw» := false, «nuw» := true } := by 
+      { «nsw» := false, «nuw» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -186,7 +186,7 @@ theorem lshr_and_add_fail_thm (e e_1 : IntW 8) :
 theorem lshr_add_or_fail_thm (e e_1 : IntW 8) :
   LLVM.or (lshr e_1 (const? 8 1)) (add (lshr e (const? 8 1)) (const? 8 123)) ⊑
     LLVM.or (lshr e_1 (const? 8 1))
-      (add (lshr e (const? 8 1)) (const? 8 123) { «nsw» := false, «nuw» := true }) := by 
+      (add (lshr e (const? 8 1)) (const? 8 123) { «nsw» := false, «nuw» := true }) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -198,7 +198,7 @@ theorem lshr_add_or_fail_thm (e e_1 : IntW 8) :
 theorem lshr_add_xor_fail_thm (e e_1 : IntW 8) :
   LLVM.xor (lshr e_1 (const? 8 1)) (add (lshr e (const? 8 1)) (const? 8 123)) ⊑
     LLVM.xor (lshr e_1 (const? 8 1))
-      (add (lshr e (const? 8 1)) (const? 8 123) { «nsw» := false, «nuw» := true }) := by 
+      (add (lshr e (const? 8 1)) (const? 8 123) { «nsw» := false, «nuw» := true }) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -210,7 +210,7 @@ theorem lshr_add_xor_fail_thm (e e_1 : IntW 8) :
 theorem shl_add_and_fail_mismatch_shift_thm (e e_1 : IntW 8) :
   LLVM.and (shl e_1 (const? 8 1)) (add (lshr e (const? 8 1)) (const? 8 123)) ⊑
     LLVM.and (shl e_1 (const? 8 1))
-      (add (lshr e (const? 8 1)) (const? 8 123) { «nsw» := false, «nuw» := true }) := by 
+      (add (lshr e (const? 8 1)) (const? 8 123) { «nsw» := false, «nuw» := true }) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -221,7 +221,7 @@ theorem shl_add_and_fail_mismatch_shift_thm (e e_1 : IntW 8) :
 
 theorem and_ashr_not_thm (e e_1 e_2 : IntW 8) :
   LLVM.and (ashr e_2 e_1) (LLVM.xor (ashr e e_1) (const? 8 (-1))) ⊑
-    ashr (LLVM.and e_2 (LLVM.xor e (const? 8 (-1)))) e_1 := by 
+    ashr (LLVM.and e_2 (LLVM.xor e (const? 8 (-1)))) e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -232,7 +232,7 @@ theorem and_ashr_not_thm (e e_1 e_2 : IntW 8) :
 
 theorem and_ashr_not_commuted_thm (e e_1 e_2 : IntW 8) :
   LLVM.and (LLVM.xor (ashr e_2 e_1) (const? 8 (-1))) (ashr e e_1) ⊑
-    ashr (LLVM.and e (LLVM.xor e_2 (const? 8 (-1)))) e_1 := by 
+    ashr (LLVM.and e (LLVM.xor e_2 (const? 8 (-1)))) e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -243,7 +243,7 @@ theorem and_ashr_not_commuted_thm (e e_1 e_2 : IntW 8) :
 
 theorem or_ashr_not_thm (e e_1 e_2 : IntW 8) :
   LLVM.or (ashr e_2 e_1) (LLVM.xor (ashr e e_1) (const? 8 (-1))) ⊑
-    ashr (LLVM.or e_2 (LLVM.xor e (const? 8 (-1)))) e_1 := by 
+    ashr (LLVM.or e_2 (LLVM.xor e (const? 8 (-1)))) e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -254,7 +254,7 @@ theorem or_ashr_not_thm (e e_1 e_2 : IntW 8) :
 
 theorem or_ashr_not_commuted_thm (e e_1 e_2 : IntW 8) :
   LLVM.or (LLVM.xor (ashr e_2 e_1) (const? 8 (-1))) (ashr e e_1) ⊑
-    ashr (LLVM.or e (LLVM.xor e_2 (const? 8 (-1)))) e_1 := by 
+    ashr (LLVM.or e (LLVM.xor e_2 (const? 8 (-1)))) e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -265,7 +265,7 @@ theorem or_ashr_not_commuted_thm (e e_1 e_2 : IntW 8) :
 
 theorem xor_ashr_not_thm (e e_1 e_2 : IntW 8) :
   LLVM.xor (ashr e_2 e_1) (LLVM.xor (ashr e e_1) (const? 8 (-1))) ⊑
-    LLVM.xor (ashr (LLVM.xor e e_2) e_1) (const? 8 (-1)) := by 
+    LLVM.xor (ashr (LLVM.xor e e_2) e_1) (const? 8 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -276,7 +276,7 @@ theorem xor_ashr_not_thm (e e_1 e_2 : IntW 8) :
 
 theorem xor_ashr_not_commuted_thm (e e_1 e_2 : IntW 8) :
   LLVM.xor (LLVM.xor (ashr e_2 e_1) (const? 8 (-1))) (ashr e e_1) ⊑
-    LLVM.xor (ashr (LLVM.xor e_2 e) e_1) (const? 8 (-1)) := by 
+    LLVM.xor (ashr (LLVM.xor e_2 e) e_1) (const? 8 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -287,7 +287,7 @@ theorem xor_ashr_not_commuted_thm (e e_1 e_2 : IntW 8) :
 
 theorem xor_ashr_not_fail_lshr_ashr_thm (e e_1 e_2 : IntW 8) :
   LLVM.xor (lshr e_2 e_1) (LLVM.xor (ashr e e_1) (const? 8 (-1))) ⊑
-    LLVM.xor (LLVM.xor (ashr e e_1) (lshr e_2 e_1)) (const? 8 (-1)) := by 
+    LLVM.xor (LLVM.xor (ashr e e_1) (lshr e_2 e_1)) (const? 8 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -298,7 +298,7 @@ theorem xor_ashr_not_fail_lshr_ashr_thm (e e_1 e_2 : IntW 8) :
 
 theorem xor_ashr_not_fail_ashr_lshr_thm (e e_1 e_2 : IntW 8) :
   LLVM.xor (ashr e_2 e_1) (LLVM.xor (lshr e e_1) (const? 8 (-1))) ⊑
-    LLVM.xor (LLVM.xor (lshr e e_1) (ashr e_2 e_1)) (const? 8 (-1)) := by 
+    LLVM.xor (LLVM.xor (lshr e e_1) (ashr e_2 e_1)) (const? 8 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -309,7 +309,7 @@ theorem xor_ashr_not_fail_ashr_lshr_thm (e e_1 e_2 : IntW 8) :
 
 theorem xor_ashr_not_fail_invalid_xor_constant_thm (e e_1 e_2 : IntW 8) :
   LLVM.xor (ashr e_2 e_1) (LLVM.xor (ashr e e_1) (const? 8 (-2))) ⊑
-    LLVM.xor (ashr (LLVM.xor e e_2) e_1) (const? 8 (-2)) := by 
+    LLVM.xor (ashr (LLVM.xor e e_2) e_1) (const? 8 (-2)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gbinophcast_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gbinophcast_proof.lean
@@ -8,7 +8,7 @@ set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
 
 section gbinophcast_proof
-theorem and_sext_to_sel_thm (e : IntW 32) (e_1 : IntW 1) : LLVM.and (sext 32 e_1) e ⊑ select e_1 e (const? 32 0) := by 
+theorem and_sext_to_sel_thm (e : IntW 32) (e_1 : IntW 1) : LLVM.and (sext 32 e_1) e ⊑ select e_1 e (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -17,7 +17,7 @@ theorem and_sext_to_sel_thm (e : IntW 32) (e_1 : IntW 1) : LLVM.and (sext 32 e_1
     all_goals sorry
 
 
-theorem or_sext_to_sel_thm (e : IntW 32) (e_1 : IntW 1) : LLVM.or (sext 32 e_1) e ⊑ select e_1 (const? 32 (-1)) e := by 
+theorem or_sext_to_sel_thm (e : IntW 32) (e_1 : IntW 1) : LLVM.or (sext 32 e_1) e ⊑ select e_1 (const? 32 (-1)) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -26,7 +26,7 @@ theorem or_sext_to_sel_thm (e : IntW 32) (e_1 : IntW 1) : LLVM.or (sext 32 e_1) 
     all_goals sorry
 
 
-theorem xor_sext_to_sel_thm (e : IntW 32) (e_1 : IntW 1) : LLVM.xor (sext 32 e_1) e ⊑ LLVM.xor e (sext 32 e_1) := by 
+theorem xor_sext_to_sel_thm (e : IntW 32) (e_1 : IntW 1) : LLVM.xor (sext 32 e_1) e ⊑ LLVM.xor e (sext 32 e_1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -36,7 +36,7 @@ theorem xor_sext_to_sel_thm (e : IntW 32) (e_1 : IntW 1) : LLVM.xor (sext 32 e_1
 
 
 theorem and_add_bool_to_select_thm (e : IntW 32) (e_1 : IntW 1) :
-  LLVM.and (add (const? 32 (-1)) (zext 32 e_1)) e ⊑ select e_1 (const? 32 0) e := by 
+  LLVM.and (add (const? 32 (-1)) (zext 32 e_1)) e ⊑ select e_1 (const? 32 0) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -47,7 +47,7 @@ theorem and_add_bool_to_select_thm (e : IntW 32) (e_1 : IntW 1) :
 
 theorem and_add_bool_no_fold_thm (e : IntW 32) :
   LLVM.and (add (const? 32 (-1)) (LLVM.and e (const? 32 1))) e ⊑
-    select (icmp IntPredicate.eq (LLVM.and e (const? 32 1)) (const? 32 0)) e (const? 32 0) := by 
+    select (icmp IntPredicate.eq (LLVM.and e (const? 32 1)) (const? 32 0)) e (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -58,7 +58,7 @@ theorem and_add_bool_no_fold_thm (e : IntW 32) :
 
 theorem and_add_bool_to_select_multi_use_thm (e : IntW 32) (e_1 : IntW 1) :
   add (LLVM.and (add (const? 32 (-1)) (zext 32 e_1)) e) (add (const? 32 (-1)) (zext 32 e_1)) ⊑
-    select e_1 (const? 32 0) (add e (const? 32 (-1))) := by 
+    select e_1 (const? 32 0) (add e (const? 32 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gbinophofhdisplacedhshifts_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gbinophofhdisplacedhshifts_proof.lean
@@ -9,7 +9,7 @@ set_option linter.unreachableTactic false
 
 section gbinophofhdisplacedhshifts_proof
 theorem shl_or_thm (e : IntW 8) :
-  LLVM.or (shl (const? 8 16) e) (shl (const? 8 3) (add e (const? 8 1))) ⊑ shl (const? 8 22) e := by 
+  LLVM.or (shl (const? 8 16) e) (shl (const? 8 3) (add e (const? 8 1))) ⊑ shl (const? 8 22) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -19,7 +19,7 @@ theorem shl_or_thm (e : IntW 8) :
 
 
 theorem lshr_or_thm (e : IntW 8) :
-  LLVM.or (lshr (const? 8 16) e) (lshr (const? 8 3) (add e (const? 8 1))) ⊑ lshr (const? 8 17) e := by 
+  LLVM.or (lshr (const? 8 16) e) (lshr (const? 8 3) (add e (const? 8 1))) ⊑ lshr (const? 8 17) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -29,7 +29,7 @@ theorem lshr_or_thm (e : IntW 8) :
 
 
 theorem ashr_or_thm (e : IntW 8) :
-  LLVM.or (ashr (const? 8 (-64)) e) (ashr (const? 8 (-128)) (add e (const? 8 1))) ⊑ ashr (const? 8 (-64)) e := by 
+  LLVM.or (ashr (const? 8 (-64)) e) (ashr (const? 8 (-128)) (add e (const? 8 1))) ⊑ ashr (const? 8 (-64)) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -39,7 +39,7 @@ theorem ashr_or_thm (e : IntW 8) :
 
 
 theorem shl_xor_thm (e : IntW 8) :
-  LLVM.xor (shl (const? 8 16) e) (shl (const? 8 3) (add e (const? 8 1))) ⊑ shl (const? 8 22) e := by 
+  LLVM.xor (shl (const? 8 16) e) (shl (const? 8 3) (add e (const? 8 1))) ⊑ shl (const? 8 22) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -49,7 +49,7 @@ theorem shl_xor_thm (e : IntW 8) :
 
 
 theorem lshr_xor_thm (e : IntW 8) :
-  LLVM.xor (lshr (const? 8 16) e) (lshr (const? 8 3) (add e (const? 8 1))) ⊑ lshr (const? 8 17) e := by 
+  LLVM.xor (lshr (const? 8 16) e) (lshr (const? 8 3) (add e (const? 8 1))) ⊑ lshr (const? 8 17) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -59,7 +59,7 @@ theorem lshr_xor_thm (e : IntW 8) :
 
 
 theorem ashr_xor_thm (e : IntW 8) :
-  LLVM.xor (ashr (const? 8 (-128)) e) (ashr (const? 8 (-64)) (add e (const? 8 1))) ⊑ lshr (const? 8 96) e := by 
+  LLVM.xor (ashr (const? 8 (-128)) e) (ashr (const? 8 (-64)) (add e (const? 8 1))) ⊑ lshr (const? 8 96) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -69,7 +69,7 @@ theorem ashr_xor_thm (e : IntW 8) :
 
 
 theorem shl_and_thm (e : IntW 8) :
-  LLVM.and (shl (const? 8 48) e) (shl (const? 8 8) (add e (const? 8 1))) ⊑ shl (const? 8 16) e := by 
+  LLVM.and (shl (const? 8 48) e) (shl (const? 8 8) (add e (const? 8 1))) ⊑ shl (const? 8 16) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -79,7 +79,7 @@ theorem shl_and_thm (e : IntW 8) :
 
 
 theorem lshr_and_thm (e : IntW 8) :
-  LLVM.and (lshr (const? 8 48) e) (lshr (const? 8 64) (add e (const? 8 1))) ⊑ lshr (const? 8 32) e := by 
+  LLVM.and (lshr (const? 8 48) e) (lshr (const? 8 64) (add e (const? 8 1))) ⊑ lshr (const? 8 32) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -89,7 +89,7 @@ theorem lshr_and_thm (e : IntW 8) :
 
 
 theorem ashr_and_thm (e : IntW 8) :
-  LLVM.and (ashr (const? 8 (-64)) e) (ashr (const? 8 (-128)) (add e (const? 8 1))) ⊑ ashr (const? 8 (-64)) e := by 
+  LLVM.and (ashr (const? 8 (-64)) e) (ashr (const? 8 (-128)) (add e (const? 8 1))) ⊑ ashr (const? 8 (-64)) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -99,7 +99,7 @@ theorem ashr_and_thm (e : IntW 8) :
 
 
 theorem shl_add_thm (e : IntW 8) :
-  add (shl (const? 8 16) e) (shl (const? 8 7) (add e (const? 8 1))) ⊑ shl (const? 8 30) e := by 
+  add (shl (const? 8 16) e) (shl (const? 8 7) (add e (const? 8 1))) ⊑ shl (const? 8 30) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -110,7 +110,7 @@ theorem shl_add_thm (e : IntW 8) :
 
 theorem lshr_add_fail_thm (e : IntW 8) :
   add (lshr (const? 8 16) e) (lshr (const? 8 7) (add e (const? 8 1))) ⊑
-    add (lshr (const? 8 16) e) (lshr (const? 8 7) (add e (const? 8 1))) { «nsw» := true, «nuw» := true } := by 
+    add (lshr (const? 8 16) e) (lshr (const? 8 7) (add e (const? 8 1))) { «nsw» := true, «nuw» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -122,7 +122,7 @@ theorem lshr_add_fail_thm (e : IntW 8) :
 theorem ashr_add_fail_thm (e : IntW 8) :
   add (ashr (const? 8 (-128)) e) (ashr (const? 8 (-128)) (add e (const? 8 1))) ⊑
     add (ashr (const? 8 (-128)) e { «exact» := true })
-      (ashr (const? 8 (-128)) (add e (const? 8 1)) { «exact» := true }) := by 
+      (ashr (const? 8 (-128)) (add e (const? 8 1)) { «exact» := true }) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -132,7 +132,7 @@ theorem ashr_add_fail_thm (e : IntW 8) :
 
 
 theorem shl_or_commuted_thm (e : IntW 8) :
-  LLVM.or (shl (const? 8 3) (add e (const? 8 1))) (shl (const? 8 16) e) ⊑ shl (const? 8 22) e := by 
+  LLVM.or (shl (const? 8 3) (add e (const? 8 1))) (shl (const? 8 16) e) ⊑ shl (const? 8 22) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -143,7 +143,7 @@ theorem shl_or_commuted_thm (e : IntW 8) :
 
 theorem mismatched_shifts_thm (e : IntW 8) :
   LLVM.or (shl (const? 8 16) e) (lshr (const? 8 3) (add e (const? 8 1))) ⊑
-    LLVM.or (shl (const? 8 16) e) (lshr (const? 8 3) (add e (const? 8 1))) { «disjoint» := true } := by 
+    LLVM.or (shl (const? 8 16) e) (lshr (const? 8 3) (add e (const? 8 1))) { «disjoint» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -154,7 +154,7 @@ theorem mismatched_shifts_thm (e : IntW 8) :
 
 theorem shl_or_with_or_disjoint_instead_of_add_thm (e : IntW 8) :
   LLVM.or (shl (const? 8 16) e) (shl (const? 8 3) (LLVM.or e (const? 8 1) { «disjoint» := true })) ⊑
-    shl (const? 8 22) e := by 
+    shl (const? 8 22) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gbinophselect_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gbinophselect_proof.lean
@@ -8,7 +8,7 @@ set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
 
 section gbinophselect_proof
-theorem and_sel_op0_thm (e : IntW 1) : LLVM.and (select e (const? 32 25) (const? 32 0)) (const? 32 1) ⊑ zext 32 e := by 
+theorem and_sel_op0_thm (e : IntW 1) : LLVM.and (select e (const? 32 25) (const? 32 0)) (const? 32 1) ⊑ zext 32 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -19,7 +19,7 @@ theorem and_sel_op0_thm (e : IntW 1) : LLVM.and (select e (const? 32 25) (const?
 
 theorem mul_sel_op0_thm (e : IntW 32) (e_1 : IntW 1) :
   mul (select e_1 (const? 32 0) (LLVM.udiv (const? 32 42) e { «exact» := true })) e ⊑
-    select e_1 (const? 32 0) (const? 32 42) := by 
+    select e_1 (const? 32 0) (const? 32 42) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -30,7 +30,7 @@ theorem mul_sel_op0_thm (e : IntW 32) (e_1 : IntW 1) :
 
 theorem sub_sel_op1_thm (e : IntW 1) :
   sub (const? 32 42) (select e (const? 32 42) (const? 32 41)) { «nsw» := true, «nuw» := false } ⊑
-    zext 32 (LLVM.xor e (const? 1 1)) := by 
+    zext 32 (LLVM.xor e (const? 1 1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -40,7 +40,7 @@ theorem sub_sel_op1_thm (e : IntW 1) :
 
 
 theorem ashr_sel_op1_thm (e : IntW 1) :
-  ashr (const? 32 (-2)) (select e (const? 32 2) (const? 32 0)) ⊑ select e (const? 32 (-1)) (const? 32 (-2)) := by 
+  ashr (const? 32 (-2)) (select e (const? 32 2) (const? 32 0)) ⊑ select e (const? 32 (-1)) (const? 32 (-2)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gbinophselecthcasthofhselecthcond_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gbinophselecthcasthofhselecthcond_proof.lean
@@ -9,7 +9,7 @@ set_option linter.unreachableTactic false
 
 section gbinophselecthcasthofhselecthcond_proof
 theorem add_select_zext_thm (e : IntW 1) :
-  add (select e (const? 64 64) (const? 64 1)) (zext 64 e) ⊑ select e (const? 64 65) (const? 64 1) := by 
+  add (select e (const? 64 64) (const? 64 1)) (zext 64 e) ⊑ select e (const? 64 65) (const? 64 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -19,7 +19,7 @@ theorem add_select_zext_thm (e : IntW 1) :
 
 
 theorem add_select_sext_thm (e : IntW 1) :
-  add (select e (const? 64 64) (const? 64 1)) (sext 64 e) ⊑ select e (const? 64 63) (const? 64 1) := by 
+  add (select e (const? 64 64) (const? 64 1)) (sext 64 e) ⊑ select e (const? 64 63) (const? 64 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -30,7 +30,7 @@ theorem add_select_sext_thm (e : IntW 1) :
 
 theorem add_select_not_zext_thm (e : IntW 1) :
   add (select e (const? 64 64) (const? 64 1)) (zext 64 (LLVM.xor e (const? 1 1))) ⊑
-    select e (const? 64 64) (const? 64 2) := by 
+    select e (const? 64 64) (const? 64 2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -41,7 +41,7 @@ theorem add_select_not_zext_thm (e : IntW 1) :
 
 theorem add_select_not_sext_thm (e : IntW 1) :
   add (select e (const? 64 64) (const? 64 1)) (sext 64 (LLVM.xor e (const? 1 1))) ⊑
-    select e (const? 64 64) (const? 64 0) := by 
+    select e (const? 64 64) (const? 64 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -51,7 +51,7 @@ theorem add_select_not_sext_thm (e : IntW 1) :
 
 
 theorem sub_select_sext_thm (e : IntW 64) (e_1 : IntW 1) :
-  sub (select e_1 (const? 64 64) e) (sext 64 e_1) ⊑ select e_1 (const? 64 65) e := by 
+  sub (select e_1 (const? 64 64) e) (sext 64 e_1) ⊑ select e_1 (const? 64 65) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -61,7 +61,7 @@ theorem sub_select_sext_thm (e : IntW 64) (e_1 : IntW 1) :
 
 
 theorem sub_select_not_zext_thm (e : IntW 64) (e_1 : IntW 1) :
-  sub (select e_1 e (const? 64 64)) (zext 64 (LLVM.xor e_1 (const? 1 1))) ⊑ select e_1 e (const? 64 63) := by 
+  sub (select e_1 e (const? 64 64)) (zext 64 (LLVM.xor e_1 (const? 1 1))) ⊑ select e_1 e (const? 64 63) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -71,7 +71,7 @@ theorem sub_select_not_zext_thm (e : IntW 64) (e_1 : IntW 1) :
 
 
 theorem sub_select_not_sext_thm (e : IntW 64) (e_1 : IntW 1) :
-  sub (select e_1 e (const? 64 64)) (sext 64 (LLVM.xor e_1 (const? 1 1))) ⊑ select e_1 e (const? 64 65) := by 
+  sub (select e_1 e (const? 64 64)) (sext 64 (LLVM.xor e_1 (const? 1 1))) ⊑ select e_1 e (const? 64 65) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -81,7 +81,7 @@ theorem sub_select_not_sext_thm (e : IntW 64) (e_1 : IntW 1) :
 
 
 theorem mul_select_zext_thm (e : IntW 64) (e_1 : IntW 1) :
-  mul (select e_1 e (const? 64 1)) (zext 64 e_1) ⊑ select e_1 e (const? 64 0) := by 
+  mul (select e_1 e (const? 64 1)) (zext 64 e_1) ⊑ select e_1 e (const? 64 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -91,7 +91,7 @@ theorem mul_select_zext_thm (e : IntW 64) (e_1 : IntW 1) :
 
 
 theorem mul_select_sext_thm (e : IntW 1) :
-  mul (select e (const? 64 64) (const? 64 1)) (sext 64 e) ⊑ select e (const? 64 (-64)) (const? 64 0) := by 
+  mul (select e (const? 64 64) (const? 64 1)) (sext 64 e) ⊑ select e (const? 64 (-64)) (const? 64 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -102,7 +102,7 @@ theorem mul_select_sext_thm (e : IntW 1) :
 
 theorem select_zext_different_condition_thm (e e_1 : IntW 1) :
   add (select e_1 (const? 64 64) (const? 64 1)) (zext 64 e) ⊑
-    add (select e_1 (const? 64 64) (const? 64 1)) (zext 64 e) { «nsw» := true, «nuw» := true } := by 
+    add (select e_1 (const? 64 64) (const? 64 1)) (zext 64 e) { «nsw» := true, «nuw» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -113,7 +113,7 @@ theorem select_zext_different_condition_thm (e e_1 : IntW 1) :
 
 theorem multiuse_add_thm (e : IntW 1) :
   add (add (select e (const? 64 64) (const? 64 1)) (zext 64 e)) (const? 64 1) ⊑
-    select e (const? 64 66) (const? 64 2) := by 
+    select e (const? 64 66) (const? 64 2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -124,7 +124,7 @@ theorem multiuse_add_thm (e : IntW 1) :
 
 theorem multiuse_select_thm (e : IntW 1) :
   mul (select e (const? 64 64) (const? 64 0)) (sub (select e (const? 64 64) (const? 64 0)) (zext 64 e)) ⊑
-    select e (const? 64 4032) (const? 64 0) := by 
+    select e (const? 64 4032) (const? 64 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -134,7 +134,7 @@ theorem multiuse_select_thm (e : IntW 1) :
 
 
 theorem select_non_const_sides_thm (e e_1 : IntW 64) (e_2 : IntW 1) :
-  sub (select e_2 e_1 e) (zext 64 e_2) ⊑ select e_2 (add e_1 (const? 64 (-1))) e := by 
+  sub (select e_2 e_1 e) (zext 64 e_2) ⊑ select e_2 (add e_1 (const? 64 (-1))) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -144,7 +144,7 @@ theorem select_non_const_sides_thm (e e_1 : IntW 64) (e_2 : IntW 1) :
 
 
 theorem sub_select_sext_op_swapped_non_const_args_thm (e e_1 : IntW 6) (e_2 : IntW 1) :
-  sub (sext 6 e_2) (select e_2 e_1 e) ⊑ select e_2 (LLVM.xor e_1 (const? 6 (-1))) (sub (const? 6 0) e) := by 
+  sub (sext 6 e_2) (select e_2 e_1 e) ⊑ select e_2 (LLVM.xor e_1 (const? 6 (-1))) (sub (const? 6 0) e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -154,7 +154,7 @@ theorem sub_select_sext_op_swapped_non_const_args_thm (e e_1 : IntW 6) (e_2 : In
 
 
 theorem sub_select_zext_op_swapped_non_const_args_thm (e e_1 : IntW 6) (e_2 : IntW 1) :
-  sub (zext 6 e_2) (select e_2 e_1 e) ⊑ select e_2 (sub (const? 6 1) e_1) (sub (const? 6 0) e) := by 
+  sub (zext 6 e_2) (select e_2 e_1 e) ⊑ select e_2 (sub (const? 6 1) e_1) (sub (const? 6 0) e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gbithchecks_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gbithchecks_proof.lean
@@ -13,7 +13,7 @@ theorem main1_thm (e : IntW 32) :
       (LLVM.and (icmp IntPredicate.ne (LLVM.and e (const? 32 1)) (const? 32 0))
         (icmp IntPredicate.ne (LLVM.and e (const? 32 2)) (const? 32 0)))
       (const? 32 2) (const? 32 1) ⊑
-    select (icmp IntPredicate.eq (LLVM.and e (const? 32 3)) (const? 32 3)) (const? 32 2) (const? 32 1) := by 
+    select (icmp IntPredicate.eq (LLVM.and e (const? 32 3)) (const? 32 3)) (const? 32 2) (const? 32 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -27,7 +27,7 @@ theorem main1_logical_thm (e : IntW 32) :
       (select (icmp IntPredicate.ne (LLVM.and e (const? 32 1)) (const? 32 0))
         (icmp IntPredicate.ne (LLVM.and e (const? 32 2)) (const? 32 0)) (const? 1 0))
       (const? 32 2) (const? 32 1) ⊑
-    select (icmp IntPredicate.eq (LLVM.and e (const? 32 3)) (const? 32 3)) (const? 32 2) (const? 32 1) := by 
+    select (icmp IntPredicate.eq (LLVM.and e (const? 32 3)) (const? 32 3)) (const? 32 2) (const? 32 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -41,7 +41,7 @@ theorem main2_thm (e : IntW 32) :
       (LLVM.or (icmp IntPredicate.eq (LLVM.and e (const? 32 1)) (const? 32 0))
         (icmp IntPredicate.eq (LLVM.and e (const? 32 2)) (const? 32 0)))
       (const? 32 0) (const? 32 1) ⊑
-    zext 32 (icmp IntPredicate.eq (LLVM.and e (const? 32 3)) (const? 32 3)) := by 
+    zext 32 (icmp IntPredicate.eq (LLVM.and e (const? 32 3)) (const? 32 3)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -55,7 +55,7 @@ theorem main2_logical_thm (e : IntW 32) :
       (select (icmp IntPredicate.eq (LLVM.and e (const? 32 1)) (const? 32 0)) (const? 1 1)
         (icmp IntPredicate.eq (LLVM.and e (const? 32 2)) (const? 32 0)))
       (const? 32 0) (const? 32 1) ⊑
-    zext 32 (icmp IntPredicate.eq (LLVM.and e (const? 32 3)) (const? 32 3)) := by 
+    zext 32 (icmp IntPredicate.eq (LLVM.and e (const? 32 3)) (const? 32 3)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -69,7 +69,7 @@ theorem main3_thm (e : IntW 32) :
       (LLVM.and (icmp IntPredicate.eq (LLVM.and e (const? 32 7)) (const? 32 0))
         (icmp IntPredicate.eq (LLVM.and e (const? 32 48)) (const? 32 0)))
       (const? 32 0) (const? 32 1) ⊑
-    zext 32 (icmp IntPredicate.ne (LLVM.and e (const? 32 55)) (const? 32 0)) := by 
+    zext 32 (icmp IntPredicate.ne (LLVM.and e (const? 32 55)) (const? 32 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -83,7 +83,7 @@ theorem main3_logical_thm (e : IntW 32) :
       (select (icmp IntPredicate.eq (LLVM.and e (const? 32 7)) (const? 32 0))
         (icmp IntPredicate.eq (LLVM.and e (const? 32 48)) (const? 32 0)) (const? 1 0))
       (const? 32 0) (const? 32 1) ⊑
-    zext 32 (icmp IntPredicate.ne (LLVM.and e (const? 32 55)) (const? 32 0)) := by 
+    zext 32 (icmp IntPredicate.ne (LLVM.and e (const? 32 55)) (const? 32 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -97,7 +97,7 @@ theorem main3b_thm (e : IntW 32) :
       (LLVM.and (icmp IntPredicate.eq (LLVM.and e (const? 32 7)) (const? 32 0))
         (icmp IntPredicate.ne (LLVM.and e (const? 32 16)) (const? 32 16)))
       (const? 32 0) (const? 32 1) ⊑
-    zext 32 (icmp IntPredicate.ne (LLVM.and e (const? 32 23)) (const? 32 0)) := by 
+    zext 32 (icmp IntPredicate.ne (LLVM.and e (const? 32 23)) (const? 32 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -111,7 +111,7 @@ theorem main3b_logical_thm (e : IntW 32) :
       (select (icmp IntPredicate.eq (LLVM.and e (const? 32 7)) (const? 32 0))
         (icmp IntPredicate.ne (LLVM.and e (const? 32 16)) (const? 32 16)) (const? 1 0))
       (const? 32 0) (const? 32 1) ⊑
-    zext 32 (icmp IntPredicate.ne (LLVM.and e (const? 32 23)) (const? 32 0)) := by 
+    zext 32 (icmp IntPredicate.ne (LLVM.and e (const? 32 23)) (const? 32 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -125,7 +125,7 @@ theorem main3e_like_thm (e e_1 e_2 : IntW 32) :
       (LLVM.and (icmp IntPredicate.eq (LLVM.and e_2 e_1) (const? 32 0))
         (icmp IntPredicate.eq (LLVM.and e_2 e) (const? 32 0)))
       (const? 32 0) (const? 32 1) ⊑
-    zext 32 (icmp IntPredicate.ne (LLVM.and e_2 (LLVM.or e_1 e)) (const? 32 0)) := by 
+    zext 32 (icmp IntPredicate.ne (LLVM.and e_2 (LLVM.or e_1 e)) (const? 32 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -141,7 +141,7 @@ theorem main3e_like_logical_thm (e e_1 e_2 : IntW 32) :
       (const? 32 0) (const? 32 1) ⊑
     zext 32
       (select (icmp IntPredicate.ne (LLVM.and e_2 e_1) (const? 32 0)) (const? 1 1)
-        (icmp IntPredicate.ne (LLVM.and e_2 e) (const? 32 0))) := by 
+        (icmp IntPredicate.ne (LLVM.and e_2 e) (const? 32 0))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -155,7 +155,7 @@ theorem main3c_thm (e : IntW 32) :
       (LLVM.or (icmp IntPredicate.ne (LLVM.and e (const? 32 7)) (const? 32 0))
         (icmp IntPredicate.ne (LLVM.and e (const? 32 48)) (const? 32 0)))
       (const? 32 0) (const? 32 1) ⊑
-    zext 32 (icmp IntPredicate.eq (LLVM.and e (const? 32 55)) (const? 32 0)) := by 
+    zext 32 (icmp IntPredicate.eq (LLVM.and e (const? 32 55)) (const? 32 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -169,7 +169,7 @@ theorem main3c_logical_thm (e : IntW 32) :
       (select (icmp IntPredicate.ne (LLVM.and e (const? 32 7)) (const? 32 0)) (const? 1 1)
         (icmp IntPredicate.ne (LLVM.and e (const? 32 48)) (const? 32 0)))
       (const? 32 0) (const? 32 1) ⊑
-    zext 32 (icmp IntPredicate.eq (LLVM.and e (const? 32 55)) (const? 32 0)) := by 
+    zext 32 (icmp IntPredicate.eq (LLVM.and e (const? 32 55)) (const? 32 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -183,7 +183,7 @@ theorem main3d_thm (e : IntW 32) :
       (LLVM.or (icmp IntPredicate.ne (LLVM.and e (const? 32 7)) (const? 32 0))
         (icmp IntPredicate.eq (LLVM.and e (const? 32 16)) (const? 32 16)))
       (const? 32 0) (const? 32 1) ⊑
-    zext 32 (icmp IntPredicate.eq (LLVM.and e (const? 32 23)) (const? 32 0)) := by 
+    zext 32 (icmp IntPredicate.eq (LLVM.and e (const? 32 23)) (const? 32 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -197,7 +197,7 @@ theorem main3d_logical_thm (e : IntW 32) :
       (select (icmp IntPredicate.ne (LLVM.and e (const? 32 7)) (const? 32 0)) (const? 1 1)
         (icmp IntPredicate.eq (LLVM.and e (const? 32 16)) (const? 32 16)))
       (const? 32 0) (const? 32 1) ⊑
-    zext 32 (icmp IntPredicate.eq (LLVM.and e (const? 32 23)) (const? 32 0)) := by 
+    zext 32 (icmp IntPredicate.eq (LLVM.and e (const? 32 23)) (const? 32 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -211,7 +211,7 @@ theorem main3f_like_thm (e e_1 e_2 : IntW 32) :
       (LLVM.or (icmp IntPredicate.ne (LLVM.and e_2 e_1) (const? 32 0))
         (icmp IntPredicate.ne (LLVM.and e_2 e) (const? 32 0)))
       (const? 32 0) (const? 32 1) ⊑
-    zext 32 (icmp IntPredicate.eq (LLVM.and e_2 (LLVM.or e_1 e)) (const? 32 0)) := by 
+    zext 32 (icmp IntPredicate.eq (LLVM.and e_2 (LLVM.or e_1 e)) (const? 32 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -227,7 +227,7 @@ theorem main3f_like_logical_thm (e e_1 e_2 : IntW 32) :
       (const? 32 0) (const? 32 1) ⊑
     zext 32
       (select (icmp IntPredicate.eq (LLVM.and e_2 e_1) (const? 32 0))
-        (icmp IntPredicate.eq (LLVM.and e_2 e) (const? 32 0)) (const? 1 0)) := by 
+        (icmp IntPredicate.eq (LLVM.and e_2 e) (const? 32 0)) (const? 1 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -241,7 +241,7 @@ theorem main4_thm (e : IntW 32) :
       (LLVM.and (icmp IntPredicate.eq (LLVM.and e (const? 32 7)) (const? 32 7))
         (icmp IntPredicate.eq (LLVM.and e (const? 32 48)) (const? 32 48)))
       (const? 32 0) (const? 32 1) ⊑
-    zext 32 (icmp IntPredicate.ne (LLVM.and e (const? 32 55)) (const? 32 55)) := by 
+    zext 32 (icmp IntPredicate.ne (LLVM.and e (const? 32 55)) (const? 32 55)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -255,7 +255,7 @@ theorem main4_logical_thm (e : IntW 32) :
       (select (icmp IntPredicate.eq (LLVM.and e (const? 32 7)) (const? 32 7))
         (icmp IntPredicate.eq (LLVM.and e (const? 32 48)) (const? 32 48)) (const? 1 0))
       (const? 32 0) (const? 32 1) ⊑
-    zext 32 (icmp IntPredicate.ne (LLVM.and e (const? 32 55)) (const? 32 55)) := by 
+    zext 32 (icmp IntPredicate.ne (LLVM.and e (const? 32 55)) (const? 32 55)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -269,7 +269,7 @@ theorem main4b_thm (e : IntW 32) :
       (LLVM.and (icmp IntPredicate.eq (LLVM.and e (const? 32 7)) (const? 32 7))
         (icmp IntPredicate.ne (LLVM.and e (const? 32 16)) (const? 32 0)))
       (const? 32 0) (const? 32 1) ⊑
-    zext 32 (icmp IntPredicate.ne (LLVM.and e (const? 32 23)) (const? 32 23)) := by 
+    zext 32 (icmp IntPredicate.ne (LLVM.and e (const? 32 23)) (const? 32 23)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -283,7 +283,7 @@ theorem main4b_logical_thm (e : IntW 32) :
       (select (icmp IntPredicate.eq (LLVM.and e (const? 32 7)) (const? 32 7))
         (icmp IntPredicate.ne (LLVM.and e (const? 32 16)) (const? 32 0)) (const? 1 0))
       (const? 32 0) (const? 32 1) ⊑
-    zext 32 (icmp IntPredicate.ne (LLVM.and e (const? 32 23)) (const? 32 23)) := by 
+    zext 32 (icmp IntPredicate.ne (LLVM.and e (const? 32 23)) (const? 32 23)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -295,7 +295,7 @@ theorem main4b_logical_thm (e : IntW 32) :
 theorem main4e_like_thm (e e_1 e_2 : IntW 32) :
   select (LLVM.and (icmp IntPredicate.eq (LLVM.and e_2 e_1) e_1) (icmp IntPredicate.eq (LLVM.and e_2 e) e))
       (const? 32 0) (const? 32 1) ⊑
-    zext 32 (icmp IntPredicate.ne (LLVM.and e_2 (LLVM.or e_1 e)) (LLVM.or e_1 e)) := by 
+    zext 32 (icmp IntPredicate.ne (LLVM.and e_2 (LLVM.or e_1 e)) (LLVM.or e_1 e)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -309,7 +309,7 @@ theorem main4e_like_logical_thm (e e_1 e_2 : IntW 32) :
       (const? 32 0) (const? 32 1) ⊑
     zext 32
       (select (icmp IntPredicate.ne (LLVM.and e_2 e_1) e_1) (const? 1 1)
-        (icmp IntPredicate.ne (LLVM.and e_2 e) e)) := by 
+        (icmp IntPredicate.ne (LLVM.and e_2 e) e)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -323,7 +323,7 @@ theorem main4c_thm (e : IntW 32) :
       (LLVM.or (icmp IntPredicate.ne (LLVM.and e (const? 32 7)) (const? 32 7))
         (icmp IntPredicate.ne (LLVM.and e (const? 32 48)) (const? 32 48)))
       (const? 32 0) (const? 32 1) ⊑
-    zext 32 (icmp IntPredicate.eq (LLVM.and e (const? 32 55)) (const? 32 55)) := by 
+    zext 32 (icmp IntPredicate.eq (LLVM.and e (const? 32 55)) (const? 32 55)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -337,7 +337,7 @@ theorem main4c_logical_thm (e : IntW 32) :
       (select (icmp IntPredicate.ne (LLVM.and e (const? 32 7)) (const? 32 7)) (const? 1 1)
         (icmp IntPredicate.ne (LLVM.and e (const? 32 48)) (const? 32 48)))
       (const? 32 0) (const? 32 1) ⊑
-    zext 32 (icmp IntPredicate.eq (LLVM.and e (const? 32 55)) (const? 32 55)) := by 
+    zext 32 (icmp IntPredicate.eq (LLVM.and e (const? 32 55)) (const? 32 55)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -351,7 +351,7 @@ theorem main4d_thm (e : IntW 32) :
       (LLVM.or (icmp IntPredicate.ne (LLVM.and e (const? 32 7)) (const? 32 7))
         (icmp IntPredicate.eq (LLVM.and e (const? 32 16)) (const? 32 0)))
       (const? 32 0) (const? 32 1) ⊑
-    zext 32 (icmp IntPredicate.eq (LLVM.and e (const? 32 23)) (const? 32 23)) := by 
+    zext 32 (icmp IntPredicate.eq (LLVM.and e (const? 32 23)) (const? 32 23)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -365,7 +365,7 @@ theorem main4d_logical_thm (e : IntW 32) :
       (select (icmp IntPredicate.ne (LLVM.and e (const? 32 7)) (const? 32 7)) (const? 1 1)
         (icmp IntPredicate.eq (LLVM.and e (const? 32 16)) (const? 32 0)))
       (const? 32 0) (const? 32 1) ⊑
-    zext 32 (icmp IntPredicate.eq (LLVM.and e (const? 32 23)) (const? 32 23)) := by 
+    zext 32 (icmp IntPredicate.eq (LLVM.and e (const? 32 23)) (const? 32 23)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -377,7 +377,7 @@ theorem main4d_logical_thm (e : IntW 32) :
 theorem main4f_like_thm (e e_1 e_2 : IntW 32) :
   select (LLVM.or (icmp IntPredicate.ne (LLVM.and e_2 e_1) e_1) (icmp IntPredicate.ne (LLVM.and e_2 e) e)) (const? 32 0)
       (const? 32 1) ⊑
-    zext 32 (icmp IntPredicate.eq (LLVM.and e_2 (LLVM.or e_1 e)) (LLVM.or e_1 e)) := by 
+    zext 32 (icmp IntPredicate.eq (LLVM.and e_2 (LLVM.or e_1 e)) (LLVM.or e_1 e)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -391,7 +391,7 @@ theorem main4f_like_logical_thm (e e_1 e_2 : IntW 32) :
       (const? 32 0) (const? 32 1) ⊑
     zext 32
       (select (icmp IntPredicate.eq (LLVM.and e_2 e_1) e_1) (icmp IntPredicate.eq (LLVM.and e_2 e) e)
-        (const? 1 0)) := by 
+        (const? 1 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -405,7 +405,7 @@ theorem main5_like_thm (e e_1 : IntW 32) :
       (LLVM.and (icmp IntPredicate.eq (LLVM.and e_1 (const? 32 7)) (const? 32 7))
         (icmp IntPredicate.eq (LLVM.and e (const? 32 7)) (const? 32 7)))
       (const? 32 0) (const? 32 1) ⊑
-    zext 32 (icmp IntPredicate.ne (LLVM.and (LLVM.and e_1 e) (const? 32 7)) (const? 32 7)) := by 
+    zext 32 (icmp IntPredicate.ne (LLVM.and (LLVM.and e_1 e) (const? 32 7)) (const? 32 7)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -421,7 +421,7 @@ theorem main5_like_logical_thm (e e_1 : IntW 32) :
       (const? 32 0) (const? 32 1) ⊑
     zext 32
       (select (icmp IntPredicate.ne (LLVM.and e_1 (const? 32 7)) (const? 32 7)) (const? 1 1)
-        (icmp IntPredicate.ne (LLVM.and e (const? 32 7)) (const? 32 7))) := by 
+        (icmp IntPredicate.ne (LLVM.and e (const? 32 7)) (const? 32 7))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -433,7 +433,7 @@ theorem main5_like_logical_thm (e e_1 : IntW 32) :
 theorem main5e_like_thm (e e_1 e_2 : IntW 32) :
   select (LLVM.and (icmp IntPredicate.eq (LLVM.and e_2 e_1) e_2) (icmp IntPredicate.eq (LLVM.and e_2 e) e_2))
       (const? 32 0) (const? 32 1) ⊑
-    zext 32 (icmp IntPredicate.ne (LLVM.and e_2 (LLVM.and e_1 e)) e_2) := by 
+    zext 32 (icmp IntPredicate.ne (LLVM.and e_2 (LLVM.and e_1 e)) e_2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -447,7 +447,7 @@ theorem main5e_like_logical_thm (e e_1 e_2 : IntW 32) :
       (const? 32 0) (const? 32 1) ⊑
     zext 32
       (select (icmp IntPredicate.ne (LLVM.and e_2 e_1) e_2) (const? 1 1)
-        (icmp IntPredicate.ne (LLVM.and e_2 e) e_2)) := by 
+        (icmp IntPredicate.ne (LLVM.and e_2 e) e_2)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -461,7 +461,7 @@ theorem main5c_like_thm (e e_1 : IntW 32) :
       (LLVM.or (icmp IntPredicate.ne (LLVM.and e_1 (const? 32 7)) (const? 32 7))
         (icmp IntPredicate.ne (LLVM.and e (const? 32 7)) (const? 32 7)))
       (const? 32 0) (const? 32 1) ⊑
-    zext 32 (icmp IntPredicate.eq (LLVM.and (LLVM.and e_1 e) (const? 32 7)) (const? 32 7)) := by 
+    zext 32 (icmp IntPredicate.eq (LLVM.and (LLVM.and e_1 e) (const? 32 7)) (const? 32 7)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -477,7 +477,7 @@ theorem main5c_like_logical_thm (e e_1 : IntW 32) :
       (const? 32 0) (const? 32 1) ⊑
     zext 32
       (select (icmp IntPredicate.eq (LLVM.and e_1 (const? 32 7)) (const? 32 7))
-        (icmp IntPredicate.eq (LLVM.and e (const? 32 7)) (const? 32 7)) (const? 1 0)) := by 
+        (icmp IntPredicate.eq (LLVM.and e (const? 32 7)) (const? 32 7)) (const? 1 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -489,7 +489,7 @@ theorem main5c_like_logical_thm (e e_1 : IntW 32) :
 theorem main5f_like_thm (e e_1 e_2 : IntW 32) :
   select (LLVM.or (icmp IntPredicate.ne (LLVM.and e_2 e_1) e_2) (icmp IntPredicate.ne (LLVM.and e_2 e) e_2))
       (const? 32 0) (const? 32 1) ⊑
-    zext 32 (icmp IntPredicate.eq (LLVM.and e_2 (LLVM.and e_1 e)) e_2) := by 
+    zext 32 (icmp IntPredicate.eq (LLVM.and e_2 (LLVM.and e_1 e)) e_2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -503,7 +503,7 @@ theorem main5f_like_logical_thm (e e_1 e_2 : IntW 32) :
       (const? 32 0) (const? 32 1) ⊑
     zext 32
       (select (icmp IntPredicate.eq (LLVM.and e_2 e_1) e_2) (icmp IntPredicate.eq (LLVM.and e_2 e) e_2)
-        (const? 1 0)) := by 
+        (const? 1 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -517,7 +517,7 @@ theorem main6_thm (e : IntW 32) :
       (LLVM.and (icmp IntPredicate.eq (LLVM.and e (const? 32 7)) (const? 32 3))
         (icmp IntPredicate.eq (LLVM.and e (const? 32 48)) (const? 32 16)))
       (const? 32 0) (const? 32 1) ⊑
-    zext 32 (icmp IntPredicate.ne (LLVM.and e (const? 32 55)) (const? 32 19)) := by 
+    zext 32 (icmp IntPredicate.ne (LLVM.and e (const? 32 55)) (const? 32 19)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -531,7 +531,7 @@ theorem main6_logical_thm (e : IntW 32) :
       (select (icmp IntPredicate.eq (LLVM.and e (const? 32 7)) (const? 32 3))
         (icmp IntPredicate.eq (LLVM.and e (const? 32 48)) (const? 32 16)) (const? 1 0))
       (const? 32 0) (const? 32 1) ⊑
-    zext 32 (icmp IntPredicate.ne (LLVM.and e (const? 32 55)) (const? 32 19)) := by 
+    zext 32 (icmp IntPredicate.ne (LLVM.and e (const? 32 55)) (const? 32 19)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -545,7 +545,7 @@ theorem main6b_thm (e : IntW 32) :
       (LLVM.and (icmp IntPredicate.eq (LLVM.and e (const? 32 7)) (const? 32 3))
         (icmp IntPredicate.ne (LLVM.and e (const? 32 16)) (const? 32 0)))
       (const? 32 0) (const? 32 1) ⊑
-    zext 32 (icmp IntPredicate.ne (LLVM.and e (const? 32 23)) (const? 32 19)) := by 
+    zext 32 (icmp IntPredicate.ne (LLVM.and e (const? 32 23)) (const? 32 19)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -559,7 +559,7 @@ theorem main6b_logical_thm (e : IntW 32) :
       (select (icmp IntPredicate.eq (LLVM.and e (const? 32 7)) (const? 32 3))
         (icmp IntPredicate.ne (LLVM.and e (const? 32 16)) (const? 32 0)) (const? 1 0))
       (const? 32 0) (const? 32 1) ⊑
-    zext 32 (icmp IntPredicate.ne (LLVM.and e (const? 32 23)) (const? 32 19)) := by 
+    zext 32 (icmp IntPredicate.ne (LLVM.and e (const? 32 23)) (const? 32 19)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -573,7 +573,7 @@ theorem main6c_thm (e : IntW 32) :
       (LLVM.or (icmp IntPredicate.ne (LLVM.and e (const? 32 7)) (const? 32 3))
         (icmp IntPredicate.ne (LLVM.and e (const? 32 48)) (const? 32 16)))
       (const? 32 0) (const? 32 1) ⊑
-    zext 32 (icmp IntPredicate.eq (LLVM.and e (const? 32 55)) (const? 32 19)) := by 
+    zext 32 (icmp IntPredicate.eq (LLVM.and e (const? 32 55)) (const? 32 19)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -587,7 +587,7 @@ theorem main6c_logical_thm (e : IntW 32) :
       (select (icmp IntPredicate.ne (LLVM.and e (const? 32 7)) (const? 32 3)) (const? 1 1)
         (icmp IntPredicate.ne (LLVM.and e (const? 32 48)) (const? 32 16)))
       (const? 32 0) (const? 32 1) ⊑
-    zext 32 (icmp IntPredicate.eq (LLVM.and e (const? 32 55)) (const? 32 19)) := by 
+    zext 32 (icmp IntPredicate.eq (LLVM.and e (const? 32 55)) (const? 32 19)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -601,7 +601,7 @@ theorem main6d_thm (e : IntW 32) :
       (LLVM.or (icmp IntPredicate.ne (LLVM.and e (const? 32 7)) (const? 32 3))
         (icmp IntPredicate.eq (LLVM.and e (const? 32 16)) (const? 32 0)))
       (const? 32 0) (const? 32 1) ⊑
-    zext 32 (icmp IntPredicate.eq (LLVM.and e (const? 32 23)) (const? 32 19)) := by 
+    zext 32 (icmp IntPredicate.eq (LLVM.and e (const? 32 23)) (const? 32 19)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -615,7 +615,7 @@ theorem main6d_logical_thm (e : IntW 32) :
       (select (icmp IntPredicate.ne (LLVM.and e (const? 32 7)) (const? 32 3)) (const? 1 1)
         (icmp IntPredicate.eq (LLVM.and e (const? 32 16)) (const? 32 0)))
       (const? 32 0) (const? 32 1) ⊑
-    zext 32 (icmp IntPredicate.eq (LLVM.and e (const? 32 23)) (const? 32 19)) := by 
+    zext 32 (icmp IntPredicate.eq (LLVM.and e (const? 32 23)) (const? 32 19)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -627,7 +627,7 @@ theorem main6d_logical_thm (e : IntW 32) :
 theorem main7a_thm (e e_1 e_2 : IntW 32) :
   select (LLVM.and (icmp IntPredicate.eq (LLVM.and e_2 e_1) e_2) (icmp IntPredicate.eq (LLVM.and e e_1) e))
       (const? 32 0) (const? 32 1) ⊑
-    zext 32 (icmp IntPredicate.ne (LLVM.and e_1 (LLVM.or e_2 e)) (LLVM.or e_2 e)) := by 
+    zext 32 (icmp IntPredicate.ne (LLVM.and e_1 (LLVM.or e_2 e)) (LLVM.or e_2 e)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -641,7 +641,7 @@ theorem main7a_logical_thm (e e_1 e_2 : IntW 32) :
       (const? 32 0) (const? 32 1) ⊑
     zext 32
       (select (icmp IntPredicate.ne (LLVM.and e_2 e_1) e_2) (const? 1 1)
-        (icmp IntPredicate.ne (LLVM.and e e_1) e)) := by 
+        (icmp IntPredicate.ne (LLVM.and e e_1) e)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -657,7 +657,7 @@ theorem main7b_thm (e e_1 e_2 : IntW 32) :
       (const? 32 0) (const? 32 1) ⊑
     zext 32
       (icmp IntPredicate.ne (LLVM.and e_1 (LLVM.or e_2 (mul e (const? 32 42))))
-        (LLVM.or e_2 (mul e (const? 32 42)))) := by 
+        (LLVM.or e_2 (mul e (const? 32 42)))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -671,7 +671,7 @@ theorem main7b_logical_thm (e e_1 e_2 : IntW 32) :
       (const? 32 0) (const? 32 1) ⊑
     zext 32
       (select (icmp IntPredicate.ne e_2 (LLVM.and e_1 e_2)) (const? 1 1)
-        (icmp IntPredicate.ne e (LLVM.and e_1 e))) := by 
+        (icmp IntPredicate.ne e (LLVM.and e_1 e))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -687,7 +687,7 @@ theorem main7c_thm (e e_1 e_2 : IntW 32) :
       (const? 32 0) (const? 32 1) ⊑
     zext 32
       (icmp IntPredicate.ne (LLVM.and e_1 (LLVM.or e_2 (mul e (const? 32 42))))
-        (LLVM.or e_2 (mul e (const? 32 42)))) := by 
+        (LLVM.or e_2 (mul e (const? 32 42)))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -701,7 +701,7 @@ theorem main7c_logical_thm (e e_1 e_2 : IntW 32) :
       (const? 32 0) (const? 32 1) ⊑
     zext 32
       (select (icmp IntPredicate.ne e_2 (LLVM.and e_2 e_1)) (const? 1 1)
-        (icmp IntPredicate.ne e (LLVM.and e e_1))) := by 
+        (icmp IntPredicate.ne e (LLVM.and e e_1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -717,7 +717,7 @@ theorem main7d_thm (e e_1 e_2 e_3 e_4 : IntW 32) :
       (const? 32 0) (const? 32 1) ⊑
     zext 32
       (icmp IntPredicate.ne (LLVM.and e_4 (LLVM.or (LLVM.and e_3 e_2) (LLVM.and e_1 e)))
-        (LLVM.or (LLVM.and e_3 e_2) (LLVM.and e_1 e))) := by 
+        (LLVM.or (LLVM.and e_3 e_2) (LLVM.and e_1 e))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -733,7 +733,7 @@ theorem main7d_logical_thm (e e_1 e_2 e_3 e_4 : IntW 32) :
       (const? 32 0) (const? 32 1) ⊑
     zext 32
       (select (icmp IntPredicate.ne (LLVM.and e_4 (LLVM.and e_3 e_2)) (LLVM.and e_3 e_2)) (const? 1 1)
-        (icmp IntPredicate.ne (LLVM.and e_4 (LLVM.and e_1 e)) (LLVM.and e_1 e))) := by 
+        (icmp IntPredicate.ne (LLVM.and e_4 (LLVM.and e_1 e)) (LLVM.and e_1 e))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -749,7 +749,7 @@ theorem main7e_thm (e e_1 e_2 e_3 e_4 : IntW 32) :
       (const? 32 0) (const? 32 1) ⊑
     zext 32
       (icmp IntPredicate.ne (LLVM.and e_2 (LLVM.or (LLVM.and e_4 e_3) (LLVM.and e_1 e)))
-        (LLVM.or (LLVM.and e_4 e_3) (LLVM.and e_1 e))) := by 
+        (LLVM.or (LLVM.and e_4 e_3) (LLVM.and e_1 e))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -765,7 +765,7 @@ theorem main7e_logical_thm (e e_1 e_2 e_3 e_4 : IntW 32) :
       (const? 32 0) (const? 32 1) ⊑
     zext 32
       (select (icmp IntPredicate.ne (LLVM.and (LLVM.and e_4 e_3) e_2) (LLVM.and e_4 e_3)) (const? 1 1)
-        (icmp IntPredicate.ne (LLVM.and (LLVM.and e_1 e) e_2) (LLVM.and e_1 e))) := by 
+        (icmp IntPredicate.ne (LLVM.and (LLVM.and e_1 e) e_2) (LLVM.and e_1 e))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -781,7 +781,7 @@ theorem main7f_thm (e e_1 e_2 e_3 e_4 : IntW 32) :
       (const? 32 0) (const? 32 1) ⊑
     zext 32
       (icmp IntPredicate.ne (LLVM.and e_2 (LLVM.or (LLVM.and e_4 e_3) (LLVM.and e_1 e)))
-        (LLVM.or (LLVM.and e_4 e_3) (LLVM.and e_1 e))) := by 
+        (LLVM.or (LLVM.and e_4 e_3) (LLVM.and e_1 e))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -797,7 +797,7 @@ theorem main7f_logical_thm (e e_1 e_2 e_3 e_4 : IntW 32) :
       (const? 32 0) (const? 32 1) ⊑
     zext 32
       (select (icmp IntPredicate.ne (LLVM.and e_4 e_3) (LLVM.and e_2 (LLVM.and e_4 e_3))) (const? 1 1)
-        (icmp IntPredicate.ne (LLVM.and e_1 e) (LLVM.and e_2 (LLVM.and e_1 e)))) := by 
+        (icmp IntPredicate.ne (LLVM.and e_1 e) (LLVM.and e_2 (LLVM.and e_1 e)))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -813,7 +813,7 @@ theorem main7g_thm (e e_1 e_2 e_3 e_4 : IntW 32) :
       (const? 32 0) (const? 32 1) ⊑
     zext 32
       (icmp IntPredicate.ne (LLVM.and e_2 (LLVM.or (LLVM.and e_4 e_3) (LLVM.and e_1 e)))
-        (LLVM.or (LLVM.and e_4 e_3) (LLVM.and e_1 e))) := by 
+        (LLVM.or (LLVM.and e_4 e_3) (LLVM.and e_1 e))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -829,7 +829,7 @@ theorem main7g_logical_thm (e e_1 e_2 e_3 e_4 : IntW 32) :
       (const? 32 0) (const? 32 1) ⊑
     zext 32
       (select (icmp IntPredicate.ne (LLVM.and e_4 e_3) (LLVM.and (LLVM.and e_4 e_3) e_2)) (const? 1 1)
-        (icmp IntPredicate.ne (LLVM.and e_1 e) (LLVM.and (LLVM.and e_1 e) e_2))) := by 
+        (icmp IntPredicate.ne (LLVM.and e_1 e) (LLVM.and (LLVM.and e_1 e) e_2))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -843,7 +843,7 @@ theorem main8_thm (e : IntW 32) :
       (LLVM.or (icmp IntPredicate.ne (LLVM.and e (const? 32 64)) (const? 32 0))
         (icmp IntPredicate.slt (trunc 8 e) (const? 8 0)))
       (const? 32 2) (const? 32 1) ⊑
-    select (icmp IntPredicate.eq (LLVM.and e (const? 32 192)) (const? 32 0)) (const? 32 1) (const? 32 2) := by 
+    select (icmp IntPredicate.eq (LLVM.and e (const? 32 192)) (const? 32 0)) (const? 32 1) (const? 32 2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -857,7 +857,7 @@ theorem main8_logical_thm (e : IntW 32) :
       (select (icmp IntPredicate.ne (LLVM.and e (const? 32 64)) (const? 32 0)) (const? 1 1)
         (icmp IntPredicate.slt (trunc 8 e) (const? 8 0)))
       (const? 32 2) (const? 32 1) ⊑
-    select (icmp IntPredicate.eq (LLVM.and e (const? 32 192)) (const? 32 0)) (const? 32 1) (const? 32 2) := by 
+    select (icmp IntPredicate.eq (LLVM.and e (const? 32 192)) (const? 32 0)) (const? 32 1) (const? 32 2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -871,7 +871,7 @@ theorem main9_thm (e : IntW 32) :
       (LLVM.and (icmp IntPredicate.ne (LLVM.and e (const? 32 64)) (const? 32 0))
         (icmp IntPredicate.slt (trunc 8 e) (const? 8 0)))
       (const? 32 2) (const? 32 1) ⊑
-    select (icmp IntPredicate.eq (LLVM.and e (const? 32 192)) (const? 32 192)) (const? 32 2) (const? 32 1) := by 
+    select (icmp IntPredicate.eq (LLVM.and e (const? 32 192)) (const? 32 192)) (const? 32 2) (const? 32 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -885,7 +885,7 @@ theorem main9_logical_thm (e : IntW 32) :
       (select (icmp IntPredicate.ne (LLVM.and e (const? 32 64)) (const? 32 0))
         (icmp IntPredicate.slt (trunc 8 e) (const? 8 0)) (const? 1 0))
       (const? 32 2) (const? 32 1) ⊑
-    select (icmp IntPredicate.eq (LLVM.and e (const? 32 192)) (const? 32 192)) (const? 32 2) (const? 32 1) := by 
+    select (icmp IntPredicate.eq (LLVM.and e (const? 32 192)) (const? 32 192)) (const? 32 2) (const? 32 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -899,7 +899,7 @@ theorem main10_thm (e : IntW 32) :
       (LLVM.and (icmp IntPredicate.eq (LLVM.and e (const? 32 64)) (const? 32 0))
         (icmp IntPredicate.sge (trunc 8 e) (const? 8 0)))
       (const? 32 2) (const? 32 1) ⊑
-    select (icmp IntPredicate.eq (LLVM.and e (const? 32 192)) (const? 32 0)) (const? 32 2) (const? 32 1) := by 
+    select (icmp IntPredicate.eq (LLVM.and e (const? 32 192)) (const? 32 0)) (const? 32 2) (const? 32 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -913,7 +913,7 @@ theorem main10_logical_thm (e : IntW 32) :
       (select (icmp IntPredicate.eq (LLVM.and e (const? 32 64)) (const? 32 0))
         (icmp IntPredicate.sge (trunc 8 e) (const? 8 0)) (const? 1 0))
       (const? 32 2) (const? 32 1) ⊑
-    select (icmp IntPredicate.eq (LLVM.and e (const? 32 192)) (const? 32 0)) (const? 32 2) (const? 32 1) := by 
+    select (icmp IntPredicate.eq (LLVM.and e (const? 32 192)) (const? 32 0)) (const? 32 2) (const? 32 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -927,7 +927,7 @@ theorem main11_thm (e : IntW 32) :
       (LLVM.or (icmp IntPredicate.eq (LLVM.and e (const? 32 64)) (const? 32 0))
         (icmp IntPredicate.sge (trunc 8 e) (const? 8 0)))
       (const? 32 2) (const? 32 1) ⊑
-    select (icmp IntPredicate.eq (LLVM.and e (const? 32 192)) (const? 32 192)) (const? 32 1) (const? 32 2) := by 
+    select (icmp IntPredicate.eq (LLVM.and e (const? 32 192)) (const? 32 192)) (const? 32 1) (const? 32 2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -941,7 +941,7 @@ theorem main11_logical_thm (e : IntW 32) :
       (select (icmp IntPredicate.eq (LLVM.and e (const? 32 64)) (const? 32 0)) (const? 1 1)
         (icmp IntPredicate.sge (trunc 8 e) (const? 8 0)))
       (const? 32 2) (const? 32 1) ⊑
-    select (icmp IntPredicate.eq (LLVM.and e (const? 32 192)) (const? 32 192)) (const? 32 1) (const? 32 2) := by 
+    select (icmp IntPredicate.eq (LLVM.and e (const? 32 192)) (const? 32 192)) (const? 32 1) (const? 32 2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -953,7 +953,7 @@ theorem main11_logical_thm (e : IntW 32) :
 theorem main12_thm (e : IntW 32) :
   select (LLVM.or (icmp IntPredicate.slt (trunc 16 e) (const? 16 0)) (icmp IntPredicate.slt (trunc 8 e) (const? 8 0)))
       (const? 32 2) (const? 32 1) ⊑
-    select (icmp IntPredicate.eq (LLVM.and e (const? 32 32896)) (const? 32 0)) (const? 32 1) (const? 32 2) := by 
+    select (icmp IntPredicate.eq (LLVM.and e (const? 32 32896)) (const? 32 0)) (const? 32 1) (const? 32 2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -967,7 +967,7 @@ theorem main12_logical_thm (e : IntW 32) :
       (select (icmp IntPredicate.slt (trunc 16 e) (const? 16 0)) (const? 1 1)
         (icmp IntPredicate.slt (trunc 8 e) (const? 8 0)))
       (const? 32 2) (const? 32 1) ⊑
-    select (icmp IntPredicate.eq (LLVM.and e (const? 32 32896)) (const? 32 0)) (const? 32 1) (const? 32 2) := by 
+    select (icmp IntPredicate.eq (LLVM.and e (const? 32 32896)) (const? 32 0)) (const? 32 1) (const? 32 2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -979,7 +979,7 @@ theorem main12_logical_thm (e : IntW 32) :
 theorem main13_thm (e : IntW 32) :
   select (LLVM.and (icmp IntPredicate.slt (trunc 16 e) (const? 16 0)) (icmp IntPredicate.slt (trunc 8 e) (const? 8 0)))
       (const? 32 2) (const? 32 1) ⊑
-    select (icmp IntPredicate.eq (LLVM.and e (const? 32 32896)) (const? 32 32896)) (const? 32 2) (const? 32 1) := by 
+    select (icmp IntPredicate.eq (LLVM.and e (const? 32 32896)) (const? 32 32896)) (const? 32 2) (const? 32 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -993,7 +993,7 @@ theorem main13_logical_thm (e : IntW 32) :
       (select (icmp IntPredicate.slt (trunc 16 e) (const? 16 0)) (icmp IntPredicate.slt (trunc 8 e) (const? 8 0))
         (const? 1 0))
       (const? 32 2) (const? 32 1) ⊑
-    select (icmp IntPredicate.eq (LLVM.and e (const? 32 32896)) (const? 32 32896)) (const? 32 2) (const? 32 1) := by 
+    select (icmp IntPredicate.eq (LLVM.and e (const? 32 32896)) (const? 32 32896)) (const? 32 2) (const? 32 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1005,7 +1005,7 @@ theorem main13_logical_thm (e : IntW 32) :
 theorem main14_thm (e : IntW 32) :
   select (LLVM.and (icmp IntPredicate.sge (trunc 16 e) (const? 16 0)) (icmp IntPredicate.sge (trunc 8 e) (const? 8 0)))
       (const? 32 2) (const? 32 1) ⊑
-    select (icmp IntPredicate.eq (LLVM.and e (const? 32 32896)) (const? 32 0)) (const? 32 2) (const? 32 1) := by 
+    select (icmp IntPredicate.eq (LLVM.and e (const? 32 32896)) (const? 32 0)) (const? 32 2) (const? 32 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1019,7 +1019,7 @@ theorem main14_logical_thm (e : IntW 32) :
       (select (icmp IntPredicate.sge (trunc 16 e) (const? 16 0)) (icmp IntPredicate.sge (trunc 8 e) (const? 8 0))
         (const? 1 0))
       (const? 32 2) (const? 32 1) ⊑
-    select (icmp IntPredicate.eq (LLVM.and e (const? 32 32896)) (const? 32 0)) (const? 32 2) (const? 32 1) := by 
+    select (icmp IntPredicate.eq (LLVM.and e (const? 32 32896)) (const? 32 0)) (const? 32 2) (const? 32 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1031,7 +1031,7 @@ theorem main14_logical_thm (e : IntW 32) :
 theorem main15_thm (e : IntW 32) :
   select (LLVM.or (icmp IntPredicate.sge (trunc 16 e) (const? 16 0)) (icmp IntPredicate.sge (trunc 8 e) (const? 8 0)))
       (const? 32 2) (const? 32 1) ⊑
-    select (icmp IntPredicate.eq (LLVM.and e (const? 32 32896)) (const? 32 32896)) (const? 32 1) (const? 32 2) := by 
+    select (icmp IntPredicate.eq (LLVM.and e (const? 32 32896)) (const? 32 32896)) (const? 32 1) (const? 32 2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1045,7 +1045,7 @@ theorem main15_logical_thm (e : IntW 32) :
       (select (icmp IntPredicate.sge (trunc 16 e) (const? 16 0)) (const? 1 1)
         (icmp IntPredicate.sge (trunc 8 e) (const? 8 0)))
       (const? 32 2) (const? 32 1) ⊑
-    select (icmp IntPredicate.eq (LLVM.and e (const? 32 32896)) (const? 32 32896)) (const? 32 1) (const? 32 2) := by 
+    select (icmp IntPredicate.eq (LLVM.and e (const? 32 32896)) (const? 32 32896)) (const? 32 1) (const? 32 2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1058,7 +1058,7 @@ theorem no_masks_with_logical_or_thm (e e_1 e_2 : IntW 32) :
   LLVM.or (select (icmp IntPredicate.ne e_2 (const? 32 0)) (const? 1 1) (icmp IntPredicate.ne e_1 (const? 32 63)))
       (icmp IntPredicate.ne e (const? 32 0)) ⊑
     select (icmp IntPredicate.ne (LLVM.or e_2 e) (const? 32 0)) (const? 1 1)
-      (icmp IntPredicate.ne e_1 (const? 32 63)) := by 
+      (icmp IntPredicate.ne e_1 (const? 32 63)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1071,7 +1071,7 @@ theorem no_masks_with_logical_or2_thm (e e_1 e_2 : IntW 32) :
   LLVM.or (select (icmp IntPredicate.ne e_2 (const? 32 (-1))) (const? 1 1) (icmp IntPredicate.ne e_1 (const? 32 63)))
       (icmp IntPredicate.ne e (const? 32 (-1))) ⊑
     select (icmp IntPredicate.ne (LLVM.and e_2 e) (const? 32 (-1))) (const? 1 1)
-      (icmp IntPredicate.ne e_1 (const? 32 63)) := by 
+      (icmp IntPredicate.ne e_1 (const? 32 63)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1083,7 +1083,7 @@ theorem no_masks_with_logical_or2_thm (e e_1 e_2 : IntW 32) :
 theorem only_one_masked_thm (e : IntW 64) :
   LLVM.and (icmp IntPredicate.ne e (const? 64 0))
       (icmp IntPredicate.eq (LLVM.and e (const? 64 9223372036854775807)) (const? 64 0)) ⊑
-    icmp IntPredicate.eq e (const? 64 (-9223372036854775808)) := by 
+    icmp IntPredicate.eq e (const? 64 (-9223372036854775808)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gbitreverse_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gbitreverse_proof.lean
@@ -23,7 +23,7 @@ theorem rev8_mul_and_lshr_thm (e : IntW 8) :
             (LLVM.and (mul (zext 64 e) (const? 64 32800) { «nsw» := true, «nuw» := true }) (const? 64 558144))
             { «disjoint» := true })
           (const? 64 65793) { «nsw» := true, «nuw» := true })
-        (const? 64 16)) := by 
+        (const? 64 16)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gbswap_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gbswap_proof.lean
@@ -12,7 +12,7 @@ theorem test1_trunc_thm (e : IntW 32) :
   trunc 16 (LLVM.or (lshr e (const? 32 24)) (LLVM.and (lshr e (const? 32 8)) (const? 32 65280))) ⊑
     trunc 16
       (LLVM.or (lshr e (const? 32 24)) (LLVM.and (lshr e (const? 32 8)) (const? 32 65280)) { «disjoint» := true })
-      { «nsw» := false, «nuw» := true } := by 
+      { «nsw» := false, «nuw» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -24,7 +24,7 @@ theorem test1_trunc_thm (e : IntW 32) :
 theorem PR39793_bswap_u64_as_u16_trunc_thm (e : IntW 64) :
   trunc 8
       (LLVM.or (LLVM.and (lshr e (const? 64 8)) (const? 64 255)) (LLVM.and (shl e (const? 64 8)) (const? 64 65280))) ⊑
-    trunc 8 (lshr e (const? 64 8)) := by 
+    trunc 8 (lshr e (const? 64 8)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -36,7 +36,7 @@ theorem PR39793_bswap_u64_as_u16_trunc_thm (e : IntW 64) :
 theorem PR39793_bswap_u32_as_u16_trunc_thm (e : IntW 32) :
   trunc 8
       (LLVM.or (LLVM.and (lshr e (const? 32 8)) (const? 32 255)) (LLVM.and (shl e (const? 32 8)) (const? 32 65280))) ⊑
-    trunc 8 (lshr e (const? 32 8)) := by 
+    trunc 8 (lshr e (const? 32 8)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -47,7 +47,7 @@ theorem PR39793_bswap_u32_as_u16_trunc_thm (e : IntW 32) :
 
 theorem bswap_and_mask_1_thm (e : IntW 64) :
   LLVM.or (LLVM.and (lshr e (const? 64 40)) (const? 64 65280)) (lshr e (const? 64 56)) ⊑
-    LLVM.or (LLVM.and (lshr e (const? 64 40)) (const? 64 65280)) (lshr e (const? 64 56)) { «disjoint» := true } := by 
+    LLVM.or (LLVM.and (lshr e (const? 64 40)) (const? 64 65280)) (lshr e (const? 64 56)) { «disjoint» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gcanonicalizehashrhshlhtohmasking_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gcanonicalizehashrhshlhtohmasking_proof.lean
@@ -9,7 +9,7 @@ set_option linter.unreachableTactic false
 
 section gcanonicalizehashrhshlhtohmasking_proof
 theorem positive_samevar_thm (e e_1 : IntW 8) :
-  shl (ashr e_1 e) e ⊑ LLVM.and (shl (const? 8 (-1)) e { «nsw» := true, «nuw» := false }) e_1 := by 
+  shl (ashr e_1 e) e ⊑ LLVM.and (shl (const? 8 (-1)) e { «nsw» := true, «nuw» := false }) e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -18,7 +18,7 @@ theorem positive_samevar_thm (e e_1 : IntW 8) :
     all_goals sorry
 
 
-theorem positive_sameconst_thm (e : IntW 8) : shl (ashr e (const? 8 3)) (const? 8 3) ⊑ LLVM.and e (const? 8 (-8)) := by 
+theorem positive_sameconst_thm (e : IntW 8) : shl (ashr e (const? 8 3)) (const? 8 3) ⊑ LLVM.and e (const? 8 (-8)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -28,7 +28,7 @@ theorem positive_sameconst_thm (e : IntW 8) : shl (ashr e (const? 8 3)) (const? 
 
 
 theorem positive_biggerashr_thm (e : IntW 8) :
-  shl (ashr e (const? 8 6)) (const? 8 3) ⊑ LLVM.and (ashr e (const? 8 3)) (const? 8 (-8)) := by 
+  shl (ashr e (const? 8 6)) (const? 8 3) ⊑ LLVM.and (ashr e (const? 8 3)) (const? 8 (-8)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -38,7 +38,7 @@ theorem positive_biggerashr_thm (e : IntW 8) :
 
 
 theorem positive_biggershl_thm (e : IntW 8) :
-  shl (ashr e (const? 8 3)) (const? 8 6) ⊑ LLVM.and (shl e (const? 8 3)) (const? 8 (-64)) := by 
+  shl (ashr e (const? 8 3)) (const? 8 6) ⊑ LLVM.and (shl e (const? 8 3)) (const? 8 (-64)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -49,7 +49,7 @@ theorem positive_biggershl_thm (e : IntW 8) :
 
 theorem positive_samevar_shlnuw_thm (e e_1 : IntW 8) :
   shl (ashr e_1 e) e { «nsw» := false, «nuw» := true } ⊑
-    LLVM.and (shl (const? 8 (-1)) e { «nsw» := true, «nuw» := false }) e_1 := by 
+    LLVM.and (shl (const? 8 (-1)) e { «nsw» := true, «nuw» := false }) e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -59,7 +59,7 @@ theorem positive_samevar_shlnuw_thm (e e_1 : IntW 8) :
 
 
 theorem positive_sameconst_shlnuw_thm (e : IntW 8) :
-  shl (ashr e (const? 8 3)) (const? 8 3) { «nsw» := false, «nuw» := true } ⊑ LLVM.and e (const? 8 (-8)) := by 
+  shl (ashr e (const? 8 3)) (const? 8 3) { «nsw» := false, «nuw» := true } ⊑ LLVM.and e (const? 8 (-8)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -70,7 +70,7 @@ theorem positive_sameconst_shlnuw_thm (e : IntW 8) :
 
 theorem positive_biggerashr_shlnuw_thm (e : IntW 8) :
   shl (ashr e (const? 8 6)) (const? 8 3) { «nsw» := false, «nuw» := true } ⊑
-    LLVM.and (ashr e (const? 8 3)) (const? 8 (-8)) := by 
+    LLVM.and (ashr e (const? 8 3)) (const? 8 (-8)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -81,7 +81,7 @@ theorem positive_biggerashr_shlnuw_thm (e : IntW 8) :
 
 theorem positive_biggershl_shlnuw_thm (e : IntW 8) :
   shl (ashr e (const? 8 3)) (const? 8 6) { «nsw» := false, «nuw» := true } ⊑
-    LLVM.and (shl e (const? 8 3) { «nsw» := false, «nuw» := true }) (const? 8 (-64)) := by 
+    LLVM.and (shl e (const? 8 3) { «nsw» := false, «nuw» := true }) (const? 8 (-64)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -92,7 +92,7 @@ theorem positive_biggershl_shlnuw_thm (e : IntW 8) :
 
 theorem positive_samevar_shlnsw_thm (e e_1 : IntW 8) :
   shl (ashr e_1 e) e { «nsw» := true, «nuw» := false } ⊑
-    LLVM.and (shl (const? 8 (-1)) e { «nsw» := true, «nuw» := false }) e_1 := by 
+    LLVM.and (shl (const? 8 (-1)) e { «nsw» := true, «nuw» := false }) e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -102,7 +102,7 @@ theorem positive_samevar_shlnsw_thm (e e_1 : IntW 8) :
 
 
 theorem positive_sameconst_shlnsw_thm (e : IntW 8) :
-  shl (ashr e (const? 8 3)) (const? 8 3) { «nsw» := true, «nuw» := false } ⊑ LLVM.and e (const? 8 (-8)) := by 
+  shl (ashr e (const? 8 3)) (const? 8 3) { «nsw» := true, «nuw» := false } ⊑ LLVM.and e (const? 8 (-8)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -113,7 +113,7 @@ theorem positive_sameconst_shlnsw_thm (e : IntW 8) :
 
 theorem positive_biggerashr_shlnsw_thm (e : IntW 8) :
   shl (ashr e (const? 8 6)) (const? 8 3) { «nsw» := true, «nuw» := false } ⊑
-    LLVM.and (ashr e (const? 8 3)) (const? 8 (-8)) := by 
+    LLVM.and (ashr e (const? 8 3)) (const? 8 (-8)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -124,7 +124,7 @@ theorem positive_biggerashr_shlnsw_thm (e : IntW 8) :
 
 theorem positive_biggershl_shlnsw_thm (e : IntW 8) :
   shl (ashr e (const? 8 3)) (const? 8 6) { «nsw» := true, «nuw» := false } ⊑
-    LLVM.and (shl e (const? 8 3) { «nsw» := true, «nuw» := false }) (const? 8 (-64)) := by 
+    LLVM.and (shl e (const? 8 3) { «nsw» := true, «nuw» := false }) (const? 8 (-64)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -135,7 +135,7 @@ theorem positive_biggershl_shlnsw_thm (e : IntW 8) :
 
 theorem positive_samevar_shlnuwnsw_thm (e e_1 : IntW 8) :
   shl (ashr e_1 e) e { «nsw» := true, «nuw» := true } ⊑
-    LLVM.and (shl (const? 8 (-1)) e { «nsw» := true, «nuw» := false }) e_1 := by 
+    LLVM.and (shl (const? 8 (-1)) e { «nsw» := true, «nuw» := false }) e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -145,7 +145,7 @@ theorem positive_samevar_shlnuwnsw_thm (e e_1 : IntW 8) :
 
 
 theorem positive_sameconst_shlnuwnsw_thm (e : IntW 8) :
-  shl (ashr e (const? 8 3)) (const? 8 3) { «nsw» := true, «nuw» := true } ⊑ LLVM.and e (const? 8 (-8)) := by 
+  shl (ashr e (const? 8 3)) (const? 8 3) { «nsw» := true, «nuw» := true } ⊑ LLVM.and e (const? 8 (-8)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -156,7 +156,7 @@ theorem positive_sameconst_shlnuwnsw_thm (e : IntW 8) :
 
 theorem positive_biggerashr_shlnuwnsw_thm (e : IntW 8) :
   shl (ashr e (const? 8 6)) (const? 8 3) { «nsw» := true, «nuw» := true } ⊑
-    LLVM.and (ashr e (const? 8 3)) (const? 8 (-8)) := by 
+    LLVM.and (ashr e (const? 8 3)) (const? 8 (-8)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -167,7 +167,7 @@ theorem positive_biggerashr_shlnuwnsw_thm (e : IntW 8) :
 
 theorem positive_biggershl_shlnuwnsw_thm (e : IntW 8) :
   shl (ashr e (const? 8 3)) (const? 8 6) { «nsw» := true, «nuw» := true } ⊑
-    LLVM.and (shl e (const? 8 3) { «nsw» := true, «nuw» := true }) (const? 8 64) := by 
+    LLVM.and (shl e (const? 8 3) { «nsw» := true, «nuw» := true }) (const? 8 64) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -176,7 +176,7 @@ theorem positive_biggershl_shlnuwnsw_thm (e : IntW 8) :
     all_goals sorry
 
 
-theorem positive_samevar_ashrexact_thm (e e_1 : IntW 8) : shl (ashr e_1 e { «exact» := true }) e ⊑ e_1 := by 
+theorem positive_samevar_ashrexact_thm (e e_1 : IntW 8) : shl (ashr e_1 e { «exact» := true }) e ⊑ e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -185,7 +185,7 @@ theorem positive_samevar_ashrexact_thm (e e_1 : IntW 8) : shl (ashr e_1 e { «ex
     all_goals sorry
 
 
-theorem positive_sameconst_ashrexact_thm (e : IntW 8) : shl (ashr e (const? 8 3) { «exact» := true }) (const? 8 3) ⊑ e := by 
+theorem positive_sameconst_ashrexact_thm (e : IntW 8) : shl (ashr e (const? 8 3) { «exact» := true }) (const? 8 3) ⊑ e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -195,7 +195,7 @@ theorem positive_sameconst_ashrexact_thm (e : IntW 8) : shl (ashr e (const? 8 3)
 
 
 theorem positive_biggerashr_ashrexact_thm (e : IntW 8) :
-  shl (ashr e (const? 8 6) { «exact» := true }) (const? 8 3) ⊑ ashr e (const? 8 3) { «exact» := true } := by 
+  shl (ashr e (const? 8 6) { «exact» := true }) (const? 8 3) ⊑ ashr e (const? 8 3) { «exact» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -205,7 +205,7 @@ theorem positive_biggerashr_ashrexact_thm (e : IntW 8) :
 
 
 theorem positive_biggershl_ashrexact_thm (e : IntW 8) :
-  shl (ashr e (const? 8 3) { «exact» := true }) (const? 8 6) ⊑ shl e (const? 8 3) := by 
+  shl (ashr e (const? 8 3) { «exact» := true }) (const? 8 6) ⊑ shl e (const? 8 3) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -215,7 +215,7 @@ theorem positive_biggershl_ashrexact_thm (e : IntW 8) :
 
 
 theorem positive_samevar_shlnsw_ashrexact_thm (e e_1 : IntW 8) :
-  shl (ashr e_1 e { «exact» := true }) e { «nsw» := true, «nuw» := false } ⊑ e_1 := by 
+  shl (ashr e_1 e { «exact» := true }) e { «nsw» := true, «nuw» := false } ⊑ e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -225,7 +225,7 @@ theorem positive_samevar_shlnsw_ashrexact_thm (e e_1 : IntW 8) :
 
 
 theorem positive_sameconst_shlnsw_ashrexact_thm (e : IntW 8) :
-  shl (ashr e (const? 8 3) { «exact» := true }) (const? 8 3) { «nsw» := true, «nuw» := false } ⊑ e := by 
+  shl (ashr e (const? 8 3) { «exact» := true }) (const? 8 3) { «nsw» := true, «nuw» := false } ⊑ e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -236,7 +236,7 @@ theorem positive_sameconst_shlnsw_ashrexact_thm (e : IntW 8) :
 
 theorem positive_biggerashr_shlnsw_ashrexact_thm (e : IntW 8) :
   shl (ashr e (const? 8 6) { «exact» := true }) (const? 8 3) { «nsw» := true, «nuw» := false } ⊑
-    ashr e (const? 8 3) { «exact» := true } := by 
+    ashr e (const? 8 3) { «exact» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -247,7 +247,7 @@ theorem positive_biggerashr_shlnsw_ashrexact_thm (e : IntW 8) :
 
 theorem positive_biggershl_shlnsw_ashrexact_thm (e : IntW 8) :
   shl (ashr e (const? 8 3) { «exact» := true }) (const? 8 6) { «nsw» := true, «nuw» := false } ⊑
-    shl e (const? 8 3) { «nsw» := true, «nuw» := false } := by 
+    shl e (const? 8 3) { «nsw» := true, «nuw» := false } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -257,7 +257,7 @@ theorem positive_biggershl_shlnsw_ashrexact_thm (e : IntW 8) :
 
 
 theorem positive_samevar_shlnuw_ashrexact_thm (e e_1 : IntW 8) :
-  shl (ashr e_1 e { «exact» := true }) e { «nsw» := false, «nuw» := true } ⊑ e_1 := by 
+  shl (ashr e_1 e { «exact» := true }) e { «nsw» := false, «nuw» := true } ⊑ e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -267,7 +267,7 @@ theorem positive_samevar_shlnuw_ashrexact_thm (e e_1 : IntW 8) :
 
 
 theorem positive_sameconst_shlnuw_ashrexact_thm (e : IntW 8) :
-  shl (ashr e (const? 8 3) { «exact» := true }) (const? 8 3) { «nsw» := false, «nuw» := true } ⊑ e := by 
+  shl (ashr e (const? 8 3) { «exact» := true }) (const? 8 3) { «nsw» := false, «nuw» := true } ⊑ e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -278,7 +278,7 @@ theorem positive_sameconst_shlnuw_ashrexact_thm (e : IntW 8) :
 
 theorem positive_biggerashr_shlnuw_ashrexact_thm (e : IntW 8) :
   shl (ashr e (const? 8 6) { «exact» := true }) (const? 8 3) { «nsw» := false, «nuw» := true } ⊑
-    ashr e (const? 8 3) { «exact» := true } := by 
+    ashr e (const? 8 3) { «exact» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -289,7 +289,7 @@ theorem positive_biggerashr_shlnuw_ashrexact_thm (e : IntW 8) :
 
 theorem positive_biggershl_shlnuw_ashrexact_thm (e : IntW 8) :
   shl (ashr e (const? 8 3) { «exact» := true }) (const? 8 6) { «nsw» := false, «nuw» := true } ⊑
-    shl e (const? 8 3) { «nsw» := false, «nuw» := true } := by 
+    shl e (const? 8 3) { «nsw» := false, «nuw» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -299,7 +299,7 @@ theorem positive_biggershl_shlnuw_ashrexact_thm (e : IntW 8) :
 
 
 theorem positive_samevar_shlnuwnsw_ashrexact_thm (e e_1 : IntW 8) :
-  shl (ashr e_1 e { «exact» := true }) e { «nsw» := true, «nuw» := true } ⊑ e_1 := by 
+  shl (ashr e_1 e { «exact» := true }) e { «nsw» := true, «nuw» := true } ⊑ e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -309,7 +309,7 @@ theorem positive_samevar_shlnuwnsw_ashrexact_thm (e e_1 : IntW 8) :
 
 
 theorem positive_sameconst_shlnuwnsw_ashrexact_thm (e : IntW 8) :
-  shl (ashr e (const? 8 3) { «exact» := true }) (const? 8 3) { «nsw» := true, «nuw» := true } ⊑ e := by 
+  shl (ashr e (const? 8 3) { «exact» := true }) (const? 8 3) { «nsw» := true, «nuw» := true } ⊑ e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -320,7 +320,7 @@ theorem positive_sameconst_shlnuwnsw_ashrexact_thm (e : IntW 8) :
 
 theorem positive_biggerashr_shlnuwnsw_ashrexact_thm (e : IntW 8) :
   shl (ashr e (const? 8 6) { «exact» := true }) (const? 8 3) { «nsw» := true, «nuw» := true } ⊑
-    ashr e (const? 8 3) { «exact» := true } := by 
+    ashr e (const? 8 3) { «exact» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -331,7 +331,7 @@ theorem positive_biggerashr_shlnuwnsw_ashrexact_thm (e : IntW 8) :
 
 theorem positive_biggershl_shlnuwnsw_ashrexact_thm (e : IntW 8) :
   shl (ashr e (const? 8 3) { «exact» := true }) (const? 8 6) { «nsw» := true, «nuw» := true } ⊑
-    shl e (const? 8 3) { «nsw» := true, «nuw» := true } := by 
+    shl e (const? 8 3) { «nsw» := true, «nuw» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gcanonicalizehclamphlikehpatternhbetweenhnegativehandhpositivehthresholds_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gcanonicalizehclamphlikehpatternhbetweenhnegativehandhpositivehthresholds_proof.lean
@@ -12,7 +12,7 @@ theorem t0_ult_slt_128_thm (e e_1 e_2 : IntW 32) :
   select (icmp IntPredicate.ult (add e_2 (const? 32 16)) (const? 32 144)) e_2
       (select (icmp IntPredicate.slt e_2 (const? 32 128)) e_1 e) ⊑
     select (icmp IntPredicate.sgt e_2 (const? 32 127)) e
-      (select (icmp IntPredicate.slt e_2 (const? 32 (-16))) e_1 e_2) := by 
+      (select (icmp IntPredicate.slt e_2 (const? 32 (-16))) e_1 e_2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -25,7 +25,7 @@ theorem t1_ult_slt_0_thm (e e_1 e_2 : IntW 32) :
   select (icmp IntPredicate.ult (add e_2 (const? 32 16)) (const? 32 144)) e_2
       (select (icmp IntPredicate.slt e_2 (const? 32 (-16))) e_1 e) ⊑
     select (icmp IntPredicate.sgt e_2 (const? 32 127)) e
-      (select (icmp IntPredicate.slt e_2 (const? 32 (-16))) e_1 e_2) := by 
+      (select (icmp IntPredicate.slt e_2 (const? 32 (-16))) e_1 e_2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -38,7 +38,7 @@ theorem t2_ult_sgt_128_thm (e e_1 e_2 : IntW 32) :
   select (icmp IntPredicate.ult (add e_2 (const? 32 16)) (const? 32 144)) e_2
       (select (icmp IntPredicate.sgt e_2 (const? 32 127)) e_1 e) ⊑
     select (icmp IntPredicate.sgt e_2 (const? 32 127)) e_1
-      (select (icmp IntPredicate.slt e_2 (const? 32 (-16))) e e_2) := by 
+      (select (icmp IntPredicate.slt e_2 (const? 32 (-16))) e e_2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -51,7 +51,7 @@ theorem t3_ult_sgt_neg1_thm (e e_1 e_2 : IntW 32) :
   select (icmp IntPredicate.ult (add e_2 (const? 32 16)) (const? 32 144)) e_2
       (select (icmp IntPredicate.sgt e_2 (const? 32 (-17))) e_1 e) ⊑
     select (icmp IntPredicate.sgt e_2 (const? 32 127)) e_1
-      (select (icmp IntPredicate.slt e_2 (const? 32 (-16))) e e_2) := by 
+      (select (icmp IntPredicate.slt e_2 (const? 32 (-16))) e e_2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -64,7 +64,7 @@ theorem t4_ugt_slt_128_thm (e e_1 e_2 : IntW 32) :
   select (icmp IntPredicate.ugt (add e_2 (const? 32 16)) (const? 32 143))
       (select (icmp IntPredicate.slt e_2 (const? 32 128)) e_1 e) e_2 ⊑
     select (icmp IntPredicate.sgt e_2 (const? 32 127)) e
-      (select (icmp IntPredicate.slt e_2 (const? 32 (-16))) e_1 e_2) := by 
+      (select (icmp IntPredicate.slt e_2 (const? 32 (-16))) e_1 e_2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -77,7 +77,7 @@ theorem t5_ugt_slt_0_thm (e e_1 e_2 : IntW 32) :
   select (icmp IntPredicate.ugt (add e_2 (const? 32 16)) (const? 32 143))
       (select (icmp IntPredicate.slt e_2 (const? 32 (-16))) e_1 e) e_2 ⊑
     select (icmp IntPredicate.sgt e_2 (const? 32 127)) e
-      (select (icmp IntPredicate.slt e_2 (const? 32 (-16))) e_1 e_2) := by 
+      (select (icmp IntPredicate.slt e_2 (const? 32 (-16))) e_1 e_2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -90,7 +90,7 @@ theorem t6_ugt_sgt_128_thm (e e_1 e_2 : IntW 32) :
   select (icmp IntPredicate.ugt (add e_2 (const? 32 16)) (const? 32 143))
       (select (icmp IntPredicate.sgt e_2 (const? 32 127)) e_1 e) e_2 ⊑
     select (icmp IntPredicate.sgt e_2 (const? 32 127)) e_1
-      (select (icmp IntPredicate.slt e_2 (const? 32 (-16))) e e_2) := by 
+      (select (icmp IntPredicate.slt e_2 (const? 32 (-16))) e e_2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -103,7 +103,7 @@ theorem t7_ugt_sgt_neg1_thm (e e_1 e_2 : IntW 32) :
   select (icmp IntPredicate.ugt (add e_2 (const? 32 16)) (const? 32 143))
       (select (icmp IntPredicate.sgt e_2 (const? 32 (-17))) e_1 e) e_2 ⊑
     select (icmp IntPredicate.sgt e_2 (const? 32 127)) e_1
-      (select (icmp IntPredicate.slt e_2 (const? 32 (-16))) e e_2) := by 
+      (select (icmp IntPredicate.slt e_2 (const? 32 (-16))) e e_2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -114,7 +114,7 @@ theorem t7_ugt_sgt_neg1_thm (e e_1 e_2 : IntW 32) :
 
 theorem n10_ugt_slt_thm (e e_1 e_2 : IntW 32) :
   select (icmp IntPredicate.ugt e_2 (const? 32 128)) e_2 (select (icmp IntPredicate.slt e_2 (const? 32 0)) e_1 e) ⊑
-    select (icmp IntPredicate.ugt e_2 (const? 32 128)) e_2 e := by 
+    select (icmp IntPredicate.ugt e_2 (const? 32 128)) e_2 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -125,7 +125,7 @@ theorem n10_ugt_slt_thm (e e_1 e_2 : IntW 32) :
 
 theorem n11_uge_slt_thm (e e_1 e_2 : IntW 32) :
   select (icmp IntPredicate.ult e_2 (const? 32 129)) (select (icmp IntPredicate.slt e_2 (const? 32 0)) e_1 e) e_2 ⊑
-    select (icmp IntPredicate.ult e_2 (const? 32 129)) e e_2 := by 
+    select (icmp IntPredicate.ult e_2 (const? 32 129)) e e_2 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gcanonicalizehclamphlikehpatternhbetweenhzerohandhpositivehthreshold_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gcanonicalizehclamphlikehpatternhbetweenhzerohandhpositivehthreshold_proof.lean
@@ -12,7 +12,7 @@ theorem t0_ult_slt_65536_thm (e e_1 e_2 : IntW 32) :
   select (icmp IntPredicate.ult e_2 (const? 32 65536)) e_2
       (select (icmp IntPredicate.slt e_2 (const? 32 65536)) e_1 e) ⊑
     select (icmp IntPredicate.sgt e_2 (const? 32 65535)) e
-      (select (icmp IntPredicate.slt e_2 (const? 32 0)) e_1 e_2) := by 
+      (select (icmp IntPredicate.slt e_2 (const? 32 0)) e_1 e_2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -24,7 +24,7 @@ theorem t0_ult_slt_65536_thm (e e_1 e_2 : IntW 32) :
 theorem t1_ult_slt_0_thm (e e_1 e_2 : IntW 32) :
   select (icmp IntPredicate.ult e_2 (const? 32 65536)) e_2 (select (icmp IntPredicate.slt e_2 (const? 32 0)) e_1 e) ⊑
     select (icmp IntPredicate.sgt e_2 (const? 32 65535)) e
-      (select (icmp IntPredicate.slt e_2 (const? 32 0)) e_1 e_2) := by 
+      (select (icmp IntPredicate.slt e_2 (const? 32 0)) e_1 e_2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -37,7 +37,7 @@ theorem t2_ult_sgt_65536_thm (e e_1 e_2 : IntW 32) :
   select (icmp IntPredicate.ult e_2 (const? 32 65536)) e_2
       (select (icmp IntPredicate.sgt e_2 (const? 32 65535)) e_1 e) ⊑
     select (icmp IntPredicate.sgt e_2 (const? 32 65535)) e_1
-      (select (icmp IntPredicate.slt e_2 (const? 32 0)) e e_2) := by 
+      (select (icmp IntPredicate.slt e_2 (const? 32 0)) e e_2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -49,7 +49,7 @@ theorem t2_ult_sgt_65536_thm (e e_1 e_2 : IntW 32) :
 theorem t3_ult_sgt_neg1_thm (e e_1 e_2 : IntW 32) :
   select (icmp IntPredicate.ult e_2 (const? 32 65536)) e_2 (select (icmp IntPredicate.sgt e_2 (const? 32 (-1))) e_1 e) ⊑
     select (icmp IntPredicate.sgt e_2 (const? 32 65535)) e_1
-      (select (icmp IntPredicate.slt e_2 (const? 32 0)) e e_2) := by 
+      (select (icmp IntPredicate.slt e_2 (const? 32 0)) e e_2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -62,7 +62,7 @@ theorem t4_ugt_slt_65536_thm (e e_1 e_2 : IntW 32) :
   select (icmp IntPredicate.ugt e_2 (const? 32 65535)) (select (icmp IntPredicate.slt e_2 (const? 32 65536)) e_1 e)
       e_2 ⊑
     select (icmp IntPredicate.sgt e_2 (const? 32 65535)) e
-      (select (icmp IntPredicate.slt e_2 (const? 32 0)) e_1 e_2) := by 
+      (select (icmp IntPredicate.slt e_2 (const? 32 0)) e_1 e_2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -74,7 +74,7 @@ theorem t4_ugt_slt_65536_thm (e e_1 e_2 : IntW 32) :
 theorem t5_ugt_slt_0_thm (e e_1 e_2 : IntW 32) :
   select (icmp IntPredicate.ugt e_2 (const? 32 65535)) (select (icmp IntPredicate.slt e_2 (const? 32 0)) e_1 e) e_2 ⊑
     select (icmp IntPredicate.sgt e_2 (const? 32 65535)) e
-      (select (icmp IntPredicate.slt e_2 (const? 32 0)) e_1 e_2) := by 
+      (select (icmp IntPredicate.slt e_2 (const? 32 0)) e_1 e_2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -87,7 +87,7 @@ theorem t6_ugt_sgt_65536_thm (e e_1 e_2 : IntW 32) :
   select (icmp IntPredicate.ugt e_2 (const? 32 65535)) (select (icmp IntPredicate.sgt e_2 (const? 32 65535)) e_1 e)
       e_2 ⊑
     select (icmp IntPredicate.sgt e_2 (const? 32 65535)) e_1
-      (select (icmp IntPredicate.slt e_2 (const? 32 0)) e e_2) := by 
+      (select (icmp IntPredicate.slt e_2 (const? 32 0)) e e_2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -99,7 +99,7 @@ theorem t6_ugt_sgt_65536_thm (e e_1 e_2 : IntW 32) :
 theorem t7_ugt_sgt_neg1_thm (e e_1 e_2 : IntW 32) :
   select (icmp IntPredicate.ugt e_2 (const? 32 65535)) (select (icmp IntPredicate.sgt e_2 (const? 32 (-1))) e_1 e) e_2 ⊑
     select (icmp IntPredicate.sgt e_2 (const? 32 65535)) e_1
-      (select (icmp IntPredicate.slt e_2 (const? 32 0)) e e_2) := by 
+      (select (icmp IntPredicate.slt e_2 (const? 32 0)) e e_2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gcanonicalizehconstanthlowhbithmaskhandhicmpheqhtohicmphule_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gcanonicalizehconstanthlowhbithmaskhandhicmpheqhtohicmphule_proof.lean
@@ -9,7 +9,7 @@ set_option linter.unreachableTactic false
 
 section gcanonicalizehconstanthlowhbithmaskhandhicmpheqhtohicmphule_proof
 theorem p0_thm (e : IntW 8) :
-  icmp IntPredicate.eq (LLVM.and e (const? 8 3)) e ⊑ icmp IntPredicate.ult e (const? 8 4) := by 
+  icmp IntPredicate.eq (LLVM.and e (const? 8 3)) e ⊑ icmp IntPredicate.ult e (const? 8 4) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -20,7 +20,7 @@ theorem p0_thm (e : IntW 8) :
 
 theorem pv_thm (e e_1 : IntW 8) :
   icmp IntPredicate.eq (LLVM.and (lshr (const? 8 (-1)) e_1) e) e ⊑
-    icmp IntPredicate.ule e (lshr (const? 8 (-1)) e_1) := by 
+    icmp IntPredicate.ule e (lshr (const? 8 (-1)) e_1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -31,7 +31,7 @@ theorem pv_thm (e e_1 : IntW 8) :
 
 theorem n0_thm (e : IntW 8) :
   icmp IntPredicate.eq (LLVM.and e (const? 8 4)) e ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 8 (-5))) (const? 8 0) := by 
+    icmp IntPredicate.eq (LLVM.and e (const? 8 (-5))) (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gcanonicalizehconstanthlowhbithmaskhandhicmphnehtohicmphugt_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gcanonicalizehconstanthlowhbithmaskhandhicmphnehtohicmphugt_proof.lean
@@ -9,7 +9,7 @@ set_option linter.unreachableTactic false
 
 section gcanonicalizehconstanthlowhbithmaskhandhicmphnehtohicmphugt_proof
 theorem p0_thm (e : IntW 8) :
-  icmp IntPredicate.ne (LLVM.and e (const? 8 3)) e ⊑ icmp IntPredicate.ugt e (const? 8 3) := by 
+  icmp IntPredicate.ne (LLVM.and e (const? 8 3)) e ⊑ icmp IntPredicate.ugt e (const? 8 3) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -20,7 +20,7 @@ theorem p0_thm (e : IntW 8) :
 
 theorem pv_thm (e e_1 : IntW 8) :
   icmp IntPredicate.ne (LLVM.and (lshr (const? 8 (-1)) e_1) e) e ⊑
-    icmp IntPredicate.ugt e (lshr (const? 8 (-1)) e_1) := by 
+    icmp IntPredicate.ugt e (lshr (const? 8 (-1)) e_1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -31,7 +31,7 @@ theorem pv_thm (e e_1 : IntW 8) :
 
 theorem n0_thm (e : IntW 8) :
   icmp IntPredicate.ne (LLVM.and e (const? 8 4)) e ⊑
-    icmp IntPredicate.ne (LLVM.and e (const? 8 (-5))) (const? 8 0) := by 
+    icmp IntPredicate.ne (LLVM.and e (const? 8 (-5))) (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gcanonicalizehconstanthlowhbithmaskhandhicmphsgehtohicmphsle_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gcanonicalizehconstanthlowhbithmaskhandhicmphsgehtohicmphsle_proof.lean
@@ -9,7 +9,7 @@ set_option linter.unreachableTactic false
 
 section gcanonicalizehconstanthlowhbithmaskhandhicmphsgehtohicmphsle_proof
 theorem p0_thm (e : IntW 8) :
-  icmp IntPredicate.sge (LLVM.and e (const? 8 3)) e ⊑ icmp IntPredicate.slt e (const? 8 4) := by 
+  icmp IntPredicate.sge (LLVM.and e (const? 8 3)) e ⊑ icmp IntPredicate.slt e (const? 8 4) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gcanonicalizehconstanthlowhbithmaskhandhicmphsgthtohicmphsgt_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gcanonicalizehconstanthlowhbithmaskhandhicmphsgthtohicmphsgt_proof.lean
@@ -9,7 +9,7 @@ set_option linter.unreachableTactic false
 
 section gcanonicalizehconstanthlowhbithmaskhandhicmphsgthtohicmphsgt_proof
 theorem c0_thm (e : IntW 8) :
-  icmp IntPredicate.sgt (LLVM.and e (const? 8 3)) e ⊑ icmp IntPredicate.slt e (const? 8 0) := by 
+  icmp IntPredicate.sgt (LLVM.and e (const? 8 3)) e ⊑ icmp IntPredicate.slt e (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gcanonicalizehconstanthlowhbithmaskhandhicmphslehtohicmphsle_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gcanonicalizehconstanthlowhbithmaskhandhicmphslehtohicmphsle_proof.lean
@@ -9,7 +9,7 @@ set_option linter.unreachableTactic false
 
 section gcanonicalizehconstanthlowhbithmaskhandhicmphslehtohicmphsle_proof
 theorem c0_thm (e : IntW 8) :
-  icmp IntPredicate.sle (LLVM.and e (const? 8 3)) e ⊑ icmp IntPredicate.sgt e (const? 8 (-1)) := by 
+  icmp IntPredicate.sle (LLVM.and e (const? 8 3)) e ⊑ icmp IntPredicate.sgt e (const? 8 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gcanonicalizehconstanthlowhbithmaskhandhicmphslthtohicmphsgt_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gcanonicalizehconstanthlowhbithmaskhandhicmphslthtohicmphsgt_proof.lean
@@ -9,7 +9,7 @@ set_option linter.unreachableTactic false
 
 section gcanonicalizehconstanthlowhbithmaskhandhicmphslthtohicmphsgt_proof
 theorem p0_thm (e : IntW 8) :
-  icmp IntPredicate.slt (LLVM.and e (const? 8 3)) e ⊑ icmp IntPredicate.sgt e (const? 8 3) := by 
+  icmp IntPredicate.slt (LLVM.and e (const? 8 3)) e ⊑ icmp IntPredicate.sgt e (const? 8 3) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gcanonicalizehconstanthlowhbithmaskhandhicmphugehtohicmphule_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gcanonicalizehconstanthlowhbithmaskhandhicmphugehtohicmphule_proof.lean
@@ -9,7 +9,7 @@ set_option linter.unreachableTactic false
 
 section gcanonicalizehconstanthlowhbithmaskhandhicmphugehtohicmphule_proof
 theorem p0_thm (e : IntW 8) :
-  icmp IntPredicate.uge (LLVM.and e (const? 8 3)) e ⊑ icmp IntPredicate.ult e (const? 8 4) := by 
+  icmp IntPredicate.uge (LLVM.and e (const? 8 3)) e ⊑ icmp IntPredicate.ult e (const? 8 4) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -20,7 +20,7 @@ theorem p0_thm (e : IntW 8) :
 
 theorem pv_thm (e e_1 : IntW 8) :
   icmp IntPredicate.uge (LLVM.and (lshr (const? 8 (-1)) e_1) e) e ⊑
-    icmp IntPredicate.ule e (lshr (const? 8 (-1)) e_1) := by 
+    icmp IntPredicate.ule e (lshr (const? 8 (-1)) e_1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -31,7 +31,7 @@ theorem pv_thm (e e_1 : IntW 8) :
 
 theorem n0_thm (e : IntW 8) :
   icmp IntPredicate.uge (LLVM.and e (const? 8 4)) e ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 8 (-5))) (const? 8 0) := by 
+    icmp IntPredicate.eq (LLVM.and e (const? 8 (-5))) (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gcanonicalizehconstanthlowhbithmaskhandhicmphugthtohicmphugt_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gcanonicalizehconstanthlowhbithmaskhandhicmphugthtohicmphugt_proof.lean
@@ -8,7 +8,7 @@ set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
 
 section gcanonicalizehconstanthlowhbithmaskhandhicmphugthtohicmphugt_proof
-theorem c0_thm (e : IntW 8) : icmp IntPredicate.ugt (LLVM.and e (const? 8 3)) e ⊑ const? 1 0 := by 
+theorem c0_thm (e : IntW 8) : icmp IntPredicate.ugt (LLVM.and e (const? 8 3)) e ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -18,7 +18,7 @@ theorem c0_thm (e : IntW 8) : icmp IntPredicate.ugt (LLVM.and e (const? 8 3)) e 
 
 
 theorem cv2_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.ugt (LLVM.and (lshr (const? 8 (-1)) e_1) e) e ⊑ const? 1 0 := by 
+  icmp IntPredicate.ugt (LLVM.and (lshr (const? 8 (-1)) e_1) e) e ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gcanonicalizehconstanthlowhbithmaskhandhicmphulehtohicmphule_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gcanonicalizehconstanthlowhbithmaskhandhicmphulehtohicmphule_proof.lean
@@ -8,7 +8,7 @@ set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
 
 section gcanonicalizehconstanthlowhbithmaskhandhicmphulehtohicmphule_proof
-theorem c0_thm (e : IntW 8) : icmp IntPredicate.ule (LLVM.and e (const? 8 3)) e ⊑ const? 1 1 := by 
+theorem c0_thm (e : IntW 8) : icmp IntPredicate.ule (LLVM.and e (const? 8 3)) e ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -18,7 +18,7 @@ theorem c0_thm (e : IntW 8) : icmp IntPredicate.ule (LLVM.and e (const? 8 3)) e 
 
 
 theorem cv2_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.ule (LLVM.and (lshr (const? 8 (-1)) e_1) e) e ⊑ const? 1 1 := by 
+  icmp IntPredicate.ule (LLVM.and (lshr (const? 8 (-1)) e_1) e) e ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gcanonicalizehconstanthlowhbithmaskhandhicmphulthtohicmphugt_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gcanonicalizehconstanthlowhbithmaskhandhicmphulthtohicmphugt_proof.lean
@@ -9,7 +9,7 @@ set_option linter.unreachableTactic false
 
 section gcanonicalizehconstanthlowhbithmaskhandhicmphulthtohicmphugt_proof
 theorem p0_thm (e : IntW 8) :
-  icmp IntPredicate.ult (LLVM.and e (const? 8 3)) e ⊑ icmp IntPredicate.ugt e (const? 8 3) := by 
+  icmp IntPredicate.ult (LLVM.and e (const? 8 3)) e ⊑ icmp IntPredicate.ugt e (const? 8 3) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -20,7 +20,7 @@ theorem p0_thm (e : IntW 8) :
 
 theorem pv_thm (e e_1 : IntW 8) :
   icmp IntPredicate.ult (LLVM.and (lshr (const? 8 (-1)) e_1) e) e ⊑
-    icmp IntPredicate.ugt e (lshr (const? 8 (-1)) e_1) := by 
+    icmp IntPredicate.ugt e (lshr (const? 8 (-1)) e_1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -31,7 +31,7 @@ theorem pv_thm (e e_1 : IntW 8) :
 
 theorem n0_thm (e : IntW 8) :
   icmp IntPredicate.ult (LLVM.and e (const? 8 4)) e ⊑
-    icmp IntPredicate.ne (LLVM.and e (const? 8 (-5))) (const? 8 0) := by 
+    icmp IntPredicate.ne (LLVM.and e (const? 8 (-5))) (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gcanonicalizehlackhofhsignedhtruncationhcheck_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gcanonicalizehlackhofhsignedhtruncationhcheck_proof.lean
@@ -10,7 +10,7 @@ set_option linter.unreachableTactic false
 section gcanonicalizehlackhofhsignedhtruncationhcheck_proof
 theorem p0_thm (e : IntW 8) :
   icmp IntPredicate.eq (ashr (shl e (const? 8 5)) (const? 8 5) { «exact» := true }) e ⊑
-    icmp IntPredicate.ult (add e (const? 8 4)) (const? 8 8) := by 
+    icmp IntPredicate.ult (add e (const? 8 4)) (const? 8 8) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -21,7 +21,7 @@ theorem p0_thm (e : IntW 8) :
 
 theorem pb_thm (e : IntW 65) :
   icmp IntPredicate.eq e (ashr (shl e (const? 65 1)) (const? 65 1) { «exact» := true }) ⊑
-    icmp IntPredicate.sgt (add e (const? 65 9223372036854775808)) (const? 65 (-1)) := by 
+    icmp IntPredicate.sgt (add e (const? 65 9223372036854775808)) (const? 65 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -32,7 +32,7 @@ theorem pb_thm (e : IntW 65) :
 
 theorem n1_thm (e : IntW 8) :
   icmp IntPredicate.eq (lshr (shl e (const? 8 5)) (const? 8 5) { «exact» := true }) e ⊑
-    icmp IntPredicate.ult e (const? 8 8) := by 
+    icmp IntPredicate.ult e (const? 8 8) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gcanonicalizehlowhbithmaskhandhicmpheqhtohicmphule_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gcanonicalizehlowhbithmaskhandhicmpheqhtohicmphule_proof.lean
@@ -10,7 +10,7 @@ set_option linter.unreachableTactic false
 section gcanonicalizehlowhbithmaskhandhicmpheqhtohicmphule_proof
 theorem p0_thm (e e_1 : IntW 8) :
   icmp IntPredicate.eq (LLVM.and (lshr (const? 8 (-1)) e_1) e) e ⊑
-    icmp IntPredicate.ule e (lshr (const? 8 (-1)) e_1) := by 
+    icmp IntPredicate.ule e (lshr (const? 8 (-1)) e_1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gcanonicalizehlowhbithmaskhandhicmphnehtohicmphugt_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gcanonicalizehlowhbithmaskhandhicmphnehtohicmphugt_proof.lean
@@ -10,7 +10,7 @@ set_option linter.unreachableTactic false
 section gcanonicalizehlowhbithmaskhandhicmphnehtohicmphugt_proof
 theorem p0_thm (e e_1 : IntW 8) :
   icmp IntPredicate.ne (LLVM.and (lshr (const? 8 (-1)) e_1) e) e ⊑
-    icmp IntPredicate.ugt e (lshr (const? 8 (-1)) e_1) := by 
+    icmp IntPredicate.ugt e (lshr (const? 8 (-1)) e_1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gcanonicalizehlowhbithmaskhv2handhicmpheqhtohicmphule_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gcanonicalizehlowhbithmaskhv2handhicmpheqhtohicmphule_proof.lean
@@ -10,7 +10,7 @@ set_option linter.unreachableTactic false
 section gcanonicalizehlowhbithmaskhv2handhicmpheqhtohicmphule_proof
 theorem p0_thm (e e_1 : IntW 8) :
   icmp IntPredicate.eq (LLVM.and (LLVM.xor (shl (const? 8 (-1)) e_1) (const? 8 (-1))) e) e ⊑
-    icmp IntPredicate.eq (lshr e e_1) (const? 8 0) := by 
+    icmp IntPredicate.eq (lshr e e_1) (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -22,7 +22,7 @@ theorem p0_thm (e e_1 : IntW 8) :
 theorem n0_thm (e e_1 e_2 : IntW 8) :
   icmp IntPredicate.eq (LLVM.and (LLVM.xor (shl (const? 8 (-1)) e_2) (const? 8 (-1))) e_1) e ⊑
     icmp IntPredicate.eq
-      (LLVM.and e_1 (LLVM.xor (shl (const? 8 (-1)) e_2 { «nsw» := true, «nuw» := false }) (const? 8 (-1)))) e := by 
+      (LLVM.and e_1 (LLVM.xor (shl (const? 8 (-1)) e_2 { «nsw» := true, «nuw» := false }) (const? 8 (-1)))) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -33,7 +33,7 @@ theorem n0_thm (e e_1 e_2 : IntW 8) :
 
 theorem n1_thm (e e_1 : IntW 8) :
   icmp IntPredicate.eq (LLVM.and (LLVM.xor (shl (const? 8 1) e_1) (const? 8 (-1))) e) e ⊑
-    icmp IntPredicate.eq (LLVM.and e (shl (const? 8 1) e_1 { «nsw» := false, «nuw» := true })) (const? 8 0) := by 
+    icmp IntPredicate.eq (LLVM.and e (shl (const? 8 1) e_1 { «nsw» := false, «nuw» := true })) (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -46,7 +46,7 @@ theorem n2_thm (e e_1 : IntW 8) :
   icmp IntPredicate.eq (LLVM.and (LLVM.xor (shl (const? 8 (-1)) e_1) (const? 8 1)) e) e ⊑
     icmp IntPredicate.eq
       (LLVM.and e (LLVM.xor (shl (const? 8 (-1)) e_1 { «nsw» := true, «nuw» := false }) (const? 8 (-2))))
-      (const? 8 0) := by 
+      (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gcanonicalizehlowhbithmaskhv2handhicmphnehtohicmphugt_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gcanonicalizehlowhbithmaskhv2handhicmphnehtohicmphugt_proof.lean
@@ -10,7 +10,7 @@ set_option linter.unreachableTactic false
 section gcanonicalizehlowhbithmaskhv2handhicmphnehtohicmphugt_proof
 theorem p0_thm (e e_1 : IntW 8) :
   icmp IntPredicate.ne (LLVM.and (LLVM.xor (shl (const? 8 (-1)) e_1) (const? 8 (-1))) e) e ⊑
-    icmp IntPredicate.ne (lshr e e_1) (const? 8 0) := by 
+    icmp IntPredicate.ne (lshr e e_1) (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -22,7 +22,7 @@ theorem p0_thm (e e_1 : IntW 8) :
 theorem n0_thm (e e_1 e_2 : IntW 8) :
   icmp IntPredicate.ne (LLVM.and (LLVM.xor (shl (const? 8 (-1)) e_2) (const? 8 (-1))) e_1) e ⊑
     icmp IntPredicate.ne
-      (LLVM.and e_1 (LLVM.xor (shl (const? 8 (-1)) e_2 { «nsw» := true, «nuw» := false }) (const? 8 (-1)))) e := by 
+      (LLVM.and e_1 (LLVM.xor (shl (const? 8 (-1)) e_2 { «nsw» := true, «nuw» := false }) (const? 8 (-1)))) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -33,7 +33,7 @@ theorem n0_thm (e e_1 e_2 : IntW 8) :
 
 theorem n1_thm (e e_1 : IntW 8) :
   icmp IntPredicate.ne (LLVM.and (LLVM.xor (shl (const? 8 1) e_1) (const? 8 (-1))) e) e ⊑
-    icmp IntPredicate.ne (LLVM.and e (shl (const? 8 1) e_1 { «nsw» := false, «nuw» := true })) (const? 8 0) := by 
+    icmp IntPredicate.ne (LLVM.and e (shl (const? 8 1) e_1 { «nsw» := false, «nuw» := true })) (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -46,7 +46,7 @@ theorem n2_thm (e e_1 : IntW 8) :
   icmp IntPredicate.ne (LLVM.and (LLVM.xor (shl (const? 8 (-1)) e_1) (const? 8 1)) e) e ⊑
     icmp IntPredicate.ne
       (LLVM.and e (LLVM.xor (shl (const? 8 (-1)) e_1 { «nsw» := true, «nuw» := false }) (const? 8 (-2))))
-      (const? 8 0) := by 
+      (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gcanonicalizehlshrhshlhtohmasking_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gcanonicalizehlshrhshlhtohmasking_proof.lean
@@ -9,7 +9,7 @@ set_option linter.unreachableTactic false
 
 section gcanonicalizehlshrhshlhtohmasking_proof
 theorem positive_samevar_thm (e e_1 : IntW 8) :
-  shl (lshr e_1 e) e ⊑ LLVM.and (shl (const? 8 (-1)) e { «nsw» := true, «nuw» := false }) e_1 := by 
+  shl (lshr e_1 e) e ⊑ LLVM.and (shl (const? 8 (-1)) e { «nsw» := true, «nuw» := false }) e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -18,7 +18,7 @@ theorem positive_samevar_thm (e e_1 : IntW 8) :
     all_goals sorry
 
 
-theorem positive_sameconst_thm (e : IntW 8) : shl (lshr e (const? 8 3)) (const? 8 3) ⊑ LLVM.and e (const? 8 (-8)) := by 
+theorem positive_sameconst_thm (e : IntW 8) : shl (lshr e (const? 8 3)) (const? 8 3) ⊑ LLVM.and e (const? 8 (-8)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -28,7 +28,7 @@ theorem positive_sameconst_thm (e : IntW 8) : shl (lshr e (const? 8 3)) (const? 
 
 
 theorem positive_biggerlshr_thm (e : IntW 8) :
-  shl (lshr e (const? 8 6)) (const? 8 3) ⊑ LLVM.and (lshr e (const? 8 3)) (const? 8 24) := by 
+  shl (lshr e (const? 8 6)) (const? 8 3) ⊑ LLVM.and (lshr e (const? 8 3)) (const? 8 24) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -38,7 +38,7 @@ theorem positive_biggerlshr_thm (e : IntW 8) :
 
 
 theorem positive_biggershl_thm (e : IntW 8) :
-  shl (lshr e (const? 8 3)) (const? 8 6) ⊑ LLVM.and (shl e (const? 8 3)) (const? 8 (-64)) := by 
+  shl (lshr e (const? 8 3)) (const? 8 6) ⊑ LLVM.and (shl e (const? 8 3)) (const? 8 (-64)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -49,7 +49,7 @@ theorem positive_biggershl_thm (e : IntW 8) :
 
 theorem positive_samevar_shlnuw_thm (e e_1 : IntW 8) :
   shl (lshr e_1 e) e { «nsw» := false, «nuw» := true } ⊑
-    LLVM.and (shl (const? 8 (-1)) e { «nsw» := true, «nuw» := false }) e_1 := by 
+    LLVM.and (shl (const? 8 (-1)) e { «nsw» := true, «nuw» := false }) e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -59,7 +59,7 @@ theorem positive_samevar_shlnuw_thm (e e_1 : IntW 8) :
 
 
 theorem positive_sameconst_shlnuw_thm (e : IntW 8) :
-  shl (lshr e (const? 8 3)) (const? 8 3) { «nsw» := false, «nuw» := true } ⊑ LLVM.and e (const? 8 (-8)) := by 
+  shl (lshr e (const? 8 3)) (const? 8 3) { «nsw» := false, «nuw» := true } ⊑ LLVM.and e (const? 8 (-8)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -70,7 +70,7 @@ theorem positive_sameconst_shlnuw_thm (e : IntW 8) :
 
 theorem positive_biggerlshr_shlnuw_thm (e : IntW 8) :
   shl (lshr e (const? 8 6)) (const? 8 3) { «nsw» := false, «nuw» := true } ⊑
-    LLVM.and (lshr e (const? 8 3)) (const? 8 24) := by 
+    LLVM.and (lshr e (const? 8 3)) (const? 8 24) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -81,7 +81,7 @@ theorem positive_biggerlshr_shlnuw_thm (e : IntW 8) :
 
 theorem positive_biggershl_shlnuw_thm (e : IntW 8) :
   shl (lshr e (const? 8 3)) (const? 8 6) { «nsw» := false, «nuw» := true } ⊑
-    LLVM.and (shl e (const? 8 3) { «nsw» := false, «nuw» := true }) (const? 8 (-64)) := by 
+    LLVM.and (shl e (const? 8 3) { «nsw» := false, «nuw» := true }) (const? 8 (-64)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -92,7 +92,7 @@ theorem positive_biggershl_shlnuw_thm (e : IntW 8) :
 
 theorem positive_samevar_shlnsw_thm (e e_1 : IntW 8) :
   shl (lshr e_1 e) e { «nsw» := true, «nuw» := false } ⊑
-    LLVM.and (shl (const? 8 (-1)) e { «nsw» := true, «nuw» := false }) e_1 := by 
+    LLVM.and (shl (const? 8 (-1)) e { «nsw» := true, «nuw» := false }) e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -102,7 +102,7 @@ theorem positive_samevar_shlnsw_thm (e e_1 : IntW 8) :
 
 
 theorem positive_sameconst_shlnsw_thm (e : IntW 8) :
-  shl (lshr e (const? 8 3)) (const? 8 3) { «nsw» := true, «nuw» := false } ⊑ LLVM.and e (const? 8 (-8)) := by 
+  shl (lshr e (const? 8 3)) (const? 8 3) { «nsw» := true, «nuw» := false } ⊑ LLVM.and e (const? 8 (-8)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -113,7 +113,7 @@ theorem positive_sameconst_shlnsw_thm (e : IntW 8) :
 
 theorem positive_biggerlshr_shlnsw_thm (e : IntW 8) :
   shl (lshr e (const? 8 6)) (const? 8 3) { «nsw» := true, «nuw» := false } ⊑
-    LLVM.and (lshr e (const? 8 3)) (const? 8 24) := by 
+    LLVM.and (lshr e (const? 8 3)) (const? 8 24) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -124,7 +124,7 @@ theorem positive_biggerlshr_shlnsw_thm (e : IntW 8) :
 
 theorem positive_biggershl_shlnsw_thm (e : IntW 8) :
   shl (lshr e (const? 8 3)) (const? 8 6) { «nsw» := true, «nuw» := false } ⊑
-    LLVM.and (shl e (const? 8 3) { «nsw» := true, «nuw» := true }) (const? 8 64) := by 
+    LLVM.and (shl e (const? 8 3) { «nsw» := true, «nuw» := true }) (const? 8 64) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -135,7 +135,7 @@ theorem positive_biggershl_shlnsw_thm (e : IntW 8) :
 
 theorem positive_samevar_shlnuwnsw_thm (e e_1 : IntW 8) :
   shl (lshr e_1 e) e { «nsw» := true, «nuw» := true } ⊑
-    LLVM.and (shl (const? 8 (-1)) e { «nsw» := true, «nuw» := false }) e_1 := by 
+    LLVM.and (shl (const? 8 (-1)) e { «nsw» := true, «nuw» := false }) e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -145,7 +145,7 @@ theorem positive_samevar_shlnuwnsw_thm (e e_1 : IntW 8) :
 
 
 theorem positive_sameconst_shlnuwnsw_thm (e : IntW 8) :
-  shl (lshr e (const? 8 3)) (const? 8 3) { «nsw» := true, «nuw» := true } ⊑ LLVM.and e (const? 8 (-8)) := by 
+  shl (lshr e (const? 8 3)) (const? 8 3) { «nsw» := true, «nuw» := true } ⊑ LLVM.and e (const? 8 (-8)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -156,7 +156,7 @@ theorem positive_sameconst_shlnuwnsw_thm (e : IntW 8) :
 
 theorem positive_biggerlshr_shlnuwnsw_thm (e : IntW 8) :
   shl (lshr e (const? 8 6)) (const? 8 3) { «nsw» := true, «nuw» := true } ⊑
-    LLVM.and (lshr e (const? 8 3)) (const? 8 24) := by 
+    LLVM.and (lshr e (const? 8 3)) (const? 8 24) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -167,7 +167,7 @@ theorem positive_biggerlshr_shlnuwnsw_thm (e : IntW 8) :
 
 theorem positive_biggershl_shlnuwnsw_thm (e : IntW 8) :
   shl (lshr e (const? 8 3)) (const? 8 6) { «nsw» := true, «nuw» := true } ⊑
-    LLVM.and (shl e (const? 8 3) { «nsw» := true, «nuw» := true }) (const? 8 64) := by 
+    LLVM.and (shl e (const? 8 3) { «nsw» := true, «nuw» := true }) (const? 8 64) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -176,7 +176,7 @@ theorem positive_biggershl_shlnuwnsw_thm (e : IntW 8) :
     all_goals sorry
 
 
-theorem positive_samevar_lshrexact_thm (e e_1 : IntW 8) : shl (lshr e_1 e { «exact» := true }) e ⊑ e_1 := by 
+theorem positive_samevar_lshrexact_thm (e e_1 : IntW 8) : shl (lshr e_1 e { «exact» := true }) e ⊑ e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -185,7 +185,7 @@ theorem positive_samevar_lshrexact_thm (e e_1 : IntW 8) : shl (lshr e_1 e { «ex
     all_goals sorry
 
 
-theorem positive_sameconst_lshrexact_thm (e : IntW 8) : shl (lshr e (const? 8 3) { «exact» := true }) (const? 8 3) ⊑ e := by 
+theorem positive_sameconst_lshrexact_thm (e : IntW 8) : shl (lshr e (const? 8 3) { «exact» := true }) (const? 8 3) ⊑ e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -195,7 +195,7 @@ theorem positive_sameconst_lshrexact_thm (e : IntW 8) : shl (lshr e (const? 8 3)
 
 
 theorem positive_biggerlshr_lshrexact_thm (e : IntW 8) :
-  shl (lshr e (const? 8 6) { «exact» := true }) (const? 8 3) ⊑ lshr e (const? 8 3) { «exact» := true } := by 
+  shl (lshr e (const? 8 6) { «exact» := true }) (const? 8 3) ⊑ lshr e (const? 8 3) { «exact» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -205,7 +205,7 @@ theorem positive_biggerlshr_lshrexact_thm (e : IntW 8) :
 
 
 theorem positive_biggershl_lshrexact_thm (e : IntW 8) :
-  shl (lshr e (const? 8 3) { «exact» := true }) (const? 8 6) ⊑ shl e (const? 8 3) := by 
+  shl (lshr e (const? 8 3) { «exact» := true }) (const? 8 6) ⊑ shl e (const? 8 3) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -215,7 +215,7 @@ theorem positive_biggershl_lshrexact_thm (e : IntW 8) :
 
 
 theorem positive_samevar_shlnsw_lshrexact_thm (e e_1 : IntW 8) :
-  shl (lshr e_1 e { «exact» := true }) e { «nsw» := true, «nuw» := false } ⊑ e_1 := by 
+  shl (lshr e_1 e { «exact» := true }) e { «nsw» := true, «nuw» := false } ⊑ e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -225,7 +225,7 @@ theorem positive_samevar_shlnsw_lshrexact_thm (e e_1 : IntW 8) :
 
 
 theorem positive_sameconst_shlnsw_lshrexact_thm (e : IntW 8) :
-  shl (lshr e (const? 8 3) { «exact» := true }) (const? 8 3) { «nsw» := true, «nuw» := false } ⊑ e := by 
+  shl (lshr e (const? 8 3) { «exact» := true }) (const? 8 3) { «nsw» := true, «nuw» := false } ⊑ e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -236,7 +236,7 @@ theorem positive_sameconst_shlnsw_lshrexact_thm (e : IntW 8) :
 
 theorem positive_biggerlshr_shlnsw_lshrexact_thm (e : IntW 8) :
   shl (lshr e (const? 8 6) { «exact» := true }) (const? 8 3) { «nsw» := true, «nuw» := false } ⊑
-    lshr e (const? 8 3) { «exact» := true } := by 
+    lshr e (const? 8 3) { «exact» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -247,7 +247,7 @@ theorem positive_biggerlshr_shlnsw_lshrexact_thm (e : IntW 8) :
 
 theorem positive_biggershl_shlnsw_lshrexact_thm (e : IntW 8) :
   shl (lshr e (const? 8 3) { «exact» := true }) (const? 8 6) { «nsw» := true, «nuw» := false } ⊑
-    shl e (const? 8 3) { «nsw» := true, «nuw» := true } := by 
+    shl e (const? 8 3) { «nsw» := true, «nuw» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -257,7 +257,7 @@ theorem positive_biggershl_shlnsw_lshrexact_thm (e : IntW 8) :
 
 
 theorem positive_samevar_shlnuw_lshrexact_thm (e e_1 : IntW 8) :
-  shl (lshr e_1 e { «exact» := true }) e { «nsw» := false, «nuw» := true } ⊑ e_1 := by 
+  shl (lshr e_1 e { «exact» := true }) e { «nsw» := false, «nuw» := true } ⊑ e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -267,7 +267,7 @@ theorem positive_samevar_shlnuw_lshrexact_thm (e e_1 : IntW 8) :
 
 
 theorem positive_sameconst_shlnuw_lshrexact_thm (e : IntW 8) :
-  shl (lshr e (const? 8 3) { «exact» := true }) (const? 8 3) { «nsw» := false, «nuw» := true } ⊑ e := by 
+  shl (lshr e (const? 8 3) { «exact» := true }) (const? 8 3) { «nsw» := false, «nuw» := true } ⊑ e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -278,7 +278,7 @@ theorem positive_sameconst_shlnuw_lshrexact_thm (e : IntW 8) :
 
 theorem positive_biggerlshr_shlnuw_lshrexact_thm (e : IntW 8) :
   shl (lshr e (const? 8 6) { «exact» := true }) (const? 8 3) { «nsw» := false, «nuw» := true } ⊑
-    lshr e (const? 8 3) { «exact» := true } := by 
+    lshr e (const? 8 3) { «exact» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -289,7 +289,7 @@ theorem positive_biggerlshr_shlnuw_lshrexact_thm (e : IntW 8) :
 
 theorem positive_biggershl_shlnuw_lshrexact_thm (e : IntW 8) :
   shl (lshr e (const? 8 3) { «exact» := true }) (const? 8 6) { «nsw» := false, «nuw» := true } ⊑
-    shl e (const? 8 3) { «nsw» := false, «nuw» := true } := by 
+    shl e (const? 8 3) { «nsw» := false, «nuw» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -299,7 +299,7 @@ theorem positive_biggershl_shlnuw_lshrexact_thm (e : IntW 8) :
 
 
 theorem positive_samevar_shlnuwnsw_lshrexact_thm (e e_1 : IntW 8) :
-  shl (lshr e_1 e { «exact» := true }) e { «nsw» := true, «nuw» := true } ⊑ e_1 := by 
+  shl (lshr e_1 e { «exact» := true }) e { «nsw» := true, «nuw» := true } ⊑ e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -309,7 +309,7 @@ theorem positive_samevar_shlnuwnsw_lshrexact_thm (e e_1 : IntW 8) :
 
 
 theorem positive_sameconst_shlnuwnsw_lshrexact_thm (e : IntW 8) :
-  shl (lshr e (const? 8 3) { «exact» := true }) (const? 8 3) { «nsw» := true, «nuw» := true } ⊑ e := by 
+  shl (lshr e (const? 8 3) { «exact» := true }) (const? 8 3) { «nsw» := true, «nuw» := true } ⊑ e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -320,7 +320,7 @@ theorem positive_sameconst_shlnuwnsw_lshrexact_thm (e : IntW 8) :
 
 theorem positive_biggerlshr_shlnuwnsw_lshrexact_thm (e : IntW 8) :
   shl (lshr e (const? 8 6) { «exact» := true }) (const? 8 3) { «nsw» := true, «nuw» := true } ⊑
-    lshr e (const? 8 3) { «exact» := true } := by 
+    lshr e (const? 8 3) { «exact» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -331,7 +331,7 @@ theorem positive_biggerlshr_shlnuwnsw_lshrexact_thm (e : IntW 8) :
 
 theorem positive_biggershl_shlnuwnsw_lshrexact_thm (e : IntW 8) :
   shl (lshr e (const? 8 3) { «exact» := true }) (const? 8 6) { «nsw» := true, «nuw» := true } ⊑
-    shl e (const? 8 3) { «nsw» := true, «nuw» := true } := by 
+    shl e (const? 8 3) { «nsw» := true, «nuw» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gcanonicalizehselectshicmphconditionhbittest_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gcanonicalizehselectshicmphconditionhbittest_proof.lean
@@ -10,7 +10,7 @@ set_option linter.unreachableTactic false
 section gcanonicalizehselectshicmphconditionhbittest_proof
 theorem p0_thm (e e_1 e_2 : IntW 8) :
   select (icmp IntPredicate.eq (LLVM.and e_2 (const? 8 1)) (const? 8 1)) e_1 e ⊑
-    select (icmp IntPredicate.eq (LLVM.and e_2 (const? 8 1)) (const? 8 0)) e e_1 := by 
+    select (icmp IntPredicate.eq (LLVM.and e_2 (const? 8 1)) (const? 8 0)) e e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -21,7 +21,7 @@ theorem p0_thm (e e_1 e_2 : IntW 8) :
 
 theorem p1_thm (e e_1 e_2 : IntW 8) :
   select (icmp IntPredicate.ne (LLVM.and e_2 (const? 8 1)) (const? 8 0)) e_1 e ⊑
-    select (icmp IntPredicate.eq (LLVM.and e_2 (const? 8 1)) (const? 8 0)) e e_1 := by 
+    select (icmp IntPredicate.eq (LLVM.and e_2 (const? 8 1)) (const? 8 0)) e e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -31,7 +31,7 @@ theorem p1_thm (e e_1 e_2 : IntW 8) :
 
 
 theorem n5_thm (e e_1 e_2 : IntW 8) :
-  select (icmp IntPredicate.eq (LLVM.and e_2 (const? 8 1)) (const? 8 2)) e_1 e ⊑ e := by 
+  select (icmp IntPredicate.eq (LLVM.and e_2 (const? 8 1)) (const? 8 2)) e_1 e ⊑ e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -41,7 +41,7 @@ theorem n5_thm (e e_1 e_2 : IntW 8) :
 
 
 theorem n6_thm (e e_1 e_2 : IntW 8) :
-  select (icmp IntPredicate.eq (LLVM.and e_2 (const? 8 1)) (const? 8 3)) e_1 e ⊑ e := by 
+  select (icmp IntPredicate.eq (LLVM.and e_2 (const? 8 1)) (const? 8 3)) e_1 e ⊑ e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -52,7 +52,7 @@ theorem n6_thm (e e_1 e_2 : IntW 8) :
 
 theorem n7_thm (e e_1 e_2 : IntW 8) :
   select (icmp IntPredicate.ne (LLVM.and e_2 (const? 8 1)) (const? 8 1)) e_1 e ⊑
-    select (icmp IntPredicate.eq (LLVM.and e_2 (const? 8 1)) (const? 8 0)) e_1 e := by 
+    select (icmp IntPredicate.eq (LLVM.and e_2 (const? 8 1)) (const? 8 0)) e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gcanonicalizehshlhlshrhtohmasking_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gcanonicalizehshlhlshrhtohmasking_proof.lean
@@ -8,7 +8,7 @@ set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
 
 section gcanonicalizehshlhlshrhtohmasking_proof
-theorem positive_samevar_thm (e e_1 : IntW 32) : lshr (shl e_1 e) e ⊑ LLVM.and (lshr (const? 32 (-1)) e) e_1 := by 
+theorem positive_samevar_thm (e e_1 : IntW 32) : lshr (shl e_1 e) e ⊑ LLVM.and (lshr (const? 32 (-1)) e) e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -17,7 +17,7 @@ theorem positive_samevar_thm (e e_1 : IntW 32) : lshr (shl e_1 e) e ⊑ LLVM.and
     all_goals sorry
 
 
-theorem positive_sameconst_thm (e : IntW 32) : lshr (shl e (const? 32 5)) (const? 32 5) ⊑ LLVM.and e (const? 32 134217727) := by 
+theorem positive_sameconst_thm (e : IntW 32) : lshr (shl e (const? 32 5)) (const? 32 5) ⊑ LLVM.and e (const? 32 134217727) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -27,7 +27,7 @@ theorem positive_sameconst_thm (e : IntW 32) : lshr (shl e (const? 32 5)) (const
 
 
 theorem positive_biggerShl_thm (e : IntW 32) :
-  lshr (shl e (const? 32 10)) (const? 32 5) ⊑ LLVM.and (shl e (const? 32 5)) (const? 32 134217696) := by 
+  lshr (shl e (const? 32 10)) (const? 32 5) ⊑ LLVM.and (shl e (const? 32 5)) (const? 32 134217696) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -37,7 +37,7 @@ theorem positive_biggerShl_thm (e : IntW 32) :
 
 
 theorem positive_biggerLshr_thm (e : IntW 32) :
-  lshr (shl e (const? 32 5)) (const? 32 10) ⊑ LLVM.and (lshr e (const? 32 5)) (const? 32 4194303) := by 
+  lshr (shl e (const? 32 5)) (const? 32 10) ⊑ LLVM.and (lshr e (const? 32 5)) (const? 32 4194303) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -48,7 +48,7 @@ theorem positive_biggerLshr_thm (e : IntW 32) :
 
 theorem positive_biggerLshr_lshrexact_thm (e : IntW 32) :
   lshr (shl e (const? 32 5)) (const? 32 10) { «exact» := true } ⊑
-    LLVM.and (lshr e (const? 32 5) { «exact» := true }) (const? 32 4194303) := by 
+    LLVM.and (lshr e (const? 32 5) { «exact» := true }) (const? 32 4194303) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -57,7 +57,7 @@ theorem positive_biggerLshr_lshrexact_thm (e : IntW 32) :
     all_goals sorry
 
 
-theorem positive_samevar_shlnuw_thm (e e_1 : IntW 32) : lshr (shl e_1 e { «nsw» := false, «nuw» := true }) e ⊑ e_1 := by 
+theorem positive_samevar_shlnuw_thm (e e_1 : IntW 32) : lshr (shl e_1 e { «nsw» := false, «nuw» := true }) e ⊑ e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -67,7 +67,7 @@ theorem positive_samevar_shlnuw_thm (e e_1 : IntW 32) : lshr (shl e_1 e { «nsw�
 
 
 theorem positive_sameconst_shlnuw_thm (e : IntW 32) :
-  lshr (shl e (const? 32 5) { «nsw» := false, «nuw» := true }) (const? 32 5) ⊑ e := by 
+  lshr (shl e (const? 32 5) { «nsw» := false, «nuw» := true }) (const? 32 5) ⊑ e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -78,7 +78,7 @@ theorem positive_sameconst_shlnuw_thm (e : IntW 32) :
 
 theorem positive_biggerShl_shlnuw_thm (e : IntW 32) :
   lshr (shl e (const? 32 10) { «nsw» := false, «nuw» := true }) (const? 32 5) ⊑
-    shl e (const? 32 5) { «nsw» := true, «nuw» := true } := by 
+    shl e (const? 32 5) { «nsw» := true, «nuw» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -88,7 +88,7 @@ theorem positive_biggerShl_shlnuw_thm (e : IntW 32) :
 
 
 theorem positive_biggerLshr_shlnuw_thm (e : IntW 32) :
-  lshr (shl e (const? 32 5) { «nsw» := false, «nuw» := true }) (const? 32 10) ⊑ lshr e (const? 32 5) := by 
+  lshr (shl e (const? 32 5) { «nsw» := false, «nuw» := true }) (const? 32 10) ⊑ lshr e (const? 32 5) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -99,7 +99,7 @@ theorem positive_biggerLshr_shlnuw_thm (e : IntW 32) :
 
 theorem positive_biggerLshr_shlnuw_lshrexact_thm (e : IntW 32) :
   lshr (shl e (const? 32 5) { «nsw» := false, «nuw» := true }) (const? 32 10) { «exact» := true } ⊑
-    lshr e (const? 32 5) { «exact» := true } := by 
+    lshr e (const? 32 5) { «exact» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gcanonicalizehsignedhtruncationhcheck_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gcanonicalizehsignedhtruncationhcheck_proof.lean
@@ -10,7 +10,7 @@ set_option linter.unreachableTactic false
 section gcanonicalizehsignedhtruncationhcheck_proof
 theorem p0_thm (e : IntW 8) :
   icmp IntPredicate.ne (ashr (shl e (const? 8 5)) (const? 8 5) { «exact» := true }) e ⊑
-    icmp IntPredicate.ult (add e (const? 8 (-4))) (const? 8 (-8)) := by 
+    icmp IntPredicate.ult (add e (const? 8 (-4))) (const? 8 (-8)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -21,7 +21,7 @@ theorem p0_thm (e : IntW 8) :
 
 theorem pb_thm (e : IntW 65) :
   icmp IntPredicate.ne e (ashr (shl e (const? 65 1)) (const? 65 1) { «exact» := true }) ⊑
-    icmp IntPredicate.slt (add e (const? 65 9223372036854775808)) (const? 65 0) := by 
+    icmp IntPredicate.slt (add e (const? 65 9223372036854775808)) (const? 65 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -32,7 +32,7 @@ theorem pb_thm (e : IntW 65) :
 
 theorem n1_thm (e : IntW 8) :
   icmp IntPredicate.ne (lshr (shl e (const? 8 5)) (const? 8 5) { «exact» := true }) e ⊑
-    icmp IntPredicate.ugt e (const? 8 7) := by 
+    icmp IntPredicate.ugt e (const? 8 7) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gcast_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gcast_proof.lean
@@ -8,7 +8,7 @@ set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
 
 section gcast_proof
-theorem test2_thm (e : IntW 8) : zext 64 (zext 32 (zext 16 e)) ⊑ zext 64 e := by 
+theorem test2_thm (e : IntW 8) : zext 64 (zext 32 (zext 16 e)) ⊑ zext 64 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -17,7 +17,7 @@ theorem test2_thm (e : IntW 8) : zext 64 (zext 32 (zext 16 e)) ⊑ zext 64 e := 
     all_goals sorry
 
 
-theorem test3_thm (e : IntW 64) : zext 64 (trunc 8 e) ⊑ LLVM.and e (const? 64 255) := by 
+theorem test3_thm (e : IntW 64) : zext 64 (trunc 8 e) ⊑ LLVM.and e (const? 64 255) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -27,7 +27,7 @@ theorem test3_thm (e : IntW 64) : zext 64 (trunc 8 e) ⊑ LLVM.and e (const? 64 
 
 
 theorem test4_thm (e e_1 : IntW 32) :
-  zext 32 (zext 8 (icmp IntPredicate.slt e_1 e)) ⊑ zext 32 (icmp IntPredicate.slt e_1 e) := by 
+  zext 32 (zext 8 (icmp IntPredicate.slt e_1 e)) ⊑ zext 32 (icmp IntPredicate.slt e_1 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -36,7 +36,7 @@ theorem test4_thm (e e_1 : IntW 32) :
     all_goals sorry
 
 
-theorem test5_thm (e : IntW 1) : zext 32 (zext 8 e) ⊑ zext 32 e := by 
+theorem test5_thm (e : IntW 1) : zext 32 (zext 8 e) ⊑ zext 32 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -45,7 +45,7 @@ theorem test5_thm (e : IntW 1) : zext 32 (zext 8 e) ⊑ zext 32 e := by
     all_goals sorry
 
 
-theorem test7_thm (e : IntW 1) : sext 64 (zext 32 e) ⊑ zext 64 e := by 
+theorem test7_thm (e : IntW 1) : sext 64 (zext 32 e) ⊑ zext 64 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -54,7 +54,7 @@ theorem test7_thm (e : IntW 1) : sext 64 (zext 32 e) ⊑ zext 64 e := by
     all_goals sorry
 
 
-theorem test9_thm (e : IntW 16) : trunc 16 (sext 32 e) ⊑ e := by 
+theorem test9_thm (e : IntW 16) : trunc 16 (sext 32 e) ⊑ e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -63,7 +63,7 @@ theorem test9_thm (e : IntW 16) : trunc 16 (sext 32 e) ⊑ e := by
     all_goals sorry
 
 
-theorem test10_thm (e : IntW 16) : trunc 16 (sext 32 e) ⊑ e := by 
+theorem test10_thm (e : IntW 16) : trunc 16 (sext 32 e) ⊑ e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -72,7 +72,7 @@ theorem test10_thm (e : IntW 16) : trunc 16 (sext 32 e) ⊑ e := by
     all_goals sorry
 
 
-theorem test17_thm (e : IntW 1) : trunc 16 (zext 32 e) ⊑ zext 16 e := by 
+theorem test17_thm (e : IntW 1) : trunc 16 (zext 32 e) ⊑ zext 16 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -81,7 +81,7 @@ theorem test17_thm (e : IntW 1) : trunc 16 (zext 32 e) ⊑ zext 16 e := by
     all_goals sorry
 
 
-theorem test18_thm (e : IntW 8) : trunc 16 (sext 32 e) ⊑ sext 16 e := by 
+theorem test18_thm (e : IntW 8) : trunc 16 (sext 32 e) ⊑ sext 16 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -91,7 +91,7 @@ theorem test18_thm (e : IntW 8) : trunc 16 (sext 32 e) ⊑ sext 16 e := by
 
 
 theorem test19_thm (e : IntW 32) :
-  icmp IntPredicate.slt (sext 64 e) (const? 64 12345) ⊑ icmp IntPredicate.slt e (const? 32 12345) := by 
+  icmp IntPredicate.slt (sext 64 e) (const? 64 12345) ⊑ icmp IntPredicate.slt e (const? 32 12345) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -100,7 +100,7 @@ theorem test19_thm (e : IntW 32) :
     all_goals sorry
 
 
-theorem test20_thm (e : IntW 1) : icmp IntPredicate.slt (zext 32 e) (const? 32 (-1)) ⊑ const? 1 0 := by 
+theorem test20_thm (e : IntW 1) : icmp IntPredicate.slt (zext 32 e) (const? 32 (-1)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -109,7 +109,7 @@ theorem test20_thm (e : IntW 1) : icmp IntPredicate.slt (zext 32 e) (const? 32 (
     all_goals sorry
 
 
-theorem test21_thm (e : IntW 32) : LLVM.and (sext 32 (trunc 8 e)) (const? 32 255) ⊑ LLVM.and e (const? 32 255) := by 
+theorem test21_thm (e : IntW 32) : LLVM.and (sext 32 (trunc 8 e)) (const? 32 255) ⊑ LLVM.and e (const? 32 255) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -118,7 +118,7 @@ theorem test21_thm (e : IntW 32) : LLVM.and (sext 32 (trunc 8 e)) (const? 32 255
     all_goals sorry
 
 
-theorem test22_thm (e : IntW 32) : shl (sext 32 (trunc 8 e)) (const? 32 24) ⊑ shl e (const? 32 24) := by 
+theorem test22_thm (e : IntW 32) : shl (sext 32 (trunc 8 e)) (const? 32 24) ⊑ shl e (const? 32 24) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -127,7 +127,7 @@ theorem test22_thm (e : IntW 32) : shl (sext 32 (trunc 8 e)) (const? 32 24) ⊑ 
     all_goals sorry
 
 
-theorem test23_thm (e : IntW 32) : zext 32 (trunc 16 e) ⊑ LLVM.and e (const? 32 65535) := by 
+theorem test23_thm (e : IntW 32) : zext 32 (trunc 16 e) ⊑ LLVM.and e (const? 32 65535) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -137,7 +137,7 @@ theorem test23_thm (e : IntW 32) : zext 32 (trunc 16 e) ⊑ LLVM.and e (const? 3
 
 
 theorem test24_thm (e : IntW 1) :
-  icmp IntPredicate.ne (select e (const? 32 14) (const? 32 1234)) (const? 32 0) ⊑ const? 1 1 := by 
+  icmp IntPredicate.ne (select e (const? 32 14) (const? 32 1234)) (const? 32 0) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -147,7 +147,7 @@ theorem test24_thm (e : IntW 1) :
 
 
 theorem test29_thm (e e_1 : IntW 32) :
-  zext 32 (LLVM.or (trunc 8 e_1) (trunc 8 e)) ⊑ LLVM.and (LLVM.or e_1 e) (const? 32 255) := by 
+  zext 32 (LLVM.or (trunc 8 e_1) (trunc 8 e)) ⊑ LLVM.and (LLVM.or e_1 e) (const? 32 255) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -158,7 +158,7 @@ theorem test29_thm (e e_1 : IntW 32) :
 
 theorem test31_thm (e : IntW 64) :
   icmp IntPredicate.eq (LLVM.and (trunc 32 e) (const? 32 42)) (const? 32 10) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 64 42)) (const? 64 10) := by 
+    icmp IntPredicate.eq (LLVM.and e (const? 64 42)) (const? 64 10) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -167,7 +167,7 @@ theorem test31_thm (e : IntW 64) :
     all_goals sorry
 
 
-theorem test34_thm (e : IntW 16) : trunc 16 (lshr (zext 32 e) (const? 32 8)) ⊑ lshr e (const? 16 8) := by 
+theorem test34_thm (e : IntW 16) : trunc 16 (lshr (zext 32 e) (const? 32 8)) ⊑ lshr e (const? 16 8) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -178,7 +178,7 @@ theorem test34_thm (e : IntW 16) : trunc 16 (lshr (zext 32 e) (const? 32 8)) ⊑
 
 theorem test36_thm (e : IntW 32) :
   icmp IntPredicate.eq (trunc 8 (lshr e (const? 32 31))) (const? 8 0) ⊑
-    icmp IntPredicate.sgt e (const? 32 (-1)) := by 
+    icmp IntPredicate.sgt e (const? 32 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -188,7 +188,7 @@ theorem test36_thm (e : IntW 32) :
 
 
 theorem test37_thm (e : IntW 32) :
-  icmp IntPredicate.eq (trunc 8 (LLVM.or (lshr e (const? 32 31)) (const? 32 512))) (const? 8 11) ⊑ const? 1 0 := by 
+  icmp IntPredicate.eq (trunc 8 (LLVM.or (lshr e (const? 32 31)) (const? 32 512))) (const? 8 11) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -199,7 +199,7 @@ theorem test37_thm (e : IntW 32) :
 
 theorem test38_thm (e : IntW 32) :
   zext 64 (LLVM.xor (zext 8 (icmp IntPredicate.eq e (const? 32 (-2)))) (const? 8 1)) ⊑
-    zext 64 (icmp IntPredicate.ne e (const? 32 (-2))) := by 
+    zext 64 (icmp IntPredicate.ne e (const? 32 (-2))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -210,7 +210,7 @@ theorem test38_thm (e : IntW 32) :
 
 theorem test40_thm (e : IntW 16) :
   trunc 16 (LLVM.or (lshr (zext 32 e) (const? 32 9)) (shl (zext 32 e) (const? 32 8))) ⊑
-    LLVM.or (lshr e (const? 16 9)) (shl e (const? 16 8)) { «disjoint» := true } := by 
+    LLVM.or (lshr e (const? 16 9)) (shl e (const? 16 8)) { «disjoint» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -219,7 +219,7 @@ theorem test40_thm (e : IntW 16) :
     all_goals sorry
 
 
-theorem test42_thm (e : IntW 32) : zext 32 (trunc 8 e) ⊑ LLVM.and e (const? 32 255) := by 
+theorem test42_thm (e : IntW 32) : zext 32 (trunc 8 e) ⊑ LLVM.and e (const? 32 255) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -230,7 +230,7 @@ theorem test42_thm (e : IntW 32) : zext 32 (trunc 8 e) ⊑ LLVM.and e (const? 32
 
 theorem test43_thm (e : IntW 8) :
   sext 64 (add (zext 32 e) (const? 32 (-1))) ⊑
-    sext 64 (add (zext 32 e) (const? 32 (-1)) { «nsw» := true, «nuw» := false }) := by 
+    sext 64 (add (zext 32 e) (const? 32 (-1)) { «nsw» := true, «nuw» := false }) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -241,7 +241,7 @@ theorem test43_thm (e : IntW 8) :
 
 theorem test44_thm (e : IntW 8) :
   zext 64 (LLVM.or (zext 16 e) (const? 16 1234)) ⊑
-    zext 64 (LLVM.or (zext 16 e) (const? 16 1234)) { «nneg» := true } := by 
+    zext 64 (LLVM.or (zext 16 e) (const? 16 1234)) { «nneg» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -252,7 +252,7 @@ theorem test44_thm (e : IntW 8) :
 
 theorem test46_thm (e : IntW 64) :
   zext 64 (shl (LLVM.and (trunc 32 e) (const? 32 42)) (const? 32 8)) ⊑
-    zext 64 (LLVM.and (shl (trunc 32 e) (const? 32 8)) (const? 32 10752)) { «nneg» := true } := by 
+    zext 64 (LLVM.and (shl (trunc 32 e) (const? 32 8)) (const? 32 10752)) { «nneg» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -262,7 +262,7 @@ theorem test46_thm (e : IntW 64) :
 
 
 theorem test47_thm (e : IntW 8) :
-  zext 64 (LLVM.or (sext 32 e) (const? 32 42)) ⊑ zext 64 (sext 32 (LLVM.or e (const? 8 42))) := by 
+  zext 64 (LLVM.or (sext 32 e) (const? 32 42)) ⊑ zext 64 (sext 32 (LLVM.or e (const? 8 42))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -275,7 +275,7 @@ theorem test48_thm (e : IntW 8) :
   zext 64 (LLVM.or (shl (zext 32 e) (const? 32 8)) (zext 32 e)) ⊑
     zext 64
       (LLVM.or (shl (zext 32 e) (const? 32 8) { «nsw» := true, «nuw» := true }) (zext 32 e) { «disjoint» := true })
-      { «nneg» := true } := by 
+      { «nneg» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -288,7 +288,7 @@ theorem test51_thm (e : IntW 64) (e_1 : IntW 1) :
   sext 64 (select e_1 (LLVM.and (trunc 32 e) (const? 32 (-2))) (LLVM.or (trunc 32 e) (const? 32 1))) ⊑
     sext 64
       (LLVM.or (LLVM.and (trunc 32 e) (const? 32 (-2))) (zext 32 (LLVM.xor e_1 (const? 1 1)))
-        { «disjoint» := true }) := by 
+        { «disjoint» := true }) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -299,7 +299,7 @@ theorem test51_thm (e : IntW 64) (e_1 : IntW 1) :
 
 theorem test52_thm (e : IntW 64) :
   zext 32 (LLVM.and (LLVM.or (trunc 16 e) (const? 16 (-32574))) (const? 16 (-25350))) ⊑
-    zext 32 (LLVM.or (LLVM.and (trunc 16 e) (const? 16 7224)) (const? 16 (-32574)) { «disjoint» := true }) := by 
+    zext 32 (LLVM.or (LLVM.and (trunc 16 e) (const? 16 7224)) (const? 16 (-32574)) { «disjoint» := true }) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -310,7 +310,7 @@ theorem test52_thm (e : IntW 64) :
 
 theorem test53_thm (e : IntW 32) :
   zext 64 (LLVM.and (LLVM.or (trunc 16 e) (const? 16 (-32574))) (const? 16 (-25350))) ⊑
-    zext 64 (LLVM.or (LLVM.and (trunc 16 e) (const? 16 7224)) (const? 16 (-32574)) { «disjoint» := true }) := by 
+    zext 64 (LLVM.or (LLVM.and (trunc 16 e) (const? 16 7224)) (const? 16 (-32574)) { «disjoint» := true }) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -321,7 +321,7 @@ theorem test53_thm (e : IntW 32) :
 
 theorem test54_thm (e : IntW 64) :
   sext 32 (LLVM.and (LLVM.or (trunc 16 e) (const? 16 (-32574))) (const? 16 (-25350))) ⊑
-    sext 32 (LLVM.or (LLVM.and (trunc 16 e) (const? 16 7224)) (const? 16 (-32574)) { «disjoint» := true }) := by 
+    sext 32 (LLVM.or (LLVM.and (trunc 16 e) (const? 16 7224)) (const? 16 (-32574)) { «disjoint» := true }) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -332,7 +332,7 @@ theorem test54_thm (e : IntW 64) :
 
 theorem test55_thm (e : IntW 32) :
   sext 64 (LLVM.and (LLVM.or (trunc 16 e) (const? 16 (-32574))) (const? 16 (-25350))) ⊑
-    sext 64 (LLVM.or (LLVM.and (trunc 16 e) (const? 16 7224)) (const? 16 (-32574)) { «disjoint» := true }) := by 
+    sext 64 (LLVM.or (LLVM.and (trunc 16 e) (const? 16 7224)) (const? 16 (-32574)) { «disjoint» := true }) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -342,7 +342,7 @@ theorem test55_thm (e : IntW 32) :
 
 
 theorem test56_thm (e : IntW 16) :
-  zext 64 (lshr (sext 32 e) (const? 32 5)) ⊑ zext 64 (lshr (sext 32 e) (const? 32 5)) { «nneg» := true } := by 
+  zext 64 (lshr (sext 32 e) (const? 32 5)) ⊑ zext 64 (lshr (sext 32 e) (const? 32 5)) { «nneg» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -352,7 +352,7 @@ theorem test56_thm (e : IntW 16) :
 
 
 theorem test57_thm (e : IntW 64) :
-  zext 64 (lshr (trunc 32 e) (const? 32 8)) ⊑ zext 64 (lshr (trunc 32 e) (const? 32 8)) { «nneg» := true } := by 
+  zext 64 (lshr (trunc 32 e) (const? 32 8)) ⊑ zext 64 (lshr (trunc 32 e) (const? 32 8)) { «nneg» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -363,7 +363,7 @@ theorem test57_thm (e : IntW 64) :
 
 theorem test58_thm (e : IntW 64) :
   zext 64 (LLVM.or (lshr (trunc 32 e) (const? 32 8)) (const? 32 128)) ⊑
-    zext 64 (LLVM.or (lshr (trunc 32 e) (const? 32 8)) (const? 32 128)) { «nneg» := true } := by 
+    zext 64 (LLVM.or (lshr (trunc 32 e) (const? 32 8)) (const? 32 128)) { «nneg» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -377,7 +377,7 @@ theorem test59_thm (e e_1 : IntW 8) :
     zext 64
       (LLVM.or (LLVM.and (shl (zext 32 e) (const? 32 4) { «nsw» := true, «nuw» := true }) (const? 32 48))
         (zext 32 (lshr e_1 (const? 8 4)) { «nneg» := true }) { «disjoint» := true })
-      { «nneg» := true } := by 
+      { «nneg» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -395,7 +395,7 @@ theorem test67_thm (e : IntW 1) (e_1 : IntW 32) :
             (const? 32 (-16777216)))
           (const? 32 24) { «exact» := true }))
       (const? 8 0) ⊑
-    const? 1 0 := by 
+    const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -406,7 +406,7 @@ theorem test67_thm (e : IntW 1) (e_1 : IntW 32) :
 
 theorem test82_thm (e : IntW 64) :
   zext 64 (shl (lshr (trunc 32 e) (const? 32 8)) (const? 32 9)) ⊑
-    zext 64 (LLVM.and (shl (trunc 32 e) (const? 32 1)) (const? 32 (-512))) := by 
+    zext 64 (LLVM.and (shl (trunc 32 e) (const? 32 1)) (const? 32 (-512))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -417,7 +417,7 @@ theorem test82_thm (e : IntW 64) :
 
 theorem test83_thm (e : IntW 64) (e_1 : IntW 16) :
   zext 64 (shl (sext 32 e_1) (trunc 32 (add e (const? 64 (-1)) { «nsw» := true, «nuw» := false }))) ⊑
-    zext 64 (shl (sext 32 e_1) (add (trunc 32 e) (const? 32 (-1)))) := by 
+    zext 64 (shl (sext 32 e_1) (add (trunc 32 e) (const? 32 (-1)))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -428,7 +428,7 @@ theorem test83_thm (e : IntW 64) (e_1 : IntW 16) :
 
 theorem test84_thm (e : IntW 32) :
   trunc 8 (lshr (add e (const? 32 (-16777216)) { «nsw» := true, «nuw» := false }) (const? 32 23) { «exact» := true }) ⊑
-    trunc 8 (lshr (add e (const? 32 2130706432)) (const? 32 23)) := by 
+    trunc 8 (lshr (add e (const? 32 2130706432)) (const? 32 23)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -439,7 +439,7 @@ theorem test84_thm (e : IntW 32) :
 
 theorem test85_thm (e : IntW 32) :
   trunc 8 (lshr (add e (const? 32 (-16777216)) { «nsw» := false, «nuw» := true }) (const? 32 23) { «exact» := true }) ⊑
-    trunc 8 (lshr (add e (const? 32 2130706432)) (const? 32 23)) := by 
+    trunc 8 (lshr (add e (const? 32 2130706432)) (const? 32 23)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -448,7 +448,7 @@ theorem test85_thm (e : IntW 32) :
     all_goals sorry
 
 
-theorem test86_thm (e : IntW 16) : trunc 16 (ashr (sext 32 e) (const? 32 4)) ⊑ ashr e (const? 16 4) := by 
+theorem test86_thm (e : IntW 16) : trunc 16 (ashr (sext 32 e) (const? 32 4)) ⊑ ashr e (const? 16 4) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -459,7 +459,7 @@ theorem test86_thm (e : IntW 16) : trunc 16 (ashr (sext 32 e) (const? 32 4)) ⊑
 
 theorem test87_thm (e : IntW 16) :
   trunc 16 (ashr (mul (sext 32 e) (const? 32 16) { «nsw» := true, «nuw» := false }) (const? 32 16)) ⊑
-    ashr e (const? 16 12) := by 
+    ashr e (const? 16 12) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -468,7 +468,7 @@ theorem test87_thm (e : IntW 16) :
     all_goals sorry
 
 
-theorem test88_thm (e : IntW 16) : trunc 16 (ashr (sext 32 e) (const? 32 18)) ⊑ ashr e (const? 16 15) := by 
+theorem test88_thm (e : IntW 16) : trunc 16 (ashr (sext 32 e) (const? 32 18)) ⊑ ashr e (const? 16 15) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -478,7 +478,7 @@ theorem test88_thm (e : IntW 16) : trunc 16 (ashr (sext 32 e) (const? 32 18)) �
 
 
 theorem PR23309_thm (e e_1 : IntW 32) :
-  trunc 1 (sub (add e_1 (const? 32 (-4))) e { «nsw» := true, «nuw» := false }) ⊑ trunc 1 (sub e_1 e) := by 
+  trunc 1 (sub (add e_1 (const? 32 (-4))) e { «nsw» := true, «nuw» := false }) ⊑ trunc 1 (sub e_1 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -488,7 +488,7 @@ theorem PR23309_thm (e e_1 : IntW 32) :
 
 
 theorem PR23309v2_thm (e e_1 : IntW 32) :
-  trunc 1 (add (add e_1 (const? 32 (-4))) e { «nsw» := false, «nuw» := true }) ⊑ trunc 1 (add e_1 e) := by 
+  trunc 1 (add (add e_1 (const? 32 (-4))) e { «nsw» := false, «nuw» := true }) ⊑ trunc 1 (add e_1 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -497,7 +497,7 @@ theorem PR23309v2_thm (e e_1 : IntW 32) :
     all_goals sorry
 
 
-theorem PR24763_thm (e : IntW 8) : trunc 16 (lshr (sext 32 e) (const? 32 1)) ⊑ sext 16 (ashr e (const? 8 1)) := by 
+theorem PR24763_thm (e : IntW 8) : trunc 16 (lshr (sext 32 e) (const? 32 1)) ⊑ sext 16 (ashr e (const? 8 1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -508,7 +508,7 @@ theorem PR24763_thm (e : IntW 8) : trunc 16 (lshr (sext 32 e) (const? 32 1)) ⊑
 
 theorem test91_thm (e : IntW 64) :
   trunc 64 (lshr (sext 96 e) (const? 96 48)) ⊑
-    trunc 64 (lshr (sext 96 e) (const? 96 48)) { «nsw» := true, «nuw» := true } := by 
+    trunc 64 (lshr (sext 96 e) (const? 96 48)) { «nsw» := true, «nuw» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -517,7 +517,7 @@ theorem test91_thm (e : IntW 64) :
     all_goals sorry
 
 
-theorem test92_thm (e : IntW 64) : trunc 64 (lshr (sext 96 e) (const? 96 32)) ⊑ ashr e (const? 64 32) := by 
+theorem test92_thm (e : IntW 64) : trunc 64 (lshr (sext 96 e) (const? 96 32)) ⊑ ashr e (const? 64 32) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -526,7 +526,7 @@ theorem test92_thm (e : IntW 64) : trunc 64 (lshr (sext 96 e) (const? 96 32)) �
     all_goals sorry
 
 
-theorem test93_thm (e : IntW 32) : trunc 32 (lshr (sext 96 e) (const? 96 64)) ⊑ ashr e (const? 32 31) := by 
+theorem test93_thm (e : IntW 32) : trunc 32 (lshr (sext 96 e) (const? 96 64)) ⊑ ashr e (const? 32 31) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -535,7 +535,7 @@ theorem test93_thm (e : IntW 32) : trunc 32 (lshr (sext 96 e) (const? 96 64)) �
     all_goals sorry
 
 
-theorem trunc_lshr_sext_thm (e : IntW 8) : trunc 8 (lshr (sext 32 e) (const? 32 6)) ⊑ ashr e (const? 8 6) := by 
+theorem trunc_lshr_sext_thm (e : IntW 8) : trunc 8 (lshr (sext 32 e) (const? 32 6)) ⊑ ashr e (const? 8 6) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -545,7 +545,7 @@ theorem trunc_lshr_sext_thm (e : IntW 8) : trunc 8 (lshr (sext 32 e) (const? 32 
 
 
 theorem trunc_lshr_sext_exact_thm (e : IntW 8) :
-  trunc 8 (lshr (sext 32 e) (const? 32 6) { «exact» := true }) ⊑ ashr e (const? 8 6) { «exact» := true } := by 
+  trunc 8 (lshr (sext 32 e) (const? 32 6) { «exact» := true }) ⊑ ashr e (const? 8 6) { «exact» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -555,7 +555,7 @@ theorem trunc_lshr_sext_exact_thm (e : IntW 8) :
 
 
 theorem trunc_lshr_sext_wide_input_thm (e : IntW 16) :
-  trunc 8 (lshr (sext 32 e) (const? 32 9)) ⊑ trunc 8 (ashr e (const? 16 9)) { «nsw» := true, «nuw» := false } := by 
+  trunc 8 (lshr (sext 32 e) (const? 32 9)) ⊑ trunc 8 (ashr e (const? 16 9)) { «nsw» := true, «nuw» := false } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -566,7 +566,7 @@ theorem trunc_lshr_sext_wide_input_thm (e : IntW 16) :
 
 theorem trunc_lshr_sext_wide_input_exact_thm (e : IntW 16) :
   trunc 8 (lshr (sext 32 e) (const? 32 9) { «exact» := true }) ⊑
-    trunc 8 (ashr e (const? 16 9) { «exact» := true }) { «nsw» := true, «nuw» := false } := by 
+    trunc 8 (ashr e (const? 16 9) { «exact» := true }) { «nsw» := true, «nuw» := false } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -575,7 +575,7 @@ theorem trunc_lshr_sext_wide_input_exact_thm (e : IntW 16) :
     all_goals sorry
 
 
-theorem trunc_lshr_sext_narrow_input_thm (e : IntW 8) : trunc 16 (lshr (sext 32 e) (const? 32 6)) ⊑ sext 16 (ashr e (const? 8 6)) := by 
+theorem trunc_lshr_sext_narrow_input_thm (e : IntW 8) : trunc 16 (lshr (sext 32 e) (const? 32 6)) ⊑ sext 16 (ashr e (const? 8 6)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -584,7 +584,7 @@ theorem trunc_lshr_sext_narrow_input_thm (e : IntW 8) : trunc 16 (lshr (sext 32 
     all_goals sorry
 
 
-theorem trunc_lshr_zext_thm (e : IntW 8) : trunc 8 (lshr (zext 32 e) (const? 32 6)) ⊑ lshr e (const? 8 6) := by 
+theorem trunc_lshr_zext_thm (e : IntW 8) : trunc 8 (lshr (zext 32 e) (const? 32 6)) ⊑ lshr e (const? 8 6) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -594,7 +594,7 @@ theorem trunc_lshr_zext_thm (e : IntW 8) : trunc 8 (lshr (zext 32 e) (const? 32 
 
 
 theorem trunc_lshr_zext_exact_thm (e : IntW 8) :
-  trunc 8 (lshr (zext 32 e) (const? 32 6) { «exact» := true }) ⊑ lshr e (const? 8 6) := by 
+  trunc 8 (lshr (zext 32 e) (const? 32 6) { «exact» := true }) ⊑ lshr e (const? 8 6) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -603,7 +603,7 @@ theorem trunc_lshr_zext_exact_thm (e : IntW 8) :
     all_goals sorry
 
 
-theorem pr33078_1_thm (e : IntW 8) : trunc 8 (lshr (sext 16 e) (const? 16 8)) ⊑ ashr e (const? 8 7) := by 
+theorem pr33078_1_thm (e : IntW 8) : trunc 8 (lshr (sext 16 e) (const? 16 8)) ⊑ ashr e (const? 8 7) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -612,7 +612,7 @@ theorem pr33078_1_thm (e : IntW 8) : trunc 8 (lshr (sext 16 e) (const? 16 8)) �
     all_goals sorry
 
 
-theorem pr33078_2_thm (e : IntW 8) : trunc 12 (lshr (sext 16 e) (const? 16 4)) ⊑ sext 12 (ashr e (const? 8 4)) := by 
+theorem pr33078_2_thm (e : IntW 8) : trunc 12 (lshr (sext 16 e) (const? 16 4)) ⊑ sext 12 (ashr e (const? 8 4)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -623,7 +623,7 @@ theorem pr33078_2_thm (e : IntW 8) : trunc 12 (lshr (sext 16 e) (const? 16 4)) �
 
 theorem pr33078_3_thm (e : IntW 8) :
   trunc 4 (lshr (sext 16 e) (const? 16 12)) ⊑
-    trunc 4 (lshr (sext 16 e) (const? 16 12)) { «nsw» := false, «nuw» := true } := by 
+    trunc 4 (lshr (sext 16 e) (const? 16 12)) { «nsw» := false, «nuw» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -634,7 +634,7 @@ theorem pr33078_3_thm (e : IntW 8) :
 
 theorem pr33078_4_thm (e : IntW 3) :
   trunc 8 (lshr (sext 16 e) (const? 16 13)) ⊑
-    trunc 8 (lshr (sext 16 e) (const? 16 13)) { «nsw» := true, «nuw» := true } := by 
+    trunc 8 (lshr (sext 16 e) (const? 16 13)) { «nsw» := true, «nuw» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -645,7 +645,7 @@ theorem pr33078_4_thm (e : IntW 3) :
 
 theorem test94_thm (e : IntW 32) :
   sext 64 (LLVM.xor (sext 8 (icmp IntPredicate.eq e (const? 32 (-2)))) (const? 8 (-1))) ⊑
-    sext 64 (icmp IntPredicate.ne e (const? 32 (-2))) := by 
+    sext 64 (icmp IntPredicate.ne e (const? 32 (-2))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -657,7 +657,7 @@ theorem test94_thm (e : IntW 32) :
 theorem test95_thm (e : IntW 32) :
   zext 32 (LLVM.or (LLVM.and (lshr (trunc 8 e) (const? 8 6)) (const? 8 2)) (const? 8 40)) ⊑
     zext 32 (LLVM.or (LLVM.and (lshr (trunc 8 e) (const? 8 6)) (const? 8 2)) (const? 8 40) { «disjoint» := true })
-      { «nneg» := true } := by 
+      { «nneg» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gcasthmulhselect_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gcasthmulhselect_proof.lean
@@ -9,7 +9,7 @@ set_option linter.unreachableTactic false
 
 section gcasthmulhselect_proof
 theorem mul_thm (e e_1 : IntW 32) :
-  zext 32 (mul (trunc 8 e_1) (trunc 8 e)) ⊑ LLVM.and (mul e_1 e) (const? 32 255) := by 
+  zext 32 (mul (trunc 8 e_1) (trunc 8 e)) ⊑ LLVM.and (mul e_1 e) (const? 32 255) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -20,7 +20,7 @@ theorem mul_thm (e e_1 : IntW 32) :
 
 theorem select1_thm (e e_1 e_2 : IntW 32) (e_3 : IntW 1) :
   zext 32 (select e_3 (trunc 8 e_2) (add (trunc 8 e_1) (trunc 8 e))) ⊑
-    LLVM.and (select e_3 e_2 (add e_1 e)) (const? 32 255) := by 
+    LLVM.and (select e_3 e_2 (add e_1 e)) (const? 32 255) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -30,7 +30,7 @@ theorem select1_thm (e e_1 e_2 : IntW 32) (e_3 : IntW 1) :
 
 
 theorem select2_thm (e e_1 e_2 : IntW 8) (e_3 : IntW 1) :
-  trunc 8 (select e_3 (zext 32 e_2) (add (zext 32 e_1) (zext 32 e))) ⊑ select e_3 e_2 (add e_1 e) := by 
+  trunc 8 (select e_3 (zext 32 e_2) (add (zext 32 e_1) (zext 32 e))) ⊑ select e_3 e_2 (add e_1 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -45,7 +45,7 @@ theorem eval_zext_multi_use_in_one_inst_thm (e : IntW 32) :
         { «nsw» := true, «nuw» := true }) ⊑
     zext 32
       (mul (LLVM.and (trunc 16 e) (const? 16 5)) (LLVM.and (trunc 16 e) (const? 16 5)) { «nsw» := true, «nuw» := true })
-      { «nneg» := true } := by 
+      { «nneg» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -64,7 +64,7 @@ theorem eval_sext_multi_use_in_one_inst_thm (e : IntW 32) :
       (LLVM.or
         (mul (LLVM.and (trunc 16 e) (const? 16 14)) (LLVM.and (trunc 16 e) (const? 16 14))
           { «nsw» := true, «nuw» := true })
-        (const? 16 (-32768)) { «disjoint» := true }) := by 
+        (const? 16 (-32768)) { «disjoint» := true }) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -73,7 +73,7 @@ theorem eval_sext_multi_use_in_one_inst_thm (e : IntW 32) :
     all_goals sorry
 
 
-theorem foo_thm (e : IntW 1) : e ⊑ e := by 
+theorem foo_thm (e : IntW 1) : e ⊑ e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gcasthselect_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gcasthselect_proof.lean
@@ -10,7 +10,7 @@ set_option linter.unreachableTactic false
 section gcasthselect_proof
 theorem trunc_thm (e e_1 e_2 : IntW 32) :
   trunc 16 (select (icmp IntPredicate.ult e_2 e_1) (const? 32 42) e) ⊑
-    select (icmp IntPredicate.ult e_2 e_1) (const? 16 42) (trunc 16 e) := by 
+    select (icmp IntPredicate.ult e_2 e_1) (const? 16 42) (trunc 16 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gcasthset_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gcasthset_proof.lean
@@ -8,7 +8,7 @@ set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
 
 section gcasthset_proof
-theorem test5_thm (e : IntW 16) : trunc 16 (LLVM.and (sext 32 e) (const? 32 15)) ⊑ LLVM.and e (const? 16 15) := by 
+theorem test5_thm (e : IntW 16) : trunc 16 (LLVM.and (sext 32 e) (const? 32 15)) ⊑ LLVM.and e (const? 16 15) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -17,7 +17,7 @@ theorem test5_thm (e : IntW 16) : trunc 16 (LLVM.and (sext 32 e) (const? 32 15))
     all_goals sorry
 
 
-theorem test6_thm (e : IntW 1) : icmp IntPredicate.ne (zext 32 e) (const? 32 0) ⊑ e := by 
+theorem test6_thm (e : IntW 1) : icmp IntPredicate.ne (zext 32 e) (const? 32 0) ⊑ e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -26,7 +26,7 @@ theorem test6_thm (e : IntW 1) : icmp IntPredicate.ne (zext 32 e) (const? 32 0) 
     all_goals sorry
 
 
-theorem test6a_thm (e : IntW 1) : icmp IntPredicate.ne (zext 32 e) (const? 32 (-1)) ⊑ const? 1 1 := by 
+theorem test6a_thm (e : IntW 1) : icmp IntPredicate.ne (zext 32 e) (const? 32 (-1)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gcmphxhvshneghx_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gcmphxhvshneghx_proof.lean
@@ -10,7 +10,7 @@ set_option linter.unreachableTactic false
 section gcmphxhvshneghx_proof
 theorem t0_thm (e : IntW 8) :
   icmp IntPredicate.sgt (sub (const? 8 0) e { «nsw» := true, «nuw» := false }) e ⊑
-    icmp IntPredicate.slt e (const? 8 0) := by 
+    icmp IntPredicate.slt e (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -21,7 +21,7 @@ theorem t0_thm (e : IntW 8) :
 
 theorem t1_thm (e : IntW 8) :
   icmp IntPredicate.sge (sub (const? 8 0) e { «nsw» := true, «nuw» := false }) e ⊑
-    icmp IntPredicate.slt e (const? 8 1) := by 
+    icmp IntPredicate.slt e (const? 8 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -32,7 +32,7 @@ theorem t1_thm (e : IntW 8) :
 
 theorem t2_thm (e : IntW 8) :
   icmp IntPredicate.slt (sub (const? 8 0) e { «nsw» := true, «nuw» := false }) e ⊑
-    icmp IntPredicate.sgt e (const? 8 0) := by 
+    icmp IntPredicate.sgt e (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -43,7 +43,7 @@ theorem t2_thm (e : IntW 8) :
 
 theorem t3_thm (e : IntW 8) :
   icmp IntPredicate.sle (sub (const? 8 0) e { «nsw» := true, «nuw» := false }) e ⊑
-    icmp IntPredicate.sgt e (const? 8 (-1)) := by 
+    icmp IntPredicate.sgt e (const? 8 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -54,7 +54,7 @@ theorem t3_thm (e : IntW 8) :
 
 theorem t4_thm (e : IntW 8) :
   icmp IntPredicate.ugt (sub (const? 8 0) e { «nsw» := true, «nuw» := false }) e ⊑
-    icmp IntPredicate.sgt e (const? 8 0) := by 
+    icmp IntPredicate.sgt e (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -65,7 +65,7 @@ theorem t4_thm (e : IntW 8) :
 
 theorem t5_thm (e : IntW 8) :
   icmp IntPredicate.uge (sub (const? 8 0) e { «nsw» := true, «nuw» := false }) e ⊑
-    icmp IntPredicate.sgt e (const? 8 (-1)) := by 
+    icmp IntPredicate.sgt e (const? 8 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -76,7 +76,7 @@ theorem t5_thm (e : IntW 8) :
 
 theorem t6_thm (e : IntW 8) :
   icmp IntPredicate.ult (sub (const? 8 0) e { «nsw» := true, «nuw» := false }) e ⊑
-    icmp IntPredicate.slt e (const? 8 0) := by 
+    icmp IntPredicate.slt e (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -87,7 +87,7 @@ theorem t6_thm (e : IntW 8) :
 
 theorem t7_thm (e : IntW 8) :
   icmp IntPredicate.ule (sub (const? 8 0) e { «nsw» := true, «nuw» := false }) e ⊑
-    icmp IntPredicate.slt e (const? 8 1) := by 
+    icmp IntPredicate.slt e (const? 8 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -98,7 +98,7 @@ theorem t7_thm (e : IntW 8) :
 
 theorem t8_thm (e : IntW 8) :
   icmp IntPredicate.eq (sub (const? 8 0) e { «nsw» := true, «nuw» := false }) e ⊑
-    icmp IntPredicate.eq e (const? 8 0) := by 
+    icmp IntPredicate.eq e (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -109,7 +109,7 @@ theorem t8_thm (e : IntW 8) :
 
 theorem t9_thm (e : IntW 8) :
   icmp IntPredicate.ne (sub (const? 8 0) e { «nsw» := true, «nuw» := false }) e ⊑
-    icmp IntPredicate.ne e (const? 8 0) := by 
+    icmp IntPredicate.ne e (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -119,7 +119,7 @@ theorem t9_thm (e : IntW 8) :
 
 
 theorem n10_thm (e : IntW 8) :
-  icmp IntPredicate.sgt (sub (const? 8 0) e) e ⊑ icmp IntPredicate.slt e (sub (const? 8 0) e) := by 
+  icmp IntPredicate.sgt (sub (const? 8 0) e) e ⊑ icmp IntPredicate.slt e (sub (const? 8 0) e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -130,7 +130,7 @@ theorem n10_thm (e : IntW 8) :
 
 theorem n12_thm (e e_1 : IntW 8) :
   icmp IntPredicate.sgt (sub (const? 8 0) e_1 { «nsw» := true, «nuw» := false }) e ⊑
-    icmp IntPredicate.slt e (sub (const? 8 0) e_1 { «nsw» := true, «nuw» := false }) := by 
+    icmp IntPredicate.slt e (sub (const? 8 0) e_1 { «nsw» := true, «nuw» := false }) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gcomparehsigns_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gcomparehsigns_proof.lean
@@ -10,7 +10,7 @@ set_option linter.unreachableTactic false
 section gcomparehsigns_proof
 theorem test1_thm (e e_1 : IntW 32) :
   zext 32 (LLVM.xor (icmp IntPredicate.slt e_1 (const? 32 0)) (icmp IntPredicate.sgt e (const? 32 (-1)))) ⊑
-    zext 32 (icmp IntPredicate.sgt (LLVM.xor e_1 e) (const? 32 (-1))) := by 
+    zext 32 (icmp IntPredicate.sgt (LLVM.xor e_1 e) (const? 32 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -21,7 +21,7 @@ theorem test1_thm (e e_1 : IntW 32) :
 
 theorem test2_thm (e e_1 : IntW 32) :
   zext 32 (icmp IntPredicate.eq (LLVM.and e_1 (const? 32 8)) (LLVM.and e (const? 32 8))) ⊑
-    LLVM.xor (LLVM.and (lshr (LLVM.xor e_1 e) (const? 32 3)) (const? 32 1)) (const? 32 1) := by 
+    LLVM.xor (LLVM.and (lshr (LLVM.xor e_1 e) (const? 32 3)) (const? 32 1)) (const? 32 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -32,7 +32,7 @@ theorem test2_thm (e e_1 : IntW 32) :
 
 theorem test3_thm (e e_1 : IntW 32) :
   zext 32 (icmp IntPredicate.eq (lshr e_1 (const? 32 31)) (lshr e (const? 32 31))) ⊑
-    zext 32 (icmp IntPredicate.sgt (LLVM.xor e_1 e) (const? 32 (-1))) := by 
+    zext 32 (icmp IntPredicate.sgt (LLVM.xor e_1 e) (const? 32 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -45,7 +45,7 @@ theorem test3i_thm (e e_1 : IntW 32) :
   zext 32
       (icmp IntPredicate.eq (LLVM.or (lshr e_1 (const? 32 29)) (const? 32 35))
         (LLVM.or (lshr e (const? 32 29)) (const? 32 35))) ⊑
-    zext 32 (icmp IntPredicate.sgt (LLVM.xor e_1 e) (const? 32 (-1))) := by 
+    zext 32 (icmp IntPredicate.sgt (LLVM.xor e_1 e) (const? 32 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -56,7 +56,7 @@ theorem test3i_thm (e e_1 : IntW 32) :
 
 theorem test4a_thm (e : IntW 32) :
   icmp IntPredicate.slt (LLVM.or (ashr e (const? 32 31)) (lshr (sub (const? 32 0) e) (const? 32 31))) (const? 32 1) ⊑
-    icmp IntPredicate.slt e (const? 32 1) := by 
+    icmp IntPredicate.slt e (const? 32 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -67,7 +67,7 @@ theorem test4a_thm (e : IntW 32) :
 
 theorem test4b_thm (e : IntW 64) :
   icmp IntPredicate.slt (LLVM.or (ashr e (const? 64 63)) (lshr (sub (const? 64 0) e) (const? 64 63))) (const? 64 1) ⊑
-    icmp IntPredicate.slt e (const? 64 1) := by 
+    icmp IntPredicate.slt e (const? 64 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -79,7 +79,7 @@ theorem test4b_thm (e : IntW 64) :
 theorem test4c_thm (e : IntW 64) :
   icmp IntPredicate.slt (trunc 32 (LLVM.or (ashr e (const? 64 63)) (lshr (sub (const? 64 0) e) (const? 64 63))))
       (const? 32 1) ⊑
-    icmp IntPredicate.slt e (const? 64 1) := by 
+    icmp IntPredicate.slt e (const? 64 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -89,7 +89,7 @@ theorem test4c_thm (e : IntW 64) :
 
 
 theorem shift_trunc_signbit_test_thm (e : IntW 32) :
-  icmp IntPredicate.slt (trunc 8 (lshr e (const? 32 24))) (const? 8 0) ⊑ icmp IntPredicate.slt e (const? 32 0) := by 
+  icmp IntPredicate.slt (trunc 8 (lshr e (const? 32 24))) (const? 8 0) ⊑ icmp IntPredicate.slt e (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -100,7 +100,7 @@ theorem shift_trunc_signbit_test_thm (e : IntW 32) :
 
 theorem shift_trunc_wrong_shift_thm (e : IntW 32) :
   icmp IntPredicate.slt (trunc 8 (lshr e (const? 32 23))) (const? 8 0) ⊑
-    icmp IntPredicate.ne (LLVM.and e (const? 32 1073741824)) (const? 32 0) := by 
+    icmp IntPredicate.ne (LLVM.and e (const? 32 1073741824)) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -111,7 +111,7 @@ theorem shift_trunc_wrong_shift_thm (e : IntW 32) :
 
 theorem shift_trunc_wrong_cmp_thm (e : IntW 32) :
   icmp IntPredicate.slt (trunc 8 (lshr e (const? 32 24))) (const? 8 1) ⊑
-    icmp IntPredicate.slt (trunc 8 (lshr e (const? 32 24)) { «nsw» := false, «nuw» := true }) (const? 8 1) := by 
+    icmp IntPredicate.slt (trunc 8 (lshr e (const? 32 24)) { «nsw» := false, «nuw» := true }) (const? 8 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gcomparehudiv_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gcomparehudiv_proof.lean
@@ -9,7 +9,7 @@ set_option linter.unreachableTactic false
 
 section gcomparehudiv_proof
 theorem test1_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.eq (LLVM.udiv e_1 e) (const? 32 0) ⊑ icmp IntPredicate.ugt e e_1 := by 
+  icmp IntPredicate.eq (LLVM.udiv e_1 e) (const? 32 0) ⊑ icmp IntPredicate.ugt e e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -19,7 +19,7 @@ theorem test1_thm (e e_1 : IntW 32) :
 
 
 theorem test2_thm (e : IntW 32) :
-  icmp IntPredicate.eq (LLVM.udiv (const? 32 64) e) (const? 32 0) ⊑ icmp IntPredicate.ugt e (const? 32 64) := by 
+  icmp IntPredicate.eq (LLVM.udiv (const? 32 64) e) (const? 32 0) ⊑ icmp IntPredicate.ugt e (const? 32 64) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -29,7 +29,7 @@ theorem test2_thm (e : IntW 32) :
 
 
 theorem test3_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.ne (LLVM.udiv e_1 e) (const? 32 0) ⊑ icmp IntPredicate.ule e e_1 := by 
+  icmp IntPredicate.ne (LLVM.udiv e_1 e) (const? 32 0) ⊑ icmp IntPredicate.ule e e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -39,7 +39,7 @@ theorem test3_thm (e e_1 : IntW 32) :
 
 
 theorem test4_thm (e : IntW 32) :
-  icmp IntPredicate.ne (LLVM.udiv (const? 32 64) e) (const? 32 0) ⊑ icmp IntPredicate.ult e (const? 32 65) := by 
+  icmp IntPredicate.ne (LLVM.udiv (const? 32 64) e) (const? 32 0) ⊑ icmp IntPredicate.ult e (const? 32 65) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -49,7 +49,7 @@ theorem test4_thm (e : IntW 32) :
 
 
 theorem test5_thm (e : IntW 32) :
-  icmp IntPredicate.ne (LLVM.udiv (const? 32 (-1)) e) (const? 32 0) ⊑ const? 1 1 := by 
+  icmp IntPredicate.ne (LLVM.udiv (const? 32 (-1)) e) (const? 32 0) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -59,7 +59,7 @@ theorem test5_thm (e : IntW 32) :
 
 
 theorem test6_thm (e : IntW 32) :
-  icmp IntPredicate.ugt (LLVM.udiv (const? 32 5) e) (const? 32 0) ⊑ icmp IntPredicate.ult e (const? 32 6) := by 
+  icmp IntPredicate.ugt (LLVM.udiv (const? 32 5) e) (const? 32 0) ⊑ icmp IntPredicate.ult e (const? 32 6) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -69,7 +69,7 @@ theorem test6_thm (e : IntW 32) :
 
 
 theorem test7_thm (e : IntW 32) :
-  icmp IntPredicate.ugt (LLVM.udiv (const? 32 8) e) (const? 32 8) ⊑ const? 1 0 := by 
+  icmp IntPredicate.ugt (LLVM.udiv (const? 32 8) e) (const? 32 8) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -79,7 +79,7 @@ theorem test7_thm (e : IntW 32) :
 
 
 theorem test8_thm (e : IntW 32) :
-  icmp IntPredicate.ugt (LLVM.udiv (const? 32 4) e) (const? 32 3) ⊑ icmp IntPredicate.ult e (const? 32 2) := by 
+  icmp IntPredicate.ugt (LLVM.udiv (const? 32 4) e) (const? 32 3) ⊑ icmp IntPredicate.ult e (const? 32 2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -89,7 +89,7 @@ theorem test8_thm (e : IntW 32) :
 
 
 theorem test9_thm (e : IntW 32) :
-  icmp IntPredicate.ugt (LLVM.udiv (const? 32 4) e) (const? 32 2) ⊑ icmp IntPredicate.ult e (const? 32 2) := by 
+  icmp IntPredicate.ugt (LLVM.udiv (const? 32 4) e) (const? 32 2) ⊑ icmp IntPredicate.ult e (const? 32 2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -99,7 +99,7 @@ theorem test9_thm (e : IntW 32) :
 
 
 theorem test10_thm (e : IntW 32) :
-  icmp IntPredicate.ugt (LLVM.udiv (const? 32 4) e) (const? 32 1) ⊑ icmp IntPredicate.ult e (const? 32 3) := by 
+  icmp IntPredicate.ugt (LLVM.udiv (const? 32 4) e) (const? 32 1) ⊑ icmp IntPredicate.ult e (const? 32 3) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -109,7 +109,7 @@ theorem test10_thm (e : IntW 32) :
 
 
 theorem test11_thm (e : IntW 32) :
-  icmp IntPredicate.ult (LLVM.udiv (const? 32 4) e) (const? 32 1) ⊑ icmp IntPredicate.ugt e (const? 32 4) := by 
+  icmp IntPredicate.ult (LLVM.udiv (const? 32 4) e) (const? 32 1) ⊑ icmp IntPredicate.ugt e (const? 32 4) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -119,7 +119,7 @@ theorem test11_thm (e : IntW 32) :
 
 
 theorem test12_thm (e : IntW 32) :
-  icmp IntPredicate.ult (LLVM.udiv (const? 32 4) e) (const? 32 2) ⊑ icmp IntPredicate.ugt e (const? 32 2) := by 
+  icmp IntPredicate.ult (LLVM.udiv (const? 32 4) e) (const? 32 2) ⊑ icmp IntPredicate.ugt e (const? 32 2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -129,7 +129,7 @@ theorem test12_thm (e : IntW 32) :
 
 
 theorem test13_thm (e : IntW 32) :
-  icmp IntPredicate.ult (LLVM.udiv (const? 32 4) e) (const? 32 3) ⊑ icmp IntPredicate.ugt e (const? 32 1) := by 
+  icmp IntPredicate.ult (LLVM.udiv (const? 32 4) e) (const? 32 3) ⊑ icmp IntPredicate.ugt e (const? 32 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -139,7 +139,7 @@ theorem test13_thm (e : IntW 32) :
 
 
 theorem test14_thm (e : IntW 32) :
-  icmp IntPredicate.ult (LLVM.udiv (const? 32 4) e) (const? 32 4) ⊑ icmp IntPredicate.ugt e (const? 32 1) := by 
+  icmp IntPredicate.ult (LLVM.udiv (const? 32 4) e) (const? 32 4) ⊑ icmp IntPredicate.ugt e (const? 32 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -149,7 +149,7 @@ theorem test14_thm (e : IntW 32) :
 
 
 theorem test15_thm (e : IntW 32) :
-  icmp IntPredicate.ugt (LLVM.udiv (const? 32 4) e) (const? 32 (-1)) ⊑ const? 1 0 := by 
+  icmp IntPredicate.ugt (LLVM.udiv (const? 32 4) e) (const? 32 (-1)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -159,7 +159,7 @@ theorem test15_thm (e : IntW 32) :
 
 
 theorem test16_thm (e : IntW 32) :
-  icmp IntPredicate.ult (LLVM.udiv (const? 32 4) e) (const? 32 (-1)) ⊑ const? 1 1 := by 
+  icmp IntPredicate.ult (LLVM.udiv (const? 32 4) e) (const? 32 (-1)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gconditionalhnegation_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gconditionalhnegation_proof.lean
@@ -9,7 +9,7 @@ set_option linter.unreachableTactic false
 
 section gconditionalhnegation_proof
 theorem t0_thm (e : IntW 8) (e_1 : IntW 1) :
-  LLVM.xor (add (sext 8 e_1) e) (sext 8 e_1) ⊑ select e_1 (sub (const? 8 0) e) e := by 
+  LLVM.xor (add (sext 8 e_1) e) (sext 8 e_1) ⊑ select e_1 (sub (const? 8 0) e) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -19,7 +19,7 @@ theorem t0_thm (e : IntW 8) (e_1 : IntW 1) :
 
 
 theorem t1_thm (e : IntW 8) (e_1 : IntW 1) :
-  LLVM.xor (add (sext 8 e_1) e) (sext 8 e_1) ⊑ select e_1 (sub (const? 8 0) e) e := by 
+  LLVM.xor (add (sext 8 e_1) e) (sext 8 e_1) ⊑ select e_1 (sub (const? 8 0) e) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -29,7 +29,7 @@ theorem t1_thm (e : IntW 8) (e_1 : IntW 1) :
 
 
 theorem t2_thm (e : IntW 1) (e_1 : IntW 8) (e_2 : IntW 1) :
-  LLVM.xor (add (sext 8 e_2) e_1) (sext 8 e) ⊑ LLVM.xor (add e_1 (sext 8 e_2)) (sext 8 e) := by 
+  LLVM.xor (add (sext 8 e_2) e_1) (sext 8 e) ⊑ LLVM.xor (add e_1 (sext 8 e_2)) (sext 8 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -39,7 +39,7 @@ theorem t2_thm (e : IntW 1) (e_1 : IntW 8) (e_2 : IntW 1) :
 
 
 theorem t3_thm (e : IntW 8) (e_1 : IntW 2) :
-  LLVM.xor (add (sext 8 e_1) e) (sext 8 e_1) ⊑ LLVM.xor (add e (sext 8 e_1)) (sext 8 e_1) := by 
+  LLVM.xor (add (sext 8 e_1) e) (sext 8 e_1) ⊑ LLVM.xor (add e (sext 8 e_1)) (sext 8 e_1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gdebuginfohvariables_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gdebuginfohvariables_proof.lean
@@ -8,7 +8,7 @@ set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
 
 section gdebuginfohvariables_proof
-theorem test_sext_zext_thm (e : IntW 16) : sext 64 (zext 32 e) ⊑ zext 64 e := by 
+theorem test_sext_zext_thm (e : IntW 16) : sext 64 (zext 32 e) ⊑ zext 64 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -18,7 +18,7 @@ theorem test_sext_zext_thm (e : IntW 16) : sext 64 (zext 32 e) ⊑ zext 64 e := 
 
 
 theorem test_cast_select_thm (e : IntW 1) :
-  zext 32 (select e (const? 16 3) (const? 16 5)) ⊑ select e (const? 32 3) (const? 32 5) := by 
+  zext 32 (select e (const? 16 3) (const? 16 5)) ⊑ select e (const? 32 3) (const? 32 5) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gdemand_shrink_nsw_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gdemand_shrink_nsw_proof.lean
@@ -33,7 +33,7 @@ theorem foo_thm (e : IntW 32) :
             (const? 32 290))
           { «nsw» := true, «nuw» := true })
         (const? 32 1533579450) { «nsw» := false, «nuw» := true })
-      (const? 32 749011377) := by 
+      (const? 32 749011377) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gdemorgan_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gdemorgan_proof.lean
@@ -10,7 +10,7 @@ set_option linter.unreachableTactic false
 section gdemorgan_proof
 theorem demorgan_or_apint1_thm (e e_1 : IntW 43) :
   LLVM.or (LLVM.xor e_1 (const? 43 (-1))) (LLVM.xor e (const? 43 (-1))) ⊑
-    LLVM.xor (LLVM.and e_1 e) (const? 43 (-1)) := by 
+    LLVM.xor (LLVM.and e_1 e) (const? 43 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -21,7 +21,7 @@ theorem demorgan_or_apint1_thm (e e_1 : IntW 43) :
 
 theorem demorgan_or_apint2_thm (e e_1 : IntW 129) :
   LLVM.or (LLVM.xor e_1 (const? 129 (-1))) (LLVM.xor e (const? 129 (-1))) ⊑
-    LLVM.xor (LLVM.and e_1 e) (const? 129 (-1)) := by 
+    LLVM.xor (LLVM.and e_1 e) (const? 129 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -32,7 +32,7 @@ theorem demorgan_or_apint2_thm (e e_1 : IntW 129) :
 
 theorem demorgan_and_apint1_thm (e e_1 : IntW 477) :
   LLVM.and (LLVM.xor e_1 (const? 477 (-1))) (LLVM.xor e (const? 477 (-1))) ⊑
-    LLVM.xor (LLVM.or e_1 e) (const? 477 (-1)) := by 
+    LLVM.xor (LLVM.or e_1 e) (const? 477 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -43,7 +43,7 @@ theorem demorgan_and_apint1_thm (e e_1 : IntW 477) :
 
 theorem demorgan_and_apint2_thm (e e_1 : IntW 129) :
   LLVM.and (LLVM.xor e_1 (const? 129 (-1))) (LLVM.xor e (const? 129 (-1))) ⊑
-    LLVM.xor (LLVM.or e_1 e) (const? 129 (-1)) := by 
+    LLVM.xor (LLVM.or e_1 e) (const? 129 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -54,7 +54,7 @@ theorem demorgan_and_apint2_thm (e e_1 : IntW 129) :
 
 theorem demorgan_and_apint3_thm (e e_1 : IntW 65) :
   LLVM.and (LLVM.xor e_1 (const? 65 (-1))) (LLVM.xor (const? 65 (-1)) e) ⊑
-    LLVM.xor (LLVM.or e_1 e) (const? 65 (-1)) := by 
+    LLVM.xor (LLVM.or e_1 e) (const? 65 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -65,7 +65,7 @@ theorem demorgan_and_apint3_thm (e e_1 : IntW 65) :
 
 theorem demorgan_and_apint4_thm (e e_1 : IntW 66) :
   LLVM.and (LLVM.xor e_1 (const? 66 (-1))) (LLVM.xor e (const? 66 (-1))) ⊑
-    LLVM.xor (LLVM.or e_1 e) (const? 66 (-1)) := by 
+    LLVM.xor (LLVM.or e_1 e) (const? 66 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -76,7 +76,7 @@ theorem demorgan_and_apint4_thm (e e_1 : IntW 66) :
 
 theorem demorgan_and_apint5_thm (e e_1 : IntW 47) :
   LLVM.and (LLVM.xor e_1 (const? 47 (-1))) (LLVM.xor e (const? 47 (-1))) ⊑
-    LLVM.xor (LLVM.or e_1 e) (const? 47 (-1)) := by 
+    LLVM.xor (LLVM.or e_1 e) (const? 47 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -87,7 +87,7 @@ theorem demorgan_and_apint5_thm (e e_1 : IntW 47) :
 
 theorem test3_thm (e e_1 : IntW 32) :
   LLVM.xor (LLVM.and (LLVM.xor e_1 (const? 32 (-1))) (LLVM.xor e (const? 32 (-1)))) (const? 32 (-1)) ⊑
-    LLVM.or e_1 e := by 
+    LLVM.or e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -97,7 +97,7 @@ theorem test3_thm (e e_1 : IntW 32) :
 
 
 theorem test4_thm (e : IntW 32) :
-  LLVM.xor (LLVM.and (LLVM.xor e (const? 32 (-1))) (const? 32 5)) (const? 32 (-1)) ⊑ LLVM.or e (const? 32 (-6)) := by 
+  LLVM.xor (LLVM.and (LLVM.xor e (const? 32 (-1))) (const? 32 5)) (const? 32 (-1)) ⊑ LLVM.or e (const? 32 (-6)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -108,7 +108,7 @@ theorem test4_thm (e : IntW 32) :
 
 theorem test5_thm (e e_1 : IntW 32) :
   LLVM.xor (LLVM.or (LLVM.xor e_1 (const? 32 (-1))) (LLVM.xor e (const? 32 (-1)))) (const? 32 (-1)) ⊑
-    LLVM.and e_1 e := by 
+    LLVM.and e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -119,7 +119,7 @@ theorem test5_thm (e e_1 : IntW 32) :
 
 theorem test3_apint_thm (e e_1 : IntW 47) :
   LLVM.xor (LLVM.and (LLVM.xor e_1 (const? 47 (-1))) (LLVM.xor e (const? 47 (-1)))) (const? 47 (-1)) ⊑
-    LLVM.or e_1 e := by 
+    LLVM.or e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -129,7 +129,7 @@ theorem test3_apint_thm (e e_1 : IntW 47) :
 
 
 theorem test4_apint_thm (e : IntW 61) :
-  LLVM.and (LLVM.xor e (const? 61 (-1))) (const? 61 5) ⊑ LLVM.xor (LLVM.and e (const? 61 5)) (const? 61 5) := by 
+  LLVM.and (LLVM.xor e (const? 61 (-1))) (const? 61 5) ⊑ LLVM.xor (LLVM.and e (const? 61 5)) (const? 61 5) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -140,7 +140,7 @@ theorem test4_apint_thm (e : IntW 61) :
 
 theorem test5_apint_thm (e e_1 : IntW 71) :
   LLVM.xor (LLVM.or (LLVM.xor e_1 (const? 71 (-1))) (LLVM.xor e (const? 71 (-1)))) (const? 71 (-1)) ⊑
-    LLVM.and e_1 e := by 
+    LLVM.and e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -151,7 +151,7 @@ theorem test5_apint_thm (e e_1 : IntW 71) :
 
 theorem demorgan_nand_thm (e e_1 : IntW 8) :
   LLVM.xor (LLVM.and (LLVM.xor e_1 (const? 8 (-1))) e) (const? 8 (-1)) ⊑
-    LLVM.or e_1 (LLVM.xor e (const? 8 (-1))) := by 
+    LLVM.or e_1 (LLVM.xor e (const? 8 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -162,7 +162,7 @@ theorem demorgan_nand_thm (e e_1 : IntW 8) :
 
 theorem demorgan_nand_apint1_thm (e e_1 : IntW 7) :
   LLVM.xor (LLVM.and (LLVM.xor e_1 (const? 7 (-1))) e) (const? 7 (-1)) ⊑
-    LLVM.or e_1 (LLVM.xor e (const? 7 (-1))) := by 
+    LLVM.or e_1 (LLVM.xor e (const? 7 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -173,7 +173,7 @@ theorem demorgan_nand_apint1_thm (e e_1 : IntW 7) :
 
 theorem demorgan_nand_apint2_thm (e e_1 : IntW 117) :
   LLVM.xor (LLVM.and (LLVM.xor e_1 (const? 117 (-1))) e) (const? 117 (-1)) ⊑
-    LLVM.or e_1 (LLVM.xor e (const? 117 (-1))) := by 
+    LLVM.or e_1 (LLVM.xor e (const? 117 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -184,7 +184,7 @@ theorem demorgan_nand_apint2_thm (e e_1 : IntW 117) :
 
 theorem demorgan_nor_thm (e e_1 : IntW 8) :
   LLVM.xor (LLVM.or (LLVM.xor e_1 (const? 8 (-1))) e) (const? 8 (-1)) ⊑
-    LLVM.and e_1 (LLVM.xor e (const? 8 (-1))) := by 
+    LLVM.and e_1 (LLVM.xor e (const? 8 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -196,7 +196,7 @@ theorem demorgan_nor_thm (e e_1 : IntW 8) :
 theorem demorgan_nor_use2a_thm (e e_1 : IntW 8) :
   LLVM.sdiv (LLVM.xor (LLVM.or (LLVM.xor e_1 (const? 8 (-1))) e) (const? 8 (-1)))
       (mul (LLVM.xor e_1 (const? 8 (-1))) (const? 8 23)) ⊑
-    LLVM.sdiv (LLVM.and e_1 (LLVM.xor e (const? 8 (-1)))) (mul (LLVM.xor e_1 (const? 8 (-1))) (const? 8 23)) := by 
+    LLVM.sdiv (LLVM.and e_1 (LLVM.xor e (const? 8 (-1)))) (mul (LLVM.xor e_1 (const? 8 (-1))) (const? 8 23)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -207,7 +207,7 @@ theorem demorgan_nor_use2a_thm (e e_1 : IntW 8) :
 
 theorem demorgan_nor_use2b_thm (e e_1 : IntW 8) :
   LLVM.sdiv (LLVM.xor (LLVM.or (LLVM.xor e_1 (const? 8 (-1))) e) (const? 8 (-1))) (mul e (const? 8 23)) ⊑
-    LLVM.sdiv (LLVM.and e_1 (LLVM.xor e (const? 8 (-1)))) (mul e (const? 8 23)) := by 
+    LLVM.sdiv (LLVM.and e_1 (LLVM.xor e (const? 8 (-1)))) (mul e (const? 8 23)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -220,7 +220,7 @@ theorem demorgan_nor_use2c_thm (e e_1 : IntW 8) :
   LLVM.sdiv (LLVM.xor (LLVM.or (LLVM.xor e_1 (const? 8 (-1))) e) (const? 8 (-1)))
       (mul (LLVM.or (LLVM.xor e_1 (const? 8 (-1))) e) (const? 8 23)) ⊑
     LLVM.sdiv (LLVM.xor (LLVM.or e (LLVM.xor e_1 (const? 8 (-1)))) (const? 8 (-1)))
-      (mul (LLVM.or e (LLVM.xor e_1 (const? 8 (-1)))) (const? 8 23)) := by 
+      (mul (LLVM.or e (LLVM.xor e_1 (const? 8 (-1)))) (const? 8 23)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -233,7 +233,7 @@ theorem demorgan_nor_use2ab_thm (e e_1 : IntW 8) :
   LLVM.sdiv (LLVM.sdiv (LLVM.xor (LLVM.or (LLVM.xor e_1 (const? 8 (-1))) e) (const? 8 (-1))) (mul e (const? 8 23)))
       (mul (LLVM.xor e_1 (const? 8 (-1))) (const? 8 17)) ⊑
     LLVM.sdiv (LLVM.sdiv (LLVM.and e_1 (LLVM.xor e (const? 8 (-1)))) (mul e (const? 8 23)))
-      (mul (LLVM.xor e_1 (const? 8 (-1))) (const? 8 17)) := by 
+      (mul (LLVM.xor e_1 (const? 8 (-1))) (const? 8 17)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -250,7 +250,7 @@ theorem demorgan_nor_use2ac_thm (e e_1 : IntW 8) :
     LLVM.sdiv
       (LLVM.sdiv (LLVM.xor (LLVM.or e (LLVM.xor e_1 (const? 8 (-1)))) (const? 8 (-1)))
         (mul (LLVM.or e (LLVM.xor e_1 (const? 8 (-1)))) (const? 8 23)))
-      (mul (LLVM.xor e_1 (const? 8 (-1))) (const? 8 17)) := by 
+      (mul (LLVM.xor e_1 (const? 8 (-1))) (const? 8 17)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -267,7 +267,7 @@ theorem demorgan_nor_use2bc_thm (e e_1 : IntW 8) :
     LLVM.sdiv
       (LLVM.sdiv (LLVM.xor (LLVM.or e (LLVM.xor e_1 (const? 8 (-1)))) (const? 8 (-1)))
         (mul (LLVM.or e (LLVM.xor e_1 (const? 8 (-1)))) (const? 8 23)))
-      (mul e (const? 8 23)) := by 
+      (mul e (const? 8 23)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -278,7 +278,7 @@ theorem demorgan_nor_use2bc_thm (e e_1 : IntW 8) :
 
 theorem demorganize_constant2_thm (e : IntW 32) :
   LLVM.xor (LLVM.or e (const? 32 15)) (const? 32 (-1)) ⊑
-    LLVM.xor (LLVM.and e (const? 32 (-16))) (const? 32 (-16)) := by 
+    LLVM.xor (LLVM.and e (const? 32 (-16))) (const? 32 (-16)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -289,7 +289,7 @@ theorem demorganize_constant2_thm (e : IntW 32) :
 
 theorem demorgan_or_zext_thm (e e_1 : IntW 1) :
   LLVM.or (LLVM.xor (zext 32 e_1) (const? 32 1)) (LLVM.xor (zext 32 e) (const? 32 1)) ⊑
-    zext 32 (LLVM.xor (LLVM.and e_1 e) (const? 1 1)) := by 
+    zext 32 (LLVM.xor (LLVM.and e_1 e) (const? 1 1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -300,7 +300,7 @@ theorem demorgan_or_zext_thm (e e_1 : IntW 1) :
 
 theorem demorgan_and_zext_thm (e e_1 : IntW 1) :
   LLVM.and (LLVM.xor (zext 32 e_1) (const? 32 1)) (LLVM.xor (zext 32 e) (const? 32 1)) ⊑
-    zext 32 (LLVM.xor (LLVM.or e_1 e) (const? 1 1)) := by 
+    zext 32 (LLVM.xor (LLVM.or e_1 e) (const? 1 1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -312,7 +312,7 @@ theorem demorgan_and_zext_thm (e e_1 : IntW 1) :
 theorem PR28476_thm (e e_1 : IntW 32) :
   LLVM.xor (zext 32 (LLVM.and (icmp IntPredicate.ne e_1 (const? 32 0)) (icmp IntPredicate.ne e (const? 32 0))))
       (const? 32 1) ⊑
-    zext 32 (LLVM.or (icmp IntPredicate.eq e_1 (const? 32 0)) (icmp IntPredicate.eq e (const? 32 0))) := by 
+    zext 32 (LLVM.or (icmp IntPredicate.eq e_1 (const? 32 0)) (icmp IntPredicate.eq e (const? 32 0))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -326,7 +326,7 @@ theorem PR28476_logical_thm (e e_1 : IntW 32) :
       (zext 32 (select (icmp IntPredicate.ne e_1 (const? 32 0)) (icmp IntPredicate.ne e (const? 32 0)) (const? 1 0)))
       (const? 32 1) ⊑
     zext 32
-      (select (icmp IntPredicate.eq e_1 (const? 32 0)) (const? 1 1) (icmp IntPredicate.eq e (const? 32 0))) := by 
+      (select (icmp IntPredicate.eq e_1 (const? 32 0)) (const? 1 1) (icmp IntPredicate.eq e (const? 32 0))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -337,7 +337,7 @@ theorem PR28476_logical_thm (e e_1 : IntW 32) :
 
 theorem demorgan_plus_and_to_xor_thm (e e_1 : IntW 32) :
   LLVM.xor (LLVM.or (LLVM.and e_1 e) (LLVM.xor (LLVM.or e_1 e) (const? 32 (-1)))) (const? 32 (-1)) ⊑
-    LLVM.xor e_1 e := by 
+    LLVM.xor e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -348,7 +348,7 @@ theorem demorgan_plus_and_to_xor_thm (e e_1 : IntW 32) :
 
 theorem PR45984_thm (e e_1 : IntW 32) :
   LLVM.or (LLVM.xor e_1 e) (LLVM.xor (LLVM.or e_1 e) (const? 32 (-1))) ⊑
-    LLVM.xor (LLVM.and e_1 e) (const? 32 (-1)) := by 
+    LLVM.xor (LLVM.and e_1 e) (const? 32 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gdemorganhsinkhnothintohxor_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gdemorganhsinkhnothintohxor_proof.lean
@@ -10,7 +10,7 @@ set_option linter.unreachableTactic false
 section gdemorganhsinkhnothintohxor_proof
 theorem positive_easyinvert_thm (e : IntW 16) (e_1 : IntW 8) :
   LLVM.xor (LLVM.xor (icmp IntPredicate.slt e_1 (const? 8 0)) (icmp IntPredicate.slt e (const? 16 0))) (const? 1 1) ⊑
-    LLVM.xor (icmp IntPredicate.slt e_1 (const? 8 0)) (icmp IntPredicate.sgt e (const? 16 (-1))) := by 
+    LLVM.xor (icmp IntPredicate.slt e_1 (const? 8 0)) (icmp IntPredicate.sgt e (const? 16 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gdistribute_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gdistribute_proof.lean
@@ -8,7 +8,7 @@ set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
 
 section gdistribute_proof
-theorem factorize_thm (e : IntW 32) : LLVM.and (LLVM.or e (const? 32 1)) (LLVM.or e (const? 32 2)) ⊑ e := by 
+theorem factorize_thm (e : IntW 32) : LLVM.and (LLVM.or e (const? 32 1)) (LLVM.or e (const? 32 2)) ⊑ e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -17,7 +17,7 @@ theorem factorize_thm (e : IntW 32) : LLVM.and (LLVM.or e (const? 32 1)) (LLVM.o
     all_goals sorry
 
 
-theorem factorize2_thm (e : IntW 32) : sub (mul (const? 32 3) e) (mul (const? 32 2) e) ⊑ e := by 
+theorem factorize2_thm (e : IntW 32) : sub (mul (const? 32 3) e) (mul (const? 32 2) e) ⊑ e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -27,7 +27,7 @@ theorem factorize2_thm (e : IntW 32) : sub (mul (const? 32 3) e) (mul (const? 32
 
 
 theorem factorize3_thm (e e_1 e_2 : IntW 32) :
-  LLVM.and (LLVM.or e_2 (LLVM.or e_1 e)) (LLVM.or e_2 e) ⊑ LLVM.or e_2 e := by 
+  LLVM.and (LLVM.or e_2 (LLVM.or e_1 e)) (LLVM.or e_2 e) ⊑ LLVM.or e_2 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -36,7 +36,7 @@ theorem factorize3_thm (e e_1 e_2 : IntW 32) :
     all_goals sorry
 
 
-theorem factorize4_thm (e e_1 : IntW 32) : sub (mul (shl e_1 (const? 32 1)) e) (mul e e_1) ⊑ mul e_1 e := by 
+theorem factorize4_thm (e e_1 : IntW 32) : sub (mul (shl e_1 (const? 32 1)) e) (mul e e_1) ⊑ mul e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -45,7 +45,7 @@ theorem factorize4_thm (e e_1 : IntW 32) : sub (mul (shl e_1 (const? 32 1)) e) (
     all_goals sorry
 
 
-theorem factorize5_thm (e e_1 : IntW 32) : sub (mul (mul e_1 (const? 32 2)) e) (mul e e_1) ⊑ mul e_1 e := by 
+theorem factorize5_thm (e e_1 : IntW 32) : sub (mul (mul e_1 (const? 32 2)) e) (mul e e_1) ⊑ mul e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -55,7 +55,7 @@ theorem factorize5_thm (e e_1 : IntW 32) : sub (mul (mul e_1 (const? 32 2)) e) (
 
 
 theorem expand_thm (e : IntW 32) :
-  LLVM.and (LLVM.or (LLVM.and e (const? 32 1)) (const? 32 2)) (const? 32 1) ⊑ LLVM.and e (const? 32 1) := by 
+  LLVM.and (LLVM.or (LLVM.and e (const? 32 1)) (const? 32 2)) (const? 32 1) ⊑ LLVM.and e (const? 32 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gdivhi1_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gdivhi1_proof.lean
@@ -8,7 +8,7 @@ set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
 
 section gdivhi1_proof
-theorem sdiv_i1_is_op0_thm (e e_1 : IntW 1) : LLVM.sdiv e_1 e ⊑ e_1 := by 
+theorem sdiv_i1_is_op0_thm (e e_1 : IntW 1) : LLVM.sdiv e_1 e ⊑ e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -17,7 +17,7 @@ theorem sdiv_i1_is_op0_thm (e e_1 : IntW 1) : LLVM.sdiv e_1 e ⊑ e_1 := by
     all_goals sorry
 
 
-theorem udiv_i1_is_op0_thm (e e_1 : IntW 1) : LLVM.udiv e_1 e ⊑ e_1 := by 
+theorem udiv_i1_is_op0_thm (e e_1 : IntW 1) : LLVM.udiv e_1 e ⊑ e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -26,7 +26,7 @@ theorem udiv_i1_is_op0_thm (e e_1 : IntW 1) : LLVM.udiv e_1 e ⊑ e_1 := by
     all_goals sorry
 
 
-theorem srem_i1_is_zero_thm (e e_1 : IntW 1) : LLVM.srem e_1 e ⊑ const? 1 0 := by 
+theorem srem_i1_is_zero_thm (e e_1 : IntW 1) : LLVM.srem e_1 e ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -35,7 +35,7 @@ theorem srem_i1_is_zero_thm (e e_1 : IntW 1) : LLVM.srem e_1 e ⊑ const? 1 0 :=
     all_goals sorry
 
 
-theorem urem_i1_is_zero_thm (e e_1 : IntW 1) : urem e_1 e ⊑ const? 1 0 := by 
+theorem urem_i1_is_zero_thm (e e_1 : IntW 1) : urem e_1 e ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gdivhshift_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gdivhshift_proof.lean
@@ -9,7 +9,7 @@ set_option linter.unreachableTactic false
 
 section gdivhshift_proof
 theorem t1_thm (e : IntW 32) (e_1 : IntW 16) :
-  LLVM.sdiv (zext 32 e_1) (shl (const? 32 2) e) ⊑ lshr (zext 32 e_1) (add e (const? 32 1)) := by 
+  LLVM.sdiv (zext 32 e_1) (shl (const? 32 2) e) ⊑ lshr (zext 32 e_1) (add e (const? 32 1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -19,7 +19,7 @@ theorem t1_thm (e : IntW 32) (e_1 : IntW 16) :
 
 
 theorem t2_thm (e : IntW 32) (e_1 : IntW 64) :
-  LLVM.udiv e_1 (zext 64 (shl (const? 32 1) e)) ⊑ lshr e_1 (zext 64 e { «nneg» := true }) := by 
+  LLVM.udiv e_1 (zext 64 (shl (const? 32 1) e)) ⊑ lshr e_1 (zext 64 e { «nneg» := true }) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -29,7 +29,7 @@ theorem t2_thm (e : IntW 32) (e_1 : IntW 64) :
 
 
 theorem t3_thm (e : IntW 32) (e_1 : IntW 64) :
-  LLVM.udiv e_1 (zext 64 (shl (const? 32 4) e)) ⊑ lshr e_1 (zext 64 (add e (const? 32 2)) { «nneg» := true }) := by 
+  LLVM.udiv e_1 (zext 64 (shl (const? 32 4) e)) ⊑ lshr e_1 (zext 64 (add e (const? 32 2)) { «nneg» := true }) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -40,7 +40,7 @@ theorem t3_thm (e : IntW 32) (e_1 : IntW 64) :
 
 theorem t5_thm (e e_1 : IntW 1) (e_2 : IntW 32) :
   LLVM.udiv e_2 (select e_1 (select e (const? 32 32) (const? 32 64)) (shl (const? 32 1) e_2)) ⊑
-    lshr e_2 (select e_1 (select e (const? 32 5) (const? 32 6)) e_2) := by 
+    lshr e_2 (select e_1 (select e (const? 32 5) (const? 32 6)) e_2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -50,7 +50,7 @@ theorem t5_thm (e e_1 : IntW 1) (e_2 : IntW 32) :
 
 
 theorem t7_thm (e : IntW 32) :
-  LLVM.sdiv (shl e (const? 32 2) { «nsw» := true, «nuw» := false }) e ⊑ const? 32 4 := by 
+  LLVM.sdiv (shl e (const? 32 2) { «nsw» := true, «nuw» := false }) e ⊑ const? 32 4 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -61,7 +61,7 @@ theorem t7_thm (e : IntW 32) :
 
 theorem t10_thm (e e_1 : IntW 32) :
   LLVM.sdiv (shl e_1 e { «nsw» := true, «nuw» := false }) e_1 ⊑
-    shl (const? 32 1) e { «nsw» := true, «nuw» := true } := by 
+    shl (const? 32 1) e { «nsw» := true, «nuw» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -71,7 +71,7 @@ theorem t10_thm (e e_1 : IntW 32) :
 
 
 theorem t12_thm (e : IntW 32) :
-  LLVM.udiv (shl e (const? 32 2) { «nsw» := false, «nuw» := true }) e ⊑ const? 32 4 := by 
+  LLVM.udiv (shl e (const? 32 2) { «nsw» := false, «nuw» := true }) e ⊑ const? 32 4 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -82,7 +82,7 @@ theorem t12_thm (e : IntW 32) :
 
 theorem t15_thm (e e_1 : IntW 32) :
   LLVM.udiv (shl e_1 e { «nsw» := false, «nuw» := true }) e_1 ⊑
-    shl (const? 32 1) e { «nsw» := false, «nuw» := true } := by 
+    shl (const? 32 1) e { «nsw» := false, «nuw» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -93,7 +93,7 @@ theorem t15_thm (e e_1 : IntW 32) :
 
 theorem sdiv_mul_shl_nsw_thm (e e_1 e_2 : IntW 5) :
   LLVM.sdiv (mul e_2 e_1 { «nsw» := true, «nuw» := false }) (shl e_2 e { «nsw» := true, «nuw» := false }) ⊑
-    LLVM.sdiv e_1 (shl (const? 5 1) e { «nsw» := false, «nuw» := true }) := by 
+    LLVM.sdiv e_1 (shl (const? 5 1) e { «nsw» := false, «nuw» := true }) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -105,7 +105,7 @@ theorem sdiv_mul_shl_nsw_thm (e e_1 e_2 : IntW 5) :
 theorem sdiv_mul_shl_nsw_exact_commute1_thm (e e_1 e_2 : IntW 5) :
   LLVM.sdiv (mul e_2 e_1 { «nsw» := true, «nuw» := false }) (shl e_1 e { «nsw» := true, «nuw» := false })
       { «exact» := true } ⊑
-    LLVM.sdiv e_2 (shl (const? 5 1) e { «nsw» := false, «nuw» := true }) { «exact» := true } := by 
+    LLVM.sdiv e_2 (shl (const? 5 1) e { «nsw» := false, «nuw» := true }) { «exact» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -116,7 +116,7 @@ theorem sdiv_mul_shl_nsw_exact_commute1_thm (e e_1 e_2 : IntW 5) :
 
 theorem udiv_mul_shl_nuw_thm (e e_1 e_2 : IntW 5) :
   LLVM.udiv (mul e_2 e_1 { «nsw» := false, «nuw» := true }) (shl e_2 e { «nsw» := false, «nuw» := true }) ⊑
-    lshr e_1 e := by 
+    lshr e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -128,7 +128,7 @@ theorem udiv_mul_shl_nuw_thm (e e_1 e_2 : IntW 5) :
 theorem udiv_mul_shl_nuw_exact_commute1_thm (e e_1 e_2 : IntW 5) :
   LLVM.udiv (mul e_2 e_1 { «nsw» := false, «nuw» := true }) (shl e_1 e { «nsw» := false, «nuw» := true })
       { «exact» := true } ⊑
-    lshr e_2 e { «exact» := true } := by 
+    lshr e_2 e { «exact» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -139,7 +139,7 @@ theorem udiv_mul_shl_nuw_exact_commute1_thm (e e_1 e_2 : IntW 5) :
 
 theorem udiv_shl_mul_nuw_thm (e e_1 e_2 : IntW 5) :
   LLVM.udiv (shl e_2 e_1 { «nsw» := false, «nuw» := true }) (mul e_2 e { «nsw» := false, «nuw» := true }) ⊑
-    LLVM.udiv (shl (const? 5 1) e_1 { «nsw» := false, «nuw» := true }) e := by 
+    LLVM.udiv (shl (const? 5 1) e_1 { «nsw» := false, «nuw» := true }) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -150,7 +150,7 @@ theorem udiv_shl_mul_nuw_thm (e e_1 e_2 : IntW 5) :
 
 theorem udiv_shl_mul_nuw_swap_thm (e e_1 e_2 : IntW 5) :
   LLVM.udiv (shl e_2 e_1 { «nsw» := false, «nuw» := true }) (mul e e_2 { «nsw» := false, «nuw» := true }) ⊑
-    LLVM.udiv (shl (const? 5 1) e_1 { «nsw» := false, «nuw» := true }) e := by 
+    LLVM.udiv (shl (const? 5 1) e_1 { «nsw» := false, «nuw» := true }) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -162,7 +162,7 @@ theorem udiv_shl_mul_nuw_swap_thm (e e_1 e_2 : IntW 5) :
 theorem udiv_shl_mul_nuw_exact_thm (e e_1 e_2 : IntW 5) :
   LLVM.udiv (shl e_2 e_1 { «nsw» := false, «nuw» := true }) (mul e_2 e { «nsw» := false, «nuw» := true })
       { «exact» := true } ⊑
-    LLVM.udiv (shl (const? 5 1) e_1 { «nsw» := false, «nuw» := true }) e { «exact» := true } := by 
+    LLVM.udiv (shl (const? 5 1) e_1 { «nsw» := false, «nuw» := true }) e { «exact» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -172,7 +172,7 @@ theorem udiv_shl_mul_nuw_exact_thm (e e_1 e_2 : IntW 5) :
 
 
 theorem udiv_lshr_mul_nuw_thm (e e_1 e_2 : IntW 8) :
-  LLVM.udiv (lshr (mul e_2 e_1 { «nsw» := false, «nuw» := true }) e) e_2 ⊑ lshr e_1 e := by 
+  LLVM.udiv (lshr (mul e_2 e_1 { «nsw» := false, «nuw» := true }) e) e_2 ⊑ lshr e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -183,7 +183,7 @@ theorem udiv_lshr_mul_nuw_thm (e e_1 e_2 : IntW 8) :
 
 theorem sdiv_shl_shl_nsw2_nuw_thm (e e_1 e_2 : IntW 8) :
   LLVM.sdiv (shl e_2 e_1 { «nsw» := true, «nuw» := false }) (shl e e_1 { «nsw» := true, «nuw» := true }) ⊑
-    LLVM.sdiv e_2 e := by 
+    LLVM.sdiv e_2 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -194,7 +194,7 @@ theorem sdiv_shl_shl_nsw2_nuw_thm (e e_1 e_2 : IntW 8) :
 
 theorem udiv_shl_shl_nuw_nsw2_thm (e e_1 e_2 : IntW 8) :
   LLVM.udiv (shl e_2 e_1 { «nsw» := true, «nuw» := true }) (shl e e_1 { «nsw» := true, «nuw» := false }) ⊑
-    LLVM.udiv e_2 e := by 
+    LLVM.udiv e_2 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -206,7 +206,7 @@ theorem udiv_shl_shl_nuw_nsw2_thm (e e_1 e_2 : IntW 8) :
 theorem sdiv_shl_pair_const_thm (e : IntW 32) :
   LLVM.sdiv (shl e (const? 32 2) { «nsw» := true, «nuw» := false })
       (shl e (const? 32 1) { «nsw» := true, «nuw» := false }) ⊑
-    const? 32 2 := by 
+    const? 32 2 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -218,7 +218,7 @@ theorem sdiv_shl_pair_const_thm (e : IntW 32) :
 theorem udiv_shl_pair_const_thm (e : IntW 32) :
   LLVM.udiv (shl e (const? 32 2) { «nsw» := false, «nuw» := true })
       (shl e (const? 32 1) { «nsw» := false, «nuw» := true }) ⊑
-    const? 32 2 := by 
+    const? 32 2 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -229,7 +229,7 @@ theorem udiv_shl_pair_const_thm (e : IntW 32) :
 
 theorem sdiv_shl_pair1_thm (e e_1 e_2 : IntW 32) :
   LLVM.sdiv (shl e_2 e_1 { «nsw» := true, «nuw» := false }) (shl e_2 e { «nsw» := true, «nuw» := true }) ⊑
-    lshr (shl (const? 32 1) e_1 { «nsw» := true, «nuw» := true }) e := by 
+    lshr (shl (const? 32 1) e_1 { «nsw» := true, «nuw» := true }) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -240,7 +240,7 @@ theorem sdiv_shl_pair1_thm (e e_1 e_2 : IntW 32) :
 
 theorem sdiv_shl_pair2_thm (e e_1 e_2 : IntW 32) :
   LLVM.sdiv (shl e_2 e_1 { «nsw» := true, «nuw» := true }) (shl e_2 e { «nsw» := true, «nuw» := false }) ⊑
-    lshr (shl (const? 32 1) e_1 { «nsw» := true, «nuw» := true }) e := by 
+    lshr (shl (const? 32 1) e_1 { «nsw» := true, «nuw» := true }) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -251,7 +251,7 @@ theorem sdiv_shl_pair2_thm (e e_1 e_2 : IntW 32) :
 
 theorem sdiv_shl_pair3_thm (e e_1 e_2 : IntW 32) :
   LLVM.sdiv (shl e_2 e_1 { «nsw» := true, «nuw» := false }) (shl e_2 e { «nsw» := true, «nuw» := false }) ⊑
-    lshr (shl (const? 32 1) e_1 { «nsw» := false, «nuw» := true }) e := by 
+    lshr (shl (const? 32 1) e_1 { «nsw» := false, «nuw» := true }) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -262,7 +262,7 @@ theorem sdiv_shl_pair3_thm (e e_1 e_2 : IntW 32) :
 
 theorem udiv_shl_pair1_thm (e e_1 e_2 : IntW 32) :
   LLVM.udiv (shl e_2 e_1 { «nsw» := false, «nuw» := true }) (shl e_2 e { «nsw» := false, «nuw» := true }) ⊑
-    lshr (shl (const? 32 1) e_1 { «nsw» := false, «nuw» := true }) e := by 
+    lshr (shl (const? 32 1) e_1 { «nsw» := false, «nuw» := true }) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -273,7 +273,7 @@ theorem udiv_shl_pair1_thm (e e_1 e_2 : IntW 32) :
 
 theorem udiv_shl_pair2_thm (e e_1 e_2 : IntW 32) :
   LLVM.udiv (shl e_2 e_1 { «nsw» := true, «nuw» := true }) (shl e_2 e { «nsw» := false, «nuw» := true }) ⊑
-    lshr (shl (const? 32 1) e_1 { «nsw» := true, «nuw» := true }) e := by 
+    lshr (shl (const? 32 1) e_1 { «nsw» := true, «nuw» := true }) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -284,7 +284,7 @@ theorem udiv_shl_pair2_thm (e e_1 e_2 : IntW 32) :
 
 theorem udiv_shl_pair3_thm (e e_1 e_2 : IntW 32) :
   LLVM.udiv (shl e_2 e_1 { «nsw» := false, «nuw» := true }) (shl e_2 e { «nsw» := true, «nuw» := true }) ⊑
-    lshr (shl (const? 32 1) e_1 { «nsw» := false, «nuw» := true }) e := by 
+    lshr (shl (const? 32 1) e_1 { «nsw» := false, «nuw» := true }) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gearly_constfold_changes_IR_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gearly_constfold_changes_IR_proof.lean
@@ -8,7 +8,7 @@ set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
 
 section gearly_constfold_changes_IR_proof
-theorem foo_thm (e : IntW 32) : LLVM.and e (LLVM.or (const? 32 0) (const? 32 7)) ⊑ LLVM.and e (const? 32 7) := by 
+theorem foo_thm (e : IntW 32) : LLVM.and e (LLVM.or (const? 32 0) (const? 32 7)) ⊑ LLVM.and e (const? 32 7) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/geqhofhparts_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/geqhofhparts_proof.lean
@@ -11,7 +11,7 @@ section geqhofhparts_proof
 theorem eq_10_thm (e e_1 : IntW 32) :
   LLVM.and (icmp IntPredicate.eq (trunc 8 e_1) (trunc 8 e))
       (icmp IntPredicate.eq (trunc 8 (lshr e_1 (const? 32 8))) (trunc 8 (lshr e (const? 32 8)))) ⊑
-    icmp IntPredicate.eq (trunc 16 e_1) (trunc 16 e) := by 
+    icmp IntPredicate.eq (trunc 16 e_1) (trunc 16 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -24,7 +24,7 @@ theorem eq_210_thm (e e_1 : IntW 32) :
   LLVM.and (icmp IntPredicate.eq (trunc 8 (lshr e_1 (const? 32 16))) (trunc 8 (lshr e (const? 32 16))))
       (LLVM.and (icmp IntPredicate.eq (trunc 8 e_1) (trunc 8 e))
         (icmp IntPredicate.eq (trunc 8 (lshr e_1 (const? 32 8))) (trunc 8 (lshr e (const? 32 8))))) ⊑
-    icmp IntPredicate.eq (trunc 24 e_1) (trunc 24 e) := by 
+    icmp IntPredicate.eq (trunc 24 e_1) (trunc 24 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -38,7 +38,7 @@ theorem eq_3210_thm (e e_1 : IntW 32) :
       (LLVM.and (icmp IntPredicate.eq (trunc 8 (lshr e_1 (const? 32 16))) (trunc 8 (lshr e (const? 32 16))))
         (LLVM.and (icmp IntPredicate.eq (trunc 8 e_1) (trunc 8 e))
           (icmp IntPredicate.eq (trunc 8 (lshr e_1 (const? 32 8))) (trunc 8 (lshr e (const? 32 8)))))) ⊑
-    icmp IntPredicate.eq e_1 e := by 
+    icmp IntPredicate.eq e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -50,7 +50,7 @@ theorem eq_3210_thm (e e_1 : IntW 32) :
 theorem eq_21_thm (e e_1 : IntW 32) :
   LLVM.and (icmp IntPredicate.eq (trunc 8 (lshr e_1 (const? 32 16))) (trunc 8 (lshr e (const? 32 16))))
       (icmp IntPredicate.eq (trunc 8 (lshr e_1 (const? 32 8))) (trunc 8 (lshr e (const? 32 8)))) ⊑
-    icmp IntPredicate.eq (trunc 16 (lshr e_1 (const? 32 8))) (trunc 16 (lshr e (const? 32 8))) := by 
+    icmp IntPredicate.eq (trunc 16 (lshr e_1 (const? 32 8))) (trunc 16 (lshr e (const? 32 8))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -62,7 +62,7 @@ theorem eq_21_thm (e e_1 : IntW 32) :
 theorem eq_21_comm_and_thm (e e_1 : IntW 32) :
   LLVM.and (icmp IntPredicate.eq (trunc 8 (lshr e_1 (const? 32 8))) (trunc 8 (lshr e (const? 32 8))))
       (icmp IntPredicate.eq (trunc 8 (lshr e_1 (const? 32 16))) (trunc 8 (lshr e (const? 32 16)))) ⊑
-    icmp IntPredicate.eq (trunc 16 (lshr e_1 (const? 32 8))) (trunc 16 (lshr e (const? 32 8))) := by 
+    icmp IntPredicate.eq (trunc 16 (lshr e_1 (const? 32 8))) (trunc 16 (lshr e (const? 32 8))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -74,7 +74,7 @@ theorem eq_21_comm_and_thm (e e_1 : IntW 32) :
 theorem eq_21_comm_eq_thm (e e_1 : IntW 32) :
   LLVM.and (icmp IntPredicate.eq (trunc 8 (lshr e_1 (const? 32 16))) (trunc 8 (lshr e (const? 32 16))))
       (icmp IntPredicate.eq (trunc 8 (lshr e (const? 32 8))) (trunc 8 (lshr e_1 (const? 32 8)))) ⊑
-    icmp IntPredicate.eq (trunc 16 (lshr e_1 (const? 32 8))) (trunc 16 (lshr e (const? 32 8))) := by 
+    icmp IntPredicate.eq (trunc 16 (lshr e_1 (const? 32 8))) (trunc 16 (lshr e (const? 32 8))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -86,7 +86,7 @@ theorem eq_21_comm_eq_thm (e e_1 : IntW 32) :
 theorem eq_21_comm_eq2_thm (e e_1 : IntW 32) :
   LLVM.and (icmp IntPredicate.eq (trunc 8 (lshr e_1 (const? 32 16))) (trunc 8 (lshr e (const? 32 16))))
       (icmp IntPredicate.eq (trunc 8 (lshr e (const? 32 8))) (trunc 8 (lshr e_1 (const? 32 8)))) ⊑
-    icmp IntPredicate.eq (trunc 16 (lshr e_1 (const? 32 8))) (trunc 16 (lshr e (const? 32 8))) := by 
+    icmp IntPredicate.eq (trunc 16 (lshr e_1 (const? 32 8))) (trunc 16 (lshr e (const? 32 8))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -98,7 +98,7 @@ theorem eq_21_comm_eq2_thm (e e_1 : IntW 32) :
 theorem eq_irregular_bit_widths_thm (e e_1 : IntW 31) :
   LLVM.and (icmp IntPredicate.eq (trunc 5 (lshr e_1 (const? 31 13))) (trunc 5 (lshr e (const? 31 13))))
       (icmp IntPredicate.eq (trunc 6 (lshr e_1 (const? 31 7))) (trunc 6 (lshr e (const? 31 7)))) ⊑
-    icmp IntPredicate.eq (trunc 11 (lshr e_1 (const? 31 7))) (trunc 11 (lshr e (const? 31 7))) := by 
+    icmp IntPredicate.eq (trunc 11 (lshr e_1 (const? 31 7))) (trunc 11 (lshr e (const? 31 7))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -110,7 +110,7 @@ theorem eq_irregular_bit_widths_thm (e e_1 : IntW 31) :
 theorem eq_21_logical_thm (e e_1 : IntW 32) :
   select (icmp IntPredicate.eq (trunc 8 (lshr e_1 (const? 32 16))) (trunc 8 (lshr e (const? 32 16))))
       (icmp IntPredicate.eq (trunc 8 (lshr e_1 (const? 32 8))) (trunc 8 (lshr e (const? 32 8)))) (const? 1 0) ⊑
-    icmp IntPredicate.eq (trunc 16 (lshr e_1 (const? 32 8))) (trunc 16 (lshr e (const? 32 8))) := by 
+    icmp IntPredicate.eq (trunc 16 (lshr e_1 (const? 32 8))) (trunc 16 (lshr e (const? 32 8))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -122,7 +122,7 @@ theorem eq_21_logical_thm (e e_1 : IntW 32) :
 theorem eq_shift_in_zeros_thm (e e_1 : IntW 32) :
   LLVM.and (icmp IntPredicate.eq (trunc 24 (lshr e_1 (const? 32 16))) (trunc 24 (lshr e (const? 32 16))))
       (icmp IntPredicate.eq (trunc 8 (lshr e_1 (const? 32 8))) (trunc 8 (lshr e (const? 32 8)))) ⊑
-    icmp IntPredicate.ult (LLVM.xor e_1 e) (const? 32 256) := by 
+    icmp IntPredicate.ult (LLVM.xor e_1 e) (const? 32 256) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -134,7 +134,7 @@ theorem eq_shift_in_zeros_thm (e e_1 : IntW 32) :
 theorem ne_10_thm (e e_1 : IntW 32) :
   LLVM.or (icmp IntPredicate.ne (trunc 8 e_1) (trunc 8 e))
       (icmp IntPredicate.ne (trunc 8 (lshr e_1 (const? 32 8))) (trunc 8 (lshr e (const? 32 8)))) ⊑
-    icmp IntPredicate.ne (trunc 16 e_1) (trunc 16 e) := by 
+    icmp IntPredicate.ne (trunc 16 e_1) (trunc 16 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -147,7 +147,7 @@ theorem ne_210_thm (e e_1 : IntW 32) :
   LLVM.or (icmp IntPredicate.ne (trunc 8 (lshr e_1 (const? 32 16))) (trunc 8 (lshr e (const? 32 16))))
       (LLVM.or (icmp IntPredicate.ne (trunc 8 e_1) (trunc 8 e))
         (icmp IntPredicate.ne (trunc 8 (lshr e_1 (const? 32 8))) (trunc 8 (lshr e (const? 32 8))))) ⊑
-    icmp IntPredicate.ne (trunc 24 e_1) (trunc 24 e) := by 
+    icmp IntPredicate.ne (trunc 24 e_1) (trunc 24 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -161,7 +161,7 @@ theorem ne_3210_thm (e e_1 : IntW 32) :
       (LLVM.or (icmp IntPredicate.ne (trunc 8 (lshr e_1 (const? 32 16))) (trunc 8 (lshr e (const? 32 16))))
         (LLVM.or (icmp IntPredicate.ne (trunc 8 e_1) (trunc 8 e))
           (icmp IntPredicate.ne (trunc 8 (lshr e_1 (const? 32 8))) (trunc 8 (lshr e (const? 32 8)))))) ⊑
-    icmp IntPredicate.ne e_1 e := by 
+    icmp IntPredicate.ne e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -173,7 +173,7 @@ theorem ne_3210_thm (e e_1 : IntW 32) :
 theorem ne_21_thm (e e_1 : IntW 32) :
   LLVM.or (icmp IntPredicate.ne (trunc 8 (lshr e_1 (const? 32 16))) (trunc 8 (lshr e (const? 32 16))))
       (icmp IntPredicate.ne (trunc 8 (lshr e_1 (const? 32 8))) (trunc 8 (lshr e (const? 32 8)))) ⊑
-    icmp IntPredicate.ne (trunc 16 (lshr e_1 (const? 32 8))) (trunc 16 (lshr e (const? 32 8))) := by 
+    icmp IntPredicate.ne (trunc 16 (lshr e_1 (const? 32 8))) (trunc 16 (lshr e (const? 32 8))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -185,7 +185,7 @@ theorem ne_21_thm (e e_1 : IntW 32) :
 theorem ne_21_comm_or_thm (e e_1 : IntW 32) :
   LLVM.or (icmp IntPredicate.ne (trunc 8 (lshr e_1 (const? 32 8))) (trunc 8 (lshr e (const? 32 8))))
       (icmp IntPredicate.ne (trunc 8 (lshr e_1 (const? 32 16))) (trunc 8 (lshr e (const? 32 16)))) ⊑
-    icmp IntPredicate.ne (trunc 16 (lshr e_1 (const? 32 8))) (trunc 16 (lshr e (const? 32 8))) := by 
+    icmp IntPredicate.ne (trunc 16 (lshr e_1 (const? 32 8))) (trunc 16 (lshr e (const? 32 8))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -197,7 +197,7 @@ theorem ne_21_comm_or_thm (e e_1 : IntW 32) :
 theorem ne_21_comm_ne_thm (e e_1 : IntW 32) :
   LLVM.or (icmp IntPredicate.ne (trunc 8 (lshr e_1 (const? 32 16))) (trunc 8 (lshr e (const? 32 16))))
       (icmp IntPredicate.ne (trunc 8 (lshr e (const? 32 8))) (trunc 8 (lshr e_1 (const? 32 8)))) ⊑
-    icmp IntPredicate.ne (trunc 16 (lshr e_1 (const? 32 8))) (trunc 16 (lshr e (const? 32 8))) := by 
+    icmp IntPredicate.ne (trunc 16 (lshr e_1 (const? 32 8))) (trunc 16 (lshr e (const? 32 8))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -209,7 +209,7 @@ theorem ne_21_comm_ne_thm (e e_1 : IntW 32) :
 theorem ne_21_comm_ne2_thm (e e_1 : IntW 32) :
   LLVM.or (icmp IntPredicate.ne (trunc 8 (lshr e_1 (const? 32 16))) (trunc 8 (lshr e (const? 32 16))))
       (icmp IntPredicate.ne (trunc 8 (lshr e (const? 32 8))) (trunc 8 (lshr e_1 (const? 32 8)))) ⊑
-    icmp IntPredicate.ne (trunc 16 (lshr e_1 (const? 32 8))) (trunc 16 (lshr e (const? 32 8))) := by 
+    icmp IntPredicate.ne (trunc 16 (lshr e_1 (const? 32 8))) (trunc 16 (lshr e (const? 32 8))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -221,7 +221,7 @@ theorem ne_21_comm_ne2_thm (e e_1 : IntW 32) :
 theorem ne_irregular_bit_widths_thm (e e_1 : IntW 31) :
   LLVM.or (icmp IntPredicate.ne (trunc 5 (lshr e_1 (const? 31 13))) (trunc 5 (lshr e (const? 31 13))))
       (icmp IntPredicate.ne (trunc 6 (lshr e_1 (const? 31 7))) (trunc 6 (lshr e (const? 31 7)))) ⊑
-    icmp IntPredicate.ne (trunc 11 (lshr e_1 (const? 31 7))) (trunc 11 (lshr e (const? 31 7))) := by 
+    icmp IntPredicate.ne (trunc 11 (lshr e_1 (const? 31 7))) (trunc 11 (lshr e (const? 31 7))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -233,7 +233,7 @@ theorem ne_irregular_bit_widths_thm (e e_1 : IntW 31) :
 theorem ne_21_logical_thm (e e_1 : IntW 32) :
   select (icmp IntPredicate.ne (trunc 8 (lshr e_1 (const? 32 16))) (trunc 8 (lshr e (const? 32 16)))) (const? 1 1)
       (icmp IntPredicate.ne (trunc 8 (lshr e_1 (const? 32 8))) (trunc 8 (lshr e (const? 32 8)))) ⊑
-    icmp IntPredicate.ne (trunc 16 (lshr e_1 (const? 32 8))) (trunc 16 (lshr e (const? 32 8))) := by 
+    icmp IntPredicate.ne (trunc 16 (lshr e_1 (const? 32 8))) (trunc 16 (lshr e (const? 32 8))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -245,7 +245,7 @@ theorem ne_21_logical_thm (e e_1 : IntW 32) :
 theorem ne_shift_in_zeros_thm (e e_1 : IntW 32) :
   LLVM.or (icmp IntPredicate.ne (trunc 24 (lshr e_1 (const? 32 16))) (trunc 24 (lshr e (const? 32 16))))
       (icmp IntPredicate.ne (trunc 8 (lshr e_1 (const? 32 8))) (trunc 8 (lshr e (const? 32 8)))) ⊑
-    icmp IntPredicate.ugt (LLVM.xor e_1 e) (const? 32 255) := by 
+    icmp IntPredicate.ugt (LLVM.xor e_1 e) (const? 32 255) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -257,7 +257,7 @@ theorem ne_shift_in_zeros_thm (e e_1 : IntW 32) :
 theorem eq_optimized_highbits_cmp_thm (e e_1 : IntW 32) :
   LLVM.and (icmp IntPredicate.ult (LLVM.xor e_1 e) (const? 32 33554432))
       (icmp IntPredicate.eq (trunc 25 e) (trunc 25 e_1)) ⊑
-    icmp IntPredicate.eq e_1 e := by 
+    icmp IntPredicate.eq e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -269,7 +269,7 @@ theorem eq_optimized_highbits_cmp_thm (e e_1 : IntW 32) :
 theorem ne_optimized_highbits_cmp_thm (e e_1 : IntW 32) :
   LLVM.or (icmp IntPredicate.ugt (LLVM.xor e_1 e) (const? 32 16777215))
       (icmp IntPredicate.ne (trunc 24 e) (trunc 24 e_1)) ⊑
-    icmp IntPredicate.ne e_1 e := by 
+    icmp IntPredicate.ne e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gexact_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gexact_proof.lean
@@ -9,7 +9,7 @@ set_option linter.unreachableTactic false
 
 section gexact_proof
 theorem sdiv2_thm (e : IntW 32) :
-  LLVM.sdiv e (const? 32 8) { «exact» := true } ⊑ ashr e (const? 32 3) { «exact» := true } := by 
+  LLVM.sdiv e (const? 32 8) { «exact» := true } ⊑ ashr e (const? 32 3) { «exact» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -18,7 +18,7 @@ theorem sdiv2_thm (e : IntW 32) :
     all_goals sorry
 
 
-theorem sdiv4_thm (e : IntW 32) : mul (LLVM.sdiv e (const? 32 3) { «exact» := true }) (const? 32 3) ⊑ e := by 
+theorem sdiv4_thm (e : IntW 32) : mul (LLVM.sdiv e (const? 32 3) { «exact» := true }) (const? 32 3) ⊑ e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -28,7 +28,7 @@ theorem sdiv4_thm (e : IntW 32) : mul (LLVM.sdiv e (const? 32 3) { «exact» := 
 
 
 theorem sdiv6_thm (e : IntW 32) :
-  mul (LLVM.sdiv e (const? 32 3) { «exact» := true }) (const? 32 (-3)) ⊑ sub (const? 32 0) e := by 
+  mul (LLVM.sdiv e (const? 32 3) { «exact» := true }) (const? 32 (-3)) ⊑ sub (const? 32 0) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -37,7 +37,7 @@ theorem sdiv6_thm (e : IntW 32) :
     all_goals sorry
 
 
-theorem udiv1_thm (e e_1 : IntW 32) : mul (LLVM.udiv e_1 e { «exact» := true }) e ⊑ e_1 := by 
+theorem udiv1_thm (e e_1 : IntW 32) : mul (LLVM.udiv e_1 e { «exact» := true }) e ⊑ e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -47,7 +47,7 @@ theorem udiv1_thm (e e_1 : IntW 32) : mul (LLVM.udiv e_1 e { «exact» := true }
 
 
 theorem udiv2_thm (e e_1 : IntW 32) :
-  LLVM.udiv e_1 (shl (const? 32 1) e) { «exact» := true } ⊑ lshr e_1 e { «exact» := true } := by 
+  LLVM.udiv e_1 (shl (const? 32 1) e) { «exact» := true } ⊑ lshr e_1 e { «exact» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -57,7 +57,7 @@ theorem udiv2_thm (e e_1 : IntW 32) :
 
 
 theorem ashr1_thm (e : IntW 64) :
-  ashr (shl e (const? 64 8)) (const? 64 2) ⊑ ashr (shl e (const? 64 8)) (const? 64 2) { «exact» := true } := by 
+  ashr (shl e (const? 64 8)) (const? 64 2) ⊑ ashr (shl e (const? 64 8)) (const? 64 2) { «exact» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -68,7 +68,7 @@ theorem ashr1_thm (e : IntW 64) :
 
 theorem ashr_icmp1_thm (e : IntW 64) :
   icmp IntPredicate.eq (ashr e (const? 64 2) { «exact» := true }) (const? 64 0) ⊑
-    icmp IntPredicate.eq e (const? 64 0) := by 
+    icmp IntPredicate.eq e (const? 64 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -79,7 +79,7 @@ theorem ashr_icmp1_thm (e : IntW 64) :
 
 theorem ashr_icmp2_thm (e : IntW 64) :
   icmp IntPredicate.slt (ashr e (const? 64 2) { «exact» := true }) (const? 64 4) ⊑
-    icmp IntPredicate.slt e (const? 64 16) := by 
+    icmp IntPredicate.slt e (const? 64 16) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -91,7 +91,7 @@ theorem ashr_icmp2_thm (e : IntW 64) :
 theorem pr9998_thm (e : IntW 32) :
   icmp IntPredicate.ugt (sext 64 (ashr (shl e (const? 32 31)) (const? 32 31) { «exact» := true }))
       (const? 64 7297771788697658747) ⊑
-    icmp IntPredicate.ne (LLVM.and e (const? 32 1)) (const? 32 0) := by 
+    icmp IntPredicate.ne (LLVM.and e (const? 32 1)) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -102,7 +102,7 @@ theorem pr9998_thm (e : IntW 32) :
 
 theorem udiv_icmp1_thm (e : IntW 64) :
   icmp IntPredicate.ne (LLVM.udiv e (const? 64 5) { «exact» := true }) (const? 64 0) ⊑
-    icmp IntPredicate.ne e (const? 64 0) := by 
+    icmp IntPredicate.ne e (const? 64 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -113,7 +113,7 @@ theorem udiv_icmp1_thm (e : IntW 64) :
 
 theorem udiv_icmp2_thm (e : IntW 64) :
   icmp IntPredicate.eq (LLVM.udiv e (const? 64 5) { «exact» := true }) (const? 64 0) ⊑
-    icmp IntPredicate.eq e (const? 64 0) := by 
+    icmp IntPredicate.eq e (const? 64 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -124,7 +124,7 @@ theorem udiv_icmp2_thm (e : IntW 64) :
 
 theorem sdiv_icmp1_thm (e : IntW 64) :
   icmp IntPredicate.eq (LLVM.sdiv e (const? 64 5) { «exact» := true }) (const? 64 0) ⊑
-    icmp IntPredicate.eq e (const? 64 0) := by 
+    icmp IntPredicate.eq e (const? 64 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -135,7 +135,7 @@ theorem sdiv_icmp1_thm (e : IntW 64) :
 
 theorem sdiv_icmp2_thm (e : IntW 64) :
   icmp IntPredicate.eq (LLVM.sdiv e (const? 64 5) { «exact» := true }) (const? 64 1) ⊑
-    icmp IntPredicate.eq e (const? 64 5) := by 
+    icmp IntPredicate.eq e (const? 64 5) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -146,7 +146,7 @@ theorem sdiv_icmp2_thm (e : IntW 64) :
 
 theorem sdiv_icmp3_thm (e : IntW 64) :
   icmp IntPredicate.eq (LLVM.sdiv e (const? 64 5) { «exact» := true }) (const? 64 (-1)) ⊑
-    icmp IntPredicate.eq e (const? 64 (-5)) := by 
+    icmp IntPredicate.eq e (const? 64 (-5)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -157,7 +157,7 @@ theorem sdiv_icmp3_thm (e : IntW 64) :
 
 theorem sdiv_icmp4_thm (e : IntW 64) :
   icmp IntPredicate.eq (LLVM.sdiv e (const? 64 (-5)) { «exact» := true }) (const? 64 0) ⊑
-    icmp IntPredicate.eq e (const? 64 0) := by 
+    icmp IntPredicate.eq e (const? 64 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -168,7 +168,7 @@ theorem sdiv_icmp4_thm (e : IntW 64) :
 
 theorem sdiv_icmp5_thm (e : IntW 64) :
   icmp IntPredicate.eq (LLVM.sdiv e (const? 64 (-5)) { «exact» := true }) (const? 64 1) ⊑
-    icmp IntPredicate.eq e (const? 64 (-5)) := by 
+    icmp IntPredicate.eq e (const? 64 (-5)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -179,7 +179,7 @@ theorem sdiv_icmp5_thm (e : IntW 64) :
 
 theorem sdiv_icmp6_thm (e : IntW 64) :
   icmp IntPredicate.eq (LLVM.sdiv e (const? 64 (-5)) { «exact» := true }) (const? 64 (-1)) ⊑
-    icmp IntPredicate.eq e (const? 64 5) := by 
+    icmp IntPredicate.eq e (const? 64 5) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -189,7 +189,7 @@ theorem sdiv_icmp6_thm (e : IntW 64) :
 
 
 theorem mul_of_udiv_thm (e : IntW 8) :
-  mul (LLVM.udiv e (const? 8 12) { «exact» := true }) (const? 8 6) ⊑ lshr e (const? 8 1) { «exact» := true } := by 
+  mul (LLVM.udiv e (const? 8 12) { «exact» := true }) (const? 8 6) ⊑ lshr e (const? 8 1) { «exact» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -200,7 +200,7 @@ theorem mul_of_udiv_thm (e : IntW 8) :
 
 theorem mul_of_sdiv_thm (e : IntW 8) :
   mul (LLVM.sdiv e (const? 8 12) { «exact» := true }) (const? 8 (-6)) ⊑
-    sub (const? 8 0) (ashr e (const? 8 1) { «exact» := true }) { «nsw» := true, «nuw» := false } := by 
+    sub (const? 8 0) (ashr e (const? 8 1) { «exact» := true }) { «nsw» := true, «nuw» := false } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -211,7 +211,7 @@ theorem mul_of_sdiv_thm (e : IntW 8) :
 
 theorem mul_of_udiv_fail_bad_remainder_thm (e : IntW 8) :
   mul (LLVM.udiv e (const? 8 11) { «exact» := true }) (const? 8 6) ⊑
-    mul (LLVM.udiv e (const? 8 11) { «exact» := true }) (const? 8 6) { «nsw» := false, «nuw» := true } := by 
+    mul (LLVM.udiv e (const? 8 11) { «exact» := true }) (const? 8 6) { «nsw» := false, «nuw» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -221,7 +221,7 @@ theorem mul_of_udiv_fail_bad_remainder_thm (e : IntW 8) :
 
 
 theorem mul_of_sdiv_fail_ub_thm (e : IntW 8) :
-  mul (LLVM.sdiv e (const? 8 6) { «exact» := true }) (const? 8 (-6)) ⊑ sub (const? 8 0) e := by 
+  mul (LLVM.sdiv e (const? 8 6) { «exact» := true }) (const? 8 (-6)) ⊑ sub (const? 8 0) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gfoldhahorhbhzero_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gfoldhahorhbhzero_proof.lean
@@ -11,7 +11,7 @@ section gfoldhahorhbhzero_proof
 theorem a_or_b_thm (e e_1 : IntW 32) :
   LLVM.or (LLVM.and (icmp IntPredicate.eq e_1 (const? 32 0)) (icmp IntPredicate.ne e (const? 32 0)))
       (LLVM.and (icmp IntPredicate.ne e_1 (const? 32 0)) (icmp IntPredicate.eq e (const? 32 0))) ⊑
-    LLVM.xor (icmp IntPredicate.eq e_1 (const? 32 0)) (icmp IntPredicate.eq e (const? 32 0)) := by 
+    LLVM.xor (icmp IntPredicate.eq e_1 (const? 32 0)) (icmp IntPredicate.eq e (const? 32 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -23,7 +23,7 @@ theorem a_or_b_thm (e e_1 : IntW 32) :
 theorem a_or_b_const_thm (e e_1 e_2 : IntW 32) :
   LLVM.or (LLVM.and (icmp IntPredicate.eq e_2 e_1) (icmp IntPredicate.ne e e_1))
       (LLVM.and (icmp IntPredicate.ne e_2 e_1) (icmp IntPredicate.eq e e_1)) ⊑
-    LLVM.xor (icmp IntPredicate.eq e_2 e_1) (icmp IntPredicate.eq e e_1) := by 
+    LLVM.xor (icmp IntPredicate.eq e_2 e_1) (icmp IntPredicate.eq e e_1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -35,7 +35,7 @@ theorem a_or_b_const_thm (e e_1 e_2 : IntW 32) :
 theorem a_or_b_const2_thm (e e_1 e_2 e_3 : IntW 32) :
   LLVM.or (LLVM.and (icmp IntPredicate.eq e_3 e_2) (icmp IntPredicate.ne e_1 e))
       (LLVM.and (icmp IntPredicate.ne e_3 e_2) (icmp IntPredicate.eq e_1 e)) ⊑
-    LLVM.xor (icmp IntPredicate.eq e_3 e_2) (icmp IntPredicate.eq e_1 e) := by 
+    LLVM.xor (icmp IntPredicate.eq e_3 e_2) (icmp IntPredicate.eq e_1 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gfoldhinchofhaddhofhnothxhandhyhtohsubhxhfromhy_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gfoldhinchofhaddhofhnothxhandhyhtohsubhxhfromhy_proof.lean
@@ -8,7 +8,7 @@ set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
 
 section gfoldhinchofhaddhofhnothxhandhyhtohsubhxhfromhy_proof
-theorem t0_thm (e e_1 : IntW 32) : add (add (LLVM.xor e_1 (const? 32 (-1))) e) (const? 32 1) ⊑ sub e e_1 := by 
+theorem t0_thm (e e_1 : IntW 32) : add (add (LLVM.xor e_1 (const? 32 (-1))) e) (const? 32 1) ⊑ sub e e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -19,7 +19,7 @@ theorem t0_thm (e e_1 : IntW 32) : add (add (LLVM.xor e_1 (const? 32 (-1))) e) (
 
 theorem n12_thm (e e_1 : IntW 32) :
   add (add (LLVM.xor e_1 (const? 32 (-1))) e) (const? 32 2) ⊑
-    add (add e (LLVM.xor e_1 (const? 32 (-1)))) (const? 32 2) := by 
+    add (add e (LLVM.xor e_1 (const? 32 (-1)))) (const? 32 2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gfoldhselecthtrunc_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gfoldhselecthtrunc_proof.lean
@@ -10,7 +10,7 @@ set_option linter.unreachableTactic false
 section gfoldhselecthtrunc_proof
 theorem fold_select_trunc_nuw_true_thm (e e_1 : IntW 8) :
   select (trunc 1 e_1 { «nsw» := false, «nuw» := true }) e_1 e ⊑
-    select (trunc 1 e_1 { «nsw» := false, «nuw» := true }) (const? 8 1) e := by 
+    select (trunc 1 e_1 { «nsw» := false, «nuw» := true }) (const? 8 1) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -21,7 +21,7 @@ theorem fold_select_trunc_nuw_true_thm (e e_1 : IntW 8) :
 
 theorem fold_select_trunc_nuw_false_thm (e e_1 : IntW 8) :
   select (trunc 1 e_1 { «nsw» := false, «nuw» := true }) e e_1 ⊑
-    select (trunc 1 e_1 { «nsw» := false, «nuw» := true }) e (const? 8 0) := by 
+    select (trunc 1 e_1 { «nsw» := false, «nuw» := true }) e (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -32,7 +32,7 @@ theorem fold_select_trunc_nuw_false_thm (e e_1 : IntW 8) :
 
 theorem fold_select_trunc_nsw_true_thm (e e_1 : IntW 128) :
   select (trunc 1 e_1 { «nsw» := true, «nuw» := false }) e_1 e ⊑
-    select (trunc 1 e_1 { «nsw» := true, «nuw» := false }) (const? 128 (-1)) e := by 
+    select (trunc 1 e_1 { «nsw» := true, «nuw» := false }) (const? 128 (-1)) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -43,7 +43,7 @@ theorem fold_select_trunc_nsw_true_thm (e e_1 : IntW 128) :
 
 theorem fold_select_trunc_nsw_false_thm (e e_1 : IntW 8) :
   select (trunc 1 e_1 { «nsw» := true, «nuw» := false }) e e_1 ⊑
-    select (trunc 1 e_1 { «nsw» := true, «nuw» := false }) e (const? 8 0) := by 
+    select (trunc 1 e_1 { «nsw» := true, «nuw» := false }) e (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gfoldhsignbithtesthpower2_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gfoldhsignbithtesthpower2_proof.lean
@@ -10,7 +10,7 @@ set_option linter.unreachableTactic false
 section gfoldhsignbithtesthpower2_proof
 theorem pow2_or_zero_is_negative_commute_thm (e : IntW 8) :
   icmp IntPredicate.slt (LLVM.and (sub (const? 8 0) (mul (const? 8 42) e)) (mul (const? 8 42) e)) (const? 8 0) ⊑
-    icmp IntPredicate.eq (mul e (const? 8 42)) (const? 8 (-128)) := by 
+    icmp IntPredicate.eq (mul e (const? 8 42)) (const? 8 (-128)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -21,7 +21,7 @@ theorem pow2_or_zero_is_negative_commute_thm (e : IntW 8) :
 
 theorem pow2_or_zero_is_not_negative_commute_thm (e : IntW 8) :
   icmp IntPredicate.sgt (LLVM.and (sub (const? 8 0) (mul (const? 8 42) e)) (mul (const? 8 42) e)) (const? 8 (-1)) ⊑
-    icmp IntPredicate.ne (mul e (const? 8 42)) (const? 8 (-128)) := by 
+    icmp IntPredicate.ne (mul e (const? 8 42)) (const? 8 (-128)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gfoldhsubhofhnothtohinchofhadd_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gfoldhsubhofhnothtohinchofhadd_proof.lean
@@ -8,7 +8,7 @@ set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
 
 section gfoldhsubhofhnothtohinchofhadd_proof
-theorem p0_scalar_thm (e e_1 : IntW 32) : sub e_1 (LLVM.xor e (const? 32 (-1))) ⊑ add (add e (const? 32 1)) e_1 := by 
+theorem p0_scalar_thm (e e_1 : IntW 32) : sub e_1 (LLVM.xor e (const? 32 (-1))) ⊑ add (add e (const? 32 1)) e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gfreehinversion_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gfreehinversion_proof.lean
@@ -10,7 +10,7 @@ set_option linter.unreachableTactic false
 section gfreehinversion_proof
 theorem xor_1_thm (e e_1 e_2 : IntW 8) (e_3 : IntW 1) :
   LLVM.xor (LLVM.xor (select e_3 (LLVM.xor e_2 (const? 8 (-1))) (LLVM.xor e_1 (const? 8 123))) e) (const? 8 (-1)) ⊑
-    LLVM.xor (select e_3 e_2 (LLVM.xor e_1 (const? 8 (-124)))) e := by 
+    LLVM.xor (select e_3 e_2 (LLVM.xor e_1 (const? 8 (-124)))) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -21,7 +21,7 @@ theorem xor_1_thm (e e_1 e_2 : IntW 8) (e_3 : IntW 1) :
 
 theorem xor_2_thm (e e_1 : IntW 8) (e_2 : IntW 1) (e_3 : IntW 8) :
   LLVM.xor (LLVM.xor e_3 (select e_2 (LLVM.xor e_1 (const? 8 (-1))) (LLVM.xor e (const? 8 123)))) (const? 8 (-1)) ⊑
-    LLVM.xor e_3 (select e_2 e_1 (LLVM.xor e (const? 8 (-124)))) := by 
+    LLVM.xor e_3 (select e_2 e_1 (LLVM.xor e (const? 8 (-124)))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -32,7 +32,7 @@ theorem xor_2_thm (e e_1 : IntW 8) (e_2 : IntW 1) (e_3 : IntW 8) :
 
 theorem add_1_thm (e e_1 e_2 : IntW 8) (e_3 : IntW 1) :
   LLVM.xor (add (select e_3 (LLVM.xor e_2 (const? 8 (-1))) (LLVM.xor e_1 (const? 8 123))) e) (const? 8 (-1)) ⊑
-    sub (select e_3 e_2 (LLVM.xor e_1 (const? 8 (-124)))) e := by 
+    sub (select e_3 e_2 (LLVM.xor e_1 (const? 8 (-124)))) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -43,7 +43,7 @@ theorem add_1_thm (e e_1 e_2 : IntW 8) (e_3 : IntW 1) :
 
 theorem add_2_thm (e e_1 : IntW 8) (e_2 : IntW 1) (e_3 : IntW 8) :
   LLVM.xor (add e_3 (select e_2 (LLVM.xor e_1 (const? 8 (-1))) (LLVM.xor e (const? 8 123)))) (const? 8 (-1)) ⊑
-    sub (select e_2 e_1 (LLVM.xor e (const? 8 (-124)))) e_3 := by 
+    sub (select e_2 e_1 (LLVM.xor e (const? 8 (-124)))) e_3 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -54,7 +54,7 @@ theorem add_2_thm (e e_1 : IntW 8) (e_2 : IntW 1) (e_3 : IntW 8) :
 
 theorem sub_1_thm (e e_1 e_2 : IntW 8) (e_3 : IntW 1) :
   LLVM.xor (sub (select e_3 (LLVM.xor e_2 (const? 8 (-1))) (LLVM.xor e_1 (const? 8 123))) e) (const? 8 (-1)) ⊑
-    add (select e_3 e_2 (LLVM.xor e_1 (const? 8 (-124)))) e := by 
+    add (select e_3 e_2 (LLVM.xor e_1 (const? 8 (-124)))) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -65,7 +65,7 @@ theorem sub_1_thm (e e_1 e_2 : IntW 8) (e_3 : IntW 1) :
 
 theorem sub_2_thm (e e_1 : IntW 8) (e_2 : IntW 1) (e_3 : IntW 8) :
   LLVM.xor (sub e_3 (select e_2 (LLVM.xor e_1 (const? 8 (-1))) (LLVM.xor e (const? 8 123)))) (const? 8 (-1)) ⊑
-    sub (const? 8 (-2)) (add (select e_2 e_1 (LLVM.xor e (const? 8 (-124)))) e_3) := by 
+    sub (const? 8 (-2)) (add (select e_2 e_1 (LLVM.xor e (const? 8 (-124)))) e_3) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -76,7 +76,7 @@ theorem sub_2_thm (e e_1 : IntW 8) (e_2 : IntW 1) (e_3 : IntW 8) :
 
 theorem sub_3_thm (e e_1 : IntW 128) (e_2 : IntW 1) (e_3 : IntW 128) :
   LLVM.xor (sub e_3 (select e_2 (LLVM.xor e_1 (const? 128 (-1))) (LLVM.xor e (const? 128 123)))) (const? 128 (-1)) ⊑
-    sub (const? 128 (-2)) (add (select e_2 e_1 (LLVM.xor e (const? 128 (-124)))) e_3) := by 
+    sub (const? 128 (-2)) (add (select e_2 e_1 (LLVM.xor e (const? 128 (-124)))) e_3) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -87,7 +87,7 @@ theorem sub_3_thm (e e_1 : IntW 128) (e_2 : IntW 1) (e_3 : IntW 128) :
 
 theorem ashr_1_thm (e e_1 e_2 : IntW 8) (e_3 : IntW 1) :
   LLVM.xor (ashr (select e_3 (LLVM.xor e_2 (const? 8 (-1))) (LLVM.xor e_1 (const? 8 123))) e) (const? 8 (-1)) ⊑
-    ashr (select e_3 e_2 (LLVM.xor e_1 (const? 8 (-124)))) e := by 
+    ashr (select e_3 e_2 (LLVM.xor e_1 (const? 8 (-124)))) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -101,7 +101,7 @@ theorem select_1_thm (e e_1 : IntW 8) (e_2 : IntW 1) (e_3 e_4 : IntW 8) (e_5 : I
       (select e_5 (LLVM.xor e_4 (LLVM.xor e_3 (const? 8 45)))
         (select e_2 (LLVM.xor e_1 (const? 8 (-1))) (LLVM.xor e (const? 8 123))))
       (const? 8 (-1)) ⊑
-    select e_5 (LLVM.xor (LLVM.xor e_3 e_4) (const? 8 (-46))) (select e_2 e_1 (LLVM.xor e (const? 8 (-124)))) := by 
+    select e_5 (LLVM.xor (LLVM.xor e_3 e_4) (const? 8 (-46))) (select e_2 e_1 (LLVM.xor e (const? 8 (-124)))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -114,7 +114,7 @@ theorem select_2_thm (e e_1 e_2 : IntW 8) (e_3 e_4 : IntW 1) :
   LLVM.xor
       (select e_4 (select e_3 (LLVM.xor e_2 (const? 8 (-1))) (LLVM.xor e_1 (const? 8 123))) (LLVM.xor e (const? 8 45)))
       (const? 8 (-1)) ⊑
-    select e_4 (select e_3 e_2 (LLVM.xor e_1 (const? 8 (-124)))) (LLVM.xor e (const? 8 (-46))) := by 
+    select e_4 (select e_3 e_2 (LLVM.xor e_1 (const? 8 (-124)))) (LLVM.xor e (const? 8 (-46))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -125,7 +125,7 @@ theorem select_2_thm (e e_1 e_2 : IntW 8) (e_3 e_4 : IntW 1) :
 
 theorem lshr_not_nneg2_thm (e : IntW 8) :
   LLVM.xor (lshr (LLVM.xor e (const? 8 (-1))) (const? 8 1)) (const? 8 (-1)) ⊑
-    LLVM.or (lshr e (const? 8 1)) (const? 8 (-128)) { «disjoint» := true } := by 
+    LLVM.or (lshr e (const? 8 1)) (const? 8 (-128)) { «disjoint» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gfunnel_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gfunnel_proof.lean
@@ -14,7 +14,7 @@ theorem unmasked_shlop_insufficient_mask_shift_amount_thm (e e_1 e_2 : IntW 16) 
         (lshr (LLVM.and e (const? 16 255)) (LLVM.and e_1 (const? 16 15)))) ⊑
     trunc 8
       (LLVM.or (shl e_2 (sub (const? 16 8) (LLVM.and e_1 (const? 16 15)) { «nsw» := true, «nuw» := false }))
-        (lshr (LLVM.and e (const? 16 255)) (LLVM.and e_1 (const? 16 15)))) := by 
+        (lshr (LLVM.and e (const? 16 255)) (LLVM.and e_1 (const? 16 15)))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/ggethlowbitmaskhuptohandhincludinghbit_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/ggethlowbitmaskhuptohandhincludinghbit_proof.lean
@@ -10,7 +10,7 @@ set_option linter.unreachableTactic false
 section ggethlowbitmaskhuptohandhincludinghbit_proof
 theorem t0_thm (e : IntW 8) :
   LLVM.or (add (shl (const? 8 1) e) (const? 8 (-1))) (shl (const? 8 1) e) ⊑
-    lshr (const? 8 (-1)) (sub (const? 8 7) e) := by 
+    lshr (const? 8 (-1)) (sub (const? 8 7) e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -21,7 +21,7 @@ theorem t0_thm (e : IntW 8) :
 
 theorem t1_thm (e : IntW 16) :
   LLVM.or (add (shl (const? 16 1) e) (const? 16 (-1))) (shl (const? 16 1) e) ⊑
-    lshr (const? 16 (-1)) (sub (const? 16 15) e) := by 
+    lshr (const? 16 (-1)) (sub (const? 16 15) e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -33,7 +33,7 @@ theorem t1_thm (e : IntW 16) :
 theorem t9_nocse_thm (e : IntW 8) :
   LLVM.or (add (shl (const? 8 1) e) (const? 8 (-1))) (shl (const? 8 1) e) ⊑
     LLVM.or (shl (const? 8 1) e { «nsw» := false, «nuw» := true })
-      (LLVM.xor (shl (const? 8 (-1)) e { «nsw» := true, «nuw» := false }) (const? 8 (-1))) := by 
+      (LLVM.xor (shl (const? 8 (-1)) e { «nsw» := true, «nuw» := false }) (const? 8 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -45,7 +45,7 @@ theorem t9_nocse_thm (e : IntW 8) :
 theorem t17_nocse_mismatching_x_thm (e e_1 : IntW 8) :
   LLVM.or (add (shl (const? 8 1) e_1) (const? 8 (-1))) (shl (const? 8 1) e) ⊑
     LLVM.or (shl (const? 8 1) e { «nsw» := false, «nuw» := true })
-      (LLVM.xor (shl (const? 8 (-1)) e_1 { «nsw» := true, «nuw» := false }) (const? 8 (-1))) := by 
+      (LLVM.xor (shl (const? 8 (-1)) e_1 { «nsw» := true, «nuw» := false }) (const? 8 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/ghighhbithsignmask_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/ghighhbithsignmask_proof.lean
@@ -8,7 +8,7 @@ set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
 
 section ghighhbithsignmask_proof
-theorem t0_thm (e : IntW 64) : sub (const? 64 0) (lshr e (const? 64 63)) ⊑ ashr e (const? 64 63) := by 
+theorem t0_thm (e : IntW 64) : sub (const? 64 0) (lshr e (const? 64 63)) ⊑ ashr e (const? 64 63) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -18,7 +18,7 @@ theorem t0_thm (e : IntW 64) : sub (const? 64 0) (lshr e (const? 64 63)) ⊑ ash
 
 
 theorem t0_exact_thm (e : IntW 64) :
-  sub (const? 64 0) (lshr e (const? 64 63) { «exact» := true }) ⊑ ashr e (const? 64 63) { «exact» := true } := by 
+  sub (const? 64 0) (lshr e (const? 64 63) { «exact» := true }) ⊑ ashr e (const? 64 63) { «exact» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -27,7 +27,7 @@ theorem t0_exact_thm (e : IntW 64) :
     all_goals sorry
 
 
-theorem t2_thm (e : IntW 64) : sub (const? 64 0) (ashr e (const? 64 63)) ⊑ lshr e (const? 64 63) := by 
+theorem t2_thm (e : IntW 64) : sub (const? 64 0) (ashr e (const? 64 63)) ⊑ lshr e (const? 64 63) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -37,7 +37,7 @@ theorem t2_thm (e : IntW 64) : sub (const? 64 0) (ashr e (const? 64 63)) ⊑ lsh
 
 
 theorem t3_exact_thm (e : IntW 64) :
-  sub (const? 64 0) (ashr e (const? 64 63) { «exact» := true }) ⊑ lshr e (const? 64 63) { «exact» := true } := by 
+  sub (const? 64 0) (ashr e (const? 64 63) { «exact» := true }) ⊑ lshr e (const? 64 63) { «exact» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -48,7 +48,7 @@ theorem t3_exact_thm (e : IntW 64) :
 
 theorem n9_thm (e : IntW 64) :
   sub (const? 64 0) (lshr e (const? 64 62)) ⊑
-    sub (const? 64 0) (lshr e (const? 64 62)) { «nsw» := true, «nuw» := false } := by 
+    sub (const? 64 0) (lshr e (const? 64 62)) { «nsw» := true, «nuw» := false } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -58,7 +58,7 @@ theorem n9_thm (e : IntW 64) :
 
 
 theorem n10_thm (e : IntW 64) :
-  sub (const? 64 1) (lshr e (const? 64 63)) ⊑ zext 64 (icmp IntPredicate.sgt e (const? 64 (-1))) := by 
+  sub (const? 64 1) (lshr e (const? 64 63)) ⊑ zext 64 (icmp IntPredicate.sgt e (const? 64 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/ghighhbithsignmaskhwithhtrunc_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/ghighhbithsignmaskhwithhtrunc_proof.lean
@@ -10,7 +10,7 @@ set_option linter.unreachableTactic false
 section ghighhbithsignmaskhwithhtrunc_proof
 theorem t0_thm (e : IntW 64) :
   sub (const? 32 0) (trunc 32 (lshr e (const? 64 63))) ⊑
-    trunc 32 (ashr e (const? 64 63)) { «nsw» := true, «nuw» := false } := by 
+    trunc 32 (ashr e (const? 64 63)) { «nsw» := true, «nuw» := false } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -21,7 +21,7 @@ theorem t0_thm (e : IntW 64) :
 
 theorem t1_exact_thm (e : IntW 64) :
   sub (const? 32 0) (trunc 32 (lshr e (const? 64 63) { «exact» := true })) ⊑
-    trunc 32 (ashr e (const? 64 63) { «exact» := true }) { «nsw» := true, «nuw» := false } := by 
+    trunc 32 (ashr e (const? 64 63) { «exact» := true }) { «nsw» := true, «nuw» := false } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -32,7 +32,7 @@ theorem t1_exact_thm (e : IntW 64) :
 
 theorem t2_thm (e : IntW 64) :
   sub (const? 32 0) (trunc 32 (ashr e (const? 64 63))) ⊑
-    trunc 32 (lshr e (const? 64 63)) { «nsw» := true, «nuw» := true } := by 
+    trunc 32 (lshr e (const? 64 63)) { «nsw» := true, «nuw» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -43,7 +43,7 @@ theorem t2_thm (e : IntW 64) :
 
 theorem t3_exact_thm (e : IntW 64) :
   sub (const? 32 0) (trunc 32 (ashr e (const? 64 63) { «exact» := true })) ⊑
-    trunc 32 (lshr e (const? 64 63) { «exact» := true }) { «nsw» := true, «nuw» := true } := by 
+    trunc 32 (lshr e (const? 64 63) { «exact» := true }) { «nsw» := true, «nuw» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -55,7 +55,7 @@ theorem t3_exact_thm (e : IntW 64) :
 theorem n9_thm (e : IntW 64) :
   sub (const? 32 0) (trunc 32 (lshr e (const? 64 62))) ⊑
     sub (const? 32 0) (trunc 32 (lshr e (const? 64 62)) { «nsw» := true, «nuw» := true })
-      { «nsw» := true, «nuw» := false } := by 
+      { «nsw» := true, «nuw» := false } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -67,7 +67,7 @@ theorem n9_thm (e : IntW 64) :
 theorem n10_thm (e : IntW 64) :
   sub (const? 32 1) (trunc 32 (lshr e (const? 64 63))) ⊑
     add (trunc 32 (ashr e (const? 64 63)) { «nsw» := true, «nuw» := false }) (const? 32 1)
-      { «nsw» := true, «nuw» := false } := by 
+      { «nsw» := true, «nuw» := false } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/ghoisthnegationhouthofhbiashcalculation_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/ghoisthnegationhouthofhbiashcalculation_proof.lean
@@ -9,7 +9,7 @@ set_option linter.unreachableTactic false
 
 section ghoisthnegationhouthofhbiashcalculation_proof
 theorem t0_thm (e e_1 : IntW 8) :
-  sub (LLVM.and (sub (const? 8 0) e_1) e) e ⊑ sub (const? 8 0) (LLVM.and e (add e_1 (const? 8 (-1)))) := by 
+  sub (LLVM.and (sub (const? 8 0) e_1) e) e ⊑ sub (const? 8 0) (LLVM.and e (add e_1 (const? 8 (-1)))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -19,7 +19,7 @@ theorem t0_thm (e e_1 : IntW 8) :
 
 
 theorem n7_thm (e e_1 : IntW 8) :
-  sub e_1 (LLVM.and (sub (const? 8 0) e) e_1) ⊑ LLVM.and e_1 (add e (const? 8 (-1))) := by 
+  sub e_1 (LLVM.and (sub (const? 8 0) e) e_1) ⊑ LLVM.and e_1 (add e (const? 8 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/ghoisthnegationhouthofhbiashcalculationhwithhconstant_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/ghoisthnegationhouthofhbiashcalculationhwithhconstant_proof.lean
@@ -9,7 +9,7 @@ set_option linter.unreachableTactic false
 
 section ghoisthnegationhouthofhbiashcalculationhwithhconstant_proof
 theorem t0_thm (e : IntW 8) :
-  sub (LLVM.and e (const? 8 42)) e ⊑ sub (const? 8 0) (LLVM.and e (const? 8 (-43))) := by 
+  sub (LLVM.and e (const? 8 42)) e ⊑ sub (const? 8 0) (LLVM.and e (const? 8 (-43))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -18,7 +18,7 @@ theorem t0_thm (e : IntW 8) :
     all_goals sorry
 
 
-theorem n5_thm (e : IntW 8) : sub e (LLVM.and e (const? 8 42)) ⊑ LLVM.and e (const? 8 (-43)) := by 
+theorem n5_thm (e : IntW 8) : sub e (LLVM.and e (const? 8 42)) ⊑ LLVM.and e (const? 8 (-43)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/ghoisthnothfromhashrhoperand_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/ghoisthnothfromhashrhoperand_proof.lean
@@ -9,7 +9,7 @@ set_option linter.unreachableTactic false
 
 section ghoisthnothfromhashrhoperand_proof
 theorem t0_thm (e e_1 : IntW 8) :
-  ashr (LLVM.xor e_1 (const? 8 (-1))) e ⊑ LLVM.xor (ashr e_1 e) (const? 8 (-1)) := by 
+  ashr (LLVM.xor e_1 (const? 8 (-1))) e ⊑ LLVM.xor (ashr e_1 e) (const? 8 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -19,7 +19,7 @@ theorem t0_thm (e e_1 : IntW 8) :
 
 
 theorem t1_thm (e e_1 : IntW 8) :
-  ashr (LLVM.xor e_1 (const? 8 (-1))) e { «exact» := true } ⊑ LLVM.xor (ashr e_1 e) (const? 8 (-1)) := by 
+  ashr (LLVM.xor e_1 (const? 8 (-1))) e { «exact» := true } ⊑ LLVM.xor (ashr e_1 e) (const? 8 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/ghoisthxorhbyhconstanthfromhxorhbyhvalue_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/ghoisthxorhbyhconstanthfromhxorhbyhvalue_proof.lean
@@ -9,7 +9,7 @@ set_option linter.unreachableTactic false
 
 section ghoisthxorhbyhconstanthfromhxorhbyhvalue_proof
 theorem t0_scalar_thm (e e_1 : IntW 8) :
-  LLVM.xor (LLVM.xor e_1 (const? 8 42)) e ⊑ LLVM.xor (LLVM.xor e_1 e) (const? 8 42) := by 
+  LLVM.xor (LLVM.xor e_1 (const? 8 42)) e ⊑ LLVM.xor (LLVM.xor e_1 e) (const? 8 42) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gicmphandhlowbithmask_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gicmphandhlowbithmask_proof.lean
@@ -11,7 +11,7 @@ section gicmphandhlowbithmask_proof
 theorem src_is_mask_zext_thm (e : IntW 8) (e_1 : IntW 16) :
   icmp IntPredicate.eq (LLVM.and (LLVM.xor e_1 (const? 16 123)) (zext 16 (lshr (const? 8 (-1)) e)))
       (LLVM.xor e_1 (const? 16 123)) ⊑
-    icmp IntPredicate.ule (LLVM.xor e_1 (const? 16 123)) (zext 16 (lshr (const? 8 (-1)) e)) := by 
+    icmp IntPredicate.ule (LLVM.xor e_1 (const? 16 123)) (zext 16 (lshr (const? 8 (-1)) e)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -24,7 +24,7 @@ theorem src_is_mask_zext_fail_not_mask_thm (e : IntW 8) (e_1 : IntW 16) :
   icmp IntPredicate.eq (LLVM.and (LLVM.xor e_1 (const? 16 123)) (zext 16 (lshr (const? 8 (-2)) e)))
       (LLVM.xor e_1 (const? 16 123)) ⊑
     icmp IntPredicate.eq (LLVM.or (LLVM.xor e_1 (const? 16 (-124))) (zext 16 (lshr (const? 8 (-2)) e)))
-      (const? 16 (-1)) := by 
+      (const? 16 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -37,7 +37,7 @@ theorem src_is_mask_sext_thm (e : IntW 16) (e_1 : IntW 8) :
   icmp IntPredicate.eq
       (LLVM.and (LLVM.xor (sext 16 (lshr (const? 8 31) e_1)) (const? 16 (-1))) (LLVM.xor e (const? 16 123)))
       (const? 16 0) ⊑
-    icmp IntPredicate.ule (LLVM.xor e (const? 16 123)) (zext 16 (lshr (const? 8 31) e_1) { «nneg» := true }) := by 
+    icmp IntPredicate.ule (LLVM.xor e (const? 16 123)) (zext 16 (lshr (const? 8 31) e_1) { «nneg» := true }) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -50,7 +50,7 @@ theorem src_is_mask_and_thm (e e_1 e_2 : IntW 8) :
   icmp IntPredicate.eq (LLVM.xor e_2 (const? 8 123))
       (LLVM.and (LLVM.xor e_2 (const? 8 123)) (LLVM.and (ashr (const? 8 7) e_1) (lshr (const? 8 (-1)) e))) ⊑
     icmp IntPredicate.ule (LLVM.xor e_2 (const? 8 123))
-      (LLVM.and (lshr (const? 8 7) e_1) (lshr (const? 8 (-1)) e)) := by 
+      (LLVM.and (lshr (const? 8 7) e_1) (lshr (const? 8 (-1)) e)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -64,7 +64,7 @@ theorem src_is_mask_and_fail_mixed_thm (e e_1 e_2 : IntW 8) :
       (LLVM.and (LLVM.xor e_2 (const? 8 123)) (LLVM.and (ashr (const? 8 (-8)) e_1) (lshr (const? 8 (-1)) e))) ⊑
     icmp IntPredicate.eq
       (LLVM.or (LLVM.and (ashr (const? 8 (-8)) e_1) (lshr (const? 8 (-1)) e)) (LLVM.xor e_2 (const? 8 (-124))))
-      (const? 8 (-1)) := by 
+      (const? 8 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -76,7 +76,7 @@ theorem src_is_mask_and_fail_mixed_thm (e e_1 e_2 : IntW 8) :
 theorem src_is_mask_or_thm (e e_1 : IntW 8) :
   icmp IntPredicate.eq (LLVM.xor e_1 (const? 8 123))
       (LLVM.and (LLVM.and (lshr (const? 8 (-1)) e) (const? 8 7)) (LLVM.xor e_1 (const? 8 123))) ⊑
-    icmp IntPredicate.ule (LLVM.xor e_1 (const? 8 123)) (LLVM.and (lshr (const? 8 (-1)) e) (const? 8 7)) := by 
+    icmp IntPredicate.ule (LLVM.xor e_1 (const? 8 123)) (LLVM.and (lshr (const? 8 (-1)) e) (const? 8 7)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -88,7 +88,7 @@ theorem src_is_mask_or_thm (e e_1 : IntW 8) :
 theorem src_is_mask_xor_thm (e e_1 : IntW 8) :
   icmp IntPredicate.ne (LLVM.and (LLVM.xor e_1 (const? 8 123)) (LLVM.xor e (add e (const? 8 (-1)))))
       (LLVM.xor e_1 (const? 8 123)) ⊑
-    icmp IntPredicate.ugt (LLVM.xor e_1 (const? 8 123)) (LLVM.xor e (add e (const? 8 (-1)))) := by 
+    icmp IntPredicate.ugt (LLVM.xor e_1 (const? 8 123)) (LLVM.xor e (add e (const? 8 (-1)))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -102,7 +102,7 @@ theorem src_is_mask_xor_fail_notmask_thm (e e_1 : IntW 8) :
       (LLVM.and (LLVM.xor e_1 (const? 8 123)) (LLVM.xor (LLVM.xor e (add e (const? 8 (-1)))) (const? 8 (-1))))
       (LLVM.xor e_1 (const? 8 123)) ⊑
     icmp IntPredicate.ne (LLVM.or (LLVM.xor e (sub (const? 8 0) e)) (LLVM.xor e_1 (const? 8 (-124))))
-      (const? 8 (-1)) := by 
+      (const? 8 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -116,7 +116,7 @@ theorem src_is_mask_select_thm (e e_1 : IntW 8) (e_2 : IntW 1) :
       (LLVM.and (select e_2 (LLVM.xor e_1 (add e_1 (const? 8 (-1)))) (const? 8 15)) (LLVM.xor e (const? 8 123)))
       (LLVM.xor e (const? 8 123)) ⊑
     icmp IntPredicate.ugt (LLVM.xor e (const? 8 123))
-      (select e_2 (LLVM.xor e_1 (add e_1 (const? 8 (-1)))) (const? 8 15)) := by 
+      (select e_2 (LLVM.xor e_1 (add e_1 (const? 8 (-1)))) (const? 8 15)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -128,7 +128,7 @@ theorem src_is_mask_select_thm (e e_1 : IntW 8) (e_2 : IntW 1) :
 theorem src_is_mask_shl_lshr_thm (e e_1 : IntW 8) :
   icmp IntPredicate.ne (const? 8 0)
       (LLVM.and (LLVM.xor e_1 (const? 8 123)) (LLVM.xor (lshr (shl (const? 8 (-1)) e) e) (const? 8 (-1)))) ⊑
-    icmp IntPredicate.ugt (LLVM.xor e_1 (const? 8 122)) (lshr (const? 8 (-1)) e) := by 
+    icmp IntPredicate.ugt (LLVM.xor e_1 (const? 8 122)) (lshr (const? 8 (-1)) e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -141,7 +141,7 @@ theorem src_is_mask_shl_lshr_fail_not_allones_thm (e e_1 : IntW 8) :
   icmp IntPredicate.ne (const? 8 0)
       (LLVM.and (LLVM.xor e_1 (const? 8 123)) (LLVM.xor (lshr (shl (const? 8 (-2)) e) e) (const? 8 (-1)))) ⊑
     icmp IntPredicate.ne (LLVM.or (LLVM.xor e_1 (const? 8 (-124))) (LLVM.and (lshr (const? 8 (-1)) e) (const? 8 (-2))))
-      (const? 8 (-1)) := by 
+      (const? 8 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -155,7 +155,7 @@ theorem src_is_mask_lshr_thm (e e_1 : IntW 8) (e_2 : IntW 1) (e_3 : IntW 8) :
       (LLVM.and (lshr (select e_2 (LLVM.xor e_1 (add e_1 (const? 8 (-1)))) (const? 8 15)) e)
         (LLVM.xor e_3 (const? 8 123))) ⊑
     icmp IntPredicate.ugt (LLVM.xor e_3 (const? 8 123))
-      (lshr (select e_2 (LLVM.xor e_1 (add e_1 (const? 8 (-1)))) (const? 8 15)) e) := by 
+      (lshr (select e_2 (LLVM.xor e_1 (add e_1 (const? 8 (-1)))) (const? 8 15)) e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -170,7 +170,7 @@ theorem src_is_mask_ashr_thm (e e_1 : IntW 8) (e_2 : IntW 1) (e_3 : IntW 8) :
         (ashr (select e_2 (LLVM.xor e_1 (add e_1 (const? 8 (-1)))) (const? 8 15)) e))
       (LLVM.xor e_3 (const? 8 123)) ⊑
     icmp IntPredicate.ugt (LLVM.xor e_3 (const? 8 123))
-      (ashr (select e_2 (LLVM.xor e_1 (add e_1 (const? 8 (-1)))) (const? 8 15)) e) := by 
+      (ashr (select e_2 (LLVM.xor e_1 (add e_1 (const? 8 (-1)))) (const? 8 15)) e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -182,7 +182,7 @@ theorem src_is_mask_ashr_thm (e e_1 : IntW 8) (e_2 : IntW 1) (e_3 : IntW 8) :
 theorem src_is_mask_p2_m1_thm (e e_1 : IntW 8) :
   icmp IntPredicate.ult (LLVM.and (add (shl (const? 8 2) e_1) (const? 8 (-1))) (LLVM.xor e (const? 8 123)))
       (LLVM.xor e (const? 8 123)) ⊑
-    icmp IntPredicate.ugt (LLVM.xor e (const? 8 123)) (add (shl (const? 8 2) e_1) (const? 8 (-1))) := by 
+    icmp IntPredicate.ugt (LLVM.xor e (const? 8 123)) (add (shl (const? 8 2) e_1) (const? 8 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -194,7 +194,7 @@ theorem src_is_mask_p2_m1_thm (e e_1 : IntW 8) :
 theorem src_is_notmask_sext_thm (e : IntW 8) (e_1 : IntW 16) :
   icmp IntPredicate.ule (LLVM.xor e_1 (const? 16 123))
       (LLVM.and (LLVM.xor (sext 16 (shl (const? 8 (-8)) e)) (const? 16 (-1))) (LLVM.xor e_1 (const? 16 123))) ⊑
-    icmp IntPredicate.uge (LLVM.xor e_1 (const? 16 (-128))) (sext 16 (shl (const? 8 (-8)) e)) := by 
+    icmp IntPredicate.uge (LLVM.xor e_1 (const? 16 (-128))) (sext 16 (shl (const? 8 (-8)) e)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -208,7 +208,7 @@ theorem src_is_notmask_x_xor_neg_x_thm (e : IntW 8) (e_1 : IntW 1) (e_2 : IntW 8
       (LLVM.and (LLVM.xor e_2 (const? 8 123)) (select e_1 (LLVM.xor e (sub (const? 8 0) e)) (const? 8 (-8))))
       (const? 8 0) ⊑
     icmp IntPredicate.ule (LLVM.xor e_2 (const? 8 123))
-      (select e_1 (LLVM.xor e (add e (const? 8 (-1)))) (const? 8 7)) := by 
+      (select e_1 (LLVM.xor e (add e (const? 8 (-1)))) (const? 8 7)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -222,7 +222,7 @@ theorem src_is_notmask_x_xor_neg_x_inv_thm (e e_1 : IntW 8) (e_2 : IntW 1) :
       (LLVM.and (select e_2 (LLVM.xor e_1 (sub (const? 8 0) e_1)) (const? 8 (-8))) (LLVM.xor e (const? 8 123)))
       (const? 8 0) ⊑
     icmp IntPredicate.ule (LLVM.xor e (const? 8 123))
-      (select e_2 (LLVM.xor e_1 (add e_1 (const? 8 (-1)))) (const? 8 7)) := by 
+      (select e_2 (LLVM.xor e_1 (add e_1 (const? 8 (-1)))) (const? 8 7)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -236,7 +236,7 @@ theorem src_is_notmask_lshr_shl_thm (e e_1 : IntW 8) :
       (LLVM.and (LLVM.xor (shl (lshr (const? 8 (-1)) e_1) e_1) (const? 8 (-1))) (LLVM.xor e (const? 8 123)))
       (LLVM.xor e (const? 8 123)) ⊑
     icmp IntPredicate.uge (LLVM.xor e (const? 8 (-124)))
-      (shl (const? 8 (-1)) e_1 { «nsw» := true, «nuw» := false }) := by 
+      (shl (const? 8 (-1)) e_1 { «nsw» := true, «nuw» := false }) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -250,7 +250,7 @@ theorem src_is_notmask_lshr_shl_fail_mismatch_shifts_thm (e e_1 e_2 : IntW 8) :
       (LLVM.and (LLVM.xor (shl (lshr (const? 8 (-1)) e_2) e_1) (const? 8 (-1))) (LLVM.xor e (const? 8 123)))
       (LLVM.xor e (const? 8 123)) ⊑
     icmp IntPredicate.eq (LLVM.and (LLVM.xor e (const? 8 123)) (shl (lshr (const? 8 (-1)) e_2) e_1))
-      (const? 8 0) := by 
+      (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -263,7 +263,7 @@ theorem src_is_notmask_ashr_thm (e : IntW 16) (e_1 : IntW 8) (e_2 : IntW 16) :
   icmp IntPredicate.eq (LLVM.xor e_2 (const? 16 123))
       (LLVM.and (LLVM.xor e_2 (const? 16 123))
         (LLVM.xor (ashr (sext 16 (shl (const? 8 (-32)) e_1)) e) (const? 16 (-1)))) ⊑
-    icmp IntPredicate.uge (LLVM.xor e_2 (const? 16 (-124))) (ashr (sext 16 (shl (const? 8 (-32)) e_1)) e) := by 
+    icmp IntPredicate.uge (LLVM.xor e_2 (const? 16 (-124))) (ashr (sext 16 (shl (const? 8 (-32)) e_1)) e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -275,7 +275,7 @@ theorem src_is_notmask_ashr_thm (e : IntW 16) (e_1 : IntW 8) (e_2 : IntW 16) :
 theorem src_is_notmask_neg_p2_fail_not_invertable_thm (e e_1 : IntW 8) :
   icmp IntPredicate.eq (const? 8 0)
       (LLVM.and (sub (const? 8 0) (LLVM.and (sub (const? 8 0) e_1) e_1)) (LLVM.xor e (const? 8 123))) ⊑
-    icmp IntPredicate.uge (LLVM.xor e (const? 8 (-124))) (LLVM.or e_1 (sub (const? 8 0) e_1)) := by 
+    icmp IntPredicate.uge (LLVM.xor e (const? 8 (-124))) (LLVM.or e_1 (sub (const? 8 0) e_1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -286,7 +286,7 @@ theorem src_is_notmask_neg_p2_fail_not_invertable_thm (e e_1 : IntW 8) :
 
 theorem src_is_mask_const_slt_thm (e : IntW 8) :
   icmp IntPredicate.slt (LLVM.xor e (const? 8 123)) (LLVM.and (LLVM.xor e (const? 8 123)) (const? 8 7)) ⊑
-    icmp IntPredicate.slt e (const? 8 0) := by 
+    icmp IntPredicate.slt e (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -297,7 +297,7 @@ theorem src_is_mask_const_slt_thm (e : IntW 8) :
 
 theorem src_is_mask_const_sgt_thm (e : IntW 8) :
   icmp IntPredicate.sgt (LLVM.xor e (const? 8 123)) (LLVM.and (LLVM.xor e (const? 8 123)) (const? 8 7)) ⊑
-    icmp IntPredicate.sgt (LLVM.xor e (const? 8 123)) (const? 8 7) := by 
+    icmp IntPredicate.sgt (LLVM.xor e (const? 8 123)) (const? 8 7) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -308,7 +308,7 @@ theorem src_is_mask_const_sgt_thm (e : IntW 8) :
 
 theorem src_is_mask_const_sle_thm (e : IntW 8) :
   icmp IntPredicate.sle (LLVM.and (LLVM.xor e (const? 8 123)) (const? 8 31)) (LLVM.xor e (const? 8 123)) ⊑
-    icmp IntPredicate.sgt e (const? 8 (-1)) := by 
+    icmp IntPredicate.sgt e (const? 8 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -319,7 +319,7 @@ theorem src_is_mask_const_sle_thm (e : IntW 8) :
 
 theorem src_is_mask_const_sge_thm (e : IntW 8) :
   icmp IntPredicate.sge (LLVM.and (LLVM.xor e (const? 8 123)) (const? 8 31)) (LLVM.xor e (const? 8 123)) ⊑
-    icmp IntPredicate.slt (LLVM.xor e (const? 8 123)) (const? 8 32) := by 
+    icmp IntPredicate.slt (LLVM.xor e (const? 8 123)) (const? 8 32) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -332,7 +332,7 @@ theorem src_x_and_nmask_eq_thm (e e_1 : IntW 8) (e_2 : IntW 1) :
   icmp IntPredicate.eq (select e_2 (shl (const? 8 (-1)) e_1) (const? 8 0))
       (LLVM.and e (select e_2 (shl (const? 8 (-1)) e_1) (const? 8 0))) ⊑
     select (LLVM.xor e_2 (const? 1 1)) (const? 1 1)
-      (icmp IntPredicate.ule (shl (const? 8 (-1)) e_1 { «nsw» := true, «nuw» := false }) e) := by 
+      (icmp IntPredicate.ule (shl (const? 8 (-1)) e_1 { «nsw» := true, «nuw» := false }) e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -345,7 +345,7 @@ theorem src_x_and_nmask_ne_thm (e : IntW 8) (e_1 : IntW 1) (e_2 : IntW 8) :
   icmp IntPredicate.ne (LLVM.and e_2 (select e_1 (shl (const? 8 (-1)) e) (const? 8 0)))
       (select e_1 (shl (const? 8 (-1)) e) (const? 8 0)) ⊑
     select e_1 (icmp IntPredicate.ugt (shl (const? 8 (-1)) e { «nsw» := true, «nuw» := false }) e_2)
-      (const? 1 0) := by 
+      (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -358,7 +358,7 @@ theorem src_x_and_nmask_ult_thm (e : IntW 8) (e_1 : IntW 1) (e_2 : IntW 8) :
   icmp IntPredicate.ult (LLVM.and e_2 (select e_1 (shl (const? 8 (-1)) e) (const? 8 0)))
       (select e_1 (shl (const? 8 (-1)) e) (const? 8 0)) ⊑
     select e_1 (icmp IntPredicate.ugt (shl (const? 8 (-1)) e { «nsw» := true, «nuw» := false }) e_2)
-      (const? 1 0) := by 
+      (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -371,7 +371,7 @@ theorem src_x_and_nmask_uge_thm (e : IntW 8) (e_1 : IntW 1) (e_2 : IntW 8) :
   icmp IntPredicate.uge (LLVM.and e_2 (select e_1 (shl (const? 8 (-1)) e) (const? 8 0)))
       (select e_1 (shl (const? 8 (-1)) e) (const? 8 0)) ⊑
     select (LLVM.xor e_1 (const? 1 1)) (const? 1 1)
-      (icmp IntPredicate.ule (shl (const? 8 (-1)) e { «nsw» := true, «nuw» := false }) e_2) := by 
+      (icmp IntPredicate.ule (shl (const? 8 (-1)) e { «nsw» := true, «nuw» := false }) e_2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -382,7 +382,7 @@ theorem src_x_and_nmask_uge_thm (e : IntW 8) (e_1 : IntW 1) (e_2 : IntW 8) :
 
 theorem src_x_and_nmask_slt_thm (e e_1 : IntW 8) :
   icmp IntPredicate.slt (LLVM.and e_1 (shl (const? 8 (-1)) e)) (shl (const? 8 (-1)) e) ⊑
-    icmp IntPredicate.sgt (shl (const? 8 (-1)) e { «nsw» := true, «nuw» := false }) e_1 := by 
+    icmp IntPredicate.sgt (shl (const? 8 (-1)) e { «nsw» := true, «nuw» := false }) e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -393,7 +393,7 @@ theorem src_x_and_nmask_slt_thm (e e_1 : IntW 8) :
 
 theorem src_x_and_nmask_sge_thm (e e_1 : IntW 8) :
   icmp IntPredicate.sge (LLVM.and e_1 (shl (const? 8 (-1)) e)) (shl (const? 8 (-1)) e) ⊑
-    icmp IntPredicate.sle (shl (const? 8 (-1)) e { «nsw» := true, «nuw» := false }) e_1 := by 
+    icmp IntPredicate.sle (shl (const? 8 (-1)) e { «nsw» := true, «nuw» := false }) e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -407,7 +407,7 @@ theorem src_x_and_nmask_slt_fail_maybe_z_thm (e : IntW 8) (e_1 : IntW 1) (e_2 : 
       (select e_1 (shl (const? 8 (-1)) e) (const? 8 0)) ⊑
     icmp IntPredicate.slt
       (LLVM.and e_2 (select e_1 (shl (const? 8 (-1)) e { «nsw» := true, «nuw» := false }) (const? 8 0)))
-      (select e_1 (shl (const? 8 (-1)) e { «nsw» := true, «nuw» := false }) (const? 8 0)) := by 
+      (select e_1 (shl (const? 8 (-1)) e { «nsw» := true, «nuw» := false }) (const? 8 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -421,7 +421,7 @@ theorem src_x_and_nmask_sge_fail_maybe_z_thm (e : IntW 8) (e_1 : IntW 1) (e_2 : 
       (select e_1 (shl (const? 8 (-1)) e) (const? 8 0)) ⊑
     icmp IntPredicate.sge
       (LLVM.and e_2 (select e_1 (shl (const? 8 (-1)) e { «nsw» := true, «nuw» := false }) (const? 8 0)))
-      (select e_1 (shl (const? 8 (-1)) e { «nsw» := true, «nuw» := false }) (const? 8 0)) := by 
+      (select e_1 (shl (const? 8 (-1)) e { «nsw» := true, «nuw» := false }) (const? 8 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -433,7 +433,7 @@ theorem src_x_and_nmask_sge_fail_maybe_z_thm (e : IntW 8) (e_1 : IntW 1) (e_2 : 
 theorem src_x_or_mask_ne_thm (e e_1 : IntW 8) (e_2 : IntW 1) :
   icmp IntPredicate.ne (LLVM.or (select e_2 (lshr (const? 8 (-1)) e_1) (const? 8 0)) (LLVM.xor e (const? 8 (-1))))
       (const? 8 (-1)) ⊑
-    icmp IntPredicate.ugt e (select e_2 (lshr (const? 8 (-1)) e_1) (const? 8 0)) := by 
+    icmp IntPredicate.ugt e (select e_2 (lshr (const? 8 (-1)) e_1) (const? 8 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gicmphandhshift_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gicmphandhshift_proof.lean
@@ -10,7 +10,7 @@ set_option linter.unreachableTactic false
 section gicmphandhshift_proof
 theorem icmp_eq_and_pow2_shl1_thm (e : IntW 32) :
   zext 32 (icmp IntPredicate.eq (LLVM.and (shl (const? 32 1) e) (const? 32 16)) (const? 32 0)) ⊑
-    zext 32 (icmp IntPredicate.ne e (const? 32 4)) := by 
+    zext 32 (icmp IntPredicate.ne e (const? 32 4)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -21,7 +21,7 @@ theorem icmp_eq_and_pow2_shl1_thm (e : IntW 32) :
 
 theorem icmp_ne_and_pow2_shl1_thm (e : IntW 32) :
   zext 32 (icmp IntPredicate.ne (LLVM.and (shl (const? 32 1) e) (const? 32 16)) (const? 32 0)) ⊑
-    zext 32 (icmp IntPredicate.eq e (const? 32 4)) := by 
+    zext 32 (icmp IntPredicate.eq e (const? 32 4)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -32,7 +32,7 @@ theorem icmp_ne_and_pow2_shl1_thm (e : IntW 32) :
 
 theorem icmp_eq_and_pow2_shl_pow2_thm (e : IntW 32) :
   zext 32 (icmp IntPredicate.eq (LLVM.and (shl (const? 32 2) e) (const? 32 16)) (const? 32 0)) ⊑
-    zext 32 (icmp IntPredicate.ne e (const? 32 3)) := by 
+    zext 32 (icmp IntPredicate.ne e (const? 32 3)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -43,7 +43,7 @@ theorem icmp_eq_and_pow2_shl_pow2_thm (e : IntW 32) :
 
 theorem icmp_ne_and_pow2_shl_pow2_thm (e : IntW 32) :
   zext 32 (icmp IntPredicate.ne (LLVM.and (shl (const? 32 2) e) (const? 32 16)) (const? 32 0)) ⊑
-    zext 32 (icmp IntPredicate.eq e (const? 32 3)) := by 
+    zext 32 (icmp IntPredicate.eq e (const? 32 3)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -54,7 +54,7 @@ theorem icmp_ne_and_pow2_shl_pow2_thm (e : IntW 32) :
 
 theorem icmp_eq_and_pow2_shl_pow2_negative1_thm (e : IntW 32) :
   zext 32 (icmp IntPredicate.eq (LLVM.and (shl (const? 32 11) e) (const? 32 16)) (const? 32 0)) ⊑
-    LLVM.xor (LLVM.and (lshr (shl (const? 32 11) e) (const? 32 4)) (const? 32 1)) (const? 32 1) := by 
+    LLVM.xor (LLVM.and (lshr (shl (const? 32 11) e) (const? 32 4)) (const? 32 1)) (const? 32 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -65,7 +65,7 @@ theorem icmp_eq_and_pow2_shl_pow2_negative1_thm (e : IntW 32) :
 
 theorem icmp_eq_and_pow2_shl_pow2_negative2_thm (e : IntW 32) :
   zext 32 (icmp IntPredicate.eq (LLVM.and (shl (const? 32 2) e) (const? 32 14)) (const? 32 0)) ⊑
-    zext 32 (icmp IntPredicate.ugt e (const? 32 2)) := by 
+    zext 32 (icmp IntPredicate.ugt e (const? 32 2)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -75,7 +75,7 @@ theorem icmp_eq_and_pow2_shl_pow2_negative2_thm (e : IntW 32) :
 
 
 theorem icmp_eq_and_pow2_shl_pow2_negative3_thm (e : IntW 32) :
-  zext 32 (icmp IntPredicate.eq (LLVM.and (shl (const? 32 32) e) (const? 32 16)) (const? 32 0)) ⊑ const? 32 1 := by 
+  zext 32 (icmp IntPredicate.eq (LLVM.and (shl (const? 32 32) e) (const? 32 16)) (const? 32 0)) ⊑ const? 32 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -86,7 +86,7 @@ theorem icmp_eq_and_pow2_shl_pow2_negative3_thm (e : IntW 32) :
 
 theorem icmp_eq_and_pow2_minus1_shl1_thm (e : IntW 32) :
   zext 32 (icmp IntPredicate.eq (LLVM.and (shl (const? 32 1) e) (const? 32 15)) (const? 32 0)) ⊑
-    zext 32 (icmp IntPredicate.ugt e (const? 32 3)) := by 
+    zext 32 (icmp IntPredicate.ugt e (const? 32 3)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -97,7 +97,7 @@ theorem icmp_eq_and_pow2_minus1_shl1_thm (e : IntW 32) :
 
 theorem icmp_ne_and_pow2_minus1_shl1_thm (e : IntW 32) :
   zext 32 (icmp IntPredicate.ne (LLVM.and (shl (const? 32 1) e) (const? 32 15)) (const? 32 0)) ⊑
-    zext 32 (icmp IntPredicate.ult e (const? 32 4)) := by 
+    zext 32 (icmp IntPredicate.ult e (const? 32 4)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -108,7 +108,7 @@ theorem icmp_ne_and_pow2_minus1_shl1_thm (e : IntW 32) :
 
 theorem icmp_eq_and_pow2_minus1_shl_pow2_thm (e : IntW 32) :
   zext 32 (icmp IntPredicate.eq (LLVM.and (shl (const? 32 2) e) (const? 32 15)) (const? 32 0)) ⊑
-    zext 32 (icmp IntPredicate.ugt e (const? 32 2)) := by 
+    zext 32 (icmp IntPredicate.ugt e (const? 32 2)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -119,7 +119,7 @@ theorem icmp_eq_and_pow2_minus1_shl_pow2_thm (e : IntW 32) :
 
 theorem icmp_ne_and_pow2_minus1_shl_pow2_thm (e : IntW 32) :
   zext 32 (icmp IntPredicate.ne (LLVM.and (shl (const? 32 2) e) (const? 32 15)) (const? 32 0)) ⊑
-    zext 32 (icmp IntPredicate.ult e (const? 32 3)) := by 
+    zext 32 (icmp IntPredicate.ult e (const? 32 3)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -129,7 +129,7 @@ theorem icmp_ne_and_pow2_minus1_shl_pow2_thm (e : IntW 32) :
 
 
 theorem icmp_eq_and_pow2_minus1_shl1_negative2_thm (e : IntW 32) :
-  zext 32 (icmp IntPredicate.eq (LLVM.and (shl (const? 32 32) e) (const? 32 15)) (const? 32 0)) ⊑ const? 32 1 := by 
+  zext 32 (icmp IntPredicate.eq (LLVM.and (shl (const? 32 32) e) (const? 32 15)) (const? 32 0)) ⊑ const? 32 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -140,7 +140,7 @@ theorem icmp_eq_and_pow2_minus1_shl1_negative2_thm (e : IntW 32) :
 
 theorem icmp_eq_and1_lshr_pow2_thm (e : IntW 32) :
   zext 32 (icmp IntPredicate.eq (LLVM.and (lshr (const? 32 8) e) (const? 32 1)) (const? 32 0)) ⊑
-    zext 32 (icmp IntPredicate.ne e (const? 32 3)) := by 
+    zext 32 (icmp IntPredicate.ne e (const? 32 3)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -151,7 +151,7 @@ theorem icmp_eq_and1_lshr_pow2_thm (e : IntW 32) :
 
 theorem icmp_ne_and1_lshr_pow2_thm (e : IntW 32) :
   zext 32 (icmp IntPredicate.eq (LLVM.and (lshr (const? 32 8) e) (const? 32 1)) (const? 32 0)) ⊑
-    zext 32 (icmp IntPredicate.ne e (const? 32 3)) := by 
+    zext 32 (icmp IntPredicate.ne e (const? 32 3)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -162,7 +162,7 @@ theorem icmp_ne_and1_lshr_pow2_thm (e : IntW 32) :
 
 theorem icmp_eq_and_pow2_lshr_pow2_thm (e : IntW 32) :
   zext 32 (icmp IntPredicate.eq (LLVM.and (lshr (const? 32 8) e) (const? 32 4)) (const? 32 0)) ⊑
-    zext 32 (icmp IntPredicate.ne e (const? 32 1)) := by 
+    zext 32 (icmp IntPredicate.ne e (const? 32 1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -172,7 +172,7 @@ theorem icmp_eq_and_pow2_lshr_pow2_thm (e : IntW 32) :
 
 
 theorem icmp_eq_and_pow2_lshr_pow2_case2_thm (e : IntW 32) :
-  zext 32 (icmp IntPredicate.eq (LLVM.and (lshr (const? 32 4) e) (const? 32 8)) (const? 32 0)) ⊑ const? 32 1 := by 
+  zext 32 (icmp IntPredicate.eq (LLVM.and (lshr (const? 32 4) e) (const? 32 8)) (const? 32 0)) ⊑ const? 32 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -183,7 +183,7 @@ theorem icmp_eq_and_pow2_lshr_pow2_case2_thm (e : IntW 32) :
 
 theorem icmp_ne_and_pow2_lshr_pow2_thm (e : IntW 32) :
   zext 32 (icmp IntPredicate.eq (LLVM.and (lshr (const? 32 8) e) (const? 32 4)) (const? 32 0)) ⊑
-    zext 32 (icmp IntPredicate.ne e (const? 32 1)) := by 
+    zext 32 (icmp IntPredicate.ne e (const? 32 1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -193,7 +193,7 @@ theorem icmp_ne_and_pow2_lshr_pow2_thm (e : IntW 32) :
 
 
 theorem icmp_ne_and_pow2_lshr_pow2_case2_thm (e : IntW 32) :
-  zext 32 (icmp IntPredicate.eq (LLVM.and (lshr (const? 32 4) e) (const? 32 8)) (const? 32 0)) ⊑ const? 32 1 := by 
+  zext 32 (icmp IntPredicate.eq (LLVM.and (lshr (const? 32 4) e) (const? 32 8)) (const? 32 0)) ⊑ const? 32 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -204,7 +204,7 @@ theorem icmp_ne_and_pow2_lshr_pow2_case2_thm (e : IntW 32) :
 
 theorem icmp_eq_and1_lshr_pow2_minus_one_thm (e : IntW 32) :
   zext 32 (icmp IntPredicate.eq (LLVM.and (lshr (const? 32 7) e) (const? 32 1)) (const? 32 0)) ⊑
-    zext 32 (icmp IntPredicate.ugt e (const? 32 2)) := by 
+    zext 32 (icmp IntPredicate.ugt e (const? 32 2)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -215,7 +215,7 @@ theorem icmp_eq_and1_lshr_pow2_minus_one_thm (e : IntW 32) :
 
 theorem eq_and_shl_one_thm (e e_1 : IntW 8) :
   icmp IntPredicate.eq (LLVM.and (shl (const? 8 1) e_1) e) (shl (const? 8 1) e_1) ⊑
-    icmp IntPredicate.ne (LLVM.and (shl (const? 8 1) e_1 { «nsw» := false, «nuw» := true }) e) (const? 8 0) := by 
+    icmp IntPredicate.ne (LLVM.and (shl (const? 8 1) e_1 { «nsw» := false, «nuw» := true }) e) (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -226,7 +226,7 @@ theorem eq_and_shl_one_thm (e e_1 : IntW 8) :
 
 theorem ne_and_lshr_minval_thm (e e_1 : IntW 8) :
   icmp IntPredicate.ne (LLVM.and (mul e_1 e_1) (lshr (const? 8 (-128)) e)) (lshr (const? 8 (-128)) e) ⊑
-    icmp IntPredicate.eq (LLVM.and (mul e_1 e_1) (lshr (const? 8 (-128)) e { «exact» := true })) (const? 8 0) := by 
+    icmp IntPredicate.eq (LLVM.and (mul e_1 e_1) (lshr (const? 8 (-128)) e { «exact» := true })) (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -238,7 +238,7 @@ theorem ne_and_lshr_minval_thm (e e_1 : IntW 8) :
 theorem slt_and_shl_one_thm (e e_1 : IntW 8) :
   icmp IntPredicate.slt (LLVM.and e_1 (shl (const? 8 1) e)) (shl (const? 8 1) e) ⊑
     icmp IntPredicate.slt (LLVM.and e_1 (shl (const? 8 1) e { «nsw» := false, «nuw» := true }))
-      (shl (const? 8 1) e { «nsw» := false, «nuw» := true }) := by 
+      (shl (const? 8 1) e { «nsw» := false, «nuw» := true }) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -249,7 +249,7 @@ theorem slt_and_shl_one_thm (e e_1 : IntW 8) :
 
 theorem fold_eq_lhs_thm (e e_1 : IntW 8) :
   icmp IntPredicate.eq (LLVM.and (shl (const? 8 (-1)) e_1) e) (const? 8 0) ⊑
-    icmp IntPredicate.eq (lshr e e_1) (const? 8 0) := by 
+    icmp IntPredicate.eq (lshr e e_1) (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -260,7 +260,7 @@ theorem fold_eq_lhs_thm (e e_1 : IntW 8) :
 
 theorem fold_eq_lhs_fail_eq_nonzero_thm (e e_1 : IntW 8) :
   icmp IntPredicate.eq (LLVM.and (shl (const? 8 (-1)) e_1) e) (const? 8 1) ⊑
-    icmp IntPredicate.eq (LLVM.and (shl (const? 8 (-1)) e_1 { «nsw» := true, «nuw» := false }) e) (const? 8 1) := by 
+    icmp IntPredicate.eq (LLVM.and (shl (const? 8 (-1)) e_1 { «nsw» := true, «nuw» := false }) e) (const? 8 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -271,7 +271,7 @@ theorem fold_eq_lhs_fail_eq_nonzero_thm (e e_1 : IntW 8) :
 
 theorem fold_ne_rhs_thm (e e_1 : IntW 8) :
   icmp IntPredicate.ne (LLVM.and (LLVM.xor e_1 (const? 8 123)) (shl (const? 8 (-1)) e)) (const? 8 0) ⊑
-    icmp IntPredicate.ne (lshr (LLVM.xor e_1 (const? 8 123)) e) (const? 8 0) := by 
+    icmp IntPredicate.ne (lshr (LLVM.xor e_1 (const? 8 123)) e) (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -282,7 +282,7 @@ theorem fold_ne_rhs_thm (e e_1 : IntW 8) :
 
 theorem fold_ne_rhs_fail_shift_not_1s_thm (e e_1 : IntW 8) :
   icmp IntPredicate.ne (LLVM.and (LLVM.xor e_1 (const? 8 123)) (shl (const? 8 (-2)) e)) (const? 8 0) ⊑
-    icmp IntPredicate.ne (LLVM.and (LLVM.xor e_1 (const? 8 122)) (shl (const? 8 (-2)) e)) (const? 8 0) := by 
+    icmp IntPredicate.ne (LLVM.and (LLVM.xor e_1 (const? 8 122)) (shl (const? 8 (-2)) e)) (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -293,7 +293,7 @@ theorem fold_ne_rhs_fail_shift_not_1s_thm (e e_1 : IntW 8) :
 
 theorem test_shr_and_1_ne_0_thm (e e_1 : IntW 32) :
   icmp IntPredicate.ne (LLVM.and (lshr e_1 e) (const? 32 1)) (const? 32 0) ⊑
-    icmp IntPredicate.ne (LLVM.and e_1 (shl (const? 32 1) e { «nsw» := false, «nuw» := true })) (const? 32 0) := by 
+    icmp IntPredicate.ne (LLVM.and e_1 (shl (const? 32 1) e { «nsw» := false, «nuw» := true })) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -304,7 +304,7 @@ theorem test_shr_and_1_ne_0_thm (e e_1 : IntW 32) :
 
 theorem test_shr_and_1_ne_0_samesign_thm (e e_1 : IntW 32) :
   icmp IntPredicate.ne (LLVM.and (lshr e_1 e) (const? 32 1)) (const? 32 0) ⊑
-    icmp IntPredicate.ne (LLVM.and e_1 (shl (const? 32 1) e { «nsw» := false, «nuw» := true })) (const? 32 0) := by 
+    icmp IntPredicate.ne (LLVM.and e_1 (shl (const? 32 1) e { «nsw» := false, «nuw» := true })) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -316,7 +316,7 @@ theorem test_shr_and_1_ne_0_samesign_thm (e e_1 : IntW 32) :
 theorem test_const_shr_and_1_ne_0_thm (e : IntW 32) :
   icmp IntPredicate.ne (LLVM.and (lshr (const? 32 42) e) (const? 32 1)) (const? 32 0) ⊑
     icmp IntPredicate.ne (LLVM.and (shl (const? 32 1) e { «nsw» := false, «nuw» := true }) (const? 32 42))
-      (const? 32 0) := by 
+      (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -328,7 +328,7 @@ theorem test_const_shr_and_1_ne_0_thm (e : IntW 32) :
 theorem test_not_const_shr_and_1_ne_0_thm (e : IntW 32) :
   icmp IntPredicate.eq (LLVM.and (lshr (const? 32 42) e) (const? 32 1)) (const? 32 0) ⊑
     icmp IntPredicate.eq (LLVM.and (shl (const? 32 1) e { «nsw» := false, «nuw» := true }) (const? 32 42))
-      (const? 32 0) := by 
+      (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -340,7 +340,7 @@ theorem test_not_const_shr_and_1_ne_0_thm (e : IntW 32) :
 theorem test_const_shr_exact_and_1_ne_0_thm (e : IntW 32) :
   icmp IntPredicate.ne (LLVM.and (lshr (const? 32 42) e { «exact» := true }) (const? 32 1)) (const? 32 0) ⊑
     icmp IntPredicate.ne (LLVM.and (shl (const? 32 1) e { «nsw» := false, «nuw» := true }) (const? 32 42))
-      (const? 32 0) := by 
+      (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -350,7 +350,7 @@ theorem test_const_shr_exact_and_1_ne_0_thm (e : IntW 32) :
 
 
 theorem test_const_shr_and_1_ne_0_i1_negative_thm (e : IntW 1) :
-  icmp IntPredicate.ne (LLVM.and (lshr (const? 1 1) e) (const? 1 1)) (const? 1 0) ⊑ const? 1 1 := by 
+  icmp IntPredicate.ne (LLVM.and (lshr (const? 1 1) e) (const? 1 1)) (const? 1 0) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gicmphbinop_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gicmphbinop_proof.lean
@@ -9,7 +9,7 @@ set_option linter.unreachableTactic false
 
 section gicmphbinop_proof
 theorem mul_unkV_oddC_eq_thm (e : IntW 32) :
-  icmp IntPredicate.eq (mul e (const? 32 3)) (const? 32 0) ⊑ icmp IntPredicate.eq e (const? 32 0) := by 
+  icmp IntPredicate.eq (mul e (const? 32 3)) (const? 32 0) ⊑ icmp IntPredicate.eq e (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -20,7 +20,7 @@ theorem mul_unkV_oddC_eq_thm (e : IntW 32) :
 
 theorem mul_unkV_oddC_sge_thm (e : IntW 8) :
   icmp IntPredicate.sge (mul e (const? 8 3)) (const? 8 0) ⊑
-    icmp IntPredicate.sgt (mul e (const? 8 3)) (const? 8 (-1)) := by 
+    icmp IntPredicate.sgt (mul e (const? 8 3)) (const? 8 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -31,7 +31,7 @@ theorem mul_unkV_oddC_sge_thm (e : IntW 8) :
 
 theorem mul_unkV_evenC_ne_thm (e : IntW 64) :
   icmp IntPredicate.ne (mul e (const? 64 4)) (const? 64 0) ⊑
-    icmp IntPredicate.ne (LLVM.and e (const? 64 4611686018427387903)) (const? 64 0) := by 
+    icmp IntPredicate.ne (LLVM.and e (const? 64 4611686018427387903)) (const? 64 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -42,7 +42,7 @@ theorem mul_unkV_evenC_ne_thm (e : IntW 64) :
 
 theorem mul_setnzV_unkV_nuw_eq_thm (e e_1 : IntW 8) :
   icmp IntPredicate.eq (mul (LLVM.or e_1 (const? 8 2)) e { «nsw» := false, «nuw» := true }) (const? 8 0) ⊑
-    icmp IntPredicate.eq e (const? 8 0) := by 
+    icmp IntPredicate.eq e (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gicmphcustomhdl_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gicmphcustomhdl_proof.lean
@@ -12,7 +12,7 @@ theorem icmp_and_ashr_multiuse_thm (e : IntW 32) :
   LLVM.and (icmp IntPredicate.ne (LLVM.and (ashr e (const? 32 4)) (const? 32 15)) (const? 32 14))
       (icmp IntPredicate.ne (LLVM.and (ashr e (const? 32 4)) (const? 32 31)) (const? 32 27)) ⊑
     LLVM.and (icmp IntPredicate.ne (LLVM.and e (const? 32 240)) (const? 32 224))
-      (icmp IntPredicate.ne (LLVM.and e (const? 32 496)) (const? 32 432)) := by 
+      (icmp IntPredicate.ne (LLVM.and e (const? 32 496)) (const? 32 432)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -25,7 +25,7 @@ theorem icmp_and_ashr_multiuse_logical_thm (e : IntW 32) :
   select (icmp IntPredicate.ne (LLVM.and (ashr e (const? 32 4)) (const? 32 15)) (const? 32 14))
       (icmp IntPredicate.ne (LLVM.and (ashr e (const? 32 4)) (const? 32 31)) (const? 32 27)) (const? 1 0) ⊑
     LLVM.and (icmp IntPredicate.ne (LLVM.and e (const? 32 240)) (const? 32 224))
-      (icmp IntPredicate.ne (LLVM.and e (const? 32 496)) (const? 32 432)) := by 
+      (icmp IntPredicate.ne (LLVM.and e (const? 32 496)) (const? 32 432)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -36,7 +36,7 @@ theorem icmp_and_ashr_multiuse_logical_thm (e : IntW 32) :
 
 theorem icmp_lshr_and_overshift_thm (e : IntW 8) :
   icmp IntPredicate.ne (LLVM.and (lshr e (const? 8 5)) (const? 8 15)) (const? 8 0) ⊑
-    icmp IntPredicate.ugt e (const? 8 31) := by 
+    icmp IntPredicate.ugt e (const? 8 31) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gicmphdivhconstant_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gicmphdivhconstant_proof.lean
@@ -10,7 +10,7 @@ set_option linter.unreachableTactic false
 section gicmphdivhconstant_proof
 theorem is_rem2_neg_i8_thm (e : IntW 8) :
   icmp IntPredicate.slt (LLVM.srem e (const? 8 2)) (const? 8 0) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 8 (-127))) (const? 8 (-127)) := by 
+    icmp IntPredicate.eq (LLVM.and e (const? 8 (-127))) (const? 8 (-127)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -21,7 +21,7 @@ theorem is_rem2_neg_i8_thm (e : IntW 8) :
 
 theorem is_rem32_pos_i8_thm (e : IntW 8) :
   icmp IntPredicate.sgt (LLVM.srem e (const? 8 32)) (const? 8 0) ⊑
-    icmp IntPredicate.sgt (LLVM.and e (const? 8 (-97))) (const? 8 0) := by 
+    icmp IntPredicate.sgt (LLVM.and e (const? 8 (-97))) (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -32,7 +32,7 @@ theorem is_rem32_pos_i8_thm (e : IntW 8) :
 
 theorem is_rem4_neg_i16_thm (e : IntW 16) :
   icmp IntPredicate.slt (LLVM.srem e (const? 16 4)) (const? 16 0) ⊑
-    icmp IntPredicate.ugt (LLVM.and e (const? 16 (-32765))) (const? 16 (-32768)) := by 
+    icmp IntPredicate.ugt (LLVM.and e (const? 16 (-32765))) (const? 16 (-32768)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -43,7 +43,7 @@ theorem is_rem4_neg_i16_thm (e : IntW 16) :
 
 theorem udiv_eq_umax_thm (e e_1 : IntW 8) :
   icmp IntPredicate.eq (LLVM.udiv e_1 e) (const? 8 (-1)) ⊑
-    LLVM.and (icmp IntPredicate.eq e_1 (const? 8 (-1))) (icmp IntPredicate.eq e (const? 8 1)) := by 
+    LLVM.and (icmp IntPredicate.eq e_1 (const? 8 (-1))) (icmp IntPredicate.eq e (const? 8 1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -54,7 +54,7 @@ theorem udiv_eq_umax_thm (e e_1 : IntW 8) :
 
 theorem udiv_eq_big_thm (e e_1 : IntW 8) :
   icmp IntPredicate.eq (LLVM.udiv e_1 e) (const? 8 (-128)) ⊑
-    LLVM.and (icmp IntPredicate.eq e_1 (const? 8 (-128))) (icmp IntPredicate.eq e (const? 8 1)) := by 
+    LLVM.and (icmp IntPredicate.eq e_1 (const? 8 (-128))) (icmp IntPredicate.eq e (const? 8 1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -65,7 +65,7 @@ theorem udiv_eq_big_thm (e e_1 : IntW 8) :
 
 theorem udiv_ne_big_thm (e e_1 : IntW 8) :
   icmp IntPredicate.ne (LLVM.udiv e_1 e) (const? 8 (-128)) ⊑
-    LLVM.or (icmp IntPredicate.ne e_1 (const? 8 (-128))) (icmp IntPredicate.ne e (const? 8 1)) := by 
+    LLVM.or (icmp IntPredicate.ne e_1 (const? 8 (-128))) (icmp IntPredicate.ne e (const? 8 1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -76,7 +76,7 @@ theorem udiv_ne_big_thm (e e_1 : IntW 8) :
 
 theorem sdiv_eq_smin_thm (e e_1 : IntW 8) :
   icmp IntPredicate.eq (LLVM.sdiv e_1 e) (const? 8 (-128)) ⊑
-    LLVM.and (icmp IntPredicate.eq e_1 (const? 8 (-128))) (icmp IntPredicate.eq e (const? 8 1)) := by 
+    LLVM.and (icmp IntPredicate.eq e_1 (const? 8 (-128))) (icmp IntPredicate.eq e (const? 8 1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -87,7 +87,7 @@ theorem sdiv_eq_smin_thm (e e_1 : IntW 8) :
 
 theorem sdiv_ult_smin_thm (e e_1 : IntW 8) :
   icmp IntPredicate.ult (LLVM.sdiv e_1 e) (const? 8 (-128)) ⊑
-    icmp IntPredicate.sgt (LLVM.sdiv e_1 e) (const? 8 (-1)) := by 
+    icmp IntPredicate.sgt (LLVM.sdiv e_1 e) (const? 8 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -97,7 +97,7 @@ theorem sdiv_ult_smin_thm (e e_1 : IntW 8) :
 
 
 theorem sdiv_x_by_const_cmp_x_thm (e : IntW 32) :
-  icmp IntPredicate.eq (LLVM.sdiv e (const? 32 13)) e ⊑ icmp IntPredicate.eq e (const? 32 0) := by 
+  icmp IntPredicate.eq (LLVM.sdiv e (const? 32 13)) e ⊑ icmp IntPredicate.eq e (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -107,7 +107,7 @@ theorem sdiv_x_by_const_cmp_x_thm (e : IntW 32) :
 
 
 theorem udiv_x_by_const_cmp_x_thm (e : IntW 32) :
-  icmp IntPredicate.slt (LLVM.udiv e (const? 32 123)) e ⊑ icmp IntPredicate.sgt e (const? 32 0) := by 
+  icmp IntPredicate.slt (LLVM.udiv e (const? 32 123)) e ⊑ icmp IntPredicate.sgt e (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -117,7 +117,7 @@ theorem udiv_x_by_const_cmp_x_thm (e : IntW 32) :
 
 
 theorem lshr_x_by_const_cmp_x_thm (e : IntW 32) :
-  icmp IntPredicate.eq (lshr e (const? 32 1)) e ⊑ icmp IntPredicate.eq e (const? 32 0) := by 
+  icmp IntPredicate.eq (lshr e (const? 32 1)) e ⊑ icmp IntPredicate.eq e (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -127,7 +127,7 @@ theorem lshr_x_by_const_cmp_x_thm (e : IntW 32) :
 
 
 theorem lshr_by_const_cmp_sge_value_thm (e : IntW 32) :
-  icmp IntPredicate.sge (lshr e (const? 32 3)) e ⊑ icmp IntPredicate.slt e (const? 32 1) := by 
+  icmp IntPredicate.sge (lshr e (const? 32 3)) e ⊑ icmp IntPredicate.slt e (const? 32 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -137,7 +137,7 @@ theorem lshr_by_const_cmp_sge_value_thm (e : IntW 32) :
 
 
 theorem ashr_x_by_const_cmp_sge_x_thm (e : IntW 32) :
-  icmp IntPredicate.sge (ashr e (const? 32 5)) e ⊑ icmp IntPredicate.slt e (const? 32 1) := by 
+  icmp IntPredicate.sge (ashr e (const? 32 5)) e ⊑ icmp IntPredicate.slt e (const? 32 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gicmphequalityhtest_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gicmphequalityhtest_proof.lean
@@ -11,7 +11,7 @@ section gicmphequalityhtest_proof
 theorem icmp_equality_test_thm (e e_1 e_2 : IntW 64) :
   select (icmp IntPredicate.eq e_2 e_1) (icmp IntPredicate.eq e e_1)
       (select (LLVM.xor (icmp IntPredicate.eq e e_1) (const? 1 1)) (icmp IntPredicate.eq e_2 e) (const? 1 0)) ⊑
-    icmp IntPredicate.eq e_2 e := by 
+    icmp IntPredicate.eq e_2 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -24,7 +24,7 @@ theorem icmp_equality_test_constant_thm (e e_1 : IntW 42) :
   select (icmp IntPredicate.eq e_1 (const? 42 (-42))) (icmp IntPredicate.eq e (const? 42 (-42)))
       (select (LLVM.xor (icmp IntPredicate.eq e (const? 42 (-42))) (const? 1 1)) (icmp IntPredicate.eq e_1 e)
         (const? 1 0)) ⊑
-    icmp IntPredicate.eq e_1 e := by 
+    icmp IntPredicate.eq e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -37,7 +37,7 @@ theorem icmp_equality_test_constant_samesign_thm (e e_1 : IntW 42) :
   select (icmp IntPredicate.eq e_1 (const? 42 (-42))) (icmp IntPredicate.eq e (const? 42 (-42)))
       (select (LLVM.xor (icmp IntPredicate.eq e (const? 42 (-42))) (const? 1 1)) (icmp IntPredicate.eq e_1 e)
         (const? 1 0)) ⊑
-    icmp IntPredicate.eq e_1 e := by 
+    icmp IntPredicate.eq e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -50,7 +50,7 @@ theorem icmp_equality_test_swift_optional_pointers_thm (e e_1 : IntW 64) :
   select (select (icmp IntPredicate.eq e_1 (const? 64 0)) (const? 1 1) (icmp IntPredicate.eq e (const? 64 0)))
       (select (icmp IntPredicate.eq e_1 (const? 64 0)) (icmp IntPredicate.eq e (const? 64 0)) (const? 1 0))
       (icmp IntPredicate.eq e_1 e) ⊑
-    icmp IntPredicate.eq e_1 e := by 
+    icmp IntPredicate.eq e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -62,7 +62,7 @@ theorem icmp_equality_test_swift_optional_pointers_thm (e e_1 : IntW 64) :
 theorem icmp_equality_test_commute_icmp1_thm (e e_1 e_2 : IntW 64) :
   select (icmp IntPredicate.eq e_2 e_1) (icmp IntPredicate.eq e_2 e)
       (select (LLVM.xor (icmp IntPredicate.eq e_2 e) (const? 1 1)) (icmp IntPredicate.eq e e_1) (const? 1 0)) ⊑
-    icmp IntPredicate.eq e e_1 := by 
+    icmp IntPredicate.eq e e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -74,7 +74,7 @@ theorem icmp_equality_test_commute_icmp1_thm (e e_1 e_2 : IntW 64) :
 theorem icmp_equality_test_commute_icmp2_thm (e e_1 e_2 : IntW 64) :
   select (icmp IntPredicate.eq e_2 e_1) (icmp IntPredicate.eq e e_2)
       (select (LLVM.xor (icmp IntPredicate.eq e e_2) (const? 1 1)) (icmp IntPredicate.eq e e_1) (const? 1 0)) ⊑
-    icmp IntPredicate.eq e e_1 := by 
+    icmp IntPredicate.eq e e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -86,7 +86,7 @@ theorem icmp_equality_test_commute_icmp2_thm (e e_1 e_2 : IntW 64) :
 theorem icmp_equality_test_commute_select1_thm (e e_1 e_2 : IntW 64) :
   select (icmp IntPredicate.eq e_2 e_1) (icmp IntPredicate.eq e e_1)
       (select (icmp IntPredicate.eq e e_1) (const? 1 0) (icmp IntPredicate.eq e_2 e)) ⊑
-    icmp IntPredicate.eq e_2 e := by 
+    icmp IntPredicate.eq e_2 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -98,7 +98,7 @@ theorem icmp_equality_test_commute_select1_thm (e e_1 e_2 : IntW 64) :
 theorem icmp_equality_test_commute_select2_thm (e e_1 e_2 : IntW 64) :
   select (LLVM.xor (icmp IntPredicate.eq e_2 e_1) (const? 1 1))
       (select (icmp IntPredicate.eq e e_1) (const? 1 0) (icmp IntPredicate.eq e_2 e)) (icmp IntPredicate.eq e e_1) ⊑
-    icmp IntPredicate.eq e_2 e := by 
+    icmp IntPredicate.eq e_2 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -111,7 +111,7 @@ theorem icmp_equality_test_wrong_and_thm (e e_1 e_2 : IntW 64) :
   select (icmp IntPredicate.eq e_2 e_1) (icmp IntPredicate.eq e e_1)
       (select (LLVM.xor (icmp IntPredicate.eq e e_1) (const? 1 1)) (const? 1 0) (icmp IntPredicate.eq e_2 e)) ⊑
     select (icmp IntPredicate.eq e_2 e_1) (icmp IntPredicate.eq e e_1)
-      (select (icmp IntPredicate.eq e e_1) (icmp IntPredicate.eq e_2 e) (const? 1 0)) := by 
+      (select (icmp IntPredicate.eq e e_1) (icmp IntPredicate.eq e_2 e) (const? 1 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gicmphequalityhxor_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gicmphequalityhxor_proof.lean
@@ -9,7 +9,7 @@ set_option linter.unreachableTactic false
 
 section gicmphequalityhxor_proof
 theorem cmpeq_xor_cst1_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.eq (LLVM.xor e_1 (const? 32 10)) e ⊑ icmp IntPredicate.eq (LLVM.xor e_1 e) (const? 32 10) := by 
+  icmp IntPredicate.eq (LLVM.xor e_1 (const? 32 10)) e ⊑ icmp IntPredicate.eq (LLVM.xor e_1 e) (const? 32 10) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -19,7 +19,7 @@ theorem cmpeq_xor_cst1_thm (e e_1 : IntW 32) :
 
 
 theorem cmpeq_xor_cst3_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.eq (LLVM.xor e_1 (const? 32 10)) (LLVM.xor e (const? 32 10)) ⊑ icmp IntPredicate.eq e_1 e := by 
+  icmp IntPredicate.eq (LLVM.xor e_1 (const? 32 10)) (LLVM.xor e (const? 32 10)) ⊑ icmp IntPredicate.eq e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -29,7 +29,7 @@ theorem cmpeq_xor_cst3_thm (e e_1 : IntW 32) :
 
 
 theorem cmpne_xor_cst1_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.ne (LLVM.xor e_1 (const? 32 10)) e ⊑ icmp IntPredicate.ne (LLVM.xor e_1 e) (const? 32 10) := by 
+  icmp IntPredicate.ne (LLVM.xor e_1 (const? 32 10)) e ⊑ icmp IntPredicate.ne (LLVM.xor e_1 e) (const? 32 10) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -39,7 +39,7 @@ theorem cmpne_xor_cst1_thm (e e_1 : IntW 32) :
 
 
 theorem cmpne_xor_cst3_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.ne (LLVM.xor e_1 (const? 32 10)) (LLVM.xor e (const? 32 10)) ⊑ icmp IntPredicate.ne e_1 e := by 
+  icmp IntPredicate.ne (LLVM.xor e_1 (const? 32 10)) (LLVM.xor e (const? 32 10)) ⊑ icmp IntPredicate.ne e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -50,7 +50,7 @@ theorem cmpne_xor_cst3_thm (e e_1 : IntW 32) :
 
 theorem cmpeq_xor_cst1_commuted_thm (e e_1 : IntW 32) :
   icmp IntPredicate.eq (mul e_1 e_1) (LLVM.xor e (const? 32 10)) ⊑
-    icmp IntPredicate.eq (LLVM.xor e (mul e_1 e_1)) (const? 32 10) := by 
+    icmp IntPredicate.eq (LLVM.xor e (mul e_1 e_1)) (const? 32 10) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -62,7 +62,7 @@ theorem cmpeq_xor_cst1_commuted_thm (e e_1 : IntW 32) :
 theorem foo1_thm (e e_1 : IntW 32) :
   icmp IntPredicate.eq (LLVM.and e_1 (const? 32 (-2147483648)))
       (LLVM.and (LLVM.xor e (const? 32 (-1))) (const? 32 (-2147483648))) ⊑
-    icmp IntPredicate.slt (LLVM.xor e e_1) (const? 32 0) := by 
+    icmp IntPredicate.slt (LLVM.xor e e_1) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -74,7 +74,7 @@ theorem foo1_thm (e e_1 : IntW 32) :
 theorem foo2_thm (e e_1 : IntW 32) :
   icmp IntPredicate.eq (LLVM.and e_1 (const? 32 (-2147483648)))
       (LLVM.xor (LLVM.and e (const? 32 (-2147483648))) (const? 32 (-2147483648))) ⊑
-    icmp IntPredicate.slt (LLVM.xor e e_1) (const? 32 0) := by 
+    icmp IntPredicate.slt (LLVM.xor e e_1) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gicmphexthext_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gicmphexthext_proof.lean
@@ -9,7 +9,7 @@ set_option linter.unreachableTactic false
 
 section gicmphexthext_proof
 theorem zext_zext_sgt_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.sgt (zext 32 e_1) (zext 32 e) ⊑ icmp IntPredicate.ugt e_1 e := by 
+  icmp IntPredicate.sgt (zext 32 e_1) (zext 32 e) ⊑ icmp IntPredicate.ugt e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -19,7 +19,7 @@ theorem zext_zext_sgt_thm (e e_1 : IntW 8) :
 
 
 theorem zext_zext_eq_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.eq (zext 32 e_1) (zext 32 e) ⊑ icmp IntPredicate.eq e_1 e := by 
+  icmp IntPredicate.eq (zext 32 e_1) (zext 32 e) ⊑ icmp IntPredicate.eq e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -29,7 +29,7 @@ theorem zext_zext_eq_thm (e e_1 : IntW 8) :
 
 
 theorem zext_zext_sle_op0_narrow_thm (e : IntW 16) (e_1 : IntW 8) :
-  icmp IntPredicate.sle (zext 32 e_1) (zext 32 e) ⊑ icmp IntPredicate.uge e (zext 16 e_1) := by 
+  icmp IntPredicate.sle (zext 32 e_1) (zext 32 e) ⊑ icmp IntPredicate.uge e (zext 16 e_1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -39,7 +39,7 @@ theorem zext_zext_sle_op0_narrow_thm (e : IntW 16) (e_1 : IntW 8) :
 
 
 theorem zext_zext_ule_op0_wide_thm (e : IntW 8) (e_1 : IntW 9) :
-  icmp IntPredicate.ule (zext 32 e_1) (zext 32 e) ⊑ icmp IntPredicate.ule e_1 (zext 9 e) := by 
+  icmp IntPredicate.ule (zext 32 e_1) (zext 32 e) ⊑ icmp IntPredicate.ule e_1 (zext 9 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -49,7 +49,7 @@ theorem zext_zext_ule_op0_wide_thm (e : IntW 8) (e_1 : IntW 9) :
 
 
 theorem sext_sext_slt_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.slt (sext 32 e_1) (sext 32 e) ⊑ icmp IntPredicate.slt e_1 e := by 
+  icmp IntPredicate.slt (sext 32 e_1) (sext 32 e) ⊑ icmp IntPredicate.slt e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -59,7 +59,7 @@ theorem sext_sext_slt_thm (e e_1 : IntW 8) :
 
 
 theorem sext_sext_ult_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.ult (sext 32 e_1) (sext 32 e) ⊑ icmp IntPredicate.ult e_1 e := by 
+  icmp IntPredicate.ult (sext 32 e_1) (sext 32 e) ⊑ icmp IntPredicate.ult e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -69,7 +69,7 @@ theorem sext_sext_ult_thm (e e_1 : IntW 8) :
 
 
 theorem sext_sext_ne_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.ne (sext 32 e_1) (sext 32 e) ⊑ icmp IntPredicate.ne e_1 e := by 
+  icmp IntPredicate.ne (sext 32 e_1) (sext 32 e) ⊑ icmp IntPredicate.ne e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -79,7 +79,7 @@ theorem sext_sext_ne_thm (e e_1 : IntW 8) :
 
 
 theorem sext_sext_sge_op0_narrow_thm (e : IntW 8) (e_1 : IntW 5) :
-  icmp IntPredicate.sge (sext 32 e_1) (sext 32 e) ⊑ icmp IntPredicate.sle e (sext 8 e_1) := by 
+  icmp IntPredicate.sge (sext 32 e_1) (sext 32 e) ⊑ icmp IntPredicate.sle e (sext 8 e_1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -89,7 +89,7 @@ theorem sext_sext_sge_op0_narrow_thm (e : IntW 8) (e_1 : IntW 5) :
 
 
 theorem zext_nneg_sext_sgt_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.sgt (zext 32 e_1 { «nneg» := true }) (sext 32 e) ⊑ icmp IntPredicate.sgt e_1 e := by 
+  icmp IntPredicate.sgt (zext 32 e_1 { «nneg» := true }) (sext 32 e) ⊑ icmp IntPredicate.sgt e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -99,7 +99,7 @@ theorem zext_nneg_sext_sgt_thm (e e_1 : IntW 8) :
 
 
 theorem zext_nneg_sext_ugt_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.ugt (zext 32 e_1 { «nneg» := true }) (sext 32 e) ⊑ icmp IntPredicate.ugt e_1 e := by 
+  icmp IntPredicate.ugt (zext 32 e_1 { «nneg» := true }) (sext 32 e) ⊑ icmp IntPredicate.ugt e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -109,7 +109,7 @@ theorem zext_nneg_sext_ugt_thm (e e_1 : IntW 8) :
 
 
 theorem zext_nneg_sext_eq_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.eq (zext 32 e_1 { «nneg» := true }) (sext 32 e) ⊑ icmp IntPredicate.eq e_1 e := by 
+  icmp IntPredicate.eq (zext 32 e_1 { «nneg» := true }) (sext 32 e) ⊑ icmp IntPredicate.eq e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -119,7 +119,7 @@ theorem zext_nneg_sext_eq_thm (e e_1 : IntW 8) :
 
 
 theorem zext_nneg_sext_sle_op0_narrow_thm (e : IntW 16) (e_1 : IntW 8) :
-  icmp IntPredicate.sle (zext 32 e_1 { «nneg» := true }) (sext 32 e) ⊑ icmp IntPredicate.sge e (sext 16 e_1) := by 
+  icmp IntPredicate.sle (zext 32 e_1 { «nneg» := true }) (sext 32 e) ⊑ icmp IntPredicate.sge e (sext 16 e_1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -129,7 +129,7 @@ theorem zext_nneg_sext_sle_op0_narrow_thm (e : IntW 16) (e_1 : IntW 8) :
 
 
 theorem zext_nneg_sext_ule_op0_wide_thm (e : IntW 8) (e_1 : IntW 9) :
-  icmp IntPredicate.ule (zext 32 e_1 { «nneg» := true }) (sext 32 e) ⊑ icmp IntPredicate.ule e_1 (sext 9 e) := by 
+  icmp IntPredicate.ule (zext 32 e_1 { «nneg» := true }) (sext 32 e) ⊑ icmp IntPredicate.ule e_1 (sext 9 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -139,7 +139,7 @@ theorem zext_nneg_sext_ule_op0_wide_thm (e : IntW 8) (e_1 : IntW 9) :
 
 
 theorem sext_zext_nneg_slt_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.slt (sext 32 e_1) (zext 32 e { «nneg» := true }) ⊑ icmp IntPredicate.slt e_1 e := by 
+  icmp IntPredicate.slt (sext 32 e_1) (zext 32 e { «nneg» := true }) ⊑ icmp IntPredicate.slt e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -149,7 +149,7 @@ theorem sext_zext_nneg_slt_thm (e e_1 : IntW 8) :
 
 
 theorem sext_zext_nneg_ult_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.ult (sext 32 e_1) (zext 32 e { «nneg» := true }) ⊑ icmp IntPredicate.ult e_1 e := by 
+  icmp IntPredicate.ult (sext 32 e_1) (zext 32 e { «nneg» := true }) ⊑ icmp IntPredicate.ult e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -159,7 +159,7 @@ theorem sext_zext_nneg_ult_thm (e e_1 : IntW 8) :
 
 
 theorem sext_zext_nneg_sge_op0_narrow_thm (e : IntW 8) (e_1 : IntW 5) :
-  icmp IntPredicate.sge (sext 32 e_1) (zext 32 e { «nneg» := true }) ⊑ icmp IntPredicate.sle e (sext 8 e_1) := by 
+  icmp IntPredicate.sge (sext 32 e_1) (zext 32 e { «nneg» := true }) ⊑ icmp IntPredicate.sle e (sext 8 e_1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -169,7 +169,7 @@ theorem sext_zext_nneg_sge_op0_narrow_thm (e : IntW 8) (e_1 : IntW 5) :
 
 
 theorem sext_zext_nneg_uge_op0_wide_thm (e : IntW 8) (e_1 : IntW 16) :
-  icmp IntPredicate.uge (sext 32 e_1) (zext 32 e { «nneg» := true }) ⊑ icmp IntPredicate.uge e_1 (sext 16 e) := by 
+  icmp IntPredicate.uge (sext 32 e_1) (zext 32 e { «nneg» := true }) ⊑ icmp IntPredicate.uge e_1 (sext 16 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -180,7 +180,7 @@ theorem sext_zext_nneg_uge_op0_wide_thm (e : IntW 8) (e_1 : IntW 16) :
 
 theorem zext_sext_sgt_known_nonneg_thm (e e_1 : IntW 8) :
   icmp IntPredicate.sgt (zext 32 (LLVM.udiv (const? 8 127) e_1)) (sext 32 e) ⊑
-    icmp IntPredicate.sgt (LLVM.udiv (const? 8 127) e_1) e := by 
+    icmp IntPredicate.sgt (LLVM.udiv (const? 8 127) e_1) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -191,7 +191,7 @@ theorem zext_sext_sgt_known_nonneg_thm (e e_1 : IntW 8) :
 
 theorem zext_sext_ugt_known_nonneg_thm (e e_1 : IntW 8) :
   icmp IntPredicate.ugt (zext 32 (LLVM.and e_1 (const? 8 127))) (sext 32 e) ⊑
-    icmp IntPredicate.ugt (LLVM.and e_1 (const? 8 127)) e := by 
+    icmp IntPredicate.ugt (LLVM.and e_1 (const? 8 127)) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -202,7 +202,7 @@ theorem zext_sext_ugt_known_nonneg_thm (e e_1 : IntW 8) :
 
 theorem zext_sext_eq_known_nonneg_thm (e e_1 : IntW 8) :
   icmp IntPredicate.eq (zext 32 (lshr e_1 (const? 8 1))) (sext 32 e) ⊑
-    icmp IntPredicate.eq (lshr e_1 (const? 8 1)) e := by 
+    icmp IntPredicate.eq (lshr e_1 (const? 8 1)) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -213,7 +213,7 @@ theorem zext_sext_eq_known_nonneg_thm (e e_1 : IntW 8) :
 
 theorem zext_sext_sle_known_nonneg_op0_narrow_thm (e : IntW 16) (e_1 : IntW 8) :
   icmp IntPredicate.sle (zext 32 (LLVM.and e_1 (const? 8 12))) (sext 32 e) ⊑
-    icmp IntPredicate.sge e (zext 16 (LLVM.and e_1 (const? 8 12)) { «nneg» := true }) := by 
+    icmp IntPredicate.sge e (zext 16 (LLVM.and e_1 (const? 8 12)) { «nneg» := true }) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -224,7 +224,7 @@ theorem zext_sext_sle_known_nonneg_op0_narrow_thm (e : IntW 16) (e_1 : IntW 8) :
 
 theorem zext_sext_ule_known_nonneg_op0_wide_thm (e : IntW 8) (e_1 : IntW 9) :
   icmp IntPredicate.ule (zext 32 (urem e_1 (const? 9 254))) (sext 32 e) ⊑
-    icmp IntPredicate.ule (urem e_1 (const? 9 254)) (sext 9 e) := by 
+    icmp IntPredicate.ule (urem e_1 (const? 9 254)) (sext 9 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -235,7 +235,7 @@ theorem zext_sext_ule_known_nonneg_op0_wide_thm (e : IntW 8) (e_1 : IntW 9) :
 
 theorem sext_zext_slt_known_nonneg_thm (e e_1 : IntW 8) :
   icmp IntPredicate.slt (sext 32 e_1) (zext 32 (LLVM.and e (const? 8 126))) ⊑
-    icmp IntPredicate.slt e_1 (LLVM.and e (const? 8 126)) := by 
+    icmp IntPredicate.slt e_1 (LLVM.and e (const? 8 126)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -246,7 +246,7 @@ theorem sext_zext_slt_known_nonneg_thm (e e_1 : IntW 8) :
 
 theorem sext_zext_ult_known_nonneg_thm (e e_1 : IntW 8) :
   icmp IntPredicate.ult (sext 32 e_1) (zext 32 (lshr e (const? 8 6))) ⊑
-    icmp IntPredicate.ult e_1 (lshr e (const? 8 6)) := by 
+    icmp IntPredicate.ult e_1 (lshr e (const? 8 6)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -257,7 +257,7 @@ theorem sext_zext_ult_known_nonneg_thm (e e_1 : IntW 8) :
 
 theorem sext_zext_ne_known_nonneg_thm (e e_1 : IntW 8) :
   icmp IntPredicate.ne (sext 32 e_1) (zext 32 (LLVM.udiv e (const? 8 6))) ⊑
-    icmp IntPredicate.ne e_1 (LLVM.udiv e (const? 8 6)) := by 
+    icmp IntPredicate.ne e_1 (LLVM.udiv e (const? 8 6)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -268,7 +268,7 @@ theorem sext_zext_ne_known_nonneg_thm (e e_1 : IntW 8) :
 
 theorem sext_zext_uge_known_nonneg_op0_wide_thm (e : IntW 8) (e_1 : IntW 16) :
   icmp IntPredicate.uge (sext 32 e_1) (zext 32 (LLVM.and e (const? 8 12))) ⊑
-    icmp IntPredicate.uge e_1 (zext 16 (LLVM.and e (const? 8 12)) { «nneg» := true }) := by 
+    icmp IntPredicate.uge e_1 (zext 16 (LLVM.and e (const? 8 12)) { «nneg» := true }) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -278,7 +278,7 @@ theorem sext_zext_uge_known_nonneg_op0_wide_thm (e : IntW 8) (e_1 : IntW 16) :
 
 
 theorem zext_eq_sext_thm (e e_1 : IntW 1) :
-  icmp IntPredicate.eq (zext 32 e_1) (sext 32 e) ⊑ LLVM.xor (LLVM.or e_1 e) (const? 1 1) := by 
+  icmp IntPredicate.eq (zext 32 e_1) (sext 32 e) ⊑ LLVM.xor (LLVM.or e_1 e) (const? 1 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gicmphlogical_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gicmphlogical_proof.lean
@@ -11,7 +11,7 @@ section gicmphlogical_proof
 theorem masked_and_notallzeroes_thm (e : IntW 32) :
   LLVM.and (icmp IntPredicate.ne (LLVM.and e (const? 32 7)) (const? 32 0))
       (icmp IntPredicate.ne (LLVM.and e (const? 32 39)) (const? 32 0)) ⊑
-    icmp IntPredicate.ne (LLVM.and e (const? 32 7)) (const? 32 0) := by 
+    icmp IntPredicate.ne (LLVM.and e (const? 32 7)) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -23,7 +23,7 @@ theorem masked_and_notallzeroes_thm (e : IntW 32) :
 theorem masked_and_notallzeroes_logical_thm (e : IntW 32) :
   select (icmp IntPredicate.ne (LLVM.and e (const? 32 7)) (const? 32 0))
       (icmp IntPredicate.ne (LLVM.and e (const? 32 39)) (const? 32 0)) (const? 1 0) ⊑
-    icmp IntPredicate.ne (LLVM.and e (const? 32 7)) (const? 32 0) := by 
+    icmp IntPredicate.ne (LLVM.and e (const? 32 7)) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -35,7 +35,7 @@ theorem masked_and_notallzeroes_logical_thm (e : IntW 32) :
 theorem masked_or_allzeroes_thm (e : IntW 32) :
   LLVM.or (icmp IntPredicate.eq (LLVM.and e (const? 32 7)) (const? 32 0))
       (icmp IntPredicate.eq (LLVM.and e (const? 32 39)) (const? 32 0)) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 32 7)) (const? 32 0) := by 
+    icmp IntPredicate.eq (LLVM.and e (const? 32 7)) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -47,7 +47,7 @@ theorem masked_or_allzeroes_thm (e : IntW 32) :
 theorem masked_or_allzeroes_logical_thm (e : IntW 32) :
   select (icmp IntPredicate.eq (LLVM.and e (const? 32 7)) (const? 32 0)) (const? 1 1)
       (icmp IntPredicate.eq (LLVM.and e (const? 32 39)) (const? 32 0)) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 32 7)) (const? 32 0) := by 
+    icmp IntPredicate.eq (LLVM.and e (const? 32 7)) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -59,7 +59,7 @@ theorem masked_or_allzeroes_logical_thm (e : IntW 32) :
 theorem masked_and_notallones_thm (e : IntW 32) :
   LLVM.and (icmp IntPredicate.ne (LLVM.and e (const? 32 7)) (const? 32 7))
       (icmp IntPredicate.ne (LLVM.and e (const? 32 39)) (const? 32 39)) ⊑
-    icmp IntPredicate.ne (LLVM.and e (const? 32 7)) (const? 32 7) := by 
+    icmp IntPredicate.ne (LLVM.and e (const? 32 7)) (const? 32 7) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -71,7 +71,7 @@ theorem masked_and_notallones_thm (e : IntW 32) :
 theorem masked_and_notallones_logical_thm (e : IntW 32) :
   select (icmp IntPredicate.ne (LLVM.and e (const? 32 7)) (const? 32 7))
       (icmp IntPredicate.ne (LLVM.and e (const? 32 39)) (const? 32 39)) (const? 1 0) ⊑
-    icmp IntPredicate.ne (LLVM.and e (const? 32 7)) (const? 32 7) := by 
+    icmp IntPredicate.ne (LLVM.and e (const? 32 7)) (const? 32 7) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -83,7 +83,7 @@ theorem masked_and_notallones_logical_thm (e : IntW 32) :
 theorem masked_or_allones_thm (e : IntW 32) :
   LLVM.or (icmp IntPredicate.eq (LLVM.and e (const? 32 7)) (const? 32 7))
       (icmp IntPredicate.eq (LLVM.and e (const? 32 39)) (const? 32 39)) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 32 7)) (const? 32 7) := by 
+    icmp IntPredicate.eq (LLVM.and e (const? 32 7)) (const? 32 7) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -95,7 +95,7 @@ theorem masked_or_allones_thm (e : IntW 32) :
 theorem masked_or_allones_logical_thm (e : IntW 32) :
   select (icmp IntPredicate.eq (LLVM.and e (const? 32 7)) (const? 32 7)) (const? 1 1)
       (icmp IntPredicate.eq (LLVM.and e (const? 32 39)) (const? 32 39)) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 32 7)) (const? 32 7) := by 
+    icmp IntPredicate.eq (LLVM.and e (const? 32 7)) (const? 32 7) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -106,7 +106,7 @@ theorem masked_or_allones_logical_thm (e : IntW 32) :
 
 theorem masked_and_notA_thm (e : IntW 32) :
   LLVM.and (icmp IntPredicate.ne (LLVM.and e (const? 32 14)) e) (icmp IntPredicate.ne (LLVM.and e (const? 32 78)) e) ⊑
-    icmp IntPredicate.ne (LLVM.and e (const? 32 (-79))) (const? 32 0) := by 
+    icmp IntPredicate.ne (LLVM.and e (const? 32 (-79))) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -118,7 +118,7 @@ theorem masked_and_notA_thm (e : IntW 32) :
 theorem masked_and_notA_logical_thm (e : IntW 32) :
   select (icmp IntPredicate.ne (LLVM.and e (const? 32 14)) e) (icmp IntPredicate.ne (LLVM.and e (const? 32 78)) e)
       (const? 1 0) ⊑
-    icmp IntPredicate.ne (LLVM.and e (const? 32 (-79))) (const? 32 0) := by 
+    icmp IntPredicate.ne (LLVM.and e (const? 32 (-79))) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -129,7 +129,7 @@ theorem masked_and_notA_logical_thm (e : IntW 32) :
 
 theorem masked_and_notA_slightly_optimized_thm (e : IntW 32) :
   LLVM.and (icmp IntPredicate.uge e (const? 32 8)) (icmp IntPredicate.ne (LLVM.and e (const? 32 39)) e) ⊑
-    icmp IntPredicate.ne (LLVM.and e (const? 32 (-40))) (const? 32 0) := by 
+    icmp IntPredicate.ne (LLVM.and e (const? 32 (-40))) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -140,7 +140,7 @@ theorem masked_and_notA_slightly_optimized_thm (e : IntW 32) :
 
 theorem masked_and_notA_slightly_optimized_logical_thm (e : IntW 32) :
   select (icmp IntPredicate.uge e (const? 32 8)) (icmp IntPredicate.ne (LLVM.and e (const? 32 39)) e) (const? 1 0) ⊑
-    icmp IntPredicate.ne (LLVM.and e (const? 32 (-40))) (const? 32 0) := by 
+    icmp IntPredicate.ne (LLVM.and e (const? 32 (-40))) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -151,7 +151,7 @@ theorem masked_and_notA_slightly_optimized_logical_thm (e : IntW 32) :
 
 theorem masked_or_A_thm (e : IntW 32) :
   LLVM.or (icmp IntPredicate.eq (LLVM.and e (const? 32 14)) e) (icmp IntPredicate.eq (LLVM.and e (const? 32 78)) e) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 32 (-79))) (const? 32 0) := by 
+    icmp IntPredicate.eq (LLVM.and e (const? 32 (-79))) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -163,7 +163,7 @@ theorem masked_or_A_thm (e : IntW 32) :
 theorem masked_or_A_logical_thm (e : IntW 32) :
   select (icmp IntPredicate.eq (LLVM.and e (const? 32 14)) e) (const? 1 1)
       (icmp IntPredicate.eq (LLVM.and e (const? 32 78)) e) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 32 (-79))) (const? 32 0) := by 
+    icmp IntPredicate.eq (LLVM.and e (const? 32 (-79))) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -174,7 +174,7 @@ theorem masked_or_A_logical_thm (e : IntW 32) :
 
 theorem masked_or_A_slightly_optimized_thm (e : IntW 32) :
   LLVM.or (icmp IntPredicate.ult e (const? 32 8)) (icmp IntPredicate.eq (LLVM.and e (const? 32 39)) e) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 32 (-40))) (const? 32 0) := by 
+    icmp IntPredicate.eq (LLVM.and e (const? 32 (-40))) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -185,7 +185,7 @@ theorem masked_or_A_slightly_optimized_thm (e : IntW 32) :
 
 theorem masked_or_A_slightly_optimized_logical_thm (e : IntW 32) :
   select (icmp IntPredicate.ult e (const? 32 8)) (const? 1 1) (icmp IntPredicate.eq (LLVM.and e (const? 32 39)) e) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 32 (-40))) (const? 32 0) := by 
+    icmp IntPredicate.eq (LLVM.and e (const? 32 (-40))) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -198,7 +198,7 @@ theorem masked_or_allzeroes_notoptimised_logical_thm (e : IntW 32) :
   select (icmp IntPredicate.eq (LLVM.and e (const? 32 15)) (const? 32 0)) (const? 1 1)
       (icmp IntPredicate.eq (LLVM.and e (const? 32 39)) (const? 32 0)) ⊑
     LLVM.or (icmp IntPredicate.eq (LLVM.and e (const? 32 15)) (const? 32 0))
-      (icmp IntPredicate.eq (LLVM.and e (const? 32 39)) (const? 32 0)) := by 
+      (icmp IntPredicate.eq (LLVM.and e (const? 32 39)) (const? 32 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -209,7 +209,7 @@ theorem masked_or_allzeroes_notoptimised_logical_thm (e : IntW 32) :
 
 theorem nomask_lhs_thm (e : IntW 32) :
   LLVM.or (icmp IntPredicate.eq e (const? 32 0)) (icmp IntPredicate.eq (LLVM.and e (const? 32 1)) (const? 32 0)) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 32 1)) (const? 32 0) := by 
+    icmp IntPredicate.eq (LLVM.and e (const? 32 1)) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -221,7 +221,7 @@ theorem nomask_lhs_thm (e : IntW 32) :
 theorem nomask_lhs_logical_thm (e : IntW 32) :
   select (icmp IntPredicate.eq e (const? 32 0)) (const? 1 1)
       (icmp IntPredicate.eq (LLVM.and e (const? 32 1)) (const? 32 0)) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 32 1)) (const? 32 0) := by 
+    icmp IntPredicate.eq (LLVM.and e (const? 32 1)) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -232,7 +232,7 @@ theorem nomask_lhs_logical_thm (e : IntW 32) :
 
 theorem nomask_rhs_thm (e : IntW 32) :
   LLVM.or (icmp IntPredicate.eq (LLVM.and e (const? 32 1)) (const? 32 0)) (icmp IntPredicate.eq e (const? 32 0)) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 32 1)) (const? 32 0) := by 
+    icmp IntPredicate.eq (LLVM.and e (const? 32 1)) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -244,7 +244,7 @@ theorem nomask_rhs_thm (e : IntW 32) :
 theorem nomask_rhs_logical_thm (e : IntW 32) :
   select (icmp IntPredicate.eq (LLVM.and e (const? 32 1)) (const? 32 0)) (const? 1 1)
       (icmp IntPredicate.eq e (const? 32 0)) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 32 1)) (const? 32 0) := by 
+    icmp IntPredicate.eq (LLVM.and e (const? 32 1)) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -256,7 +256,7 @@ theorem nomask_rhs_logical_thm (e : IntW 32) :
 theorem fold_mask_cmps_to_false_thm (e : IntW 32) :
   LLVM.and (icmp IntPredicate.eq e (const? 32 2147483647))
       (icmp IntPredicate.eq (LLVM.and e (const? 32 2147483647)) (const? 32 0)) ⊑
-    const? 1 0 := by 
+    const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -268,7 +268,7 @@ theorem fold_mask_cmps_to_false_thm (e : IntW 32) :
 theorem fold_mask_cmps_to_false_logical_thm (e : IntW 32) :
   select (icmp IntPredicate.eq e (const? 32 2147483647))
       (icmp IntPredicate.eq (LLVM.and e (const? 32 2147483647)) (const? 32 0)) (const? 1 0) ⊑
-    const? 1 0 := by 
+    const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -280,7 +280,7 @@ theorem fold_mask_cmps_to_false_logical_thm (e : IntW 32) :
 theorem fold_mask_cmps_to_true_thm (e : IntW 32) :
   LLVM.or (icmp IntPredicate.ne e (const? 32 2147483647))
       (icmp IntPredicate.ne (LLVM.and e (const? 32 2147483647)) (const? 32 0)) ⊑
-    const? 1 1 := by 
+    const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -292,7 +292,7 @@ theorem fold_mask_cmps_to_true_thm (e : IntW 32) :
 theorem fold_mask_cmps_to_true_logical_thm (e : IntW 32) :
   select (icmp IntPredicate.ne e (const? 32 2147483647)) (const? 1 1)
       (icmp IntPredicate.ne (LLVM.and e (const? 32 2147483647)) (const? 32 0)) ⊑
-    const? 1 1 := by 
+    const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -303,7 +303,7 @@ theorem fold_mask_cmps_to_true_logical_thm (e : IntW 32) :
 
 theorem cmpeq_bitwise_thm (e e_1 e_2 e_3 : IntW 8) :
   icmp IntPredicate.eq (LLVM.or (LLVM.xor e_3 e_2) (LLVM.xor e_1 e)) (const? 8 0) ⊑
-    LLVM.and (icmp IntPredicate.eq e_3 e_2) (icmp IntPredicate.eq e_1 e) := by 
+    LLVM.and (icmp IntPredicate.eq e_3 e_2) (icmp IntPredicate.eq e_1 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -316,7 +316,7 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_0_logical_thm (e : IntW 32) :
   select (icmp IntPredicate.ne (LLVM.and e (const? 32 12)) (const? 32 0))
       (icmp IntPredicate.eq (LLVM.and e (const? 32 3)) (const? 32 1)) (const? 1 0) ⊑
     LLVM.and (icmp IntPredicate.ne (LLVM.and e (const? 32 12)) (const? 32 0))
-      (icmp IntPredicate.eq (LLVM.and e (const? 32 3)) (const? 32 1)) := by 
+      (icmp IntPredicate.eq (LLVM.and e (const? 32 3)) (const? 32 1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -328,7 +328,7 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_0_logical_thm (e : IntW 32) :
 theorem masked_icmps_mask_notallzeros_bmask_mixed_1_thm (e : IntW 32) :
   LLVM.and (icmp IntPredicate.ne (LLVM.and e (const? 32 12)) (const? 32 0))
       (icmp IntPredicate.eq (LLVM.and e (const? 32 7)) (const? 32 1)) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 32 15)) (const? 32 9) := by 
+    icmp IntPredicate.eq (LLVM.and e (const? 32 15)) (const? 32 9) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -340,7 +340,7 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_1_thm (e : IntW 32) :
 theorem masked_icmps_mask_notallzeros_bmask_mixed_1_logical_thm (e : IntW 32) :
   select (icmp IntPredicate.ne (LLVM.and e (const? 32 12)) (const? 32 0))
       (icmp IntPredicate.eq (LLVM.and e (const? 32 7)) (const? 32 1)) (const? 1 0) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 32 15)) (const? 32 9) := by 
+    icmp IntPredicate.eq (LLVM.and e (const? 32 15)) (const? 32 9) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -353,7 +353,7 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_1b_logical_thm (e : IntW 32) :
   select (icmp IntPredicate.ne (LLVM.and e (const? 32 14)) (const? 32 0))
       (icmp IntPredicate.eq (LLVM.and e (const? 32 3)) (const? 32 1)) (const? 1 0) ⊑
     LLVM.and (icmp IntPredicate.ne (LLVM.and e (const? 32 14)) (const? 32 0))
-      (icmp IntPredicate.eq (LLVM.and e (const? 32 3)) (const? 32 1)) := by 
+      (icmp IntPredicate.eq (LLVM.and e (const? 32 3)) (const? 32 1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -365,7 +365,7 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_1b_logical_thm (e : IntW 32) :
 theorem masked_icmps_mask_notallzeros_bmask_mixed_2_thm (e : IntW 32) :
   LLVM.and (icmp IntPredicate.ne (LLVM.and e (const? 32 3)) (const? 32 0))
       (icmp IntPredicate.eq (LLVM.and e (const? 32 7)) (const? 32 0)) ⊑
-    const? 1 0 := by 
+    const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -377,7 +377,7 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_2_thm (e : IntW 32) :
 theorem masked_icmps_mask_notallzeros_bmask_mixed_2_logical_thm (e : IntW 32) :
   select (icmp IntPredicate.ne (LLVM.and e (const? 32 3)) (const? 32 0))
       (icmp IntPredicate.eq (LLVM.and e (const? 32 7)) (const? 32 0)) (const? 1 0) ⊑
-    const? 1 0 := by 
+    const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -389,7 +389,7 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_2_logical_thm (e : IntW 32) :
 theorem masked_icmps_mask_notallzeros_bmask_mixed_3_thm (e : IntW 32) :
   LLVM.and (icmp IntPredicate.ne (LLVM.and e (const? 32 15)) (const? 32 0))
       (icmp IntPredicate.eq (LLVM.and e (const? 32 7)) (const? 32 0)) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 32 15)) (const? 32 8) := by 
+    icmp IntPredicate.eq (LLVM.and e (const? 32 15)) (const? 32 8) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -401,7 +401,7 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_3_thm (e : IntW 32) :
 theorem masked_icmps_mask_notallzeros_bmask_mixed_3_logical_thm (e : IntW 32) :
   select (icmp IntPredicate.ne (LLVM.and e (const? 32 15)) (const? 32 0))
       (icmp IntPredicate.eq (LLVM.and e (const? 32 7)) (const? 32 0)) (const? 1 0) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 32 15)) (const? 32 8) := by 
+    icmp IntPredicate.eq (LLVM.and e (const? 32 15)) (const? 32 8) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -414,7 +414,7 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_3b_logical_thm (e : IntW 32) :
   select (icmp IntPredicate.ne (LLVM.and e (const? 32 15)) (const? 32 0))
       (icmp IntPredicate.eq (LLVM.and e (const? 32 3)) (const? 32 0)) (const? 1 0) ⊑
     LLVM.and (icmp IntPredicate.ne (LLVM.and e (const? 32 15)) (const? 32 0))
-      (icmp IntPredicate.eq (LLVM.and e (const? 32 3)) (const? 32 0)) := by 
+      (icmp IntPredicate.eq (LLVM.and e (const? 32 3)) (const? 32 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -426,7 +426,7 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_3b_logical_thm (e : IntW 32) :
 theorem masked_icmps_mask_notallzeros_bmask_mixed_4_thm (e : IntW 32) :
   LLVM.and (icmp IntPredicate.ne (LLVM.and e (const? 32 255)) (const? 32 0))
       (icmp IntPredicate.eq (LLVM.and e (const? 32 15)) (const? 32 8)) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 32 15)) (const? 32 8) := by 
+    icmp IntPredicate.eq (LLVM.and e (const? 32 15)) (const? 32 8) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -438,7 +438,7 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_4_thm (e : IntW 32) :
 theorem masked_icmps_mask_notallzeros_bmask_mixed_4_logical_thm (e : IntW 32) :
   select (icmp IntPredicate.ne (LLVM.and e (const? 32 255)) (const? 32 0))
       (icmp IntPredicate.eq (LLVM.and e (const? 32 15)) (const? 32 8)) (const? 1 0) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 32 15)) (const? 32 8) := by 
+    icmp IntPredicate.eq (LLVM.and e (const? 32 15)) (const? 32 8) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -450,7 +450,7 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_4_logical_thm (e : IntW 32) :
 theorem masked_icmps_mask_notallzeros_bmask_mixed_5_thm (e : IntW 32) :
   LLVM.and (icmp IntPredicate.ne (LLVM.and e (const? 32 15)) (const? 32 0))
       (icmp IntPredicate.eq (LLVM.and e (const? 32 15)) (const? 32 8)) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 32 15)) (const? 32 8) := by 
+    icmp IntPredicate.eq (LLVM.and e (const? 32 15)) (const? 32 8) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -462,7 +462,7 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_5_thm (e : IntW 32) :
 theorem masked_icmps_mask_notallzeros_bmask_mixed_5_logical_thm (e : IntW 32) :
   select (icmp IntPredicate.ne (LLVM.and e (const? 32 15)) (const? 32 0))
       (icmp IntPredicate.eq (LLVM.and e (const? 32 15)) (const? 32 8)) (const? 1 0) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 32 15)) (const? 32 8) := by 
+    icmp IntPredicate.eq (LLVM.and e (const? 32 15)) (const? 32 8) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -474,7 +474,7 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_5_logical_thm (e : IntW 32) :
 theorem masked_icmps_mask_notallzeros_bmask_mixed_6_thm (e : IntW 32) :
   LLVM.and (icmp IntPredicate.ne (LLVM.and e (const? 32 12)) (const? 32 0))
       (icmp IntPredicate.eq (LLVM.and e (const? 32 15)) (const? 32 8)) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 32 15)) (const? 32 8) := by 
+    icmp IntPredicate.eq (LLVM.and e (const? 32 15)) (const? 32 8) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -486,7 +486,7 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_6_thm (e : IntW 32) :
 theorem masked_icmps_mask_notallzeros_bmask_mixed_6_logical_thm (e : IntW 32) :
   select (icmp IntPredicate.ne (LLVM.and e (const? 32 12)) (const? 32 0))
       (icmp IntPredicate.eq (LLVM.and e (const? 32 15)) (const? 32 8)) (const? 1 0) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 32 15)) (const? 32 8) := by 
+    icmp IntPredicate.eq (LLVM.and e (const? 32 15)) (const? 32 8) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -498,7 +498,7 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_6_logical_thm (e : IntW 32) :
 theorem masked_icmps_mask_notallzeros_bmask_mixed_7_thm (e : IntW 32) :
   LLVM.and (icmp IntPredicate.ne (LLVM.and e (const? 32 7)) (const? 32 0))
       (icmp IntPredicate.eq (LLVM.and e (const? 32 15)) (const? 32 8)) ⊑
-    const? 1 0 := by 
+    const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -510,7 +510,7 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_7_thm (e : IntW 32) :
 theorem masked_icmps_mask_notallzeros_bmask_mixed_7_logical_thm (e : IntW 32) :
   select (icmp IntPredicate.ne (LLVM.and e (const? 32 7)) (const? 32 0))
       (icmp IntPredicate.eq (LLVM.and e (const? 32 15)) (const? 32 8)) (const? 1 0) ⊑
-    const? 1 0 := by 
+    const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -522,7 +522,7 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_7_logical_thm (e : IntW 32) :
 theorem masked_icmps_mask_notallzeros_bmask_mixed_7b_thm (e : IntW 32) :
   LLVM.and (icmp IntPredicate.ne (LLVM.and e (const? 32 6)) (const? 32 0))
       (icmp IntPredicate.eq (LLVM.and e (const? 32 15)) (const? 32 8)) ⊑
-    const? 1 0 := by 
+    const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -534,7 +534,7 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_7b_thm (e : IntW 32) :
 theorem masked_icmps_mask_notallzeros_bmask_mixed_7b_logical_thm (e : IntW 32) :
   select (icmp IntPredicate.ne (LLVM.and e (const? 32 6)) (const? 32 0))
       (icmp IntPredicate.eq (LLVM.and e (const? 32 15)) (const? 32 8)) (const? 1 0) ⊑
-    const? 1 0 := by 
+    const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -547,7 +547,7 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_0_logical_thm (e : Int
   select (icmp IntPredicate.eq (LLVM.and e (const? 32 12)) (const? 32 0)) (const? 1 1)
       (icmp IntPredicate.ne (LLVM.and e (const? 32 3)) (const? 32 1)) ⊑
     LLVM.or (icmp IntPredicate.eq (LLVM.and e (const? 32 12)) (const? 32 0))
-      (icmp IntPredicate.ne (LLVM.and e (const? 32 3)) (const? 32 1)) := by 
+      (icmp IntPredicate.ne (LLVM.and e (const? 32 3)) (const? 32 1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -559,7 +559,7 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_0_logical_thm (e : Int
 theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_1_thm (e : IntW 32) :
   LLVM.or (icmp IntPredicate.eq (LLVM.and e (const? 32 12)) (const? 32 0))
       (icmp IntPredicate.ne (LLVM.and e (const? 32 7)) (const? 32 1)) ⊑
-    icmp IntPredicate.ne (LLVM.and e (const? 32 15)) (const? 32 9) := by 
+    icmp IntPredicate.ne (LLVM.and e (const? 32 15)) (const? 32 9) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -571,7 +571,7 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_1_thm (e : IntW 32) :
 theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_1_logical_thm (e : IntW 32) :
   select (icmp IntPredicate.eq (LLVM.and e (const? 32 12)) (const? 32 0)) (const? 1 1)
       (icmp IntPredicate.ne (LLVM.and e (const? 32 7)) (const? 32 1)) ⊑
-    icmp IntPredicate.ne (LLVM.and e (const? 32 15)) (const? 32 9) := by 
+    icmp IntPredicate.ne (LLVM.and e (const? 32 15)) (const? 32 9) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -584,7 +584,7 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_1b_logical_thm (e : In
   select (icmp IntPredicate.eq (LLVM.and e (const? 32 14)) (const? 32 0)) (const? 1 1)
       (icmp IntPredicate.ne (LLVM.and e (const? 32 3)) (const? 32 1)) ⊑
     LLVM.or (icmp IntPredicate.eq (LLVM.and e (const? 32 14)) (const? 32 0))
-      (icmp IntPredicate.ne (LLVM.and e (const? 32 3)) (const? 32 1)) := by 
+      (icmp IntPredicate.ne (LLVM.and e (const? 32 3)) (const? 32 1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -596,7 +596,7 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_1b_logical_thm (e : In
 theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_2_thm (e : IntW 32) :
   LLVM.or (icmp IntPredicate.eq (LLVM.and e (const? 32 3)) (const? 32 0))
       (icmp IntPredicate.ne (LLVM.and e (const? 32 7)) (const? 32 0)) ⊑
-    const? 1 1 := by 
+    const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -608,7 +608,7 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_2_thm (e : IntW 32) :
 theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_2_logical_thm (e : IntW 32) :
   select (icmp IntPredicate.eq (LLVM.and e (const? 32 3)) (const? 32 0)) (const? 1 1)
       (icmp IntPredicate.ne (LLVM.and e (const? 32 7)) (const? 32 0)) ⊑
-    const? 1 1 := by 
+    const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -620,7 +620,7 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_2_logical_thm (e : Int
 theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_3_thm (e : IntW 32) :
   LLVM.or (icmp IntPredicate.eq (LLVM.and e (const? 32 15)) (const? 32 0))
       (icmp IntPredicate.ne (LLVM.and e (const? 32 7)) (const? 32 0)) ⊑
-    icmp IntPredicate.ne (LLVM.and e (const? 32 15)) (const? 32 8) := by 
+    icmp IntPredicate.ne (LLVM.and e (const? 32 15)) (const? 32 8) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -632,7 +632,7 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_3_thm (e : IntW 32) :
 theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_3_logical_thm (e : IntW 32) :
   select (icmp IntPredicate.eq (LLVM.and e (const? 32 15)) (const? 32 0)) (const? 1 1)
       (icmp IntPredicate.ne (LLVM.and e (const? 32 7)) (const? 32 0)) ⊑
-    icmp IntPredicate.ne (LLVM.and e (const? 32 15)) (const? 32 8) := by 
+    icmp IntPredicate.ne (LLVM.and e (const? 32 15)) (const? 32 8) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -645,7 +645,7 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_3b_logical_thm (e : In
   select (icmp IntPredicate.eq (LLVM.and e (const? 32 15)) (const? 32 0)) (const? 1 1)
       (icmp IntPredicate.ne (LLVM.and e (const? 32 3)) (const? 32 0)) ⊑
     LLVM.or (icmp IntPredicate.eq (LLVM.and e (const? 32 15)) (const? 32 0))
-      (icmp IntPredicate.ne (LLVM.and e (const? 32 3)) (const? 32 0)) := by 
+      (icmp IntPredicate.ne (LLVM.and e (const? 32 3)) (const? 32 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -657,7 +657,7 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_3b_logical_thm (e : In
 theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_4_thm (e : IntW 32) :
   LLVM.or (icmp IntPredicate.eq (LLVM.and e (const? 32 255)) (const? 32 0))
       (icmp IntPredicate.ne (LLVM.and e (const? 32 15)) (const? 32 8)) ⊑
-    icmp IntPredicate.ne (LLVM.and e (const? 32 15)) (const? 32 8) := by 
+    icmp IntPredicate.ne (LLVM.and e (const? 32 15)) (const? 32 8) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -669,7 +669,7 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_4_thm (e : IntW 32) :
 theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_4_logical_thm (e : IntW 32) :
   select (icmp IntPredicate.eq (LLVM.and e (const? 32 255)) (const? 32 0)) (const? 1 1)
       (icmp IntPredicate.ne (LLVM.and e (const? 32 15)) (const? 32 8)) ⊑
-    icmp IntPredicate.ne (LLVM.and e (const? 32 15)) (const? 32 8) := by 
+    icmp IntPredicate.ne (LLVM.and e (const? 32 15)) (const? 32 8) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -681,7 +681,7 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_4_logical_thm (e : Int
 theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_5_thm (e : IntW 32) :
   LLVM.or (icmp IntPredicate.eq (LLVM.and e (const? 32 15)) (const? 32 0))
       (icmp IntPredicate.ne (LLVM.and e (const? 32 15)) (const? 32 8)) ⊑
-    icmp IntPredicate.ne (LLVM.and e (const? 32 15)) (const? 32 8) := by 
+    icmp IntPredicate.ne (LLVM.and e (const? 32 15)) (const? 32 8) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -693,7 +693,7 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_5_thm (e : IntW 32) :
 theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_5_logical_thm (e : IntW 32) :
   select (icmp IntPredicate.eq (LLVM.and e (const? 32 15)) (const? 32 0)) (const? 1 1)
       (icmp IntPredicate.ne (LLVM.and e (const? 32 15)) (const? 32 8)) ⊑
-    icmp IntPredicate.ne (LLVM.and e (const? 32 15)) (const? 32 8) := by 
+    icmp IntPredicate.ne (LLVM.and e (const? 32 15)) (const? 32 8) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -705,7 +705,7 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_5_logical_thm (e : Int
 theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_6_thm (e : IntW 32) :
   LLVM.or (icmp IntPredicate.eq (LLVM.and e (const? 32 12)) (const? 32 0))
       (icmp IntPredicate.ne (LLVM.and e (const? 32 15)) (const? 32 8)) ⊑
-    icmp IntPredicate.ne (LLVM.and e (const? 32 15)) (const? 32 8) := by 
+    icmp IntPredicate.ne (LLVM.and e (const? 32 15)) (const? 32 8) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -717,7 +717,7 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_6_thm (e : IntW 32) :
 theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_6_logical_thm (e : IntW 32) :
   select (icmp IntPredicate.eq (LLVM.and e (const? 32 12)) (const? 32 0)) (const? 1 1)
       (icmp IntPredicate.ne (LLVM.and e (const? 32 15)) (const? 32 8)) ⊑
-    icmp IntPredicate.ne (LLVM.and e (const? 32 15)) (const? 32 8) := by 
+    icmp IntPredicate.ne (LLVM.and e (const? 32 15)) (const? 32 8) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -729,7 +729,7 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_6_logical_thm (e : Int
 theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_7_thm (e : IntW 32) :
   LLVM.or (icmp IntPredicate.eq (LLVM.and e (const? 32 7)) (const? 32 0))
       (icmp IntPredicate.ne (LLVM.and e (const? 32 15)) (const? 32 8)) ⊑
-    const? 1 1 := by 
+    const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -741,7 +741,7 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_7_thm (e : IntW 32) :
 theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_7_logical_thm (e : IntW 32) :
   select (icmp IntPredicate.eq (LLVM.and e (const? 32 7)) (const? 32 0)) (const? 1 1)
       (icmp IntPredicate.ne (LLVM.and e (const? 32 15)) (const? 32 8)) ⊑
-    const? 1 1 := by 
+    const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -753,7 +753,7 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_7_logical_thm (e : Int
 theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_7b_thm (e : IntW 32) :
   LLVM.or (icmp IntPredicate.eq (LLVM.and e (const? 32 6)) (const? 32 0))
       (icmp IntPredicate.ne (LLVM.and e (const? 32 15)) (const? 32 8)) ⊑
-    const? 1 1 := by 
+    const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -765,7 +765,7 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_7b_thm (e : IntW 32) :
 theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_7b_logical_thm (e : IntW 32) :
   select (icmp IntPredicate.eq (LLVM.and e (const? 32 6)) (const? 32 0)) (const? 1 1)
       (icmp IntPredicate.ne (LLVM.and e (const? 32 15)) (const? 32 8)) ⊑
-    const? 1 1 := by 
+    const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -778,7 +778,7 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_swapped_0_logical_thm (e : Int
   select (icmp IntPredicate.eq (LLVM.and e (const? 32 3)) (const? 32 1))
       (icmp IntPredicate.ne (LLVM.and e (const? 32 12)) (const? 32 0)) (const? 1 0) ⊑
     LLVM.and (icmp IntPredicate.eq (LLVM.and e (const? 32 3)) (const? 32 1))
-      (icmp IntPredicate.ne (LLVM.and e (const? 32 12)) (const? 32 0)) := by 
+      (icmp IntPredicate.ne (LLVM.and e (const? 32 12)) (const? 32 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -790,7 +790,7 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_swapped_0_logical_thm (e : Int
 theorem masked_icmps_mask_notallzeros_bmask_mixed_swapped_1_thm (e : IntW 32) :
   LLVM.and (icmp IntPredicate.eq (LLVM.and e (const? 32 7)) (const? 32 1))
       (icmp IntPredicate.ne (LLVM.and e (const? 32 12)) (const? 32 0)) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 32 15)) (const? 32 9) := by 
+    icmp IntPredicate.eq (LLVM.and e (const? 32 15)) (const? 32 9) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -802,7 +802,7 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_swapped_1_thm (e : IntW 32) :
 theorem masked_icmps_mask_notallzeros_bmask_mixed_swapped_1_logical_thm (e : IntW 32) :
   select (icmp IntPredicate.eq (LLVM.and e (const? 32 7)) (const? 32 1))
       (icmp IntPredicate.ne (LLVM.and e (const? 32 12)) (const? 32 0)) (const? 1 0) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 32 15)) (const? 32 9) := by 
+    icmp IntPredicate.eq (LLVM.and e (const? 32 15)) (const? 32 9) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -815,7 +815,7 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_swapped_1b_logical_thm (e : In
   select (icmp IntPredicate.eq (LLVM.and e (const? 32 3)) (const? 32 1))
       (icmp IntPredicate.ne (LLVM.and e (const? 32 14)) (const? 32 0)) (const? 1 0) ⊑
     LLVM.and (icmp IntPredicate.eq (LLVM.and e (const? 32 3)) (const? 32 1))
-      (icmp IntPredicate.ne (LLVM.and e (const? 32 14)) (const? 32 0)) := by 
+      (icmp IntPredicate.ne (LLVM.and e (const? 32 14)) (const? 32 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -827,7 +827,7 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_swapped_1b_logical_thm (e : In
 theorem masked_icmps_mask_notallzeros_bmask_mixed_swapped_2_thm (e : IntW 32) :
   LLVM.and (icmp IntPredicate.eq (LLVM.and e (const? 32 7)) (const? 32 0))
       (icmp IntPredicate.ne (LLVM.and e (const? 32 3)) (const? 32 0)) ⊑
-    const? 1 0 := by 
+    const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -839,7 +839,7 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_swapped_2_thm (e : IntW 32) :
 theorem masked_icmps_mask_notallzeros_bmask_mixed_swapped_2_logical_thm (e : IntW 32) :
   select (icmp IntPredicate.eq (LLVM.and e (const? 32 7)) (const? 32 0))
       (icmp IntPredicate.ne (LLVM.and e (const? 32 3)) (const? 32 0)) (const? 1 0) ⊑
-    const? 1 0 := by 
+    const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -851,7 +851,7 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_swapped_2_logical_thm (e : Int
 theorem masked_icmps_mask_notallzeros_bmask_mixed_swapped_3_thm (e : IntW 32) :
   LLVM.and (icmp IntPredicate.eq (LLVM.and e (const? 32 7)) (const? 32 0))
       (icmp IntPredicate.ne (LLVM.and e (const? 32 15)) (const? 32 0)) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 32 15)) (const? 32 8) := by 
+    icmp IntPredicate.eq (LLVM.and e (const? 32 15)) (const? 32 8) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -863,7 +863,7 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_swapped_3_thm (e : IntW 32) :
 theorem masked_icmps_mask_notallzeros_bmask_mixed_swapped_3_logical_thm (e : IntW 32) :
   select (icmp IntPredicate.eq (LLVM.and e (const? 32 7)) (const? 32 0))
       (icmp IntPredicate.ne (LLVM.and e (const? 32 15)) (const? 32 0)) (const? 1 0) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 32 15)) (const? 32 8) := by 
+    icmp IntPredicate.eq (LLVM.and e (const? 32 15)) (const? 32 8) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -876,7 +876,7 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_swapped_3b_logical_thm (e : In
   select (icmp IntPredicate.eq (LLVM.and e (const? 32 3)) (const? 32 0))
       (icmp IntPredicate.ne (LLVM.and e (const? 32 15)) (const? 32 0)) (const? 1 0) ⊑
     LLVM.and (icmp IntPredicate.eq (LLVM.and e (const? 32 3)) (const? 32 0))
-      (icmp IntPredicate.ne (LLVM.and e (const? 32 15)) (const? 32 0)) := by 
+      (icmp IntPredicate.ne (LLVM.and e (const? 32 15)) (const? 32 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -888,7 +888,7 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_swapped_3b_logical_thm (e : In
 theorem masked_icmps_mask_notallzeros_bmask_mixed_swapped_4_thm (e : IntW 32) :
   LLVM.and (icmp IntPredicate.eq (LLVM.and e (const? 32 15)) (const? 32 8))
       (icmp IntPredicate.ne (LLVM.and e (const? 32 255)) (const? 32 0)) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 32 15)) (const? 32 8) := by 
+    icmp IntPredicate.eq (LLVM.and e (const? 32 15)) (const? 32 8) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -900,7 +900,7 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_swapped_4_thm (e : IntW 32) :
 theorem masked_icmps_mask_notallzeros_bmask_mixed_swapped_4_logical_thm (e : IntW 32) :
   select (icmp IntPredicate.eq (LLVM.and e (const? 32 15)) (const? 32 8))
       (icmp IntPredicate.ne (LLVM.and e (const? 32 255)) (const? 32 0)) (const? 1 0) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 32 15)) (const? 32 8) := by 
+    icmp IntPredicate.eq (LLVM.and e (const? 32 15)) (const? 32 8) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -912,7 +912,7 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_swapped_4_logical_thm (e : Int
 theorem masked_icmps_mask_notallzeros_bmask_mixed_swapped_5_thm (e : IntW 32) :
   LLVM.and (icmp IntPredicate.eq (LLVM.and e (const? 32 15)) (const? 32 8))
       (icmp IntPredicate.ne (LLVM.and e (const? 32 15)) (const? 32 0)) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 32 15)) (const? 32 8) := by 
+    icmp IntPredicate.eq (LLVM.and e (const? 32 15)) (const? 32 8) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -924,7 +924,7 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_swapped_5_thm (e : IntW 32) :
 theorem masked_icmps_mask_notallzeros_bmask_mixed_swapped_5_logical_thm (e : IntW 32) :
   select (icmp IntPredicate.eq (LLVM.and e (const? 32 15)) (const? 32 8))
       (icmp IntPredicate.ne (LLVM.and e (const? 32 15)) (const? 32 0)) (const? 1 0) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 32 15)) (const? 32 8) := by 
+    icmp IntPredicate.eq (LLVM.and e (const? 32 15)) (const? 32 8) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -936,7 +936,7 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_swapped_5_logical_thm (e : Int
 theorem masked_icmps_mask_notallzeros_bmask_mixed_swapped_6_thm (e : IntW 32) :
   LLVM.and (icmp IntPredicate.eq (LLVM.and e (const? 32 15)) (const? 32 8))
       (icmp IntPredicate.ne (LLVM.and e (const? 32 12)) (const? 32 0)) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 32 15)) (const? 32 8) := by 
+    icmp IntPredicate.eq (LLVM.and e (const? 32 15)) (const? 32 8) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -948,7 +948,7 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_swapped_6_thm (e : IntW 32) :
 theorem masked_icmps_mask_notallzeros_bmask_mixed_swapped_6_logical_thm (e : IntW 32) :
   select (icmp IntPredicate.eq (LLVM.and e (const? 32 15)) (const? 32 8))
       (icmp IntPredicate.ne (LLVM.and e (const? 32 12)) (const? 32 0)) (const? 1 0) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 32 15)) (const? 32 8) := by 
+    icmp IntPredicate.eq (LLVM.and e (const? 32 15)) (const? 32 8) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -960,7 +960,7 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_swapped_6_logical_thm (e : Int
 theorem masked_icmps_mask_notallzeros_bmask_mixed_swapped_7_thm (e : IntW 32) :
   LLVM.and (icmp IntPredicate.eq (LLVM.and e (const? 32 15)) (const? 32 8))
       (icmp IntPredicate.ne (LLVM.and e (const? 32 7)) (const? 32 0)) ⊑
-    const? 1 0 := by 
+    const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -972,7 +972,7 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_swapped_7_thm (e : IntW 32) :
 theorem masked_icmps_mask_notallzeros_bmask_mixed_swapped_7_logical_thm (e : IntW 32) :
   select (icmp IntPredicate.eq (LLVM.and e (const? 32 15)) (const? 32 8))
       (icmp IntPredicate.ne (LLVM.and e (const? 32 7)) (const? 32 0)) (const? 1 0) ⊑
-    const? 1 0 := by 
+    const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -984,7 +984,7 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_swapped_7_logical_thm (e : Int
 theorem masked_icmps_mask_notallzeros_bmask_mixed_swapped_7b_thm (e : IntW 32) :
   LLVM.and (icmp IntPredicate.eq (LLVM.and e (const? 32 15)) (const? 32 8))
       (icmp IntPredicate.ne (LLVM.and e (const? 32 6)) (const? 32 0)) ⊑
-    const? 1 0 := by 
+    const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -996,7 +996,7 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_swapped_7b_thm (e : IntW 32) :
 theorem masked_icmps_mask_notallzeros_bmask_mixed_swapped_7b_logical_thm (e : IntW 32) :
   select (icmp IntPredicate.eq (LLVM.and e (const? 32 15)) (const? 32 8))
       (icmp IntPredicate.ne (LLVM.and e (const? 32 6)) (const? 32 0)) (const? 1 0) ⊑
-    const? 1 0 := by 
+    const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1009,7 +1009,7 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_swapped_0_logical_thm 
   select (icmp IntPredicate.ne (LLVM.and e (const? 32 3)) (const? 32 1)) (const? 1 1)
       (icmp IntPredicate.eq (LLVM.and e (const? 32 12)) (const? 32 0)) ⊑
     LLVM.or (icmp IntPredicate.ne (LLVM.and e (const? 32 3)) (const? 32 1))
-      (icmp IntPredicate.eq (LLVM.and e (const? 32 12)) (const? 32 0)) := by 
+      (icmp IntPredicate.eq (LLVM.and e (const? 32 12)) (const? 32 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1021,7 +1021,7 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_swapped_0_logical_thm 
 theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_swapped_1_thm (e : IntW 32) :
   LLVM.or (icmp IntPredicate.ne (LLVM.and e (const? 32 7)) (const? 32 1))
       (icmp IntPredicate.eq (LLVM.and e (const? 32 12)) (const? 32 0)) ⊑
-    icmp IntPredicate.ne (LLVM.and e (const? 32 15)) (const? 32 9) := by 
+    icmp IntPredicate.ne (LLVM.and e (const? 32 15)) (const? 32 9) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1033,7 +1033,7 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_swapped_1_thm (e : Int
 theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_swapped_1_logical_thm (e : IntW 32) :
   select (icmp IntPredicate.ne (LLVM.and e (const? 32 7)) (const? 32 1)) (const? 1 1)
       (icmp IntPredicate.eq (LLVM.and e (const? 32 12)) (const? 32 0)) ⊑
-    icmp IntPredicate.ne (LLVM.and e (const? 32 15)) (const? 32 9) := by 
+    icmp IntPredicate.ne (LLVM.and e (const? 32 15)) (const? 32 9) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1046,7 +1046,7 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_swapped_1b_logical_thm
   select (icmp IntPredicate.ne (LLVM.and e (const? 32 3)) (const? 32 1)) (const? 1 1)
       (icmp IntPredicate.eq (LLVM.and e (const? 32 14)) (const? 32 0)) ⊑
     LLVM.or (icmp IntPredicate.ne (LLVM.and e (const? 32 3)) (const? 32 1))
-      (icmp IntPredicate.eq (LLVM.and e (const? 32 14)) (const? 32 0)) := by 
+      (icmp IntPredicate.eq (LLVM.and e (const? 32 14)) (const? 32 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1058,7 +1058,7 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_swapped_1b_logical_thm
 theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_swapped_2_thm (e : IntW 32) :
   LLVM.or (icmp IntPredicate.ne (LLVM.and e (const? 32 7)) (const? 32 0))
       (icmp IntPredicate.eq (LLVM.and e (const? 32 3)) (const? 32 0)) ⊑
-    const? 1 1 := by 
+    const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1070,7 +1070,7 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_swapped_2_thm (e : Int
 theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_swapped_2_logical_thm (e : IntW 32) :
   select (icmp IntPredicate.ne (LLVM.and e (const? 32 7)) (const? 32 0)) (const? 1 1)
       (icmp IntPredicate.eq (LLVM.and e (const? 32 3)) (const? 32 0)) ⊑
-    const? 1 1 := by 
+    const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1082,7 +1082,7 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_swapped_2_logical_thm 
 theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_swapped_3_thm (e : IntW 32) :
   LLVM.or (icmp IntPredicate.ne (LLVM.and e (const? 32 7)) (const? 32 0))
       (icmp IntPredicate.eq (LLVM.and e (const? 32 15)) (const? 32 0)) ⊑
-    icmp IntPredicate.ne (LLVM.and e (const? 32 15)) (const? 32 8) := by 
+    icmp IntPredicate.ne (LLVM.and e (const? 32 15)) (const? 32 8) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1094,7 +1094,7 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_swapped_3_thm (e : Int
 theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_swapped_3_logical_thm (e : IntW 32) :
   select (icmp IntPredicate.ne (LLVM.and e (const? 32 7)) (const? 32 0)) (const? 1 1)
       (icmp IntPredicate.eq (LLVM.and e (const? 32 15)) (const? 32 0)) ⊑
-    icmp IntPredicate.ne (LLVM.and e (const? 32 15)) (const? 32 8) := by 
+    icmp IntPredicate.ne (LLVM.and e (const? 32 15)) (const? 32 8) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1107,7 +1107,7 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_swapped_3b_logical_thm
   select (icmp IntPredicate.ne (LLVM.and e (const? 32 3)) (const? 32 0)) (const? 1 1)
       (icmp IntPredicate.eq (LLVM.and e (const? 32 15)) (const? 32 0)) ⊑
     LLVM.or (icmp IntPredicate.ne (LLVM.and e (const? 32 3)) (const? 32 0))
-      (icmp IntPredicate.eq (LLVM.and e (const? 32 15)) (const? 32 0)) := by 
+      (icmp IntPredicate.eq (LLVM.and e (const? 32 15)) (const? 32 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1119,7 +1119,7 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_swapped_3b_logical_thm
 theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_swapped_4_thm (e : IntW 32) :
   LLVM.or (icmp IntPredicate.ne (LLVM.and e (const? 32 15)) (const? 32 8))
       (icmp IntPredicate.eq (LLVM.and e (const? 32 255)) (const? 32 0)) ⊑
-    icmp IntPredicate.ne (LLVM.and e (const? 32 15)) (const? 32 8) := by 
+    icmp IntPredicate.ne (LLVM.and e (const? 32 15)) (const? 32 8) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1131,7 +1131,7 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_swapped_4_thm (e : Int
 theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_swapped_4_logical_thm (e : IntW 32) :
   select (icmp IntPredicate.ne (LLVM.and e (const? 32 15)) (const? 32 8)) (const? 1 1)
       (icmp IntPredicate.eq (LLVM.and e (const? 32 255)) (const? 32 0)) ⊑
-    icmp IntPredicate.ne (LLVM.and e (const? 32 15)) (const? 32 8) := by 
+    icmp IntPredicate.ne (LLVM.and e (const? 32 15)) (const? 32 8) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1143,7 +1143,7 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_swapped_4_logical_thm 
 theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_swapped_5_thm (e : IntW 32) :
   LLVM.or (icmp IntPredicate.ne (LLVM.and e (const? 32 15)) (const? 32 8))
       (icmp IntPredicate.eq (LLVM.and e (const? 32 15)) (const? 32 0)) ⊑
-    icmp IntPredicate.ne (LLVM.and e (const? 32 15)) (const? 32 8) := by 
+    icmp IntPredicate.ne (LLVM.and e (const? 32 15)) (const? 32 8) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1155,7 +1155,7 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_swapped_5_thm (e : Int
 theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_swapped_5_logical_thm (e : IntW 32) :
   select (icmp IntPredicate.ne (LLVM.and e (const? 32 15)) (const? 32 8)) (const? 1 1)
       (icmp IntPredicate.eq (LLVM.and e (const? 32 15)) (const? 32 0)) ⊑
-    icmp IntPredicate.ne (LLVM.and e (const? 32 15)) (const? 32 8) := by 
+    icmp IntPredicate.ne (LLVM.and e (const? 32 15)) (const? 32 8) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1167,7 +1167,7 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_swapped_5_logical_thm 
 theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_swapped_6_thm (e : IntW 32) :
   LLVM.or (icmp IntPredicate.ne (LLVM.and e (const? 32 15)) (const? 32 8))
       (icmp IntPredicate.eq (LLVM.and e (const? 32 12)) (const? 32 0)) ⊑
-    icmp IntPredicate.ne (LLVM.and e (const? 32 15)) (const? 32 8) := by 
+    icmp IntPredicate.ne (LLVM.and e (const? 32 15)) (const? 32 8) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1179,7 +1179,7 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_swapped_6_thm (e : Int
 theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_swapped_6_logical_thm (e : IntW 32) :
   select (icmp IntPredicate.ne (LLVM.and e (const? 32 15)) (const? 32 8)) (const? 1 1)
       (icmp IntPredicate.eq (LLVM.and e (const? 32 12)) (const? 32 0)) ⊑
-    icmp IntPredicate.ne (LLVM.and e (const? 32 15)) (const? 32 8) := by 
+    icmp IntPredicate.ne (LLVM.and e (const? 32 15)) (const? 32 8) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1191,7 +1191,7 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_swapped_6_logical_thm 
 theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_swapped_7_thm (e : IntW 32) :
   LLVM.or (icmp IntPredicate.ne (LLVM.and e (const? 32 15)) (const? 32 8))
       (icmp IntPredicate.eq (LLVM.and e (const? 32 7)) (const? 32 0)) ⊑
-    const? 1 1 := by 
+    const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1203,7 +1203,7 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_swapped_7_thm (e : Int
 theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_swapped_7_logical_thm (e : IntW 32) :
   select (icmp IntPredicate.ne (LLVM.and e (const? 32 15)) (const? 32 8)) (const? 1 1)
       (icmp IntPredicate.eq (LLVM.and e (const? 32 7)) (const? 32 0)) ⊑
-    const? 1 1 := by 
+    const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1215,7 +1215,7 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_swapped_7_logical_thm 
 theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_swapped_7b_thm (e : IntW 32) :
   LLVM.or (icmp IntPredicate.ne (LLVM.and e (const? 32 15)) (const? 32 8))
       (icmp IntPredicate.eq (LLVM.and e (const? 32 6)) (const? 32 0)) ⊑
-    const? 1 1 := by 
+    const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1227,7 +1227,7 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_swapped_7b_thm (e : In
 theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_swapped_7b_logical_thm (e : IntW 32) :
   select (icmp IntPredicate.ne (LLVM.and e (const? 32 15)) (const? 32 8)) (const? 1 1)
       (icmp IntPredicate.eq (LLVM.and e (const? 32 6)) (const? 32 0)) ⊑
-    const? 1 1 := by 
+    const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1239,7 +1239,7 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_swapped_7b_logical_thm
 theorem masked_icmps_bmask_notmixed_or_thm (e : IntW 32) :
   LLVM.or (icmp IntPredicate.eq (LLVM.and e (const? 32 15)) (const? 32 3))
       (icmp IntPredicate.eq (LLVM.and e (const? 32 255)) (const? 32 243)) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 32 15)) (const? 32 3) := by 
+    icmp IntPredicate.eq (LLVM.and e (const? 32 15)) (const? 32 3) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1251,7 +1251,7 @@ theorem masked_icmps_bmask_notmixed_or_thm (e : IntW 32) :
 theorem masked_icmps_bmask_notmixed_and_thm (e : IntW 32) :
   LLVM.and (icmp IntPredicate.ne (LLVM.and e (const? 32 15)) (const? 32 3))
       (icmp IntPredicate.ne (LLVM.and e (const? 32 255)) (const? 32 243)) ⊑
-    icmp IntPredicate.ne (LLVM.and e (const? 32 15)) (const? 32 3) := by 
+    icmp IntPredicate.ne (LLVM.and e (const? 32 15)) (const? 32 3) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1263,7 +1263,7 @@ theorem masked_icmps_bmask_notmixed_and_thm (e : IntW 32) :
 theorem masked_icmps_bmask_notmixed_and_expected_false_thm (e : IntW 32) :
   LLVM.and (icmp IntPredicate.ne (LLVM.and e (const? 32 3)) (const? 32 15))
       (icmp IntPredicate.ne (LLVM.and e (const? 32 255)) (const? 32 242)) ⊑
-    icmp IntPredicate.ne (LLVM.and e (const? 32 255)) (const? 32 242) := by 
+    icmp IntPredicate.ne (LLVM.and e (const? 32 255)) (const? 32 242) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gicmphmul_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gicmphmul_proof.lean
@@ -10,7 +10,7 @@ set_option linter.unreachableTactic false
 section gicmphmul_proof
 theorem squared_nsw_eq0_thm (e : IntW 5) :
   icmp IntPredicate.eq (mul e e { «nsw» := true, «nuw» := false }) (const? 5 0) ⊑
-    icmp IntPredicate.eq e (const? 5 0) := by 
+    icmp IntPredicate.eq e (const? 5 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -21,7 +21,7 @@ theorem squared_nsw_eq0_thm (e : IntW 5) :
 
 theorem squared_nsw_sgt0_thm (e : IntW 5) :
   icmp IntPredicate.sgt (mul e e { «nsw» := true, «nuw» := false }) (const? 5 0) ⊑
-    icmp IntPredicate.ne e (const? 5 0) := by 
+    icmp IntPredicate.ne e (const? 5 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -32,7 +32,7 @@ theorem squared_nsw_sgt0_thm (e : IntW 5) :
 
 theorem slt_positive_multip_rem_zero_thm (e : IntW 8) :
   icmp IntPredicate.slt (mul e (const? 8 7) { «nsw» := true, «nuw» := false }) (const? 8 21) ⊑
-    icmp IntPredicate.slt e (const? 8 3) := by 
+    icmp IntPredicate.slt e (const? 8 3) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -43,7 +43,7 @@ theorem slt_positive_multip_rem_zero_thm (e : IntW 8) :
 
 theorem slt_negative_multip_rem_zero_thm (e : IntW 8) :
   icmp IntPredicate.slt (mul e (const? 8 (-7)) { «nsw» := true, «nuw» := false }) (const? 8 21) ⊑
-    icmp IntPredicate.sgt e (const? 8 (-3)) := by 
+    icmp IntPredicate.sgt e (const? 8 (-3)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -54,7 +54,7 @@ theorem slt_negative_multip_rem_zero_thm (e : IntW 8) :
 
 theorem slt_positive_multip_rem_nz_thm (e : IntW 8) :
   icmp IntPredicate.slt (mul e (const? 8 5) { «nsw» := true, «nuw» := false }) (const? 8 21) ⊑
-    icmp IntPredicate.slt e (const? 8 5) := by 
+    icmp IntPredicate.slt e (const? 8 5) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -65,7 +65,7 @@ theorem slt_positive_multip_rem_nz_thm (e : IntW 8) :
 
 theorem ult_rem_zero_thm (e : IntW 8) :
   icmp IntPredicate.ult (mul e (const? 8 7) { «nsw» := false, «nuw» := true }) (const? 8 21) ⊑
-    icmp IntPredicate.ult e (const? 8 3) := by 
+    icmp IntPredicate.ult e (const? 8 3) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -76,7 +76,7 @@ theorem ult_rem_zero_thm (e : IntW 8) :
 
 theorem ult_rem_zero_nsw_thm (e : IntW 8) :
   icmp IntPredicate.ult (mul e (const? 8 7) { «nsw» := true, «nuw» := true }) (const? 8 21) ⊑
-    icmp IntPredicate.ult e (const? 8 3) := by 
+    icmp IntPredicate.ult e (const? 8 3) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -87,7 +87,7 @@ theorem ult_rem_zero_nsw_thm (e : IntW 8) :
 
 theorem ult_rem_nz_thm (e : IntW 8) :
   icmp IntPredicate.ult (mul e (const? 8 5) { «nsw» := false, «nuw» := true }) (const? 8 21) ⊑
-    icmp IntPredicate.ult e (const? 8 5) := by 
+    icmp IntPredicate.ult e (const? 8 5) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -98,7 +98,7 @@ theorem ult_rem_nz_thm (e : IntW 8) :
 
 theorem ult_rem_nz_nsw_thm (e : IntW 8) :
   icmp IntPredicate.ult (mul e (const? 8 5) { «nsw» := true, «nuw» := true }) (const? 8 21) ⊑
-    icmp IntPredicate.ult e (const? 8 5) := by 
+    icmp IntPredicate.ult e (const? 8 5) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -109,7 +109,7 @@ theorem ult_rem_nz_nsw_thm (e : IntW 8) :
 
 theorem sgt_positive_multip_rem_zero_thm (e : IntW 8) :
   icmp IntPredicate.sgt (mul e (const? 8 7) { «nsw» := true, «nuw» := false }) (const? 8 21) ⊑
-    icmp IntPredicate.sgt e (const? 8 3) := by 
+    icmp IntPredicate.sgt e (const? 8 3) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -120,7 +120,7 @@ theorem sgt_positive_multip_rem_zero_thm (e : IntW 8) :
 
 theorem sgt_negative_multip_rem_zero_thm (e : IntW 8) :
   icmp IntPredicate.sgt (mul e (const? 8 (-7)) { «nsw» := true, «nuw» := false }) (const? 8 21) ⊑
-    icmp IntPredicate.slt e (const? 8 (-3)) := by 
+    icmp IntPredicate.slt e (const? 8 (-3)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -131,7 +131,7 @@ theorem sgt_negative_multip_rem_zero_thm (e : IntW 8) :
 
 theorem sgt_positive_multip_rem_nz_thm (e : IntW 8) :
   icmp IntPredicate.sgt (mul e (const? 8 5) { «nsw» := true, «nuw» := false }) (const? 8 21) ⊑
-    icmp IntPredicate.sgt e (const? 8 4) := by 
+    icmp IntPredicate.sgt e (const? 8 4) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -142,7 +142,7 @@ theorem sgt_positive_multip_rem_nz_thm (e : IntW 8) :
 
 theorem ugt_rem_zero_thm (e : IntW 8) :
   icmp IntPredicate.ugt (mul e (const? 8 7) { «nsw» := false, «nuw» := true }) (const? 8 21) ⊑
-    icmp IntPredicate.ugt e (const? 8 3) := by 
+    icmp IntPredicate.ugt e (const? 8 3) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -153,7 +153,7 @@ theorem ugt_rem_zero_thm (e : IntW 8) :
 
 theorem ugt_rem_zero_nsw_thm (e : IntW 8) :
   icmp IntPredicate.ugt (mul e (const? 8 7) { «nsw» := true, «nuw» := true }) (const? 8 21) ⊑
-    icmp IntPredicate.ugt e (const? 8 3) := by 
+    icmp IntPredicate.ugt e (const? 8 3) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -164,7 +164,7 @@ theorem ugt_rem_zero_nsw_thm (e : IntW 8) :
 
 theorem ugt_rem_nz_thm (e : IntW 8) :
   icmp IntPredicate.ugt (mul e (const? 8 5) { «nsw» := false, «nuw» := true }) (const? 8 21) ⊑
-    icmp IntPredicate.ugt e (const? 8 4) := by 
+    icmp IntPredicate.ugt e (const? 8 4) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -175,7 +175,7 @@ theorem ugt_rem_nz_thm (e : IntW 8) :
 
 theorem ugt_rem_nz_nsw_thm (e : IntW 8) :
   icmp IntPredicate.ugt (mul e (const? 8 5) { «nsw» := true, «nuw» := true }) (const? 8 21) ⊑
-    icmp IntPredicate.ugt e (const? 8 4) := by 
+    icmp IntPredicate.ugt e (const? 8 4) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -186,7 +186,7 @@ theorem ugt_rem_nz_nsw_thm (e : IntW 8) :
 
 theorem eq_nsw_rem_zero_thm (e : IntW 8) :
   icmp IntPredicate.eq (mul e (const? 8 (-5)) { «nsw» := true, «nuw» := false }) (const? 8 20) ⊑
-    icmp IntPredicate.eq e (const? 8 (-4)) := by 
+    icmp IntPredicate.eq e (const? 8 (-4)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -196,7 +196,7 @@ theorem eq_nsw_rem_zero_thm (e : IntW 8) :
 
 
 theorem eq_nsw_rem_nz_thm (e : IntW 8) :
-  icmp IntPredicate.eq (mul e (const? 8 5) { «nsw» := true, «nuw» := false }) (const? 8 (-11)) ⊑ const? 1 0 := by 
+  icmp IntPredicate.eq (mul e (const? 8 5) { «nsw» := true, «nuw» := false }) (const? 8 (-11)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -206,7 +206,7 @@ theorem eq_nsw_rem_nz_thm (e : IntW 8) :
 
 
 theorem ne_nsw_rem_nz_thm (e : IntW 8) :
-  icmp IntPredicate.ne (mul e (const? 8 5) { «nsw» := true, «nuw» := false }) (const? 8 (-126)) ⊑ const? 1 1 := by 
+  icmp IntPredicate.ne (mul e (const? 8 5) { «nsw» := true, «nuw» := false }) (const? 8 (-126)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -217,7 +217,7 @@ theorem ne_nsw_rem_nz_thm (e : IntW 8) :
 
 theorem ne_nuw_rem_zero_thm (e : IntW 8) :
   icmp IntPredicate.ne (mul e (const? 8 5) { «nsw» := false, «nuw» := true }) (const? 8 (-126)) ⊑
-    icmp IntPredicate.ne e (const? 8 26) := by 
+    icmp IntPredicate.ne e (const? 8 26) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -227,7 +227,7 @@ theorem ne_nuw_rem_zero_thm (e : IntW 8) :
 
 
 theorem eq_nuw_rem_nz_thm (e : IntW 8) :
-  icmp IntPredicate.eq (mul e (const? 8 (-5)) { «nsw» := false, «nuw» := true }) (const? 8 20) ⊑ const? 1 0 := by 
+  icmp IntPredicate.eq (mul e (const? 8 (-5)) { «nsw» := false, «nuw» := true }) (const? 8 20) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -237,7 +237,7 @@ theorem eq_nuw_rem_nz_thm (e : IntW 8) :
 
 
 theorem ne_nuw_rem_nz_thm (e : IntW 8) :
-  icmp IntPredicate.ne (mul e (const? 8 5) { «nsw» := false, «nuw» := true }) (const? 8 (-30)) ⊑ const? 1 1 := by 
+  icmp IntPredicate.ne (mul e (const? 8 5) { «nsw» := false, «nuw» := true }) (const? 8 (-30)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -247,7 +247,7 @@ theorem ne_nuw_rem_nz_thm (e : IntW 8) :
 
 
 theorem sgt_minnum_thm (e : IntW 8) :
-  icmp IntPredicate.sgt (mul e (const? 8 7) { «nsw» := true, «nuw» := false }) (const? 8 (-128)) ⊑ const? 1 1 := by 
+  icmp IntPredicate.sgt (mul e (const? 8 7) { «nsw» := true, «nuw» := false }) (const? 8 (-128)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -257,7 +257,7 @@ theorem sgt_minnum_thm (e : IntW 8) :
 
 
 theorem ule_bignum_thm (e : IntW 8) :
-  icmp IntPredicate.ule (mul e (const? 8 (-1))) (const? 8 0) ⊑ icmp IntPredicate.eq e (const? 8 0) := by 
+  icmp IntPredicate.ule (mul e (const? 8 (-1))) (const? 8 0) ⊑ icmp IntPredicate.eq e (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -267,7 +267,7 @@ theorem ule_bignum_thm (e : IntW 8) :
 
 
 theorem sgt_mulzero_thm (e : IntW 8) :
-  icmp IntPredicate.sgt (mul e (const? 8 0) { «nsw» := true, «nuw» := false }) (const? 8 21) ⊑ const? 1 0 := by 
+  icmp IntPredicate.sgt (mul e (const? 8 0) { «nsw» := true, «nuw» := false }) (const? 8 21) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -277,7 +277,7 @@ theorem sgt_mulzero_thm (e : IntW 8) :
 
 
 theorem eq_rem_zero_nonuw_thm (e : IntW 8) :
-  icmp IntPredicate.eq (mul e (const? 8 5)) (const? 8 20) ⊑ icmp IntPredicate.eq e (const? 8 4) := by 
+  icmp IntPredicate.eq (mul e (const? 8 5)) (const? 8 20) ⊑ icmp IntPredicate.eq e (const? 8 4) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -287,7 +287,7 @@ theorem eq_rem_zero_nonuw_thm (e : IntW 8) :
 
 
 theorem ne_rem_zero_nonuw_thm (e : IntW 8) :
-  icmp IntPredicate.ne (mul e (const? 8 5)) (const? 8 30) ⊑ icmp IntPredicate.ne e (const? 8 6) := by 
+  icmp IntPredicate.ne (mul e (const? 8 5)) (const? 8 30) ⊑ icmp IntPredicate.ne e (const? 8 6) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -297,7 +297,7 @@ theorem ne_rem_zero_nonuw_thm (e : IntW 8) :
 
 
 theorem mul_constant_eq_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.eq (mul e_1 (const? 32 5)) (mul e (const? 32 5)) ⊑ icmp IntPredicate.eq e_1 e := by 
+  icmp IntPredicate.eq (mul e_1 (const? 32 5)) (mul e (const? 32 5)) ⊑ icmp IntPredicate.eq e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -309,7 +309,7 @@ theorem mul_constant_eq_thm (e e_1 : IntW 32) :
 theorem mul_constant_eq_nsw_thm (e e_1 : IntW 32) :
   icmp IntPredicate.eq (mul e_1 (const? 32 6) { «nsw» := true, «nuw» := false })
       (mul e (const? 32 6) { «nsw» := true, «nuw» := false }) ⊑
-    icmp IntPredicate.eq e_1 e := by 
+    icmp IntPredicate.eq e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -321,7 +321,7 @@ theorem mul_constant_eq_nsw_thm (e e_1 : IntW 32) :
 theorem mul_constant_nuw_eq_thm (e e_1 : IntW 32) :
   icmp IntPredicate.eq (mul e_1 (const? 32 22) { «nsw» := false, «nuw» := true })
       (mul e (const? 32 22) { «nsw» := false, «nuw» := true }) ⊑
-    icmp IntPredicate.eq e_1 e := by 
+    icmp IntPredicate.eq e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -332,7 +332,7 @@ theorem mul_constant_nuw_eq_thm (e e_1 : IntW 32) :
 
 theorem mul_constant_partial_nuw_eq_thm (e e_1 : IntW 32) :
   icmp IntPredicate.eq (mul e_1 (const? 32 44)) (mul e (const? 32 44) { «nsw» := false, «nuw» := true }) ⊑
-    icmp IntPredicate.eq (LLVM.and (LLVM.xor e_1 e) (const? 32 1073741823)) (const? 32 0) := by 
+    icmp IntPredicate.eq (LLVM.and (LLVM.xor e_1 e) (const? 32 1073741823)) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -344,7 +344,7 @@ theorem mul_constant_partial_nuw_eq_thm (e e_1 : IntW 32) :
 theorem mul_constant_mismatch_wrap_eq_thm (e e_1 : IntW 32) :
   icmp IntPredicate.eq (mul e_1 (const? 32 54) { «nsw» := true, «nuw» := false })
       (mul e (const? 32 54) { «nsw» := false, «nuw» := true }) ⊑
-    icmp IntPredicate.eq (LLVM.and (LLVM.xor e_1 e) (const? 32 2147483647)) (const? 32 0) := by 
+    icmp IntPredicate.eq (LLVM.and (LLVM.xor e_1 e) (const? 32 2147483647)) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -355,7 +355,7 @@ theorem mul_constant_mismatch_wrap_eq_thm (e e_1 : IntW 32) :
 
 theorem eq_mul_constants_with_tz_thm (e e_1 : IntW 32) :
   icmp IntPredicate.ne (mul e_1 (const? 32 12)) (mul e (const? 32 12)) ⊑
-    icmp IntPredicate.ne (LLVM.and (LLVM.xor e_1 e) (const? 32 1073741823)) (const? 32 0) := by 
+    icmp IntPredicate.ne (LLVM.and (LLVM.xor e_1 e) (const? 32 1073741823)) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -365,7 +365,7 @@ theorem eq_mul_constants_with_tz_thm (e e_1 : IntW 32) :
 
 
 theorem mul_of_bool_thm (e : IntW 8) (e_1 : IntW 32) :
-  icmp IntPredicate.ugt (mul (LLVM.and e_1 (const? 32 1)) (zext 32 e)) (const? 32 255) ⊑ const? 1 0 := by 
+  icmp IntPredicate.ugt (mul (LLVM.and e_1 (const? 32 1)) (zext 32 e)) (const? 32 255) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -376,7 +376,7 @@ theorem mul_of_bool_thm (e : IntW 8) (e_1 : IntW 32) :
 
 theorem mul_of_bool_commute_thm (e e_1 : IntW 32) :
   icmp IntPredicate.ugt (mul (LLVM.and e_1 (const? 32 255)) (LLVM.and e (const? 32 1))) (const? 32 255) ⊑
-    const? 1 0 := by 
+    const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -387,7 +387,7 @@ theorem mul_of_bool_commute_thm (e e_1 : IntW 32) :
 
 theorem mul_of_bools_thm (e e_1 : IntW 32) :
   icmp IntPredicate.ult (mul (LLVM.and e_1 (const? 32 1)) (LLVM.and e (const? 32 1))) (const? 32 2) ⊑
-    const? 1 1 := by 
+    const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -399,7 +399,7 @@ theorem mul_of_bools_thm (e e_1 : IntW 32) :
 theorem not_mul_of_bool_thm (e : IntW 8) (e_1 : IntW 32) :
   icmp IntPredicate.ugt (mul (LLVM.and e_1 (const? 32 3)) (zext 32 e)) (const? 32 255) ⊑
     icmp IntPredicate.ugt (mul (LLVM.and e_1 (const? 32 3)) (zext 32 e) { «nsw» := true, «nuw» := true })
-      (const? 32 255) := by 
+      (const? 32 255) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -411,7 +411,7 @@ theorem not_mul_of_bool_thm (e : IntW 8) (e_1 : IntW 32) :
 theorem not_mul_of_bool_commute_thm (e e_1 : IntW 32) :
   icmp IntPredicate.ugt (mul (LLVM.and e_1 (const? 32 255)) (lshr e (const? 32 30))) (const? 32 255) ⊑
     icmp IntPredicate.ugt (mul (LLVM.and e_1 (const? 32 255)) (lshr e (const? 32 30)) { «nsw» := true, «nuw» := true })
-      (const? 32 255) := by 
+      (const? 32 255) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -423,7 +423,7 @@ theorem not_mul_of_bool_commute_thm (e e_1 : IntW 32) :
 theorem mul_of_bool_no_lz_other_op_thm (e : IntW 8) (e_1 : IntW 32) :
   icmp IntPredicate.sgt (mul (LLVM.and e_1 (const? 32 1)) (sext 32 e) { «nsw» := true, «nuw» := true })
       (const? 32 127) ⊑
-    const? 1 0 := by 
+    const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -433,7 +433,7 @@ theorem mul_of_bool_no_lz_other_op_thm (e : IntW 8) (e_1 : IntW 32) :
 
 
 theorem mul_of_pow2_thm (e : IntW 8) (e_1 : IntW 32) :
-  icmp IntPredicate.ugt (mul (LLVM.and e_1 (const? 32 2)) (zext 32 e)) (const? 32 510) ⊑ const? 1 0 := by 
+  icmp IntPredicate.ugt (mul (LLVM.and e_1 (const? 32 2)) (zext 32 e)) (const? 32 510) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -444,7 +444,7 @@ theorem mul_of_pow2_thm (e : IntW 8) (e_1 : IntW 32) :
 
 theorem mul_of_pow2_commute_thm (e e_1 : IntW 32) :
   icmp IntPredicate.ugt (mul (LLVM.and e_1 (const? 32 255)) (LLVM.and e (const? 32 4))) (const? 32 1020) ⊑
-    const? 1 0 := by 
+    const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -454,7 +454,7 @@ theorem mul_of_pow2_commute_thm (e e_1 : IntW 32) :
 
 
 theorem mul_of_pow2s_thm (e e_1 : IntW 32) :
-  LLVM.or (mul (LLVM.and e_1 (const? 32 8)) (LLVM.and e (const? 32 16))) (const? 32 128) ⊑ const? 32 128 := by 
+  LLVM.or (mul (LLVM.and e_1 (const? 32 8)) (LLVM.and e (const? 32 16))) (const? 32 128) ⊑ const? 32 128 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -466,7 +466,7 @@ theorem mul_of_pow2s_thm (e e_1 : IntW 32) :
 theorem not_mul_of_pow2_thm (e : IntW 8) (e_1 : IntW 32) :
   icmp IntPredicate.ugt (mul (LLVM.and e_1 (const? 32 6)) (zext 32 e)) (const? 32 1530) ⊑
     icmp IntPredicate.ugt (mul (LLVM.and e_1 (const? 32 6)) (zext 32 e) { «nsw» := true, «nuw» := true })
-      (const? 32 1530) := by 
+      (const? 32 1530) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -479,7 +479,7 @@ theorem not_mul_of_pow2_commute_thm (e e_1 : IntW 32) :
   icmp IntPredicate.ugt (mul (LLVM.and e_1 (const? 32 255)) (LLVM.and e (const? 32 12))) (const? 32 3060) ⊑
     icmp IntPredicate.ugt
       (mul (LLVM.and e_1 (const? 32 255)) (LLVM.and e (const? 32 12)) { «nsw» := true, «nuw» := true })
-      (const? 32 3060) := by 
+      (const? 32 3060) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -490,7 +490,7 @@ theorem not_mul_of_pow2_commute_thm (e e_1 : IntW 32) :
 
 theorem splat_mul_known_lz_thm (e : IntW 32) :
   icmp IntPredicate.eq (lshr (mul (zext 128 e) (const? 128 18446744078004518913)) (const? 128 96)) (const? 128 0) ⊑
-    const? 1 1 := by 
+    const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -501,7 +501,7 @@ theorem splat_mul_known_lz_thm (e : IntW 32) :
 
 theorem splat_mul_unknown_lz_thm (e : IntW 32) :
   icmp IntPredicate.eq (lshr (mul (zext 128 e) (const? 128 18446744078004518913)) (const? 128 95)) (const? 128 0) ⊑
-    icmp IntPredicate.sgt e (const? 32 (-1)) := by 
+    icmp IntPredicate.sgt e (const? 32 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -517,7 +517,7 @@ theorem reused_mul_nuw_xy_z_selectnonzero_ugt_thm (e e_1 e_2 : IntW 8) :
       (const? 1 1) ⊑
     select (icmp IntPredicate.eq e_2 (const? 8 0)) (const? 1 1)
       (icmp IntPredicate.ugt (mul e_1 e_2 { «nsw» := false, «nuw» := true })
-        (mul e e_2 { «nsw» := false, «nuw» := true })) := by 
+        (mul e e_2 { «nsw» := false, «nuw» := true })) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -529,7 +529,7 @@ theorem reused_mul_nuw_xy_z_selectnonzero_ugt_thm (e e_1 e_2 : IntW 8) :
 theorem icmp_eq_mul_nsw_nonequal_thm (e e_1 : IntW 8) :
   icmp IntPredicate.eq (mul e_1 e { «nsw» := true, «nuw» := false })
       (mul (add e_1 (const? 8 1)) e { «nsw» := true, «nuw» := false }) ⊑
-    icmp IntPredicate.eq e (const? 8 0) := by 
+    icmp IntPredicate.eq e (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -541,7 +541,7 @@ theorem icmp_eq_mul_nsw_nonequal_thm (e e_1 : IntW 8) :
 theorem icmp_eq_mul_nuw_nonequal_thm (e e_1 : IntW 8) :
   icmp IntPredicate.eq (mul e_1 e { «nsw» := false, «nuw» := true })
       (mul (add e_1 (const? 8 1)) e { «nsw» := false, «nuw» := true }) ⊑
-    icmp IntPredicate.eq e (const? 8 0) := by 
+    icmp IntPredicate.eq e (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -553,7 +553,7 @@ theorem icmp_eq_mul_nuw_nonequal_thm (e e_1 : IntW 8) :
 theorem icmp_eq_mul_nsw_nonequal_commuted_thm (e e_1 : IntW 8) :
   icmp IntPredicate.eq (mul e_1 e { «nsw» := true, «nuw» := false })
       (mul e (add e_1 (const? 8 1)) { «nsw» := true, «nuw» := false }) ⊑
-    icmp IntPredicate.eq e (const? 8 0) := by 
+    icmp IntPredicate.eq e (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -565,7 +565,7 @@ theorem icmp_eq_mul_nsw_nonequal_commuted_thm (e e_1 : IntW 8) :
 theorem icmp_ne_mul_nsw_nonequal_thm (e e_1 : IntW 8) :
   icmp IntPredicate.ne (mul e_1 e { «nsw» := true, «nuw» := false })
       (mul (add e_1 (const? 8 1)) e { «nsw» := true, «nuw» := false }) ⊑
-    icmp IntPredicate.ne e (const? 8 0) := by 
+    icmp IntPredicate.ne e (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -577,7 +577,7 @@ theorem icmp_ne_mul_nsw_nonequal_thm (e e_1 : IntW 8) :
 theorem icmp_mul_nsw_slt_thm (e e_1 : IntW 8) :
   icmp IntPredicate.slt (mul e_1 (const? 8 7) { «nsw» := true, «nuw» := false })
       (mul e (const? 8 7) { «nsw» := true, «nuw» := false }) ⊑
-    icmp IntPredicate.slt e_1 e := by 
+    icmp IntPredicate.slt e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -589,7 +589,7 @@ theorem icmp_mul_nsw_slt_thm (e e_1 : IntW 8) :
 theorem icmp_mul_nsw_sle_thm (e e_1 : IntW 8) :
   icmp IntPredicate.sle (mul e_1 (const? 8 7) { «nsw» := true, «nuw» := false })
       (mul e (const? 8 7) { «nsw» := true, «nuw» := false }) ⊑
-    icmp IntPredicate.sle e_1 e := by 
+    icmp IntPredicate.sle e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -601,7 +601,7 @@ theorem icmp_mul_nsw_sle_thm (e e_1 : IntW 8) :
 theorem icmp_mul_nsw_sgt_thm (e e_1 : IntW 8) :
   icmp IntPredicate.sgt (mul e_1 (const? 8 7) { «nsw» := true, «nuw» := false })
       (mul e (const? 8 7) { «nsw» := true, «nuw» := false }) ⊑
-    icmp IntPredicate.sgt e_1 e := by 
+    icmp IntPredicate.sgt e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -613,7 +613,7 @@ theorem icmp_mul_nsw_sgt_thm (e e_1 : IntW 8) :
 theorem icmp_mul_nsw_sge_thm (e e_1 : IntW 8) :
   icmp IntPredicate.sge (mul e_1 (const? 8 7) { «nsw» := true, «nuw» := false })
       (mul e (const? 8 7) { «nsw» := true, «nuw» := false }) ⊑
-    icmp IntPredicate.sge e_1 e := by 
+    icmp IntPredicate.sge e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -625,7 +625,7 @@ theorem icmp_mul_nsw_sge_thm (e e_1 : IntW 8) :
 theorem icmp_mul_nsw_slt_neg_thm (e e_1 : IntW 8) :
   icmp IntPredicate.slt (mul e_1 (const? 8 (-7)) { «nsw» := true, «nuw» := false })
       (mul e (const? 8 (-7)) { «nsw» := true, «nuw» := false }) ⊑
-    icmp IntPredicate.sgt e_1 e := by 
+    icmp IntPredicate.sgt e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gicmphmulhand_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gicmphmulhand_proof.lean
@@ -10,7 +10,7 @@ set_option linter.unreachableTactic false
 section gicmphmulhand_proof
 theorem mul_mask_pow2_eq0_thm (e : IntW 8) :
   icmp IntPredicate.eq (LLVM.and (mul e (const? 8 44)) (const? 8 4)) (const? 8 0) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 8 1)) (const? 8 0) := by 
+    icmp IntPredicate.eq (LLVM.and e (const? 8 1)) (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -21,7 +21,7 @@ theorem mul_mask_pow2_eq0_thm (e : IntW 8) :
 
 theorem mul_mask_pow2_sgt0_thm (e : IntW 8) :
   icmp IntPredicate.sgt (LLVM.and (mul e (const? 8 44)) (const? 8 4)) (const? 8 0) ⊑
-    icmp IntPredicate.ne (LLVM.and e (const? 8 1)) (const? 8 0) := by 
+    icmp IntPredicate.ne (LLVM.and e (const? 8 1)) (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -32,7 +32,7 @@ theorem mul_mask_pow2_sgt0_thm (e : IntW 8) :
 
 theorem mul_mask_fakepow2_ne0_thm (e : IntW 8) :
   icmp IntPredicate.ne (LLVM.and (mul e (const? 8 44)) (const? 8 5)) (const? 8 0) ⊑
-    icmp IntPredicate.ne (LLVM.and e (const? 8 1)) (const? 8 0) := by 
+    icmp IntPredicate.ne (LLVM.and e (const? 8 1)) (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -43,7 +43,7 @@ theorem mul_mask_fakepow2_ne0_thm (e : IntW 8) :
 
 theorem mul_mask_pow2_eq4_thm (e : IntW 8) :
   icmp IntPredicate.eq (LLVM.and (mul e (const? 8 44)) (const? 8 4)) (const? 8 4) ⊑
-    icmp IntPredicate.ne (LLVM.and e (const? 8 1)) (const? 8 0) := by 
+    icmp IntPredicate.ne (LLVM.and e (const? 8 1)) (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -54,7 +54,7 @@ theorem mul_mask_pow2_eq4_thm (e : IntW 8) :
 
 theorem mul_mask_notpow2_ne_thm (e : IntW 8) :
   icmp IntPredicate.ne (LLVM.and (mul e (const? 8 60)) (const? 8 12)) (const? 8 0) ⊑
-    icmp IntPredicate.ne (LLVM.and (mul e (const? 8 12)) (const? 8 12)) (const? 8 0) := by 
+    icmp IntPredicate.ne (LLVM.and (mul e (const? 8 12)) (const? 8 12)) (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -65,7 +65,7 @@ theorem mul_mask_notpow2_ne_thm (e : IntW 8) :
 
 theorem pr40493_thm (e : IntW 32) :
   icmp IntPredicate.eq (LLVM.and (mul e (const? 32 12)) (const? 32 4)) (const? 32 0) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 32 1)) (const? 32 0) := by 
+    icmp IntPredicate.eq (LLVM.and e (const? 32 1)) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -76,7 +76,7 @@ theorem pr40493_thm (e : IntW 32) :
 
 theorem pr40493_neg1_thm (e : IntW 32) :
   icmp IntPredicate.eq (LLVM.and (mul e (const? 32 11)) (const? 32 4)) (const? 32 0) ⊑
-    icmp IntPredicate.eq (LLVM.and (mul e (const? 32 3)) (const? 32 4)) (const? 32 0) := by 
+    icmp IntPredicate.eq (LLVM.and (mul e (const? 32 3)) (const? 32 4)) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -87,7 +87,7 @@ theorem pr40493_neg1_thm (e : IntW 32) :
 
 theorem pr40493_neg2_thm (e : IntW 32) :
   icmp IntPredicate.eq (LLVM.and (mul e (const? 32 12)) (const? 32 15)) (const? 32 0) ⊑
-    icmp IntPredicate.eq (LLVM.and (mul e (const? 32 12)) (const? 32 12)) (const? 32 0) := by 
+    icmp IntPredicate.eq (LLVM.and (mul e (const? 32 12)) (const? 32 12)) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -97,7 +97,7 @@ theorem pr40493_neg2_thm (e : IntW 32) :
 
 
 theorem pr40493_neg3_thm (e : IntW 32) :
-  LLVM.and (mul e (const? 32 12)) (const? 32 4) ⊑ LLVM.and (shl e (const? 32 2)) (const? 32 4) := by 
+  LLVM.and (mul e (const? 32 12)) (const? 32 4) ⊑ LLVM.and (shl e (const? 32 2)) (const? 32 4) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -111,7 +111,7 @@ theorem pr51551_thm (e e_1 : IntW 32) :
       (LLVM.and (mul (LLVM.or (LLVM.and e_1 (const? 32 (-7))) (const? 32 1)) e { «nsw» := true, «nuw» := false })
         (const? 32 3))
       (const? 32 0) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 32 3)) (const? 32 0) := by 
+    icmp IntPredicate.eq (LLVM.and e (const? 32 3)) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -125,7 +125,7 @@ theorem pr51551_2_thm (e e_1 : IntW 32) :
       (LLVM.and (mul (LLVM.or (LLVM.and e_1 (const? 32 (-7))) (const? 32 1)) e { «nsw» := true, «nuw» := false })
         (const? 32 1))
       (const? 32 0) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 32 1)) (const? 32 0) := by 
+    icmp IntPredicate.eq (LLVM.and e (const? 32 1)) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -141,7 +141,7 @@ theorem pr51551_neg1_thm (e e_1 : IntW 32) :
       (const? 32 0) ⊑
     icmp IntPredicate.eq
       (LLVM.and (mul (LLVM.or (LLVM.and e_1 (const? 32 4)) (const? 32 1) { «disjoint» := true }) e) (const? 32 7))
-      (const? 32 0) := by 
+      (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -154,7 +154,7 @@ theorem pr51551_neg2_thm (e e_1 : IntW 32) :
   icmp IntPredicate.eq
       (LLVM.and (mul (LLVM.and e_1 (const? 32 (-7))) e { «nsw» := true, «nuw» := false }) (const? 32 7)) (const? 32 0) ⊑
     select (LLVM.xor (trunc 1 e_1) (const? 1 1)) (const? 1 1)
-      (icmp IntPredicate.eq (LLVM.and e (const? 32 7)) (const? 32 0)) := by 
+      (icmp IntPredicate.eq (LLVM.and e (const? 32 7)) (const? 32 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -166,7 +166,7 @@ theorem pr51551_neg2_thm (e e_1 : IntW 32) :
 theorem pr51551_demand3bits_thm (e e_1 : IntW 32) :
   LLVM.and (mul (LLVM.or (LLVM.and e_1 (const? 32 (-7))) (const? 32 1)) e { «nsw» := true, «nuw» := false })
       (const? 32 7) ⊑
-    LLVM.and e (const? 32 7) := by 
+    LLVM.and e (const? 32 7) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gicmphofhandhx_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gicmphofhandhx_proof.lean
@@ -9,7 +9,7 @@ set_option linter.unreachableTactic false
 
 section gicmphofhandhx_proof
 theorem icmp_ult_x_y_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.ult (LLVM.and e_1 e) e_1 ⊑ icmp IntPredicate.ne (LLVM.and e_1 e) e_1 := by 
+  icmp IntPredicate.ult (LLVM.and e_1 e) e_1 ⊑ icmp IntPredicate.ne (LLVM.and e_1 e) e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -20,7 +20,7 @@ theorem icmp_ult_x_y_thm (e e_1 : IntW 8) :
 
 theorem icmp_ult_x_y_2_thm (e e_1 : IntW 8) :
   icmp IntPredicate.ugt (mul e_1 e_1) (LLVM.and (mul e_1 e_1) e) ⊑
-    icmp IntPredicate.ne (LLVM.and (mul e_1 e_1) e) (mul e_1 e_1) := by 
+    icmp IntPredicate.ne (LLVM.and (mul e_1 e_1) e) (mul e_1 e_1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -31,7 +31,7 @@ theorem icmp_ult_x_y_2_thm (e e_1 : IntW 8) :
 
 theorem icmp_uge_x_y_2_thm (e e_1 : IntW 8) :
   icmp IntPredicate.ule (mul e_1 e_1) (LLVM.and (mul e_1 e_1) e) ⊑
-    icmp IntPredicate.eq (LLVM.and (mul e_1 e_1) e) (mul e_1 e_1) := by 
+    icmp IntPredicate.eq (LLVM.and (mul e_1 e_1) e) (mul e_1 e_1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -41,7 +41,7 @@ theorem icmp_uge_x_y_2_thm (e e_1 : IntW 8) :
 
 
 theorem icmp_sle_x_negy_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.sle (LLVM.and (LLVM.or e_1 (const? 8 (-128))) e) e ⊑ const? 1 1 := by 
+  icmp IntPredicate.sle (LLVM.and (LLVM.or e_1 (const? 8 (-128))) e) e ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -52,7 +52,7 @@ theorem icmp_sle_x_negy_thm (e e_1 : IntW 8) :
 
 theorem icmp_eq_x_invertable_y_todo_thm (e : IntW 1) (e_1 : IntW 8) :
   icmp IntPredicate.eq e_1 (LLVM.and e_1 (select e (const? 8 7) (const? 8 24))) ⊑
-    icmp IntPredicate.eq (LLVM.and e_1 (select e (const? 8 (-8)) (const? 8 (-25)))) (const? 8 0) := by 
+    icmp IntPredicate.eq (LLVM.and e_1 (select e (const? 8 (-8)) (const? 8 (-25)))) (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -63,7 +63,7 @@ theorem icmp_eq_x_invertable_y_todo_thm (e : IntW 1) (e_1 : IntW 8) :
 
 theorem icmp_eq_x_invertable_y_thm (e e_1 : IntW 8) :
   icmp IntPredicate.eq e_1 (LLVM.and e_1 (LLVM.xor e (const? 8 (-1)))) ⊑
-    icmp IntPredicate.eq (LLVM.and e_1 e) (const? 8 0) := by 
+    icmp IntPredicate.eq (LLVM.and e_1 e) (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -74,7 +74,7 @@ theorem icmp_eq_x_invertable_y_thm (e e_1 : IntW 8) :
 
 theorem icmp_eq_x_invertable_y2_todo_thm (e : IntW 8) (e_1 : IntW 1) :
   icmp IntPredicate.eq (select e_1 (const? 8 7) (const? 8 24)) (LLVM.and e (select e_1 (const? 8 7) (const? 8 24))) ⊑
-    icmp IntPredicate.eq (LLVM.or e (select e_1 (const? 8 (-8)) (const? 8 (-25)))) (const? 8 (-1)) := by 
+    icmp IntPredicate.eq (LLVM.or e (select e_1 (const? 8 (-8)) (const? 8 (-25)))) (const? 8 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -85,7 +85,7 @@ theorem icmp_eq_x_invertable_y2_todo_thm (e : IntW 8) (e_1 : IntW 1) :
 
 theorem icmp_eq_x_invertable_y2_thm (e e_1 : IntW 8) :
   icmp IntPredicate.eq (LLVM.xor e_1 (const? 8 (-1))) (LLVM.and e (LLVM.xor e_1 (const? 8 (-1)))) ⊑
-    icmp IntPredicate.eq (LLVM.or e e_1) (const? 8 (-1)) := by 
+    icmp IntPredicate.eq (LLVM.or e e_1) (const? 8 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gicmphofhorhx_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gicmphofhorhx_proof.lean
@@ -9,7 +9,7 @@ set_option linter.unreachableTactic false
 
 section gicmphofhorhx_proof
 theorem or_ugt_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.ugt (LLVM.or e_1 e) e_1 ⊑ icmp IntPredicate.ne (LLVM.or e_1 e) e_1 := by 
+  icmp IntPredicate.ugt (LLVM.or e_1 e) e_1 ⊑ icmp IntPredicate.ne (LLVM.or e_1 e) e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -20,7 +20,7 @@ theorem or_ugt_thm (e e_1 : IntW 8) :
 
 theorem or_eq_notY_eq_0_thm (e e_1 : IntW 8) :
   icmp IntPredicate.eq (LLVM.or e_1 (LLVM.xor e (const? 8 (-1)))) (LLVM.xor e (const? 8 (-1))) ⊑
-    icmp IntPredicate.eq (LLVM.and e_1 e) (const? 8 0) := by 
+    icmp IntPredicate.eq (LLVM.and e_1 e) (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -31,7 +31,7 @@ theorem or_eq_notY_eq_0_thm (e e_1 : IntW 8) :
 
 theorem or_ne_notY_eq_1s_thm (e e_1 : IntW 8) :
   icmp IntPredicate.ne (LLVM.or e_1 (LLVM.xor e (const? 8 (-1)))) e_1 ⊑
-    icmp IntPredicate.ne (LLVM.or e_1 e) (const? 8 (-1)) := by 
+    icmp IntPredicate.ne (LLVM.or e_1 e) (const? 8 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -42,7 +42,7 @@ theorem or_ne_notY_eq_1s_thm (e e_1 : IntW 8) :
 
 theorem or_ne_notY_eq_1s_fail_bad_not_thm (e e_1 : IntW 8) :
   icmp IntPredicate.ne (LLVM.or e_1 (LLVM.xor e (const? 8 (-2)))) e_1 ⊑
-    icmp IntPredicate.ne (LLVM.or e_1 (LLVM.xor e (const? 8 1))) (const? 8 (-1)) := by 
+    icmp IntPredicate.ne (LLVM.or e_1 (LLVM.xor e (const? 8 1))) (const? 8 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -53,7 +53,7 @@ theorem or_ne_notY_eq_1s_fail_bad_not_thm (e e_1 : IntW 8) :
 
 theorem or_simplify_ule_thm (e e_1 : IntW 8) :
   icmp IntPredicate.ule (LLVM.or (LLVM.or e_1 (const? 8 1)) (LLVM.and e (const? 8 (-2)))) (LLVM.and e (const? 8 (-2))) ⊑
-    icmp IntPredicate.ule (LLVM.or (LLVM.or e_1 e) (const? 8 1)) (LLVM.and e (const? 8 (-2))) := by 
+    icmp IntPredicate.ule (LLVM.or (LLVM.or e_1 e) (const? 8 1)) (LLVM.and e (const? 8 (-2))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -65,7 +65,7 @@ theorem or_simplify_ule_thm (e e_1 : IntW 8) :
 theorem or_simplify_uge_thm (e e_1 : IntW 8) :
   icmp IntPredicate.uge (LLVM.and e_1 (const? 8 127))
       (LLVM.or (LLVM.or e (const? 8 (-127))) (LLVM.and e_1 (const? 8 127))) ⊑
-    const? 1 0 := by 
+    const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -77,7 +77,7 @@ theorem or_simplify_uge_thm (e e_1 : IntW 8) :
 theorem or_simplify_ule_fail_thm (e e_1 : IntW 8) :
   icmp IntPredicate.ule (LLVM.or (LLVM.or e_1 (const? 8 64)) (LLVM.and e (const? 8 127))) (LLVM.and e (const? 8 127)) ⊑
     icmp IntPredicate.ule (LLVM.or (LLVM.or e_1 (LLVM.and e (const? 8 127))) (const? 8 64))
-      (LLVM.and e (const? 8 127)) := by 
+      (LLVM.and e (const? 8 127)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -88,7 +88,7 @@ theorem or_simplify_ule_fail_thm (e e_1 : IntW 8) :
 
 theorem or_simplify_ugt_thm (e e_1 : IntW 8) :
   icmp IntPredicate.ugt (LLVM.or (LLVM.or e_1 (const? 8 1)) (LLVM.and e (const? 8 (-2)))) (LLVM.and e (const? 8 (-2))) ⊑
-    icmp IntPredicate.ugt (LLVM.or (LLVM.or e_1 e) (const? 8 1)) (LLVM.and e (const? 8 (-2))) := by 
+    icmp IntPredicate.ugt (LLVM.or (LLVM.or e_1 e) (const? 8 1)) (LLVM.and e (const? 8 (-2))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -100,7 +100,7 @@ theorem or_simplify_ugt_thm (e e_1 : IntW 8) :
 theorem or_simplify_ult_thm (e e_1 : IntW 8) :
   icmp IntPredicate.ult (LLVM.and e_1 (const? 8 (-5)))
       (LLVM.or (LLVM.or e (const? 8 36)) (LLVM.and e_1 (const? 8 (-5)))) ⊑
-    icmp IntPredicate.ult (LLVM.and e_1 (const? 8 (-5))) (LLVM.or (LLVM.or e e_1) (const? 8 36)) := by 
+    icmp IntPredicate.ult (LLVM.and e_1 (const? 8 (-5))) (LLVM.or (LLVM.or e e_1) (const? 8 36)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -111,7 +111,7 @@ theorem or_simplify_ult_thm (e e_1 : IntW 8) :
 
 theorem or_simplify_ugt_fail_thm (e e_1 : IntW 8) :
   icmp IntPredicate.ugt (LLVM.or (LLVM.and e_1 (const? 8 (-2))) (LLVM.or e (const? 8 1))) (LLVM.or e (const? 8 1)) ⊑
-    icmp IntPredicate.ne (LLVM.or e_1 (LLVM.or e (const? 8 1))) (LLVM.or e (const? 8 1)) := by 
+    icmp IntPredicate.ne (LLVM.or e_1 (LLVM.or e (const? 8 1))) (LLVM.or e (const? 8 1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -123,7 +123,7 @@ theorem or_simplify_ugt_fail_thm (e e_1 : IntW 8) :
 theorem icmp_eq_x_invertable_y2_todo_thm (e e_1 : IntW 8) (e_2 : IntW 1) :
   icmp IntPredicate.eq (select e_2 (const? 8 7) (LLVM.xor e_1 (const? 8 (-1))))
       (LLVM.or e (select e_2 (const? 8 7) (LLVM.xor e_1 (const? 8 (-1))))) ⊑
-    icmp IntPredicate.eq (LLVM.and e (select e_2 (const? 8 (-8)) e_1)) (const? 8 0) := by 
+    icmp IntPredicate.eq (LLVM.and e (select e_2 (const? 8 (-8)) e_1)) (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -134,7 +134,7 @@ theorem icmp_eq_x_invertable_y2_todo_thm (e e_1 : IntW 8) (e_2 : IntW 1) :
 
 theorem icmp_eq_x_invertable_y2_thm (e e_1 : IntW 8) :
   icmp IntPredicate.eq (LLVM.xor e_1 (const? 8 (-1))) (LLVM.or e (LLVM.xor e_1 (const? 8 (-1)))) ⊑
-    icmp IntPredicate.eq (LLVM.and e e_1) (const? 8 0) := by 
+    icmp IntPredicate.eq (LLVM.and e e_1) (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -144,7 +144,7 @@ theorem icmp_eq_x_invertable_y2_thm (e e_1 : IntW 8) :
 
 
 theorem PR38139_thm (e : IntW 8) :
-  icmp IntPredicate.ne (LLVM.or e (const? 8 (-64))) e ⊑ icmp IntPredicate.ult e (const? 8 (-64)) := by 
+  icmp IntPredicate.ne (LLVM.or e (const? 8 (-64))) e ⊑ icmp IntPredicate.ult e (const? 8 (-64)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gicmphofhtrunchext_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gicmphofhtrunchext_proof.lean
@@ -10,7 +10,7 @@ set_option linter.unreachableTactic false
 section gicmphofhtrunchext_proof
 theorem trunc_unsigned_nuw_thm (e e_1 : IntW 16) :
   icmp IntPredicate.ult (trunc 8 e_1 { «nsw» := false, «nuw» := true }) (trunc 8 e { «nsw» := false, «nuw» := true }) ⊑
-    icmp IntPredicate.ult e_1 e := by 
+    icmp IntPredicate.ult e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -21,7 +21,7 @@ theorem trunc_unsigned_nuw_thm (e e_1 : IntW 16) :
 
 theorem trunc_unsigned_nsw_thm (e e_1 : IntW 16) :
   icmp IntPredicate.ult (trunc 8 e_1 { «nsw» := true, «nuw» := false }) (trunc 8 e { «nsw» := true, «nuw» := false }) ⊑
-    icmp IntPredicate.ult e_1 e := by 
+    icmp IntPredicate.ult e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -32,7 +32,7 @@ theorem trunc_unsigned_nsw_thm (e e_1 : IntW 16) :
 
 theorem trunc_unsigned_both_thm (e e_1 : IntW 16) :
   icmp IntPredicate.ult (trunc 8 e_1 { «nsw» := true, «nuw» := true }) (trunc 8 e { «nsw» := true, «nuw» := true }) ⊑
-    icmp IntPredicate.ult e_1 e := by 
+    icmp IntPredicate.ult e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -43,7 +43,7 @@ theorem trunc_unsigned_both_thm (e e_1 : IntW 16) :
 
 theorem trunc_signed_nsw_thm (e e_1 : IntW 16) :
   icmp IntPredicate.slt (trunc 8 e_1 { «nsw» := true, «nuw» := false }) (trunc 8 e { «nsw» := true, «nuw» := false }) ⊑
-    icmp IntPredicate.slt e_1 e := by 
+    icmp IntPredicate.slt e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -54,7 +54,7 @@ theorem trunc_signed_nsw_thm (e e_1 : IntW 16) :
 
 theorem trunc_signed_both_thm (e e_1 : IntW 16) :
   icmp IntPredicate.slt (trunc 8 e_1 { «nsw» := true, «nuw» := true }) (trunc 8 e { «nsw» := true, «nuw» := true }) ⊑
-    icmp IntPredicate.slt e_1 e := by 
+    icmp IntPredicate.slt e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -65,7 +65,7 @@ theorem trunc_signed_both_thm (e e_1 : IntW 16) :
 
 theorem trunc_equality_nuw_thm (e e_1 : IntW 16) :
   icmp IntPredicate.eq (trunc 8 e_1 { «nsw» := false, «nuw» := true }) (trunc 8 e { «nsw» := false, «nuw» := true }) ⊑
-    icmp IntPredicate.eq e_1 e := by 
+    icmp IntPredicate.eq e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -76,7 +76,7 @@ theorem trunc_equality_nuw_thm (e e_1 : IntW 16) :
 
 theorem trunc_equality_nsw_thm (e e_1 : IntW 16) :
   icmp IntPredicate.eq (trunc 8 e_1 { «nsw» := true, «nuw» := false }) (trunc 8 e { «nsw» := true, «nuw» := false }) ⊑
-    icmp IntPredicate.eq e_1 e := by 
+    icmp IntPredicate.eq e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -87,7 +87,7 @@ theorem trunc_equality_nsw_thm (e e_1 : IntW 16) :
 
 theorem trunc_equality_both_thm (e e_1 : IntW 16) :
   icmp IntPredicate.eq (trunc 8 e_1 { «nsw» := true, «nuw» := true }) (trunc 8 e { «nsw» := true, «nuw» := true }) ⊑
-    icmp IntPredicate.eq e_1 e := by 
+    icmp IntPredicate.eq e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -98,7 +98,7 @@ theorem trunc_equality_both_thm (e e_1 : IntW 16) :
 
 theorem trunc_unsigned_nuw_zext_thm (e : IntW 8) (e_1 : IntW 32) :
   icmp IntPredicate.ult (trunc 16 e_1 { «nsw» := false, «nuw» := true }) (zext 16 e) ⊑
-    icmp IntPredicate.ult e_1 (zext 32 e) := by 
+    icmp IntPredicate.ult e_1 (zext 32 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -109,7 +109,7 @@ theorem trunc_unsigned_nuw_zext_thm (e : IntW 8) (e_1 : IntW 32) :
 
 theorem trunc_unsigned_nsw_zext_thm (e : IntW 8) (e_1 : IntW 32) :
   icmp IntPredicate.ult (trunc 16 e_1 { «nsw» := true, «nuw» := false }) (zext 16 e) ⊑
-    icmp IntPredicate.ult e_1 (zext 32 e) := by 
+    icmp IntPredicate.ult e_1 (zext 32 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -120,7 +120,7 @@ theorem trunc_unsigned_nsw_zext_thm (e : IntW 8) (e_1 : IntW 32) :
 
 theorem trunc_unsigned_nsw_sext_thm (e : IntW 8) (e_1 : IntW 32) :
   icmp IntPredicate.ult (trunc 16 e_1 { «nsw» := true, «nuw» := false }) (sext 16 e) ⊑
-    icmp IntPredicate.ult e_1 (sext 32 e) := by 
+    icmp IntPredicate.ult e_1 (sext 32 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -131,7 +131,7 @@ theorem trunc_unsigned_nsw_sext_thm (e : IntW 8) (e_1 : IntW 32) :
 
 theorem trunc_signed_nsw_sext_thm (e : IntW 8) (e_1 : IntW 32) :
   icmp IntPredicate.slt (trunc 16 e_1 { «nsw» := true, «nuw» := false }) (sext 16 e) ⊑
-    icmp IntPredicate.slt e_1 (sext 32 e) := by 
+    icmp IntPredicate.slt e_1 (sext 32 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -142,7 +142,7 @@ theorem trunc_signed_nsw_sext_thm (e : IntW 8) (e_1 : IntW 32) :
 
 theorem trunc_signed_nsw_zext_thm (e : IntW 8) (e_1 : IntW 32) :
   icmp IntPredicate.slt (trunc 16 e_1 { «nsw» := true, «nuw» := false }) (zext 16 e) ⊑
-    icmp IntPredicate.slt e_1 (zext 32 e) := by 
+    icmp IntPredicate.slt e_1 (zext 32 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -153,7 +153,7 @@ theorem trunc_signed_nsw_zext_thm (e : IntW 8) (e_1 : IntW 32) :
 
 theorem trunc_equality_nuw_zext_thm (e : IntW 8) (e_1 : IntW 32) :
   icmp IntPredicate.ne (trunc 16 e_1 { «nsw» := false, «nuw» := true }) (zext 16 e) ⊑
-    icmp IntPredicate.ne e_1 (zext 32 e) := by 
+    icmp IntPredicate.ne e_1 (zext 32 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -164,7 +164,7 @@ theorem trunc_equality_nuw_zext_thm (e : IntW 8) (e_1 : IntW 32) :
 
 theorem trunc_equality_nsw_zext_thm (e : IntW 8) (e_1 : IntW 32) :
   icmp IntPredicate.ne (trunc 16 e_1 { «nsw» := true, «nuw» := false }) (zext 16 e) ⊑
-    icmp IntPredicate.ne e_1 (zext 32 e) := by 
+    icmp IntPredicate.ne e_1 (zext 32 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -175,7 +175,7 @@ theorem trunc_equality_nsw_zext_thm (e : IntW 8) (e_1 : IntW 32) :
 
 theorem trunc_equality_nsw_sext_thm (e : IntW 8) (e_1 : IntW 32) :
   icmp IntPredicate.ne (trunc 16 e_1 { «nsw» := true, «nuw» := false }) (sext 16 e) ⊑
-    icmp IntPredicate.ne e_1 (sext 32 e) := by 
+    icmp IntPredicate.ne e_1 (sext 32 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -186,7 +186,7 @@ theorem trunc_equality_nsw_sext_thm (e : IntW 8) (e_1 : IntW 32) :
 
 theorem trunc_equality_both_sext_thm (e : IntW 8) (e_1 : IntW 32) :
   icmp IntPredicate.ne (trunc 16 e_1 { «nsw» := true, «nuw» := true }) (sext 16 e) ⊑
-    icmp IntPredicate.ne e_1 (sext 32 e) := by 
+    icmp IntPredicate.ne e_1 (sext 32 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -197,7 +197,7 @@ theorem trunc_equality_both_sext_thm (e : IntW 8) (e_1 : IntW 32) :
 
 theorem test_eq1_thm (e : IntW 16) (e_1 : IntW 32) :
   icmp IntPredicate.eq (trunc 8 e_1 { «nsw» := true, «nuw» := false }) (trunc 8 e { «nsw» := true, «nuw» := false }) ⊑
-    icmp IntPredicate.eq e_1 (sext 32 e) := by 
+    icmp IntPredicate.eq e_1 (sext 32 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -208,7 +208,7 @@ theorem test_eq1_thm (e : IntW 16) (e_1 : IntW 32) :
 
 theorem test_eq2_thm (e : IntW 32) (e_1 : IntW 16) :
   icmp IntPredicate.eq (trunc 8 e_1 { «nsw» := true, «nuw» := false }) (trunc 8 e { «nsw» := true, «nuw» := false }) ⊑
-    icmp IntPredicate.eq e_1 (trunc 16 e) := by 
+    icmp IntPredicate.eq e_1 (trunc 16 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -219,7 +219,7 @@ theorem test_eq2_thm (e : IntW 32) (e_1 : IntW 16) :
 
 theorem test_ult_thm (e : IntW 16) (e_1 : IntW 32) :
   icmp IntPredicate.ult (trunc 8 e_1 { «nsw» := true, «nuw» := false }) (trunc 8 e { «nsw» := true, «nuw» := false }) ⊑
-    icmp IntPredicate.ult e_1 (sext 32 e) := by 
+    icmp IntPredicate.ult e_1 (sext 32 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -230,7 +230,7 @@ theorem test_ult_thm (e : IntW 16) (e_1 : IntW 32) :
 
 theorem test_slt_thm (e : IntW 16) (e_1 : IntW 32) :
   icmp IntPredicate.slt (trunc 8 e_1 { «nsw» := true, «nuw» := false }) (trunc 8 e { «nsw» := true, «nuw» := false }) ⊑
-    icmp IntPredicate.slt e_1 (sext 32 e) := by 
+    icmp IntPredicate.slt e_1 (sext 32 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -241,7 +241,7 @@ theorem test_slt_thm (e : IntW 16) (e_1 : IntW 32) :
 
 theorem test_ult_nuw_thm (e : IntW 16) (e_1 : IntW 32) :
   icmp IntPredicate.ult (trunc 8 e_1 { «nsw» := true, «nuw» := true }) (trunc 8 e { «nsw» := true, «nuw» := true }) ⊑
-    icmp IntPredicate.ult e_1 (zext 32 e) := by 
+    icmp IntPredicate.ult e_1 (zext 32 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -252,7 +252,7 @@ theorem test_ult_nuw_thm (e : IntW 16) (e_1 : IntW 32) :
 
 theorem test_slt_nuw_thm (e : IntW 16) (e_1 : IntW 32) :
   icmp IntPredicate.slt (trunc 8 e_1 { «nsw» := true, «nuw» := true }) (trunc 8 e { «nsw» := true, «nuw» := true }) ⊑
-    icmp IntPredicate.slt e_1 (zext 32 e) := by 
+    icmp IntPredicate.slt e_1 (zext 32 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gicmphofhxorhx_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gicmphofhxorhx_proof.lean
@@ -10,7 +10,7 @@ set_option linter.unreachableTactic false
 section gicmphofhxorhx_proof
 theorem test_xor_ne_thm (e e_1 e_2 : IntW 8) :
   icmp IntPredicate.ne (LLVM.xor e_2 (const? 8 (-1))) (LLVM.xor (LLVM.xor e_1 (const? 8 (-1))) e) ⊑
-    icmp IntPredicate.ne e_2 (LLVM.xor e_1 e) := by 
+    icmp IntPredicate.ne e_2 (LLVM.xor e_1 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -21,7 +21,7 @@ theorem test_xor_ne_thm (e e_1 e_2 : IntW 8) :
 
 theorem test_xor_eq_thm (e e_1 e_2 : IntW 8) :
   icmp IntPredicate.eq (LLVM.xor e_2 (const? 8 (-1))) (LLVM.xor (LLVM.xor e_1 (const? 8 (-1))) e) ⊑
-    icmp IntPredicate.eq e_2 (LLVM.xor e_1 e) := by 
+    icmp IntPredicate.eq e_2 (LLVM.xor e_1 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -32,7 +32,7 @@ theorem test_xor_eq_thm (e e_1 e_2 : IntW 8) :
 
 theorem test_slt_xor_thm (e e_1 : IntW 32) :
   icmp IntPredicate.slt (LLVM.xor (LLVM.xor e_1 (const? 32 (-1))) e) (LLVM.xor e_1 (const? 32 (-1))) ⊑
-    icmp IntPredicate.sgt (LLVM.xor e e_1) e_1 := by 
+    icmp IntPredicate.sgt (LLVM.xor e e_1) e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -43,7 +43,7 @@ theorem test_slt_xor_thm (e e_1 : IntW 32) :
 
 theorem test_sle_xor_thm (e e_1 : IntW 32) :
   icmp IntPredicate.sle (LLVM.xor (LLVM.xor e_1 (const? 32 (-1))) e) (LLVM.xor e_1 (const? 32 (-1))) ⊑
-    icmp IntPredicate.sge (LLVM.xor e e_1) e_1 := by 
+    icmp IntPredicate.sge (LLVM.xor e e_1) e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -54,7 +54,7 @@ theorem test_sle_xor_thm (e e_1 : IntW 32) :
 
 theorem test_sgt_xor_thm (e e_1 : IntW 32) :
   icmp IntPredicate.sgt (LLVM.xor (LLVM.xor e_1 (const? 32 (-1))) e) (LLVM.xor e_1 (const? 32 (-1))) ⊑
-    icmp IntPredicate.slt (LLVM.xor e e_1) e_1 := by 
+    icmp IntPredicate.slt (LLVM.xor e e_1) e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -65,7 +65,7 @@ theorem test_sgt_xor_thm (e e_1 : IntW 32) :
 
 theorem test_sge_xor_thm (e e_1 : IntW 32) :
   icmp IntPredicate.sge (LLVM.xor (LLVM.xor e_1 (const? 32 (-1))) e) (LLVM.xor e_1 (const? 32 (-1))) ⊑
-    icmp IntPredicate.sle (LLVM.xor e e_1) e_1 := by 
+    icmp IntPredicate.sle (LLVM.xor e e_1) e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -76,7 +76,7 @@ theorem test_sge_xor_thm (e e_1 : IntW 32) :
 
 theorem test_ult_xor_thm (e e_1 : IntW 32) :
   icmp IntPredicate.ult (LLVM.xor (LLVM.xor e_1 (const? 32 (-1))) e) (LLVM.xor e_1 (const? 32 (-1))) ⊑
-    icmp IntPredicate.ugt (LLVM.xor e e_1) e_1 := by 
+    icmp IntPredicate.ugt (LLVM.xor e e_1) e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -87,7 +87,7 @@ theorem test_ult_xor_thm (e e_1 : IntW 32) :
 
 theorem test_ule_xor_thm (e e_1 : IntW 32) :
   icmp IntPredicate.ule (LLVM.xor (LLVM.xor e_1 (const? 32 (-1))) e) (LLVM.xor e_1 (const? 32 (-1))) ⊑
-    icmp IntPredicate.uge (LLVM.xor e e_1) e_1 := by 
+    icmp IntPredicate.uge (LLVM.xor e e_1) e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -98,7 +98,7 @@ theorem test_ule_xor_thm (e e_1 : IntW 32) :
 
 theorem test_ugt_xor_thm (e e_1 : IntW 32) :
   icmp IntPredicate.ugt (LLVM.xor (LLVM.xor e_1 (const? 32 (-1))) e) (LLVM.xor e_1 (const? 32 (-1))) ⊑
-    icmp IntPredicate.ult (LLVM.xor e e_1) e_1 := by 
+    icmp IntPredicate.ult (LLVM.xor e e_1) e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -109,7 +109,7 @@ theorem test_ugt_xor_thm (e e_1 : IntW 32) :
 
 theorem test_uge_xor_thm (e e_1 : IntW 32) :
   icmp IntPredicate.uge (LLVM.xor (LLVM.xor e_1 (const? 32 (-1))) e) (LLVM.xor e_1 (const? 32 (-1))) ⊑
-    icmp IntPredicate.ule (LLVM.xor e e_1) e_1 := by 
+    icmp IntPredicate.ule (LLVM.xor e e_1) e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -120,7 +120,7 @@ theorem test_uge_xor_thm (e e_1 : IntW 32) :
 
 theorem xor_sge_thm (e e_1 : IntW 8) :
   icmp IntPredicate.sge (mul e_1 e_1) (LLVM.xor (LLVM.or e (const? 8 (-128))) (mul e_1 e_1)) ⊑
-    icmp IntPredicate.slt (LLVM.xor (LLVM.or e (const? 8 (-128))) (mul e_1 e_1)) (mul e_1 e_1) := by 
+    icmp IntPredicate.slt (LLVM.xor (LLVM.or e (const? 8 (-128))) (mul e_1 e_1)) (mul e_1 e_1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -132,7 +132,7 @@ theorem xor_sge_thm (e e_1 : IntW 8) :
 theorem xor_ugt_2_thm (e e_1 e_2 : IntW 8) :
   icmp IntPredicate.ugt (add e_2 e_1) (LLVM.xor (add e_2 e_1) (LLVM.or (LLVM.and e (const? 8 63)) (const? 8 64))) ⊑
     icmp IntPredicate.ugt (add e_2 e_1)
-      (LLVM.xor (add e_2 e_1) (LLVM.or (LLVM.and e (const? 8 63)) (const? 8 64) { «disjoint» := true })) := by 
+      (LLVM.xor (add e_2 e_1) (LLVM.or (LLVM.and e (const? 8 63)) (const? 8 64) { «disjoint» := true })) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gicmphorhofhselecthwithhzero_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gicmphorhofhselecthwithhzero_proof.lean
@@ -11,7 +11,7 @@ section gicmphorhofhselecthwithhzero_proof
 theorem src_tv_eq_thm (e e_1 : IntW 8) (e_2 : IntW 1) :
   icmp IntPredicate.eq (LLVM.or (select e_2 (const? 8 0) (add e_1 (const? 8 1) { «nsw» := false, «nuw» := true })) e)
       (const? 8 0) ⊑
-    LLVM.and (icmp IntPredicate.eq e (const? 8 0)) e_2 := by 
+    LLVM.and (icmp IntPredicate.eq e (const? 8 0)) e_2 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -23,7 +23,7 @@ theorem src_tv_eq_thm (e e_1 : IntW 8) (e_2 : IntW 1) :
 theorem src_fv_ne_thm (e e_1 : IntW 8) (e_2 : IntW 1) :
   icmp IntPredicate.ne (LLVM.or (select e_2 (add e_1 (const? 8 1) { «nsw» := false, «nuw» := true }) (const? 8 0)) e)
       (const? 8 0) ⊑
-    LLVM.or (icmp IntPredicate.ne e (const? 8 0)) e_2 := by 
+    LLVM.or (icmp IntPredicate.ne e (const? 8 0)) e_2 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -35,7 +35,7 @@ theorem src_fv_ne_thm (e e_1 : IntW 8) (e_2 : IntW 1) :
 theorem src_tv_ne_thm (e e_1 : IntW 8) (e_2 : IntW 1) :
   icmp IntPredicate.ne (LLVM.or (select e_2 (const? 8 0) (add e_1 (const? 8 1) { «nsw» := false, «nuw» := true })) e)
       (const? 8 0) ⊑
-    LLVM.or (icmp IntPredicate.ne e (const? 8 0)) (LLVM.xor e_2 (const? 1 1)) := by 
+    LLVM.or (icmp IntPredicate.ne e (const? 8 0)) (LLVM.xor e_2 (const? 1 1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -47,7 +47,7 @@ theorem src_tv_ne_thm (e e_1 : IntW 8) (e_2 : IntW 1) :
 theorem src_fv_eq_thm (e e_1 : IntW 8) (e_2 : IntW 1) :
   icmp IntPredicate.eq (LLVM.or (select e_2 (add e_1 (const? 8 1) { «nsw» := false, «nuw» := true }) (const? 8 0)) e)
       (const? 8 0) ⊑
-    LLVM.and (icmp IntPredicate.eq e (const? 8 0)) (LLVM.xor e_2 (const? 1 1)) := by 
+    LLVM.and (icmp IntPredicate.eq e (const? 8 0)) (LLVM.xor e_2 (const? 1 1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gicmphpower2handhicmphshiftedhmask_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gicmphpower2handhicmphshiftedhmask_proof.lean
@@ -11,7 +11,7 @@ section gicmphpower2handhicmphshiftedhmask_proof
 theorem icmp_power2_and_icmp_shifted_mask_2147483648_1610612736_thm (e : IntW 32) :
   LLVM.and (icmp IntPredicate.ult e (const? 32 (-2147483648)))
       (icmp IntPredicate.ne (LLVM.and e (const? 32 1610612736)) (const? 32 1610612736)) ⊑
-    icmp IntPredicate.ult e (const? 32 1610612736) := by 
+    icmp IntPredicate.ult e (const? 32 1610612736) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -23,7 +23,7 @@ theorem icmp_power2_and_icmp_shifted_mask_2147483648_1610612736_thm (e : IntW 32
 theorem icmp_power2_and_icmp_shifted_mask_swapped_2147483648_1610612736_thm (e : IntW 32) :
   LLVM.and (icmp IntPredicate.ne (LLVM.and e (const? 32 1610612736)) (const? 32 1610612736))
       (icmp IntPredicate.ult e (const? 32 (-2147483648))) ⊑
-    icmp IntPredicate.ult e (const? 32 1610612736) := by 
+    icmp IntPredicate.ult e (const? 32 1610612736) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -35,7 +35,7 @@ theorem icmp_power2_and_icmp_shifted_mask_swapped_2147483648_1610612736_thm (e :
 theorem icmp_power2_and_icmp_shifted_mask_2147483648_2147483647_thm (e : IntW 32) :
   LLVM.and (icmp IntPredicate.ult e (const? 32 (-2147483648)))
       (icmp IntPredicate.ne (LLVM.and e (const? 32 2147483647)) (const? 32 2147483647)) ⊑
-    icmp IntPredicate.ult e (const? 32 2147483647) := by 
+    icmp IntPredicate.ult e (const? 32 2147483647) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -47,7 +47,7 @@ theorem icmp_power2_and_icmp_shifted_mask_2147483648_2147483647_thm (e : IntW 32
 theorem icmp_power2_and_icmp_shifted_mask_swapped_2147483648_2147483647_thm (e : IntW 32) :
   LLVM.and (icmp IntPredicate.ne (LLVM.and e (const? 32 2147483647)) (const? 32 2147483647))
       (icmp IntPredicate.ult e (const? 32 (-2147483648))) ⊑
-    icmp IntPredicate.ult e (const? 32 2147483647) := by 
+    icmp IntPredicate.ult e (const? 32 2147483647) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -59,7 +59,7 @@ theorem icmp_power2_and_icmp_shifted_mask_swapped_2147483648_2147483647_thm (e :
 theorem icmp_power2_and_icmp_shifted_mask_2147483648_805306368_thm (e : IntW 32) :
   LLVM.and (icmp IntPredicate.ult e (const? 32 1073741824))
       (icmp IntPredicate.ne (LLVM.and e (const? 32 805306368)) (const? 32 805306368)) ⊑
-    icmp IntPredicate.ult e (const? 32 805306368) := by 
+    icmp IntPredicate.ult e (const? 32 805306368) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -71,7 +71,7 @@ theorem icmp_power2_and_icmp_shifted_mask_2147483648_805306368_thm (e : IntW 32)
 theorem icmp_power2_and_icmp_shifted_mask_swapped_2147483648_805306368_thm (e : IntW 32) :
   LLVM.and (icmp IntPredicate.ne (LLVM.and e (const? 32 805306368)) (const? 32 805306368))
       (icmp IntPredicate.ult e (const? 32 1073741824)) ⊑
-    icmp IntPredicate.ult e (const? 32 805306368) := by 
+    icmp IntPredicate.ult e (const? 32 805306368) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -83,7 +83,7 @@ theorem icmp_power2_and_icmp_shifted_mask_swapped_2147483648_805306368_thm (e : 
 theorem icmp_power2_and_icmp_shifted_mask_1073741824_1073741823_thm (e : IntW 32) :
   LLVM.and (icmp IntPredicate.ult e (const? 32 1073741824))
       (icmp IntPredicate.ne (LLVM.and e (const? 32 1073741823)) (const? 32 1073741823)) ⊑
-    icmp IntPredicate.ult e (const? 32 1073741823) := by 
+    icmp IntPredicate.ult e (const? 32 1073741823) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -95,7 +95,7 @@ theorem icmp_power2_and_icmp_shifted_mask_1073741824_1073741823_thm (e : IntW 32
 theorem icmp_power2_and_icmp_shifted_mask_swapped_1073741824_1073741823_thm (e : IntW 32) :
   LLVM.and (icmp IntPredicate.ne (LLVM.and e (const? 32 1073741823)) (const? 32 1073741823))
       (icmp IntPredicate.ult e (const? 32 1073741824)) ⊑
-    icmp IntPredicate.ult e (const? 32 1073741823) := by 
+    icmp IntPredicate.ult e (const? 32 1073741823) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -106,7 +106,7 @@ theorem icmp_power2_and_icmp_shifted_mask_swapped_1073741824_1073741823_thm (e :
 
 theorem icmp_power2_and_icmp_shifted_mask_8_7_thm (e : IntW 32) :
   LLVM.and (icmp IntPredicate.ult e (const? 32 8)) (icmp IntPredicate.ne (LLVM.and e (const? 32 7)) (const? 32 7)) ⊑
-    icmp IntPredicate.ult e (const? 32 7) := by 
+    icmp IntPredicate.ult e (const? 32 7) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -117,7 +117,7 @@ theorem icmp_power2_and_icmp_shifted_mask_8_7_thm (e : IntW 32) :
 
 theorem icmp_power2_and_icmp_shifted_mask_swapped_8_7_thm (e : IntW 32) :
   LLVM.and (icmp IntPredicate.ne (LLVM.and e (const? 32 7)) (const? 32 7)) (icmp IntPredicate.ult e (const? 32 8)) ⊑
-    icmp IntPredicate.ult e (const? 32 7) := by 
+    icmp IntPredicate.ult e (const? 32 7) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -128,7 +128,7 @@ theorem icmp_power2_and_icmp_shifted_mask_swapped_8_7_thm (e : IntW 32) :
 
 theorem icmp_power2_and_icmp_shifted_mask_8_6_thm (e : IntW 32) :
   LLVM.and (icmp IntPredicate.ult e (const? 32 8)) (icmp IntPredicate.ne (LLVM.and e (const? 32 6)) (const? 32 6)) ⊑
-    icmp IntPredicate.ult e (const? 32 6) := by 
+    icmp IntPredicate.ult e (const? 32 6) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -139,7 +139,7 @@ theorem icmp_power2_and_icmp_shifted_mask_8_6_thm (e : IntW 32) :
 
 theorem icmp_power2_and_icmp_shifted_mask_swapped_8_6_thm (e : IntW 32) :
   LLVM.and (icmp IntPredicate.ne (LLVM.and e (const? 32 6)) (const? 32 6)) (icmp IntPredicate.ult e (const? 32 8)) ⊑
-    icmp IntPredicate.ult e (const? 32 6) := by 
+    icmp IntPredicate.ult e (const? 32 6) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gicmphrange_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gicmphrange_proof.lean
@@ -9,7 +9,7 @@ set_option linter.unreachableTactic false
 
 section gicmphrange_proof
 theorem ugt_zext_thm (e : IntW 8) (e_1 : IntW 1) :
-  icmp IntPredicate.ugt (zext 8 e_1) e ⊑ LLVM.and (icmp IntPredicate.eq e (const? 8 0)) e_1 := by 
+  icmp IntPredicate.ugt (zext 8 e_1) e ⊑ LLVM.and (icmp IntPredicate.eq e (const? 8 0)) e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -19,7 +19,7 @@ theorem ugt_zext_thm (e : IntW 8) (e_1 : IntW 1) :
 
 
 theorem uge_zext_thm (e : IntW 8) (e_1 : IntW 1) :
-  icmp IntPredicate.uge (zext 8 e_1) e ⊑ icmp IntPredicate.ule e (zext 8 e_1) := by 
+  icmp IntPredicate.uge (zext 8 e_1) e ⊑ icmp IntPredicate.ule e (zext 8 e_1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -29,7 +29,7 @@ theorem uge_zext_thm (e : IntW 8) (e_1 : IntW 1) :
 
 
 theorem sub_ult_zext_thm (e : IntW 1) (e_1 e_2 : IntW 8) :
-  icmp IntPredicate.ult (sub e_2 e_1) (zext 8 e) ⊑ LLVM.and (icmp IntPredicate.eq e_2 e_1) e := by 
+  icmp IntPredicate.ult (sub e_2 e_1) (zext 8 e) ⊑ LLVM.and (icmp IntPredicate.eq e_2 e_1) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -40,7 +40,7 @@ theorem sub_ult_zext_thm (e : IntW 1) (e_1 e_2 : IntW 8) :
 
 theorem zext_ult_zext_thm (e : IntW 1) (e_1 : IntW 8) :
   icmp IntPredicate.ult (zext 16 (mul e_1 e_1)) (zext 16 e) ⊑
-    LLVM.and (icmp IntPredicate.eq (mul e_1 e_1) (const? 8 0)) e := by 
+    LLVM.and (icmp IntPredicate.eq (mul e_1 e_1) (const? 8 0)) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -50,7 +50,7 @@ theorem zext_ult_zext_thm (e : IntW 1) (e_1 : IntW 8) :
 
 
 theorem uge_sext_thm (e : IntW 8) (e_1 : IntW 1) :
-  icmp IntPredicate.uge (sext 8 e_1) e ⊑ LLVM.or (icmp IntPredicate.eq e (const? 8 0)) e_1 := by 
+  icmp IntPredicate.uge (sext 8 e_1) e ⊑ LLVM.or (icmp IntPredicate.eq e (const? 8 0)) e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -60,7 +60,7 @@ theorem uge_sext_thm (e : IntW 8) (e_1 : IntW 1) :
 
 
 theorem ugt_sext_thm (e : IntW 8) (e_1 : IntW 1) :
-  icmp IntPredicate.ugt (sext 8 e_1) e ⊑ icmp IntPredicate.ult e (sext 8 e_1) := by 
+  icmp IntPredicate.ugt (sext 8 e_1) e ⊑ icmp IntPredicate.ult e (sext 8 e_1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -70,7 +70,7 @@ theorem ugt_sext_thm (e : IntW 8) (e_1 : IntW 1) :
 
 
 theorem sub_ule_sext_thm (e : IntW 1) (e_1 e_2 : IntW 8) :
-  icmp IntPredicate.ule (sub e_2 e_1) (sext 8 e) ⊑ LLVM.or (icmp IntPredicate.eq e_2 e_1) e := by 
+  icmp IntPredicate.ule (sub e_2 e_1) (sext 8 e) ⊑ LLVM.or (icmp IntPredicate.eq e_2 e_1) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -81,7 +81,7 @@ theorem sub_ule_sext_thm (e : IntW 1) (e_1 e_2 : IntW 8) :
 
 theorem sext_ule_sext_thm (e : IntW 1) (e_1 : IntW 8) :
   icmp IntPredicate.ule (sext 16 (mul e_1 e_1)) (sext 16 e) ⊑
-    LLVM.or (icmp IntPredicate.eq (mul e_1 e_1) (const? 8 0)) e := by 
+    LLVM.or (icmp IntPredicate.eq (mul e_1 e_1) (const? 8 0)) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -91,7 +91,7 @@ theorem sext_ule_sext_thm (e : IntW 1) (e_1 : IntW 8) :
 
 
 theorem zext_sext_add_icmp_slt_minus1_thm (e e_1 : IntW 1) :
-  icmp IntPredicate.slt (add (zext 8 e_1) (sext 8 e)) (const? 8 (-1)) ⊑ const? 1 0 := by 
+  icmp IntPredicate.slt (add (zext 8 e_1) (sext 8 e)) (const? 8 (-1)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -101,7 +101,7 @@ theorem zext_sext_add_icmp_slt_minus1_thm (e e_1 : IntW 1) :
 
 
 theorem zext_sext_add_icmp_sgt_1_thm (e e_1 : IntW 1) :
-  icmp IntPredicate.sgt (add (zext 8 e_1) (sext 8 e)) (const? 8 1) ⊑ const? 1 0 := by 
+  icmp IntPredicate.sgt (add (zext 8 e_1) (sext 8 e)) (const? 8 1) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -111,7 +111,7 @@ theorem zext_sext_add_icmp_sgt_1_thm (e e_1 : IntW 1) :
 
 
 theorem zext_sext_add_icmp_sgt_minus2_thm (e e_1 : IntW 1) :
-  icmp IntPredicate.sgt (add (zext 8 e_1) (sext 8 e)) (const? 8 (-2)) ⊑ const? 1 1 := by 
+  icmp IntPredicate.sgt (add (zext 8 e_1) (sext 8 e)) (const? 8 (-2)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -121,7 +121,7 @@ theorem zext_sext_add_icmp_sgt_minus2_thm (e e_1 : IntW 1) :
 
 
 theorem zext_sext_add_icmp_slt_2_thm (e e_1 : IntW 1) :
-  icmp IntPredicate.slt (add (zext 8 e_1) (sext 8 e)) (const? 8 2) ⊑ const? 1 1 := by 
+  icmp IntPredicate.slt (add (zext 8 e_1) (sext 8 e)) (const? 8 2) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -131,7 +131,7 @@ theorem zext_sext_add_icmp_slt_2_thm (e e_1 : IntW 1) :
 
 
 theorem zext_sext_add_icmp_i128_thm (e e_1 : IntW 1) :
-  icmp IntPredicate.sgt (add (zext 128 e_1) (sext 128 e)) (const? 128 9223372036854775808) ⊑ const? 1 0 := by 
+  icmp IntPredicate.sgt (add (zext 128 e_1) (sext 128 e)) (const? 128 9223372036854775808) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -141,7 +141,7 @@ theorem zext_sext_add_icmp_i128_thm (e e_1 : IntW 1) :
 
 
 theorem zext_sext_add_icmp_eq_minus1_thm (e e_1 : IntW 1) :
-  icmp IntPredicate.eq (add (zext 8 e_1) (sext 8 e)) (const? 8 (-1)) ⊑ LLVM.and e (LLVM.xor e_1 (const? 1 1)) := by 
+  icmp IntPredicate.eq (add (zext 8 e_1) (sext 8 e)) (const? 8 (-1)) ⊑ LLVM.and e (LLVM.xor e_1 (const? 1 1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -151,7 +151,7 @@ theorem zext_sext_add_icmp_eq_minus1_thm (e e_1 : IntW 1) :
 
 
 theorem zext_sext_add_icmp_ne_minus1_thm (e e_1 : IntW 1) :
-  icmp IntPredicate.ne (add (zext 8 e_1) (sext 8 e)) (const? 8 (-1)) ⊑ LLVM.or e_1 (LLVM.xor e (const? 1 1)) := by 
+  icmp IntPredicate.ne (add (zext 8 e_1) (sext 8 e)) (const? 8 (-1)) ⊑ LLVM.or e_1 (LLVM.xor e (const? 1 1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -161,7 +161,7 @@ theorem zext_sext_add_icmp_ne_minus1_thm (e e_1 : IntW 1) :
 
 
 theorem zext_sext_add_icmp_sgt_minus1_thm (e e_1 : IntW 1) :
-  icmp IntPredicate.sgt (add (zext 8 e_1) (sext 8 e)) (const? 8 (-1)) ⊑ LLVM.or e_1 (LLVM.xor e (const? 1 1)) := by 
+  icmp IntPredicate.sgt (add (zext 8 e_1) (sext 8 e)) (const? 8 (-1)) ⊑ LLVM.or e_1 (LLVM.xor e (const? 1 1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -171,7 +171,7 @@ theorem zext_sext_add_icmp_sgt_minus1_thm (e e_1 : IntW 1) :
 
 
 theorem zext_sext_add_icmp_ult_minus1_thm (e e_1 : IntW 1) :
-  icmp IntPredicate.ult (add (zext 8 e_1) (sext 8 e)) (const? 8 (-1)) ⊑ LLVM.or e_1 (LLVM.xor e (const? 1 1)) := by 
+  icmp IntPredicate.ult (add (zext 8 e_1) (sext 8 e)) (const? 8 (-1)) ⊑ LLVM.or e_1 (LLVM.xor e (const? 1 1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -181,7 +181,7 @@ theorem zext_sext_add_icmp_ult_minus1_thm (e e_1 : IntW 1) :
 
 
 theorem zext_sext_add_icmp_sgt_0_thm (e e_1 : IntW 1) :
-  icmp IntPredicate.sgt (add (zext 8 e_1) (sext 8 e)) (const? 8 0) ⊑ LLVM.and e_1 (LLVM.xor e (const? 1 1)) := by 
+  icmp IntPredicate.sgt (add (zext 8 e_1) (sext 8 e)) (const? 8 0) ⊑ LLVM.and e_1 (LLVM.xor e (const? 1 1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -191,7 +191,7 @@ theorem zext_sext_add_icmp_sgt_0_thm (e e_1 : IntW 1) :
 
 
 theorem zext_sext_add_icmp_slt_0_thm (e e_1 : IntW 1) :
-  icmp IntPredicate.slt (add (zext 8 e_1) (sext 8 e)) (const? 8 0) ⊑ LLVM.and e (LLVM.xor e_1 (const? 1 1)) := by 
+  icmp IntPredicate.slt (add (zext 8 e_1) (sext 8 e)) (const? 8 0) ⊑ LLVM.and e (LLVM.xor e_1 (const? 1 1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -201,7 +201,7 @@ theorem zext_sext_add_icmp_slt_0_thm (e e_1 : IntW 1) :
 
 
 theorem zext_sext_add_icmp_eq_1_thm (e e_1 : IntW 1) :
-  icmp IntPredicate.eq (add (zext 8 e_1) (sext 8 e)) (const? 8 1) ⊑ LLVM.and e_1 (LLVM.xor e (const? 1 1)) := by 
+  icmp IntPredicate.eq (add (zext 8 e_1) (sext 8 e)) (const? 8 1) ⊑ LLVM.and e_1 (LLVM.xor e (const? 1 1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -211,7 +211,7 @@ theorem zext_sext_add_icmp_eq_1_thm (e e_1 : IntW 1) :
 
 
 theorem zext_sext_add_icmp_ne_1_thm (e e_1 : IntW 1) :
-  icmp IntPredicate.ne (add (zext 8 e_1) (sext 8 e)) (const? 8 1) ⊑ LLVM.or e (LLVM.xor e_1 (const? 1 1)) := by 
+  icmp IntPredicate.ne (add (zext 8 e_1) (sext 8 e)) (const? 8 1) ⊑ LLVM.or e (LLVM.xor e_1 (const? 1 1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -221,7 +221,7 @@ theorem zext_sext_add_icmp_ne_1_thm (e e_1 : IntW 1) :
 
 
 theorem zext_sext_add_icmp_slt_1_thm (e e_1 : IntW 1) :
-  icmp IntPredicate.slt (add (zext 8 e_1) (sext 8 e)) (const? 8 1) ⊑ LLVM.or e (LLVM.xor e_1 (const? 1 1)) := by 
+  icmp IntPredicate.slt (add (zext 8 e_1) (sext 8 e)) (const? 8 1) ⊑ LLVM.or e (LLVM.xor e_1 (const? 1 1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -231,7 +231,7 @@ theorem zext_sext_add_icmp_slt_1_thm (e e_1 : IntW 1) :
 
 
 theorem zext_sext_add_icmp_ugt_1_thm (e e_1 : IntW 1) :
-  icmp IntPredicate.ugt (add (zext 8 e_1) (sext 8 e)) (const? 8 1) ⊑ LLVM.and e (LLVM.xor e_1 (const? 1 1)) := by 
+  icmp IntPredicate.ugt (add (zext 8 e_1) (sext 8 e)) (const? 8 1) ⊑ LLVM.and e (LLVM.xor e_1 (const? 1 1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -242,7 +242,7 @@ theorem zext_sext_add_icmp_ugt_1_thm (e e_1 : IntW 1) :
 
 theorem zext_sext_add_icmp_slt_1_rhs_not_const_thm (e : IntW 8) (e_1 e_2 : IntW 1) :
   icmp IntPredicate.slt (add (zext 8 e_2) (sext 8 e_1)) e ⊑
-    icmp IntPredicate.slt (add (zext 8 e_2) (sext 8 e_1) { «nsw» := true, «nuw» := false }) e := by 
+    icmp IntPredicate.slt (add (zext 8 e_2) (sext 8 e_1) { «nsw» := true, «nuw» := false }) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -253,7 +253,7 @@ theorem zext_sext_add_icmp_slt_1_rhs_not_const_thm (e : IntW 8) (e_1 e_2 : IntW 
 
 theorem zext_sext_add_icmp_slt_1_type_not_i1_thm (e : IntW 1) (e_1 : IntW 2) :
   icmp IntPredicate.slt (add (zext 8 e_1) (sext 8 e)) (const? 8 1) ⊑
-    icmp IntPredicate.slt (add (zext 8 e_1) (sext 8 e) { «nsw» := true, «nuw» := false }) (const? 8 1) := by 
+    icmp IntPredicate.slt (add (zext 8 e_1) (sext 8 e) { «nsw» := true, «nuw» := false }) (const? 8 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -263,7 +263,7 @@ theorem zext_sext_add_icmp_slt_1_type_not_i1_thm (e : IntW 1) (e_1 : IntW 2) :
 
 
 theorem icmp_ne_zext_eq_zero_thm (e : IntW 32) :
-  icmp IntPredicate.ne (zext 32 (icmp IntPredicate.eq e (const? 32 0))) e ⊑ const? 1 1 := by 
+  icmp IntPredicate.ne (zext 32 (icmp IntPredicate.eq e (const? 32 0))) e ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -274,7 +274,7 @@ theorem icmp_ne_zext_eq_zero_thm (e : IntW 32) :
 
 theorem icmp_ne_zext_ne_zero_thm (e : IntW 32) :
   icmp IntPredicate.ne (zext 32 (icmp IntPredicate.ne e (const? 32 0))) e ⊑
-    icmp IntPredicate.ugt e (const? 32 1) := by 
+    icmp IntPredicate.ugt e (const? 32 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -284,7 +284,7 @@ theorem icmp_ne_zext_ne_zero_thm (e : IntW 32) :
 
 
 theorem icmp_eq_zext_eq_zero_thm (e : IntW 32) :
-  icmp IntPredicate.eq (zext 32 (icmp IntPredicate.eq e (const? 32 0))) e ⊑ const? 1 0 := by 
+  icmp IntPredicate.eq (zext 32 (icmp IntPredicate.eq e (const? 32 0))) e ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -295,7 +295,7 @@ theorem icmp_eq_zext_eq_zero_thm (e : IntW 32) :
 
 theorem icmp_eq_zext_ne_zero_thm (e : IntW 32) :
   icmp IntPredicate.eq (zext 32 (icmp IntPredicate.ne e (const? 32 0))) e ⊑
-    icmp IntPredicate.ult e (const? 32 2) := by 
+    icmp IntPredicate.ult e (const? 32 2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -306,7 +306,7 @@ theorem icmp_eq_zext_ne_zero_thm (e : IntW 32) :
 
 theorem icmp_ne_zext_eq_one_thm (e : IntW 32) :
   icmp IntPredicate.ne (zext 32 (icmp IntPredicate.eq e (const? 32 1))) e ⊑
-    icmp IntPredicate.ugt e (const? 32 1) := by 
+    icmp IntPredicate.ugt e (const? 32 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -316,7 +316,7 @@ theorem icmp_ne_zext_eq_one_thm (e : IntW 32) :
 
 
 theorem icmp_ne_zext_ne_one_thm (e : IntW 32) :
-  icmp IntPredicate.ne (zext 32 (icmp IntPredicate.ne e (const? 32 1))) e ⊑ const? 1 1 := by 
+  icmp IntPredicate.ne (zext 32 (icmp IntPredicate.ne e (const? 32 1))) e ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -327,7 +327,7 @@ theorem icmp_ne_zext_ne_one_thm (e : IntW 32) :
 
 theorem icmp_eq_zext_eq_one_thm (e : IntW 32) :
   icmp IntPredicate.eq (zext 32 (icmp IntPredicate.eq e (const? 32 1))) e ⊑
-    icmp IntPredicate.ult e (const? 32 2) := by 
+    icmp IntPredicate.ult e (const? 32 2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -337,7 +337,7 @@ theorem icmp_eq_zext_eq_one_thm (e : IntW 32) :
 
 
 theorem icmp_eq_zext_ne_one_thm (e : IntW 32) :
-  icmp IntPredicate.eq (zext 32 (icmp IntPredicate.ne e (const? 32 1))) e ⊑ const? 1 0 := by 
+  icmp IntPredicate.eq (zext 32 (icmp IntPredicate.ne e (const? 32 1))) e ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -348,7 +348,7 @@ theorem icmp_eq_zext_ne_one_thm (e : IntW 32) :
 
 theorem icmp_ne_zext_eq_non_boolean_thm (e : IntW 32) :
   icmp IntPredicate.ne (zext 32 (icmp IntPredicate.eq e (const? 32 2))) e ⊑
-    icmp IntPredicate.ne e (const? 32 0) := by 
+    icmp IntPredicate.ne e (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -359,7 +359,7 @@ theorem icmp_ne_zext_eq_non_boolean_thm (e : IntW 32) :
 
 theorem icmp_ne_zext_ne_non_boolean_thm (e : IntW 32) :
   icmp IntPredicate.ne (zext 32 (icmp IntPredicate.ne e (const? 32 2))) e ⊑
-    icmp IntPredicate.ne e (const? 32 1) := by 
+    icmp IntPredicate.ne e (const? 32 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -370,7 +370,7 @@ theorem icmp_ne_zext_ne_non_boolean_thm (e : IntW 32) :
 
 theorem icmp_eq_zext_eq_non_boolean_thm (e : IntW 32) :
   icmp IntPredicate.eq (zext 32 (icmp IntPredicate.eq e (const? 32 2))) e ⊑
-    icmp IntPredicate.eq e (const? 32 0) := by 
+    icmp IntPredicate.eq e (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -381,7 +381,7 @@ theorem icmp_eq_zext_eq_non_boolean_thm (e : IntW 32) :
 
 theorem icmp_eq_zext_ne_non_boolean_thm (e : IntW 32) :
   icmp IntPredicate.eq (zext 32 (icmp IntPredicate.ne e (const? 32 2))) e ⊑
-    icmp IntPredicate.eq e (const? 32 1) := by 
+    icmp IntPredicate.eq e (const? 32 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -391,7 +391,7 @@ theorem icmp_eq_zext_ne_non_boolean_thm (e : IntW 32) :
 
 
 theorem icmp_ne_sext_eq_zero_thm (e : IntW 32) :
-  icmp IntPredicate.ne (sext 32 (icmp IntPredicate.eq e (const? 32 0))) e ⊑ const? 1 1 := by 
+  icmp IntPredicate.ne (sext 32 (icmp IntPredicate.eq e (const? 32 0))) e ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -402,7 +402,7 @@ theorem icmp_ne_sext_eq_zero_thm (e : IntW 32) :
 
 theorem icmp_ne_sext_ne_zero_thm (e : IntW 32) :
   icmp IntPredicate.ne (sext 32 (icmp IntPredicate.ne e (const? 32 0))) e ⊑
-    icmp IntPredicate.ult (add e (const? 32 (-1))) (const? 32 (-2)) := by 
+    icmp IntPredicate.ult (add e (const? 32 (-1))) (const? 32 (-2)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -412,7 +412,7 @@ theorem icmp_ne_sext_ne_zero_thm (e : IntW 32) :
 
 
 theorem icmp_eq_sext_eq_zero_thm (e : IntW 32) :
-  icmp IntPredicate.eq (sext 32 (icmp IntPredicate.eq e (const? 32 0))) e ⊑ const? 1 0 := by 
+  icmp IntPredicate.eq (sext 32 (icmp IntPredicate.eq e (const? 32 0))) e ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -423,7 +423,7 @@ theorem icmp_eq_sext_eq_zero_thm (e : IntW 32) :
 
 theorem icmp_eq_sext_ne_zero_thm (e : IntW 32) :
   icmp IntPredicate.eq (sext 32 (icmp IntPredicate.ne e (const? 32 0))) e ⊑
-    icmp IntPredicate.ult (add e (const? 32 1)) (const? 32 2) := by 
+    icmp IntPredicate.ult (add e (const? 32 1)) (const? 32 2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -434,7 +434,7 @@ theorem icmp_eq_sext_ne_zero_thm (e : IntW 32) :
 
 theorem icmp_ne_sext_eq_allones_thm (e : IntW 32) :
   icmp IntPredicate.ne (sext 32 (icmp IntPredicate.eq e (const? 32 (-1)))) e ⊑
-    icmp IntPredicate.ult (add e (const? 32 (-1))) (const? 32 (-2)) := by 
+    icmp IntPredicate.ult (add e (const? 32 (-1))) (const? 32 (-2)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -444,7 +444,7 @@ theorem icmp_ne_sext_eq_allones_thm (e : IntW 32) :
 
 
 theorem icmp_ne_sext_ne_allones_thm (e : IntW 32) :
-  icmp IntPredicate.ne (sext 32 (icmp IntPredicate.ne e (const? 32 (-1)))) e ⊑ const? 1 1 := by 
+  icmp IntPredicate.ne (sext 32 (icmp IntPredicate.ne e (const? 32 (-1)))) e ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -455,7 +455,7 @@ theorem icmp_ne_sext_ne_allones_thm (e : IntW 32) :
 
 theorem icmp_eq_sext_eq_allones_thm (e : IntW 32) :
   icmp IntPredicate.eq (sext 32 (icmp IntPredicate.eq e (const? 32 (-1)))) e ⊑
-    icmp IntPredicate.ult (add e (const? 32 1)) (const? 32 2) := by 
+    icmp IntPredicate.ult (add e (const? 32 1)) (const? 32 2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -465,7 +465,7 @@ theorem icmp_eq_sext_eq_allones_thm (e : IntW 32) :
 
 
 theorem icmp_eq_sext_ne_allones_thm (e : IntW 32) :
-  icmp IntPredicate.eq (sext 32 (icmp IntPredicate.ne e (const? 32 (-1)))) e ⊑ const? 1 0 := by 
+  icmp IntPredicate.eq (sext 32 (icmp IntPredicate.ne e (const? 32 (-1)))) e ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -476,7 +476,7 @@ theorem icmp_eq_sext_ne_allones_thm (e : IntW 32) :
 
 theorem icmp_ne_sext_eq_otherwise_thm (e : IntW 32) :
   icmp IntPredicate.ne (sext 32 (icmp IntPredicate.eq e (const? 32 2))) e ⊑
-    icmp IntPredicate.ne e (const? 32 0) := by 
+    icmp IntPredicate.ne e (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -487,7 +487,7 @@ theorem icmp_ne_sext_eq_otherwise_thm (e : IntW 32) :
 
 theorem icmp_ne_sext_ne_otherwise_thm (e : IntW 32) :
   icmp IntPredicate.ne (sext 32 (icmp IntPredicate.ne e (const? 32 2))) e ⊑
-    icmp IntPredicate.ne e (const? 32 (-1)) := by 
+    icmp IntPredicate.ne e (const? 32 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -498,7 +498,7 @@ theorem icmp_ne_sext_ne_otherwise_thm (e : IntW 32) :
 
 theorem icmp_eq_sext_eq_otherwise_thm (e : IntW 32) :
   icmp IntPredicate.eq (sext 32 (icmp IntPredicate.eq e (const? 32 2))) e ⊑
-    icmp IntPredicate.eq e (const? 32 0) := by 
+    icmp IntPredicate.eq e (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -509,7 +509,7 @@ theorem icmp_eq_sext_eq_otherwise_thm (e : IntW 32) :
 
 theorem icmp_eq_sext_ne_otherwise_thm (e : IntW 32) :
   icmp IntPredicate.eq (sext 32 (icmp IntPredicate.ne e (const? 32 2))) e ⊑
-    icmp IntPredicate.eq e (const? 32 (-1)) := by 
+    icmp IntPredicate.eq e (const? 32 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -520,7 +520,7 @@ theorem icmp_eq_sext_ne_otherwise_thm (e : IntW 32) :
 
 theorem icmp_ne_sext_ne_zero_i128_thm (e : IntW 128) :
   icmp IntPredicate.ne (sext 128 (icmp IntPredicate.ne e (const? 128 0))) e ⊑
-    icmp IntPredicate.ult (add e (const? 128 (-1))) (const? 128 (-2)) := by 
+    icmp IntPredicate.ult (add e (const? 128 (-1))) (const? 128 (-2)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -531,7 +531,7 @@ theorem icmp_ne_sext_ne_zero_i128_thm (e : IntW 128) :
 
 theorem icmp_ne_sext_ne_otherwise_i128_thm (e : IntW 128) :
   icmp IntPredicate.ne (sext 128 (icmp IntPredicate.ne e (const? 128 2))) e ⊑
-    icmp IntPredicate.ne e (const? 128 (-1)) := by 
+    icmp IntPredicate.ne e (const? 128 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -542,7 +542,7 @@ theorem icmp_ne_sext_ne_otherwise_i128_thm (e : IntW 128) :
 
 theorem icmp_ne_sext_sgt_zero_nofold_thm (e : IntW 32) :
   icmp IntPredicate.ne (sext 32 (icmp IntPredicate.sgt e (const? 32 0))) e ⊑
-    icmp IntPredicate.ne e (sext 32 (icmp IntPredicate.sgt e (const? 32 0))) := by 
+    icmp IntPredicate.ne e (sext 32 (icmp IntPredicate.sgt e (const? 32 0))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -553,7 +553,7 @@ theorem icmp_ne_sext_sgt_zero_nofold_thm (e : IntW 32) :
 
 theorem icmp_slt_sext_ne_zero_nofold_thm (e : IntW 32) :
   icmp IntPredicate.slt (sext 32 (icmp IntPredicate.ne e (const? 32 0))) e ⊑
-    icmp IntPredicate.sgt e (sext 32 (icmp IntPredicate.ne e (const? 32 0))) := by 
+    icmp IntPredicate.sgt e (sext 32 (icmp IntPredicate.ne e (const? 32 0))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -564,7 +564,7 @@ theorem icmp_slt_sext_ne_zero_nofold_thm (e : IntW 32) :
 
 theorem icmp_ne_sext_slt_allones_nofold_thm (e : IntW 32) :
   icmp IntPredicate.ne (sext 32 (icmp IntPredicate.slt e (const? 32 (-1)))) e ⊑
-    icmp IntPredicate.ne e (sext 32 (icmp IntPredicate.slt e (const? 32 (-1)))) := by 
+    icmp IntPredicate.ne e (sext 32 (icmp IntPredicate.slt e (const? 32 (-1)))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -575,7 +575,7 @@ theorem icmp_ne_sext_slt_allones_nofold_thm (e : IntW 32) :
 
 theorem icmp_slt_sext_ne_allones_nofold_thm (e : IntW 32) :
   icmp IntPredicate.slt (sext 32 (icmp IntPredicate.ne e (const? 32 (-1)))) e ⊑
-    icmp IntPredicate.sgt e (sext 32 (icmp IntPredicate.ne e (const? 32 (-1)))) := by 
+    icmp IntPredicate.sgt e (sext 32 (icmp IntPredicate.ne e (const? 32 (-1)))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -586,7 +586,7 @@ theorem icmp_slt_sext_ne_allones_nofold_thm (e : IntW 32) :
 
 theorem icmp_ne_sext_slt_otherwise_nofold_thm (e : IntW 32) :
   icmp IntPredicate.ne (sext 32 (icmp IntPredicate.slt e (const? 32 2))) e ⊑
-    icmp IntPredicate.ne e (sext 32 (icmp IntPredicate.slt e (const? 32 2))) := by 
+    icmp IntPredicate.ne e (sext 32 (icmp IntPredicate.slt e (const? 32 2))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -597,7 +597,7 @@ theorem icmp_ne_sext_slt_otherwise_nofold_thm (e : IntW 32) :
 
 theorem icmp_slt_sext_ne_otherwise_nofold_thm (e : IntW 32) :
   icmp IntPredicate.slt (sext 32 (icmp IntPredicate.ne e (const? 32 2))) e ⊑
-    icmp IntPredicate.sgt e (sext 32 (icmp IntPredicate.ne e (const? 32 2))) := by 
+    icmp IntPredicate.sgt e (sext 32 (icmp IntPredicate.ne e (const? 32 2))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gicmphselect_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gicmphselect_proof.lean
@@ -10,7 +10,7 @@ set_option linter.unreachableTactic false
 section gicmphselect_proof
 theorem icmp_select_const_thm (e e_1 : IntW 8) :
   icmp IntPredicate.eq (select (icmp IntPredicate.eq e_1 (const? 8 0)) (const? 8 0) e) (const? 8 0) ⊑
-    select (icmp IntPredicate.eq e_1 (const? 8 0)) (const? 1 1) (icmp IntPredicate.eq e (const? 8 0)) := by 
+    select (icmp IntPredicate.eq e_1 (const? 8 0)) (const? 1 1) (icmp IntPredicate.eq e (const? 8 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -21,7 +21,7 @@ theorem icmp_select_const_thm (e e_1 : IntW 8) :
 
 theorem icmp_select_var_thm (e e_1 e_2 : IntW 8) :
   icmp IntPredicate.eq (select (icmp IntPredicate.eq e_2 (const? 8 0)) e_1 e) e_1 ⊑
-    select (icmp IntPredicate.eq e_2 (const? 8 0)) (const? 1 1) (icmp IntPredicate.eq e e_1) := by 
+    select (icmp IntPredicate.eq e_2 (const? 8 0)) (const? 1 1) (icmp IntPredicate.eq e e_1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -34,7 +34,7 @@ theorem icmp_select_var_commuted_thm (e e_1 e_2 : IntW 8) :
   icmp IntPredicate.eq (LLVM.udiv (const? 8 42) e_2)
       (select (icmp IntPredicate.eq e_1 (const? 8 0)) (LLVM.udiv (const? 8 42) e_2) e) ⊑
     select (icmp IntPredicate.eq e_1 (const? 8 0)) (const? 1 1)
-      (icmp IntPredicate.eq e (LLVM.udiv (const? 8 42) e_2)) := by 
+      (icmp IntPredicate.eq e (LLVM.udiv (const? 8 42) e_2)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -46,7 +46,7 @@ theorem icmp_select_var_commuted_thm (e e_1 e_2 : IntW 8) :
 theorem icmp_select_var_select_thm (e e_1 : IntW 8) (e_2 : IntW 1) :
   icmp IntPredicate.eq (select e_2 e_1 e) (select (icmp IntPredicate.eq e_1 (const? 8 0)) (select e_2 e_1 e) e) ⊑
     select (select (icmp IntPredicate.eq e_1 (const? 8 0)) (const? 1 1) (LLVM.xor e_2 (const? 1 1))) (const? 1 1)
-      (icmp IntPredicate.eq e_1 e) := by 
+      (icmp IntPredicate.eq e_1 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -58,7 +58,7 @@ theorem icmp_select_var_select_thm (e e_1 : IntW 8) (e_2 : IntW 1) :
 theorem icmp_select_var_both_fold_thm (e e_1 : IntW 8) :
   icmp IntPredicate.eq (select (icmp IntPredicate.eq e_1 (const? 8 0)) (LLVM.or e (const? 8 1)) (const? 8 2))
       (LLVM.or e (const? 8 1)) ⊑
-    icmp IntPredicate.eq e_1 (const? 8 0) := by 
+    icmp IntPredicate.eq e_1 (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -69,7 +69,7 @@ theorem icmp_select_var_both_fold_thm (e e_1 : IntW 8) :
 
 theorem icmp_select_var_pred_ne_thm (e e_1 e_2 : IntW 8) :
   icmp IntPredicate.ne (select (icmp IntPredicate.eq e_2 (const? 8 0)) e_1 e) e_1 ⊑
-    select (icmp IntPredicate.ne e_2 (const? 8 0)) (icmp IntPredicate.ne e e_1) (const? 1 0) := by 
+    select (icmp IntPredicate.ne e_2 (const? 8 0)) (icmp IntPredicate.ne e e_1) (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -82,7 +82,7 @@ theorem icmp_select_var_pred_ult_thm (e e_1 e_2 : IntW 8) :
   icmp IntPredicate.ult (select (icmp IntPredicate.eq e_2 (const? 8 0)) e_1 e)
       (add e_1 (const? 8 2) { «nsw» := false, «nuw» := true }) ⊑
     select (icmp IntPredicate.eq e_2 (const? 8 0)) (const? 1 1)
-      (icmp IntPredicate.ult e (add e_1 (const? 8 2) { «nsw» := false, «nuw» := true })) := by 
+      (icmp IntPredicate.ult e (add e_1 (const? 8 2) { «nsw» := false, «nuw» := true })) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -95,7 +95,7 @@ theorem icmp_select_var_pred_uge_thm (e e_1 e_2 : IntW 8) :
   icmp IntPredicate.uge (select (icmp IntPredicate.eq e_2 (const? 8 0)) e_1 e)
       (add e_1 (const? 8 2) { «nsw» := false, «nuw» := true }) ⊑
     select (icmp IntPredicate.ne e_2 (const? 8 0))
-      (icmp IntPredicate.uge e (add e_1 (const? 8 2) { «nsw» := false, «nuw» := true })) (const? 1 0) := by 
+      (icmp IntPredicate.uge e (add e_1 (const? 8 2) { «nsw» := false, «nuw» := true })) (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -108,7 +108,7 @@ theorem icmp_select_var_pred_uge_commuted_thm (e e_1 e_2 : IntW 8) :
   icmp IntPredicate.uge (add e_2 (const? 8 2) { «nsw» := false, «nuw» := true })
       (select (icmp IntPredicate.eq e_1 (const? 8 0)) e_2 e) ⊑
     select (icmp IntPredicate.eq e_1 (const? 8 0)) (const? 1 1)
-      (icmp IntPredicate.ule e (add e_2 (const? 8 2) { «nsw» := false, «nuw» := true })) := by 
+      (icmp IntPredicate.ule e (add e_2 (const? 8 2) { «nsw» := false, «nuw» := true })) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -119,7 +119,7 @@ theorem icmp_select_var_pred_uge_commuted_thm (e e_1 e_2 : IntW 8) :
 
 theorem icmp_select_implied_cond_thm (e e_1 : IntW 8) :
   icmp IntPredicate.eq (select (icmp IntPredicate.eq e_1 (const? 8 0)) (const? 8 0) e) e_1 ⊑
-    select (icmp IntPredicate.eq e_1 (const? 8 0)) (const? 1 1) (icmp IntPredicate.eq e e_1) := by 
+    select (icmp IntPredicate.eq e_1 (const? 8 0)) (const? 1 1) (icmp IntPredicate.eq e e_1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -130,7 +130,7 @@ theorem icmp_select_implied_cond_thm (e e_1 : IntW 8) :
 
 theorem icmp_select_implied_cond_ne_thm (e e_1 : IntW 8) :
   icmp IntPredicate.ne (select (icmp IntPredicate.eq e_1 (const? 8 0)) (const? 8 0) e) e_1 ⊑
-    select (icmp IntPredicate.ne e_1 (const? 8 0)) (icmp IntPredicate.ne e e_1) (const? 1 0) := by 
+    select (icmp IntPredicate.ne e_1 (const? 8 0)) (icmp IntPredicate.ne e e_1) (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -141,7 +141,7 @@ theorem icmp_select_implied_cond_ne_thm (e e_1 : IntW 8) :
 
 theorem icmp_select_implied_cond_swapped_select_thm (e e_1 : IntW 8) :
   icmp IntPredicate.eq (select (icmp IntPredicate.eq e_1 (const? 8 0)) e (const? 8 0)) e_1 ⊑
-    select (icmp IntPredicate.eq e_1 (const? 8 0)) (icmp IntPredicate.eq e (const? 8 0)) (const? 1 0) := by 
+    select (icmp IntPredicate.eq e_1 (const? 8 0)) (icmp IntPredicate.eq e (const? 8 0)) (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -152,7 +152,7 @@ theorem icmp_select_implied_cond_swapped_select_thm (e e_1 : IntW 8) :
 
 theorem icmp_select_implied_cond_relational_thm (e e_1 : IntW 8) :
   icmp IntPredicate.ult (select (icmp IntPredicate.ugt e_1 (const? 8 10)) (const? 8 10) e) e_1 ⊑
-    select (icmp IntPredicate.ugt e_1 (const? 8 10)) (const? 1 1) (icmp IntPredicate.ult e e_1) := by 
+    select (icmp IntPredicate.ugt e_1 (const? 8 10)) (const? 1 1) (icmp IntPredicate.ult e e_1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -164,7 +164,7 @@ theorem icmp_select_implied_cond_relational_thm (e e_1 : IntW 8) :
 theorem select_constants_and_icmp_eq0_thm (e e_1 : IntW 1) :
   icmp IntPredicate.eq (LLVM.and (select e_1 (const? 8 2) (const? 8 1)) (select e (const? 8 2) (const? 8 1)))
       (const? 8 0) ⊑
-    LLVM.xor e_1 e := by 
+    LLVM.xor e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -176,7 +176,7 @@ theorem select_constants_and_icmp_eq0_thm (e e_1 : IntW 1) :
 theorem select_constants_and_icmp_eq0_common_bit_thm (e e_1 : IntW 1) :
   icmp IntPredicate.eq (LLVM.and (select e_1 (const? 8 2) (const? 8 3)) (select e (const? 8 2) (const? 8 3)))
       (const? 8 0) ⊑
-    const? 1 0 := by 
+    const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -188,7 +188,7 @@ theorem select_constants_and_icmp_eq0_common_bit_thm (e e_1 : IntW 1) :
 theorem select_constants_and_icmp_eq0_zero_tval_thm (e e_1 : IntW 1) :
   icmp IntPredicate.eq (LLVM.and (select e_1 (const? 8 0) (const? 8 12)) (select e (const? 8 0) (const? 8 12)))
       (const? 8 0) ⊑
-    select e_1 (const? 1 1) e := by 
+    select e_1 (const? 1 1) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -200,7 +200,7 @@ theorem select_constants_and_icmp_eq0_zero_tval_thm (e e_1 : IntW 1) :
 theorem select_constants_and_icmp_eq0_zero_fval_thm (e e_1 : IntW 1) :
   icmp IntPredicate.eq (LLVM.and (select e_1 (const? 8 12) (const? 8 0)) (select e (const? 8 12) (const? 8 0)))
       (const? 8 0) ⊑
-    LLVM.xor (select e_1 e (const? 1 0)) (const? 1 1) := by 
+    LLVM.xor (select e_1 e (const? 1 0)) (const? 1 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -212,7 +212,7 @@ theorem select_constants_and_icmp_eq0_zero_fval_thm (e e_1 : IntW 1) :
 theorem select_constants_and_icmp_ne0_thm (e e_1 : IntW 1) :
   icmp IntPredicate.ne (LLVM.and (select e_1 (const? 8 2) (const? 8 1)) (select e (const? 8 2) (const? 8 1)))
       (const? 8 0) ⊑
-    LLVM.xor (LLVM.xor e_1 e) (const? 1 1) := by 
+    LLVM.xor (LLVM.xor e_1 e) (const? 1 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -224,7 +224,7 @@ theorem select_constants_and_icmp_ne0_thm (e e_1 : IntW 1) :
 theorem select_constants_and_icmp_ne0_common_bit_thm (e e_1 : IntW 1) :
   icmp IntPredicate.ne (LLVM.and (select e_1 (const? 8 2) (const? 8 3)) (select e (const? 8 2) (const? 8 3)))
       (const? 8 0) ⊑
-    const? 1 1 := by 
+    const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -236,7 +236,7 @@ theorem select_constants_and_icmp_ne0_common_bit_thm (e e_1 : IntW 1) :
 theorem select_constants_and_icmp_ne0_zero_tval_thm (e e_1 : IntW 1) :
   icmp IntPredicate.ne (LLVM.and (select e_1 (const? 8 0) (const? 8 12)) (select e (const? 8 0) (const? 8 12)))
       (const? 8 0) ⊑
-    LLVM.xor (select e_1 (const? 1 1) e) (const? 1 1) := by 
+    LLVM.xor (select e_1 (const? 1 1) e) (const? 1 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -248,7 +248,7 @@ theorem select_constants_and_icmp_ne0_zero_tval_thm (e e_1 : IntW 1) :
 theorem select_constants_and_icmp_ne0_zero_fval_thm (e e_1 : IntW 1) :
   icmp IntPredicate.ne (LLVM.and (select e_1 (const? 8 12) (const? 8 0)) (select e (const? 8 12) (const? 8 0)))
       (const? 8 0) ⊑
-    select e_1 e (const? 1 0) := by 
+    select e_1 e (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -258,7 +258,7 @@ theorem select_constants_and_icmp_ne0_zero_fval_thm (e e_1 : IntW 1) :
 
 
 theorem icmp_eq_select_thm (e e_1 : IntW 32) (e_2 : IntW 1) :
-  icmp IntPredicate.eq (select e_2 e_1 e) (select e_2 e e_1) ⊑ icmp IntPredicate.eq e_1 e := by 
+  icmp IntPredicate.eq (select e_2 e_1 e) (select e_2 e e_1) ⊑ icmp IntPredicate.eq e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gicmphselecthimplieshcommonhop_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gicmphselecthimplieshcommonhop_proof.lean
@@ -10,7 +10,7 @@ set_option linter.unreachableTactic false
 section gicmphselecthimplieshcommonhop_proof
 theorem sgt_3_impliesF_eq_2_thm (e e_1 : IntW 8) :
   icmp IntPredicate.eq (select (icmp IntPredicate.sgt e_1 (const? 8 3)) (const? 8 2) e) e_1 ⊑
-    select (icmp IntPredicate.slt e_1 (const? 8 4)) (icmp IntPredicate.eq e e_1) (const? 1 0) := by 
+    select (icmp IntPredicate.slt e_1 (const? 8 4)) (icmp IntPredicate.eq e e_1) (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -21,7 +21,7 @@ theorem sgt_3_impliesF_eq_2_thm (e e_1 : IntW 8) :
 
 theorem sgt_3_impliesT_sgt_2_thm (e e_1 : IntW 8) :
   icmp IntPredicate.sgt (select (icmp IntPredicate.sgt e_1 (const? 8 3)) (const? 8 2) e) e_1 ⊑
-    select (icmp IntPredicate.slt e_1 (const? 8 4)) (icmp IntPredicate.sgt e e_1) (const? 1 0) := by 
+    select (icmp IntPredicate.slt e_1 (const? 8 4)) (icmp IntPredicate.sgt e e_1) (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -32,7 +32,7 @@ theorem sgt_3_impliesT_sgt_2_thm (e e_1 : IntW 8) :
 
 theorem sgt_x_impliesF_eq_smin_todo_thm (e e_1 e_2 : IntW 8) :
   icmp IntPredicate.eq (select (icmp IntPredicate.sgt e_2 e_1) (const? 8 (-128)) e) e_2 ⊑
-    select (icmp IntPredicate.sle e_2 e_1) (icmp IntPredicate.eq e e_2) (const? 1 0) := by 
+    select (icmp IntPredicate.sle e_2 e_1) (icmp IntPredicate.eq e e_2) (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -43,7 +43,7 @@ theorem sgt_x_impliesF_eq_smin_todo_thm (e e_1 e_2 : IntW 8) :
 
 theorem slt_x_impliesT_ne_smin_todo_thm (e e_1 e_2 : IntW 8) :
   icmp IntPredicate.ne e_2 (select (icmp IntPredicate.slt e_2 e_1) (const? 8 127) e) ⊑
-    select (icmp IntPredicate.slt e_2 e_1) (const? 1 1) (icmp IntPredicate.ne e e_2) := by 
+    select (icmp IntPredicate.slt e_2 e_1) (const? 1 1) (icmp IntPredicate.ne e e_2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -54,7 +54,7 @@ theorem slt_x_impliesT_ne_smin_todo_thm (e e_1 e_2 : IntW 8) :
 
 theorem ult_x_impliesT_eq_umax_todo_thm (e e_1 e_2 : IntW 8) :
   icmp IntPredicate.ne (select (icmp IntPredicate.ugt e_2 e_1) (const? 8 (-1)) e) e_1 ⊑
-    select (icmp IntPredicate.ugt e_2 e_1) (const? 1 1) (icmp IntPredicate.ne e e_1) := by 
+    select (icmp IntPredicate.ugt e_2 e_1) (const? 1 1) (icmp IntPredicate.ne e e_1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -65,7 +65,7 @@ theorem ult_x_impliesT_eq_umax_todo_thm (e e_1 e_2 : IntW 8) :
 
 theorem ult_1_impliesF_eq_1_thm (e e_1 : IntW 8) :
   icmp IntPredicate.eq e_1 (select (icmp IntPredicate.ult e_1 (const? 8 1)) (const? 8 1) e) ⊑
-    select (icmp IntPredicate.ne e_1 (const? 8 0)) (icmp IntPredicate.eq e e_1) (const? 1 0) := by 
+    select (icmp IntPredicate.ne e_1 (const? 8 0)) (icmp IntPredicate.eq e e_1) (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gicmphshl_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gicmphshl_proof.lean
@@ -10,7 +10,7 @@ set_option linter.unreachableTactic false
 section gicmphshl_proof
 theorem shl_nuw_eq_0_thm (e e_1 : IntW 8) :
   icmp IntPredicate.eq (shl e_1 e { «nsw» := false, «nuw» := true }) (const? 8 0) ⊑
-    icmp IntPredicate.eq e_1 (const? 8 0) := by 
+    icmp IntPredicate.eq e_1 (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -21,7 +21,7 @@ theorem shl_nuw_eq_0_thm (e e_1 : IntW 8) :
 
 theorem shl_nsw_slt_1_thm (e e_1 : IntW 8) :
   icmp IntPredicate.slt (shl e_1 e { «nsw» := true, «nuw» := false }) (const? 8 1) ⊑
-    icmp IntPredicate.slt e_1 (const? 8 1) := by 
+    icmp IntPredicate.slt e_1 (const? 8 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -32,7 +32,7 @@ theorem shl_nsw_slt_1_thm (e e_1 : IntW 8) :
 
 theorem shl_nsw_sgt_n1_thm (e e_1 : IntW 8) :
   icmp IntPredicate.sgt (shl e_1 e { «nsw» := true, «nuw» := false }) (const? 8 (-1)) ⊑
-    icmp IntPredicate.sgt e_1 (const? 8 (-1)) := by 
+    icmp IntPredicate.sgt e_1 (const? 8 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -43,7 +43,7 @@ theorem shl_nsw_sgt_n1_thm (e e_1 : IntW 8) :
 
 theorem shl_nsw_nuw_ult_Csle0_thm (e e_1 : IntW 8) :
   icmp IntPredicate.ult (shl e_1 e { «nsw» := true, «nuw» := true }) (const? 8 (-19)) ⊑
-    icmp IntPredicate.ult e_1 (const? 8 (-19)) := by 
+    icmp IntPredicate.ult e_1 (const? 8 (-19)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -54,7 +54,7 @@ theorem shl_nsw_nuw_ult_Csle0_thm (e e_1 : IntW 8) :
 
 theorem shl_nsw_ule_Csle0_fail_missing_flag_thm (e e_1 : IntW 8) :
   icmp IntPredicate.ule (shl e_1 e { «nsw» := true, «nuw» := false }) (const? 8 (-19)) ⊑
-    icmp IntPredicate.ult (shl e_1 e { «nsw» := true, «nuw» := false }) (const? 8 (-18)) := by 
+    icmp IntPredicate.ult (shl e_1 e { «nsw» := true, «nuw» := false }) (const? 8 (-18)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -65,7 +65,7 @@ theorem shl_nsw_ule_Csle0_fail_missing_flag_thm (e e_1 : IntW 8) :
 
 theorem shl_nsw_nuw_uge_Csle0_thm (e e_1 : IntW 8) :
   icmp IntPredicate.uge (shl e_1 e { «nsw» := true, «nuw» := true }) (const? 8 (-120)) ⊑
-    icmp IntPredicate.ugt e_1 (const? 8 (-121)) := by 
+    icmp IntPredicate.ugt e_1 (const? 8 (-121)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gicmphshlh1hoverflow_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gicmphshlh1hoverflow_proof.lean
@@ -9,7 +9,7 @@ set_option linter.unreachableTactic false
 
 section gicmphshlh1hoverflow_proof
 theorem icmp_shl_ugt_1_thm (e : IntW 8) :
-  icmp IntPredicate.ugt (shl e (const? 8 1)) e ⊑ icmp IntPredicate.sgt e (const? 8 0) := by 
+  icmp IntPredicate.ugt (shl e (const? 8 1)) e ⊑ icmp IntPredicate.sgt e (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -20,7 +20,7 @@ theorem icmp_shl_ugt_1_thm (e : IntW 8) :
 
 theorem icmp_shl_uge_2_thm (e : IntW 5) :
   icmp IntPredicate.uge (add (const? 5 10) e) (shl (add (const? 5 10) e) (const? 5 1)) ⊑
-    icmp IntPredicate.slt (add e (const? 5 10)) (const? 5 1) := by 
+    icmp IntPredicate.slt (add e (const? 5 10)) (const? 5 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -31,7 +31,7 @@ theorem icmp_shl_uge_2_thm (e : IntW 5) :
 
 theorem icmp_shl_ule_2_thm (e : IntW 8) :
   icmp IntPredicate.ule (add (const? 8 42) e) (shl (add (const? 8 42) e) (const? 8 1)) ⊑
-    icmp IntPredicate.sgt (add e (const? 8 42)) (const? 8 (-1)) := by 
+    icmp IntPredicate.sgt (add e (const? 8 42)) (const? 8 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -41,7 +41,7 @@ theorem icmp_shl_ule_2_thm (e : IntW 8) :
 
 
 theorem icmp_shl_eq_1_thm (e : IntW 8) :
-  icmp IntPredicate.eq (shl e (const? 8 1)) e ⊑ icmp IntPredicate.eq e (const? 8 0) := by 
+  icmp IntPredicate.eq (shl e (const? 8 1)) e ⊑ icmp IntPredicate.eq e (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -52,7 +52,7 @@ theorem icmp_shl_eq_1_thm (e : IntW 8) :
 
 theorem icmp_shl_ne_2_thm (e : IntW 8) :
   icmp IntPredicate.ne (LLVM.sdiv (const? 8 42) e) (shl (LLVM.sdiv (const? 8 42) e) (const? 8 1)) ⊑
-    icmp IntPredicate.ne (LLVM.sdiv (const? 8 42) e) (const? 8 0) := by 
+    icmp IntPredicate.ne (LLVM.sdiv (const? 8 42) e) (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gicmphshlhnsw_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gicmphshlhnsw_proof.lean
@@ -10,7 +10,7 @@ set_option linter.unreachableTactic false
 section gicmphshlhnsw_proof
 theorem icmp_shl_nsw_sgt_thm (e : IntW 32) :
   icmp IntPredicate.sgt (shl e (const? 32 21) { «nsw» := true, «nuw» := false }) (const? 32 0) ⊑
-    icmp IntPredicate.sgt e (const? 32 0) := by 
+    icmp IntPredicate.sgt e (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -21,7 +21,7 @@ theorem icmp_shl_nsw_sgt_thm (e : IntW 32) :
 
 theorem icmp_shl_nsw_sge0_thm (e : IntW 32) :
   icmp IntPredicate.sge (shl e (const? 32 21) { «nsw» := true, «nuw» := false }) (const? 32 0) ⊑
-    icmp IntPredicate.sgt e (const? 32 (-1)) := by 
+    icmp IntPredicate.sgt e (const? 32 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -32,7 +32,7 @@ theorem icmp_shl_nsw_sge0_thm (e : IntW 32) :
 
 theorem icmp_shl_nsw_sge1_thm (e : IntW 32) :
   icmp IntPredicate.sge (shl e (const? 32 21) { «nsw» := true, «nuw» := false }) (const? 32 1) ⊑
-    icmp IntPredicate.sgt e (const? 32 0) := by 
+    icmp IntPredicate.sgt e (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -43,7 +43,7 @@ theorem icmp_shl_nsw_sge1_thm (e : IntW 32) :
 
 theorem icmp_shl_nsw_eq_thm (e : IntW 32) :
   icmp IntPredicate.eq (shl e (const? 32 5) { «nsw» := true, «nuw» := false }) (const? 32 0) ⊑
-    icmp IntPredicate.eq e (const? 32 0) := by 
+    icmp IntPredicate.eq e (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -54,7 +54,7 @@ theorem icmp_shl_nsw_eq_thm (e : IntW 32) :
 
 theorem icmp_sgt1_thm (e : IntW 8) :
   icmp IntPredicate.sgt (shl e (const? 8 1) { «nsw» := true, «nuw» := false }) (const? 8 (-128)) ⊑
-    icmp IntPredicate.ne e (const? 8 (-64)) := by 
+    icmp IntPredicate.ne e (const? 8 (-64)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -65,7 +65,7 @@ theorem icmp_sgt1_thm (e : IntW 8) :
 
 theorem icmp_sgt2_thm (e : IntW 8) :
   icmp IntPredicate.sgt (shl e (const? 8 1) { «nsw» := true, «nuw» := false }) (const? 8 (-127)) ⊑
-    icmp IntPredicate.sgt e (const? 8 (-64)) := by 
+    icmp IntPredicate.sgt e (const? 8 (-64)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -76,7 +76,7 @@ theorem icmp_sgt2_thm (e : IntW 8) :
 
 theorem icmp_sgt3_thm (e : IntW 8) :
   icmp IntPredicate.sgt (shl e (const? 8 1) { «nsw» := true, «nuw» := false }) (const? 8 (-16)) ⊑
-    icmp IntPredicate.sgt e (const? 8 (-8)) := by 
+    icmp IntPredicate.sgt e (const? 8 (-8)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -87,7 +87,7 @@ theorem icmp_sgt3_thm (e : IntW 8) :
 
 theorem icmp_sgt4_thm (e : IntW 8) :
   icmp IntPredicate.sgt (shl e (const? 8 1) { «nsw» := true, «nuw» := false }) (const? 8 (-2)) ⊑
-    icmp IntPredicate.sgt e (const? 8 (-1)) := by 
+    icmp IntPredicate.sgt e (const? 8 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -98,7 +98,7 @@ theorem icmp_sgt4_thm (e : IntW 8) :
 
 theorem icmp_sgt5_thm (e : IntW 8) :
   icmp IntPredicate.sgt (shl e (const? 8 1) { «nsw» := true, «nuw» := false }) (const? 8 1) ⊑
-    icmp IntPredicate.sgt e (const? 8 0) := by 
+    icmp IntPredicate.sgt e (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -109,7 +109,7 @@ theorem icmp_sgt5_thm (e : IntW 8) :
 
 theorem icmp_sgt6_thm (e : IntW 8) :
   icmp IntPredicate.sgt (shl e (const? 8 1) { «nsw» := true, «nuw» := false }) (const? 8 16) ⊑
-    icmp IntPredicate.sgt e (const? 8 8) := by 
+    icmp IntPredicate.sgt e (const? 8 8) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -120,7 +120,7 @@ theorem icmp_sgt6_thm (e : IntW 8) :
 
 theorem icmp_sgt7_thm (e : IntW 8) :
   icmp IntPredicate.sgt (shl e (const? 8 1) { «nsw» := true, «nuw» := false }) (const? 8 124) ⊑
-    icmp IntPredicate.sgt e (const? 8 62) := by 
+    icmp IntPredicate.sgt e (const? 8 62) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -131,7 +131,7 @@ theorem icmp_sgt7_thm (e : IntW 8) :
 
 theorem icmp_sgt8_thm (e : IntW 8) :
   icmp IntPredicate.sgt (shl e (const? 8 1) { «nsw» := true, «nuw» := false }) (const? 8 125) ⊑
-    icmp IntPredicate.eq e (const? 8 63) := by 
+    icmp IntPredicate.eq e (const? 8 63) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -142,7 +142,7 @@ theorem icmp_sgt8_thm (e : IntW 8) :
 
 theorem icmp_sgt9_thm (e : IntW 8) :
   icmp IntPredicate.sgt (shl e (const? 8 7) { «nsw» := true, «nuw» := false }) (const? 8 (-128)) ⊑
-    icmp IntPredicate.eq e (const? 8 0) := by 
+    icmp IntPredicate.eq e (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -153,7 +153,7 @@ theorem icmp_sgt9_thm (e : IntW 8) :
 
 theorem icmp_sgt10_thm (e : IntW 8) :
   icmp IntPredicate.sgt (shl e (const? 8 7) { «nsw» := true, «nuw» := false }) (const? 8 (-127)) ⊑
-    icmp IntPredicate.sgt e (const? 8 (-1)) := by 
+    icmp IntPredicate.sgt e (const? 8 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -164,7 +164,7 @@ theorem icmp_sgt10_thm (e : IntW 8) :
 
 theorem icmp_sgt11_thm (e : IntW 8) :
   icmp IntPredicate.sgt (shl e (const? 8 7) { «nsw» := true, «nuw» := false }) (const? 8 (-2)) ⊑
-    icmp IntPredicate.sgt e (const? 8 (-1)) := by 
+    icmp IntPredicate.sgt e (const? 8 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -175,7 +175,7 @@ theorem icmp_sgt11_thm (e : IntW 8) :
 
 theorem icmp_sle1_thm (e : IntW 8) :
   icmp IntPredicate.sle (shl e (const? 8 1) { «nsw» := true, «nuw» := false }) (const? 8 (-128)) ⊑
-    icmp IntPredicate.eq e (const? 8 (-64)) := by 
+    icmp IntPredicate.eq e (const? 8 (-64)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -186,7 +186,7 @@ theorem icmp_sle1_thm (e : IntW 8) :
 
 theorem icmp_sle2_thm (e : IntW 8) :
   icmp IntPredicate.sle (shl e (const? 8 1) { «nsw» := true, «nuw» := false }) (const? 8 (-127)) ⊑
-    icmp IntPredicate.slt e (const? 8 (-63)) := by 
+    icmp IntPredicate.slt e (const? 8 (-63)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -197,7 +197,7 @@ theorem icmp_sle2_thm (e : IntW 8) :
 
 theorem icmp_sle3_thm (e : IntW 8) :
   icmp IntPredicate.sle (shl e (const? 8 1) { «nsw» := true, «nuw» := false }) (const? 8 (-16)) ⊑
-    icmp IntPredicate.slt e (const? 8 (-7)) := by 
+    icmp IntPredicate.slt e (const? 8 (-7)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -208,7 +208,7 @@ theorem icmp_sle3_thm (e : IntW 8) :
 
 theorem icmp_sle4_thm (e : IntW 8) :
   icmp IntPredicate.sle (shl e (const? 8 1) { «nsw» := true, «nuw» := false }) (const? 8 (-2)) ⊑
-    icmp IntPredicate.slt e (const? 8 0) := by 
+    icmp IntPredicate.slt e (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -219,7 +219,7 @@ theorem icmp_sle4_thm (e : IntW 8) :
 
 theorem icmp_sle5_thm (e : IntW 8) :
   icmp IntPredicate.sle (shl e (const? 8 1) { «nsw» := true, «nuw» := false }) (const? 8 1) ⊑
-    icmp IntPredicate.slt e (const? 8 1) := by 
+    icmp IntPredicate.slt e (const? 8 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -230,7 +230,7 @@ theorem icmp_sle5_thm (e : IntW 8) :
 
 theorem icmp_sle6_thm (e : IntW 8) :
   icmp IntPredicate.sle (shl e (const? 8 1) { «nsw» := true, «nuw» := false }) (const? 8 16) ⊑
-    icmp IntPredicate.slt e (const? 8 9) := by 
+    icmp IntPredicate.slt e (const? 8 9) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -241,7 +241,7 @@ theorem icmp_sle6_thm (e : IntW 8) :
 
 theorem icmp_sle7_thm (e : IntW 8) :
   icmp IntPredicate.sle (shl e (const? 8 1) { «nsw» := true, «nuw» := false }) (const? 8 124) ⊑
-    icmp IntPredicate.slt e (const? 8 63) := by 
+    icmp IntPredicate.slt e (const? 8 63) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -252,7 +252,7 @@ theorem icmp_sle7_thm (e : IntW 8) :
 
 theorem icmp_sle8_thm (e : IntW 8) :
   icmp IntPredicate.sle (shl e (const? 8 1) { «nsw» := true, «nuw» := false }) (const? 8 125) ⊑
-    icmp IntPredicate.ne e (const? 8 63) := by 
+    icmp IntPredicate.ne e (const? 8 63) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -263,7 +263,7 @@ theorem icmp_sle8_thm (e : IntW 8) :
 
 theorem icmp_sle9_thm (e : IntW 8) :
   icmp IntPredicate.sle (shl e (const? 8 7) { «nsw» := true, «nuw» := false }) (const? 8 (-128)) ⊑
-    icmp IntPredicate.ne e (const? 8 0) := by 
+    icmp IntPredicate.ne e (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -274,7 +274,7 @@ theorem icmp_sle9_thm (e : IntW 8) :
 
 theorem icmp_sle10_thm (e : IntW 8) :
   icmp IntPredicate.sle (shl e (const? 8 7) { «nsw» := true, «nuw» := false }) (const? 8 (-127)) ⊑
-    icmp IntPredicate.slt e (const? 8 0) := by 
+    icmp IntPredicate.slt e (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -285,7 +285,7 @@ theorem icmp_sle10_thm (e : IntW 8) :
 
 theorem icmp_sle11_thm (e : IntW 8) :
   icmp IntPredicate.sle (shl e (const? 8 7) { «nsw» := true, «nuw» := false }) (const? 8 (-2)) ⊑
-    icmp IntPredicate.slt e (const? 8 0) := by 
+    icmp IntPredicate.slt e (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -296,7 +296,7 @@ theorem icmp_sle11_thm (e : IntW 8) :
 
 theorem icmp_eq1_thm (e : IntW 8) :
   icmp IntPredicate.eq (shl e (const? 8 1) { «nsw» := true, «nuw» := false }) (const? 8 12) ⊑
-    icmp IntPredicate.eq e (const? 8 6) := by 
+    icmp IntPredicate.eq e (const? 8 6) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -307,7 +307,7 @@ theorem icmp_eq1_thm (e : IntW 8) :
 
 theorem icmp_ne1_thm (e : IntW 8) :
   icmp IntPredicate.ne (shl e (const? 8 6) { «nsw» := true, «nuw» := false }) (const? 8 (-128)) ⊑
-    icmp IntPredicate.ne e (const? 8 (-2)) := by 
+    icmp IntPredicate.ne e (const? 8 (-2)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gicmphshlhnuw_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gicmphshlhnuw_proof.lean
@@ -10,7 +10,7 @@ set_option linter.unreachableTactic false
 section gicmphshlhnuw_proof
 theorem icmp_ugt_32_thm (e : IntW 64) :
   icmp IntPredicate.ugt (shl e (const? 64 32) { «nsw» := false, «nuw» := true }) (const? 64 4294967295) ⊑
-    icmp IntPredicate.ne e (const? 64 0) := by 
+    icmp IntPredicate.ne e (const? 64 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -21,7 +21,7 @@ theorem icmp_ugt_32_thm (e : IntW 64) :
 
 theorem icmp_ule_64_thm (e : IntW 128) :
   icmp IntPredicate.ule (shl e (const? 128 64) { «nsw» := false, «nuw» := true }) (const? 128 18446744073709551615) ⊑
-    icmp IntPredicate.eq e (const? 128 0) := by 
+    icmp IntPredicate.eq e (const? 128 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -32,7 +32,7 @@ theorem icmp_ule_64_thm (e : IntW 128) :
 
 theorem icmp_ugt_16_thm (e : IntW 64) :
   icmp IntPredicate.ugt (shl e (const? 64 16) { «nsw» := false, «nuw» := true }) (const? 64 1048575) ⊑
-    icmp IntPredicate.ugt e (const? 64 15) := by 
+    icmp IntPredicate.ugt e (const? 64 15) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -43,7 +43,7 @@ theorem icmp_ugt_16_thm (e : IntW 64) :
 
 theorem icmp_ult_8_thm (e : IntW 64) :
   icmp IntPredicate.ult (shl e (const? 64 8) { «nsw» := false, «nuw» := true }) (const? 64 4095) ⊑
-    icmp IntPredicate.ult e (const? 64 16) := by 
+    icmp IntPredicate.ult e (const? 64 16) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -56,7 +56,7 @@ theorem fold_icmp_shl_nuw_c1_thm (e : IntW 32) :
   icmp IntPredicate.ult
       (shl (const? 32 2) (LLVM.and (lshr e (const? 32 12)) (const? 32 15)) { «nsw» := false, «nuw» := true })
       (const? 32 4) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 32 61440)) (const? 32 0) := by 
+    icmp IntPredicate.eq (LLVM.and e (const? 32 61440)) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -67,7 +67,7 @@ theorem fold_icmp_shl_nuw_c1_thm (e : IntW 32) :
 
 theorem fold_icmp_shl_nuw_c2_thm (e : IntW 32) :
   icmp IntPredicate.ult (shl (const? 32 16) e { «nsw» := false, «nuw» := true }) (const? 32 64) ⊑
-    icmp IntPredicate.ult e (const? 32 2) := by 
+    icmp IntPredicate.ult e (const? 32 2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -78,7 +78,7 @@ theorem fold_icmp_shl_nuw_c2_thm (e : IntW 32) :
 
 theorem fold_icmp_shl_nuw_c2_non_pow2_thm (e : IntW 32) :
   icmp IntPredicate.ult (shl (const? 32 48) e { «nsw» := false, «nuw» := true }) (const? 32 192) ⊑
-    icmp IntPredicate.ult e (const? 32 2) := by 
+    icmp IntPredicate.ult e (const? 32 2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -89,7 +89,7 @@ theorem fold_icmp_shl_nuw_c2_non_pow2_thm (e : IntW 32) :
 
 theorem fold_icmp_shl_nuw_c2_div_non_pow2_thm (e : IntW 32) :
   icmp IntPredicate.ult (shl (const? 32 2) e { «nsw» := false, «nuw» := true }) (const? 32 60) ⊑
-    icmp IntPredicate.ult e (const? 32 5) := by 
+    icmp IntPredicate.ult e (const? 32 5) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -100,7 +100,7 @@ theorem fold_icmp_shl_nuw_c2_div_non_pow2_thm (e : IntW 32) :
 
 theorem fold_icmp_shl_nuw_c3_thm (e : IntW 32) :
   icmp IntPredicate.uge (shl (const? 32 48) e { «nsw» := false, «nuw» := true }) (const? 32 144) ⊑
-    icmp IntPredicate.ugt e (const? 32 1) := by 
+    icmp IntPredicate.ugt e (const? 32 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -111,7 +111,7 @@ theorem fold_icmp_shl_nuw_c3_thm (e : IntW 32) :
 
 theorem fold_icmp_shl_nuw_c2_indivisible_thm (e : IntW 32) :
   icmp IntPredicate.ult (shl (const? 32 16) e { «nsw» := false, «nuw» := true }) (const? 32 63) ⊑
-    icmp IntPredicate.ult e (const? 32 2) := by 
+    icmp IntPredicate.ult e (const? 32 2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -121,7 +121,7 @@ theorem fold_icmp_shl_nuw_c2_indivisible_thm (e : IntW 32) :
 
 
 theorem fold_icmp_shl_nuw_c2_precondition1_thm (e : IntW 32) :
-  icmp IntPredicate.ult (shl (const? 32 0) e { «nsw» := false, «nuw» := true }) (const? 32 63) ⊑ const? 1 1 := by 
+  icmp IntPredicate.ult (shl (const? 32 0) e { «nsw» := false, «nuw» := true }) (const? 32 63) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -131,7 +131,7 @@ theorem fold_icmp_shl_nuw_c2_precondition1_thm (e : IntW 32) :
 
 
 theorem fold_icmp_shl_nuw_c2_precondition2_thm (e : IntW 32) :
-  icmp IntPredicate.ult (shl (const? 32 127) e { «nsw» := false, «nuw» := true }) (const? 32 63) ⊑ const? 1 0 := by 
+  icmp IntPredicate.ult (shl (const? 32 127) e { «nsw» := false, «nuw» := true }) (const? 32 63) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -141,7 +141,7 @@ theorem fold_icmp_shl_nuw_c2_precondition2_thm (e : IntW 32) :
 
 
 theorem fold_icmp_shl_nuw_c2_precondition3_thm (e : IntW 32) :
-  icmp IntPredicate.ult (shl (const? 32 1) e { «nsw» := false, «nuw» := true }) (const? 32 1) ⊑ const? 1 0 := by 
+  icmp IntPredicate.ult (shl (const? 32 1) e { «nsw» := false, «nuw» := true }) (const? 32 1) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gicmphshr_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gicmphshr_proof.lean
@@ -9,7 +9,7 @@ set_option linter.unreachableTactic false
 
 section gicmphshr_proof
 theorem lshr_eq_msb_low_last_zero_thm (e : IntW 8) :
-  icmp IntPredicate.eq (lshr (const? 8 127) e) (const? 8 0) ⊑ icmp IntPredicate.ugt e (const? 8 6) := by 
+  icmp IntPredicate.eq (lshr (const? 8 127) e) (const? 8 0) ⊑ icmp IntPredicate.ugt e (const? 8 6) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -19,7 +19,7 @@ theorem lshr_eq_msb_low_last_zero_thm (e : IntW 8) :
 
 
 theorem ashr_eq_msb_low_second_zero_thm (e : IntW 8) :
-  icmp IntPredicate.eq (ashr (const? 8 127) e) (const? 8 0) ⊑ icmp IntPredicate.ugt e (const? 8 6) := by 
+  icmp IntPredicate.eq (ashr (const? 8 127) e) (const? 8 0) ⊑ icmp IntPredicate.ugt e (const? 8 6) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -29,7 +29,7 @@ theorem ashr_eq_msb_low_second_zero_thm (e : IntW 8) :
 
 
 theorem lshr_ne_msb_low_last_zero_thm (e : IntW 8) :
-  icmp IntPredicate.ne (lshr (const? 8 127) e) (const? 8 0) ⊑ icmp IntPredicate.ult e (const? 8 7) := by 
+  icmp IntPredicate.ne (lshr (const? 8 127) e) (const? 8 0) ⊑ icmp IntPredicate.ult e (const? 8 7) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -39,7 +39,7 @@ theorem lshr_ne_msb_low_last_zero_thm (e : IntW 8) :
 
 
 theorem ashr_ne_msb_low_second_zero_thm (e : IntW 8) :
-  icmp IntPredicate.ne (ashr (const? 8 127) e) (const? 8 0) ⊑ icmp IntPredicate.ult e (const? 8 7) := by 
+  icmp IntPredicate.ne (ashr (const? 8 127) e) (const? 8 0) ⊑ icmp IntPredicate.ult e (const? 8 7) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -49,7 +49,7 @@ theorem ashr_ne_msb_low_second_zero_thm (e : IntW 8) :
 
 
 theorem ashr_eq_both_equal_thm (e : IntW 8) :
-  icmp IntPredicate.eq (ashr (const? 8 (-128)) e) (const? 8 (-128)) ⊑ icmp IntPredicate.eq e (const? 8 0) := by 
+  icmp IntPredicate.eq (ashr (const? 8 (-128)) e) (const? 8 (-128)) ⊑ icmp IntPredicate.eq e (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -59,7 +59,7 @@ theorem ashr_eq_both_equal_thm (e : IntW 8) :
 
 
 theorem ashr_ne_both_equal_thm (e : IntW 8) :
-  icmp IntPredicate.ne (ashr (const? 8 (-128)) e) (const? 8 (-128)) ⊑ icmp IntPredicate.ne e (const? 8 0) := by 
+  icmp IntPredicate.ne (ashr (const? 8 (-128)) e) (const? 8 (-128)) ⊑ icmp IntPredicate.ne e (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -69,7 +69,7 @@ theorem ashr_ne_both_equal_thm (e : IntW 8) :
 
 
 theorem lshr_eq_both_equal_thm (e : IntW 8) :
-  icmp IntPredicate.eq (lshr (const? 8 127) e) (const? 8 127) ⊑ icmp IntPredicate.eq e (const? 8 0) := by 
+  icmp IntPredicate.eq (lshr (const? 8 127) e) (const? 8 127) ⊑ icmp IntPredicate.eq e (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -79,7 +79,7 @@ theorem lshr_eq_both_equal_thm (e : IntW 8) :
 
 
 theorem lshr_ne_both_equal_thm (e : IntW 8) :
-  icmp IntPredicate.ne (lshr (const? 8 127) e) (const? 8 127) ⊑ icmp IntPredicate.ne e (const? 8 0) := by 
+  icmp IntPredicate.ne (lshr (const? 8 127) e) (const? 8 127) ⊑ icmp IntPredicate.ne e (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -90,7 +90,7 @@ theorem lshr_ne_both_equal_thm (e : IntW 8) :
 
 theorem exact_ashr_eq_both_equal_thm (e : IntW 8) :
   icmp IntPredicate.eq (ashr (const? 8 (-128)) e { «exact» := true }) (const? 8 (-128)) ⊑
-    icmp IntPredicate.eq e (const? 8 0) := by 
+    icmp IntPredicate.eq e (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -101,7 +101,7 @@ theorem exact_ashr_eq_both_equal_thm (e : IntW 8) :
 
 theorem exact_ashr_ne_both_equal_thm (e : IntW 8) :
   icmp IntPredicate.ne (ashr (const? 8 (-128)) e { «exact» := true }) (const? 8 (-128)) ⊑
-    icmp IntPredicate.ne e (const? 8 0) := by 
+    icmp IntPredicate.ne e (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -112,7 +112,7 @@ theorem exact_ashr_ne_both_equal_thm (e : IntW 8) :
 
 theorem exact_lshr_eq_both_equal_thm (e : IntW 8) :
   icmp IntPredicate.eq (lshr (const? 8 126) e { «exact» := true }) (const? 8 126) ⊑
-    icmp IntPredicate.eq e (const? 8 0) := by 
+    icmp IntPredicate.eq e (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -123,7 +123,7 @@ theorem exact_lshr_eq_both_equal_thm (e : IntW 8) :
 
 theorem exact_lshr_ne_both_equal_thm (e : IntW 8) :
   icmp IntPredicate.ne (lshr (const? 8 126) e { «exact» := true }) (const? 8 126) ⊑
-    icmp IntPredicate.ne e (const? 8 0) := by 
+    icmp IntPredicate.ne e (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -134,7 +134,7 @@ theorem exact_lshr_ne_both_equal_thm (e : IntW 8) :
 
 theorem exact_lshr_eq_opposite_msb_thm (e : IntW 8) :
   icmp IntPredicate.eq (lshr (const? 8 (-128)) e { «exact» := true }) (const? 8 1) ⊑
-    icmp IntPredicate.eq e (const? 8 7) := by 
+    icmp IntPredicate.eq e (const? 8 7) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -144,7 +144,7 @@ theorem exact_lshr_eq_opposite_msb_thm (e : IntW 8) :
 
 
 theorem lshr_eq_opposite_msb_thm (e : IntW 8) :
-  icmp IntPredicate.eq (lshr (const? 8 (-128)) e) (const? 8 1) ⊑ icmp IntPredicate.eq e (const? 8 7) := by 
+  icmp IntPredicate.eq (lshr (const? 8 (-128)) e) (const? 8 1) ⊑ icmp IntPredicate.eq e (const? 8 7) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -155,7 +155,7 @@ theorem lshr_eq_opposite_msb_thm (e : IntW 8) :
 
 theorem exact_lshr_ne_opposite_msb_thm (e : IntW 8) :
   icmp IntPredicate.ne (lshr (const? 8 (-128)) e { «exact» := true }) (const? 8 1) ⊑
-    icmp IntPredicate.ne e (const? 8 7) := by 
+    icmp IntPredicate.ne e (const? 8 7) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -165,7 +165,7 @@ theorem exact_lshr_ne_opposite_msb_thm (e : IntW 8) :
 
 
 theorem lshr_ne_opposite_msb_thm (e : IntW 8) :
-  icmp IntPredicate.ne (lshr (const? 8 (-128)) e) (const? 8 1) ⊑ icmp IntPredicate.ne e (const? 8 7) := by 
+  icmp IntPredicate.ne (lshr (const? 8 (-128)) e) (const? 8 1) ⊑ icmp IntPredicate.ne e (const? 8 7) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -176,7 +176,7 @@ theorem lshr_ne_opposite_msb_thm (e : IntW 8) :
 
 theorem exact_ashr_eq_thm (e : IntW 8) :
   icmp IntPredicate.eq (ashr (const? 8 (-128)) e { «exact» := true }) (const? 8 (-1)) ⊑
-    icmp IntPredicate.eq e (const? 8 7) := by 
+    icmp IntPredicate.eq e (const? 8 7) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -187,7 +187,7 @@ theorem exact_ashr_eq_thm (e : IntW 8) :
 
 theorem exact_ashr_ne_thm (e : IntW 8) :
   icmp IntPredicate.ne (ashr (const? 8 (-128)) e { «exact» := true }) (const? 8 (-1)) ⊑
-    icmp IntPredicate.ne e (const? 8 7) := by 
+    icmp IntPredicate.ne e (const? 8 7) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -198,7 +198,7 @@ theorem exact_ashr_ne_thm (e : IntW 8) :
 
 theorem exact_lshr_eq_thm (e : IntW 8) :
   icmp IntPredicate.eq (lshr (const? 8 4) e { «exact» := true }) (const? 8 1) ⊑
-    icmp IntPredicate.eq e (const? 8 2) := by 
+    icmp IntPredicate.eq e (const? 8 2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -209,7 +209,7 @@ theorem exact_lshr_eq_thm (e : IntW 8) :
 
 theorem exact_lshr_ne_thm (e : IntW 8) :
   icmp IntPredicate.ne (lshr (const? 8 4) e { «exact» := true }) (const? 8 1) ⊑
-    icmp IntPredicate.ne e (const? 8 2) := by 
+    icmp IntPredicate.ne e (const? 8 2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -219,7 +219,7 @@ theorem exact_lshr_ne_thm (e : IntW 8) :
 
 
 theorem nonexact_ashr_eq_thm (e : IntW 8) :
-  icmp IntPredicate.eq (ashr (const? 8 (-128)) e) (const? 8 (-1)) ⊑ icmp IntPredicate.eq e (const? 8 7) := by 
+  icmp IntPredicate.eq (ashr (const? 8 (-128)) e) (const? 8 (-1)) ⊑ icmp IntPredicate.eq e (const? 8 7) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -229,7 +229,7 @@ theorem nonexact_ashr_eq_thm (e : IntW 8) :
 
 
 theorem nonexact_ashr_ne_thm (e : IntW 8) :
-  icmp IntPredicate.ne (ashr (const? 8 (-128)) e) (const? 8 (-1)) ⊑ icmp IntPredicate.ne e (const? 8 7) := by 
+  icmp IntPredicate.ne (ashr (const? 8 (-128)) e) (const? 8 (-1)) ⊑ icmp IntPredicate.ne e (const? 8 7) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -239,7 +239,7 @@ theorem nonexact_ashr_ne_thm (e : IntW 8) :
 
 
 theorem nonexact_lshr_eq_thm (e : IntW 8) :
-  icmp IntPredicate.eq (lshr (const? 8 4) e) (const? 8 1) ⊑ icmp IntPredicate.eq e (const? 8 2) := by 
+  icmp IntPredicate.eq (lshr (const? 8 4) e) (const? 8 1) ⊑ icmp IntPredicate.eq e (const? 8 2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -249,7 +249,7 @@ theorem nonexact_lshr_eq_thm (e : IntW 8) :
 
 
 theorem nonexact_lshr_ne_thm (e : IntW 8) :
-  icmp IntPredicate.ne (lshr (const? 8 4) e) (const? 8 1) ⊑ icmp IntPredicate.ne e (const? 8 2) := by 
+  icmp IntPredicate.ne (lshr (const? 8 4) e) (const? 8 1) ⊑ icmp IntPredicate.ne e (const? 8 2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -260,7 +260,7 @@ theorem nonexact_lshr_ne_thm (e : IntW 8) :
 
 theorem exact_lshr_eq_exactdiv_thm (e : IntW 8) :
   icmp IntPredicate.eq (lshr (const? 8 80) e { «exact» := true }) (const? 8 5) ⊑
-    icmp IntPredicate.eq e (const? 8 4) := by 
+    icmp IntPredicate.eq e (const? 8 4) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -271,7 +271,7 @@ theorem exact_lshr_eq_exactdiv_thm (e : IntW 8) :
 
 theorem exact_lshr_ne_exactdiv_thm (e : IntW 8) :
   icmp IntPredicate.ne (lshr (const? 8 80) e { «exact» := true }) (const? 8 5) ⊑
-    icmp IntPredicate.ne e (const? 8 4) := by 
+    icmp IntPredicate.ne e (const? 8 4) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -281,7 +281,7 @@ theorem exact_lshr_ne_exactdiv_thm (e : IntW 8) :
 
 
 theorem nonexact_lshr_eq_exactdiv_thm (e : IntW 8) :
-  icmp IntPredicate.eq (lshr (const? 8 80) e) (const? 8 5) ⊑ icmp IntPredicate.eq e (const? 8 4) := by 
+  icmp IntPredicate.eq (lshr (const? 8 80) e) (const? 8 5) ⊑ icmp IntPredicate.eq e (const? 8 4) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -291,7 +291,7 @@ theorem nonexact_lshr_eq_exactdiv_thm (e : IntW 8) :
 
 
 theorem nonexact_lshr_ne_exactdiv_thm (e : IntW 8) :
-  icmp IntPredicate.ne (lshr (const? 8 80) e) (const? 8 5) ⊑ icmp IntPredicate.ne e (const? 8 4) := by 
+  icmp IntPredicate.ne (lshr (const? 8 80) e) (const? 8 5) ⊑ icmp IntPredicate.ne e (const? 8 4) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -302,7 +302,7 @@ theorem nonexact_lshr_ne_exactdiv_thm (e : IntW 8) :
 
 theorem exact_ashr_eq_exactdiv_thm (e : IntW 8) :
   icmp IntPredicate.eq (ashr (const? 8 (-80)) e { «exact» := true }) (const? 8 (-5)) ⊑
-    icmp IntPredicate.eq e (const? 8 4) := by 
+    icmp IntPredicate.eq e (const? 8 4) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -313,7 +313,7 @@ theorem exact_ashr_eq_exactdiv_thm (e : IntW 8) :
 
 theorem exact_ashr_ne_exactdiv_thm (e : IntW 8) :
   icmp IntPredicate.ne (ashr (const? 8 (-80)) e { «exact» := true }) (const? 8 (-5)) ⊑
-    icmp IntPredicate.ne e (const? 8 4) := by 
+    icmp IntPredicate.ne e (const? 8 4) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -323,7 +323,7 @@ theorem exact_ashr_ne_exactdiv_thm (e : IntW 8) :
 
 
 theorem nonexact_ashr_eq_exactdiv_thm (e : IntW 8) :
-  icmp IntPredicate.eq (ashr (const? 8 (-80)) e) (const? 8 (-5)) ⊑ icmp IntPredicate.eq e (const? 8 4) := by 
+  icmp IntPredicate.eq (ashr (const? 8 (-80)) e) (const? 8 (-5)) ⊑ icmp IntPredicate.eq e (const? 8 4) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -333,7 +333,7 @@ theorem nonexact_ashr_eq_exactdiv_thm (e : IntW 8) :
 
 
 theorem nonexact_ashr_ne_exactdiv_thm (e : IntW 8) :
-  icmp IntPredicate.ne (ashr (const? 8 (-80)) e) (const? 8 (-5)) ⊑ icmp IntPredicate.ne e (const? 8 4) := by 
+  icmp IntPredicate.ne (ashr (const? 8 (-80)) e) (const? 8 (-5)) ⊑ icmp IntPredicate.ne e (const? 8 4) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -343,7 +343,7 @@ theorem nonexact_ashr_ne_exactdiv_thm (e : IntW 8) :
 
 
 theorem exact_lshr_eq_noexactdiv_thm (e : IntW 8) :
-  icmp IntPredicate.eq (lshr (const? 8 80) e { «exact» := true }) (const? 8 31) ⊑ const? 1 0 := by 
+  icmp IntPredicate.eq (lshr (const? 8 80) e { «exact» := true }) (const? 8 31) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -353,7 +353,7 @@ theorem exact_lshr_eq_noexactdiv_thm (e : IntW 8) :
 
 
 theorem exact_lshr_ne_noexactdiv_thm (e : IntW 8) :
-  icmp IntPredicate.ne (lshr (const? 8 80) e { «exact» := true }) (const? 8 31) ⊑ const? 1 1 := by 
+  icmp IntPredicate.ne (lshr (const? 8 80) e { «exact» := true }) (const? 8 31) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -362,7 +362,7 @@ theorem exact_lshr_ne_noexactdiv_thm (e : IntW 8) :
     all_goals sorry
 
 
-theorem nonexact_lshr_eq_noexactdiv_thm (e : IntW 8) : icmp IntPredicate.eq (lshr (const? 8 80) e) (const? 8 31) ⊑ const? 1 0 := by 
+theorem nonexact_lshr_eq_noexactdiv_thm (e : IntW 8) : icmp IntPredicate.eq (lshr (const? 8 80) e) (const? 8 31) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -371,7 +371,7 @@ theorem nonexact_lshr_eq_noexactdiv_thm (e : IntW 8) : icmp IntPredicate.eq (lsh
     all_goals sorry
 
 
-theorem nonexact_lshr_ne_noexactdiv_thm (e : IntW 8) : icmp IntPredicate.ne (lshr (const? 8 80) e) (const? 8 31) ⊑ const? 1 1 := by 
+theorem nonexact_lshr_ne_noexactdiv_thm (e : IntW 8) : icmp IntPredicate.ne (lshr (const? 8 80) e) (const? 8 31) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -381,7 +381,7 @@ theorem nonexact_lshr_ne_noexactdiv_thm (e : IntW 8) : icmp IntPredicate.ne (lsh
 
 
 theorem exact_ashr_eq_noexactdiv_thm (e : IntW 8) :
-  icmp IntPredicate.eq (ashr (const? 8 (-80)) e { «exact» := true }) (const? 8 (-31)) ⊑ const? 1 0 := by 
+  icmp IntPredicate.eq (ashr (const? 8 (-80)) e { «exact» := true }) (const? 8 (-31)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -391,7 +391,7 @@ theorem exact_ashr_eq_noexactdiv_thm (e : IntW 8) :
 
 
 theorem exact_ashr_ne_noexactdiv_thm (e : IntW 8) :
-  icmp IntPredicate.ne (ashr (const? 8 (-80)) e { «exact» := true }) (const? 8 (-31)) ⊑ const? 1 1 := by 
+  icmp IntPredicate.ne (ashr (const? 8 (-80)) e { «exact» := true }) (const? 8 (-31)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -400,7 +400,7 @@ theorem exact_ashr_ne_noexactdiv_thm (e : IntW 8) :
     all_goals sorry
 
 
-theorem nonexact_ashr_eq_noexactdiv_thm (e : IntW 8) : icmp IntPredicate.eq (ashr (const? 8 (-80)) e) (const? 8 (-31)) ⊑ const? 1 0 := by 
+theorem nonexact_ashr_eq_noexactdiv_thm (e : IntW 8) : icmp IntPredicate.eq (ashr (const? 8 (-80)) e) (const? 8 (-31)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -409,7 +409,7 @@ theorem nonexact_ashr_eq_noexactdiv_thm (e : IntW 8) : icmp IntPredicate.eq (ash
     all_goals sorry
 
 
-theorem nonexact_ashr_ne_noexactdiv_thm (e : IntW 8) : icmp IntPredicate.ne (ashr (const? 8 (-80)) e) (const? 8 (-31)) ⊑ const? 1 1 := by 
+theorem nonexact_ashr_ne_noexactdiv_thm (e : IntW 8) : icmp IntPredicate.ne (ashr (const? 8 (-80)) e) (const? 8 (-31)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -418,7 +418,7 @@ theorem nonexact_ashr_ne_noexactdiv_thm (e : IntW 8) : icmp IntPredicate.ne (ash
     all_goals sorry
 
 
-theorem nonexact_lshr_eq_noexactlog_thm (e : IntW 8) : icmp IntPredicate.eq (lshr (const? 8 90) e) (const? 8 30) ⊑ const? 1 0 := by 
+theorem nonexact_lshr_eq_noexactlog_thm (e : IntW 8) : icmp IntPredicate.eq (lshr (const? 8 90) e) (const? 8 30) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -427,7 +427,7 @@ theorem nonexact_lshr_eq_noexactlog_thm (e : IntW 8) : icmp IntPredicate.eq (lsh
     all_goals sorry
 
 
-theorem nonexact_lshr_ne_noexactlog_thm (e : IntW 8) : icmp IntPredicate.ne (lshr (const? 8 90) e) (const? 8 30) ⊑ const? 1 1 := by 
+theorem nonexact_lshr_ne_noexactlog_thm (e : IntW 8) : icmp IntPredicate.ne (lshr (const? 8 90) e) (const? 8 30) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -436,7 +436,7 @@ theorem nonexact_lshr_ne_noexactlog_thm (e : IntW 8) : icmp IntPredicate.ne (lsh
     all_goals sorry
 
 
-theorem nonexact_ashr_eq_noexactlog_thm (e : IntW 8) : icmp IntPredicate.eq (ashr (const? 8 (-90)) e) (const? 8 (-30)) ⊑ const? 1 0 := by 
+theorem nonexact_ashr_eq_noexactlog_thm (e : IntW 8) : icmp IntPredicate.eq (ashr (const? 8 (-90)) e) (const? 8 (-30)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -445,7 +445,7 @@ theorem nonexact_ashr_eq_noexactlog_thm (e : IntW 8) : icmp IntPredicate.eq (ash
     all_goals sorry
 
 
-theorem nonexact_ashr_ne_noexactlog_thm (e : IntW 8) : icmp IntPredicate.ne (ashr (const? 8 (-90)) e) (const? 8 (-30)) ⊑ const? 1 1 := by 
+theorem nonexact_ashr_ne_noexactlog_thm (e : IntW 8) : icmp IntPredicate.ne (ashr (const? 8 (-90)) e) (const? 8 (-30)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -455,7 +455,7 @@ theorem nonexact_ashr_ne_noexactlog_thm (e : IntW 8) : icmp IntPredicate.ne (ash
 
 
 theorem PR20945_thm (e : IntW 32) :
-  icmp IntPredicate.ne (ashr (const? 32 (-9)) e) (const? 32 (-5)) ⊑ icmp IntPredicate.ne e (const? 32 1) := by 
+  icmp IntPredicate.ne (ashr (const? 32 (-9)) e) (const? 32 (-5)) ⊑ icmp IntPredicate.ne e (const? 32 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -465,7 +465,7 @@ theorem PR20945_thm (e : IntW 32) :
 
 
 theorem PR21222_thm (e : IntW 32) :
-  icmp IntPredicate.eq (ashr (const? 32 (-93)) e) (const? 32 (-2)) ⊑ icmp IntPredicate.eq e (const? 32 6) := by 
+  icmp IntPredicate.eq (ashr (const? 32 (-93)) e) (const? 32 (-2)) ⊑ icmp IntPredicate.eq e (const? 32 6) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -476,7 +476,7 @@ theorem PR21222_thm (e : IntW 32) :
 
 theorem PR24873_thm (e : IntW 64) :
   icmp IntPredicate.eq (ashr (const? 64 (-4611686018427387904)) e) (const? 64 (-1)) ⊑
-    icmp IntPredicate.ugt e (const? 64 61) := by 
+    icmp IntPredicate.ugt e (const? 64 61) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -486,7 +486,7 @@ theorem PR24873_thm (e : IntW 64) :
 
 
 theorem ashr_exact_eq_0_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.eq (ashr e_1 e { «exact» := true }) (const? 32 0) ⊑ icmp IntPredicate.eq e_1 (const? 32 0) := by 
+  icmp IntPredicate.eq (ashr e_1 e { «exact» := true }) (const? 32 0) ⊑ icmp IntPredicate.eq e_1 (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -496,7 +496,7 @@ theorem ashr_exact_eq_0_thm (e e_1 : IntW 32) :
 
 
 theorem lshr_exact_ne_0_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.ne (lshr e_1 e { «exact» := true }) (const? 32 0) ⊑ icmp IntPredicate.ne e_1 (const? 32 0) := by 
+  icmp IntPredicate.ne (lshr e_1 e { «exact» := true }) (const? 32 0) ⊑ icmp IntPredicate.ne e_1 (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -506,7 +506,7 @@ theorem lshr_exact_ne_0_thm (e e_1 : IntW 32) :
 
 
 theorem ashr_ugt_0_thm (e : IntW 4) :
-  icmp IntPredicate.ugt (ashr e (const? 4 1)) (const? 4 0) ⊑ icmp IntPredicate.ugt e (const? 4 1) := by 
+  icmp IntPredicate.ugt (ashr e (const? 4 1)) (const? 4 0) ⊑ icmp IntPredicate.ugt e (const? 4 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -516,7 +516,7 @@ theorem ashr_ugt_0_thm (e : IntW 4) :
 
 
 theorem ashr_ugt_1_thm (e : IntW 4) :
-  icmp IntPredicate.ugt (ashr e (const? 4 1)) (const? 4 1) ⊑ icmp IntPredicate.ugt e (const? 4 3) := by 
+  icmp IntPredicate.ugt (ashr e (const? 4 1)) (const? 4 1) ⊑ icmp IntPredicate.ugt e (const? 4 3) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -526,7 +526,7 @@ theorem ashr_ugt_1_thm (e : IntW 4) :
 
 
 theorem ashr_ugt_2_thm (e : IntW 4) :
-  icmp IntPredicate.ugt (ashr e (const? 4 1)) (const? 4 2) ⊑ icmp IntPredicate.ugt e (const? 4 5) := by 
+  icmp IntPredicate.ugt (ashr e (const? 4 1)) (const? 4 2) ⊑ icmp IntPredicate.ugt e (const? 4 5) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -536,7 +536,7 @@ theorem ashr_ugt_2_thm (e : IntW 4) :
 
 
 theorem ashr_ugt_3_thm (e : IntW 4) :
-  icmp IntPredicate.ugt (ashr e (const? 4 1)) (const? 4 3) ⊑ icmp IntPredicate.slt e (const? 4 0) := by 
+  icmp IntPredicate.ugt (ashr e (const? 4 1)) (const? 4 3) ⊑ icmp IntPredicate.slt e (const? 4 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -546,7 +546,7 @@ theorem ashr_ugt_3_thm (e : IntW 4) :
 
 
 theorem ashr_ugt_4_thm (e : IntW 4) :
-  icmp IntPredicate.ugt (ashr e (const? 4 1)) (const? 4 4) ⊑ icmp IntPredicate.slt e (const? 4 0) := by 
+  icmp IntPredicate.ugt (ashr e (const? 4 1)) (const? 4 4) ⊑ icmp IntPredicate.slt e (const? 4 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -556,7 +556,7 @@ theorem ashr_ugt_4_thm (e : IntW 4) :
 
 
 theorem ashr_ugt_5_thm (e : IntW 4) :
-  icmp IntPredicate.ugt (ashr e (const? 4 1)) (const? 4 5) ⊑ icmp IntPredicate.slt e (const? 4 0) := by 
+  icmp IntPredicate.ugt (ashr e (const? 4 1)) (const? 4 5) ⊑ icmp IntPredicate.slt e (const? 4 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -566,7 +566,7 @@ theorem ashr_ugt_5_thm (e : IntW 4) :
 
 
 theorem ashr_ugt_6_thm (e : IntW 4) :
-  icmp IntPredicate.ugt (ashr e (const? 4 1)) (const? 4 6) ⊑ icmp IntPredicate.slt e (const? 4 0) := by 
+  icmp IntPredicate.ugt (ashr e (const? 4 1)) (const? 4 6) ⊑ icmp IntPredicate.slt e (const? 4 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -576,7 +576,7 @@ theorem ashr_ugt_6_thm (e : IntW 4) :
 
 
 theorem ashr_ugt_7_thm (e : IntW 4) :
-  icmp IntPredicate.ugt (ashr e (const? 4 1)) (const? 4 7) ⊑ icmp IntPredicate.slt e (const? 4 0) := by 
+  icmp IntPredicate.ugt (ashr e (const? 4 1)) (const? 4 7) ⊑ icmp IntPredicate.slt e (const? 4 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -586,7 +586,7 @@ theorem ashr_ugt_7_thm (e : IntW 4) :
 
 
 theorem ashr_ugt_8_thm (e : IntW 4) :
-  icmp IntPredicate.ugt (ashr e (const? 4 1)) (const? 4 (-8)) ⊑ icmp IntPredicate.slt e (const? 4 0) := by 
+  icmp IntPredicate.ugt (ashr e (const? 4 1)) (const? 4 (-8)) ⊑ icmp IntPredicate.slt e (const? 4 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -596,7 +596,7 @@ theorem ashr_ugt_8_thm (e : IntW 4) :
 
 
 theorem ashr_ugt_9_thm (e : IntW 4) :
-  icmp IntPredicate.ugt (ashr e (const? 4 1)) (const? 4 (-7)) ⊑ icmp IntPredicate.slt e (const? 4 0) := by 
+  icmp IntPredicate.ugt (ashr e (const? 4 1)) (const? 4 (-7)) ⊑ icmp IntPredicate.slt e (const? 4 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -606,7 +606,7 @@ theorem ashr_ugt_9_thm (e : IntW 4) :
 
 
 theorem ashr_ugt_10_thm (e : IntW 4) :
-  icmp IntPredicate.ugt (ashr e (const? 4 1)) (const? 4 (-6)) ⊑ icmp IntPredicate.slt e (const? 4 0) := by 
+  icmp IntPredicate.ugt (ashr e (const? 4 1)) (const? 4 (-6)) ⊑ icmp IntPredicate.slt e (const? 4 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -616,7 +616,7 @@ theorem ashr_ugt_10_thm (e : IntW 4) :
 
 
 theorem ashr_ugt_11_thm (e : IntW 4) :
-  icmp IntPredicate.ugt (ashr e (const? 4 1)) (const? 4 (-5)) ⊑ icmp IntPredicate.slt e (const? 4 0) := by 
+  icmp IntPredicate.ugt (ashr e (const? 4 1)) (const? 4 (-5)) ⊑ icmp IntPredicate.slt e (const? 4 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -626,7 +626,7 @@ theorem ashr_ugt_11_thm (e : IntW 4) :
 
 
 theorem ashr_ugt_12_thm (e : IntW 4) :
-  icmp IntPredicate.ugt (ashr e (const? 4 1)) (const? 4 (-4)) ⊑ icmp IntPredicate.ugt e (const? 4 (-7)) := by 
+  icmp IntPredicate.ugt (ashr e (const? 4 1)) (const? 4 (-4)) ⊑ icmp IntPredicate.ugt e (const? 4 (-7)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -636,7 +636,7 @@ theorem ashr_ugt_12_thm (e : IntW 4) :
 
 
 theorem ashr_ugt_13_thm (e : IntW 4) :
-  icmp IntPredicate.ugt (ashr e (const? 4 1)) (const? 4 (-3)) ⊑ icmp IntPredicate.ugt e (const? 4 (-5)) := by 
+  icmp IntPredicate.ugt (ashr e (const? 4 1)) (const? 4 (-3)) ⊑ icmp IntPredicate.ugt e (const? 4 (-5)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -646,7 +646,7 @@ theorem ashr_ugt_13_thm (e : IntW 4) :
 
 
 theorem ashr_ugt_14_thm (e : IntW 4) :
-  icmp IntPredicate.ugt (ashr e (const? 4 1)) (const? 4 (-2)) ⊑ icmp IntPredicate.ugt e (const? 4 (-3)) := by 
+  icmp IntPredicate.ugt (ashr e (const? 4 1)) (const? 4 (-2)) ⊑ icmp IntPredicate.ugt e (const? 4 (-3)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -655,7 +655,7 @@ theorem ashr_ugt_14_thm (e : IntW 4) :
     all_goals sorry
 
 
-theorem ashr_ugt_15_thm (e : IntW 4) : icmp IntPredicate.ugt (ashr e (const? 4 1)) (const? 4 (-1)) ⊑ const? 1 0 := by 
+theorem ashr_ugt_15_thm (e : IntW 4) : icmp IntPredicate.ugt (ashr e (const? 4 1)) (const? 4 (-1)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -664,7 +664,7 @@ theorem ashr_ugt_15_thm (e : IntW 4) : icmp IntPredicate.ugt (ashr e (const? 4 1
     all_goals sorry
 
 
-theorem ashr_ult_0_thm (e : IntW 4) : icmp IntPredicate.ult (ashr e (const? 4 1)) (const? 4 0) ⊑ const? 1 0 := by 
+theorem ashr_ult_0_thm (e : IntW 4) : icmp IntPredicate.ult (ashr e (const? 4 1)) (const? 4 0) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -674,7 +674,7 @@ theorem ashr_ult_0_thm (e : IntW 4) : icmp IntPredicate.ult (ashr e (const? 4 1)
 
 
 theorem ashr_ult_1_thm (e : IntW 4) :
-  icmp IntPredicate.ult (ashr e (const? 4 1)) (const? 4 1) ⊑ icmp IntPredicate.ult e (const? 4 2) := by 
+  icmp IntPredicate.ult (ashr e (const? 4 1)) (const? 4 1) ⊑ icmp IntPredicate.ult e (const? 4 2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -684,7 +684,7 @@ theorem ashr_ult_1_thm (e : IntW 4) :
 
 
 theorem ashr_ult_2_thm (e : IntW 4) :
-  icmp IntPredicate.ult (ashr e (const? 4 1)) (const? 4 2) ⊑ icmp IntPredicate.ult e (const? 4 4) := by 
+  icmp IntPredicate.ult (ashr e (const? 4 1)) (const? 4 2) ⊑ icmp IntPredicate.ult e (const? 4 4) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -694,7 +694,7 @@ theorem ashr_ult_2_thm (e : IntW 4) :
 
 
 theorem ashr_ult_3_thm (e : IntW 4) :
-  icmp IntPredicate.ult (ashr e (const? 4 1)) (const? 4 3) ⊑ icmp IntPredicate.ult e (const? 4 6) := by 
+  icmp IntPredicate.ult (ashr e (const? 4 1)) (const? 4 3) ⊑ icmp IntPredicate.ult e (const? 4 6) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -704,7 +704,7 @@ theorem ashr_ult_3_thm (e : IntW 4) :
 
 
 theorem ashr_ult_4_thm (e : IntW 4) :
-  icmp IntPredicate.ult (ashr e (const? 4 1)) (const? 4 4) ⊑ icmp IntPredicate.sgt e (const? 4 (-1)) := by 
+  icmp IntPredicate.ult (ashr e (const? 4 1)) (const? 4 4) ⊑ icmp IntPredicate.sgt e (const? 4 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -714,7 +714,7 @@ theorem ashr_ult_4_thm (e : IntW 4) :
 
 
 theorem ashr_ult_5_thm (e : IntW 4) :
-  icmp IntPredicate.ult (ashr e (const? 4 1)) (const? 4 5) ⊑ icmp IntPredicate.sgt e (const? 4 (-1)) := by 
+  icmp IntPredicate.ult (ashr e (const? 4 1)) (const? 4 5) ⊑ icmp IntPredicate.sgt e (const? 4 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -724,7 +724,7 @@ theorem ashr_ult_5_thm (e : IntW 4) :
 
 
 theorem ashr_ult_6_thm (e : IntW 4) :
-  icmp IntPredicate.ult (ashr e (const? 4 1)) (const? 4 6) ⊑ icmp IntPredicate.sgt e (const? 4 (-1)) := by 
+  icmp IntPredicate.ult (ashr e (const? 4 1)) (const? 4 6) ⊑ icmp IntPredicate.sgt e (const? 4 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -734,7 +734,7 @@ theorem ashr_ult_6_thm (e : IntW 4) :
 
 
 theorem ashr_ult_7_thm (e : IntW 4) :
-  icmp IntPredicate.ult (ashr e (const? 4 1)) (const? 4 7) ⊑ icmp IntPredicate.sgt e (const? 4 (-1)) := by 
+  icmp IntPredicate.ult (ashr e (const? 4 1)) (const? 4 7) ⊑ icmp IntPredicate.sgt e (const? 4 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -744,7 +744,7 @@ theorem ashr_ult_7_thm (e : IntW 4) :
 
 
 theorem ashr_ult_8_thm (e : IntW 4) :
-  icmp IntPredicate.ult (ashr e (const? 4 1)) (const? 4 (-8)) ⊑ icmp IntPredicate.sgt e (const? 4 (-1)) := by 
+  icmp IntPredicate.ult (ashr e (const? 4 1)) (const? 4 (-8)) ⊑ icmp IntPredicate.sgt e (const? 4 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -754,7 +754,7 @@ theorem ashr_ult_8_thm (e : IntW 4) :
 
 
 theorem ashr_ult_9_thm (e : IntW 4) :
-  icmp IntPredicate.ult (ashr e (const? 4 1)) (const? 4 (-7)) ⊑ icmp IntPredicate.sgt e (const? 4 (-1)) := by 
+  icmp IntPredicate.ult (ashr e (const? 4 1)) (const? 4 (-7)) ⊑ icmp IntPredicate.sgt e (const? 4 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -764,7 +764,7 @@ theorem ashr_ult_9_thm (e : IntW 4) :
 
 
 theorem ashr_ult_10_thm (e : IntW 4) :
-  icmp IntPredicate.ult (ashr e (const? 4 1)) (const? 4 (-6)) ⊑ icmp IntPredicate.sgt e (const? 4 (-1)) := by 
+  icmp IntPredicate.ult (ashr e (const? 4 1)) (const? 4 (-6)) ⊑ icmp IntPredicate.sgt e (const? 4 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -774,7 +774,7 @@ theorem ashr_ult_10_thm (e : IntW 4) :
 
 
 theorem ashr_ult_11_thm (e : IntW 4) :
-  icmp IntPredicate.ult (ashr e (const? 4 1)) (const? 4 (-5)) ⊑ icmp IntPredicate.sgt e (const? 4 (-1)) := by 
+  icmp IntPredicate.ult (ashr e (const? 4 1)) (const? 4 (-5)) ⊑ icmp IntPredicate.sgt e (const? 4 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -784,7 +784,7 @@ theorem ashr_ult_11_thm (e : IntW 4) :
 
 
 theorem ashr_ult_12_thm (e : IntW 4) :
-  icmp IntPredicate.ult (ashr e (const? 4 1)) (const? 4 (-4)) ⊑ icmp IntPredicate.sgt e (const? 4 (-1)) := by 
+  icmp IntPredicate.ult (ashr e (const? 4 1)) (const? 4 (-4)) ⊑ icmp IntPredicate.sgt e (const? 4 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -794,7 +794,7 @@ theorem ashr_ult_12_thm (e : IntW 4) :
 
 
 theorem ashr_ult_13_thm (e : IntW 4) :
-  icmp IntPredicate.ult (ashr e (const? 4 1)) (const? 4 (-3)) ⊑ icmp IntPredicate.ult e (const? 4 (-6)) := by 
+  icmp IntPredicate.ult (ashr e (const? 4 1)) (const? 4 (-3)) ⊑ icmp IntPredicate.ult e (const? 4 (-6)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -804,7 +804,7 @@ theorem ashr_ult_13_thm (e : IntW 4) :
 
 
 theorem ashr_ult_14_thm (e : IntW 4) :
-  icmp IntPredicate.ult (ashr e (const? 4 1)) (const? 4 (-2)) ⊑ icmp IntPredicate.ult e (const? 4 (-4)) := by 
+  icmp IntPredicate.ult (ashr e (const? 4 1)) (const? 4 (-2)) ⊑ icmp IntPredicate.ult e (const? 4 (-4)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -814,7 +814,7 @@ theorem ashr_ult_14_thm (e : IntW 4) :
 
 
 theorem ashr_ult_15_thm (e : IntW 4) :
-  icmp IntPredicate.ult (ashr e (const? 4 1)) (const? 4 (-1)) ⊑ icmp IntPredicate.ult e (const? 4 (-2)) := by 
+  icmp IntPredicate.ult (ashr e (const? 4 1)) (const? 4 (-1)) ⊑ icmp IntPredicate.ult e (const? 4 (-2)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -824,7 +824,7 @@ theorem ashr_ult_15_thm (e : IntW 4) :
 
 
 theorem lshr_pow2_ugt_thm (e : IntW 8) :
-  icmp IntPredicate.ugt (lshr (const? 8 2) e) (const? 8 1) ⊑ icmp IntPredicate.eq e (const? 8 0) := by 
+  icmp IntPredicate.ugt (lshr (const? 8 2) e) (const? 8 1) ⊑ icmp IntPredicate.eq e (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -834,7 +834,7 @@ theorem lshr_pow2_ugt_thm (e : IntW 8) :
 
 
 theorem lshr_pow2_ugt1_thm (e : IntW 8) :
-  icmp IntPredicate.ugt (lshr (const? 8 (-128)) e) (const? 8 1) ⊑ icmp IntPredicate.ult e (const? 8 7) := by 
+  icmp IntPredicate.ugt (lshr (const? 8 (-128)) e) (const? 8 1) ⊑ icmp IntPredicate.ult e (const? 8 7) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -845,7 +845,7 @@ theorem lshr_pow2_ugt1_thm (e : IntW 8) :
 
 theorem ashr_pow2_ugt_thm (e : IntW 8) :
   icmp IntPredicate.ugt (ashr (const? 8 (-128)) e) (const? 8 (-96)) ⊑
-    icmp IntPredicate.ugt (ashr (const? 8 (-128)) e { «exact» := true }) (const? 8 (-96)) := by 
+    icmp IntPredicate.ugt (ashr (const? 8 (-128)) e { «exact» := true }) (const? 8 (-96)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -856,7 +856,7 @@ theorem ashr_pow2_ugt_thm (e : IntW 8) :
 
 theorem lshr_pow2_sgt_thm (e : IntW 8) :
   icmp IntPredicate.sgt (lshr (const? 8 (-128)) e) (const? 8 3) ⊑
-    icmp IntPredicate.sgt (lshr (const? 8 (-128)) e { «exact» := true }) (const? 8 3) := by 
+    icmp IntPredicate.sgt (lshr (const? 8 (-128)) e { «exact» := true }) (const? 8 3) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -866,7 +866,7 @@ theorem lshr_pow2_sgt_thm (e : IntW 8) :
 
 
 theorem lshr_pow2_ult_thm (e : IntW 8) :
-  icmp IntPredicate.ult (lshr (const? 8 4) e) (const? 8 2) ⊑ icmp IntPredicate.ugt e (const? 8 1) := by 
+  icmp IntPredicate.ult (lshr (const? 8 4) e) (const? 8 2) ⊑ icmp IntPredicate.ugt e (const? 8 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -876,7 +876,7 @@ theorem lshr_pow2_ult_thm (e : IntW 8) :
 
 
 theorem lshr_pow2_ult_equal_constants_thm (e : IntW 32) :
-  icmp IntPredicate.ult (lshr (const? 32 16) e) (const? 32 16) ⊑ icmp IntPredicate.ne e (const? 32 0) := by 
+  icmp IntPredicate.ult (lshr (const? 32 16) e) (const? 32 16) ⊑ icmp IntPredicate.ne e (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -886,7 +886,7 @@ theorem lshr_pow2_ult_equal_constants_thm (e : IntW 32) :
 
 
 theorem lshr_pow2_ult_smin_thm (e : IntW 8) :
-  icmp IntPredicate.ult (lshr (const? 8 (-128)) e) (const? 8 (-128)) ⊑ icmp IntPredicate.ne e (const? 8 0) := by 
+  icmp IntPredicate.ult (lshr (const? 8 (-128)) e) (const? 8 (-128)) ⊑ icmp IntPredicate.ne e (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -897,7 +897,7 @@ theorem lshr_pow2_ult_smin_thm (e : IntW 8) :
 
 theorem ashr_pow2_ult_thm (e : IntW 8) :
   icmp IntPredicate.ult (ashr (const? 8 (-128)) e) (const? 8 (-96)) ⊑
-    icmp IntPredicate.ult (ashr (const? 8 (-128)) e { «exact» := true }) (const? 8 (-96)) := by 
+    icmp IntPredicate.ult (ashr (const? 8 (-128)) e { «exact» := true }) (const? 8 (-96)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -908,7 +908,7 @@ theorem ashr_pow2_ult_thm (e : IntW 8) :
 
 theorem lshr_pow2_slt_thm (e : IntW 8) :
   icmp IntPredicate.slt (lshr (const? 8 (-128)) e) (const? 8 3) ⊑
-    icmp IntPredicate.slt (lshr (const? 8 (-128)) e { «exact» := true }) (const? 8 3) := by 
+    icmp IntPredicate.slt (lshr (const? 8 (-128)) e { «exact» := true }) (const? 8 3) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -918,7 +918,7 @@ theorem lshr_pow2_slt_thm (e : IntW 8) :
 
 
 theorem lshr_neg_sgt_minus_1_thm (e : IntW 8) :
-  icmp IntPredicate.sgt (lshr (const? 8 (-17)) e) (const? 8 (-1)) ⊑ icmp IntPredicate.ne e (const? 8 0) := by 
+  icmp IntPredicate.sgt (lshr (const? 8 (-17)) e) (const? 8 (-1)) ⊑ icmp IntPredicate.ne e (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -928,7 +928,7 @@ theorem lshr_neg_sgt_minus_1_thm (e : IntW 8) :
 
 
 theorem lshr_neg_slt_zero_thm (e : IntW 8) :
-  icmp IntPredicate.slt (lshr (const? 8 (-17)) e) (const? 8 0) ⊑ icmp IntPredicate.eq e (const? 8 0) := by 
+  icmp IntPredicate.slt (lshr (const? 8 (-17)) e) (const? 8 0) ⊑ icmp IntPredicate.eq e (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -939,7 +939,7 @@ theorem lshr_neg_slt_zero_thm (e : IntW 8) :
 
 theorem exactly_one_set_signbit_thm (e e_1 : IntW 8) :
   icmp IntPredicate.eq (lshr e_1 (const? 8 7)) (zext 8 (icmp IntPredicate.sgt e (const? 8 (-1)))) ⊑
-    icmp IntPredicate.slt (LLVM.xor e_1 e) (const? 8 0) := by 
+    icmp IntPredicate.slt (LLVM.xor e_1 e) (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -950,7 +950,7 @@ theorem exactly_one_set_signbit_thm (e e_1 : IntW 8) :
 
 theorem same_signbit_wrong_type_thm (e : IntW 32) (e_1 : IntW 8) :
   icmp IntPredicate.ne (lshr e_1 (const? 8 7)) (zext 8 (icmp IntPredicate.sgt e (const? 32 (-1)))) ⊑
-    LLVM.xor (icmp IntPredicate.slt e_1 (const? 8 0)) (icmp IntPredicate.sgt e (const? 32 (-1))) := by 
+    LLVM.xor (icmp IntPredicate.slt e_1 (const? 8 0)) (icmp IntPredicate.sgt e (const? 32 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -961,7 +961,7 @@ theorem same_signbit_wrong_type_thm (e : IntW 32) (e_1 : IntW 8) :
 
 theorem exactly_one_set_signbit_wrong_pred_thm (e e_1 : IntW 8) :
   icmp IntPredicate.sgt (lshr e_1 (const? 8 7)) (zext 8 (icmp IntPredicate.sgt e (const? 8 (-1)))) ⊑
-    icmp IntPredicate.slt (LLVM.and e e_1) (const? 8 0) := by 
+    icmp IntPredicate.slt (LLVM.and e e_1) (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -972,7 +972,7 @@ theorem exactly_one_set_signbit_wrong_pred_thm (e e_1 : IntW 8) :
 
 theorem exactly_one_set_signbit_signed_thm (e e_1 : IntW 8) :
   icmp IntPredicate.eq (ashr e_1 (const? 8 7)) (sext 8 (icmp IntPredicate.sgt e (const? 8 (-1)))) ⊑
-    icmp IntPredicate.slt (LLVM.xor e_1 e) (const? 8 0) := by 
+    icmp IntPredicate.slt (LLVM.xor e_1 e) (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -983,7 +983,7 @@ theorem exactly_one_set_signbit_signed_thm (e e_1 : IntW 8) :
 
 theorem same_signbit_wrong_type_signed_thm (e : IntW 32) (e_1 : IntW 8) :
   icmp IntPredicate.ne (ashr e_1 (const? 8 7)) (sext 8 (icmp IntPredicate.sgt e (const? 32 (-1)))) ⊑
-    LLVM.xor (icmp IntPredicate.slt e_1 (const? 8 0)) (icmp IntPredicate.sgt e (const? 32 (-1))) := by 
+    LLVM.xor (icmp IntPredicate.slt e_1 (const? 8 0)) (icmp IntPredicate.sgt e (const? 32 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -994,7 +994,7 @@ theorem same_signbit_wrong_type_signed_thm (e : IntW 32) (e_1 : IntW 8) :
 
 theorem slt_zero_ult_i1_thm (e : IntW 32) (e_1 : IntW 1) :
   icmp IntPredicate.ult (zext 32 e_1) (lshr e (const? 32 31)) ⊑
-    LLVM.and (icmp IntPredicate.slt e (const? 32 0)) (LLVM.xor e_1 (const? 1 1)) := by 
+    LLVM.and (icmp IntPredicate.slt e (const? 32 0)) (LLVM.xor e_1 (const? 1 1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1005,7 +1005,7 @@ theorem slt_zero_ult_i1_thm (e : IntW 32) (e_1 : IntW 1) :
 
 theorem slt_zero_ult_i1_fail1_thm (e : IntW 32) (e_1 : IntW 1) :
   icmp IntPredicate.ult (zext 32 e_1) (lshr e (const? 32 30)) ⊑
-    icmp IntPredicate.ugt (lshr e (const? 32 30)) (zext 32 e_1) := by 
+    icmp IntPredicate.ugt (lshr e (const? 32 30)) (zext 32 e_1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1016,7 +1016,7 @@ theorem slt_zero_ult_i1_fail1_thm (e : IntW 32) (e_1 : IntW 1) :
 
 theorem slt_zero_ult_i1_fail2_thm (e : IntW 32) (e_1 : IntW 1) :
   icmp IntPredicate.ult (zext 32 e_1) (ashr e (const? 32 31)) ⊑
-    icmp IntPredicate.ugt (ashr e (const? 32 31)) (zext 32 e_1) := by 
+    icmp IntPredicate.ugt (ashr e (const? 32 31)) (zext 32 e_1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1027,7 +1027,7 @@ theorem slt_zero_ult_i1_fail2_thm (e : IntW 32) (e_1 : IntW 1) :
 
 theorem slt_zero_slt_i1_fail_thm (e : IntW 32) (e_1 : IntW 1) :
   icmp IntPredicate.slt (zext 32 e_1) (lshr e (const? 32 31)) ⊑
-    LLVM.and (icmp IntPredicate.slt e (const? 32 0)) (LLVM.xor e_1 (const? 1 1)) := by 
+    LLVM.and (icmp IntPredicate.slt e (const? 32 0)) (LLVM.xor e_1 (const? 1 1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1038,7 +1038,7 @@ theorem slt_zero_slt_i1_fail_thm (e : IntW 32) (e_1 : IntW 1) :
 
 theorem slt_zero_eq_i1_signed_thm (e : IntW 32) (e_1 : IntW 1) :
   icmp IntPredicate.eq (sext 32 e_1) (ashr e (const? 32 31)) ⊑
-    LLVM.xor (icmp IntPredicate.sgt e (const? 32 (-1))) e_1 := by 
+    LLVM.xor (icmp IntPredicate.sgt e (const? 32 (-1))) e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1049,7 +1049,7 @@ theorem slt_zero_eq_i1_signed_thm (e : IntW 32) (e_1 : IntW 1) :
 
 theorem slt_zero_eq_i1_fail_signed_thm (e : IntW 32) (e_1 : IntW 1) :
   icmp IntPredicate.eq (sext 32 e_1) (lshr e (const? 32 31)) ⊑
-    icmp IntPredicate.eq (lshr e (const? 32 31)) (sext 32 e_1) := by 
+    icmp IntPredicate.eq (lshr e (const? 32 31)) (sext 32 e_1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gicmphshrhlthgt_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gicmphshrhlthgt_proof.lean
@@ -9,7 +9,7 @@ set_option linter.unreachableTactic false
 
 section gicmphshrhlthgt_proof
 theorem lshrugt_01_00_thm (e : IntW 4) :
-  icmp IntPredicate.ugt (lshr e (const? 4 1)) (const? 4 0) ⊑ icmp IntPredicate.ugt e (const? 4 1) := by 
+  icmp IntPredicate.ugt (lshr e (const? 4 1)) (const? 4 0) ⊑ icmp IntPredicate.ugt e (const? 4 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -19,7 +19,7 @@ theorem lshrugt_01_00_thm (e : IntW 4) :
 
 
 theorem lshrugt_01_01_thm (e : IntW 4) :
-  icmp IntPredicate.ugt (lshr e (const? 4 1)) (const? 4 1) ⊑ icmp IntPredicate.ugt e (const? 4 3) := by 
+  icmp IntPredicate.ugt (lshr e (const? 4 1)) (const? 4 1) ⊑ icmp IntPredicate.ugt e (const? 4 3) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -29,7 +29,7 @@ theorem lshrugt_01_01_thm (e : IntW 4) :
 
 
 theorem lshrugt_01_02_thm (e : IntW 4) :
-  icmp IntPredicate.ugt (lshr e (const? 4 1)) (const? 4 2) ⊑ icmp IntPredicate.ugt e (const? 4 5) := by 
+  icmp IntPredicate.ugt (lshr e (const? 4 1)) (const? 4 2) ⊑ icmp IntPredicate.ugt e (const? 4 5) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -39,7 +39,7 @@ theorem lshrugt_01_02_thm (e : IntW 4) :
 
 
 theorem lshrugt_01_03_thm (e : IntW 4) :
-  icmp IntPredicate.ugt (lshr e (const? 4 1)) (const? 4 3) ⊑ icmp IntPredicate.slt e (const? 4 0) := by 
+  icmp IntPredicate.ugt (lshr e (const? 4 1)) (const? 4 3) ⊑ icmp IntPredicate.slt e (const? 4 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -49,7 +49,7 @@ theorem lshrugt_01_03_thm (e : IntW 4) :
 
 
 theorem lshrugt_01_04_thm (e : IntW 4) :
-  icmp IntPredicate.ugt (lshr e (const? 4 1)) (const? 4 4) ⊑ icmp IntPredicate.ugt e (const? 4 (-7)) := by 
+  icmp IntPredicate.ugt (lshr e (const? 4 1)) (const? 4 4) ⊑ icmp IntPredicate.ugt e (const? 4 (-7)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -59,7 +59,7 @@ theorem lshrugt_01_04_thm (e : IntW 4) :
 
 
 theorem lshrugt_01_05_thm (e : IntW 4) :
-  icmp IntPredicate.ugt (lshr e (const? 4 1)) (const? 4 5) ⊑ icmp IntPredicate.ugt e (const? 4 (-5)) := by 
+  icmp IntPredicate.ugt (lshr e (const? 4 1)) (const? 4 5) ⊑ icmp IntPredicate.ugt e (const? 4 (-5)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -69,7 +69,7 @@ theorem lshrugt_01_05_thm (e : IntW 4) :
 
 
 theorem lshrugt_01_06_thm (e : IntW 4) :
-  icmp IntPredicate.ugt (lshr e (const? 4 1)) (const? 4 6) ⊑ icmp IntPredicate.ugt e (const? 4 (-3)) := by 
+  icmp IntPredicate.ugt (lshr e (const? 4 1)) (const? 4 6) ⊑ icmp IntPredicate.ugt e (const? 4 (-3)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -78,7 +78,7 @@ theorem lshrugt_01_06_thm (e : IntW 4) :
     all_goals sorry
 
 
-theorem lshrugt_01_07_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4 1)) (const? 4 7) ⊑ const? 1 0 := by 
+theorem lshrugt_01_07_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4 1)) (const? 4 7) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -87,7 +87,7 @@ theorem lshrugt_01_07_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4
     all_goals sorry
 
 
-theorem lshrugt_01_08_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4 1)) (const? 4 (-8)) ⊑ const? 1 0 := by 
+theorem lshrugt_01_08_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4 1)) (const? 4 (-8)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -96,7 +96,7 @@ theorem lshrugt_01_08_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4
     all_goals sorry
 
 
-theorem lshrugt_01_09_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4 1)) (const? 4 (-7)) ⊑ const? 1 0 := by 
+theorem lshrugt_01_09_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4 1)) (const? 4 (-7)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -105,7 +105,7 @@ theorem lshrugt_01_09_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4
     all_goals sorry
 
 
-theorem lshrugt_01_10_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4 1)) (const? 4 (-6)) ⊑ const? 1 0 := by 
+theorem lshrugt_01_10_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4 1)) (const? 4 (-6)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -114,7 +114,7 @@ theorem lshrugt_01_10_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4
     all_goals sorry
 
 
-theorem lshrugt_01_11_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4 1)) (const? 4 (-5)) ⊑ const? 1 0 := by 
+theorem lshrugt_01_11_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4 1)) (const? 4 (-5)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -123,7 +123,7 @@ theorem lshrugt_01_11_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4
     all_goals sorry
 
 
-theorem lshrugt_01_12_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4 1)) (const? 4 (-4)) ⊑ const? 1 0 := by 
+theorem lshrugt_01_12_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4 1)) (const? 4 (-4)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -132,7 +132,7 @@ theorem lshrugt_01_12_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4
     all_goals sorry
 
 
-theorem lshrugt_01_13_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4 1)) (const? 4 (-3)) ⊑ const? 1 0 := by 
+theorem lshrugt_01_13_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4 1)) (const? 4 (-3)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -141,7 +141,7 @@ theorem lshrugt_01_13_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4
     all_goals sorry
 
 
-theorem lshrugt_01_14_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4 1)) (const? 4 (-2)) ⊑ const? 1 0 := by 
+theorem lshrugt_01_14_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4 1)) (const? 4 (-2)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -150,7 +150,7 @@ theorem lshrugt_01_14_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4
     all_goals sorry
 
 
-theorem lshrugt_01_15_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4 1)) (const? 4 (-1)) ⊑ const? 1 0 := by 
+theorem lshrugt_01_15_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4 1)) (const? 4 (-1)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -160,7 +160,7 @@ theorem lshrugt_01_15_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4
 
 
 theorem lshrugt_02_00_thm (e : IntW 4) :
-  icmp IntPredicate.ugt (lshr e (const? 4 2)) (const? 4 0) ⊑ icmp IntPredicate.ugt e (const? 4 3) := by 
+  icmp IntPredicate.ugt (lshr e (const? 4 2)) (const? 4 0) ⊑ icmp IntPredicate.ugt e (const? 4 3) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -170,7 +170,7 @@ theorem lshrugt_02_00_thm (e : IntW 4) :
 
 
 theorem lshrugt_02_01_thm (e : IntW 4) :
-  icmp IntPredicate.ugt (lshr e (const? 4 2)) (const? 4 1) ⊑ icmp IntPredicate.slt e (const? 4 0) := by 
+  icmp IntPredicate.ugt (lshr e (const? 4 2)) (const? 4 1) ⊑ icmp IntPredicate.slt e (const? 4 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -180,7 +180,7 @@ theorem lshrugt_02_01_thm (e : IntW 4) :
 
 
 theorem lshrugt_02_02_thm (e : IntW 4) :
-  icmp IntPredicate.ugt (lshr e (const? 4 2)) (const? 4 2) ⊑ icmp IntPredicate.ugt e (const? 4 (-5)) := by 
+  icmp IntPredicate.ugt (lshr e (const? 4 2)) (const? 4 2) ⊑ icmp IntPredicate.ugt e (const? 4 (-5)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -189,7 +189,7 @@ theorem lshrugt_02_02_thm (e : IntW 4) :
     all_goals sorry
 
 
-theorem lshrugt_02_03_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4 2)) (const? 4 3) ⊑ const? 1 0 := by 
+theorem lshrugt_02_03_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4 2)) (const? 4 3) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -198,7 +198,7 @@ theorem lshrugt_02_03_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4
     all_goals sorry
 
 
-theorem lshrugt_02_04_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4 2)) (const? 4 4) ⊑ const? 1 0 := by 
+theorem lshrugt_02_04_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4 2)) (const? 4 4) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -207,7 +207,7 @@ theorem lshrugt_02_04_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4
     all_goals sorry
 
 
-theorem lshrugt_02_05_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4 2)) (const? 4 5) ⊑ const? 1 0 := by 
+theorem lshrugt_02_05_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4 2)) (const? 4 5) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -216,7 +216,7 @@ theorem lshrugt_02_05_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4
     all_goals sorry
 
 
-theorem lshrugt_02_06_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4 2)) (const? 4 6) ⊑ const? 1 0 := by 
+theorem lshrugt_02_06_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4 2)) (const? 4 6) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -225,7 +225,7 @@ theorem lshrugt_02_06_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4
     all_goals sorry
 
 
-theorem lshrugt_02_07_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4 2)) (const? 4 7) ⊑ const? 1 0 := by 
+theorem lshrugt_02_07_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4 2)) (const? 4 7) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -234,7 +234,7 @@ theorem lshrugt_02_07_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4
     all_goals sorry
 
 
-theorem lshrugt_02_08_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4 2)) (const? 4 (-8)) ⊑ const? 1 0 := by 
+theorem lshrugt_02_08_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4 2)) (const? 4 (-8)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -243,7 +243,7 @@ theorem lshrugt_02_08_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4
     all_goals sorry
 
 
-theorem lshrugt_02_09_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4 2)) (const? 4 (-7)) ⊑ const? 1 0 := by 
+theorem lshrugt_02_09_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4 2)) (const? 4 (-7)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -252,7 +252,7 @@ theorem lshrugt_02_09_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4
     all_goals sorry
 
 
-theorem lshrugt_02_10_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4 2)) (const? 4 (-6)) ⊑ const? 1 0 := by 
+theorem lshrugt_02_10_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4 2)) (const? 4 (-6)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -261,7 +261,7 @@ theorem lshrugt_02_10_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4
     all_goals sorry
 
 
-theorem lshrugt_02_11_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4 2)) (const? 4 (-5)) ⊑ const? 1 0 := by 
+theorem lshrugt_02_11_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4 2)) (const? 4 (-5)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -270,7 +270,7 @@ theorem lshrugt_02_11_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4
     all_goals sorry
 
 
-theorem lshrugt_02_12_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4 2)) (const? 4 (-4)) ⊑ const? 1 0 := by 
+theorem lshrugt_02_12_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4 2)) (const? 4 (-4)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -279,7 +279,7 @@ theorem lshrugt_02_12_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4
     all_goals sorry
 
 
-theorem lshrugt_02_13_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4 2)) (const? 4 (-3)) ⊑ const? 1 0 := by 
+theorem lshrugt_02_13_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4 2)) (const? 4 (-3)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -288,7 +288,7 @@ theorem lshrugt_02_13_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4
     all_goals sorry
 
 
-theorem lshrugt_02_14_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4 2)) (const? 4 (-2)) ⊑ const? 1 0 := by 
+theorem lshrugt_02_14_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4 2)) (const? 4 (-2)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -297,7 +297,7 @@ theorem lshrugt_02_14_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4
     all_goals sorry
 
 
-theorem lshrugt_02_15_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4 2)) (const? 4 (-1)) ⊑ const? 1 0 := by 
+theorem lshrugt_02_15_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4 2)) (const? 4 (-1)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -307,7 +307,7 @@ theorem lshrugt_02_15_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4
 
 
 theorem lshrugt_03_00_thm (e : IntW 4) :
-  icmp IntPredicate.ugt (lshr e (const? 4 3)) (const? 4 0) ⊑ icmp IntPredicate.slt e (const? 4 0) := by 
+  icmp IntPredicate.ugt (lshr e (const? 4 3)) (const? 4 0) ⊑ icmp IntPredicate.slt e (const? 4 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -316,7 +316,7 @@ theorem lshrugt_03_00_thm (e : IntW 4) :
     all_goals sorry
 
 
-theorem lshrugt_03_01_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4 3)) (const? 4 1) ⊑ const? 1 0 := by 
+theorem lshrugt_03_01_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4 3)) (const? 4 1) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -325,7 +325,7 @@ theorem lshrugt_03_01_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4
     all_goals sorry
 
 
-theorem lshrugt_03_02_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4 3)) (const? 4 2) ⊑ const? 1 0 := by 
+theorem lshrugt_03_02_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4 3)) (const? 4 2) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -334,7 +334,7 @@ theorem lshrugt_03_02_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4
     all_goals sorry
 
 
-theorem lshrugt_03_03_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4 3)) (const? 4 3) ⊑ const? 1 0 := by 
+theorem lshrugt_03_03_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4 3)) (const? 4 3) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -343,7 +343,7 @@ theorem lshrugt_03_03_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4
     all_goals sorry
 
 
-theorem lshrugt_03_04_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4 3)) (const? 4 4) ⊑ const? 1 0 := by 
+theorem lshrugt_03_04_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4 3)) (const? 4 4) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -352,7 +352,7 @@ theorem lshrugt_03_04_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4
     all_goals sorry
 
 
-theorem lshrugt_03_05_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4 3)) (const? 4 5) ⊑ const? 1 0 := by 
+theorem lshrugt_03_05_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4 3)) (const? 4 5) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -361,7 +361,7 @@ theorem lshrugt_03_05_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4
     all_goals sorry
 
 
-theorem lshrugt_03_06_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4 3)) (const? 4 6) ⊑ const? 1 0 := by 
+theorem lshrugt_03_06_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4 3)) (const? 4 6) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -370,7 +370,7 @@ theorem lshrugt_03_06_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4
     all_goals sorry
 
 
-theorem lshrugt_03_07_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4 3)) (const? 4 7) ⊑ const? 1 0 := by 
+theorem lshrugt_03_07_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4 3)) (const? 4 7) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -379,7 +379,7 @@ theorem lshrugt_03_07_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4
     all_goals sorry
 
 
-theorem lshrugt_03_08_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4 3)) (const? 4 (-8)) ⊑ const? 1 0 := by 
+theorem lshrugt_03_08_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4 3)) (const? 4 (-8)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -388,7 +388,7 @@ theorem lshrugt_03_08_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4
     all_goals sorry
 
 
-theorem lshrugt_03_09_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4 3)) (const? 4 (-7)) ⊑ const? 1 0 := by 
+theorem lshrugt_03_09_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4 3)) (const? 4 (-7)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -397,7 +397,7 @@ theorem lshrugt_03_09_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4
     all_goals sorry
 
 
-theorem lshrugt_03_10_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4 3)) (const? 4 (-6)) ⊑ const? 1 0 := by 
+theorem lshrugt_03_10_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4 3)) (const? 4 (-6)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -406,7 +406,7 @@ theorem lshrugt_03_10_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4
     all_goals sorry
 
 
-theorem lshrugt_03_11_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4 3)) (const? 4 (-5)) ⊑ const? 1 0 := by 
+theorem lshrugt_03_11_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4 3)) (const? 4 (-5)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -415,7 +415,7 @@ theorem lshrugt_03_11_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4
     all_goals sorry
 
 
-theorem lshrugt_03_12_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4 3)) (const? 4 (-4)) ⊑ const? 1 0 := by 
+theorem lshrugt_03_12_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4 3)) (const? 4 (-4)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -424,7 +424,7 @@ theorem lshrugt_03_12_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4
     all_goals sorry
 
 
-theorem lshrugt_03_13_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4 3)) (const? 4 (-3)) ⊑ const? 1 0 := by 
+theorem lshrugt_03_13_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4 3)) (const? 4 (-3)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -433,7 +433,7 @@ theorem lshrugt_03_13_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4
     all_goals sorry
 
 
-theorem lshrugt_03_14_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4 3)) (const? 4 (-2)) ⊑ const? 1 0 := by 
+theorem lshrugt_03_14_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4 3)) (const? 4 (-2)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -442,7 +442,7 @@ theorem lshrugt_03_14_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4
     all_goals sorry
 
 
-theorem lshrugt_03_15_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4 3)) (const? 4 (-1)) ⊑ const? 1 0 := by 
+theorem lshrugt_03_15_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4 3)) (const? 4 (-1)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -451,7 +451,7 @@ theorem lshrugt_03_15_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4
     all_goals sorry
 
 
-theorem lshrult_01_00_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4 1)) (const? 4 0) ⊑ const? 1 0 := by 
+theorem lshrult_01_00_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4 1)) (const? 4 0) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -461,7 +461,7 @@ theorem lshrult_01_00_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4
 
 
 theorem lshrult_01_01_thm (e : IntW 4) :
-  icmp IntPredicate.ult (lshr e (const? 4 1)) (const? 4 1) ⊑ icmp IntPredicate.ult e (const? 4 2) := by 
+  icmp IntPredicate.ult (lshr e (const? 4 1)) (const? 4 1) ⊑ icmp IntPredicate.ult e (const? 4 2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -471,7 +471,7 @@ theorem lshrult_01_01_thm (e : IntW 4) :
 
 
 theorem lshrult_01_02_thm (e : IntW 4) :
-  icmp IntPredicate.ult (lshr e (const? 4 1)) (const? 4 2) ⊑ icmp IntPredicate.ult e (const? 4 4) := by 
+  icmp IntPredicate.ult (lshr e (const? 4 1)) (const? 4 2) ⊑ icmp IntPredicate.ult e (const? 4 4) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -481,7 +481,7 @@ theorem lshrult_01_02_thm (e : IntW 4) :
 
 
 theorem lshrult_01_03_thm (e : IntW 4) :
-  icmp IntPredicate.ult (lshr e (const? 4 1)) (const? 4 3) ⊑ icmp IntPredicate.ult e (const? 4 6) := by 
+  icmp IntPredicate.ult (lshr e (const? 4 1)) (const? 4 3) ⊑ icmp IntPredicate.ult e (const? 4 6) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -491,7 +491,7 @@ theorem lshrult_01_03_thm (e : IntW 4) :
 
 
 theorem lshrult_01_04_thm (e : IntW 4) :
-  icmp IntPredicate.ult (lshr e (const? 4 1)) (const? 4 4) ⊑ icmp IntPredicate.sgt e (const? 4 (-1)) := by 
+  icmp IntPredicate.ult (lshr e (const? 4 1)) (const? 4 4) ⊑ icmp IntPredicate.sgt e (const? 4 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -501,7 +501,7 @@ theorem lshrult_01_04_thm (e : IntW 4) :
 
 
 theorem lshrult_01_05_thm (e : IntW 4) :
-  icmp IntPredicate.ult (lshr e (const? 4 1)) (const? 4 5) ⊑ icmp IntPredicate.ult e (const? 4 (-6)) := by 
+  icmp IntPredicate.ult (lshr e (const? 4 1)) (const? 4 5) ⊑ icmp IntPredicate.ult e (const? 4 (-6)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -511,7 +511,7 @@ theorem lshrult_01_05_thm (e : IntW 4) :
 
 
 theorem lshrult_01_06_thm (e : IntW 4) :
-  icmp IntPredicate.ult (lshr e (const? 4 1)) (const? 4 6) ⊑ icmp IntPredicate.ult e (const? 4 (-4)) := by 
+  icmp IntPredicate.ult (lshr e (const? 4 1)) (const? 4 6) ⊑ icmp IntPredicate.ult e (const? 4 (-4)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -521,7 +521,7 @@ theorem lshrult_01_06_thm (e : IntW 4) :
 
 
 theorem lshrult_01_07_thm (e : IntW 4) :
-  icmp IntPredicate.ult (lshr e (const? 4 1)) (const? 4 7) ⊑ icmp IntPredicate.ult e (const? 4 (-2)) := by 
+  icmp IntPredicate.ult (lshr e (const? 4 1)) (const? 4 7) ⊑ icmp IntPredicate.ult e (const? 4 (-2)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -530,7 +530,7 @@ theorem lshrult_01_07_thm (e : IntW 4) :
     all_goals sorry
 
 
-theorem lshrult_01_08_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4 1)) (const? 4 (-8)) ⊑ const? 1 1 := by 
+theorem lshrult_01_08_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4 1)) (const? 4 (-8)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -539,7 +539,7 @@ theorem lshrult_01_08_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4
     all_goals sorry
 
 
-theorem lshrult_01_09_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4 1)) (const? 4 (-7)) ⊑ const? 1 1 := by 
+theorem lshrult_01_09_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4 1)) (const? 4 (-7)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -548,7 +548,7 @@ theorem lshrult_01_09_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4
     all_goals sorry
 
 
-theorem lshrult_01_10_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4 1)) (const? 4 (-6)) ⊑ const? 1 1 := by 
+theorem lshrult_01_10_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4 1)) (const? 4 (-6)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -557,7 +557,7 @@ theorem lshrult_01_10_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4
     all_goals sorry
 
 
-theorem lshrult_01_11_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4 1)) (const? 4 (-5)) ⊑ const? 1 1 := by 
+theorem lshrult_01_11_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4 1)) (const? 4 (-5)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -566,7 +566,7 @@ theorem lshrult_01_11_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4
     all_goals sorry
 
 
-theorem lshrult_01_12_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4 1)) (const? 4 (-4)) ⊑ const? 1 1 := by 
+theorem lshrult_01_12_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4 1)) (const? 4 (-4)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -575,7 +575,7 @@ theorem lshrult_01_12_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4
     all_goals sorry
 
 
-theorem lshrult_01_13_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4 1)) (const? 4 (-3)) ⊑ const? 1 1 := by 
+theorem lshrult_01_13_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4 1)) (const? 4 (-3)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -584,7 +584,7 @@ theorem lshrult_01_13_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4
     all_goals sorry
 
 
-theorem lshrult_01_14_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4 1)) (const? 4 (-2)) ⊑ const? 1 1 := by 
+theorem lshrult_01_14_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4 1)) (const? 4 (-2)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -593,7 +593,7 @@ theorem lshrult_01_14_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4
     all_goals sorry
 
 
-theorem lshrult_01_15_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4 1)) (const? 4 (-1)) ⊑ const? 1 1 := by 
+theorem lshrult_01_15_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4 1)) (const? 4 (-1)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -602,7 +602,7 @@ theorem lshrult_01_15_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4
     all_goals sorry
 
 
-theorem lshrult_02_00_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4 2)) (const? 4 0) ⊑ const? 1 0 := by 
+theorem lshrult_02_00_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4 2)) (const? 4 0) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -612,7 +612,7 @@ theorem lshrult_02_00_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4
 
 
 theorem lshrult_02_01_thm (e : IntW 4) :
-  icmp IntPredicate.ult (lshr e (const? 4 2)) (const? 4 1) ⊑ icmp IntPredicate.ult e (const? 4 4) := by 
+  icmp IntPredicate.ult (lshr e (const? 4 2)) (const? 4 1) ⊑ icmp IntPredicate.ult e (const? 4 4) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -622,7 +622,7 @@ theorem lshrult_02_01_thm (e : IntW 4) :
 
 
 theorem lshrult_02_02_thm (e : IntW 4) :
-  icmp IntPredicate.ult (lshr e (const? 4 2)) (const? 4 2) ⊑ icmp IntPredicate.sgt e (const? 4 (-1)) := by 
+  icmp IntPredicate.ult (lshr e (const? 4 2)) (const? 4 2) ⊑ icmp IntPredicate.sgt e (const? 4 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -632,7 +632,7 @@ theorem lshrult_02_02_thm (e : IntW 4) :
 
 
 theorem lshrult_02_03_thm (e : IntW 4) :
-  icmp IntPredicate.ult (lshr e (const? 4 2)) (const? 4 3) ⊑ icmp IntPredicate.ult e (const? 4 (-4)) := by 
+  icmp IntPredicate.ult (lshr e (const? 4 2)) (const? 4 3) ⊑ icmp IntPredicate.ult e (const? 4 (-4)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -641,7 +641,7 @@ theorem lshrult_02_03_thm (e : IntW 4) :
     all_goals sorry
 
 
-theorem lshrult_02_04_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4 2)) (const? 4 4) ⊑ const? 1 1 := by 
+theorem lshrult_02_04_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4 2)) (const? 4 4) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -650,7 +650,7 @@ theorem lshrult_02_04_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4
     all_goals sorry
 
 
-theorem lshrult_02_05_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4 2)) (const? 4 5) ⊑ const? 1 1 := by 
+theorem lshrult_02_05_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4 2)) (const? 4 5) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -659,7 +659,7 @@ theorem lshrult_02_05_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4
     all_goals sorry
 
 
-theorem lshrult_02_06_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4 2)) (const? 4 6) ⊑ const? 1 1 := by 
+theorem lshrult_02_06_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4 2)) (const? 4 6) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -668,7 +668,7 @@ theorem lshrult_02_06_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4
     all_goals sorry
 
 
-theorem lshrult_02_07_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4 2)) (const? 4 7) ⊑ const? 1 1 := by 
+theorem lshrult_02_07_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4 2)) (const? 4 7) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -677,7 +677,7 @@ theorem lshrult_02_07_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4
     all_goals sorry
 
 
-theorem lshrult_02_08_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4 2)) (const? 4 (-8)) ⊑ const? 1 1 := by 
+theorem lshrult_02_08_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4 2)) (const? 4 (-8)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -686,7 +686,7 @@ theorem lshrult_02_08_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4
     all_goals sorry
 
 
-theorem lshrult_02_09_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4 2)) (const? 4 (-7)) ⊑ const? 1 1 := by 
+theorem lshrult_02_09_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4 2)) (const? 4 (-7)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -695,7 +695,7 @@ theorem lshrult_02_09_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4
     all_goals sorry
 
 
-theorem lshrult_02_10_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4 2)) (const? 4 (-6)) ⊑ const? 1 1 := by 
+theorem lshrult_02_10_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4 2)) (const? 4 (-6)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -704,7 +704,7 @@ theorem lshrult_02_10_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4
     all_goals sorry
 
 
-theorem lshrult_02_11_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4 2)) (const? 4 (-5)) ⊑ const? 1 1 := by 
+theorem lshrult_02_11_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4 2)) (const? 4 (-5)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -713,7 +713,7 @@ theorem lshrult_02_11_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4
     all_goals sorry
 
 
-theorem lshrult_02_12_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4 2)) (const? 4 (-4)) ⊑ const? 1 1 := by 
+theorem lshrult_02_12_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4 2)) (const? 4 (-4)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -722,7 +722,7 @@ theorem lshrult_02_12_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4
     all_goals sorry
 
 
-theorem lshrult_02_13_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4 2)) (const? 4 (-3)) ⊑ const? 1 1 := by 
+theorem lshrult_02_13_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4 2)) (const? 4 (-3)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -731,7 +731,7 @@ theorem lshrult_02_13_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4
     all_goals sorry
 
 
-theorem lshrult_02_14_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4 2)) (const? 4 (-2)) ⊑ const? 1 1 := by 
+theorem lshrult_02_14_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4 2)) (const? 4 (-2)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -740,7 +740,7 @@ theorem lshrult_02_14_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4
     all_goals sorry
 
 
-theorem lshrult_02_15_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4 2)) (const? 4 (-1)) ⊑ const? 1 1 := by 
+theorem lshrult_02_15_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4 2)) (const? 4 (-1)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -749,7 +749,7 @@ theorem lshrult_02_15_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4
     all_goals sorry
 
 
-theorem lshrult_03_00_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4 3)) (const? 4 0) ⊑ const? 1 0 := by 
+theorem lshrult_03_00_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4 3)) (const? 4 0) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -759,7 +759,7 @@ theorem lshrult_03_00_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4
 
 
 theorem lshrult_03_01_thm (e : IntW 4) :
-  icmp IntPredicate.ult (lshr e (const? 4 3)) (const? 4 1) ⊑ icmp IntPredicate.sgt e (const? 4 (-1)) := by 
+  icmp IntPredicate.ult (lshr e (const? 4 3)) (const? 4 1) ⊑ icmp IntPredicate.sgt e (const? 4 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -768,7 +768,7 @@ theorem lshrult_03_01_thm (e : IntW 4) :
     all_goals sorry
 
 
-theorem lshrult_03_02_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4 3)) (const? 4 2) ⊑ const? 1 1 := by 
+theorem lshrult_03_02_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4 3)) (const? 4 2) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -777,7 +777,7 @@ theorem lshrult_03_02_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4
     all_goals sorry
 
 
-theorem lshrult_03_03_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4 3)) (const? 4 3) ⊑ const? 1 1 := by 
+theorem lshrult_03_03_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4 3)) (const? 4 3) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -786,7 +786,7 @@ theorem lshrult_03_03_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4
     all_goals sorry
 
 
-theorem lshrult_03_04_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4 3)) (const? 4 4) ⊑ const? 1 1 := by 
+theorem lshrult_03_04_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4 3)) (const? 4 4) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -795,7 +795,7 @@ theorem lshrult_03_04_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4
     all_goals sorry
 
 
-theorem lshrult_03_05_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4 3)) (const? 4 5) ⊑ const? 1 1 := by 
+theorem lshrult_03_05_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4 3)) (const? 4 5) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -804,7 +804,7 @@ theorem lshrult_03_05_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4
     all_goals sorry
 
 
-theorem lshrult_03_06_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4 3)) (const? 4 6) ⊑ const? 1 1 := by 
+theorem lshrult_03_06_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4 3)) (const? 4 6) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -813,7 +813,7 @@ theorem lshrult_03_06_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4
     all_goals sorry
 
 
-theorem lshrult_03_07_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4 3)) (const? 4 7) ⊑ const? 1 1 := by 
+theorem lshrult_03_07_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4 3)) (const? 4 7) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -822,7 +822,7 @@ theorem lshrult_03_07_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4
     all_goals sorry
 
 
-theorem lshrult_03_08_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4 3)) (const? 4 (-8)) ⊑ const? 1 1 := by 
+theorem lshrult_03_08_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4 3)) (const? 4 (-8)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -831,7 +831,7 @@ theorem lshrult_03_08_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4
     all_goals sorry
 
 
-theorem lshrult_03_09_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4 3)) (const? 4 (-7)) ⊑ const? 1 1 := by 
+theorem lshrult_03_09_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4 3)) (const? 4 (-7)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -840,7 +840,7 @@ theorem lshrult_03_09_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4
     all_goals sorry
 
 
-theorem lshrult_03_10_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4 3)) (const? 4 (-6)) ⊑ const? 1 1 := by 
+theorem lshrult_03_10_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4 3)) (const? 4 (-6)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -849,7 +849,7 @@ theorem lshrult_03_10_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4
     all_goals sorry
 
 
-theorem lshrult_03_11_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4 3)) (const? 4 (-5)) ⊑ const? 1 1 := by 
+theorem lshrult_03_11_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4 3)) (const? 4 (-5)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -858,7 +858,7 @@ theorem lshrult_03_11_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4
     all_goals sorry
 
 
-theorem lshrult_03_12_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4 3)) (const? 4 (-4)) ⊑ const? 1 1 := by 
+theorem lshrult_03_12_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4 3)) (const? 4 (-4)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -867,7 +867,7 @@ theorem lshrult_03_12_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4
     all_goals sorry
 
 
-theorem lshrult_03_13_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4 3)) (const? 4 (-3)) ⊑ const? 1 1 := by 
+theorem lshrult_03_13_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4 3)) (const? 4 (-3)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -876,7 +876,7 @@ theorem lshrult_03_13_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4
     all_goals sorry
 
 
-theorem lshrult_03_14_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4 3)) (const? 4 (-2)) ⊑ const? 1 1 := by 
+theorem lshrult_03_14_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4 3)) (const? 4 (-2)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -885,7 +885,7 @@ theorem lshrult_03_14_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4
     all_goals sorry
 
 
-theorem lshrult_03_15_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4 3)) (const? 4 (-1)) ⊑ const? 1 1 := by 
+theorem lshrult_03_15_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4 3)) (const? 4 (-1)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -895,7 +895,7 @@ theorem lshrult_03_15_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4
 
 
 theorem ashrsgt_01_00_thm (e : IntW 4) :
-  icmp IntPredicate.sgt (ashr e (const? 4 1)) (const? 4 0) ⊑ icmp IntPredicate.sgt e (const? 4 1) := by 
+  icmp IntPredicate.sgt (ashr e (const? 4 1)) (const? 4 0) ⊑ icmp IntPredicate.sgt e (const? 4 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -905,7 +905,7 @@ theorem ashrsgt_01_00_thm (e : IntW 4) :
 
 
 theorem ashrsgt_01_01_thm (e : IntW 4) :
-  icmp IntPredicate.sgt (ashr e (const? 4 1)) (const? 4 1) ⊑ icmp IntPredicate.sgt e (const? 4 3) := by 
+  icmp IntPredicate.sgt (ashr e (const? 4 1)) (const? 4 1) ⊑ icmp IntPredicate.sgt e (const? 4 3) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -915,7 +915,7 @@ theorem ashrsgt_01_01_thm (e : IntW 4) :
 
 
 theorem ashrsgt_01_02_thm (e : IntW 4) :
-  icmp IntPredicate.sgt (ashr e (const? 4 1)) (const? 4 2) ⊑ icmp IntPredicate.sgt e (const? 4 5) := by 
+  icmp IntPredicate.sgt (ashr e (const? 4 1)) (const? 4 2) ⊑ icmp IntPredicate.sgt e (const? 4 5) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -924,7 +924,7 @@ theorem ashrsgt_01_02_thm (e : IntW 4) :
     all_goals sorry
 
 
-theorem ashrsgt_01_03_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4 1)) (const? 4 3) ⊑ const? 1 0 := by 
+theorem ashrsgt_01_03_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4 1)) (const? 4 3) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -933,7 +933,7 @@ theorem ashrsgt_01_03_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4
     all_goals sorry
 
 
-theorem ashrsgt_01_04_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4 1)) (const? 4 4) ⊑ const? 1 0 := by 
+theorem ashrsgt_01_04_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4 1)) (const? 4 4) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -942,7 +942,7 @@ theorem ashrsgt_01_04_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4
     all_goals sorry
 
 
-theorem ashrsgt_01_05_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4 1)) (const? 4 5) ⊑ const? 1 0 := by 
+theorem ashrsgt_01_05_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4 1)) (const? 4 5) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -951,7 +951,7 @@ theorem ashrsgt_01_05_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4
     all_goals sorry
 
 
-theorem ashrsgt_01_06_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4 1)) (const? 4 6) ⊑ const? 1 0 := by 
+theorem ashrsgt_01_06_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4 1)) (const? 4 6) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -960,7 +960,7 @@ theorem ashrsgt_01_06_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4
     all_goals sorry
 
 
-theorem ashrsgt_01_07_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4 1)) (const? 4 7) ⊑ const? 1 0 := by 
+theorem ashrsgt_01_07_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4 1)) (const? 4 7) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -969,7 +969,7 @@ theorem ashrsgt_01_07_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4
     all_goals sorry
 
 
-theorem ashrsgt_01_08_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4 1)) (const? 4 (-8)) ⊑ const? 1 1 := by 
+theorem ashrsgt_01_08_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4 1)) (const? 4 (-8)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -978,7 +978,7 @@ theorem ashrsgt_01_08_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4
     all_goals sorry
 
 
-theorem ashrsgt_01_09_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4 1)) (const? 4 (-7)) ⊑ const? 1 1 := by 
+theorem ashrsgt_01_09_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4 1)) (const? 4 (-7)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -987,7 +987,7 @@ theorem ashrsgt_01_09_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4
     all_goals sorry
 
 
-theorem ashrsgt_01_10_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4 1)) (const? 4 (-6)) ⊑ const? 1 1 := by 
+theorem ashrsgt_01_10_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4 1)) (const? 4 (-6)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -996,7 +996,7 @@ theorem ashrsgt_01_10_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4
     all_goals sorry
 
 
-theorem ashrsgt_01_11_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4 1)) (const? 4 (-5)) ⊑ const? 1 1 := by 
+theorem ashrsgt_01_11_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4 1)) (const? 4 (-5)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1006,7 +1006,7 @@ theorem ashrsgt_01_11_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4
 
 
 theorem ashrsgt_01_12_thm (e : IntW 4) :
-  icmp IntPredicate.sgt (ashr e (const? 4 1)) (const? 4 (-4)) ⊑ icmp IntPredicate.sgt e (const? 4 (-7)) := by 
+  icmp IntPredicate.sgt (ashr e (const? 4 1)) (const? 4 (-4)) ⊑ icmp IntPredicate.sgt e (const? 4 (-7)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1016,7 +1016,7 @@ theorem ashrsgt_01_12_thm (e : IntW 4) :
 
 
 theorem ashrsgt_01_13_thm (e : IntW 4) :
-  icmp IntPredicate.sgt (ashr e (const? 4 1)) (const? 4 (-3)) ⊑ icmp IntPredicate.sgt e (const? 4 (-5)) := by 
+  icmp IntPredicate.sgt (ashr e (const? 4 1)) (const? 4 (-3)) ⊑ icmp IntPredicate.sgt e (const? 4 (-5)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1026,7 +1026,7 @@ theorem ashrsgt_01_13_thm (e : IntW 4) :
 
 
 theorem ashrsgt_01_14_thm (e : IntW 4) :
-  icmp IntPredicate.sgt (ashr e (const? 4 1)) (const? 4 (-2)) ⊑ icmp IntPredicate.sgt e (const? 4 (-3)) := by 
+  icmp IntPredicate.sgt (ashr e (const? 4 1)) (const? 4 (-2)) ⊑ icmp IntPredicate.sgt e (const? 4 (-3)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1036,7 +1036,7 @@ theorem ashrsgt_01_14_thm (e : IntW 4) :
 
 
 theorem ashrsgt_01_15_thm (e : IntW 4) :
-  icmp IntPredicate.sgt (ashr e (const? 4 1)) (const? 4 (-1)) ⊑ icmp IntPredicate.sgt e (const? 4 (-1)) := by 
+  icmp IntPredicate.sgt (ashr e (const? 4 1)) (const? 4 (-1)) ⊑ icmp IntPredicate.sgt e (const? 4 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1046,7 +1046,7 @@ theorem ashrsgt_01_15_thm (e : IntW 4) :
 
 
 theorem ashrsgt_02_00_thm (e : IntW 4) :
-  icmp IntPredicate.sgt (ashr e (const? 4 2)) (const? 4 0) ⊑ icmp IntPredicate.sgt e (const? 4 3) := by 
+  icmp IntPredicate.sgt (ashr e (const? 4 2)) (const? 4 0) ⊑ icmp IntPredicate.sgt e (const? 4 3) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1055,7 +1055,7 @@ theorem ashrsgt_02_00_thm (e : IntW 4) :
     all_goals sorry
 
 
-theorem ashrsgt_02_01_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4 2)) (const? 4 1) ⊑ const? 1 0 := by 
+theorem ashrsgt_02_01_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4 2)) (const? 4 1) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1064,7 +1064,7 @@ theorem ashrsgt_02_01_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4
     all_goals sorry
 
 
-theorem ashrsgt_02_02_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4 2)) (const? 4 2) ⊑ const? 1 0 := by 
+theorem ashrsgt_02_02_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4 2)) (const? 4 2) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1073,7 +1073,7 @@ theorem ashrsgt_02_02_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4
     all_goals sorry
 
 
-theorem ashrsgt_02_03_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4 2)) (const? 4 3) ⊑ const? 1 0 := by 
+theorem ashrsgt_02_03_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4 2)) (const? 4 3) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1082,7 +1082,7 @@ theorem ashrsgt_02_03_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4
     all_goals sorry
 
 
-theorem ashrsgt_02_04_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4 2)) (const? 4 4) ⊑ const? 1 0 := by 
+theorem ashrsgt_02_04_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4 2)) (const? 4 4) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1091,7 +1091,7 @@ theorem ashrsgt_02_04_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4
     all_goals sorry
 
 
-theorem ashrsgt_02_05_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4 2)) (const? 4 5) ⊑ const? 1 0 := by 
+theorem ashrsgt_02_05_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4 2)) (const? 4 5) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1100,7 +1100,7 @@ theorem ashrsgt_02_05_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4
     all_goals sorry
 
 
-theorem ashrsgt_02_06_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4 2)) (const? 4 6) ⊑ const? 1 0 := by 
+theorem ashrsgt_02_06_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4 2)) (const? 4 6) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1109,7 +1109,7 @@ theorem ashrsgt_02_06_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4
     all_goals sorry
 
 
-theorem ashrsgt_02_07_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4 2)) (const? 4 7) ⊑ const? 1 0 := by 
+theorem ashrsgt_02_07_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4 2)) (const? 4 7) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1118,7 +1118,7 @@ theorem ashrsgt_02_07_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4
     all_goals sorry
 
 
-theorem ashrsgt_02_08_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4 2)) (const? 4 (-8)) ⊑ const? 1 1 := by 
+theorem ashrsgt_02_08_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4 2)) (const? 4 (-8)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1127,7 +1127,7 @@ theorem ashrsgt_02_08_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4
     all_goals sorry
 
 
-theorem ashrsgt_02_09_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4 2)) (const? 4 (-7)) ⊑ const? 1 1 := by 
+theorem ashrsgt_02_09_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4 2)) (const? 4 (-7)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1136,7 +1136,7 @@ theorem ashrsgt_02_09_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4
     all_goals sorry
 
 
-theorem ashrsgt_02_10_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4 2)) (const? 4 (-6)) ⊑ const? 1 1 := by 
+theorem ashrsgt_02_10_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4 2)) (const? 4 (-6)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1145,7 +1145,7 @@ theorem ashrsgt_02_10_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4
     all_goals sorry
 
 
-theorem ashrsgt_02_11_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4 2)) (const? 4 (-5)) ⊑ const? 1 1 := by 
+theorem ashrsgt_02_11_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4 2)) (const? 4 (-5)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1154,7 +1154,7 @@ theorem ashrsgt_02_11_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4
     all_goals sorry
 
 
-theorem ashrsgt_02_12_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4 2)) (const? 4 (-4)) ⊑ const? 1 1 := by 
+theorem ashrsgt_02_12_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4 2)) (const? 4 (-4)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1163,7 +1163,7 @@ theorem ashrsgt_02_12_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4
     all_goals sorry
 
 
-theorem ashrsgt_02_13_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4 2)) (const? 4 (-3)) ⊑ const? 1 1 := by 
+theorem ashrsgt_02_13_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4 2)) (const? 4 (-3)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1173,7 +1173,7 @@ theorem ashrsgt_02_13_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4
 
 
 theorem ashrsgt_02_14_thm (e : IntW 4) :
-  icmp IntPredicate.sgt (ashr e (const? 4 2)) (const? 4 (-2)) ⊑ icmp IntPredicate.sgt e (const? 4 (-5)) := by 
+  icmp IntPredicate.sgt (ashr e (const? 4 2)) (const? 4 (-2)) ⊑ icmp IntPredicate.sgt e (const? 4 (-5)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1183,7 +1183,7 @@ theorem ashrsgt_02_14_thm (e : IntW 4) :
 
 
 theorem ashrsgt_02_15_thm (e : IntW 4) :
-  icmp IntPredicate.sgt (ashr e (const? 4 2)) (const? 4 (-1)) ⊑ icmp IntPredicate.sgt e (const? 4 (-1)) := by 
+  icmp IntPredicate.sgt (ashr e (const? 4 2)) (const? 4 (-1)) ⊑ icmp IntPredicate.sgt e (const? 4 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1192,7 +1192,7 @@ theorem ashrsgt_02_15_thm (e : IntW 4) :
     all_goals sorry
 
 
-theorem ashrsgt_03_00_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4 3)) (const? 4 0) ⊑ const? 1 0 := by 
+theorem ashrsgt_03_00_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4 3)) (const? 4 0) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1201,7 +1201,7 @@ theorem ashrsgt_03_00_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4
     all_goals sorry
 
 
-theorem ashrsgt_03_01_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4 3)) (const? 4 1) ⊑ const? 1 0 := by 
+theorem ashrsgt_03_01_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4 3)) (const? 4 1) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1210,7 +1210,7 @@ theorem ashrsgt_03_01_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4
     all_goals sorry
 
 
-theorem ashrsgt_03_02_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4 3)) (const? 4 2) ⊑ const? 1 0 := by 
+theorem ashrsgt_03_02_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4 3)) (const? 4 2) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1219,7 +1219,7 @@ theorem ashrsgt_03_02_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4
     all_goals sorry
 
 
-theorem ashrsgt_03_03_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4 3)) (const? 4 3) ⊑ const? 1 0 := by 
+theorem ashrsgt_03_03_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4 3)) (const? 4 3) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1228,7 +1228,7 @@ theorem ashrsgt_03_03_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4
     all_goals sorry
 
 
-theorem ashrsgt_03_04_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4 3)) (const? 4 4) ⊑ const? 1 0 := by 
+theorem ashrsgt_03_04_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4 3)) (const? 4 4) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1237,7 +1237,7 @@ theorem ashrsgt_03_04_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4
     all_goals sorry
 
 
-theorem ashrsgt_03_05_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4 3)) (const? 4 5) ⊑ const? 1 0 := by 
+theorem ashrsgt_03_05_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4 3)) (const? 4 5) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1246,7 +1246,7 @@ theorem ashrsgt_03_05_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4
     all_goals sorry
 
 
-theorem ashrsgt_03_06_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4 3)) (const? 4 6) ⊑ const? 1 0 := by 
+theorem ashrsgt_03_06_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4 3)) (const? 4 6) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1255,7 +1255,7 @@ theorem ashrsgt_03_06_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4
     all_goals sorry
 
 
-theorem ashrsgt_03_07_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4 3)) (const? 4 7) ⊑ const? 1 0 := by 
+theorem ashrsgt_03_07_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4 3)) (const? 4 7) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1264,7 +1264,7 @@ theorem ashrsgt_03_07_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4
     all_goals sorry
 
 
-theorem ashrsgt_03_08_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4 3)) (const? 4 (-8)) ⊑ const? 1 1 := by 
+theorem ashrsgt_03_08_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4 3)) (const? 4 (-8)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1273,7 +1273,7 @@ theorem ashrsgt_03_08_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4
     all_goals sorry
 
 
-theorem ashrsgt_03_09_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4 3)) (const? 4 (-7)) ⊑ const? 1 1 := by 
+theorem ashrsgt_03_09_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4 3)) (const? 4 (-7)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1282,7 +1282,7 @@ theorem ashrsgt_03_09_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4
     all_goals sorry
 
 
-theorem ashrsgt_03_10_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4 3)) (const? 4 (-6)) ⊑ const? 1 1 := by 
+theorem ashrsgt_03_10_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4 3)) (const? 4 (-6)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1291,7 +1291,7 @@ theorem ashrsgt_03_10_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4
     all_goals sorry
 
 
-theorem ashrsgt_03_11_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4 3)) (const? 4 (-5)) ⊑ const? 1 1 := by 
+theorem ashrsgt_03_11_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4 3)) (const? 4 (-5)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1300,7 +1300,7 @@ theorem ashrsgt_03_11_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4
     all_goals sorry
 
 
-theorem ashrsgt_03_12_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4 3)) (const? 4 (-4)) ⊑ const? 1 1 := by 
+theorem ashrsgt_03_12_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4 3)) (const? 4 (-4)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1309,7 +1309,7 @@ theorem ashrsgt_03_12_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4
     all_goals sorry
 
 
-theorem ashrsgt_03_13_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4 3)) (const? 4 (-3)) ⊑ const? 1 1 := by 
+theorem ashrsgt_03_13_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4 3)) (const? 4 (-3)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1318,7 +1318,7 @@ theorem ashrsgt_03_13_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4
     all_goals sorry
 
 
-theorem ashrsgt_03_14_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4 3)) (const? 4 (-2)) ⊑ const? 1 1 := by 
+theorem ashrsgt_03_14_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4 3)) (const? 4 (-2)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1328,7 +1328,7 @@ theorem ashrsgt_03_14_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4
 
 
 theorem ashrsgt_03_15_thm (e : IntW 4) :
-  icmp IntPredicate.sgt (ashr e (const? 4 3)) (const? 4 (-1)) ⊑ icmp IntPredicate.sgt e (const? 4 (-1)) := by 
+  icmp IntPredicate.sgt (ashr e (const? 4 3)) (const? 4 (-1)) ⊑ icmp IntPredicate.sgt e (const? 4 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1338,7 +1338,7 @@ theorem ashrsgt_03_15_thm (e : IntW 4) :
 
 
 theorem ashrslt_01_00_thm (e : IntW 4) :
-  icmp IntPredicate.slt (ashr e (const? 4 1)) (const? 4 0) ⊑ icmp IntPredicate.slt e (const? 4 0) := by 
+  icmp IntPredicate.slt (ashr e (const? 4 1)) (const? 4 0) ⊑ icmp IntPredicate.slt e (const? 4 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1348,7 +1348,7 @@ theorem ashrslt_01_00_thm (e : IntW 4) :
 
 
 theorem ashrslt_01_01_thm (e : IntW 4) :
-  icmp IntPredicate.slt (ashr e (const? 4 1)) (const? 4 1) ⊑ icmp IntPredicate.slt e (const? 4 2) := by 
+  icmp IntPredicate.slt (ashr e (const? 4 1)) (const? 4 1) ⊑ icmp IntPredicate.slt e (const? 4 2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1358,7 +1358,7 @@ theorem ashrslt_01_01_thm (e : IntW 4) :
 
 
 theorem ashrslt_01_02_thm (e : IntW 4) :
-  icmp IntPredicate.slt (ashr e (const? 4 1)) (const? 4 2) ⊑ icmp IntPredicate.slt e (const? 4 4) := by 
+  icmp IntPredicate.slt (ashr e (const? 4 1)) (const? 4 2) ⊑ icmp IntPredicate.slt e (const? 4 4) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1368,7 +1368,7 @@ theorem ashrslt_01_02_thm (e : IntW 4) :
 
 
 theorem ashrslt_01_03_thm (e : IntW 4) :
-  icmp IntPredicate.slt (ashr e (const? 4 1)) (const? 4 3) ⊑ icmp IntPredicate.slt e (const? 4 6) := by 
+  icmp IntPredicate.slt (ashr e (const? 4 1)) (const? 4 3) ⊑ icmp IntPredicate.slt e (const? 4 6) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1377,7 +1377,7 @@ theorem ashrslt_01_03_thm (e : IntW 4) :
     all_goals sorry
 
 
-theorem ashrslt_01_04_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4 1)) (const? 4 4) ⊑ const? 1 1 := by 
+theorem ashrslt_01_04_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4 1)) (const? 4 4) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1386,7 +1386,7 @@ theorem ashrslt_01_04_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4
     all_goals sorry
 
 
-theorem ashrslt_01_05_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4 1)) (const? 4 5) ⊑ const? 1 1 := by 
+theorem ashrslt_01_05_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4 1)) (const? 4 5) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1395,7 +1395,7 @@ theorem ashrslt_01_05_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4
     all_goals sorry
 
 
-theorem ashrslt_01_06_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4 1)) (const? 4 6) ⊑ const? 1 1 := by 
+theorem ashrslt_01_06_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4 1)) (const? 4 6) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1404,7 +1404,7 @@ theorem ashrslt_01_06_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4
     all_goals sorry
 
 
-theorem ashrslt_01_07_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4 1)) (const? 4 7) ⊑ const? 1 1 := by 
+theorem ashrslt_01_07_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4 1)) (const? 4 7) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1413,7 +1413,7 @@ theorem ashrslt_01_07_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4
     all_goals sorry
 
 
-theorem ashrslt_01_08_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4 1)) (const? 4 (-8)) ⊑ const? 1 0 := by 
+theorem ashrslt_01_08_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4 1)) (const? 4 (-8)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1422,7 +1422,7 @@ theorem ashrslt_01_08_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4
     all_goals sorry
 
 
-theorem ashrslt_01_09_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4 1)) (const? 4 (-7)) ⊑ const? 1 0 := by 
+theorem ashrslt_01_09_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4 1)) (const? 4 (-7)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1431,7 +1431,7 @@ theorem ashrslt_01_09_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4
     all_goals sorry
 
 
-theorem ashrslt_01_10_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4 1)) (const? 4 (-6)) ⊑ const? 1 0 := by 
+theorem ashrslt_01_10_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4 1)) (const? 4 (-6)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1440,7 +1440,7 @@ theorem ashrslt_01_10_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4
     all_goals sorry
 
 
-theorem ashrslt_01_11_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4 1)) (const? 4 (-5)) ⊑ const? 1 0 := by 
+theorem ashrslt_01_11_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4 1)) (const? 4 (-5)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1449,7 +1449,7 @@ theorem ashrslt_01_11_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4
     all_goals sorry
 
 
-theorem ashrslt_01_12_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4 1)) (const? 4 (-4)) ⊑ const? 1 0 := by 
+theorem ashrslt_01_12_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4 1)) (const? 4 (-4)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1459,7 +1459,7 @@ theorem ashrslt_01_12_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4
 
 
 theorem ashrslt_01_13_thm (e : IntW 4) :
-  icmp IntPredicate.slt (ashr e (const? 4 1)) (const? 4 (-3)) ⊑ icmp IntPredicate.slt e (const? 4 (-6)) := by 
+  icmp IntPredicate.slt (ashr e (const? 4 1)) (const? 4 (-3)) ⊑ icmp IntPredicate.slt e (const? 4 (-6)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1469,7 +1469,7 @@ theorem ashrslt_01_13_thm (e : IntW 4) :
 
 
 theorem ashrslt_01_14_thm (e : IntW 4) :
-  icmp IntPredicate.slt (ashr e (const? 4 1)) (const? 4 (-2)) ⊑ icmp IntPredicate.slt e (const? 4 (-4)) := by 
+  icmp IntPredicate.slt (ashr e (const? 4 1)) (const? 4 (-2)) ⊑ icmp IntPredicate.slt e (const? 4 (-4)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1479,7 +1479,7 @@ theorem ashrslt_01_14_thm (e : IntW 4) :
 
 
 theorem ashrslt_01_15_thm (e : IntW 4) :
-  icmp IntPredicate.slt (ashr e (const? 4 1)) (const? 4 (-1)) ⊑ icmp IntPredicate.slt e (const? 4 (-2)) := by 
+  icmp IntPredicate.slt (ashr e (const? 4 1)) (const? 4 (-1)) ⊑ icmp IntPredicate.slt e (const? 4 (-2)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1489,7 +1489,7 @@ theorem ashrslt_01_15_thm (e : IntW 4) :
 
 
 theorem ashrslt_02_00_thm (e : IntW 4) :
-  icmp IntPredicate.slt (ashr e (const? 4 2)) (const? 4 0) ⊑ icmp IntPredicate.slt e (const? 4 0) := by 
+  icmp IntPredicate.slt (ashr e (const? 4 2)) (const? 4 0) ⊑ icmp IntPredicate.slt e (const? 4 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1499,7 +1499,7 @@ theorem ashrslt_02_00_thm (e : IntW 4) :
 
 
 theorem ashrslt_02_01_thm (e : IntW 4) :
-  icmp IntPredicate.slt (ashr e (const? 4 2)) (const? 4 1) ⊑ icmp IntPredicate.slt e (const? 4 4) := by 
+  icmp IntPredicate.slt (ashr e (const? 4 2)) (const? 4 1) ⊑ icmp IntPredicate.slt e (const? 4 4) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1508,7 +1508,7 @@ theorem ashrslt_02_01_thm (e : IntW 4) :
     all_goals sorry
 
 
-theorem ashrslt_02_02_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4 2)) (const? 4 2) ⊑ const? 1 1 := by 
+theorem ashrslt_02_02_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4 2)) (const? 4 2) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1517,7 +1517,7 @@ theorem ashrslt_02_02_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4
     all_goals sorry
 
 
-theorem ashrslt_02_03_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4 2)) (const? 4 3) ⊑ const? 1 1 := by 
+theorem ashrslt_02_03_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4 2)) (const? 4 3) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1526,7 +1526,7 @@ theorem ashrslt_02_03_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4
     all_goals sorry
 
 
-theorem ashrslt_02_04_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4 2)) (const? 4 4) ⊑ const? 1 1 := by 
+theorem ashrslt_02_04_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4 2)) (const? 4 4) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1535,7 +1535,7 @@ theorem ashrslt_02_04_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4
     all_goals sorry
 
 
-theorem ashrslt_02_05_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4 2)) (const? 4 5) ⊑ const? 1 1 := by 
+theorem ashrslt_02_05_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4 2)) (const? 4 5) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1544,7 +1544,7 @@ theorem ashrslt_02_05_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4
     all_goals sorry
 
 
-theorem ashrslt_02_06_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4 2)) (const? 4 6) ⊑ const? 1 1 := by 
+theorem ashrslt_02_06_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4 2)) (const? 4 6) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1553,7 +1553,7 @@ theorem ashrslt_02_06_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4
     all_goals sorry
 
 
-theorem ashrslt_02_07_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4 2)) (const? 4 7) ⊑ const? 1 1 := by 
+theorem ashrslt_02_07_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4 2)) (const? 4 7) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1562,7 +1562,7 @@ theorem ashrslt_02_07_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4
     all_goals sorry
 
 
-theorem ashrslt_02_08_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4 2)) (const? 4 (-8)) ⊑ const? 1 0 := by 
+theorem ashrslt_02_08_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4 2)) (const? 4 (-8)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1571,7 +1571,7 @@ theorem ashrslt_02_08_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4
     all_goals sorry
 
 
-theorem ashrslt_02_09_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4 2)) (const? 4 (-7)) ⊑ const? 1 0 := by 
+theorem ashrslt_02_09_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4 2)) (const? 4 (-7)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1580,7 +1580,7 @@ theorem ashrslt_02_09_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4
     all_goals sorry
 
 
-theorem ashrslt_02_10_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4 2)) (const? 4 (-6)) ⊑ const? 1 0 := by 
+theorem ashrslt_02_10_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4 2)) (const? 4 (-6)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1589,7 +1589,7 @@ theorem ashrslt_02_10_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4
     all_goals sorry
 
 
-theorem ashrslt_02_11_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4 2)) (const? 4 (-5)) ⊑ const? 1 0 := by 
+theorem ashrslt_02_11_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4 2)) (const? 4 (-5)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1598,7 +1598,7 @@ theorem ashrslt_02_11_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4
     all_goals sorry
 
 
-theorem ashrslt_02_12_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4 2)) (const? 4 (-4)) ⊑ const? 1 0 := by 
+theorem ashrslt_02_12_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4 2)) (const? 4 (-4)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1607,7 +1607,7 @@ theorem ashrslt_02_12_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4
     all_goals sorry
 
 
-theorem ashrslt_02_13_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4 2)) (const? 4 (-3)) ⊑ const? 1 0 := by 
+theorem ashrslt_02_13_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4 2)) (const? 4 (-3)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1616,7 +1616,7 @@ theorem ashrslt_02_13_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4
     all_goals sorry
 
 
-theorem ashrslt_02_14_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4 2)) (const? 4 (-2)) ⊑ const? 1 0 := by 
+theorem ashrslt_02_14_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4 2)) (const? 4 (-2)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1626,7 +1626,7 @@ theorem ashrslt_02_14_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4
 
 
 theorem ashrslt_02_15_thm (e : IntW 4) :
-  icmp IntPredicate.slt (ashr e (const? 4 2)) (const? 4 (-1)) ⊑ icmp IntPredicate.slt e (const? 4 (-4)) := by 
+  icmp IntPredicate.slt (ashr e (const? 4 2)) (const? 4 (-1)) ⊑ icmp IntPredicate.slt e (const? 4 (-4)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1636,7 +1636,7 @@ theorem ashrslt_02_15_thm (e : IntW 4) :
 
 
 theorem ashrslt_03_00_thm (e : IntW 4) :
-  icmp IntPredicate.slt (ashr e (const? 4 3)) (const? 4 0) ⊑ icmp IntPredicate.slt e (const? 4 0) := by 
+  icmp IntPredicate.slt (ashr e (const? 4 3)) (const? 4 0) ⊑ icmp IntPredicate.slt e (const? 4 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1645,7 +1645,7 @@ theorem ashrslt_03_00_thm (e : IntW 4) :
     all_goals sorry
 
 
-theorem ashrslt_03_01_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4 3)) (const? 4 1) ⊑ const? 1 1 := by 
+theorem ashrslt_03_01_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4 3)) (const? 4 1) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1654,7 +1654,7 @@ theorem ashrslt_03_01_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4
     all_goals sorry
 
 
-theorem ashrslt_03_02_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4 3)) (const? 4 2) ⊑ const? 1 1 := by 
+theorem ashrslt_03_02_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4 3)) (const? 4 2) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1663,7 +1663,7 @@ theorem ashrslt_03_02_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4
     all_goals sorry
 
 
-theorem ashrslt_03_03_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4 3)) (const? 4 3) ⊑ const? 1 1 := by 
+theorem ashrslt_03_03_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4 3)) (const? 4 3) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1672,7 +1672,7 @@ theorem ashrslt_03_03_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4
     all_goals sorry
 
 
-theorem ashrslt_03_04_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4 3)) (const? 4 4) ⊑ const? 1 1 := by 
+theorem ashrslt_03_04_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4 3)) (const? 4 4) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1681,7 +1681,7 @@ theorem ashrslt_03_04_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4
     all_goals sorry
 
 
-theorem ashrslt_03_05_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4 3)) (const? 4 5) ⊑ const? 1 1 := by 
+theorem ashrslt_03_05_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4 3)) (const? 4 5) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1690,7 +1690,7 @@ theorem ashrslt_03_05_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4
     all_goals sorry
 
 
-theorem ashrslt_03_06_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4 3)) (const? 4 6) ⊑ const? 1 1 := by 
+theorem ashrslt_03_06_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4 3)) (const? 4 6) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1699,7 +1699,7 @@ theorem ashrslt_03_06_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4
     all_goals sorry
 
 
-theorem ashrslt_03_07_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4 3)) (const? 4 7) ⊑ const? 1 1 := by 
+theorem ashrslt_03_07_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4 3)) (const? 4 7) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1708,7 +1708,7 @@ theorem ashrslt_03_07_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4
     all_goals sorry
 
 
-theorem ashrslt_03_08_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4 3)) (const? 4 (-8)) ⊑ const? 1 0 := by 
+theorem ashrslt_03_08_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4 3)) (const? 4 (-8)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1717,7 +1717,7 @@ theorem ashrslt_03_08_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4
     all_goals sorry
 
 
-theorem ashrslt_03_09_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4 3)) (const? 4 (-7)) ⊑ const? 1 0 := by 
+theorem ashrslt_03_09_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4 3)) (const? 4 (-7)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1726,7 +1726,7 @@ theorem ashrslt_03_09_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4
     all_goals sorry
 
 
-theorem ashrslt_03_10_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4 3)) (const? 4 (-6)) ⊑ const? 1 0 := by 
+theorem ashrslt_03_10_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4 3)) (const? 4 (-6)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1735,7 +1735,7 @@ theorem ashrslt_03_10_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4
     all_goals sorry
 
 
-theorem ashrslt_03_11_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4 3)) (const? 4 (-5)) ⊑ const? 1 0 := by 
+theorem ashrslt_03_11_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4 3)) (const? 4 (-5)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1744,7 +1744,7 @@ theorem ashrslt_03_11_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4
     all_goals sorry
 
 
-theorem ashrslt_03_12_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4 3)) (const? 4 (-4)) ⊑ const? 1 0 := by 
+theorem ashrslt_03_12_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4 3)) (const? 4 (-4)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1753,7 +1753,7 @@ theorem ashrslt_03_12_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4
     all_goals sorry
 
 
-theorem ashrslt_03_13_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4 3)) (const? 4 (-3)) ⊑ const? 1 0 := by 
+theorem ashrslt_03_13_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4 3)) (const? 4 (-3)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1762,7 +1762,7 @@ theorem ashrslt_03_13_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4
     all_goals sorry
 
 
-theorem ashrslt_03_14_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4 3)) (const? 4 (-2)) ⊑ const? 1 0 := by 
+theorem ashrslt_03_14_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4 3)) (const? 4 (-2)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1771,7 +1771,7 @@ theorem ashrslt_03_14_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4
     all_goals sorry
 
 
-theorem ashrslt_03_15_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4 3)) (const? 4 (-1)) ⊑ const? 1 0 := by 
+theorem ashrslt_03_15_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4 3)) (const? 4 (-1)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1782,7 +1782,7 @@ theorem ashrslt_03_15_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4
 
 theorem lshrugt_01_00_exact_thm (e : IntW 4) :
   icmp IntPredicate.ugt (lshr e (const? 4 1) { «exact» := true }) (const? 4 0) ⊑
-    icmp IntPredicate.ne e (const? 4 0) := by 
+    icmp IntPredicate.ne e (const? 4 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1793,7 +1793,7 @@ theorem lshrugt_01_00_exact_thm (e : IntW 4) :
 
 theorem lshrugt_01_01_exact_thm (e : IntW 4) :
   icmp IntPredicate.ugt (lshr e (const? 4 1) { «exact» := true }) (const? 4 1) ⊑
-    icmp IntPredicate.ugt e (const? 4 2) := by 
+    icmp IntPredicate.ugt e (const? 4 2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1804,7 +1804,7 @@ theorem lshrugt_01_01_exact_thm (e : IntW 4) :
 
 theorem lshrugt_01_02_exact_thm (e : IntW 4) :
   icmp IntPredicate.ugt (lshr e (const? 4 1) { «exact» := true }) (const? 4 2) ⊑
-    icmp IntPredicate.ugt e (const? 4 4) := by 
+    icmp IntPredicate.ugt e (const? 4 4) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1815,7 +1815,7 @@ theorem lshrugt_01_02_exact_thm (e : IntW 4) :
 
 theorem lshrugt_01_03_exact_thm (e : IntW 4) :
   icmp IntPredicate.ugt (lshr e (const? 4 1) { «exact» := true }) (const? 4 3) ⊑
-    icmp IntPredicate.ugt e (const? 4 6) := by 
+    icmp IntPredicate.ugt e (const? 4 6) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1826,7 +1826,7 @@ theorem lshrugt_01_03_exact_thm (e : IntW 4) :
 
 theorem lshrugt_01_04_exact_thm (e : IntW 4) :
   icmp IntPredicate.ugt (lshr e (const? 4 1) { «exact» := true }) (const? 4 4) ⊑
-    icmp IntPredicate.ugt e (const? 4 (-8)) := by 
+    icmp IntPredicate.ugt e (const? 4 (-8)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1837,7 +1837,7 @@ theorem lshrugt_01_04_exact_thm (e : IntW 4) :
 
 theorem lshrugt_01_05_exact_thm (e : IntW 4) :
   icmp IntPredicate.ugt (lshr e (const? 4 1) { «exact» := true }) (const? 4 5) ⊑
-    icmp IntPredicate.ugt e (const? 4 (-6)) := by 
+    icmp IntPredicate.ugt e (const? 4 (-6)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1848,7 +1848,7 @@ theorem lshrugt_01_05_exact_thm (e : IntW 4) :
 
 theorem lshrugt_01_06_exact_thm (e : IntW 4) :
   icmp IntPredicate.ugt (lshr e (const? 4 1) { «exact» := true }) (const? 4 6) ⊑
-    icmp IntPredicate.eq e (const? 4 (-2)) := by 
+    icmp IntPredicate.eq e (const? 4 (-2)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1858,7 +1858,7 @@ theorem lshrugt_01_06_exact_thm (e : IntW 4) :
 
 
 theorem lshrugt_01_07_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ugt (lshr e (const? 4 1) { «exact» := true }) (const? 4 7) ⊑ const? 1 0 := by 
+  icmp IntPredicate.ugt (lshr e (const? 4 1) { «exact» := true }) (const? 4 7) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1868,7 +1868,7 @@ theorem lshrugt_01_07_exact_thm (e : IntW 4) :
 
 
 theorem lshrugt_01_08_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ugt (lshr e (const? 4 1) { «exact» := true }) (const? 4 (-8)) ⊑ const? 1 0 := by 
+  icmp IntPredicate.ugt (lshr e (const? 4 1) { «exact» := true }) (const? 4 (-8)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1878,7 +1878,7 @@ theorem lshrugt_01_08_exact_thm (e : IntW 4) :
 
 
 theorem lshrugt_01_09_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ugt (lshr e (const? 4 1) { «exact» := true }) (const? 4 (-7)) ⊑ const? 1 0 := by 
+  icmp IntPredicate.ugt (lshr e (const? 4 1) { «exact» := true }) (const? 4 (-7)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1888,7 +1888,7 @@ theorem lshrugt_01_09_exact_thm (e : IntW 4) :
 
 
 theorem lshrugt_01_10_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ugt (lshr e (const? 4 1) { «exact» := true }) (const? 4 (-6)) ⊑ const? 1 0 := by 
+  icmp IntPredicate.ugt (lshr e (const? 4 1) { «exact» := true }) (const? 4 (-6)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1898,7 +1898,7 @@ theorem lshrugt_01_10_exact_thm (e : IntW 4) :
 
 
 theorem lshrugt_01_11_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ugt (lshr e (const? 4 1) { «exact» := true }) (const? 4 (-5)) ⊑ const? 1 0 := by 
+  icmp IntPredicate.ugt (lshr e (const? 4 1) { «exact» := true }) (const? 4 (-5)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1908,7 +1908,7 @@ theorem lshrugt_01_11_exact_thm (e : IntW 4) :
 
 
 theorem lshrugt_01_12_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ugt (lshr e (const? 4 1) { «exact» := true }) (const? 4 (-4)) ⊑ const? 1 0 := by 
+  icmp IntPredicate.ugt (lshr e (const? 4 1) { «exact» := true }) (const? 4 (-4)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1918,7 +1918,7 @@ theorem lshrugt_01_12_exact_thm (e : IntW 4) :
 
 
 theorem lshrugt_01_13_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ugt (lshr e (const? 4 1) { «exact» := true }) (const? 4 (-3)) ⊑ const? 1 0 := by 
+  icmp IntPredicate.ugt (lshr e (const? 4 1) { «exact» := true }) (const? 4 (-3)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1928,7 +1928,7 @@ theorem lshrugt_01_13_exact_thm (e : IntW 4) :
 
 
 theorem lshrugt_01_14_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ugt (lshr e (const? 4 1) { «exact» := true }) (const? 4 (-2)) ⊑ const? 1 0 := by 
+  icmp IntPredicate.ugt (lshr e (const? 4 1) { «exact» := true }) (const? 4 (-2)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1938,7 +1938,7 @@ theorem lshrugt_01_14_exact_thm (e : IntW 4) :
 
 
 theorem lshrugt_01_15_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ugt (lshr e (const? 4 1) { «exact» := true }) (const? 4 (-1)) ⊑ const? 1 0 := by 
+  icmp IntPredicate.ugt (lshr e (const? 4 1) { «exact» := true }) (const? 4 (-1)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1949,7 +1949,7 @@ theorem lshrugt_01_15_exact_thm (e : IntW 4) :
 
 theorem lshrugt_02_00_exact_thm (e : IntW 4) :
   icmp IntPredicate.ugt (lshr e (const? 4 2) { «exact» := true }) (const? 4 0) ⊑
-    icmp IntPredicate.ne e (const? 4 0) := by 
+    icmp IntPredicate.ne e (const? 4 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1960,7 +1960,7 @@ theorem lshrugt_02_00_exact_thm (e : IntW 4) :
 
 theorem lshrugt_02_01_exact_thm (e : IntW 4) :
   icmp IntPredicate.ugt (lshr e (const? 4 2) { «exact» := true }) (const? 4 1) ⊑
-    icmp IntPredicate.ugt e (const? 4 4) := by 
+    icmp IntPredicate.ugt e (const? 4 4) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1971,7 +1971,7 @@ theorem lshrugt_02_01_exact_thm (e : IntW 4) :
 
 theorem lshrugt_02_02_exact_thm (e : IntW 4) :
   icmp IntPredicate.ugt (lshr e (const? 4 2) { «exact» := true }) (const? 4 2) ⊑
-    icmp IntPredicate.eq e (const? 4 (-4)) := by 
+    icmp IntPredicate.eq e (const? 4 (-4)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1981,7 +1981,7 @@ theorem lshrugt_02_02_exact_thm (e : IntW 4) :
 
 
 theorem lshrugt_02_03_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ugt (lshr e (const? 4 2) { «exact» := true }) (const? 4 3) ⊑ const? 1 0 := by 
+  icmp IntPredicate.ugt (lshr e (const? 4 2) { «exact» := true }) (const? 4 3) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1991,7 +1991,7 @@ theorem lshrugt_02_03_exact_thm (e : IntW 4) :
 
 
 theorem lshrugt_02_04_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ugt (lshr e (const? 4 2) { «exact» := true }) (const? 4 4) ⊑ const? 1 0 := by 
+  icmp IntPredicate.ugt (lshr e (const? 4 2) { «exact» := true }) (const? 4 4) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2001,7 +2001,7 @@ theorem lshrugt_02_04_exact_thm (e : IntW 4) :
 
 
 theorem lshrugt_02_05_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ugt (lshr e (const? 4 2) { «exact» := true }) (const? 4 5) ⊑ const? 1 0 := by 
+  icmp IntPredicate.ugt (lshr e (const? 4 2) { «exact» := true }) (const? 4 5) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2011,7 +2011,7 @@ theorem lshrugt_02_05_exact_thm (e : IntW 4) :
 
 
 theorem lshrugt_02_06_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ugt (lshr e (const? 4 2) { «exact» := true }) (const? 4 6) ⊑ const? 1 0 := by 
+  icmp IntPredicate.ugt (lshr e (const? 4 2) { «exact» := true }) (const? 4 6) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2021,7 +2021,7 @@ theorem lshrugt_02_06_exact_thm (e : IntW 4) :
 
 
 theorem lshrugt_02_07_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ugt (lshr e (const? 4 2) { «exact» := true }) (const? 4 7) ⊑ const? 1 0 := by 
+  icmp IntPredicate.ugt (lshr e (const? 4 2) { «exact» := true }) (const? 4 7) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2031,7 +2031,7 @@ theorem lshrugt_02_07_exact_thm (e : IntW 4) :
 
 
 theorem lshrugt_02_08_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ugt (lshr e (const? 4 2) { «exact» := true }) (const? 4 (-8)) ⊑ const? 1 0 := by 
+  icmp IntPredicate.ugt (lshr e (const? 4 2) { «exact» := true }) (const? 4 (-8)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2041,7 +2041,7 @@ theorem lshrugt_02_08_exact_thm (e : IntW 4) :
 
 
 theorem lshrugt_02_09_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ugt (lshr e (const? 4 2) { «exact» := true }) (const? 4 (-7)) ⊑ const? 1 0 := by 
+  icmp IntPredicate.ugt (lshr e (const? 4 2) { «exact» := true }) (const? 4 (-7)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2051,7 +2051,7 @@ theorem lshrugt_02_09_exact_thm (e : IntW 4) :
 
 
 theorem lshrugt_02_10_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ugt (lshr e (const? 4 2) { «exact» := true }) (const? 4 (-6)) ⊑ const? 1 0 := by 
+  icmp IntPredicate.ugt (lshr e (const? 4 2) { «exact» := true }) (const? 4 (-6)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2061,7 +2061,7 @@ theorem lshrugt_02_10_exact_thm (e : IntW 4) :
 
 
 theorem lshrugt_02_11_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ugt (lshr e (const? 4 2) { «exact» := true }) (const? 4 (-5)) ⊑ const? 1 0 := by 
+  icmp IntPredicate.ugt (lshr e (const? 4 2) { «exact» := true }) (const? 4 (-5)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2071,7 +2071,7 @@ theorem lshrugt_02_11_exact_thm (e : IntW 4) :
 
 
 theorem lshrugt_02_12_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ugt (lshr e (const? 4 2) { «exact» := true }) (const? 4 (-4)) ⊑ const? 1 0 := by 
+  icmp IntPredicate.ugt (lshr e (const? 4 2) { «exact» := true }) (const? 4 (-4)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2081,7 +2081,7 @@ theorem lshrugt_02_12_exact_thm (e : IntW 4) :
 
 
 theorem lshrugt_02_13_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ugt (lshr e (const? 4 2) { «exact» := true }) (const? 4 (-3)) ⊑ const? 1 0 := by 
+  icmp IntPredicate.ugt (lshr e (const? 4 2) { «exact» := true }) (const? 4 (-3)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2091,7 +2091,7 @@ theorem lshrugt_02_13_exact_thm (e : IntW 4) :
 
 
 theorem lshrugt_02_14_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ugt (lshr e (const? 4 2) { «exact» := true }) (const? 4 (-2)) ⊑ const? 1 0 := by 
+  icmp IntPredicate.ugt (lshr e (const? 4 2) { «exact» := true }) (const? 4 (-2)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2101,7 +2101,7 @@ theorem lshrugt_02_14_exact_thm (e : IntW 4) :
 
 
 theorem lshrugt_02_15_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ugt (lshr e (const? 4 2) { «exact» := true }) (const? 4 (-1)) ⊑ const? 1 0 := by 
+  icmp IntPredicate.ugt (lshr e (const? 4 2) { «exact» := true }) (const? 4 (-1)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2112,7 +2112,7 @@ theorem lshrugt_02_15_exact_thm (e : IntW 4) :
 
 theorem lshrugt_03_00_exact_thm (e : IntW 4) :
   icmp IntPredicate.ugt (lshr e (const? 4 3) { «exact» := true }) (const? 4 0) ⊑
-    icmp IntPredicate.ne e (const? 4 0) := by 
+    icmp IntPredicate.ne e (const? 4 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2122,7 +2122,7 @@ theorem lshrugt_03_00_exact_thm (e : IntW 4) :
 
 
 theorem lshrugt_03_01_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ugt (lshr e (const? 4 3) { «exact» := true }) (const? 4 1) ⊑ const? 1 0 := by 
+  icmp IntPredicate.ugt (lshr e (const? 4 3) { «exact» := true }) (const? 4 1) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2132,7 +2132,7 @@ theorem lshrugt_03_01_exact_thm (e : IntW 4) :
 
 
 theorem lshrugt_03_02_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ugt (lshr e (const? 4 3) { «exact» := true }) (const? 4 2) ⊑ const? 1 0 := by 
+  icmp IntPredicate.ugt (lshr e (const? 4 3) { «exact» := true }) (const? 4 2) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2142,7 +2142,7 @@ theorem lshrugt_03_02_exact_thm (e : IntW 4) :
 
 
 theorem lshrugt_03_03_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ugt (lshr e (const? 4 3) { «exact» := true }) (const? 4 3) ⊑ const? 1 0 := by 
+  icmp IntPredicate.ugt (lshr e (const? 4 3) { «exact» := true }) (const? 4 3) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2152,7 +2152,7 @@ theorem lshrugt_03_03_exact_thm (e : IntW 4) :
 
 
 theorem lshrugt_03_04_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ugt (lshr e (const? 4 3) { «exact» := true }) (const? 4 4) ⊑ const? 1 0 := by 
+  icmp IntPredicate.ugt (lshr e (const? 4 3) { «exact» := true }) (const? 4 4) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2162,7 +2162,7 @@ theorem lshrugt_03_04_exact_thm (e : IntW 4) :
 
 
 theorem lshrugt_03_05_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ugt (lshr e (const? 4 3) { «exact» := true }) (const? 4 5) ⊑ const? 1 0 := by 
+  icmp IntPredicate.ugt (lshr e (const? 4 3) { «exact» := true }) (const? 4 5) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2172,7 +2172,7 @@ theorem lshrugt_03_05_exact_thm (e : IntW 4) :
 
 
 theorem lshrugt_03_06_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ugt (lshr e (const? 4 3) { «exact» := true }) (const? 4 6) ⊑ const? 1 0 := by 
+  icmp IntPredicate.ugt (lshr e (const? 4 3) { «exact» := true }) (const? 4 6) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2182,7 +2182,7 @@ theorem lshrugt_03_06_exact_thm (e : IntW 4) :
 
 
 theorem lshrugt_03_07_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ugt (lshr e (const? 4 3) { «exact» := true }) (const? 4 7) ⊑ const? 1 0 := by 
+  icmp IntPredicate.ugt (lshr e (const? 4 3) { «exact» := true }) (const? 4 7) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2192,7 +2192,7 @@ theorem lshrugt_03_07_exact_thm (e : IntW 4) :
 
 
 theorem lshrugt_03_08_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ugt (lshr e (const? 4 3) { «exact» := true }) (const? 4 (-8)) ⊑ const? 1 0 := by 
+  icmp IntPredicate.ugt (lshr e (const? 4 3) { «exact» := true }) (const? 4 (-8)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2202,7 +2202,7 @@ theorem lshrugt_03_08_exact_thm (e : IntW 4) :
 
 
 theorem lshrugt_03_09_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ugt (lshr e (const? 4 3) { «exact» := true }) (const? 4 (-7)) ⊑ const? 1 0 := by 
+  icmp IntPredicate.ugt (lshr e (const? 4 3) { «exact» := true }) (const? 4 (-7)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2212,7 +2212,7 @@ theorem lshrugt_03_09_exact_thm (e : IntW 4) :
 
 
 theorem lshrugt_03_10_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ugt (lshr e (const? 4 3) { «exact» := true }) (const? 4 (-6)) ⊑ const? 1 0 := by 
+  icmp IntPredicate.ugt (lshr e (const? 4 3) { «exact» := true }) (const? 4 (-6)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2222,7 +2222,7 @@ theorem lshrugt_03_10_exact_thm (e : IntW 4) :
 
 
 theorem lshrugt_03_11_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ugt (lshr e (const? 4 3) { «exact» := true }) (const? 4 (-5)) ⊑ const? 1 0 := by 
+  icmp IntPredicate.ugt (lshr e (const? 4 3) { «exact» := true }) (const? 4 (-5)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2232,7 +2232,7 @@ theorem lshrugt_03_11_exact_thm (e : IntW 4) :
 
 
 theorem lshrugt_03_12_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ugt (lshr e (const? 4 3) { «exact» := true }) (const? 4 (-4)) ⊑ const? 1 0 := by 
+  icmp IntPredicate.ugt (lshr e (const? 4 3) { «exact» := true }) (const? 4 (-4)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2242,7 +2242,7 @@ theorem lshrugt_03_12_exact_thm (e : IntW 4) :
 
 
 theorem lshrugt_03_13_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ugt (lshr e (const? 4 3) { «exact» := true }) (const? 4 (-3)) ⊑ const? 1 0 := by 
+  icmp IntPredicate.ugt (lshr e (const? 4 3) { «exact» := true }) (const? 4 (-3)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2252,7 +2252,7 @@ theorem lshrugt_03_13_exact_thm (e : IntW 4) :
 
 
 theorem lshrugt_03_14_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ugt (lshr e (const? 4 3) { «exact» := true }) (const? 4 (-2)) ⊑ const? 1 0 := by 
+  icmp IntPredicate.ugt (lshr e (const? 4 3) { «exact» := true }) (const? 4 (-2)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2262,7 +2262,7 @@ theorem lshrugt_03_14_exact_thm (e : IntW 4) :
 
 
 theorem lshrugt_03_15_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ugt (lshr e (const? 4 3) { «exact» := true }) (const? 4 (-1)) ⊑ const? 1 0 := by 
+  icmp IntPredicate.ugt (lshr e (const? 4 3) { «exact» := true }) (const? 4 (-1)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2273,7 +2273,7 @@ theorem lshrugt_03_15_exact_thm (e : IntW 4) :
 
 theorem ashr_eq_exact_thm (e : IntW 8) :
   icmp IntPredicate.eq (ashr e (const? 8 3) { «exact» := true }) (const? 8 10) ⊑
-    icmp IntPredicate.eq e (const? 8 80) := by 
+    icmp IntPredicate.eq e (const? 8 80) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2284,7 +2284,7 @@ theorem ashr_eq_exact_thm (e : IntW 8) :
 
 theorem ashr_ne_exact_thm (e : IntW 8) :
   icmp IntPredicate.ne (ashr e (const? 8 3) { «exact» := true }) (const? 8 10) ⊑
-    icmp IntPredicate.ne e (const? 8 80) := by 
+    icmp IntPredicate.ne e (const? 8 80) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2295,7 +2295,7 @@ theorem ashr_ne_exact_thm (e : IntW 8) :
 
 theorem ashr_ugt_exact_thm (e : IntW 8) :
   icmp IntPredicate.ugt (ashr e (const? 8 3) { «exact» := true }) (const? 8 10) ⊑
-    icmp IntPredicate.ugt e (const? 8 80) := by 
+    icmp IntPredicate.ugt e (const? 8 80) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2306,7 +2306,7 @@ theorem ashr_ugt_exact_thm (e : IntW 8) :
 
 theorem ashr_uge_exact_thm (e : IntW 8) :
   icmp IntPredicate.uge (ashr e (const? 8 3) { «exact» := true }) (const? 8 10) ⊑
-    icmp IntPredicate.ugt e (const? 8 72) := by 
+    icmp IntPredicate.ugt e (const? 8 72) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2317,7 +2317,7 @@ theorem ashr_uge_exact_thm (e : IntW 8) :
 
 theorem ashr_ult_exact_thm (e : IntW 8) :
   icmp IntPredicate.ult (ashr e (const? 8 3) { «exact» := true }) (const? 8 10) ⊑
-    icmp IntPredicate.ult e (const? 8 80) := by 
+    icmp IntPredicate.ult e (const? 8 80) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2328,7 +2328,7 @@ theorem ashr_ult_exact_thm (e : IntW 8) :
 
 theorem ashr_ule_exact_thm (e : IntW 8) :
   icmp IntPredicate.ule (ashr e (const? 8 3) { «exact» := true }) (const? 8 10) ⊑
-    icmp IntPredicate.ult e (const? 8 88) := by 
+    icmp IntPredicate.ult e (const? 8 88) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2339,7 +2339,7 @@ theorem ashr_ule_exact_thm (e : IntW 8) :
 
 theorem ashr_sgt_exact_thm (e : IntW 8) :
   icmp IntPredicate.sgt (ashr e (const? 8 3) { «exact» := true }) (const? 8 10) ⊑
-    icmp IntPredicate.sgt e (const? 8 80) := by 
+    icmp IntPredicate.sgt e (const? 8 80) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2350,7 +2350,7 @@ theorem ashr_sgt_exact_thm (e : IntW 8) :
 
 theorem ashr_sge_exact_thm (e : IntW 8) :
   icmp IntPredicate.sge (ashr e (const? 8 3) { «exact» := true }) (const? 8 10) ⊑
-    icmp IntPredicate.sgt e (const? 8 72) := by 
+    icmp IntPredicate.sgt e (const? 8 72) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2361,7 +2361,7 @@ theorem ashr_sge_exact_thm (e : IntW 8) :
 
 theorem ashr_slt_exact_thm (e : IntW 8) :
   icmp IntPredicate.slt (ashr e (const? 8 3) { «exact» := true }) (const? 8 10) ⊑
-    icmp IntPredicate.slt e (const? 8 80) := by 
+    icmp IntPredicate.slt e (const? 8 80) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2372,7 +2372,7 @@ theorem ashr_slt_exact_thm (e : IntW 8) :
 
 theorem ashr_sle_exact_thm (e : IntW 8) :
   icmp IntPredicate.sle (ashr e (const? 8 3) { «exact» := true }) (const? 8 10) ⊑
-    icmp IntPredicate.slt e (const? 8 88) := by 
+    icmp IntPredicate.slt e (const? 8 88) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2383,7 +2383,7 @@ theorem ashr_sle_exact_thm (e : IntW 8) :
 
 theorem ashr_eq_noexact_thm (e : IntW 8) :
   icmp IntPredicate.eq (ashr e (const? 8 3)) (const? 8 10) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 8 (-8))) (const? 8 80) := by 
+    icmp IntPredicate.eq (LLVM.and e (const? 8 (-8))) (const? 8 80) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2394,7 +2394,7 @@ theorem ashr_eq_noexact_thm (e : IntW 8) :
 
 theorem ashr_ne_noexact_thm (e : IntW 8) :
   icmp IntPredicate.ne (ashr e (const? 8 3)) (const? 8 10) ⊑
-    icmp IntPredicate.ne (LLVM.and e (const? 8 (-8))) (const? 8 80) := by 
+    icmp IntPredicate.ne (LLVM.and e (const? 8 (-8))) (const? 8 80) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2404,7 +2404,7 @@ theorem ashr_ne_noexact_thm (e : IntW 8) :
 
 
 theorem ashr_ugt_noexact_thm (e : IntW 8) :
-  icmp IntPredicate.ugt (ashr e (const? 8 3)) (const? 8 10) ⊑ icmp IntPredicate.ugt e (const? 8 87) := by 
+  icmp IntPredicate.ugt (ashr e (const? 8 3)) (const? 8 10) ⊑ icmp IntPredicate.ugt e (const? 8 87) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2414,7 +2414,7 @@ theorem ashr_ugt_noexact_thm (e : IntW 8) :
 
 
 theorem ashr_uge_noexact_thm (e : IntW 8) :
-  icmp IntPredicate.uge (ashr e (const? 8 3)) (const? 8 10) ⊑ icmp IntPredicate.ugt e (const? 8 79) := by 
+  icmp IntPredicate.uge (ashr e (const? 8 3)) (const? 8 10) ⊑ icmp IntPredicate.ugt e (const? 8 79) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2424,7 +2424,7 @@ theorem ashr_uge_noexact_thm (e : IntW 8) :
 
 
 theorem ashr_ult_noexact_thm (e : IntW 8) :
-  icmp IntPredicate.ult (ashr e (const? 8 3)) (const? 8 10) ⊑ icmp IntPredicate.ult e (const? 8 80) := by 
+  icmp IntPredicate.ult (ashr e (const? 8 3)) (const? 8 10) ⊑ icmp IntPredicate.ult e (const? 8 80) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2434,7 +2434,7 @@ theorem ashr_ult_noexact_thm (e : IntW 8) :
 
 
 theorem ashr_ule_noexact_thm (e : IntW 8) :
-  icmp IntPredicate.ule (ashr e (const? 8 3)) (const? 8 10) ⊑ icmp IntPredicate.ult e (const? 8 88) := by 
+  icmp IntPredicate.ule (ashr e (const? 8 3)) (const? 8 10) ⊑ icmp IntPredicate.ult e (const? 8 88) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2444,7 +2444,7 @@ theorem ashr_ule_noexact_thm (e : IntW 8) :
 
 
 theorem ashr_sgt_noexact_thm (e : IntW 8) :
-  icmp IntPredicate.sgt (ashr e (const? 8 3)) (const? 8 10) ⊑ icmp IntPredicate.sgt e (const? 8 87) := by 
+  icmp IntPredicate.sgt (ashr e (const? 8 3)) (const? 8 10) ⊑ icmp IntPredicate.sgt e (const? 8 87) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2454,7 +2454,7 @@ theorem ashr_sgt_noexact_thm (e : IntW 8) :
 
 
 theorem ashr_sge_noexact_thm (e : IntW 8) :
-  icmp IntPredicate.sge (ashr e (const? 8 3)) (const? 8 10) ⊑ icmp IntPredicate.sgt e (const? 8 79) := by 
+  icmp IntPredicate.sge (ashr e (const? 8 3)) (const? 8 10) ⊑ icmp IntPredicate.sgt e (const? 8 79) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2464,7 +2464,7 @@ theorem ashr_sge_noexact_thm (e : IntW 8) :
 
 
 theorem ashr_slt_noexact_thm (e : IntW 8) :
-  icmp IntPredicate.slt (ashr e (const? 8 3)) (const? 8 10) ⊑ icmp IntPredicate.slt e (const? 8 80) := by 
+  icmp IntPredicate.slt (ashr e (const? 8 3)) (const? 8 10) ⊑ icmp IntPredicate.slt e (const? 8 80) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2474,7 +2474,7 @@ theorem ashr_slt_noexact_thm (e : IntW 8) :
 
 
 theorem ashr_sle_noexact_thm (e : IntW 8) :
-  icmp IntPredicate.sle (ashr e (const? 8 3)) (const? 8 10) ⊑ icmp IntPredicate.slt e (const? 8 88) := by 
+  icmp IntPredicate.sle (ashr e (const? 8 3)) (const? 8 10) ⊑ icmp IntPredicate.slt e (const? 8 88) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2483,7 +2483,7 @@ theorem ashr_sle_noexact_thm (e : IntW 8) :
     all_goals sorry
 
 
-theorem ashr_sgt_overflow_thm (e : IntW 8) : icmp IntPredicate.sgt (ashr e (const? 8 1)) (const? 8 63) ⊑ const? 1 0 := by 
+theorem ashr_sgt_overflow_thm (e : IntW 8) : icmp IntPredicate.sgt (ashr e (const? 8 1)) (const? 8 63) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2493,7 +2493,7 @@ theorem ashr_sgt_overflow_thm (e : IntW 8) : icmp IntPredicate.sgt (ashr e (cons
 
 
 theorem lshrult_01_00_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ult (lshr e (const? 4 1) { «exact» := true }) (const? 4 0) ⊑ const? 1 0 := by 
+  icmp IntPredicate.ult (lshr e (const? 4 1) { «exact» := true }) (const? 4 0) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2504,7 +2504,7 @@ theorem lshrult_01_00_exact_thm (e : IntW 4) :
 
 theorem lshrult_01_01_exact_thm (e : IntW 4) :
   icmp IntPredicate.ult (lshr e (const? 4 1) { «exact» := true }) (const? 4 1) ⊑
-    icmp IntPredicate.eq e (const? 4 0) := by 
+    icmp IntPredicate.eq e (const? 4 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2515,7 +2515,7 @@ theorem lshrult_01_01_exact_thm (e : IntW 4) :
 
 theorem lshrult_01_02_exact_thm (e : IntW 4) :
   icmp IntPredicate.ult (lshr e (const? 4 1) { «exact» := true }) (const? 4 2) ⊑
-    icmp IntPredicate.ult e (const? 4 4) := by 
+    icmp IntPredicate.ult e (const? 4 4) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2526,7 +2526,7 @@ theorem lshrult_01_02_exact_thm (e : IntW 4) :
 
 theorem lshrult_01_03_exact_thm (e : IntW 4) :
   icmp IntPredicate.ult (lshr e (const? 4 1) { «exact» := true }) (const? 4 3) ⊑
-    icmp IntPredicate.ult e (const? 4 6) := by 
+    icmp IntPredicate.ult e (const? 4 6) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2537,7 +2537,7 @@ theorem lshrult_01_03_exact_thm (e : IntW 4) :
 
 theorem lshrult_01_04_exact_thm (e : IntW 4) :
   icmp IntPredicate.ult (lshr e (const? 4 1) { «exact» := true }) (const? 4 4) ⊑
-    icmp IntPredicate.sgt e (const? 4 (-1)) := by 
+    icmp IntPredicate.sgt e (const? 4 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2548,7 +2548,7 @@ theorem lshrult_01_04_exact_thm (e : IntW 4) :
 
 theorem lshrult_01_05_exact_thm (e : IntW 4) :
   icmp IntPredicate.ult (lshr e (const? 4 1) { «exact» := true }) (const? 4 5) ⊑
-    icmp IntPredicate.ult e (const? 4 (-6)) := by 
+    icmp IntPredicate.ult e (const? 4 (-6)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2559,7 +2559,7 @@ theorem lshrult_01_05_exact_thm (e : IntW 4) :
 
 theorem lshrult_01_06_exact_thm (e : IntW 4) :
   icmp IntPredicate.ult (lshr e (const? 4 1) { «exact» := true }) (const? 4 6) ⊑
-    icmp IntPredicate.ult e (const? 4 (-4)) := by 
+    icmp IntPredicate.ult e (const? 4 (-4)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2570,7 +2570,7 @@ theorem lshrult_01_06_exact_thm (e : IntW 4) :
 
 theorem lshrult_01_07_exact_thm (e : IntW 4) :
   icmp IntPredicate.ult (lshr e (const? 4 1) { «exact» := true }) (const? 4 7) ⊑
-    icmp IntPredicate.ne e (const? 4 (-2)) := by 
+    icmp IntPredicate.ne e (const? 4 (-2)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2580,7 +2580,7 @@ theorem lshrult_01_07_exact_thm (e : IntW 4) :
 
 
 theorem lshrult_01_08_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ult (lshr e (const? 4 1) { «exact» := true }) (const? 4 (-8)) ⊑ const? 1 1 := by 
+  icmp IntPredicate.ult (lshr e (const? 4 1) { «exact» := true }) (const? 4 (-8)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2590,7 +2590,7 @@ theorem lshrult_01_08_exact_thm (e : IntW 4) :
 
 
 theorem lshrult_01_09_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ult (lshr e (const? 4 1) { «exact» := true }) (const? 4 (-7)) ⊑ const? 1 1 := by 
+  icmp IntPredicate.ult (lshr e (const? 4 1) { «exact» := true }) (const? 4 (-7)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2600,7 +2600,7 @@ theorem lshrult_01_09_exact_thm (e : IntW 4) :
 
 
 theorem lshrult_01_10_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ult (lshr e (const? 4 1) { «exact» := true }) (const? 4 (-6)) ⊑ const? 1 1 := by 
+  icmp IntPredicate.ult (lshr e (const? 4 1) { «exact» := true }) (const? 4 (-6)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2610,7 +2610,7 @@ theorem lshrult_01_10_exact_thm (e : IntW 4) :
 
 
 theorem lshrult_01_11_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ult (lshr e (const? 4 1) { «exact» := true }) (const? 4 (-5)) ⊑ const? 1 1 := by 
+  icmp IntPredicate.ult (lshr e (const? 4 1) { «exact» := true }) (const? 4 (-5)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2620,7 +2620,7 @@ theorem lshrult_01_11_exact_thm (e : IntW 4) :
 
 
 theorem lshrult_01_12_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ult (lshr e (const? 4 1) { «exact» := true }) (const? 4 (-4)) ⊑ const? 1 1 := by 
+  icmp IntPredicate.ult (lshr e (const? 4 1) { «exact» := true }) (const? 4 (-4)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2630,7 +2630,7 @@ theorem lshrult_01_12_exact_thm (e : IntW 4) :
 
 
 theorem lshrult_01_13_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ult (lshr e (const? 4 1) { «exact» := true }) (const? 4 (-3)) ⊑ const? 1 1 := by 
+  icmp IntPredicate.ult (lshr e (const? 4 1) { «exact» := true }) (const? 4 (-3)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2640,7 +2640,7 @@ theorem lshrult_01_13_exact_thm (e : IntW 4) :
 
 
 theorem lshrult_01_14_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ult (lshr e (const? 4 1) { «exact» := true }) (const? 4 (-2)) ⊑ const? 1 1 := by 
+  icmp IntPredicate.ult (lshr e (const? 4 1) { «exact» := true }) (const? 4 (-2)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2650,7 +2650,7 @@ theorem lshrult_01_14_exact_thm (e : IntW 4) :
 
 
 theorem lshrult_01_15_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ult (lshr e (const? 4 1) { «exact» := true }) (const? 4 (-1)) ⊑ const? 1 1 := by 
+  icmp IntPredicate.ult (lshr e (const? 4 1) { «exact» := true }) (const? 4 (-1)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2660,7 +2660,7 @@ theorem lshrult_01_15_exact_thm (e : IntW 4) :
 
 
 theorem lshrult_02_00_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ult (lshr e (const? 4 2) { «exact» := true }) (const? 4 0) ⊑ const? 1 0 := by 
+  icmp IntPredicate.ult (lshr e (const? 4 2) { «exact» := true }) (const? 4 0) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2671,7 +2671,7 @@ theorem lshrult_02_00_exact_thm (e : IntW 4) :
 
 theorem lshrult_02_01_exact_thm (e : IntW 4) :
   icmp IntPredicate.ult (lshr e (const? 4 2) { «exact» := true }) (const? 4 1) ⊑
-    icmp IntPredicate.eq e (const? 4 0) := by 
+    icmp IntPredicate.eq e (const? 4 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2682,7 +2682,7 @@ theorem lshrult_02_01_exact_thm (e : IntW 4) :
 
 theorem lshrult_02_02_exact_thm (e : IntW 4) :
   icmp IntPredicate.ult (lshr e (const? 4 2) { «exact» := true }) (const? 4 2) ⊑
-    icmp IntPredicate.sgt e (const? 4 (-1)) := by 
+    icmp IntPredicate.sgt e (const? 4 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2693,7 +2693,7 @@ theorem lshrult_02_02_exact_thm (e : IntW 4) :
 
 theorem lshrult_02_03_exact_thm (e : IntW 4) :
   icmp IntPredicate.ult (lshr e (const? 4 2) { «exact» := true }) (const? 4 3) ⊑
-    icmp IntPredicate.ne e (const? 4 (-4)) := by 
+    icmp IntPredicate.ne e (const? 4 (-4)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2703,7 +2703,7 @@ theorem lshrult_02_03_exact_thm (e : IntW 4) :
 
 
 theorem lshrult_02_04_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ult (lshr e (const? 4 2) { «exact» := true }) (const? 4 4) ⊑ const? 1 1 := by 
+  icmp IntPredicate.ult (lshr e (const? 4 2) { «exact» := true }) (const? 4 4) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2713,7 +2713,7 @@ theorem lshrult_02_04_exact_thm (e : IntW 4) :
 
 
 theorem lshrult_02_05_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ult (lshr e (const? 4 2) { «exact» := true }) (const? 4 5) ⊑ const? 1 1 := by 
+  icmp IntPredicate.ult (lshr e (const? 4 2) { «exact» := true }) (const? 4 5) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2723,7 +2723,7 @@ theorem lshrult_02_05_exact_thm (e : IntW 4) :
 
 
 theorem lshrult_02_06_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ult (lshr e (const? 4 2) { «exact» := true }) (const? 4 6) ⊑ const? 1 1 := by 
+  icmp IntPredicate.ult (lshr e (const? 4 2) { «exact» := true }) (const? 4 6) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2733,7 +2733,7 @@ theorem lshrult_02_06_exact_thm (e : IntW 4) :
 
 
 theorem lshrult_02_07_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ult (lshr e (const? 4 2) { «exact» := true }) (const? 4 7) ⊑ const? 1 1 := by 
+  icmp IntPredicate.ult (lshr e (const? 4 2) { «exact» := true }) (const? 4 7) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2743,7 +2743,7 @@ theorem lshrult_02_07_exact_thm (e : IntW 4) :
 
 
 theorem lshrult_02_08_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ult (lshr e (const? 4 2) { «exact» := true }) (const? 4 (-8)) ⊑ const? 1 1 := by 
+  icmp IntPredicate.ult (lshr e (const? 4 2) { «exact» := true }) (const? 4 (-8)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2753,7 +2753,7 @@ theorem lshrult_02_08_exact_thm (e : IntW 4) :
 
 
 theorem lshrult_02_09_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ult (lshr e (const? 4 2) { «exact» := true }) (const? 4 (-7)) ⊑ const? 1 1 := by 
+  icmp IntPredicate.ult (lshr e (const? 4 2) { «exact» := true }) (const? 4 (-7)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2763,7 +2763,7 @@ theorem lshrult_02_09_exact_thm (e : IntW 4) :
 
 
 theorem lshrult_02_10_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ult (lshr e (const? 4 2) { «exact» := true }) (const? 4 (-6)) ⊑ const? 1 1 := by 
+  icmp IntPredicate.ult (lshr e (const? 4 2) { «exact» := true }) (const? 4 (-6)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2773,7 +2773,7 @@ theorem lshrult_02_10_exact_thm (e : IntW 4) :
 
 
 theorem lshrult_02_11_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ult (lshr e (const? 4 2) { «exact» := true }) (const? 4 (-5)) ⊑ const? 1 1 := by 
+  icmp IntPredicate.ult (lshr e (const? 4 2) { «exact» := true }) (const? 4 (-5)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2783,7 +2783,7 @@ theorem lshrult_02_11_exact_thm (e : IntW 4) :
 
 
 theorem lshrult_02_12_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ult (lshr e (const? 4 2) { «exact» := true }) (const? 4 (-4)) ⊑ const? 1 1 := by 
+  icmp IntPredicate.ult (lshr e (const? 4 2) { «exact» := true }) (const? 4 (-4)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2793,7 +2793,7 @@ theorem lshrult_02_12_exact_thm (e : IntW 4) :
 
 
 theorem lshrult_02_13_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ult (lshr e (const? 4 2) { «exact» := true }) (const? 4 (-3)) ⊑ const? 1 1 := by 
+  icmp IntPredicate.ult (lshr e (const? 4 2) { «exact» := true }) (const? 4 (-3)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2803,7 +2803,7 @@ theorem lshrult_02_13_exact_thm (e : IntW 4) :
 
 
 theorem lshrult_02_14_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ult (lshr e (const? 4 2) { «exact» := true }) (const? 4 (-2)) ⊑ const? 1 1 := by 
+  icmp IntPredicate.ult (lshr e (const? 4 2) { «exact» := true }) (const? 4 (-2)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2813,7 +2813,7 @@ theorem lshrult_02_14_exact_thm (e : IntW 4) :
 
 
 theorem lshrult_02_15_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ult (lshr e (const? 4 2) { «exact» := true }) (const? 4 (-1)) ⊑ const? 1 1 := by 
+  icmp IntPredicate.ult (lshr e (const? 4 2) { «exact» := true }) (const? 4 (-1)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2823,7 +2823,7 @@ theorem lshrult_02_15_exact_thm (e : IntW 4) :
 
 
 theorem lshrult_03_00_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ult (lshr e (const? 4 3) { «exact» := true }) (const? 4 0) ⊑ const? 1 0 := by 
+  icmp IntPredicate.ult (lshr e (const? 4 3) { «exact» := true }) (const? 4 0) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2834,7 +2834,7 @@ theorem lshrult_03_00_exact_thm (e : IntW 4) :
 
 theorem lshrult_03_01_exact_thm (e : IntW 4) :
   icmp IntPredicate.ult (lshr e (const? 4 3) { «exact» := true }) (const? 4 1) ⊑
-    icmp IntPredicate.eq e (const? 4 0) := by 
+    icmp IntPredicate.eq e (const? 4 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2844,7 +2844,7 @@ theorem lshrult_03_01_exact_thm (e : IntW 4) :
 
 
 theorem lshrult_03_02_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ult (lshr e (const? 4 3) { «exact» := true }) (const? 4 2) ⊑ const? 1 1 := by 
+  icmp IntPredicate.ult (lshr e (const? 4 3) { «exact» := true }) (const? 4 2) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2854,7 +2854,7 @@ theorem lshrult_03_02_exact_thm (e : IntW 4) :
 
 
 theorem lshrult_03_03_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ult (lshr e (const? 4 3) { «exact» := true }) (const? 4 3) ⊑ const? 1 1 := by 
+  icmp IntPredicate.ult (lshr e (const? 4 3) { «exact» := true }) (const? 4 3) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2864,7 +2864,7 @@ theorem lshrult_03_03_exact_thm (e : IntW 4) :
 
 
 theorem lshrult_03_04_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ult (lshr e (const? 4 3) { «exact» := true }) (const? 4 4) ⊑ const? 1 1 := by 
+  icmp IntPredicate.ult (lshr e (const? 4 3) { «exact» := true }) (const? 4 4) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2874,7 +2874,7 @@ theorem lshrult_03_04_exact_thm (e : IntW 4) :
 
 
 theorem lshrult_03_05_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ult (lshr e (const? 4 3) { «exact» := true }) (const? 4 5) ⊑ const? 1 1 := by 
+  icmp IntPredicate.ult (lshr e (const? 4 3) { «exact» := true }) (const? 4 5) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2884,7 +2884,7 @@ theorem lshrult_03_05_exact_thm (e : IntW 4) :
 
 
 theorem lshrult_03_06_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ult (lshr e (const? 4 3) { «exact» := true }) (const? 4 6) ⊑ const? 1 1 := by 
+  icmp IntPredicate.ult (lshr e (const? 4 3) { «exact» := true }) (const? 4 6) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2894,7 +2894,7 @@ theorem lshrult_03_06_exact_thm (e : IntW 4) :
 
 
 theorem lshrult_03_07_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ult (lshr e (const? 4 3) { «exact» := true }) (const? 4 7) ⊑ const? 1 1 := by 
+  icmp IntPredicate.ult (lshr e (const? 4 3) { «exact» := true }) (const? 4 7) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2904,7 +2904,7 @@ theorem lshrult_03_07_exact_thm (e : IntW 4) :
 
 
 theorem lshrult_03_08_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ult (lshr e (const? 4 3) { «exact» := true }) (const? 4 (-8)) ⊑ const? 1 1 := by 
+  icmp IntPredicate.ult (lshr e (const? 4 3) { «exact» := true }) (const? 4 (-8)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2914,7 +2914,7 @@ theorem lshrult_03_08_exact_thm (e : IntW 4) :
 
 
 theorem lshrult_03_09_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ult (lshr e (const? 4 3) { «exact» := true }) (const? 4 (-7)) ⊑ const? 1 1 := by 
+  icmp IntPredicate.ult (lshr e (const? 4 3) { «exact» := true }) (const? 4 (-7)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2924,7 +2924,7 @@ theorem lshrult_03_09_exact_thm (e : IntW 4) :
 
 
 theorem lshrult_03_10_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ult (lshr e (const? 4 3) { «exact» := true }) (const? 4 (-6)) ⊑ const? 1 1 := by 
+  icmp IntPredicate.ult (lshr e (const? 4 3) { «exact» := true }) (const? 4 (-6)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2934,7 +2934,7 @@ theorem lshrult_03_10_exact_thm (e : IntW 4) :
 
 
 theorem lshrult_03_11_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ult (lshr e (const? 4 3) { «exact» := true }) (const? 4 (-5)) ⊑ const? 1 1 := by 
+  icmp IntPredicate.ult (lshr e (const? 4 3) { «exact» := true }) (const? 4 (-5)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2944,7 +2944,7 @@ theorem lshrult_03_11_exact_thm (e : IntW 4) :
 
 
 theorem lshrult_03_12_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ult (lshr e (const? 4 3) { «exact» := true }) (const? 4 (-4)) ⊑ const? 1 1 := by 
+  icmp IntPredicate.ult (lshr e (const? 4 3) { «exact» := true }) (const? 4 (-4)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2954,7 +2954,7 @@ theorem lshrult_03_12_exact_thm (e : IntW 4) :
 
 
 theorem lshrult_03_13_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ult (lshr e (const? 4 3) { «exact» := true }) (const? 4 (-3)) ⊑ const? 1 1 := by 
+  icmp IntPredicate.ult (lshr e (const? 4 3) { «exact» := true }) (const? 4 (-3)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2964,7 +2964,7 @@ theorem lshrult_03_13_exact_thm (e : IntW 4) :
 
 
 theorem lshrult_03_14_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ult (lshr e (const? 4 3) { «exact» := true }) (const? 4 (-2)) ⊑ const? 1 1 := by 
+  icmp IntPredicate.ult (lshr e (const? 4 3) { «exact» := true }) (const? 4 (-2)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2974,7 +2974,7 @@ theorem lshrult_03_14_exact_thm (e : IntW 4) :
 
 
 theorem lshrult_03_15_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ult (lshr e (const? 4 3) { «exact» := true }) (const? 4 (-1)) ⊑ const? 1 1 := by 
+  icmp IntPredicate.ult (lshr e (const? 4 3) { «exact» := true }) (const? 4 (-1)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2985,7 +2985,7 @@ theorem lshrult_03_15_exact_thm (e : IntW 4) :
 
 theorem ashrsgt_01_00_exact_thm (e : IntW 4) :
   icmp IntPredicate.sgt (ashr e (const? 4 1) { «exact» := true }) (const? 4 0) ⊑
-    icmp IntPredicate.sgt e (const? 4 0) := by 
+    icmp IntPredicate.sgt e (const? 4 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2996,7 +2996,7 @@ theorem ashrsgt_01_00_exact_thm (e : IntW 4) :
 
 theorem ashrsgt_01_01_exact_thm (e : IntW 4) :
   icmp IntPredicate.sgt (ashr e (const? 4 1) { «exact» := true }) (const? 4 1) ⊑
-    icmp IntPredicate.sgt e (const? 4 2) := by 
+    icmp IntPredicate.sgt e (const? 4 2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3007,7 +3007,7 @@ theorem ashrsgt_01_01_exact_thm (e : IntW 4) :
 
 theorem ashrsgt_01_02_exact_thm (e : IntW 4) :
   icmp IntPredicate.sgt (ashr e (const? 4 1) { «exact» := true }) (const? 4 2) ⊑
-    icmp IntPredicate.sgt e (const? 4 4) := by 
+    icmp IntPredicate.sgt e (const? 4 4) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3017,7 +3017,7 @@ theorem ashrsgt_01_02_exact_thm (e : IntW 4) :
 
 
 theorem ashrsgt_01_03_exact_thm (e : IntW 4) :
-  icmp IntPredicate.sgt (ashr e (const? 4 1) { «exact» := true }) (const? 4 3) ⊑ const? 1 0 := by 
+  icmp IntPredicate.sgt (ashr e (const? 4 1) { «exact» := true }) (const? 4 3) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3027,7 +3027,7 @@ theorem ashrsgt_01_03_exact_thm (e : IntW 4) :
 
 
 theorem ashrsgt_01_04_exact_thm (e : IntW 4) :
-  icmp IntPredicate.sgt (ashr e (const? 4 1) { «exact» := true }) (const? 4 4) ⊑ const? 1 0 := by 
+  icmp IntPredicate.sgt (ashr e (const? 4 1) { «exact» := true }) (const? 4 4) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3037,7 +3037,7 @@ theorem ashrsgt_01_04_exact_thm (e : IntW 4) :
 
 
 theorem ashrsgt_01_05_exact_thm (e : IntW 4) :
-  icmp IntPredicate.sgt (ashr e (const? 4 1) { «exact» := true }) (const? 4 5) ⊑ const? 1 0 := by 
+  icmp IntPredicate.sgt (ashr e (const? 4 1) { «exact» := true }) (const? 4 5) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3047,7 +3047,7 @@ theorem ashrsgt_01_05_exact_thm (e : IntW 4) :
 
 
 theorem ashrsgt_01_06_exact_thm (e : IntW 4) :
-  icmp IntPredicate.sgt (ashr e (const? 4 1) { «exact» := true }) (const? 4 6) ⊑ const? 1 0 := by 
+  icmp IntPredicate.sgt (ashr e (const? 4 1) { «exact» := true }) (const? 4 6) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3057,7 +3057,7 @@ theorem ashrsgt_01_06_exact_thm (e : IntW 4) :
 
 
 theorem ashrsgt_01_07_exact_thm (e : IntW 4) :
-  icmp IntPredicate.sgt (ashr e (const? 4 1) { «exact» := true }) (const? 4 7) ⊑ const? 1 0 := by 
+  icmp IntPredicate.sgt (ashr e (const? 4 1) { «exact» := true }) (const? 4 7) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3067,7 +3067,7 @@ theorem ashrsgt_01_07_exact_thm (e : IntW 4) :
 
 
 theorem ashrsgt_01_08_exact_thm (e : IntW 4) :
-  icmp IntPredicate.sgt (ashr e (const? 4 1) { «exact» := true }) (const? 4 (-8)) ⊑ const? 1 1 := by 
+  icmp IntPredicate.sgt (ashr e (const? 4 1) { «exact» := true }) (const? 4 (-8)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3077,7 +3077,7 @@ theorem ashrsgt_01_08_exact_thm (e : IntW 4) :
 
 
 theorem ashrsgt_01_09_exact_thm (e : IntW 4) :
-  icmp IntPredicate.sgt (ashr e (const? 4 1) { «exact» := true }) (const? 4 (-7)) ⊑ const? 1 1 := by 
+  icmp IntPredicate.sgt (ashr e (const? 4 1) { «exact» := true }) (const? 4 (-7)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3087,7 +3087,7 @@ theorem ashrsgt_01_09_exact_thm (e : IntW 4) :
 
 
 theorem ashrsgt_01_10_exact_thm (e : IntW 4) :
-  icmp IntPredicate.sgt (ashr e (const? 4 1) { «exact» := true }) (const? 4 (-6)) ⊑ const? 1 1 := by 
+  icmp IntPredicate.sgt (ashr e (const? 4 1) { «exact» := true }) (const? 4 (-6)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3097,7 +3097,7 @@ theorem ashrsgt_01_10_exact_thm (e : IntW 4) :
 
 
 theorem ashrsgt_01_11_exact_thm (e : IntW 4) :
-  icmp IntPredicate.sgt (ashr e (const? 4 1) { «exact» := true }) (const? 4 (-5)) ⊑ const? 1 1 := by 
+  icmp IntPredicate.sgt (ashr e (const? 4 1) { «exact» := true }) (const? 4 (-5)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3108,7 +3108,7 @@ theorem ashrsgt_01_11_exact_thm (e : IntW 4) :
 
 theorem ashrsgt_01_12_exact_thm (e : IntW 4) :
   icmp IntPredicate.sgt (ashr e (const? 4 1) { «exact» := true }) (const? 4 (-4)) ⊑
-    icmp IntPredicate.ne e (const? 4 (-8)) := by 
+    icmp IntPredicate.ne e (const? 4 (-8)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3119,7 +3119,7 @@ theorem ashrsgt_01_12_exact_thm (e : IntW 4) :
 
 theorem ashrsgt_01_13_exact_thm (e : IntW 4) :
   icmp IntPredicate.sgt (ashr e (const? 4 1) { «exact» := true }) (const? 4 (-3)) ⊑
-    icmp IntPredicate.sgt e (const? 4 (-6)) := by 
+    icmp IntPredicate.sgt e (const? 4 (-6)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3130,7 +3130,7 @@ theorem ashrsgt_01_13_exact_thm (e : IntW 4) :
 
 theorem ashrsgt_01_14_exact_thm (e : IntW 4) :
   icmp IntPredicate.sgt (ashr e (const? 4 1) { «exact» := true }) (const? 4 (-2)) ⊑
-    icmp IntPredicate.sgt e (const? 4 (-4)) := by 
+    icmp IntPredicate.sgt e (const? 4 (-4)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3141,7 +3141,7 @@ theorem ashrsgt_01_14_exact_thm (e : IntW 4) :
 
 theorem ashrsgt_01_15_exact_thm (e : IntW 4) :
   icmp IntPredicate.sgt (ashr e (const? 4 1) { «exact» := true }) (const? 4 (-1)) ⊑
-    icmp IntPredicate.sgt e (const? 4 (-1)) := by 
+    icmp IntPredicate.sgt e (const? 4 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3152,7 +3152,7 @@ theorem ashrsgt_01_15_exact_thm (e : IntW 4) :
 
 theorem ashrsgt_02_00_exact_thm (e : IntW 4) :
   icmp IntPredicate.sgt (ashr e (const? 4 2) { «exact» := true }) (const? 4 0) ⊑
-    icmp IntPredicate.sgt e (const? 4 0) := by 
+    icmp IntPredicate.sgt e (const? 4 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3162,7 +3162,7 @@ theorem ashrsgt_02_00_exact_thm (e : IntW 4) :
 
 
 theorem ashrsgt_02_01_exact_thm (e : IntW 4) :
-  icmp IntPredicate.sgt (ashr e (const? 4 2) { «exact» := true }) (const? 4 1) ⊑ const? 1 0 := by 
+  icmp IntPredicate.sgt (ashr e (const? 4 2) { «exact» := true }) (const? 4 1) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3172,7 +3172,7 @@ theorem ashrsgt_02_01_exact_thm (e : IntW 4) :
 
 
 theorem ashrsgt_02_02_exact_thm (e : IntW 4) :
-  icmp IntPredicate.sgt (ashr e (const? 4 2) { «exact» := true }) (const? 4 2) ⊑ const? 1 0 := by 
+  icmp IntPredicate.sgt (ashr e (const? 4 2) { «exact» := true }) (const? 4 2) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3182,7 +3182,7 @@ theorem ashrsgt_02_02_exact_thm (e : IntW 4) :
 
 
 theorem ashrsgt_02_03_exact_thm (e : IntW 4) :
-  icmp IntPredicate.sgt (ashr e (const? 4 2) { «exact» := true }) (const? 4 3) ⊑ const? 1 0 := by 
+  icmp IntPredicate.sgt (ashr e (const? 4 2) { «exact» := true }) (const? 4 3) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3192,7 +3192,7 @@ theorem ashrsgt_02_03_exact_thm (e : IntW 4) :
 
 
 theorem ashrsgt_02_04_exact_thm (e : IntW 4) :
-  icmp IntPredicate.sgt (ashr e (const? 4 2) { «exact» := true }) (const? 4 4) ⊑ const? 1 0 := by 
+  icmp IntPredicate.sgt (ashr e (const? 4 2) { «exact» := true }) (const? 4 4) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3202,7 +3202,7 @@ theorem ashrsgt_02_04_exact_thm (e : IntW 4) :
 
 
 theorem ashrsgt_02_05_exact_thm (e : IntW 4) :
-  icmp IntPredicate.sgt (ashr e (const? 4 2) { «exact» := true }) (const? 4 5) ⊑ const? 1 0 := by 
+  icmp IntPredicate.sgt (ashr e (const? 4 2) { «exact» := true }) (const? 4 5) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3212,7 +3212,7 @@ theorem ashrsgt_02_05_exact_thm (e : IntW 4) :
 
 
 theorem ashrsgt_02_06_exact_thm (e : IntW 4) :
-  icmp IntPredicate.sgt (ashr e (const? 4 2) { «exact» := true }) (const? 4 6) ⊑ const? 1 0 := by 
+  icmp IntPredicate.sgt (ashr e (const? 4 2) { «exact» := true }) (const? 4 6) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3222,7 +3222,7 @@ theorem ashrsgt_02_06_exact_thm (e : IntW 4) :
 
 
 theorem ashrsgt_02_07_exact_thm (e : IntW 4) :
-  icmp IntPredicate.sgt (ashr e (const? 4 2) { «exact» := true }) (const? 4 7) ⊑ const? 1 0 := by 
+  icmp IntPredicate.sgt (ashr e (const? 4 2) { «exact» := true }) (const? 4 7) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3232,7 +3232,7 @@ theorem ashrsgt_02_07_exact_thm (e : IntW 4) :
 
 
 theorem ashrsgt_02_08_exact_thm (e : IntW 4) :
-  icmp IntPredicate.sgt (ashr e (const? 4 2) { «exact» := true }) (const? 4 (-8)) ⊑ const? 1 1 := by 
+  icmp IntPredicate.sgt (ashr e (const? 4 2) { «exact» := true }) (const? 4 (-8)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3242,7 +3242,7 @@ theorem ashrsgt_02_08_exact_thm (e : IntW 4) :
 
 
 theorem ashrsgt_02_09_exact_thm (e : IntW 4) :
-  icmp IntPredicate.sgt (ashr e (const? 4 2) { «exact» := true }) (const? 4 (-7)) ⊑ const? 1 1 := by 
+  icmp IntPredicate.sgt (ashr e (const? 4 2) { «exact» := true }) (const? 4 (-7)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3252,7 +3252,7 @@ theorem ashrsgt_02_09_exact_thm (e : IntW 4) :
 
 
 theorem ashrsgt_02_10_exact_thm (e : IntW 4) :
-  icmp IntPredicate.sgt (ashr e (const? 4 2) { «exact» := true }) (const? 4 (-6)) ⊑ const? 1 1 := by 
+  icmp IntPredicate.sgt (ashr e (const? 4 2) { «exact» := true }) (const? 4 (-6)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3262,7 +3262,7 @@ theorem ashrsgt_02_10_exact_thm (e : IntW 4) :
 
 
 theorem ashrsgt_02_11_exact_thm (e : IntW 4) :
-  icmp IntPredicate.sgt (ashr e (const? 4 2) { «exact» := true }) (const? 4 (-5)) ⊑ const? 1 1 := by 
+  icmp IntPredicate.sgt (ashr e (const? 4 2) { «exact» := true }) (const? 4 (-5)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3272,7 +3272,7 @@ theorem ashrsgt_02_11_exact_thm (e : IntW 4) :
 
 
 theorem ashrsgt_02_12_exact_thm (e : IntW 4) :
-  icmp IntPredicate.sgt (ashr e (const? 4 2) { «exact» := true }) (const? 4 (-4)) ⊑ const? 1 1 := by 
+  icmp IntPredicate.sgt (ashr e (const? 4 2) { «exact» := true }) (const? 4 (-4)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3282,7 +3282,7 @@ theorem ashrsgt_02_12_exact_thm (e : IntW 4) :
 
 
 theorem ashrsgt_02_13_exact_thm (e : IntW 4) :
-  icmp IntPredicate.sgt (ashr e (const? 4 2) { «exact» := true }) (const? 4 (-3)) ⊑ const? 1 1 := by 
+  icmp IntPredicate.sgt (ashr e (const? 4 2) { «exact» := true }) (const? 4 (-3)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3293,7 +3293,7 @@ theorem ashrsgt_02_13_exact_thm (e : IntW 4) :
 
 theorem ashrsgt_02_14_exact_thm (e : IntW 4) :
   icmp IntPredicate.sgt (ashr e (const? 4 2) { «exact» := true }) (const? 4 (-2)) ⊑
-    icmp IntPredicate.ne e (const? 4 (-8)) := by 
+    icmp IntPredicate.ne e (const? 4 (-8)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3304,7 +3304,7 @@ theorem ashrsgt_02_14_exact_thm (e : IntW 4) :
 
 theorem ashrsgt_02_15_exact_thm (e : IntW 4) :
   icmp IntPredicate.sgt (ashr e (const? 4 2) { «exact» := true }) (const? 4 (-1)) ⊑
-    icmp IntPredicate.sgt e (const? 4 (-1)) := by 
+    icmp IntPredicate.sgt e (const? 4 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3314,7 +3314,7 @@ theorem ashrsgt_02_15_exact_thm (e : IntW 4) :
 
 
 theorem ashrsgt_03_00_exact_thm (e : IntW 4) :
-  icmp IntPredicate.sgt (ashr e (const? 4 3) { «exact» := true }) (const? 4 0) ⊑ const? 1 0 := by 
+  icmp IntPredicate.sgt (ashr e (const? 4 3) { «exact» := true }) (const? 4 0) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3324,7 +3324,7 @@ theorem ashrsgt_03_00_exact_thm (e : IntW 4) :
 
 
 theorem ashrsgt_03_01_exact_thm (e : IntW 4) :
-  icmp IntPredicate.sgt (ashr e (const? 4 3) { «exact» := true }) (const? 4 1) ⊑ const? 1 0 := by 
+  icmp IntPredicate.sgt (ashr e (const? 4 3) { «exact» := true }) (const? 4 1) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3334,7 +3334,7 @@ theorem ashrsgt_03_01_exact_thm (e : IntW 4) :
 
 
 theorem ashrsgt_03_02_exact_thm (e : IntW 4) :
-  icmp IntPredicate.sgt (ashr e (const? 4 3) { «exact» := true }) (const? 4 2) ⊑ const? 1 0 := by 
+  icmp IntPredicate.sgt (ashr e (const? 4 3) { «exact» := true }) (const? 4 2) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3344,7 +3344,7 @@ theorem ashrsgt_03_02_exact_thm (e : IntW 4) :
 
 
 theorem ashrsgt_03_03_exact_thm (e : IntW 4) :
-  icmp IntPredicate.sgt (ashr e (const? 4 3) { «exact» := true }) (const? 4 3) ⊑ const? 1 0 := by 
+  icmp IntPredicate.sgt (ashr e (const? 4 3) { «exact» := true }) (const? 4 3) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3354,7 +3354,7 @@ theorem ashrsgt_03_03_exact_thm (e : IntW 4) :
 
 
 theorem ashrsgt_03_04_exact_thm (e : IntW 4) :
-  icmp IntPredicate.sgt (ashr e (const? 4 3) { «exact» := true }) (const? 4 4) ⊑ const? 1 0 := by 
+  icmp IntPredicate.sgt (ashr e (const? 4 3) { «exact» := true }) (const? 4 4) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3364,7 +3364,7 @@ theorem ashrsgt_03_04_exact_thm (e : IntW 4) :
 
 
 theorem ashrsgt_03_05_exact_thm (e : IntW 4) :
-  icmp IntPredicate.sgt (ashr e (const? 4 3) { «exact» := true }) (const? 4 5) ⊑ const? 1 0 := by 
+  icmp IntPredicate.sgt (ashr e (const? 4 3) { «exact» := true }) (const? 4 5) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3374,7 +3374,7 @@ theorem ashrsgt_03_05_exact_thm (e : IntW 4) :
 
 
 theorem ashrsgt_03_06_exact_thm (e : IntW 4) :
-  icmp IntPredicate.sgt (ashr e (const? 4 3) { «exact» := true }) (const? 4 6) ⊑ const? 1 0 := by 
+  icmp IntPredicate.sgt (ashr e (const? 4 3) { «exact» := true }) (const? 4 6) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3384,7 +3384,7 @@ theorem ashrsgt_03_06_exact_thm (e : IntW 4) :
 
 
 theorem ashrsgt_03_07_exact_thm (e : IntW 4) :
-  icmp IntPredicate.sgt (ashr e (const? 4 3) { «exact» := true }) (const? 4 7) ⊑ const? 1 0 := by 
+  icmp IntPredicate.sgt (ashr e (const? 4 3) { «exact» := true }) (const? 4 7) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3394,7 +3394,7 @@ theorem ashrsgt_03_07_exact_thm (e : IntW 4) :
 
 
 theorem ashrsgt_03_08_exact_thm (e : IntW 4) :
-  icmp IntPredicate.sgt (ashr e (const? 4 3) { «exact» := true }) (const? 4 (-8)) ⊑ const? 1 1 := by 
+  icmp IntPredicate.sgt (ashr e (const? 4 3) { «exact» := true }) (const? 4 (-8)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3404,7 +3404,7 @@ theorem ashrsgt_03_08_exact_thm (e : IntW 4) :
 
 
 theorem ashrsgt_03_09_exact_thm (e : IntW 4) :
-  icmp IntPredicate.sgt (ashr e (const? 4 3) { «exact» := true }) (const? 4 (-7)) ⊑ const? 1 1 := by 
+  icmp IntPredicate.sgt (ashr e (const? 4 3) { «exact» := true }) (const? 4 (-7)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3414,7 +3414,7 @@ theorem ashrsgt_03_09_exact_thm (e : IntW 4) :
 
 
 theorem ashrsgt_03_10_exact_thm (e : IntW 4) :
-  icmp IntPredicate.sgt (ashr e (const? 4 3) { «exact» := true }) (const? 4 (-6)) ⊑ const? 1 1 := by 
+  icmp IntPredicate.sgt (ashr e (const? 4 3) { «exact» := true }) (const? 4 (-6)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3424,7 +3424,7 @@ theorem ashrsgt_03_10_exact_thm (e : IntW 4) :
 
 
 theorem ashrsgt_03_11_exact_thm (e : IntW 4) :
-  icmp IntPredicate.sgt (ashr e (const? 4 3) { «exact» := true }) (const? 4 (-5)) ⊑ const? 1 1 := by 
+  icmp IntPredicate.sgt (ashr e (const? 4 3) { «exact» := true }) (const? 4 (-5)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3434,7 +3434,7 @@ theorem ashrsgt_03_11_exact_thm (e : IntW 4) :
 
 
 theorem ashrsgt_03_12_exact_thm (e : IntW 4) :
-  icmp IntPredicate.sgt (ashr e (const? 4 3) { «exact» := true }) (const? 4 (-4)) ⊑ const? 1 1 := by 
+  icmp IntPredicate.sgt (ashr e (const? 4 3) { «exact» := true }) (const? 4 (-4)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3444,7 +3444,7 @@ theorem ashrsgt_03_12_exact_thm (e : IntW 4) :
 
 
 theorem ashrsgt_03_13_exact_thm (e : IntW 4) :
-  icmp IntPredicate.sgt (ashr e (const? 4 3) { «exact» := true }) (const? 4 (-3)) ⊑ const? 1 1 := by 
+  icmp IntPredicate.sgt (ashr e (const? 4 3) { «exact» := true }) (const? 4 (-3)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3454,7 +3454,7 @@ theorem ashrsgt_03_13_exact_thm (e : IntW 4) :
 
 
 theorem ashrsgt_03_14_exact_thm (e : IntW 4) :
-  icmp IntPredicate.sgt (ashr e (const? 4 3) { «exact» := true }) (const? 4 (-2)) ⊑ const? 1 1 := by 
+  icmp IntPredicate.sgt (ashr e (const? 4 3) { «exact» := true }) (const? 4 (-2)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3465,7 +3465,7 @@ theorem ashrsgt_03_14_exact_thm (e : IntW 4) :
 
 theorem ashrsgt_03_15_exact_thm (e : IntW 4) :
   icmp IntPredicate.sgt (ashr e (const? 4 3) { «exact» := true }) (const? 4 (-1)) ⊑
-    icmp IntPredicate.sgt e (const? 4 (-1)) := by 
+    icmp IntPredicate.sgt e (const? 4 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3476,7 +3476,7 @@ theorem ashrsgt_03_15_exact_thm (e : IntW 4) :
 
 theorem ashrslt_01_00_exact_thm (e : IntW 4) :
   icmp IntPredicate.slt (ashr e (const? 4 1) { «exact» := true }) (const? 4 0) ⊑
-    icmp IntPredicate.slt e (const? 4 0) := by 
+    icmp IntPredicate.slt e (const? 4 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3487,7 +3487,7 @@ theorem ashrslt_01_00_exact_thm (e : IntW 4) :
 
 theorem ashrslt_01_01_exact_thm (e : IntW 4) :
   icmp IntPredicate.slt (ashr e (const? 4 1) { «exact» := true }) (const? 4 1) ⊑
-    icmp IntPredicate.slt e (const? 4 2) := by 
+    icmp IntPredicate.slt e (const? 4 2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3498,7 +3498,7 @@ theorem ashrslt_01_01_exact_thm (e : IntW 4) :
 
 theorem ashrslt_01_02_exact_thm (e : IntW 4) :
   icmp IntPredicate.slt (ashr e (const? 4 1) { «exact» := true }) (const? 4 2) ⊑
-    icmp IntPredicate.slt e (const? 4 3) := by 
+    icmp IntPredicate.slt e (const? 4 3) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3509,7 +3509,7 @@ theorem ashrslt_01_02_exact_thm (e : IntW 4) :
 
 theorem ashrslt_01_03_exact_thm (e : IntW 4) :
   icmp IntPredicate.slt (ashr e (const? 4 1) { «exact» := true }) (const? 4 3) ⊑
-    icmp IntPredicate.slt e (const? 4 5) := by 
+    icmp IntPredicate.slt e (const? 4 5) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3519,7 +3519,7 @@ theorem ashrslt_01_03_exact_thm (e : IntW 4) :
 
 
 theorem ashrslt_01_04_exact_thm (e : IntW 4) :
-  icmp IntPredicate.slt (ashr e (const? 4 1) { «exact» := true }) (const? 4 4) ⊑ const? 1 1 := by 
+  icmp IntPredicate.slt (ashr e (const? 4 1) { «exact» := true }) (const? 4 4) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3529,7 +3529,7 @@ theorem ashrslt_01_04_exact_thm (e : IntW 4) :
 
 
 theorem ashrslt_01_05_exact_thm (e : IntW 4) :
-  icmp IntPredicate.slt (ashr e (const? 4 1) { «exact» := true }) (const? 4 5) ⊑ const? 1 1 := by 
+  icmp IntPredicate.slt (ashr e (const? 4 1) { «exact» := true }) (const? 4 5) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3539,7 +3539,7 @@ theorem ashrslt_01_05_exact_thm (e : IntW 4) :
 
 
 theorem ashrslt_01_06_exact_thm (e : IntW 4) :
-  icmp IntPredicate.slt (ashr e (const? 4 1) { «exact» := true }) (const? 4 6) ⊑ const? 1 1 := by 
+  icmp IntPredicate.slt (ashr e (const? 4 1) { «exact» := true }) (const? 4 6) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3549,7 +3549,7 @@ theorem ashrslt_01_06_exact_thm (e : IntW 4) :
 
 
 theorem ashrslt_01_07_exact_thm (e : IntW 4) :
-  icmp IntPredicate.slt (ashr e (const? 4 1) { «exact» := true }) (const? 4 7) ⊑ const? 1 1 := by 
+  icmp IntPredicate.slt (ashr e (const? 4 1) { «exact» := true }) (const? 4 7) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3559,7 +3559,7 @@ theorem ashrslt_01_07_exact_thm (e : IntW 4) :
 
 
 theorem ashrslt_01_08_exact_thm (e : IntW 4) :
-  icmp IntPredicate.slt (ashr e (const? 4 1) { «exact» := true }) (const? 4 (-8)) ⊑ const? 1 0 := by 
+  icmp IntPredicate.slt (ashr e (const? 4 1) { «exact» := true }) (const? 4 (-8)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3569,7 +3569,7 @@ theorem ashrslt_01_08_exact_thm (e : IntW 4) :
 
 
 theorem ashrslt_01_09_exact_thm (e : IntW 4) :
-  icmp IntPredicate.slt (ashr e (const? 4 1) { «exact» := true }) (const? 4 (-7)) ⊑ const? 1 0 := by 
+  icmp IntPredicate.slt (ashr e (const? 4 1) { «exact» := true }) (const? 4 (-7)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3579,7 +3579,7 @@ theorem ashrslt_01_09_exact_thm (e : IntW 4) :
 
 
 theorem ashrslt_01_10_exact_thm (e : IntW 4) :
-  icmp IntPredicate.slt (ashr e (const? 4 1) { «exact» := true }) (const? 4 (-6)) ⊑ const? 1 0 := by 
+  icmp IntPredicate.slt (ashr e (const? 4 1) { «exact» := true }) (const? 4 (-6)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3589,7 +3589,7 @@ theorem ashrslt_01_10_exact_thm (e : IntW 4) :
 
 
 theorem ashrslt_01_11_exact_thm (e : IntW 4) :
-  icmp IntPredicate.slt (ashr e (const? 4 1) { «exact» := true }) (const? 4 (-5)) ⊑ const? 1 0 := by 
+  icmp IntPredicate.slt (ashr e (const? 4 1) { «exact» := true }) (const? 4 (-5)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3599,7 +3599,7 @@ theorem ashrslt_01_11_exact_thm (e : IntW 4) :
 
 
 theorem ashrslt_01_12_exact_thm (e : IntW 4) :
-  icmp IntPredicate.slt (ashr e (const? 4 1) { «exact» := true }) (const? 4 (-4)) ⊑ const? 1 0 := by 
+  icmp IntPredicate.slt (ashr e (const? 4 1) { «exact» := true }) (const? 4 (-4)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3610,7 +3610,7 @@ theorem ashrslt_01_12_exact_thm (e : IntW 4) :
 
 theorem ashrslt_01_13_exact_thm (e : IntW 4) :
   icmp IntPredicate.slt (ashr e (const? 4 1) { «exact» := true }) (const? 4 (-3)) ⊑
-    icmp IntPredicate.slt e (const? 4 (-6)) := by 
+    icmp IntPredicate.slt e (const? 4 (-6)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3621,7 +3621,7 @@ theorem ashrslt_01_13_exact_thm (e : IntW 4) :
 
 theorem ashrslt_01_14_exact_thm (e : IntW 4) :
   icmp IntPredicate.slt (ashr e (const? 4 1) { «exact» := true }) (const? 4 (-2)) ⊑
-    icmp IntPredicate.slt e (const? 4 (-4)) := by 
+    icmp IntPredicate.slt e (const? 4 (-4)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3632,7 +3632,7 @@ theorem ashrslt_01_14_exact_thm (e : IntW 4) :
 
 theorem ashrslt_01_15_exact_thm (e : IntW 4) :
   icmp IntPredicate.slt (ashr e (const? 4 1) { «exact» := true }) (const? 4 (-1)) ⊑
-    icmp IntPredicate.slt e (const? 4 (-2)) := by 
+    icmp IntPredicate.slt e (const? 4 (-2)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3643,7 +3643,7 @@ theorem ashrslt_01_15_exact_thm (e : IntW 4) :
 
 theorem ashrslt_02_00_exact_thm (e : IntW 4) :
   icmp IntPredicate.slt (ashr e (const? 4 2) { «exact» := true }) (const? 4 0) ⊑
-    icmp IntPredicate.slt e (const? 4 0) := by 
+    icmp IntPredicate.slt e (const? 4 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3654,7 +3654,7 @@ theorem ashrslt_02_00_exact_thm (e : IntW 4) :
 
 theorem ashrslt_02_01_exact_thm (e : IntW 4) :
   icmp IntPredicate.slt (ashr e (const? 4 2) { «exact» := true }) (const? 4 1) ⊑
-    icmp IntPredicate.slt e (const? 4 4) := by 
+    icmp IntPredicate.slt e (const? 4 4) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3664,7 +3664,7 @@ theorem ashrslt_02_01_exact_thm (e : IntW 4) :
 
 
 theorem ashrslt_02_02_exact_thm (e : IntW 4) :
-  icmp IntPredicate.slt (ashr e (const? 4 2) { «exact» := true }) (const? 4 2) ⊑ const? 1 1 := by 
+  icmp IntPredicate.slt (ashr e (const? 4 2) { «exact» := true }) (const? 4 2) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3674,7 +3674,7 @@ theorem ashrslt_02_02_exact_thm (e : IntW 4) :
 
 
 theorem ashrslt_02_03_exact_thm (e : IntW 4) :
-  icmp IntPredicate.slt (ashr e (const? 4 2) { «exact» := true }) (const? 4 3) ⊑ const? 1 1 := by 
+  icmp IntPredicate.slt (ashr e (const? 4 2) { «exact» := true }) (const? 4 3) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3684,7 +3684,7 @@ theorem ashrslt_02_03_exact_thm (e : IntW 4) :
 
 
 theorem ashrslt_02_04_exact_thm (e : IntW 4) :
-  icmp IntPredicate.slt (ashr e (const? 4 2) { «exact» := true }) (const? 4 4) ⊑ const? 1 1 := by 
+  icmp IntPredicate.slt (ashr e (const? 4 2) { «exact» := true }) (const? 4 4) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3694,7 +3694,7 @@ theorem ashrslt_02_04_exact_thm (e : IntW 4) :
 
 
 theorem ashrslt_02_05_exact_thm (e : IntW 4) :
-  icmp IntPredicate.slt (ashr e (const? 4 2) { «exact» := true }) (const? 4 5) ⊑ const? 1 1 := by 
+  icmp IntPredicate.slt (ashr e (const? 4 2) { «exact» := true }) (const? 4 5) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3704,7 +3704,7 @@ theorem ashrslt_02_05_exact_thm (e : IntW 4) :
 
 
 theorem ashrslt_02_06_exact_thm (e : IntW 4) :
-  icmp IntPredicate.slt (ashr e (const? 4 2) { «exact» := true }) (const? 4 6) ⊑ const? 1 1 := by 
+  icmp IntPredicate.slt (ashr e (const? 4 2) { «exact» := true }) (const? 4 6) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3714,7 +3714,7 @@ theorem ashrslt_02_06_exact_thm (e : IntW 4) :
 
 
 theorem ashrslt_02_07_exact_thm (e : IntW 4) :
-  icmp IntPredicate.slt (ashr e (const? 4 2) { «exact» := true }) (const? 4 7) ⊑ const? 1 1 := by 
+  icmp IntPredicate.slt (ashr e (const? 4 2) { «exact» := true }) (const? 4 7) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3724,7 +3724,7 @@ theorem ashrslt_02_07_exact_thm (e : IntW 4) :
 
 
 theorem ashrslt_02_08_exact_thm (e : IntW 4) :
-  icmp IntPredicate.slt (ashr e (const? 4 2) { «exact» := true }) (const? 4 (-8)) ⊑ const? 1 0 := by 
+  icmp IntPredicate.slt (ashr e (const? 4 2) { «exact» := true }) (const? 4 (-8)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3734,7 +3734,7 @@ theorem ashrslt_02_08_exact_thm (e : IntW 4) :
 
 
 theorem ashrslt_02_09_exact_thm (e : IntW 4) :
-  icmp IntPredicate.slt (ashr e (const? 4 2) { «exact» := true }) (const? 4 (-7)) ⊑ const? 1 0 := by 
+  icmp IntPredicate.slt (ashr e (const? 4 2) { «exact» := true }) (const? 4 (-7)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3744,7 +3744,7 @@ theorem ashrslt_02_09_exact_thm (e : IntW 4) :
 
 
 theorem ashrslt_02_10_exact_thm (e : IntW 4) :
-  icmp IntPredicate.slt (ashr e (const? 4 2) { «exact» := true }) (const? 4 (-6)) ⊑ const? 1 0 := by 
+  icmp IntPredicate.slt (ashr e (const? 4 2) { «exact» := true }) (const? 4 (-6)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3754,7 +3754,7 @@ theorem ashrslt_02_10_exact_thm (e : IntW 4) :
 
 
 theorem ashrslt_02_11_exact_thm (e : IntW 4) :
-  icmp IntPredicate.slt (ashr e (const? 4 2) { «exact» := true }) (const? 4 (-5)) ⊑ const? 1 0 := by 
+  icmp IntPredicate.slt (ashr e (const? 4 2) { «exact» := true }) (const? 4 (-5)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3764,7 +3764,7 @@ theorem ashrslt_02_11_exact_thm (e : IntW 4) :
 
 
 theorem ashrslt_02_12_exact_thm (e : IntW 4) :
-  icmp IntPredicate.slt (ashr e (const? 4 2) { «exact» := true }) (const? 4 (-4)) ⊑ const? 1 0 := by 
+  icmp IntPredicate.slt (ashr e (const? 4 2) { «exact» := true }) (const? 4 (-4)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3774,7 +3774,7 @@ theorem ashrslt_02_12_exact_thm (e : IntW 4) :
 
 
 theorem ashrslt_02_13_exact_thm (e : IntW 4) :
-  icmp IntPredicate.slt (ashr e (const? 4 2) { «exact» := true }) (const? 4 (-3)) ⊑ const? 1 0 := by 
+  icmp IntPredicate.slt (ashr e (const? 4 2) { «exact» := true }) (const? 4 (-3)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3784,7 +3784,7 @@ theorem ashrslt_02_13_exact_thm (e : IntW 4) :
 
 
 theorem ashrslt_02_14_exact_thm (e : IntW 4) :
-  icmp IntPredicate.slt (ashr e (const? 4 2) { «exact» := true }) (const? 4 (-2)) ⊑ const? 1 0 := by 
+  icmp IntPredicate.slt (ashr e (const? 4 2) { «exact» := true }) (const? 4 (-2)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3795,7 +3795,7 @@ theorem ashrslt_02_14_exact_thm (e : IntW 4) :
 
 theorem ashrslt_02_15_exact_thm (e : IntW 4) :
   icmp IntPredicate.slt (ashr e (const? 4 2) { «exact» := true }) (const? 4 (-1)) ⊑
-    icmp IntPredicate.slt e (const? 4 (-4)) := by 
+    icmp IntPredicate.slt e (const? 4 (-4)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3806,7 +3806,7 @@ theorem ashrslt_02_15_exact_thm (e : IntW 4) :
 
 theorem ashrslt_03_00_exact_thm (e : IntW 4) :
   icmp IntPredicate.slt (ashr e (const? 4 3) { «exact» := true }) (const? 4 0) ⊑
-    icmp IntPredicate.slt e (const? 4 0) := by 
+    icmp IntPredicate.slt e (const? 4 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3816,7 +3816,7 @@ theorem ashrslt_03_00_exact_thm (e : IntW 4) :
 
 
 theorem ashrslt_03_01_exact_thm (e : IntW 4) :
-  icmp IntPredicate.slt (ashr e (const? 4 3) { «exact» := true }) (const? 4 1) ⊑ const? 1 1 := by 
+  icmp IntPredicate.slt (ashr e (const? 4 3) { «exact» := true }) (const? 4 1) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3826,7 +3826,7 @@ theorem ashrslt_03_01_exact_thm (e : IntW 4) :
 
 
 theorem ashrslt_03_02_exact_thm (e : IntW 4) :
-  icmp IntPredicate.slt (ashr e (const? 4 3) { «exact» := true }) (const? 4 2) ⊑ const? 1 1 := by 
+  icmp IntPredicate.slt (ashr e (const? 4 3) { «exact» := true }) (const? 4 2) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3836,7 +3836,7 @@ theorem ashrslt_03_02_exact_thm (e : IntW 4) :
 
 
 theorem ashrslt_03_03_exact_thm (e : IntW 4) :
-  icmp IntPredicate.slt (ashr e (const? 4 3) { «exact» := true }) (const? 4 3) ⊑ const? 1 1 := by 
+  icmp IntPredicate.slt (ashr e (const? 4 3) { «exact» := true }) (const? 4 3) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3846,7 +3846,7 @@ theorem ashrslt_03_03_exact_thm (e : IntW 4) :
 
 
 theorem ashrslt_03_04_exact_thm (e : IntW 4) :
-  icmp IntPredicate.slt (ashr e (const? 4 3) { «exact» := true }) (const? 4 4) ⊑ const? 1 1 := by 
+  icmp IntPredicate.slt (ashr e (const? 4 3) { «exact» := true }) (const? 4 4) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3856,7 +3856,7 @@ theorem ashrslt_03_04_exact_thm (e : IntW 4) :
 
 
 theorem ashrslt_03_05_exact_thm (e : IntW 4) :
-  icmp IntPredicate.slt (ashr e (const? 4 3) { «exact» := true }) (const? 4 5) ⊑ const? 1 1 := by 
+  icmp IntPredicate.slt (ashr e (const? 4 3) { «exact» := true }) (const? 4 5) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3866,7 +3866,7 @@ theorem ashrslt_03_05_exact_thm (e : IntW 4) :
 
 
 theorem ashrslt_03_06_exact_thm (e : IntW 4) :
-  icmp IntPredicate.slt (ashr e (const? 4 3) { «exact» := true }) (const? 4 6) ⊑ const? 1 1 := by 
+  icmp IntPredicate.slt (ashr e (const? 4 3) { «exact» := true }) (const? 4 6) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3876,7 +3876,7 @@ theorem ashrslt_03_06_exact_thm (e : IntW 4) :
 
 
 theorem ashrslt_03_07_exact_thm (e : IntW 4) :
-  icmp IntPredicate.slt (ashr e (const? 4 3) { «exact» := true }) (const? 4 7) ⊑ const? 1 1 := by 
+  icmp IntPredicate.slt (ashr e (const? 4 3) { «exact» := true }) (const? 4 7) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3886,7 +3886,7 @@ theorem ashrslt_03_07_exact_thm (e : IntW 4) :
 
 
 theorem ashrslt_03_08_exact_thm (e : IntW 4) :
-  icmp IntPredicate.slt (ashr e (const? 4 3) { «exact» := true }) (const? 4 (-8)) ⊑ const? 1 0 := by 
+  icmp IntPredicate.slt (ashr e (const? 4 3) { «exact» := true }) (const? 4 (-8)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3896,7 +3896,7 @@ theorem ashrslt_03_08_exact_thm (e : IntW 4) :
 
 
 theorem ashrslt_03_09_exact_thm (e : IntW 4) :
-  icmp IntPredicate.slt (ashr e (const? 4 3) { «exact» := true }) (const? 4 (-7)) ⊑ const? 1 0 := by 
+  icmp IntPredicate.slt (ashr e (const? 4 3) { «exact» := true }) (const? 4 (-7)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3906,7 +3906,7 @@ theorem ashrslt_03_09_exact_thm (e : IntW 4) :
 
 
 theorem ashrslt_03_10_exact_thm (e : IntW 4) :
-  icmp IntPredicate.slt (ashr e (const? 4 3) { «exact» := true }) (const? 4 (-6)) ⊑ const? 1 0 := by 
+  icmp IntPredicate.slt (ashr e (const? 4 3) { «exact» := true }) (const? 4 (-6)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3916,7 +3916,7 @@ theorem ashrslt_03_10_exact_thm (e : IntW 4) :
 
 
 theorem ashrslt_03_11_exact_thm (e : IntW 4) :
-  icmp IntPredicate.slt (ashr e (const? 4 3) { «exact» := true }) (const? 4 (-5)) ⊑ const? 1 0 := by 
+  icmp IntPredicate.slt (ashr e (const? 4 3) { «exact» := true }) (const? 4 (-5)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3926,7 +3926,7 @@ theorem ashrslt_03_11_exact_thm (e : IntW 4) :
 
 
 theorem ashrslt_03_12_exact_thm (e : IntW 4) :
-  icmp IntPredicate.slt (ashr e (const? 4 3) { «exact» := true }) (const? 4 (-4)) ⊑ const? 1 0 := by 
+  icmp IntPredicate.slt (ashr e (const? 4 3) { «exact» := true }) (const? 4 (-4)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3936,7 +3936,7 @@ theorem ashrslt_03_12_exact_thm (e : IntW 4) :
 
 
 theorem ashrslt_03_13_exact_thm (e : IntW 4) :
-  icmp IntPredicate.slt (ashr e (const? 4 3) { «exact» := true }) (const? 4 (-3)) ⊑ const? 1 0 := by 
+  icmp IntPredicate.slt (ashr e (const? 4 3) { «exact» := true }) (const? 4 (-3)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3946,7 +3946,7 @@ theorem ashrslt_03_13_exact_thm (e : IntW 4) :
 
 
 theorem ashrslt_03_14_exact_thm (e : IntW 4) :
-  icmp IntPredicate.slt (ashr e (const? 4 3) { «exact» := true }) (const? 4 (-2)) ⊑ const? 1 0 := by 
+  icmp IntPredicate.slt (ashr e (const? 4 3) { «exact» := true }) (const? 4 (-2)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3956,7 +3956,7 @@ theorem ashrslt_03_14_exact_thm (e : IntW 4) :
 
 
 theorem ashrslt_03_15_exact_thm (e : IntW 4) :
-  icmp IntPredicate.slt (ashr e (const? 4 3) { «exact» := true }) (const? 4 (-1)) ⊑ const? 1 0 := by 
+  icmp IntPredicate.slt (ashr e (const? 4 3) { «exact» := true }) (const? 4 (-1)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3967,7 +3967,7 @@ theorem ashrslt_03_15_exact_thm (e : IntW 4) :
 
 theorem ashr_slt_exact_near_pow2_cmpval_thm (e : IntW 8) :
   icmp IntPredicate.slt (ashr e (const? 8 1) { «exact» := true }) (const? 8 5) ⊑
-    icmp IntPredicate.slt e (const? 8 9) := by 
+    icmp IntPredicate.slt e (const? 8 9) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3978,7 +3978,7 @@ theorem ashr_slt_exact_near_pow2_cmpval_thm (e : IntW 8) :
 
 theorem ashr_ult_exact_near_pow2_cmpval_thm (e : IntW 8) :
   icmp IntPredicate.ult (ashr e (const? 8 1) { «exact» := true }) (const? 8 5) ⊑
-    icmp IntPredicate.ult e (const? 8 9) := by 
+    icmp IntPredicate.ult e (const? 8 9) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3988,7 +3988,7 @@ theorem ashr_ult_exact_near_pow2_cmpval_thm (e : IntW 8) :
 
 
 theorem negtest_near_pow2_cmpval_ashr_slt_noexact_thm (e : IntW 8) :
-  icmp IntPredicate.slt (ashr e (const? 8 1)) (const? 8 5) ⊑ icmp IntPredicate.slt e (const? 8 10) := by 
+  icmp IntPredicate.slt (ashr e (const? 8 1)) (const? 8 5) ⊑ icmp IntPredicate.slt e (const? 8 10) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3999,7 +3999,7 @@ theorem negtest_near_pow2_cmpval_ashr_slt_noexact_thm (e : IntW 8) :
 
 theorem negtest_near_pow2_cmpval_ashr_wrong_cmp_pred_thm (e : IntW 8) :
   icmp IntPredicate.eq (ashr e (const? 8 1) { «exact» := true }) (const? 8 5) ⊑
-    icmp IntPredicate.eq e (const? 8 10) := by 
+    icmp IntPredicate.eq e (const? 8 10) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -4010,7 +4010,7 @@ theorem negtest_near_pow2_cmpval_ashr_wrong_cmp_pred_thm (e : IntW 8) :
 
 theorem negtest_near_pow2_cmpval_isnt_close_to_pow2_thm (e : IntW 8) :
   icmp IntPredicate.slt (ashr e (const? 8 1) { «exact» := true }) (const? 8 6) ⊑
-    icmp IntPredicate.slt e (const? 8 12) := by 
+    icmp IntPredicate.slt e (const? 8 12) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -4021,7 +4021,7 @@ theorem negtest_near_pow2_cmpval_isnt_close_to_pow2_thm (e : IntW 8) :
 
 theorem negtest_near_pow2_cmpval_would_overflow_into_signbit_thm (e : IntW 8) :
   icmp IntPredicate.ult (ashr e (const? 8 2) { «exact» := true }) (const? 8 33) ⊑
-    icmp IntPredicate.sgt e (const? 8 (-1)) := by 
+    icmp IntPredicate.sgt e (const? 8 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gicmphsignmask_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gicmphsignmask_proof.lean
@@ -10,7 +10,7 @@ set_option linter.unreachableTactic false
 section gicmphsignmask_proof
 theorem cmp_x_and_negp2_with_eq_thm (e : IntW 8) :
   icmp IntPredicate.eq (LLVM.and e (const? 8 (-2))) (const? 8 (-128)) ⊑
-    icmp IntPredicate.slt e (const? 8 (-126)) := by 
+    icmp IntPredicate.slt e (const? 8 (-126)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gicmphsub_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gicmphsub_proof.lean
@@ -10,7 +10,7 @@ set_option linter.unreachableTactic false
 section gicmphsub_proof
 theorem test_nuw_and_unsigned_pred_thm (e : IntW 64) :
   icmp IntPredicate.ult (sub (const? 64 10) e { «nsw» := false, «nuw» := true }) (const? 64 3) ⊑
-    icmp IntPredicate.ugt e (const? 64 7) := by 
+    icmp IntPredicate.ugt e (const? 64 7) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -21,7 +21,7 @@ theorem test_nuw_and_unsigned_pred_thm (e : IntW 64) :
 
 theorem test_nsw_and_signed_pred_thm (e : IntW 64) :
   icmp IntPredicate.sgt (sub (const? 64 3) e { «nsw» := true, «nuw» := false }) (const? 64 10) ⊑
-    icmp IntPredicate.slt e (const? 64 (-7)) := by 
+    icmp IntPredicate.slt e (const? 64 (-7)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -32,7 +32,7 @@ theorem test_nsw_and_signed_pred_thm (e : IntW 64) :
 
 theorem test_nuw_nsw_and_unsigned_pred_thm (e : IntW 64) :
   icmp IntPredicate.ule (sub (const? 64 10) e { «nsw» := true, «nuw» := true }) (const? 64 3) ⊑
-    icmp IntPredicate.ugt e (const? 64 6) := by 
+    icmp IntPredicate.ugt e (const? 64 6) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -43,7 +43,7 @@ theorem test_nuw_nsw_and_unsigned_pred_thm (e : IntW 64) :
 
 theorem test_nuw_nsw_and_signed_pred_thm (e : IntW 64) :
   icmp IntPredicate.slt (sub (const? 64 10) e { «nsw» := true, «nuw» := true }) (const? 64 3) ⊑
-    icmp IntPredicate.ugt e (const? 64 7) := by 
+    icmp IntPredicate.ugt e (const? 64 7) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -54,7 +54,7 @@ theorem test_nuw_nsw_and_signed_pred_thm (e : IntW 64) :
 
 theorem test_negative_nuw_and_signed_pred_thm (e : IntW 64) :
   icmp IntPredicate.slt (sub (const? 64 10) e { «nsw» := false, «nuw» := true }) (const? 64 3) ⊑
-    icmp IntPredicate.ugt e (const? 64 7) := by 
+    icmp IntPredicate.ugt e (const? 64 7) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -65,7 +65,7 @@ theorem test_negative_nuw_and_signed_pred_thm (e : IntW 64) :
 
 theorem test_negative_nsw_and_unsigned_pred_thm (e : IntW 64) :
   icmp IntPredicate.ult (sub (const? 64 10) e { «nsw» := true, «nuw» := false }) (const? 64 3) ⊑
-    icmp IntPredicate.ult (add e (const? 64 (-8))) (const? 64 3) := by 
+    icmp IntPredicate.ult (add e (const? 64 (-8))) (const? 64 3) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -75,7 +75,7 @@ theorem test_negative_nsw_and_unsigned_pred_thm (e : IntW 64) :
 
 
 theorem test_negative_combined_sub_unsigned_overflow_thm (e : IntW 64) :
-  icmp IntPredicate.ult (sub (const? 64 10) e { «nsw» := false, «nuw» := true }) (const? 64 11) ⊑ const? 1 1 := by 
+  icmp IntPredicate.ult (sub (const? 64 10) e { «nsw» := false, «nuw» := true }) (const? 64 11) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -85,7 +85,7 @@ theorem test_negative_combined_sub_unsigned_overflow_thm (e : IntW 64) :
 
 
 theorem test_negative_combined_sub_signed_overflow_thm (e : IntW 8) :
-  icmp IntPredicate.slt (sub (const? 8 127) e { «nsw» := true, «nuw» := false }) (const? 8 (-1)) ⊑ const? 1 0 := by 
+  icmp IntPredicate.slt (sub (const? 8 127) e { «nsw» := true, «nuw» := false }) (const? 8 (-1)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -95,7 +95,7 @@ theorem test_negative_combined_sub_signed_overflow_thm (e : IntW 8) :
 
 
 theorem test_sub_0_Y_eq_0_thm (e : IntW 8) :
-  icmp IntPredicate.eq (sub (const? 8 0) e) (const? 8 0) ⊑ icmp IntPredicate.eq e (const? 8 0) := by 
+  icmp IntPredicate.eq (sub (const? 8 0) e) (const? 8 0) ⊑ icmp IntPredicate.eq e (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -105,7 +105,7 @@ theorem test_sub_0_Y_eq_0_thm (e : IntW 8) :
 
 
 theorem test_sub_0_Y_ne_0_thm (e : IntW 8) :
-  icmp IntPredicate.ne (sub (const? 8 0) e) (const? 8 0) ⊑ icmp IntPredicate.ne e (const? 8 0) := by 
+  icmp IntPredicate.ne (sub (const? 8 0) e) (const? 8 0) ⊑ icmp IntPredicate.ne e (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -115,7 +115,7 @@ theorem test_sub_0_Y_ne_0_thm (e : IntW 8) :
 
 
 theorem test_sub_4_Y_ne_4_thm (e : IntW 8) :
-  icmp IntPredicate.ne (sub (const? 8 4) e) (const? 8 4) ⊑ icmp IntPredicate.ne e (const? 8 0) := by 
+  icmp IntPredicate.ne (sub (const? 8 4) e) (const? 8 4) ⊑ icmp IntPredicate.ne e (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -125,7 +125,7 @@ theorem test_sub_4_Y_ne_4_thm (e : IntW 8) :
 
 
 theorem test_sub_127_Y_eq_127_thm (e : IntW 8) :
-  icmp IntPredicate.eq (sub (const? 8 127) e) (const? 8 127) ⊑ icmp IntPredicate.eq e (const? 8 0) := by 
+  icmp IntPredicate.eq (sub (const? 8 127) e) (const? 8 127) ⊑ icmp IntPredicate.eq e (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -135,7 +135,7 @@ theorem test_sub_127_Y_eq_127_thm (e : IntW 8) :
 
 
 theorem test_sub_255_Y_eq_255_thm (e : IntW 8) :
-  icmp IntPredicate.eq (sub (const? 8 (-1)) e) (const? 8 (-1)) ⊑ icmp IntPredicate.eq e (const? 8 0) := by 
+  icmp IntPredicate.eq (sub (const? 8 (-1)) e) (const? 8 (-1)) ⊑ icmp IntPredicate.eq e (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -146,7 +146,7 @@ theorem test_sub_255_Y_eq_255_thm (e : IntW 8) :
 
 theorem neg_sgt_42_thm (e : IntW 32) :
   icmp IntPredicate.sgt (sub (const? 32 0) e) (const? 32 42) ⊑
-    icmp IntPredicate.slt (add e (const? 32 (-1))) (const? 32 (-43)) := by 
+    icmp IntPredicate.slt (add e (const? 32 (-1))) (const? 32 (-43)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -157,7 +157,7 @@ theorem neg_sgt_42_thm (e : IntW 32) :
 
 theorem neg_slt_42_thm (e : IntW 128) :
   icmp IntPredicate.slt (sub (const? 128 0) e) (const? 128 42) ⊑
-    icmp IntPredicate.sgt (add e (const? 128 (-1))) (const? 128 (-43)) := by 
+    icmp IntPredicate.sgt (add e (const? 128 (-1))) (const? 128 (-43)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -168,7 +168,7 @@ theorem neg_slt_42_thm (e : IntW 128) :
 
 theorem neg_slt_n1_thm (e : IntW 8) :
   icmp IntPredicate.slt (sub (const? 8 0) e) (const? 8 (-1)) ⊑
-    icmp IntPredicate.sgt (add e (const? 8 (-1))) (const? 8 0) := by 
+    icmp IntPredicate.sgt (add e (const? 8 (-1))) (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -179,7 +179,7 @@ theorem neg_slt_n1_thm (e : IntW 8) :
 
 theorem neg_slt_0_thm (e : IntW 8) :
   icmp IntPredicate.slt (sub (const? 8 0) e) (const? 8 0) ⊑
-    icmp IntPredicate.sgt (add e (const? 8 (-1))) (const? 8 (-1)) := by 
+    icmp IntPredicate.sgt (add e (const? 8 (-1))) (const? 8 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -189,7 +189,7 @@ theorem neg_slt_0_thm (e : IntW 8) :
 
 
 theorem neg_slt_1_thm (e : IntW 8) :
-  icmp IntPredicate.slt (sub (const? 8 0) e) (const? 8 1) ⊑ icmp IntPredicate.ult e (const? 8 (-127)) := by 
+  icmp IntPredicate.slt (sub (const? 8 0) e) (const? 8 1) ⊑ icmp IntPredicate.ult e (const? 8 (-127)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -200,7 +200,7 @@ theorem neg_slt_1_thm (e : IntW 8) :
 
 theorem neg_sgt_n1_thm (e : IntW 8) :
   icmp IntPredicate.sgt (sub (const? 8 0) e) (const? 8 (-1)) ⊑
-    icmp IntPredicate.slt (add e (const? 8 (-1))) (const? 8 0) := by 
+    icmp IntPredicate.slt (add e (const? 8 (-1))) (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -210,7 +210,7 @@ theorem neg_sgt_n1_thm (e : IntW 8) :
 
 
 theorem neg_sgt_0_thm (e : IntW 8) :
-  icmp IntPredicate.sgt (sub (const? 8 0) e) (const? 8 0) ⊑ icmp IntPredicate.ugt e (const? 8 (-128)) := by 
+  icmp IntPredicate.sgt (sub (const? 8 0) e) (const? 8 0) ⊑ icmp IntPredicate.ugt e (const? 8 (-128)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -221,7 +221,7 @@ theorem neg_sgt_0_thm (e : IntW 8) :
 
 theorem neg_sgt_1_thm (e : IntW 8) :
   icmp IntPredicate.sgt (sub (const? 8 0) e) (const? 8 1) ⊑
-    icmp IntPredicate.slt (add e (const? 8 (-1))) (const? 8 (-2)) := by 
+    icmp IntPredicate.slt (add e (const? 8 (-1))) (const? 8 (-2)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -232,7 +232,7 @@ theorem neg_sgt_1_thm (e : IntW 8) :
 
 theorem neg_nsw_slt_n1_thm (e : IntW 8) :
   icmp IntPredicate.slt (sub (const? 8 0) e { «nsw» := true, «nuw» := false }) (const? 8 (-1)) ⊑
-    icmp IntPredicate.sgt e (const? 8 1) := by 
+    icmp IntPredicate.sgt e (const? 8 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -243,7 +243,7 @@ theorem neg_nsw_slt_n1_thm (e : IntW 8) :
 
 theorem neg_nsw_slt_0_thm (e : IntW 8) :
   icmp IntPredicate.slt (sub (const? 8 0) e { «nsw» := true, «nuw» := false }) (const? 8 0) ⊑
-    icmp IntPredicate.sgt e (const? 8 0) := by 
+    icmp IntPredicate.sgt e (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -254,7 +254,7 @@ theorem neg_nsw_slt_0_thm (e : IntW 8) :
 
 theorem neg_nsw_slt_1_thm (e : IntW 8) :
   icmp IntPredicate.slt (sub (const? 8 0) e { «nsw» := true, «nuw» := false }) (const? 8 1) ⊑
-    icmp IntPredicate.sgt e (const? 8 (-1)) := by 
+    icmp IntPredicate.sgt e (const? 8 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -265,7 +265,7 @@ theorem neg_nsw_slt_1_thm (e : IntW 8) :
 
 theorem neg_nsw_sgt_n1_thm (e : IntW 8) :
   icmp IntPredicate.sgt (sub (const? 8 0) e { «nsw» := true, «nuw» := false }) (const? 8 (-1)) ⊑
-    icmp IntPredicate.slt e (const? 8 1) := by 
+    icmp IntPredicate.slt e (const? 8 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -276,7 +276,7 @@ theorem neg_nsw_sgt_n1_thm (e : IntW 8) :
 
 theorem neg_nsw_sgt_0_thm (e : IntW 8) :
   icmp IntPredicate.sgt (sub (const? 8 0) e { «nsw» := true, «nuw» := false }) (const? 8 0) ⊑
-    icmp IntPredicate.slt e (const? 8 0) := by 
+    icmp IntPredicate.slt e (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -287,7 +287,7 @@ theorem neg_nsw_sgt_0_thm (e : IntW 8) :
 
 theorem neg_nsw_sgt_1_thm (e : IntW 8) :
   icmp IntPredicate.sgt (sub (const? 8 0) e { «nsw» := true, «nuw» := false }) (const? 8 1) ⊑
-    icmp IntPredicate.slt e (const? 8 (-1)) := by 
+    icmp IntPredicate.slt e (const? 8 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -298,7 +298,7 @@ theorem neg_nsw_sgt_1_thm (e : IntW 8) :
 
 theorem PR60818_ne_thm (e : IntW 32) :
   icmp IntPredicate.ne (sub (const? 32 0) e) e ⊑
-    icmp IntPredicate.ne (LLVM.and e (const? 32 2147483647)) (const? 32 0) := by 
+    icmp IntPredicate.ne (LLVM.and e (const? 32 2147483647)) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -309,7 +309,7 @@ theorem PR60818_ne_thm (e : IntW 32) :
 
 theorem PR60818_eq_thm (e : IntW 32) :
   icmp IntPredicate.eq (sub (const? 32 0) e) e ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 32 2147483647)) (const? 32 0) := by 
+    icmp IntPredicate.eq (LLVM.and e (const? 32 2147483647)) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -320,7 +320,7 @@ theorem PR60818_eq_thm (e : IntW 32) :
 
 theorem PR60818_eq_commuted_thm (e : IntW 32) :
   icmp IntPredicate.eq (mul e (const? 32 43)) (sub (const? 32 0) (mul e (const? 32 43))) ⊑
-    icmp IntPredicate.eq (LLVM.and (mul e (const? 32 43)) (const? 32 2147483647)) (const? 32 0) := by 
+    icmp IntPredicate.eq (LLVM.and (mul e (const? 32 43)) (const? 32 2147483647)) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -330,7 +330,7 @@ theorem PR60818_eq_commuted_thm (e : IntW 32) :
 
 
 theorem PR60818_sgt_thm (e : IntW 32) :
-  icmp IntPredicate.sgt (sub (const? 32 0) e) e ⊑ icmp IntPredicate.slt e (sub (const? 32 0) e) := by 
+  icmp IntPredicate.sgt (sub (const? 32 0) e) e ⊑ icmp IntPredicate.slt e (sub (const? 32 0) e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gicmphtopbitssame_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gicmphtopbitssame_proof.lean
@@ -10,7 +10,7 @@ set_option linter.unreachableTactic false
 section gicmphtopbitssame_proof
 theorem testi16i8_thm (e : IntW 16) :
   icmp IntPredicate.eq (ashr (trunc 8 e) (const? 8 7)) (trunc 8 (lshr e (const? 16 8))) ⊑
-    icmp IntPredicate.ult (add e (const? 16 128)) (const? 16 256) := by 
+    icmp IntPredicate.ult (add e (const? 16 128)) (const? 16 256) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -21,7 +21,7 @@ theorem testi16i8_thm (e : IntW 16) :
 
 theorem testi16i8_com_thm (e : IntW 16) :
   icmp IntPredicate.eq (trunc 8 (lshr e (const? 16 8))) (ashr (trunc 8 e) (const? 8 7)) ⊑
-    icmp IntPredicate.ult (add e (const? 16 128)) (const? 16 256) := by 
+    icmp IntPredicate.ult (add e (const? 16 128)) (const? 16 256) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -32,7 +32,7 @@ theorem testi16i8_com_thm (e : IntW 16) :
 
 theorem testi16i8_ne_thm (e : IntW 16) :
   icmp IntPredicate.ne (ashr (trunc 8 e) (const? 8 7)) (trunc 8 (lshr e (const? 16 8))) ⊑
-    icmp IntPredicate.ult (add e (const? 16 (-128))) (const? 16 (-256)) := by 
+    icmp IntPredicate.ult (add e (const? 16 (-128))) (const? 16 (-256)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -43,7 +43,7 @@ theorem testi16i8_ne_thm (e : IntW 16) :
 
 theorem testi16i8_ne_com_thm (e : IntW 16) :
   icmp IntPredicate.ne (trunc 8 (lshr e (const? 16 8))) (ashr (trunc 8 e) (const? 8 7)) ⊑
-    icmp IntPredicate.ult (add e (const? 16 (-128))) (const? 16 (-256)) := by 
+    icmp IntPredicate.ult (add e (const? 16 (-128))) (const? 16 (-256)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -54,7 +54,7 @@ theorem testi16i8_ne_com_thm (e : IntW 16) :
 
 theorem testi64i32_thm (e : IntW 64) :
   icmp IntPredicate.eq (ashr (trunc 32 e) (const? 32 31)) (trunc 32 (lshr e (const? 64 32))) ⊑
-    icmp IntPredicate.ult (add e (const? 64 2147483648)) (const? 64 4294967296) := by 
+    icmp IntPredicate.ult (add e (const? 64 2147483648)) (const? 64 4294967296) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -65,7 +65,7 @@ theorem testi64i32_thm (e : IntW 64) :
 
 theorem testi64i32_ne_thm (e : IntW 64) :
   icmp IntPredicate.ne (ashr (trunc 32 e) (const? 32 31)) (trunc 32 (lshr e (const? 64 32))) ⊑
-    icmp IntPredicate.ult (add e (const? 64 (-2147483648))) (const? 64 (-4294967296)) := by 
+    icmp IntPredicate.ult (add e (const? 64 (-2147483648))) (const? 64 (-4294967296)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -77,7 +77,7 @@ theorem testi64i32_ne_thm (e : IntW 64) :
 theorem wrongimm2_thm (e : IntW 16) :
   icmp IntPredicate.eq (ashr (trunc 8 e) (const? 8 6)) (trunc 8 (lshr e (const? 16 8))) ⊑
     icmp IntPredicate.eq (ashr (trunc 8 e) (const? 8 6))
-      (trunc 8 (lshr e (const? 16 8)) { «nsw» := false, «nuw» := true }) := by 
+      (trunc 8 (lshr e (const? 16 8)) { «nsw» := false, «nuw» := true }) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -89,7 +89,7 @@ theorem wrongimm2_thm (e : IntW 16) :
 theorem slt_thm (e : IntW 64) :
   icmp IntPredicate.slt (ashr (trunc 32 e) (const? 32 31)) (trunc 32 (lshr e (const? 64 32))) ⊑
     icmp IntPredicate.slt (ashr (trunc 32 e) (const? 32 31))
-      (trunc 32 (lshr e (const? 64 32)) { «nsw» := false, «nuw» := true }) := by 
+      (trunc 32 (lshr e (const? 64 32)) { «nsw» := false, «nuw» := true }) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gicmphtrunc_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gicmphtrunc_proof.lean
@@ -10,7 +10,7 @@ set_option linter.unreachableTactic false
 section gicmphtrunc_proof
 theorem ult_2_thm (e : IntW 32) :
   icmp IntPredicate.ult (trunc 8 e) (const? 8 2) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 32 254)) (const? 32 0) := by 
+    icmp IntPredicate.eq (LLVM.and e (const? 32 254)) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -21,7 +21,7 @@ theorem ult_2_thm (e : IntW 32) :
 
 theorem ult_192_thm (e : IntW 32) :
   icmp IntPredicate.ult (trunc 8 e) (const? 8 (-64)) ⊑
-    icmp IntPredicate.ne (LLVM.and e (const? 32 192)) (const? 32 192) := by 
+    icmp IntPredicate.ne (LLVM.and e (const? 32 192)) (const? 32 192) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -32,7 +32,7 @@ theorem ult_192_thm (e : IntW 32) :
 
 theorem ugt_3_thm (e : IntW 32) :
   icmp IntPredicate.ugt (trunc 8 e) (const? 8 3) ⊑
-    icmp IntPredicate.ne (LLVM.and e (const? 32 252)) (const? 32 0) := by 
+    icmp IntPredicate.ne (LLVM.and e (const? 32 252)) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -43,7 +43,7 @@ theorem ugt_3_thm (e : IntW 32) :
 
 theorem ugt_253_thm (e : IntW 32) :
   icmp IntPredicate.ugt (trunc 8 e) (const? 8 (-3)) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 32 254)) (const? 32 254) := by 
+    icmp IntPredicate.eq (LLVM.and e (const? 32 254)) (const? 32 254) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -54,7 +54,7 @@ theorem ugt_253_thm (e : IntW 32) :
 
 theorem slt_0_thm (e : IntW 32) :
   icmp IntPredicate.slt (trunc 8 e) (const? 8 0) ⊑
-    icmp IntPredicate.ne (LLVM.and e (const? 32 128)) (const? 32 0) := by 
+    icmp IntPredicate.ne (LLVM.and e (const? 32 128)) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -65,7 +65,7 @@ theorem slt_0_thm (e : IntW 32) :
 
 theorem sgt_n1_thm (e : IntW 32) :
   icmp IntPredicate.sgt (trunc 8 e) (const? 8 (-1)) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 32 128)) (const? 32 0) := by 
+    icmp IntPredicate.eq (LLVM.and e (const? 32 128)) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -75,7 +75,7 @@ theorem sgt_n1_thm (e : IntW 32) :
 
 
 theorem shl1_trunc_eq0_thm (e : IntW 32) :
-  icmp IntPredicate.eq (trunc 16 (shl (const? 32 1) e)) (const? 16 0) ⊑ icmp IntPredicate.ugt e (const? 32 15) := by 
+  icmp IntPredicate.eq (trunc 16 (shl (const? 32 1) e)) (const? 16 0) ⊑ icmp IntPredicate.ugt e (const? 32 15) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -86,7 +86,7 @@ theorem shl1_trunc_eq0_thm (e : IntW 32) :
 
 theorem shl1_trunc_sgt0_thm (e : IntW 9) :
   icmp IntPredicate.sgt (trunc 6 (shl (const? 9 1) e)) (const? 6 0) ⊑
-    icmp IntPredicate.sgt (trunc 6 (shl (const? 9 1) e { «nsw» := false, «nuw» := true })) (const? 6 0) := by 
+    icmp IntPredicate.sgt (trunc 6 (shl (const? 9 1) e { «nsw» := false, «nuw» := true })) (const? 6 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -97,7 +97,7 @@ theorem shl1_trunc_sgt0_thm (e : IntW 9) :
 
 theorem shl1_trunc_sgt4_thm (e : IntW 32) :
   icmp IntPredicate.sgt (trunc 16 (shl (const? 32 1) e)) (const? 16 4) ⊑
-    icmp IntPredicate.sgt (trunc 16 (shl (const? 32 1) e { «nsw» := false, «nuw» := true })) (const? 16 4) := by 
+    icmp IntPredicate.sgt (trunc 16 (shl (const? 32 1) e { «nsw» := false, «nuw» := true })) (const? 16 4) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gicmphugehofhnothofhshlhalloneshbyhbitshandhvalhtohicmpheqhofhlshrhvalhbyhbitshandh0_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gicmphugehofhnothofhshlhalloneshbyhbitshandhvalhtohicmpheqhofhlshrhvalhbyhbitshandh0_proof.lean
@@ -10,7 +10,7 @@ set_option linter.unreachableTactic false
 section gicmphugehofhnothofhshlhalloneshbyhbitshandhvalhtohicmpheqhofhlshrhvalhbyhbitshandh0_proof
 theorem p0_thm (e e_1 : IntW 8) :
   icmp IntPredicate.uge (LLVM.xor (shl (const? 8 (-1)) e_1) (const? 8 (-1))) e ⊑
-    icmp IntPredicate.eq (lshr e e_1) (const? 8 0) := by 
+    icmp IntPredicate.eq (lshr e e_1) (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -23,7 +23,7 @@ theorem both_thm (e e_1 : IntW 8) :
   icmp IntPredicate.uge (LLVM.xor (shl (const? 8 (-1)) e_1) (const? 8 (-1)))
       (LLVM.xor (shl (const? 8 (-1)) e) (const? 8 (-1))) ⊑
     icmp IntPredicate.ule (shl (const? 8 (-1)) e_1 { «nsw» := true, «nuw» := false })
-      (shl (const? 8 (-1)) e { «nsw» := true, «nuw» := false }) := by 
+      (shl (const? 8 (-1)) e { «nsw» := true, «nuw» := false }) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -34,7 +34,7 @@ theorem both_thm (e e_1 : IntW 8) :
 
 theorem n0_thm (e e_1 : IntW 8) :
   icmp IntPredicate.uge (LLVM.xor (shl (const? 8 1) e_1) (const? 8 (-1))) e ⊑
-    icmp IntPredicate.ule e (LLVM.xor (shl (const? 8 1) e_1 { «nsw» := false, «nuw» := true }) (const? 8 (-1))) := by 
+    icmp IntPredicate.ule e (LLVM.xor (shl (const? 8 1) e_1 { «nsw» := false, «nuw» := true }) (const? 8 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -45,7 +45,7 @@ theorem n0_thm (e e_1 : IntW 8) :
 
 theorem n1_thm (e e_1 : IntW 8) :
   icmp IntPredicate.uge (LLVM.xor (shl (const? 8 (-1)) e_1) (const? 8 1)) e ⊑
-    icmp IntPredicate.uge (LLVM.xor (shl (const? 8 (-1)) e_1 { «nsw» := true, «nuw» := false }) (const? 8 1)) e := by 
+    icmp IntPredicate.uge (LLVM.xor (shl (const? 8 (-1)) e_1 { «nsw» := true, «nuw» := false }) (const? 8 1)) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -57,7 +57,7 @@ theorem n1_thm (e e_1 : IntW 8) :
 theorem n3_thm (e e_1 : IntW 8) :
   icmp IntPredicate.ugt (LLVM.xor (shl (const? 8 (-1)) e_1) (const? 8 (-1))) e ⊑
     icmp IntPredicate.ult e
-      (LLVM.xor (shl (const? 8 (-1)) e_1 { «nsw» := true, «nuw» := false }) (const? 8 (-1))) := by 
+      (LLVM.xor (shl (const? 8 (-1)) e_1 { «nsw» := true, «nuw» := false }) (const? 8 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gicmphugthofhshlh1hbyhbitshandhvalhtohicmpheqhofhlshrhvalhbyhbitshandh0_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gicmphugthofhshlh1hbyhbitshandhvalhtohicmpheqhofhlshrhvalhbyhbitshandh0_proof.lean
@@ -9,7 +9,7 @@ set_option linter.unreachableTactic false
 
 section gicmphugthofhshlh1hbyhbitshandhvalhtohicmpheqhofhlshrhvalhbyhbitshandh0_proof
 theorem p0_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.ugt (shl (const? 8 1) e_1) e ⊑ icmp IntPredicate.eq (lshr e e_1) (const? 8 0) := by 
+  icmp IntPredicate.ugt (shl (const? 8 1) e_1) e ⊑ icmp IntPredicate.eq (lshr e e_1) (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -20,7 +20,7 @@ theorem p0_thm (e e_1 : IntW 8) :
 
 theorem both_thm (e e_1 : IntW 8) :
   icmp IntPredicate.ugt (shl (const? 8 1) e_1) (shl (const? 8 1) e) ⊑
-    icmp IntPredicate.eq (lshr (shl (const? 8 1) e { «nsw» := false, «nuw» := true }) e_1) (const? 8 0) := by 
+    icmp IntPredicate.eq (lshr (shl (const? 8 1) e { «nsw» := false, «nuw» := true }) e_1) (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -31,7 +31,7 @@ theorem both_thm (e e_1 : IntW 8) :
 
 theorem n2_thm (e e_1 : IntW 8) :
   icmp IntPredicate.uge (shl (const? 8 1) e_1) e ⊑
-    icmp IntPredicate.uge (shl (const? 8 1) e_1 { «nsw» := false, «nuw» := true }) e := by 
+    icmp IntPredicate.uge (shl (const? 8 1) e_1 { «nsw» := false, «nuw» := true }) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gicmphulehofhshlh1hbyhbitshandhvalhtohicmphnehofhlshrhvalhbyhbitshandh0_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gicmphulehofhshlh1hbyhbitshandhvalhtohicmphnehofhlshrhvalhbyhbitshandh0_proof.lean
@@ -9,7 +9,7 @@ set_option linter.unreachableTactic false
 
 section gicmphulehofhshlh1hbyhbitshandhvalhtohicmphnehofhlshrhvalhbyhbitshandh0_proof
 theorem p0_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.ule (shl (const? 8 1) e_1) e ⊑ icmp IntPredicate.ne (lshr e e_1) (const? 8 0) := by 
+  icmp IntPredicate.ule (shl (const? 8 1) e_1) e ⊑ icmp IntPredicate.ne (lshr e e_1) (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -20,7 +20,7 @@ theorem p0_thm (e e_1 : IntW 8) :
 
 theorem both_thm (e e_1 : IntW 8) :
   icmp IntPredicate.ule (shl (const? 8 1) e_1) (shl (const? 8 1) e) ⊑
-    icmp IntPredicate.ne (lshr (shl (const? 8 1) e { «nsw» := false, «nuw» := true }) e_1) (const? 8 0) := by 
+    icmp IntPredicate.ne (lshr (shl (const? 8 1) e { «nsw» := false, «nuw» := true }) e_1) (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -31,7 +31,7 @@ theorem both_thm (e e_1 : IntW 8) :
 
 theorem n2_thm (e e_1 : IntW 8) :
   icmp IntPredicate.ult (shl (const? 8 1) e_1) e ⊑
-    icmp IntPredicate.ult (shl (const? 8 1) e_1 { «nsw» := false, «nuw» := true }) e := by 
+    icmp IntPredicate.ult (shl (const? 8 1) e_1 { «nsw» := false, «nuw» := true }) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gicmphulthofhnothofhshlhalloneshbyhbitshandhvalhtohicmphnehofhlshrhvalhbyhbitshandh0_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gicmphulthofhnothofhshlhalloneshbyhbitshandhvalhtohicmphnehofhlshrhvalhbyhbitshandh0_proof.lean
@@ -10,7 +10,7 @@ set_option linter.unreachableTactic false
 section gicmphulthofhnothofhshlhalloneshbyhbitshandhvalhtohicmphnehofhlshrhvalhbyhbitshandh0_proof
 theorem p0_thm (e e_1 : IntW 8) :
   icmp IntPredicate.ult (LLVM.xor (shl (const? 8 (-1)) e_1) (const? 8 (-1))) e ⊑
-    icmp IntPredicate.ne (lshr e e_1) (const? 8 0) := by 
+    icmp IntPredicate.ne (lshr e e_1) (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -23,7 +23,7 @@ theorem both_thm (e e_1 : IntW 8) :
   icmp IntPredicate.ult (LLVM.xor (shl (const? 8 (-1)) e_1) (const? 8 (-1)))
       (LLVM.xor (shl (const? 8 (-1)) e) (const? 8 (-1))) ⊑
     icmp IntPredicate.ugt (shl (const? 8 (-1)) e_1 { «nsw» := true, «nuw» := false })
-      (shl (const? 8 (-1)) e { «nsw» := true, «nuw» := false }) := by 
+      (shl (const? 8 (-1)) e { «nsw» := true, «nuw» := false }) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -34,7 +34,7 @@ theorem both_thm (e e_1 : IntW 8) :
 
 theorem n0_thm (e e_1 : IntW 8) :
   icmp IntPredicate.ult (LLVM.xor (shl (const? 8 1) e_1) (const? 8 (-1))) e ⊑
-    icmp IntPredicate.ugt e (LLVM.xor (shl (const? 8 1) e_1 { «nsw» := false, «nuw» := true }) (const? 8 (-1))) := by 
+    icmp IntPredicate.ugt e (LLVM.xor (shl (const? 8 1) e_1 { «nsw» := false, «nuw» := true }) (const? 8 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -45,7 +45,7 @@ theorem n0_thm (e e_1 : IntW 8) :
 
 theorem n1_thm (e e_1 : IntW 8) :
   icmp IntPredicate.ult (LLVM.xor (shl (const? 8 (-1)) e_1) (const? 8 1)) e ⊑
-    icmp IntPredicate.ult (LLVM.xor (shl (const? 8 (-1)) e_1 { «nsw» := true, «nuw» := false }) (const? 8 1)) e := by 
+    icmp IntPredicate.ult (LLVM.xor (shl (const? 8 (-1)) e_1 { «nsw» := true, «nuw» := false }) (const? 8 1)) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -57,7 +57,7 @@ theorem n1_thm (e e_1 : IntW 8) :
 theorem n3_thm (e e_1 : IntW 8) :
   icmp IntPredicate.ule (LLVM.xor (shl (const? 8 (-1)) e_1) (const? 8 (-1))) e ⊑
     icmp IntPredicate.uge e
-      (LLVM.xor (shl (const? 8 (-1)) e_1 { «nsw» := true, «nuw» := false }) (const? 8 (-1))) := by 
+      (LLVM.xor (shl (const? 8 (-1)) e_1 { «nsw» := true, «nuw» := false }) (const? 8 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gicmphwithhselects_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gicmphwithhselects_proof.lean
@@ -9,7 +9,7 @@ set_option linter.unreachableTactic false
 
 section gicmphwithhselects_proof
 theorem both_sides_fold_slt_thm (e : IntW 32) (e_1 : IntW 1) :
-  icmp IntPredicate.slt (select e_1 (const? 32 9) e) (select e_1 (const? 32 1) e) ⊑ const? 1 0 := by 
+  icmp IntPredicate.slt (select e_1 (const? 32 9) e) (select e_1 (const? 32 1) e) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -19,7 +19,7 @@ theorem both_sides_fold_slt_thm (e : IntW 32) (e_1 : IntW 1) :
 
 
 theorem both_sides_fold_eq_thm (e : IntW 32) (e_1 : IntW 1) :
-  icmp IntPredicate.eq (select e_1 (const? 32 9) e) (select e_1 (const? 32 1) e) ⊑ LLVM.xor e_1 (const? 1 1) := by 
+  icmp IntPredicate.eq (select e_1 (const? 32 9) e) (select e_1 (const? 32 1) e) ⊑ LLVM.xor e_1 (const? 1 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -30,7 +30,7 @@ theorem both_sides_fold_eq_thm (e : IntW 32) (e_1 : IntW 1) :
 
 theorem one_side_fold_slt_thm (e e_1 e_2 : IntW 32) (e_3 : IntW 1) :
   icmp IntPredicate.slt (select e_3 e_2 e_1) (select e_3 e e_1) ⊑
-    select e_3 (icmp IntPredicate.slt e_2 e) (const? 1 0) := by 
+    select e_3 (icmp IntPredicate.slt e_2 e) (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -41,7 +41,7 @@ theorem one_side_fold_slt_thm (e e_1 e_2 : IntW 32) (e_3 : IntW 1) :
 
 theorem one_side_fold_sgt_thm (e e_1 e_2 : IntW 32) (e_3 : IntW 1) :
   icmp IntPredicate.sgt (select e_3 e_2 e_1) (select e_3 e_2 e) ⊑
-    select (LLVM.xor e_3 (const? 1 1)) (icmp IntPredicate.sgt e_1 e) (const? 1 0) := by 
+    select (LLVM.xor e_3 (const? 1 1)) (icmp IntPredicate.sgt e_1 e) (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -52,7 +52,7 @@ theorem one_side_fold_sgt_thm (e e_1 e_2 : IntW 32) (e_3 : IntW 1) :
 
 theorem one_side_fold_eq_thm (e e_1 e_2 : IntW 32) (e_3 : IntW 1) :
   icmp IntPredicate.eq (select e_3 e_2 e_1) (select e_3 e e_1) ⊑
-    select (LLVM.xor e_3 (const? 1 1)) (const? 1 1) (icmp IntPredicate.eq e_2 e) := by 
+    select (LLVM.xor e_3 (const? 1 1)) (const? 1 1) (icmp IntPredicate.eq e_2 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gicmphxorhsignbit_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gicmphxorhsignbit_proof.lean
@@ -10,7 +10,7 @@ set_option linter.unreachableTactic false
 section gicmphxorhsignbit_proof
 theorem slt_to_ult_thm (e e_1 : IntW 8) :
   icmp IntPredicate.slt (LLVM.xor e_1 (const? 8 (-128))) (LLVM.xor e (const? 8 (-128))) ⊑
-    icmp IntPredicate.ult e_1 e := by 
+    icmp IntPredicate.ult e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -21,7 +21,7 @@ theorem slt_to_ult_thm (e e_1 : IntW 8) :
 
 theorem ult_to_slt_thm (e e_1 : IntW 8) :
   icmp IntPredicate.ult (LLVM.xor e_1 (const? 8 (-128))) (LLVM.xor e (const? 8 (-128))) ⊑
-    icmp IntPredicate.slt e_1 e := by 
+    icmp IntPredicate.slt e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -31,7 +31,7 @@ theorem ult_to_slt_thm (e e_1 : IntW 8) :
 
 
 theorem slt_to_ugt_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.slt (LLVM.xor e_1 (const? 8 127)) (LLVM.xor e (const? 8 127)) ⊑ icmp IntPredicate.ugt e_1 e := by 
+  icmp IntPredicate.slt (LLVM.xor e_1 (const? 8 127)) (LLVM.xor e (const? 8 127)) ⊑ icmp IntPredicate.ugt e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -41,7 +41,7 @@ theorem slt_to_ugt_thm (e e_1 : IntW 8) :
 
 
 theorem ult_to_sgt_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.ult (LLVM.xor e_1 (const? 8 127)) (LLVM.xor e (const? 8 127)) ⊑ icmp IntPredicate.sgt e_1 e := by 
+  icmp IntPredicate.ult (LLVM.xor e_1 (const? 8 127)) (LLVM.xor e (const? 8 127)) ⊑ icmp IntPredicate.sgt e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -52,7 +52,7 @@ theorem ult_to_sgt_thm (e e_1 : IntW 8) :
 
 theorem sge_to_ugt_thm (e : IntW 8) :
   icmp IntPredicate.sge (LLVM.xor e (const? 8 (-128))) (const? 8 15) ⊑
-    icmp IntPredicate.ugt e (const? 8 (-114)) := by 
+    icmp IntPredicate.ugt e (const? 8 (-114)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -63,7 +63,7 @@ theorem sge_to_ugt_thm (e : IntW 8) :
 
 theorem uge_to_sgt_thm (e : IntW 8) :
   icmp IntPredicate.uge (LLVM.xor e (const? 8 (-128))) (const? 8 15) ⊑
-    icmp IntPredicate.sgt e (const? 8 (-114)) := by 
+    icmp IntPredicate.sgt e (const? 8 (-114)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -73,7 +73,7 @@ theorem uge_to_sgt_thm (e : IntW 8) :
 
 
 theorem sge_to_ult_thm (e : IntW 8) :
-  icmp IntPredicate.sge (LLVM.xor e (const? 8 127)) (const? 8 15) ⊑ icmp IntPredicate.ult e (const? 8 113) := by 
+  icmp IntPredicate.sge (LLVM.xor e (const? 8 127)) (const? 8 15) ⊑ icmp IntPredicate.ult e (const? 8 113) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -83,7 +83,7 @@ theorem sge_to_ult_thm (e : IntW 8) :
 
 
 theorem uge_to_slt_thm (e : IntW 8) :
-  icmp IntPredicate.uge (LLVM.xor e (const? 8 127)) (const? 8 15) ⊑ icmp IntPredicate.slt e (const? 8 113) := by 
+  icmp IntPredicate.uge (LLVM.xor e (const? 8 127)) (const? 8 15) ⊑ icmp IntPredicate.slt e (const? 8 113) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -94,7 +94,7 @@ theorem uge_to_slt_thm (e : IntW 8) :
 
 theorem slt_zero_eq_i1_thm (e : IntW 32) (e_1 : IntW 1) :
   icmp IntPredicate.eq (zext 32 e_1) (lshr e (const? 32 31)) ⊑
-    LLVM.xor (icmp IntPredicate.sgt e (const? 32 (-1))) e_1 := by 
+    LLVM.xor (icmp IntPredicate.sgt e (const? 32 (-1))) e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -105,7 +105,7 @@ theorem slt_zero_eq_i1_thm (e : IntW 32) (e_1 : IntW 1) :
 
 theorem slt_zero_eq_i1_fail_thm (e : IntW 32) (e_1 : IntW 1) :
   icmp IntPredicate.eq (zext 32 e_1) (ashr e (const? 32 31)) ⊑
-    icmp IntPredicate.eq (ashr e (const? 32 31)) (zext 32 e_1) := by 
+    icmp IntPredicate.eq (ashr e (const? 32 31)) (zext 32 e_1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -116,7 +116,7 @@ theorem slt_zero_eq_i1_fail_thm (e : IntW 32) (e_1 : IntW 1) :
 
 theorem slt_zero_eq_ne_0_thm (e : IntW 32) :
   icmp IntPredicate.eq (zext 32 (icmp IntPredicate.ne e (const? 32 0))) (lshr e (const? 32 31)) ⊑
-    icmp IntPredicate.slt e (const? 32 1) := by 
+    icmp IntPredicate.slt e (const? 32 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -127,7 +127,7 @@ theorem slt_zero_eq_ne_0_thm (e : IntW 32) :
 
 theorem slt_zero_ne_ne_0_thm (e : IntW 32) :
   icmp IntPredicate.ne (zext 32 (icmp IntPredicate.ne e (const? 32 0))) (lshr e (const? 32 31)) ⊑
-    icmp IntPredicate.sgt e (const? 32 0) := by 
+    icmp IntPredicate.sgt e (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -138,7 +138,7 @@ theorem slt_zero_ne_ne_0_thm (e : IntW 32) :
 
 theorem slt_zero_ne_ne_b_thm (e e_1 : IntW 32) :
   icmp IntPredicate.ne (zext 32 (icmp IntPredicate.ne e_1 e)) (lshr e_1 (const? 32 31)) ⊑
-    LLVM.xor (icmp IntPredicate.slt e_1 (const? 32 0)) (icmp IntPredicate.ne e_1 e) := by 
+    LLVM.xor (icmp IntPredicate.slt e_1 (const? 32 0)) (icmp IntPredicate.ne e_1 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -149,7 +149,7 @@ theorem slt_zero_ne_ne_b_thm (e e_1 : IntW 32) :
 
 theorem slt_zero_eq_ne_0_fail1_thm (e : IntW 32) :
   icmp IntPredicate.eq (zext 32 (icmp IntPredicate.ne e (const? 32 0))) (ashr e (const? 32 31)) ⊑
-    icmp IntPredicate.eq (ashr e (const? 32 31)) (zext 32 (icmp IntPredicate.ne e (const? 32 0))) := by 
+    icmp IntPredicate.eq (ashr e (const? 32 31)) (zext 32 (icmp IntPredicate.ne e (const? 32 0))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -160,7 +160,7 @@ theorem slt_zero_eq_ne_0_fail1_thm (e : IntW 32) :
 
 theorem slt_zero_eq_ne_0_fail2_thm (e : IntW 32) :
   icmp IntPredicate.eq (zext 32 (icmp IntPredicate.ne e (const? 32 0))) (lshr e (const? 32 30)) ⊑
-    icmp IntPredicate.eq (lshr e (const? 32 30)) (zext 32 (icmp IntPredicate.ne e (const? 32 0))) := by 
+    icmp IntPredicate.eq (lshr e (const? 32 30)) (zext 32 (icmp IntPredicate.ne e (const? 32 0))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gintegerhroundhuphpow2halignment_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gintegerhroundhuphpow2halignment_proof.lean
@@ -11,7 +11,7 @@ section gintegerhroundhuphpow2halignment_proof
 theorem t0_thm (e : IntW 8) :
   select (icmp IntPredicate.eq (LLVM.and e (const? 8 15)) (const? 8 0)) e
       (LLVM.and (add e (const? 8 16)) (const? 8 (-16))) ⊑
-    LLVM.and (add e (const? 8 15)) (const? 8 (-16)) := by 
+    LLVM.and (add e (const? 8 15)) (const? 8 (-16)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -23,7 +23,7 @@ theorem t0_thm (e : IntW 8) :
 theorem t1_thm (e : IntW 8) :
   select (icmp IntPredicate.eq (LLVM.and e (const? 8 31)) (const? 8 0)) e
       (LLVM.and (add e (const? 8 32)) (const? 8 (-32))) ⊑
-    LLVM.and (add e (const? 8 31)) (const? 8 (-32)) := by 
+    LLVM.and (add e (const? 8 31)) (const? 8 (-32)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -35,7 +35,7 @@ theorem t1_thm (e : IntW 8) :
 theorem t2_thm (e : IntW 8) :
   select (icmp IntPredicate.eq (LLVM.and e (const? 8 15)) (const? 8 0)) e
       (LLVM.and (add e (const? 8 15)) (const? 8 (-16))) ⊑
-    LLVM.and (add e (const? 8 15)) (const? 8 (-16)) := by 
+    LLVM.and (add e (const? 8 15)) (const? 8 (-16)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -48,7 +48,7 @@ theorem n9_wrong_x0_thm (e e_1 : IntW 8) :
   select (icmp IntPredicate.eq (LLVM.and e_1 (const? 8 15)) (const? 8 0)) e
       (LLVM.and (add e_1 (const? 8 16)) (const? 8 (-16))) ⊑
     select (icmp IntPredicate.eq (LLVM.and e_1 (const? 8 15)) (const? 8 0)) e
-      (add (LLVM.and e_1 (const? 8 (-16))) (const? 8 16)) := by 
+      (add (LLVM.and e_1 (const? 8 (-16))) (const? 8 16)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -61,7 +61,7 @@ theorem n9_wrong_x1_thm (e e_1 : IntW 8) :
   select (icmp IntPredicate.eq (LLVM.and e_1 (const? 8 15)) (const? 8 0)) e_1
       (LLVM.and (add e (const? 8 16)) (const? 8 (-16))) ⊑
     select (icmp IntPredicate.eq (LLVM.and e_1 (const? 8 15)) (const? 8 0)) e_1
-      (add (LLVM.and e (const? 8 (-16))) (const? 8 16)) := by 
+      (add (LLVM.and e (const? 8 (-16))) (const? 8 16)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -74,7 +74,7 @@ theorem n9_wrong_x2_thm (e e_1 : IntW 8) :
   select (icmp IntPredicate.eq (LLVM.and e_1 (const? 8 15)) (const? 8 0)) e
       (LLVM.and (add e (const? 8 16)) (const? 8 (-16))) ⊑
     select (icmp IntPredicate.eq (LLVM.and e_1 (const? 8 15)) (const? 8 0)) e
-      (add (LLVM.and e (const? 8 (-16))) (const? 8 16)) := by 
+      (add (LLVM.and e (const? 8 (-16))) (const? 8 16)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -87,7 +87,7 @@ theorem n10_wrong_low_bit_mask_thm (e : IntW 8) :
   select (icmp IntPredicate.eq (LLVM.and e (const? 8 31)) (const? 8 0)) e
       (LLVM.and (add e (const? 8 16)) (const? 8 (-16))) ⊑
     select (icmp IntPredicate.eq (LLVM.and e (const? 8 31)) (const? 8 0)) e
-      (add (LLVM.and e (const? 8 (-16))) (const? 8 16)) := by 
+      (add (LLVM.and e (const? 8 (-16))) (const? 8 16)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -100,7 +100,7 @@ theorem n12_wrong_bias_thm (e : IntW 8) :
   select (icmp IntPredicate.eq (LLVM.and e (const? 8 15)) (const? 8 0)) e
       (LLVM.and (add e (const? 8 32)) (const? 8 (-16))) ⊑
     select (icmp IntPredicate.eq (LLVM.and e (const? 8 15)) (const? 8 0)) e
-      (add (LLVM.and e (const? 8 (-16))) (const? 8 32)) := by 
+      (add (LLVM.and e (const? 8 (-16))) (const? 8 32)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -113,7 +113,7 @@ theorem n14_wrong_comparison_constant_thm (e : IntW 8) :
   select (icmp IntPredicate.eq (LLVM.and e (const? 8 15)) (const? 8 1)) e
       (LLVM.and (add e (const? 8 16)) (const? 8 (-16))) ⊑
     select (icmp IntPredicate.eq (LLVM.and e (const? 8 15)) (const? 8 1)) e
-      (add (LLVM.and e (const? 8 (-16))) (const? 8 16)) := by 
+      (add (LLVM.and e (const? 8 (-16))) (const? 8 16)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -126,7 +126,7 @@ theorem n15_wrong_comparison_predicate_and_constant_thm (e : IntW 8) :
   select (icmp IntPredicate.ult (LLVM.and e (const? 8 15)) (const? 8 2)) e
       (LLVM.and (add e (const? 8 16)) (const? 8 (-16))) ⊑
     select (icmp IntPredicate.eq (LLVM.and e (const? 8 14)) (const? 8 0)) e
-      (add (LLVM.and e (const? 8 (-16))) (const? 8 16)) := by 
+      (add (LLVM.and e (const? 8 (-16))) (const? 8 16)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/ginverthvariablehmaskhinhmaskedhmergehscalar_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/ginverthvariablehmaskhinhmaskedhmergehscalar_proof.lean
@@ -10,7 +10,7 @@ set_option linter.unreachableTactic false
 section ginverthvariablehmaskhinhmaskedhmergehscalar_proof
 theorem scalar_thm (e e_1 e_2 : IntW 4) :
   LLVM.xor (LLVM.and (LLVM.xor e_2 e_1) (LLVM.xor e (const? 4 (-1)))) e_1 ⊑
-    LLVM.xor (LLVM.and (LLVM.xor e_2 e_1) e) e_2 := by 
+    LLVM.xor (LLVM.and (LLVM.xor e_2 e_1) e) e_2 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -21,7 +21,7 @@ theorem scalar_thm (e e_1 e_2 : IntW 4) :
 
 theorem in_constant_varx_mone_invmask_thm (e e_1 : IntW 4) :
   LLVM.xor (LLVM.and (LLVM.xor e_1 (const? 4 (-1))) (LLVM.xor e (const? 4 (-1)))) (const? 4 (-1)) ⊑
-    LLVM.or e_1 e := by 
+    LLVM.or e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -32,7 +32,7 @@ theorem in_constant_varx_mone_invmask_thm (e e_1 : IntW 4) :
 
 theorem in_constant_varx_6_invmask_thm (e e_1 : IntW 4) :
   LLVM.xor (LLVM.and (LLVM.xor e_1 (const? 4 6)) (LLVM.xor e (const? 4 (-1)))) (const? 4 6) ⊑
-    LLVM.xor (LLVM.and (LLVM.xor e_1 (const? 4 6)) e) e_1 := by 
+    LLVM.xor (LLVM.and (LLVM.xor e_1 (const? 4 6)) e) e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -43,7 +43,7 @@ theorem in_constant_varx_6_invmask_thm (e e_1 : IntW 4) :
 
 theorem in_constant_mone_vary_invmask_thm (e e_1 : IntW 4) :
   LLVM.xor (LLVM.and (LLVM.xor (const? 4 (-1)) e_1) (LLVM.xor e (const? 4 (-1)))) e_1 ⊑
-    LLVM.or e_1 (LLVM.xor e (const? 4 (-1))) := by 
+    LLVM.or e_1 (LLVM.xor e (const? 4 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -54,7 +54,7 @@ theorem in_constant_mone_vary_invmask_thm (e e_1 : IntW 4) :
 
 theorem in_constant_6_vary_invmask_thm (e e_1 : IntW 4) :
   LLVM.xor (LLVM.and (LLVM.xor e_1 (const? 4 6)) (LLVM.xor e (const? 4 (-1)))) e_1 ⊑
-    LLVM.xor (LLVM.and (LLVM.xor e_1 (const? 4 6)) e) (const? 4 6) := by 
+    LLVM.xor (LLVM.and (LLVM.xor e_1 (const? 4 6)) e) (const? 4 6) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -65,7 +65,7 @@ theorem in_constant_6_vary_invmask_thm (e e_1 : IntW 4) :
 
 theorem c_1_0_0_thm (e e_1 e_2 : IntW 4) :
   LLVM.xor (LLVM.and (LLVM.xor e_2 e_1) (LLVM.xor e (const? 4 (-1)))) e_2 ⊑
-    LLVM.xor (LLVM.and (LLVM.xor e_2 e_1) e) e_1 := by 
+    LLVM.xor (LLVM.and (LLVM.xor e_2 e_1) e) e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -76,7 +76,7 @@ theorem c_1_0_0_thm (e e_1 e_2 : IntW 4) :
 
 theorem c_0_1_0_thm (e e_1 e_2 : IntW 4) :
   LLVM.xor (LLVM.and (LLVM.xor e_2 e_1) (LLVM.xor e (const? 4 (-1)))) e_2 ⊑
-    LLVM.xor (LLVM.and (LLVM.xor e_2 e_1) e) e_1 := by 
+    LLVM.xor (LLVM.and (LLVM.xor e_2 e_1) e) e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -87,7 +87,7 @@ theorem c_0_1_0_thm (e e_1 e_2 : IntW 4) :
 
 theorem c_1_1_0_thm (e e_1 e_2 : IntW 4) :
   LLVM.xor (LLVM.and (LLVM.xor e_2 e_1) (LLVM.xor e (const? 4 (-1)))) e_1 ⊑
-    LLVM.xor (LLVM.and (LLVM.xor e_2 e_1) e) e_2 := by 
+    LLVM.xor (LLVM.and (LLVM.xor e_2 e_1) e) e_2 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -98,7 +98,7 @@ theorem c_1_1_0_thm (e e_1 e_2 : IntW 4) :
 
 theorem commutativity_constant_varx_6_invmask_thm (e e_1 : IntW 4) :
   LLVM.xor (LLVM.and (LLVM.xor e_1 (const? 4 (-1))) (LLVM.xor e (const? 4 6))) (const? 4 6) ⊑
-    LLVM.xor (LLVM.and (LLVM.xor e (const? 4 6)) e_1) e := by 
+    LLVM.xor (LLVM.and (LLVM.xor e (const? 4 6)) e_1) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -109,7 +109,7 @@ theorem commutativity_constant_varx_6_invmask_thm (e e_1 : IntW 4) :
 
 theorem commutativity_constant_6_vary_invmask_thm (e e_1 : IntW 4) :
   LLVM.xor (LLVM.and (LLVM.xor e_1 (const? 4 (-1))) (LLVM.xor e (const? 4 6))) e ⊑
-    LLVM.xor (LLVM.and (LLVM.xor e (const? 4 6)) e_1) (const? 4 6) := by 
+    LLVM.xor (LLVM.and (LLVM.xor e (const? 4 6)) e_1) (const? 4 6) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gknownhsignbithshift_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gknownhsignbithshift_proof.lean
@@ -10,7 +10,7 @@ set_option linter.unreachableTactic false
 section gknownhsignbithshift_proof
 theorem test_shift_nonnegative_thm (e : IntW 32) :
   icmp IntPredicate.sge (shl (lshr e (const? 32 2)) (const? 32 3) { «nsw» := true, «nuw» := false }) (const? 32 0) ⊑
-    const? 1 1 := by 
+    const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -23,7 +23,7 @@ theorem test_shift_negative_thm (e e_1 : IntW 32) :
   icmp IntPredicate.slt
       (shl (LLVM.or e_1 (const? 32 (-2147483648))) (LLVM.and e (const? 32 7)) { «nsw» := true, «nuw» := false })
       (const? 32 0) ⊑
-    const? 1 1 := by 
+    const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/glogicalhselecthinseltpoison_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/glogicalhselecthinseltpoison_proof.lean
@@ -11,7 +11,7 @@ section glogicalhselecthinseltpoison_proof
 theorem foo_thm (e e_1 e_2 e_3 : IntW 32) :
   LLVM.or (LLVM.and e_3 (sext 32 (icmp IntPredicate.slt e_2 e_1)))
       (LLVM.and e (LLVM.xor (sext 32 (icmp IntPredicate.slt e_2 e_1)) (const? 32 (-1)))) ⊑
-    select (icmp IntPredicate.slt e_2 e_1) e_3 e := by 
+    select (icmp IntPredicate.slt e_2 e_1) e_3 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -23,7 +23,7 @@ theorem foo_thm (e e_1 e_2 e_3 : IntW 32) :
 theorem bar_thm (e e_1 e_2 e_3 : IntW 32) :
   LLVM.or (LLVM.and e_3 (LLVM.xor (sext 32 (icmp IntPredicate.slt e_2 e_1)) (const? 32 (-1))))
       (LLVM.and e (sext 32 (icmp IntPredicate.slt e_2 e_1))) ⊑
-    select (icmp IntPredicate.slt e_2 e_1) e e_3 := by 
+    select (icmp IntPredicate.slt e_2 e_1) e e_3 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -35,7 +35,7 @@ theorem bar_thm (e e_1 e_2 e_3 : IntW 32) :
 theorem goo_thm (e e_1 e_2 e_3 : IntW 32) :
   LLVM.or (LLVM.and (select (icmp IntPredicate.slt e_3 e_2) (const? 32 (-1)) (const? 32 0)) e_1)
       (LLVM.and (LLVM.xor (select (icmp IntPredicate.slt e_3 e_2) (const? 32 (-1)) (const? 32 0)) (const? 32 (-1))) e) ⊑
-    select (icmp IntPredicate.slt e_3 e_2) e_1 e := by 
+    select (icmp IntPredicate.slt e_3 e_2) e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -47,7 +47,7 @@ theorem goo_thm (e e_1 e_2 e_3 : IntW 32) :
 theorem poo_thm (e e_1 e_2 e_3 : IntW 32) :
   LLVM.or (LLVM.and (select (icmp IntPredicate.slt e_3 e_2) (const? 32 (-1)) (const? 32 0)) e_1)
       (LLVM.and (select (icmp IntPredicate.slt e_3 e_2) (const? 32 0) (const? 32 (-1))) e) ⊑
-    select (icmp IntPredicate.slt e_3 e_2) e_1 e := by 
+    select (icmp IntPredicate.slt e_3 e_2) e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -60,7 +60,7 @@ theorem fold_inverted_icmp_preds_thm (e e_1 e_2 e_3 : IntW 32) :
   LLVM.or (select (icmp IntPredicate.slt e_3 e_2) e_1 (const? 32 0))
       (select (icmp IntPredicate.sge e_3 e_2) e (const? 32 0)) ⊑
     LLVM.or (select (icmp IntPredicate.slt e_3 e_2) e_1 (const? 32 0))
-      (select (icmp IntPredicate.slt e_3 e_2) (const? 32 0) e) := by 
+      (select (icmp IntPredicate.slt e_3 e_2) (const? 32 0) e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -73,7 +73,7 @@ theorem fold_inverted_icmp_preds_reverse_thm (e e_1 e_2 e_3 : IntW 32) :
   LLVM.or (select (icmp IntPredicate.slt e_3 e_2) (const? 32 0) e_1)
       (select (icmp IntPredicate.sge e_3 e_2) (const? 32 0) e) ⊑
     LLVM.or (select (icmp IntPredicate.slt e_3 e_2) (const? 32 0) e_1)
-      (select (icmp IntPredicate.slt e_3 e_2) e (const? 32 0)) := by 
+      (select (icmp IntPredicate.slt e_3 e_2) e (const? 32 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -85,7 +85,7 @@ theorem fold_inverted_icmp_preds_reverse_thm (e e_1 e_2 e_3 : IntW 32) :
 theorem par_thm (e e_1 e_2 e_3 : IntW 32) :
   LLVM.or (LLVM.and (select (icmp IntPredicate.slt e_3 e_2) (const? 32 (-1)) (const? 32 0)) e_1)
       (LLVM.and (LLVM.xor (select (icmp IntPredicate.slt e_3 e_2) (const? 32 (-1)) (const? 32 0)) (const? 32 (-1))) e) ⊑
-    select (icmp IntPredicate.slt e_3 e_2) e_1 e := by 
+    select (icmp IntPredicate.slt e_3 e_2) e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -95,7 +95,7 @@ theorem par_thm (e e_1 e_2 e_3 : IntW 32) :
 
 
 theorem bools_thm (e e_1 e_2 : IntW 1) :
-  LLVM.or (LLVM.and (LLVM.xor e_2 (const? 1 1)) e_1) (LLVM.and e_2 e) ⊑ select e_2 e e_1 := by 
+  LLVM.or (LLVM.and (LLVM.xor e_2 (const? 1 1)) e_1) (LLVM.and e_2 e) ⊑ select e_2 e e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -106,7 +106,7 @@ theorem bools_thm (e e_1 e_2 : IntW 1) :
 
 theorem bools_logical_thm (e e_1 e_2 : IntW 1) :
   select (select (LLVM.xor e_2 (const? 1 1)) e_1 (const? 1 0)) (const? 1 1) (select e_2 e (const? 1 0)) ⊑
-    select e_2 e e_1 := by 
+    select e_2 e e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -118,7 +118,7 @@ theorem bools_logical_thm (e e_1 e_2 : IntW 1) :
 theorem bools_multi_uses1_thm (e e_1 e_2 : IntW 1) :
   LLVM.xor (LLVM.or (LLVM.and (LLVM.xor e_2 (const? 1 1)) e_1) (LLVM.and e_2 e))
       (LLVM.and (LLVM.xor e_2 (const? 1 1)) e_1) ⊑
-    LLVM.xor (select e_2 e e_1) (LLVM.and e_1 (LLVM.xor e_2 (const? 1 1))) := by 
+    LLVM.xor (select e_2 e e_1) (LLVM.and e_1 (LLVM.xor e_2 (const? 1 1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -130,7 +130,7 @@ theorem bools_multi_uses1_thm (e e_1 e_2 : IntW 1) :
 theorem bools_multi_uses1_logical_thm (e e_1 e_2 : IntW 1) :
   LLVM.xor (select (select (LLVM.xor e_2 (const? 1 1)) e_1 (const? 1 0)) (const? 1 1) (select e_2 e (const? 1 0)))
       (select (LLVM.xor e_2 (const? 1 1)) e_1 (const? 1 0)) ⊑
-    LLVM.xor (select e_2 e e_1) (select (LLVM.xor e_2 (const? 1 1)) e_1 (const? 1 0)) := by 
+    LLVM.xor (select e_2 e e_1) (select (LLVM.xor e_2 (const? 1 1)) e_1 (const? 1 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -142,7 +142,7 @@ theorem bools_multi_uses1_logical_thm (e e_1 e_2 : IntW 1) :
 theorem bools_multi_uses2_thm (e e_1 e_2 : IntW 1) :
   LLVM.and (LLVM.or (LLVM.and (LLVM.xor e_2 (const? 1 1)) e_1) (LLVM.and e_2 e))
       (add (LLVM.and (LLVM.xor e_2 (const? 1 1)) e_1) (LLVM.and e_2 e)) ⊑
-    select e_2 e e_1 := by 
+    select e_2 e e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -155,7 +155,7 @@ theorem bools_multi_uses2_logical_thm (e e_1 e_2 : IntW 1) :
   select (select (select (LLVM.xor e_2 (const? 1 1)) e_1 (const? 1 0)) (const? 1 1) (select e_2 e (const? 1 0)))
       (add (select (LLVM.xor e_2 (const? 1 1)) e_1 (const? 1 0)) (select e_2 e (const? 1 0))) (const? 1 0) ⊑
     select (select e_2 e e_1)
-      (LLVM.xor (select (LLVM.xor e_2 (const? 1 1)) e_1 (const? 1 0)) (select e_2 e (const? 1 0))) (const? 1 0) := by 
+      (LLVM.xor (select (LLVM.xor e_2 (const? 1 1)) e_1 (const? 1 0)) (select e_2 e (const? 1 0))) (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -167,7 +167,7 @@ theorem bools_multi_uses2_logical_thm (e e_1 e_2 : IntW 1) :
 theorem allSignBits_thm (e e_1 e_2 : IntW 32) :
   LLVM.or (LLVM.and e_2 (ashr e_1 (const? 32 31))) (LLVM.and (LLVM.xor (ashr e_1 (const? 32 31)) (const? 32 (-1))) e) ⊑
     LLVM.or (select (icmp IntPredicate.slt e_1 (const? 32 0)) e_2 (const? 32 0))
-      (select (icmp IntPredicate.slt e_1 (const? 32 0)) (const? 32 0) e) := by 
+      (select (icmp IntPredicate.slt e_1 (const? 32 0)) (const? 32 0) e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/glowhbithsplat_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/glowhbithsplat_proof.lean
@@ -10,7 +10,7 @@ set_option linter.unreachableTactic false
 section glowhbithsplat_proof
 theorem t0_thm (e : IntW 8) :
   ashr (shl e (const? 8 7)) (const? 8 7) ⊑
-    sub (const? 8 0) (LLVM.and e (const? 8 1)) { «nsw» := true, «nuw» := false } := by 
+    sub (const? 8 0) (LLVM.and e (const? 8 1)) { «nsw» := true, «nuw» := false } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -21,7 +21,7 @@ theorem t0_thm (e : IntW 8) :
 
 theorem t1_otherbitwidth_thm (e : IntW 16) :
   ashr (shl e (const? 16 15)) (const? 16 15) ⊑
-    sub (const? 16 0) (LLVM.and e (const? 16 1)) { «nsw» := true, «nuw» := false } := by 
+    sub (const? 16 0) (LLVM.and e (const? 16 1)) { «nsw» := true, «nuw» := false } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -31,7 +31,7 @@ theorem t1_otherbitwidth_thm (e : IntW 16) :
 
 
 theorem n11_thm (e : IntW 8) :
-  ashr (shl e (const? 8 7)) (const? 8 6) ⊑ ashr (shl e (const? 8 7)) (const? 8 6) { «exact» := true } := by 
+  ashr (shl e (const? 8 7)) (const? 8 6) ⊑ ashr (shl e (const? 8 7)) (const? 8 6) { «exact» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -41,7 +41,7 @@ theorem n11_thm (e : IntW 8) :
 
 
 theorem n12_thm (e : IntW 8) :
-  ashr (shl e (const? 8 6)) (const? 8 6) ⊑ ashr (shl e (const? 8 6)) (const? 8 6) { «exact» := true } := by 
+  ashr (shl e (const? 8 6)) (const? 8 6) ⊑ ashr (shl e (const? 8 6)) (const? 8 6) { «exact» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/glshr_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/glshr_proof.lean
@@ -9,7 +9,7 @@ set_option linter.unreachableTactic false
 
 section glshr_proof
 theorem lshr_exact_thm (e : IntW 8) :
-  lshr (add (shl e (const? 8 2)) (const? 8 4)) (const? 8 2) ⊑ LLVM.and (add e (const? 8 1)) (const? 8 63) := by 
+  lshr (add (shl e (const? 8 2)) (const? 8 4)) (const? 8 2) ⊑ LLVM.and (add e (const? 8 1)) (const? 8 63) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -19,7 +19,7 @@ theorem lshr_exact_thm (e : IntW 8) :
 
 
 theorem shl_add_thm (e e_1 : IntW 8) :
-  lshr (add (shl e_1 (const? 8 2)) e) (const? 8 2) ⊑ LLVM.and (add (lshr e (const? 8 2)) e_1) (const? 8 63) := by 
+  lshr (add (shl e_1 (const? 8 2)) e) (const? 8 2) ⊑ LLVM.and (add (lshr e (const? 8 2)) e_1) (const? 8 63) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -28,7 +28,7 @@ theorem shl_add_thm (e e_1 : IntW 8) :
     all_goals sorry
 
 
-theorem bool_zext_thm (e : IntW 1) : lshr (sext 16 e) (const? 16 15) ⊑ zext 16 e := by 
+theorem bool_zext_thm (e : IntW 1) : lshr (sext 16 e) (const? 16 15) ⊑ zext 16 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -37,7 +37,7 @@ theorem bool_zext_thm (e : IntW 1) : lshr (sext 16 e) (const? 16 15) ⊑ zext 16
     all_goals sorry
 
 
-theorem smear_sign_and_widen_thm (e : IntW 8) : lshr (sext 32 e) (const? 32 24) ⊑ zext 32 (ashr e (const? 8 7)) := by 
+theorem smear_sign_and_widen_thm (e : IntW 8) : lshr (sext 32 e) (const? 32 24) ⊑ zext 32 (ashr e (const? 8 7)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -47,7 +47,7 @@ theorem smear_sign_and_widen_thm (e : IntW 8) : lshr (sext 32 e) (const? 32 24) 
 
 
 theorem fake_sext_thm (e : IntW 3) :
-  lshr (sext 18 e) (const? 18 17) ⊑ zext 18 (lshr e (const? 3 2)) { «nneg» := true } := by 
+  lshr (sext 18 e) (const? 18 17) ⊑ zext 18 (lshr e (const? 3 2)) { «nneg» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -57,7 +57,7 @@ theorem fake_sext_thm (e : IntW 3) :
 
 
 theorem mul_splat_fold_thm (e : IntW 32) :
-  lshr (mul e (const? 32 65537) { «nsw» := false, «nuw» := true }) (const? 32 16) ⊑ e := by 
+  lshr (mul e (const? 32 65537) { «nsw» := false, «nuw» := true }) (const? 32 16) ⊑ e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -69,7 +69,7 @@ theorem mul_splat_fold_thm (e : IntW 32) :
 theorem shl_add_lshr_flag_preservation_thm (e e_1 e_2 : IntW 32) :
   lshr (add (shl e_2 e_1 { «nsw» := false, «nuw» := true }) e { «nsw» := true, «nuw» := true }) e_1
       { «exact» := true } ⊑
-    add (lshr e e_1 { «exact» := true }) e_2 { «nsw» := true, «nuw» := true } := by 
+    add (lshr e e_1 { «exact» := true }) e_2 { «nsw» := true, «nuw» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -80,7 +80,7 @@ theorem shl_add_lshr_flag_preservation_thm (e e_1 e_2 : IntW 32) :
 
 theorem shl_add_lshr_thm (e e_1 e_2 : IntW 32) :
   lshr (add (shl e_2 e_1 { «nsw» := false, «nuw» := true }) e { «nsw» := false, «nuw» := true }) e_1 ⊑
-    add (lshr e e_1) e_2 { «nsw» := false, «nuw» := true } := by 
+    add (lshr e e_1) e_2 { «nsw» := false, «nuw» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -91,7 +91,7 @@ theorem shl_add_lshr_thm (e e_1 e_2 : IntW 32) :
 
 theorem shl_add_lshr_comm_thm (e e_1 e_2 : IntW 32) :
   lshr (add (mul e_2 e_2) (shl e_1 e { «nsw» := false, «nuw» := true }) { «nsw» := false, «nuw» := true }) e ⊑
-    add (lshr (mul e_2 e_2) e) e_1 { «nsw» := false, «nuw» := true } := by 
+    add (lshr (mul e_2 e_2) e) e_1 { «nsw» := false, «nuw» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -103,7 +103,7 @@ theorem shl_add_lshr_comm_thm (e e_1 e_2 : IntW 32) :
 theorem shl_sub_lshr_thm (e e_1 e_2 : IntW 32) :
   lshr (sub (shl e_2 e_1 { «nsw» := false, «nuw» := true }) e { «nsw» := true, «nuw» := true }) e_1
       { «exact» := true } ⊑
-    sub e_2 (lshr e e_1 { «exact» := true }) { «nsw» := true, «nuw» := true } := by 
+    sub e_2 (lshr e e_1 { «exact» := true }) { «nsw» := true, «nuw» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -114,7 +114,7 @@ theorem shl_sub_lshr_thm (e e_1 e_2 : IntW 32) :
 
 theorem shl_sub_lshr_reverse_thm (e e_1 e_2 : IntW 32) :
   lshr (sub e_2 (shl e_1 e { «nsw» := false, «nuw» := true }) { «nsw» := true, «nuw» := true }) e { «exact» := true } ⊑
-    sub (lshr e_2 e { «exact» := true }) e_1 { «nsw» := true, «nuw» := true } := by 
+    sub (lshr e_2 e { «exact» := true }) e_1 { «nsw» := true, «nuw» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -125,7 +125,7 @@ theorem shl_sub_lshr_reverse_thm (e e_1 e_2 : IntW 32) :
 
 theorem shl_sub_lshr_reverse_no_nsw_thm (e e_1 e_2 : IntW 32) :
   lshr (sub e_2 (shl e_1 e { «nsw» := false, «nuw» := true }) { «nsw» := false, «nuw» := true }) e { «exact» := true } ⊑
-    sub (lshr e_2 e { «exact» := true }) e_1 { «nsw» := false, «nuw» := true } := by 
+    sub (lshr e_2 e { «exact» := true }) e_1 { «nsw» := false, «nuw» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -136,7 +136,7 @@ theorem shl_sub_lshr_reverse_no_nsw_thm (e e_1 e_2 : IntW 32) :
 
 theorem shl_sub_lshr_reverse_nsw_on_op1_thm (e e_1 e_2 : IntW 32) :
   lshr (sub e_2 (shl e_1 e { «nsw» := true, «nuw» := true }) { «nsw» := false, «nuw» := true }) e { «exact» := true } ⊑
-    sub (lshr e_2 e { «exact» := true }) e_1 { «nsw» := false, «nuw» := true } := by 
+    sub (lshr e_2 e { «exact» := true }) e_1 { «nsw» := false, «nuw» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -146,7 +146,7 @@ theorem shl_sub_lshr_reverse_nsw_on_op1_thm (e e_1 e_2 : IntW 32) :
 
 
 theorem shl_or_lshr_thm (e e_1 e_2 : IntW 32) :
-  lshr (LLVM.or (shl e_2 e_1 { «nsw» := false, «nuw» := true }) e) e_1 ⊑ LLVM.or (lshr e e_1) e_2 := by 
+  lshr (LLVM.or (shl e_2 e_1 { «nsw» := false, «nuw» := true }) e) e_1 ⊑ LLVM.or (lshr e e_1) e_2 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -157,7 +157,7 @@ theorem shl_or_lshr_thm (e e_1 e_2 : IntW 32) :
 
 theorem shl_or_disjoint_lshr_thm (e e_1 e_2 : IntW 32) :
   lshr (LLVM.or (shl e_2 e_1 { «nsw» := false, «nuw» := true }) e { «disjoint» := true }) e_1 ⊑
-    LLVM.or (lshr e e_1) e_2 { «disjoint» := true } := by 
+    LLVM.or (lshr e e_1) e_2 { «disjoint» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -167,7 +167,7 @@ theorem shl_or_disjoint_lshr_thm (e e_1 e_2 : IntW 32) :
 
 
 theorem shl_or_lshr_comm_thm (e e_1 e_2 : IntW 32) :
-  lshr (LLVM.or e_2 (shl e_1 e { «nsw» := false, «nuw» := true })) e ⊑ LLVM.or (lshr e_2 e) e_1 := by 
+  lshr (LLVM.or e_2 (shl e_1 e { «nsw» := false, «nuw» := true })) e ⊑ LLVM.or (lshr e_2 e) e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -178,7 +178,7 @@ theorem shl_or_lshr_comm_thm (e e_1 e_2 : IntW 32) :
 
 theorem shl_or_disjoint_lshr_comm_thm (e e_1 e_2 : IntW 32) :
   lshr (LLVM.or e_2 (shl e_1 e { «nsw» := false, «nuw» := true }) { «disjoint» := true }) e ⊑
-    LLVM.or (lshr e_2 e) e_1 { «disjoint» := true } := by 
+    LLVM.or (lshr e_2 e) e_1 { «disjoint» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -188,7 +188,7 @@ theorem shl_or_disjoint_lshr_comm_thm (e e_1 e_2 : IntW 32) :
 
 
 theorem shl_xor_lshr_thm (e e_1 e_2 : IntW 32) :
-  lshr (LLVM.xor (shl e_2 e_1 { «nsw» := false, «nuw» := true }) e) e_1 ⊑ LLVM.xor (lshr e e_1) e_2 := by 
+  lshr (LLVM.xor (shl e_2 e_1 { «nsw» := false, «nuw» := true }) e) e_1 ⊑ LLVM.xor (lshr e e_1) e_2 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -198,7 +198,7 @@ theorem shl_xor_lshr_thm (e e_1 e_2 : IntW 32) :
 
 
 theorem shl_xor_lshr_comm_thm (e e_1 e_2 : IntW 32) :
-  lshr (LLVM.xor e_2 (shl e_1 e { «nsw» := false, «nuw» := true })) e ⊑ LLVM.xor (lshr e_2 e) e_1 := by 
+  lshr (LLVM.xor e_2 (shl e_1 e { «nsw» := false, «nuw» := true })) e ⊑ LLVM.xor (lshr e_2 e) e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -208,7 +208,7 @@ theorem shl_xor_lshr_comm_thm (e e_1 e_2 : IntW 32) :
 
 
 theorem shl_and_lshr_thm (e e_1 e_2 : IntW 32) :
-  lshr (LLVM.and (shl e_2 e_1 { «nsw» := false, «nuw» := true }) e) e_1 ⊑ LLVM.and (lshr e e_1) e_2 := by 
+  lshr (LLVM.and (shl e_2 e_1 { «nsw» := false, «nuw» := true }) e) e_1 ⊑ LLVM.and (lshr e e_1) e_2 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -218,7 +218,7 @@ theorem shl_and_lshr_thm (e e_1 e_2 : IntW 32) :
 
 
 theorem shl_and_lshr_comm_thm (e e_1 e_2 : IntW 32) :
-  lshr (LLVM.and e_2 (shl e_1 e { «nsw» := false, «nuw» := true })) e ⊑ LLVM.and (lshr e_2 e) e_1 := by 
+  lshr (LLVM.and e_2 (shl e_1 e { «nsw» := false, «nuw» := true })) e ⊑ LLVM.and (lshr e_2 e) e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -229,7 +229,7 @@ theorem shl_and_lshr_comm_thm (e e_1 e_2 : IntW 32) :
 
 theorem shl_lshr_and_exact_thm (e e_1 e_2 : IntW 32) :
   lshr (LLVM.and (shl e_2 e_1 { «nsw» := false, «nuw» := true }) e) e_1 { «exact» := true } ⊑
-    LLVM.and (lshr e e_1) e_2 := by 
+    LLVM.and (lshr e e_1) e_2 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -240,7 +240,7 @@ theorem shl_lshr_and_exact_thm (e e_1 e_2 : IntW 32) :
 
 theorem mul_splat_fold_no_nuw_thm (e : IntW 32) :
   lshr (mul e (const? 32 65537) { «nsw» := true, «nuw» := false }) (const? 32 16) ⊑
-    add e (lshr e (const? 32 16)) { «nsw» := true, «nuw» := false } := by 
+    add e (lshr e (const? 32 16)) { «nsw» := true, «nuw» := false } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -250,7 +250,7 @@ theorem mul_splat_fold_no_nuw_thm (e : IntW 32) :
 
 
 theorem mul_splat_fold_too_narrow_thm (e : IntW 2) :
-  lshr (mul e (const? 2 (-2)) { «nsw» := false, «nuw» := true }) (const? 2 1) ⊑ e := by 
+  lshr (mul e (const? 2 (-2)) { «nsw» := false, «nuw» := true }) (const? 2 1) ⊑ e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -260,7 +260,7 @@ theorem mul_splat_fold_too_narrow_thm (e : IntW 2) :
 
 
 theorem negative_and_odd_thm (e : IntW 32) :
-  lshr (LLVM.srem e (const? 32 2)) (const? 32 31) ⊑ LLVM.and (lshr e (const? 32 31)) e := by 
+  lshr (LLVM.srem e (const? 32 2)) (const? 32 31) ⊑ LLVM.and (lshr e (const? 32 31)) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -271,7 +271,7 @@ theorem negative_and_odd_thm (e : IntW 32) :
 
 theorem trunc_sandwich_thm (e : IntW 32) :
   lshr (trunc 12 (lshr e (const? 32 28))) (const? 12 2) ⊑
-    trunc 12 (lshr e (const? 32 30)) { «nsw» := true, «nuw» := true } := by 
+    trunc 12 (lshr e (const? 32 30)) { «nsw» := true, «nuw» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -282,7 +282,7 @@ theorem trunc_sandwich_thm (e : IntW 32) :
 
 theorem trunc_sandwich_min_shift1_thm (e : IntW 32) :
   lshr (trunc 12 (lshr e (const? 32 20))) (const? 12 1) ⊑
-    trunc 12 (lshr e (const? 32 21)) { «nsw» := true, «nuw» := true } := by 
+    trunc 12 (lshr e (const? 32 21)) { «nsw» := true, «nuw» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -293,7 +293,7 @@ theorem trunc_sandwich_min_shift1_thm (e : IntW 32) :
 
 theorem trunc_sandwich_small_shift1_thm (e : IntW 32) :
   lshr (trunc 12 (lshr e (const? 32 19))) (const? 12 1) ⊑
-    LLVM.and (trunc 12 (lshr e (const? 32 20)) { «nsw» := false, «nuw» := true }) (const? 12 2047) := by 
+    LLVM.and (trunc 12 (lshr e (const? 32 20)) { «nsw» := false, «nuw» := true }) (const? 12 2047) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -304,7 +304,7 @@ theorem trunc_sandwich_small_shift1_thm (e : IntW 32) :
 
 theorem trunc_sandwich_max_sum_shift_thm (e : IntW 32) :
   lshr (trunc 12 (lshr e (const? 32 20))) (const? 12 11) ⊑
-    trunc 12 (lshr e (const? 32 31)) { «nsw» := true, «nuw» := true } := by 
+    trunc 12 (lshr e (const? 32 31)) { «nsw» := true, «nuw» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -315,7 +315,7 @@ theorem trunc_sandwich_max_sum_shift_thm (e : IntW 32) :
 
 theorem trunc_sandwich_max_sum_shift2_thm (e : IntW 32) :
   lshr (trunc 12 (lshr e (const? 32 30))) (const? 12 1) ⊑
-    trunc 12 (lshr e (const? 32 31)) { «nsw» := true, «nuw» := true } := by 
+    trunc 12 (lshr e (const? 32 31)) { «nsw» := true, «nuw» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -324,7 +324,7 @@ theorem trunc_sandwich_max_sum_shift2_thm (e : IntW 32) :
     all_goals sorry
 
 
-theorem trunc_sandwich_big_sum_shift1_thm (e : IntW 32) : lshr (trunc 12 (lshr e (const? 32 21))) (const? 12 11) ⊑ const? 12 0 := by 
+theorem trunc_sandwich_big_sum_shift1_thm (e : IntW 32) : lshr (trunc 12 (lshr e (const? 32 21))) (const? 12 11) ⊑ const? 12 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -333,7 +333,7 @@ theorem trunc_sandwich_big_sum_shift1_thm (e : IntW 32) : lshr (trunc 12 (lshr e
     all_goals sorry
 
 
-theorem trunc_sandwich_big_sum_shift2_thm (e : IntW 32) : lshr (trunc 12 (lshr e (const? 32 31))) (const? 12 1) ⊑ const? 12 0 := by 
+theorem trunc_sandwich_big_sum_shift2_thm (e : IntW 32) : lshr (trunc 12 (lshr e (const? 32 31))) (const? 12 1) ⊑ const? 12 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -342,7 +342,7 @@ theorem trunc_sandwich_big_sum_shift2_thm (e : IntW 32) : lshr (trunc 12 (lshr e
     all_goals sorry
 
 
-theorem lshr_sext_i1_to_i16_thm (e : IntW 1) : lshr (sext 16 e) (const? 16 4) ⊑ select e (const? 16 4095) (const? 16 0) := by 
+theorem lshr_sext_i1_to_i16_thm (e : IntW 1) : lshr (sext 16 e) (const? 16 4) ⊑ select e (const? 16 4095) (const? 16 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -352,7 +352,7 @@ theorem lshr_sext_i1_to_i16_thm (e : IntW 1) : lshr (sext 16 e) (const? 16 4) �
 
 
 theorem lshr_sext_i1_to_i128_thm (e : IntW 1) :
-  lshr (sext 128 e) (const? 128 42) ⊑ select e (const? 128 77371252455336267181195263) (const? 128 0) := by 
+  lshr (sext 128 e) (const? 128 42) ⊑ select e (const? 128 77371252455336267181195263) (const? 128 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -361,7 +361,7 @@ theorem lshr_sext_i1_to_i128_thm (e : IntW 1) :
     all_goals sorry
 
 
-theorem icmp_ule_thm (e e_1 : IntW 32) : icmp IntPredicate.ule (lshr e_1 e) e_1 ⊑ const? 1 1 := by 
+theorem icmp_ule_thm (e e_1 : IntW 32) : icmp IntPredicate.ule (lshr e_1 e) e_1 ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -370,7 +370,7 @@ theorem icmp_ule_thm (e e_1 : IntW 32) : icmp IntPredicate.ule (lshr e_1 e) e_1 
     all_goals sorry
 
 
-theorem icmp_ugt_thm (e e_1 : IntW 32) : icmp IntPredicate.ugt (lshr e_1 e) e_1 ⊑ const? 1 0 := by 
+theorem icmp_ugt_thm (e e_1 : IntW 32) : icmp IntPredicate.ugt (lshr e_1 e) e_1 ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -380,7 +380,7 @@ theorem icmp_ugt_thm (e e_1 : IntW 32) : icmp IntPredicate.ugt (lshr e_1 e) e_1 
 
 
 theorem not_signbit_thm (e : IntW 8) :
-  lshr (LLVM.xor e (const? 8 (-1))) (const? 8 7) ⊑ zext 8 (icmp IntPredicate.sgt e (const? 8 (-1))) := by 
+  lshr (LLVM.xor e (const? 8 (-1))) (const? 8 7) ⊑ zext 8 (icmp IntPredicate.sgt e (const? 8 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -390,7 +390,7 @@ theorem not_signbit_thm (e : IntW 8) :
 
 
 theorem not_signbit_alt_xor_thm (e : IntW 8) :
-  lshr (LLVM.xor e (const? 8 (-2))) (const? 8 7) ⊑ zext 8 (icmp IntPredicate.sgt e (const? 8 (-1))) := by 
+  lshr (LLVM.xor e (const? 8 (-2))) (const? 8 7) ⊑ zext 8 (icmp IntPredicate.sgt e (const? 8 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -401,7 +401,7 @@ theorem not_signbit_alt_xor_thm (e : IntW 8) :
 
 theorem not_signbit_zext_thm (e : IntW 16) :
   zext 32 (lshr (LLVM.xor e (const? 16 (-1))) (const? 16 15)) ⊑
-    zext 32 (icmp IntPredicate.sgt e (const? 16 (-1))) := by 
+    zext 32 (icmp IntPredicate.sgt e (const? 16 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -412,7 +412,7 @@ theorem not_signbit_zext_thm (e : IntW 16) :
 
 theorem not_signbit_trunc_thm (e : IntW 16) :
   trunc 8 (lshr (LLVM.xor e (const? 16 (-1))) (const? 16 15)) ⊑
-    zext 8 (icmp IntPredicate.sgt e (const? 16 (-1))) := by 
+    zext 8 (icmp IntPredicate.sgt e (const? 16 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -422,7 +422,7 @@ theorem not_signbit_trunc_thm (e : IntW 16) :
 
 
 theorem bool_add_lshr_thm (e e_1 : IntW 1) :
-  lshr (add (zext 2 e_1) (zext 2 e)) (const? 2 1) ⊑ zext 2 (LLVM.and e_1 e) := by 
+  lshr (add (zext 2 e_1) (zext 2 e)) (const? 2 1) ⊑ zext 2 (LLVM.and e_1 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -433,7 +433,7 @@ theorem bool_add_lshr_thm (e e_1 : IntW 1) :
 
 theorem not_bool_add_lshr_thm (e e_1 : IntW 2) :
   lshr (add (zext 4 e_1) (zext 4 e)) (const? 4 2) ⊑
-    zext 4 (icmp IntPredicate.ugt e (LLVM.xor e_1 (const? 2 (-1)))) := by 
+    zext 4 (icmp IntPredicate.ugt e (LLVM.xor e_1 (const? 2 (-1)))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -444,7 +444,7 @@ theorem not_bool_add_lshr_thm (e e_1 : IntW 2) :
 
 theorem bool_add_ashr_thm (e e_1 : IntW 1) :
   ashr (add (zext 2 e_1) (zext 2 e)) (const? 2 1) ⊑
-    ashr (add (zext 2 e_1) (zext 2 e) { «nsw» := false, «nuw» := true }) (const? 2 1) := by 
+    ashr (add (zext 2 e_1) (zext 2 e) { «nsw» := false, «nuw» := true }) (const? 2 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/glshrhandhnegChicmpeqhzero_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/glshrhandhnegChicmpeqhzero_proof.lean
@@ -10,7 +10,7 @@ set_option linter.unreachableTactic false
 section glshrhandhnegChicmpeqhzero_proof
 theorem scalar_i8_lshr_and_negC_eq_thm (e e_1 : IntW 8) :
   icmp IntPredicate.eq (LLVM.and (lshr e_1 e) (const? 8 (-4))) (const? 8 0) ⊑
-    icmp IntPredicate.ult (lshr e_1 e) (const? 8 4) := by 
+    icmp IntPredicate.ult (lshr e_1 e) (const? 8 4) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -21,7 +21,7 @@ theorem scalar_i8_lshr_and_negC_eq_thm (e e_1 : IntW 8) :
 
 theorem scalar_i16_lshr_and_negC_eq_thm (e e_1 : IntW 16) :
   icmp IntPredicate.eq (LLVM.and (lshr e_1 e) (const? 16 (-128))) (const? 16 0) ⊑
-    icmp IntPredicate.ult (lshr e_1 e) (const? 16 128) := by 
+    icmp IntPredicate.ult (lshr e_1 e) (const? 16 128) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -32,7 +32,7 @@ theorem scalar_i16_lshr_and_negC_eq_thm (e e_1 : IntW 16) :
 
 theorem scalar_i32_lshr_and_negC_eq_thm (e e_1 : IntW 32) :
   icmp IntPredicate.eq (LLVM.and (lshr e_1 e) (const? 32 (-262144))) (const? 32 0) ⊑
-    icmp IntPredicate.ult (lshr e_1 e) (const? 32 262144) := by 
+    icmp IntPredicate.ult (lshr e_1 e) (const? 32 262144) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -43,7 +43,7 @@ theorem scalar_i32_lshr_and_negC_eq_thm (e e_1 : IntW 32) :
 
 theorem scalar_i64_lshr_and_negC_eq_thm (e e_1 : IntW 64) :
   icmp IntPredicate.eq (LLVM.and (lshr e_1 e) (const? 64 (-8589934592))) (const? 64 0) ⊑
-    icmp IntPredicate.ult (lshr e_1 e) (const? 64 8589934592) := by 
+    icmp IntPredicate.ult (lshr e_1 e) (const? 64 8589934592) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -54,7 +54,7 @@ theorem scalar_i64_lshr_and_negC_eq_thm (e e_1 : IntW 64) :
 
 theorem scalar_i32_lshr_and_negC_ne_thm (e e_1 : IntW 32) :
   icmp IntPredicate.ne (LLVM.and (lshr e_1 e) (const? 32 (-262144))) (const? 32 0) ⊑
-    icmp IntPredicate.ugt (lshr e_1 e) (const? 32 262143) := by 
+    icmp IntPredicate.ugt (lshr e_1 e) (const? 32 262143) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -65,7 +65,7 @@ theorem scalar_i32_lshr_and_negC_ne_thm (e e_1 : IntW 32) :
 
 theorem scalar_i32_lshr_and_negC_eq_X_is_constant1_thm (e : IntW 32) :
   icmp IntPredicate.eq (LLVM.and (lshr (const? 32 12345) e) (const? 32 (-8))) (const? 32 0) ⊑
-    icmp IntPredicate.ult (lshr (const? 32 12345) e) (const? 32 8) := by 
+    icmp IntPredicate.ult (lshr (const? 32 12345) e) (const? 32 8) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -76,7 +76,7 @@ theorem scalar_i32_lshr_and_negC_eq_X_is_constant1_thm (e : IntW 32) :
 
 theorem scalar_i32_lshr_and_negC_eq_X_is_constant2_thm (e : IntW 32) :
   icmp IntPredicate.eq (LLVM.and (lshr (const? 32 268435456) e) (const? 32 (-8))) (const? 32 0) ⊑
-    icmp IntPredicate.ugt e (const? 32 25) := by 
+    icmp IntPredicate.ugt e (const? 32 25) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -87,7 +87,7 @@ theorem scalar_i32_lshr_and_negC_eq_X_is_constant2_thm (e : IntW 32) :
 
 theorem scalar_i32_udiv_and_negC_eq_X_is_constant3_thm (e : IntW 32) :
   icmp IntPredicate.ne (LLVM.and (LLVM.udiv (const? 32 12345) e) (const? 32 16376)) (const? 32 0) ⊑
-    icmp IntPredicate.ult e (const? 32 1544) := by 
+    icmp IntPredicate.ult e (const? 32 1544) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -98,7 +98,7 @@ theorem scalar_i32_udiv_and_negC_eq_X_is_constant3_thm (e : IntW 32) :
 
 theorem scalar_i32_lshr_and_negC_slt_thm (e e_1 : IntW 32) :
   icmp IntPredicate.slt (LLVM.and (lshr e_1 e) (const? 32 (-8))) (const? 32 0) ⊑
-    icmp IntPredicate.slt (lshr e_1 e) (const? 32 0) := by 
+    icmp IntPredicate.slt (lshr e_1 e) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -108,7 +108,7 @@ theorem scalar_i32_lshr_and_negC_slt_thm (e e_1 : IntW 32) :
 
 
 theorem scalar_i32_lshr_and_negC_eq_nonzero_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.eq (LLVM.and (lshr e_1 e) (const? 32 (-8))) (const? 32 1) ⊑ const? 1 0 := by 
+  icmp IntPredicate.eq (LLVM.and (lshr e_1 e) (const? 32 (-8))) (const? 32 1) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -119,7 +119,7 @@ theorem scalar_i32_lshr_and_negC_eq_nonzero_thm (e e_1 : IntW 32) :
 
 theorem scalar_i8_lshr_and_negC_eq_not_negatedPowerOf2_thm (e e_1 : IntW 8) :
   icmp IntPredicate.eq (LLVM.and (lshr e_1 e) (const? 8 (-3))) (const? 8 0) ⊑
-    icmp IntPredicate.eq (LLVM.and e_1 (shl (const? 8 (-3)) e)) (const? 8 0) := by 
+    icmp IntPredicate.eq (LLVM.and e_1 (shl (const? 8 (-3)) e)) (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/glshrhandhsignbithicmpeqhzero_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/glshrhandhsignbithicmpeqhzero_proof.lean
@@ -10,7 +10,7 @@ set_option linter.unreachableTactic false
 section glshrhandhsignbithicmpeqhzero_proof
 theorem scalar_i8_lshr_and_signbit_eq_thm (e e_1 : IntW 8) :
   icmp IntPredicate.eq (LLVM.and (lshr e_1 e) (const? 8 (-128))) (const? 8 0) ⊑
-    icmp IntPredicate.sgt (lshr e_1 e) (const? 8 (-1)) := by 
+    icmp IntPredicate.sgt (lshr e_1 e) (const? 8 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -21,7 +21,7 @@ theorem scalar_i8_lshr_and_signbit_eq_thm (e e_1 : IntW 8) :
 
 theorem scalar_i16_lshr_and_signbit_eq_thm (e e_1 : IntW 16) :
   icmp IntPredicate.eq (LLVM.and (lshr e_1 e) (const? 16 (-32768))) (const? 16 0) ⊑
-    icmp IntPredicate.sgt (lshr e_1 e) (const? 16 (-1)) := by 
+    icmp IntPredicate.sgt (lshr e_1 e) (const? 16 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -32,7 +32,7 @@ theorem scalar_i16_lshr_and_signbit_eq_thm (e e_1 : IntW 16) :
 
 theorem scalar_i32_lshr_and_signbit_eq_thm (e e_1 : IntW 32) :
   icmp IntPredicate.eq (LLVM.and (lshr e_1 e) (const? 32 (-2147483648))) (const? 32 0) ⊑
-    icmp IntPredicate.sgt (lshr e_1 e) (const? 32 (-1)) := by 
+    icmp IntPredicate.sgt (lshr e_1 e) (const? 32 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -43,7 +43,7 @@ theorem scalar_i32_lshr_and_signbit_eq_thm (e e_1 : IntW 32) :
 
 theorem scalar_i64_lshr_and_signbit_eq_thm (e e_1 : IntW 64) :
   icmp IntPredicate.eq (LLVM.and (lshr e_1 e) (const? 64 (-9223372036854775808))) (const? 64 0) ⊑
-    icmp IntPredicate.sgt (lshr e_1 e) (const? 64 (-1)) := by 
+    icmp IntPredicate.sgt (lshr e_1 e) (const? 64 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -54,7 +54,7 @@ theorem scalar_i64_lshr_and_signbit_eq_thm (e e_1 : IntW 64) :
 
 theorem scalar_i32_lshr_and_signbit_ne_thm (e e_1 : IntW 32) :
   icmp IntPredicate.ne (LLVM.and (lshr e_1 e) (const? 32 (-2147483648))) (const? 32 0) ⊑
-    icmp IntPredicate.slt (lshr e_1 e) (const? 32 0) := by 
+    icmp IntPredicate.slt (lshr e_1 e) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -65,7 +65,7 @@ theorem scalar_i32_lshr_and_signbit_ne_thm (e e_1 : IntW 32) :
 
 theorem scalar_i32_lshr_and_signbit_eq_X_is_constant1_thm (e : IntW 32) :
   icmp IntPredicate.eq (LLVM.and (lshr (const? 32 12345) e) (const? 32 (-2147483648))) (const? 32 0) ⊑
-    const? 1 1 := by 
+    const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -76,7 +76,7 @@ theorem scalar_i32_lshr_and_signbit_eq_X_is_constant1_thm (e : IntW 32) :
 
 theorem scalar_i32_lshr_and_negC_eq_X_is_constant2_thm (e : IntW 32) :
   icmp IntPredicate.eq (LLVM.and (lshr (const? 32 (-2147483648)) e) (const? 32 (-2147483648))) (const? 32 0) ⊑
-    icmp IntPredicate.ne e (const? 32 0) := by 
+    icmp IntPredicate.ne e (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -87,7 +87,7 @@ theorem scalar_i32_lshr_and_negC_eq_X_is_constant2_thm (e : IntW 32) :
 
 theorem scalar_i32_lshr_and_negC_slt_thm (e e_1 : IntW 32) :
   icmp IntPredicate.slt (LLVM.and (lshr e_1 e) (const? 32 (-2147483648))) (const? 32 0) ⊑
-    icmp IntPredicate.slt (lshr e_1 e) (const? 32 0) := by 
+    icmp IntPredicate.slt (lshr e_1 e) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -97,7 +97,7 @@ theorem scalar_i32_lshr_and_negC_slt_thm (e e_1 : IntW 32) :
 
 
 theorem scalar_i32_lshr_and_negC_eq_nonzero_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.eq (LLVM.and (lshr e_1 e) (const? 32 (-2147483648))) (const? 32 1) ⊑ const? 1 0 := by 
+  icmp IntPredicate.eq (LLVM.and (lshr e_1 e) (const? 32 (-2147483648))) (const? 32 1) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/glshrhtrunchsexthtohashrhsext_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/glshrhtrunchsexthtohashrhsext_proof.lean
@@ -8,7 +8,7 @@ set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
 
 section glshrhtrunchsexthtohashrhsext_proof
-theorem t0_thm (e : IntW 8) : sext 16 (trunc 4 (lshr e (const? 8 4))) ⊑ sext 16 (ashr e (const? 8 4)) := by 
+theorem t0_thm (e : IntW 8) : sext 16 (trunc 4 (lshr e (const? 8 4))) ⊑ sext 16 (ashr e (const? 8 4)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -17,7 +17,7 @@ theorem t0_thm (e : IntW 8) : sext 16 (trunc 4 (lshr e (const? 8 4))) ⊑ sext 1
     all_goals sorry
 
 
-theorem t1_thm (e : IntW 8) : sext 16 (trunc 3 (lshr e (const? 8 5))) ⊑ sext 16 (ashr e (const? 8 5)) := by 
+theorem t1_thm (e : IntW 8) : sext 16 (trunc 3 (lshr e (const? 8 5))) ⊑ sext 16 (ashr e (const? 8 5)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -26,7 +26,7 @@ theorem t1_thm (e : IntW 8) : sext 16 (trunc 3 (lshr e (const? 8 5))) ⊑ sext 1
     all_goals sorry
 
 
-theorem t2_thm (e : IntW 7) : sext 16 (trunc 4 (lshr e (const? 7 3))) ⊑ sext 16 (ashr e (const? 7 3)) := by 
+theorem t2_thm (e : IntW 7) : sext 16 (trunc 4 (lshr e (const? 7 3))) ⊑ sext 16 (ashr e (const? 7 3)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -35,7 +35,7 @@ theorem t2_thm (e : IntW 7) : sext 16 (trunc 4 (lshr e (const? 7 3))) ⊑ sext 1
     all_goals sorry
 
 
-theorem same_source_shifted_signbit_thm (e : IntW 32) : sext 32 (trunc 8 (lshr e (const? 32 24))) ⊑ ashr e (const? 32 24) := by 
+theorem same_source_shifted_signbit_thm (e : IntW 32) : sext 32 (trunc 8 (lshr e (const? 32 24))) ⊑ ashr e (const? 32 24) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gmaskedhmergehadd_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gmaskedhmergehadd_proof.lean
@@ -10,7 +10,7 @@ set_option linter.unreachableTactic false
 section gmaskedhmergehadd_proof
 theorem p_thm (e e_1 e_2 : IntW 32) :
   add (LLVM.and e_2 e_1) (LLVM.and (LLVM.xor e_1 (const? 32 (-1))) e) ⊑
-    LLVM.or (LLVM.and e_2 e_1) (LLVM.and e (LLVM.xor e_1 (const? 32 (-1)))) { «disjoint» := true } := by 
+    LLVM.or (LLVM.and e_2 e_1) (LLVM.and e (LLVM.xor e_1 (const? 32 (-1)))) { «disjoint» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -21,7 +21,7 @@ theorem p_thm (e e_1 e_2 : IntW 32) :
 
 theorem p_constmask_thm (e e_1 : IntW 32) :
   add (LLVM.and e_1 (const? 32 65280)) (LLVM.and e (const? 32 (-65281))) ⊑
-    LLVM.or (LLVM.and e_1 (const? 32 65280)) (LLVM.and e (const? 32 (-65281))) { «disjoint» := true } := by 
+    LLVM.or (LLVM.and e_1 (const? 32 65280)) (LLVM.and e (const? 32 (-65281))) { «disjoint» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -32,7 +32,7 @@ theorem p_constmask_thm (e e_1 : IntW 32) :
 
 theorem p_constmask2_thm (e e_1 : IntW 32) :
   add (LLVM.and e_1 (const? 32 61440)) (LLVM.and e (const? 32 (-65281))) ⊑
-    LLVM.or (LLVM.and e_1 (const? 32 61440)) (LLVM.and e (const? 32 (-65281))) { «disjoint» := true } := by 
+    LLVM.or (LLVM.and e_1 (const? 32 61440)) (LLVM.and e (const? 32 (-65281))) { «disjoint» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -43,7 +43,7 @@ theorem p_constmask2_thm (e e_1 : IntW 32) :
 
 theorem p_commutative0_thm (e e_1 e_2 : IntW 32) :
   add (LLVM.and e_2 e_1) (LLVM.and (LLVM.xor e_2 (const? 32 (-1))) e) ⊑
-    LLVM.or (LLVM.and e_2 e_1) (LLVM.and e (LLVM.xor e_2 (const? 32 (-1)))) { «disjoint» := true } := by 
+    LLVM.or (LLVM.and e_2 e_1) (LLVM.and e (LLVM.xor e_2 (const? 32 (-1)))) { «disjoint» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -54,7 +54,7 @@ theorem p_commutative0_thm (e e_1 e_2 : IntW 32) :
 
 theorem p_commutative2_thm (e e_1 e_2 : IntW 32) :
   add (LLVM.and (LLVM.xor e_2 (const? 32 (-1))) e_1) (LLVM.and e e_2) ⊑
-    LLVM.or (LLVM.and e_1 (LLVM.xor e_2 (const? 32 (-1)))) (LLVM.and e e_2) { «disjoint» := true } := by 
+    LLVM.or (LLVM.and e_1 (LLVM.xor e_2 (const? 32 (-1)))) (LLVM.and e e_2) { «disjoint» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -65,7 +65,7 @@ theorem p_commutative2_thm (e e_1 e_2 : IntW 32) :
 
 theorem p_commutative4_thm (e e_1 e_2 : IntW 32) :
   add (LLVM.and (LLVM.xor e_2 (const? 32 (-1))) e_1) (LLVM.and e_2 e) ⊑
-    LLVM.or (LLVM.and e_1 (LLVM.xor e_2 (const? 32 (-1)))) (LLVM.and e_2 e) { «disjoint» := true } := by 
+    LLVM.or (LLVM.and e_1 (LLVM.xor e_2 (const? 32 (-1)))) (LLVM.and e_2 e) { «disjoint» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -76,7 +76,7 @@ theorem p_commutative4_thm (e e_1 e_2 : IntW 32) :
 
 theorem p_constmask_commutative_thm (e e_1 : IntW 32) :
   add (LLVM.and e_1 (const? 32 (-65281))) (LLVM.and e (const? 32 65280)) ⊑
-    LLVM.or (LLVM.and e_1 (const? 32 (-65281))) (LLVM.and e (const? 32 65280)) { «disjoint» := true } := by 
+    LLVM.or (LLVM.and e_1 (const? 32 (-65281))) (LLVM.and e (const? 32 65280)) { «disjoint» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -87,7 +87,7 @@ theorem p_constmask_commutative_thm (e e_1 : IntW 32) :
 
 theorem n2_badmask_thm (e e_1 e_2 e_3 : IntW 32) :
   add (LLVM.and e_3 e_2) (LLVM.and (LLVM.xor e_1 (const? 32 (-1))) e) ⊑
-    add (LLVM.and e_3 e_2) (LLVM.and e (LLVM.xor e_1 (const? 32 (-1)))) := by 
+    add (LLVM.and e_3 e_2) (LLVM.and e (LLVM.xor e_1 (const? 32 (-1)))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -98,7 +98,7 @@ theorem n2_badmask_thm (e e_1 e_2 e_3 : IntW 32) :
 
 theorem n3_constmask_samemask_thm (e e_1 : IntW 32) :
   add (LLVM.and e_1 (const? 32 65280)) (LLVM.and e (const? 32 65280)) ⊑
-    add (LLVM.and e_1 (const? 32 65280)) (LLVM.and e (const? 32 65280)) { «nsw» := true, «nuw» := true } := by 
+    add (LLVM.and e_1 (const? 32 65280)) (LLVM.and e (const? 32 65280)) { «nsw» := true, «nuw» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gmaskedhmergehandhofhors_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gmaskedhmergehandhofhors_proof.lean
@@ -10,7 +10,7 @@ set_option linter.unreachableTactic false
 section gmaskedhmergehandhofhors_proof
 theorem p_thm (e e_1 e_2 : IntW 32) :
   LLVM.and (LLVM.or (LLVM.xor e_2 (const? 32 (-1))) e_1) (LLVM.or e e_2) ⊑
-    LLVM.and (LLVM.or e_1 (LLVM.xor e_2 (const? 32 (-1)))) (LLVM.or e e_2) := by 
+    LLVM.and (LLVM.or e_1 (LLVM.xor e_2 (const? 32 (-1)))) (LLVM.or e e_2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -21,7 +21,7 @@ theorem p_thm (e e_1 e_2 : IntW 32) :
 
 theorem p_commutative2_thm (e e_1 e_2 : IntW 32) :
   LLVM.and (LLVM.or e_2 e_1) (LLVM.or (LLVM.xor e_1 (const? 32 (-1))) e) ⊑
-    LLVM.and (LLVM.or e_2 e_1) (LLVM.or e (LLVM.xor e_1 (const? 32 (-1)))) := by 
+    LLVM.and (LLVM.or e_2 e_1) (LLVM.or e (LLVM.xor e_1 (const? 32 (-1)))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -32,7 +32,7 @@ theorem p_commutative2_thm (e e_1 e_2 : IntW 32) :
 
 theorem n2_badmask_thm (e e_1 e_2 e_3 : IntW 32) :
   LLVM.and (LLVM.or (LLVM.xor e_3 (const? 32 (-1))) e_2) (LLVM.or e_1 e) ⊑
-    LLVM.and (LLVM.or e_2 (LLVM.xor e_3 (const? 32 (-1)))) (LLVM.or e_1 e) := by 
+    LLVM.and (LLVM.or e_2 (LLVM.xor e_3 (const? 32 (-1)))) (LLVM.or e_1 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -43,7 +43,7 @@ theorem n2_badmask_thm (e e_1 e_2 e_3 : IntW 32) :
 
 theorem n3_constmask_samemask_thm (e e_1 : IntW 32) :
   LLVM.and (LLVM.or e_1 (const? 32 (-65281))) (LLVM.or e (const? 32 (-65281))) ⊑
-    LLVM.or (LLVM.and e_1 e) (const? 32 (-65281)) := by 
+    LLVM.or (LLVM.and e_1 e) (const? 32 (-65281)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gmaskedhmergehor_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gmaskedhmergehor_proof.lean
@@ -10,7 +10,7 @@ set_option linter.unreachableTactic false
 section gmaskedhmergehor_proof
 theorem p_thm (e e_1 e_2 : IntW 32) :
   LLVM.or (LLVM.and e_2 e_1) (LLVM.and (LLVM.xor e_1 (const? 32 (-1))) e) ⊑
-    LLVM.or (LLVM.and e_2 e_1) (LLVM.and e (LLVM.xor e_1 (const? 32 (-1)))) { «disjoint» := true } := by 
+    LLVM.or (LLVM.and e_2 e_1) (LLVM.and e (LLVM.xor e_1 (const? 32 (-1)))) { «disjoint» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -21,7 +21,7 @@ theorem p_thm (e e_1 e_2 : IntW 32) :
 
 theorem p_constmask_thm (e e_1 : IntW 32) :
   LLVM.or (LLVM.and e_1 (const? 32 65280)) (LLVM.and e (const? 32 (-65281))) ⊑
-    LLVM.or (LLVM.and e_1 (const? 32 65280)) (LLVM.and e (const? 32 (-65281))) { «disjoint» := true } := by 
+    LLVM.or (LLVM.and e_1 (const? 32 65280)) (LLVM.and e (const? 32 (-65281))) { «disjoint» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -32,7 +32,7 @@ theorem p_constmask_thm (e e_1 : IntW 32) :
 
 theorem p_constmask2_thm (e e_1 : IntW 32) :
   LLVM.or (LLVM.and e_1 (const? 32 61440)) (LLVM.and e (const? 32 (-65281))) ⊑
-    LLVM.or (LLVM.and e_1 (const? 32 61440)) (LLVM.and e (const? 32 (-65281))) { «disjoint» := true } := by 
+    LLVM.or (LLVM.and e_1 (const? 32 61440)) (LLVM.and e (const? 32 (-65281))) { «disjoint» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -43,7 +43,7 @@ theorem p_constmask2_thm (e e_1 : IntW 32) :
 
 theorem p_commutative0_thm (e e_1 e_2 : IntW 32) :
   LLVM.or (LLVM.and e_2 e_1) (LLVM.and (LLVM.xor e_2 (const? 32 (-1))) e) ⊑
-    LLVM.or (LLVM.and e_2 e_1) (LLVM.and e (LLVM.xor e_2 (const? 32 (-1)))) { «disjoint» := true } := by 
+    LLVM.or (LLVM.and e_2 e_1) (LLVM.and e (LLVM.xor e_2 (const? 32 (-1)))) { «disjoint» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -54,7 +54,7 @@ theorem p_commutative0_thm (e e_1 e_2 : IntW 32) :
 
 theorem p_commutative2_thm (e e_1 e_2 : IntW 32) :
   LLVM.or (LLVM.and (LLVM.xor e_2 (const? 32 (-1))) e_1) (LLVM.and e e_2) ⊑
-    LLVM.or (LLVM.and e_1 (LLVM.xor e_2 (const? 32 (-1)))) (LLVM.and e e_2) { «disjoint» := true } := by 
+    LLVM.or (LLVM.and e_1 (LLVM.xor e_2 (const? 32 (-1)))) (LLVM.and e e_2) { «disjoint» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -65,7 +65,7 @@ theorem p_commutative2_thm (e e_1 e_2 : IntW 32) :
 
 theorem p_commutative4_thm (e e_1 e_2 : IntW 32) :
   LLVM.or (LLVM.and (LLVM.xor e_2 (const? 32 (-1))) e_1) (LLVM.and e_2 e) ⊑
-    LLVM.or (LLVM.and e_1 (LLVM.xor e_2 (const? 32 (-1)))) (LLVM.and e_2 e) { «disjoint» := true } := by 
+    LLVM.or (LLVM.and e_1 (LLVM.xor e_2 (const? 32 (-1)))) (LLVM.and e_2 e) { «disjoint» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -76,7 +76,7 @@ theorem p_commutative4_thm (e e_1 e_2 : IntW 32) :
 
 theorem p_constmask_commutative_thm (e e_1 : IntW 32) :
   LLVM.or (LLVM.and e_1 (const? 32 (-65281))) (LLVM.and e (const? 32 65280)) ⊑
-    LLVM.or (LLVM.and e_1 (const? 32 (-65281))) (LLVM.and e (const? 32 65280)) { «disjoint» := true } := by 
+    LLVM.or (LLVM.and e_1 (const? 32 (-65281))) (LLVM.and e (const? 32 65280)) { «disjoint» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -87,7 +87,7 @@ theorem p_constmask_commutative_thm (e e_1 : IntW 32) :
 
 theorem n2_badmask_thm (e e_1 e_2 e_3 : IntW 32) :
   LLVM.or (LLVM.and e_3 e_2) (LLVM.and (LLVM.xor e_1 (const? 32 (-1))) e) ⊑
-    LLVM.or (LLVM.and e_3 e_2) (LLVM.and e (LLVM.xor e_1 (const? 32 (-1)))) := by 
+    LLVM.or (LLVM.and e_3 e_2) (LLVM.and e (LLVM.xor e_1 (const? 32 (-1)))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -98,7 +98,7 @@ theorem n2_badmask_thm (e e_1 e_2 e_3 : IntW 32) :
 
 theorem n3_constmask_samemask_thm (e e_1 : IntW 32) :
   LLVM.or (LLVM.and e_1 (const? 32 65280)) (LLVM.and e (const? 32 65280)) ⊑
-    LLVM.and (LLVM.or e_1 e) (const? 32 65280) := by 
+    LLVM.and (LLVM.or e_1 e) (const? 32 65280) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gmaskedhmergehxor_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gmaskedhmergehxor_proof.lean
@@ -10,7 +10,7 @@ set_option linter.unreachableTactic false
 section gmaskedhmergehxor_proof
 theorem p_thm (e e_1 e_2 : IntW 32) :
   LLVM.xor (LLVM.and e_2 e_1) (LLVM.and (LLVM.xor e_1 (const? 32 (-1))) e) ⊑
-    LLVM.or (LLVM.and e_2 e_1) (LLVM.and e (LLVM.xor e_1 (const? 32 (-1)))) { «disjoint» := true } := by 
+    LLVM.or (LLVM.and e_2 e_1) (LLVM.and e (LLVM.xor e_1 (const? 32 (-1)))) { «disjoint» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -21,7 +21,7 @@ theorem p_thm (e e_1 e_2 : IntW 32) :
 
 theorem p_constmask_thm (e e_1 : IntW 32) :
   LLVM.xor (LLVM.and e_1 (const? 32 65280)) (LLVM.and e (const? 32 (-65281))) ⊑
-    LLVM.or (LLVM.and e_1 (const? 32 65280)) (LLVM.and e (const? 32 (-65281))) { «disjoint» := true } := by 
+    LLVM.or (LLVM.and e_1 (const? 32 65280)) (LLVM.and e (const? 32 (-65281))) { «disjoint» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -32,7 +32,7 @@ theorem p_constmask_thm (e e_1 : IntW 32) :
 
 theorem p_constmask2_thm (e e_1 : IntW 32) :
   LLVM.xor (LLVM.and e_1 (const? 32 61440)) (LLVM.and e (const? 32 (-65281))) ⊑
-    LLVM.or (LLVM.and e_1 (const? 32 61440)) (LLVM.and e (const? 32 (-65281))) { «disjoint» := true } := by 
+    LLVM.or (LLVM.and e_1 (const? 32 61440)) (LLVM.and e (const? 32 (-65281))) { «disjoint» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -43,7 +43,7 @@ theorem p_constmask2_thm (e e_1 : IntW 32) :
 
 theorem p_commutative0_thm (e e_1 e_2 : IntW 32) :
   LLVM.xor (LLVM.and e_2 e_1) (LLVM.and (LLVM.xor e_2 (const? 32 (-1))) e) ⊑
-    LLVM.or (LLVM.and e_2 e_1) (LLVM.and e (LLVM.xor e_2 (const? 32 (-1)))) { «disjoint» := true } := by 
+    LLVM.or (LLVM.and e_2 e_1) (LLVM.and e (LLVM.xor e_2 (const? 32 (-1)))) { «disjoint» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -54,7 +54,7 @@ theorem p_commutative0_thm (e e_1 e_2 : IntW 32) :
 
 theorem p_commutative2_thm (e e_1 e_2 : IntW 32) :
   LLVM.xor (LLVM.and (LLVM.xor e_2 (const? 32 (-1))) e_1) (LLVM.and e e_2) ⊑
-    LLVM.or (LLVM.and e_1 (LLVM.xor e_2 (const? 32 (-1)))) (LLVM.and e e_2) { «disjoint» := true } := by 
+    LLVM.or (LLVM.and e_1 (LLVM.xor e_2 (const? 32 (-1)))) (LLVM.and e e_2) { «disjoint» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -65,7 +65,7 @@ theorem p_commutative2_thm (e e_1 e_2 : IntW 32) :
 
 theorem p_commutative4_thm (e e_1 e_2 : IntW 32) :
   LLVM.xor (LLVM.and (LLVM.xor e_2 (const? 32 (-1))) e_1) (LLVM.and e_2 e) ⊑
-    LLVM.or (LLVM.and e_1 (LLVM.xor e_2 (const? 32 (-1)))) (LLVM.and e_2 e) { «disjoint» := true } := by 
+    LLVM.or (LLVM.and e_1 (LLVM.xor e_2 (const? 32 (-1)))) (LLVM.and e_2 e) { «disjoint» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -76,7 +76,7 @@ theorem p_commutative4_thm (e e_1 e_2 : IntW 32) :
 
 theorem p_constmask_commutative_thm (e e_1 : IntW 32) :
   LLVM.xor (LLVM.and e_1 (const? 32 (-65281))) (LLVM.and e (const? 32 65280)) ⊑
-    LLVM.or (LLVM.and e_1 (const? 32 (-65281))) (LLVM.and e (const? 32 65280)) { «disjoint» := true } := by 
+    LLVM.or (LLVM.and e_1 (const? 32 (-65281))) (LLVM.and e (const? 32 65280)) { «disjoint» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -87,7 +87,7 @@ theorem p_constmask_commutative_thm (e e_1 : IntW 32) :
 
 theorem n2_badmask_thm (e e_1 e_2 e_3 : IntW 32) :
   LLVM.xor (LLVM.and e_3 e_2) (LLVM.and (LLVM.xor e_1 (const? 32 (-1))) e) ⊑
-    LLVM.xor (LLVM.and e_3 e_2) (LLVM.and e (LLVM.xor e_1 (const? 32 (-1)))) := by 
+    LLVM.xor (LLVM.and e_3 e_2) (LLVM.and e (LLVM.xor e_1 (const? 32 (-1)))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -98,7 +98,7 @@ theorem n2_badmask_thm (e e_1 e_2 e_3 : IntW 32) :
 
 theorem n3_constmask_samemask_thm (e e_1 : IntW 32) :
   LLVM.xor (LLVM.and e_1 (const? 32 65280)) (LLVM.and e (const? 32 65280)) ⊑
-    LLVM.and (LLVM.xor e_1 e) (const? 32 65280) := by 
+    LLVM.and (LLVM.xor e_1 e) (const? 32 65280) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gmax_known_bits_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gmax_known_bits_proof.lean
@@ -14,7 +14,7 @@ theorem foo_thm (e : IntW 16) :
         (select (icmp IntPredicate.ult (zext 32 (LLVM.and e (const? 16 255))) (const? 32 255))
           (zext 32 (LLVM.and e (const? 16 255))) (const? 32 255)))
       (const? 16 255) ⊑
-    LLVM.and e (const? 16 255) := by 
+    LLVM.and e (const? 16 255) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gmaxhofhnots_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gmaxhofhnots_proof.lean
@@ -14,7 +14,7 @@ theorem max_of_min_thm (e : IntW 32) :
         (select (icmp IntPredicate.sgt e (const? 32 0)) (LLVM.xor e (const? 32 (-1))) (const? 32 (-1)))
         (const? 32 (-1)))
       (select (icmp IntPredicate.sgt e (const? 32 0)) (LLVM.xor e (const? 32 (-1))) (const? 32 (-1))) (const? 32 (-1)) ⊑
-    const? 32 (-1) := by 
+    const? 32 (-1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -29,7 +29,7 @@ theorem max_of_min_swap_thm (e : IntW 32) :
         (select (icmp IntPredicate.slt e (const? 32 0)) (const? 32 (-1)) (LLVM.xor e (const? 32 (-1))))
         (const? 32 (-1)))
       (select (icmp IntPredicate.slt e (const? 32 0)) (const? 32 (-1)) (LLVM.xor e (const? 32 (-1)))) (const? 32 (-1)) ⊑
-    const? 32 (-1) := by 
+    const? 32 (-1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -44,7 +44,7 @@ theorem min_of_max_thm (e : IntW 32) :
         (select (icmp IntPredicate.slt e (const? 32 0)) (LLVM.xor e (const? 32 (-1))) (const? 32 (-1)))
         (const? 32 (-1)))
       (select (icmp IntPredicate.slt e (const? 32 0)) (LLVM.xor e (const? 32 (-1))) (const? 32 (-1))) (const? 32 (-1)) ⊑
-    const? 32 (-1) := by 
+    const? 32 (-1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -59,7 +59,7 @@ theorem min_of_max_swap_thm (e : IntW 32) :
         (select (icmp IntPredicate.sgt e (const? 32 0)) (const? 32 (-1)) (LLVM.xor e (const? 32 (-1))))
         (const? 32 (-1)))
       (select (icmp IntPredicate.sgt e (const? 32 0)) (const? 32 (-1)) (LLVM.xor e (const? 32 (-1)))) (const? 32 (-1)) ⊑
-    const? 32 (-1) := by 
+    const? 32 (-1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gmergehicmp_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gmergehicmp_proof.lean
@@ -11,7 +11,7 @@ section gmergehicmp_proof
 theorem or_basic_thm (e : IntW 16) :
   LLVM.or (icmp IntPredicate.ne (trunc 8 e) (const? 8 127))
       (icmp IntPredicate.ne (LLVM.and e (const? 16 (-256))) (const? 16 17664)) ⊑
-    icmp IntPredicate.ne e (const? 16 17791) := by 
+    icmp IntPredicate.ne e (const? 16 17791) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -23,7 +23,7 @@ theorem or_basic_thm (e : IntW 16) :
 theorem or_basic_commuted_thm (e : IntW 16) :
   LLVM.or (icmp IntPredicate.ne (LLVM.and e (const? 16 (-256))) (const? 16 32512))
       (icmp IntPredicate.ne (trunc 8 e) (const? 8 69)) ⊑
-    icmp IntPredicate.ne e (const? 16 32581) := by 
+    icmp IntPredicate.ne e (const? 16 32581) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -35,7 +35,7 @@ theorem or_basic_commuted_thm (e : IntW 16) :
 theorem or_nontrivial_mask1_thm (e : IntW 16) :
   LLVM.or (icmp IntPredicate.ne (trunc 8 e) (const? 8 127))
       (icmp IntPredicate.ne (LLVM.and e (const? 16 3840)) (const? 16 1280)) ⊑
-    icmp IntPredicate.ne (LLVM.and e (const? 16 4095)) (const? 16 1407) := by 
+    icmp IntPredicate.ne (LLVM.and e (const? 16 4095)) (const? 16 1407) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -47,7 +47,7 @@ theorem or_nontrivial_mask1_thm (e : IntW 16) :
 theorem or_nontrivial_mask2_thm (e : IntW 16) :
   LLVM.or (icmp IntPredicate.ne (trunc 8 e) (const? 8 127))
       (icmp IntPredicate.ne (LLVM.and e (const? 16 (-4096))) (const? 16 20480)) ⊑
-    icmp IntPredicate.ne (LLVM.and e (const? 16 (-3841))) (const? 16 20607) := by 
+    icmp IntPredicate.ne (LLVM.and e (const? 16 (-3841))) (const? 16 20607) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -59,7 +59,7 @@ theorem or_nontrivial_mask2_thm (e : IntW 16) :
 theorem or_wrong_const1_thm (e : IntW 16) :
   LLVM.or (icmp IntPredicate.ne (trunc 8 e) (const? 8 127))
       (icmp IntPredicate.ne (LLVM.and e (const? 16 (-256))) (const? 16 17665)) ⊑
-    const? 1 1 := by 
+    const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gminmaxhdemandbits_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gminmaxhdemandbits_proof.lean
@@ -10,7 +10,7 @@ set_option linter.unreachableTactic false
 section gminmaxhdemandbits_proof
 theorem and_umax_less_thm (e : IntW 32) :
   LLVM.and (select (icmp IntPredicate.ugt (const? 32 31) e) (const? 32 31) e) (const? 32 (-32)) ⊑
-    LLVM.and e (const? 32 (-32)) := by 
+    LLVM.and e (const? 32 (-32)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -21,7 +21,7 @@ theorem and_umax_less_thm (e : IntW 32) :
 
 theorem and_umax_muchless_thm (e : IntW 32) :
   LLVM.and (select (icmp IntPredicate.ugt (const? 32 12) e) (const? 32 12) e) (const? 32 (-32)) ⊑
-    LLVM.and e (const? 32 (-32)) := by 
+    LLVM.and e (const? 32 (-32)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -31,7 +31,7 @@ theorem and_umax_muchless_thm (e : IntW 32) :
 
 
 theorem shr_umax_thm (e : IntW 32) :
-  lshr (select (icmp IntPredicate.ugt (const? 32 15) e) (const? 32 15) e) (const? 32 4) ⊑ lshr e (const? 32 4) := by 
+  lshr (select (icmp IntPredicate.ugt (const? 32 15) e) (const? 32 15) e) (const? 32 4) ⊑ lshr e (const? 32 4) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -42,7 +42,7 @@ theorem shr_umax_thm (e : IntW 32) :
 
 theorem t_0_1_thm (e : IntW 8) :
   LLVM.and (select (icmp IntPredicate.ugt e (const? 8 0)) e (const? 8 0)) (const? 8 1) ⊑
-    LLVM.and e (const? 8 1) := by 
+    LLVM.and e (const? 8 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -53,7 +53,7 @@ theorem t_0_1_thm (e : IntW 8) :
 
 theorem t_0_10_thm (e : IntW 8) :
   LLVM.and (select (icmp IntPredicate.ugt e (const? 8 0)) e (const? 8 0)) (const? 8 10) ⊑
-    LLVM.and e (const? 8 10) := by 
+    LLVM.and e (const? 8 10) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -64,7 +64,7 @@ theorem t_0_10_thm (e : IntW 8) :
 
 theorem t_1_10_thm (e : IntW 8) :
   LLVM.and (select (icmp IntPredicate.ugt e (const? 8 1)) e (const? 8 1)) (const? 8 10) ⊑
-    LLVM.and e (const? 8 10) := by 
+    LLVM.and e (const? 8 10) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -75,7 +75,7 @@ theorem t_1_10_thm (e : IntW 8) :
 
 theorem t_2_4_thm (e : IntW 8) :
   LLVM.and (select (icmp IntPredicate.ugt e (const? 8 2)) e (const? 8 2)) (const? 8 4) ⊑
-    LLVM.and e (const? 8 4) := by 
+    LLVM.and e (const? 8 4) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -86,7 +86,7 @@ theorem t_2_4_thm (e : IntW 8) :
 
 theorem t_2_192_thm (e : IntW 8) :
   LLVM.and (select (icmp IntPredicate.ugt e (const? 8 2)) e (const? 8 2)) (const? 8 (-64)) ⊑
-    LLVM.and e (const? 8 (-64)) := by 
+    LLVM.and e (const? 8 (-64)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -97,7 +97,7 @@ theorem t_2_192_thm (e : IntW 8) :
 
 theorem t_2_63_or_thm (e : IntW 8) :
   LLVM.or (select (icmp IntPredicate.ugt e (const? 8 2)) e (const? 8 2)) (const? 8 63) ⊑
-    LLVM.or e (const? 8 63) := by 
+    LLVM.or e (const? 8 63) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -107,7 +107,7 @@ theorem t_2_63_or_thm (e : IntW 8) :
 
 
 theorem and_umin_thm (e : IntW 32) :
-  LLVM.and (select (icmp IntPredicate.ult (const? 32 15) e) (const? 32 15) e) (const? 32 (-32)) ⊑ const? 32 0 := by 
+  LLVM.and (select (icmp IntPredicate.ult (const? 32 15) e) (const? 32 15) e) (const? 32 (-32)) ⊑ const? 32 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -117,7 +117,7 @@ theorem and_umin_thm (e : IntW 32) :
 
 
 theorem or_umin_thm (e : IntW 32) :
-  LLVM.or (select (icmp IntPredicate.ult (const? 32 15) e) (const? 32 15) e) (const? 32 31) ⊑ const? 32 31 := by 
+  LLVM.or (select (icmp IntPredicate.ult (const? 32 15) e) (const? 32 15) e) (const? 32 31) ⊑ const? 32 31 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -128,7 +128,7 @@ theorem or_umin_thm (e : IntW 32) :
 
 theorem or_min_31_30_thm (e : IntW 8) :
   LLVM.or (select (icmp IntPredicate.ult e (const? 8 (-30))) e (const? 8 (-30))) (const? 8 31) ⊑
-    LLVM.or e (const? 8 31) := by 
+    LLVM.or e (const? 8 31) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -139,7 +139,7 @@ theorem or_min_31_30_thm (e : IntW 8) :
 
 theorem and_min_7_7_thm (e : IntW 8) :
   LLVM.and (select (icmp IntPredicate.ult e (const? 8 (-7))) e (const? 8 (-7))) (const? 8 (-8)) ⊑
-    LLVM.and e (const? 8 (-8)) := by 
+    LLVM.and e (const? 8 (-8)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -150,7 +150,7 @@ theorem and_min_7_7_thm (e : IntW 8) :
 
 theorem and_min_7_8_thm (e : IntW 8) :
   LLVM.and (select (icmp IntPredicate.ult e (const? 8 (-8))) e (const? 8 (-8))) (const? 8 (-8)) ⊑
-    LLVM.and e (const? 8 (-8)) := by 
+    LLVM.and e (const? 8 (-8)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gminmaxhfold_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gminmaxhfold_proof.lean
@@ -11,7 +11,7 @@ section gminmaxhfold_proof
 theorem add_umin_constant_limit_thm (e : IntW 32) :
   select (icmp IntPredicate.ult (add e (const? 32 41) { «nsw» := false, «nuw» := true }) (const? 32 42))
       (add e (const? 32 41) { «nsw» := false, «nuw» := true }) (const? 32 42) ⊑
-    select (icmp IntPredicate.eq e (const? 32 0)) (const? 32 41) (const? 32 42) := by 
+    select (icmp IntPredicate.eq e (const? 32 0)) (const? 32 41) (const? 32 42) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -23,7 +23,7 @@ theorem add_umin_constant_limit_thm (e : IntW 32) :
 theorem add_umin_simplify_thm (e : IntW 32) :
   select (icmp IntPredicate.ult (add e (const? 32 42) { «nsw» := false, «nuw» := true }) (const? 32 42))
       (add e (const? 32 42) { «nsw» := false, «nuw» := true }) (const? 32 42) ⊑
-    const? 32 42 := by 
+    const? 32 42 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -35,7 +35,7 @@ theorem add_umin_simplify_thm (e : IntW 32) :
 theorem add_umin_simplify2_thm (e : IntW 32) :
   select (icmp IntPredicate.ult (add e (const? 32 43) { «nsw» := false, «nuw» := true }) (const? 32 42))
       (add e (const? 32 43) { «nsw» := false, «nuw» := true }) (const? 32 42) ⊑
-    const? 32 42 := by 
+    const? 32 42 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -47,7 +47,7 @@ theorem add_umin_simplify2_thm (e : IntW 32) :
 theorem add_umax_simplify_thm (e : IntW 37) :
   select (icmp IntPredicate.ugt (add e (const? 37 42) { «nsw» := false, «nuw» := true }) (const? 37 42))
       (add e (const? 37 42) { «nsw» := false, «nuw» := true }) (const? 37 42) ⊑
-    add e (const? 37 42) { «nsw» := false, «nuw» := true } := by 
+    add e (const? 37 42) { «nsw» := false, «nuw» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -59,7 +59,7 @@ theorem add_umax_simplify_thm (e : IntW 37) :
 theorem add_umax_simplify2_thm (e : IntW 32) :
   select (icmp IntPredicate.ugt (add e (const? 32 57) { «nsw» := false, «nuw» := true }) (const? 32 56))
       (add e (const? 32 57) { «nsw» := false, «nuw» := true }) (const? 32 56) ⊑
-    add e (const? 32 57) { «nsw» := false, «nuw» := true } := by 
+    add e (const? 32 57) { «nsw» := false, «nuw» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -71,7 +71,7 @@ theorem add_umax_simplify2_thm (e : IntW 32) :
 theorem add_smin_simplify_thm (e : IntW 32) :
   select (icmp IntPredicate.slt (add e (const? 32 (-3)) { «nsw» := true, «nuw» := false }) (const? 32 2147483644))
       (add e (const? 32 (-3)) { «nsw» := true, «nuw» := false }) (const? 32 2147483644) ⊑
-    add e (const? 32 (-3)) { «nsw» := true, «nuw» := false } := by 
+    add e (const? 32 (-3)) { «nsw» := true, «nuw» := false } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -83,7 +83,7 @@ theorem add_smin_simplify_thm (e : IntW 32) :
 theorem add_smin_simplify2_thm (e : IntW 32) :
   select (icmp IntPredicate.slt (add e (const? 32 (-3)) { «nsw» := true, «nuw» := false }) (const? 32 2147483645))
       (add e (const? 32 (-3)) { «nsw» := true, «nuw» := false }) (const? 32 2147483645) ⊑
-    add e (const? 32 (-3)) { «nsw» := true, «nuw» := false } := by 
+    add e (const? 32 (-3)) { «nsw» := true, «nuw» := false } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -95,7 +95,7 @@ theorem add_smin_simplify2_thm (e : IntW 32) :
 theorem add_smax_simplify_thm (e : IntW 8) :
   select (icmp IntPredicate.sgt (add e (const? 8 126) { «nsw» := true, «nuw» := false }) (const? 8 (-2)))
       (add e (const? 8 126) { «nsw» := true, «nuw» := false }) (const? 8 (-2)) ⊑
-    add e (const? 8 126) { «nsw» := true, «nuw» := false } := by 
+    add e (const? 8 126) { «nsw» := true, «nuw» := false } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -107,7 +107,7 @@ theorem add_smax_simplify_thm (e : IntW 8) :
 theorem add_smax_simplify2_thm (e : IntW 8) :
   select (icmp IntPredicate.sgt (add e (const? 8 127) { «nsw» := true, «nuw» := false }) (const? 8 (-2)))
       (add e (const? 8 127) { «nsw» := true, «nuw» := false }) (const? 8 (-2)) ⊑
-    add e (const? 8 127) { «nsw» := true, «nuw» := false } := by 
+    add e (const? 8 127) { «nsw» := true, «nuw» := false } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -120,7 +120,7 @@ theorem twoway_clamp_lt_thm (e : IntW 32) :
   select
       (icmp IntPredicate.sgt (select (icmp IntPredicate.slt e (const? 32 13768)) e (const? 32 13768)) (const? 32 13767))
       (select (icmp IntPredicate.slt e (const? 32 13768)) e (const? 32 13768)) (const? 32 13767) ⊑
-    select (icmp IntPredicate.sgt e (const? 32 13767)) (const? 32 13768) (const? 32 13767) := by 
+    select (icmp IntPredicate.sgt e (const? 32 13767)) (const? 32 13768) (const? 32 13767) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gmisch2002_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gmisch2002_proof.lean
@@ -8,7 +8,7 @@ set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
 
 section gmisch2002_proof
-theorem cast_test_2002h08h02_thm (e : IntW 64) : zext 64 (trunc 8 e) ⊑ LLVM.and e (const? 64 255) := by 
+theorem cast_test_2002h08h02_thm (e : IntW 64) : zext 64 (trunc 8 e) ⊑ LLVM.and e (const? 64 255) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -18,7 +18,7 @@ theorem cast_test_2002h08h02_thm (e : IntW 64) : zext 64 (trunc 8 e) ⊑ LLVM.an
 
 
 theorem missed_const_prop_2002h12h05_thm (e : IntW 32) :
-  add (sub (const? 32 0) e) (add e (add (sub (const? 32 0) (const? 32 1)) (const? 32 1))) ⊑ const? 32 0 := by 
+  add (sub (const? 32 0) e) (add e (add (sub (const? 32 0) (const? 32 1)) (const? 32 1))) ⊑ const? 32 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gmodulo_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gmodulo_proof.lean
@@ -11,7 +11,7 @@ section gmodulo_proof
 theorem modulo2_thm (e : IntW 32) :
   add (select (icmp IntPredicate.slt (LLVM.srem e (const? 32 2)) (const? 32 0)) (const? 32 2) (const? 32 0))
       (LLVM.srem e (const? 32 2)) { «nsw» := true, «nuw» := false } ⊑
-    LLVM.and e (const? 32 1) := by 
+    LLVM.and e (const? 32 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -23,7 +23,7 @@ theorem modulo2_thm (e : IntW 32) :
 theorem modulo4_thm (e : IntW 32) :
   add (select (icmp IntPredicate.slt (LLVM.srem e (const? 32 4)) (const? 32 0)) (const? 32 4) (const? 32 0))
       (LLVM.srem e (const? 32 4)) { «nsw» := true, «nuw» := false } ⊑
-    LLVM.and e (const? 32 3) := by 
+    LLVM.and e (const? 32 3) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -35,7 +35,7 @@ theorem modulo4_thm (e : IntW 32) :
 theorem modulo32_thm (e : IntW 32) :
   add (select (icmp IntPredicate.slt (LLVM.srem e (const? 32 32)) (const? 32 0)) (const? 32 32) (const? 32 0))
       (LLVM.srem e (const? 32 32)) { «nsw» := true, «nuw» := false } ⊑
-    LLVM.and e (const? 32 31) := by 
+    LLVM.and e (const? 32 31) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gmul_fold_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gmul_fold_proof.lean
@@ -11,7 +11,7 @@ section gmul_fold_proof
 theorem mul8_low_A0_B0_thm (e e_1 : IntW 8) :
   add (shl (add (mul (lshr e_1 (const? 8 4)) e) (mul (lshr e (const? 8 4)) e_1)) (const? 8 4))
       (mul (LLVM.and e_1 (const? 8 15)) (LLVM.and e (const? 8 15))) ⊑
-    mul e e_1 := by 
+    mul e e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -27,7 +27,7 @@ theorem mul8_low_thm (e e_1 : IntW 8) :
           (mul (LLVM.and e_1 (const? 8 15)) (lshr e (const? 8 4))))
         (const? 8 4))
       (mul (LLVM.and e_1 (const? 8 15)) (LLVM.and e (const? 8 15))) ⊑
-    mul e e_1 := by 
+    mul e e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -43,7 +43,7 @@ theorem mul16_low_thm (e e_1 : IntW 16) :
           (mul (LLVM.and e_1 (const? 16 255)) (lshr e (const? 16 8))))
         (const? 16 8))
       (mul (LLVM.and e_1 (const? 16 255)) (LLVM.and e (const? 16 255))) ⊑
-    mul e e_1 := by 
+    mul e e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -59,7 +59,7 @@ theorem mul32_low_thm (e e_1 : IntW 32) :
           (mul (LLVM.and e_1 (const? 32 65535)) (lshr e (const? 32 16))))
         (const? 32 16))
       (mul (LLVM.and e_1 (const? 32 65535)) (LLVM.and e (const? 32 65535))) ⊑
-    mul e e_1 := by 
+    mul e e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -75,7 +75,7 @@ theorem mul64_low_thm (e e_1 : IntW 64) :
           (mul (LLVM.and e_1 (const? 64 4294967295)) (lshr e (const? 64 32))))
         (const? 64 32))
       (mul (LLVM.and e_1 (const? 64 4294967295)) (LLVM.and e (const? 64 4294967295))) ⊑
-    mul e e_1 := by 
+    mul e e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -91,7 +91,7 @@ theorem mul128_low_thm (e e_1 : IntW 128) :
           (mul (LLVM.and e_1 (const? 128 18446744073709551615)) (lshr e (const? 128 64))))
         (const? 128 64))
       (mul (LLVM.and e_1 (const? 128 18446744073709551615)) (LLVM.and e (const? 128 18446744073709551615))) ⊑
-    mul e e_1 := by 
+    mul e e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -107,7 +107,7 @@ theorem mul130_low_thm (e e_1 : IntW 130) :
           (mul (LLVM.and e_1 (const? 130 36893488147419103231)) (lshr e (const? 130 65))))
         (const? 130 65))
       (mul (LLVM.and e_1 (const? 130 36893488147419103231)) (LLVM.and e (const? 130 36893488147419103231))) ⊑
-    mul e e_1 := by 
+    mul e e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -128,7 +128,7 @@ theorem mul9_low_thm (e e_1 : IntW 9) :
         (add (mul (lshr e_1 (const? 9 4)) (LLVM.and e (const? 9 15)) { «nsw» := false, «nuw» := true })
           (mul (LLVM.and e_1 (const? 9 15)) (lshr e (const? 9 4)) { «nsw» := false, «nuw» := true }))
         (const? 9 4))
-      (mul (LLVM.and e_1 (const? 9 15)) (LLVM.and e (const? 9 15)) { «nsw» := true, «nuw» := true }) := by 
+      (mul (LLVM.and e_1 (const? 9 15)) (LLVM.and e (const? 9 15)) { «nsw» := true, «nuw» := true }) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -150,7 +150,7 @@ theorem mul16_low_miss_shift_amount_thm (e e_1 : IntW 16) :
           (mul (LLVM.and e_1 (const? 16 127)) (lshr e (const? 16 8)) { «nsw» := true, «nuw» := true })
           { «nsw» := false, «nuw» := true })
         (const? 16 8))
-      (mul (LLVM.and e_1 (const? 16 127)) (LLVM.and e (const? 16 127)) { «nsw» := true, «nuw» := true }) := by 
+      (mul (LLVM.and e_1 (const? 16 127)) (LLVM.and e (const? 16 127)) { «nsw» := true, «nuw» := true }) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -171,7 +171,7 @@ theorem mul8_low_miss_half_width_thm (e e_1 : IntW 8) :
         (add (mul (lshr e_1 (const? 8 3)) (LLVM.and e (const? 8 15)))
           (mul (LLVM.and e_1 (const? 8 15)) (lshr e (const? 8 3))))
         (const? 8 3))
-      (mul (LLVM.and e_1 (const? 8 15)) (LLVM.and e (const? 8 15)) { «nsw» := false, «nuw» := true }) := by 
+      (mul (LLVM.and e_1 (const? 8 15)) (LLVM.and e (const? 8 15)) { «nsw» := false, «nuw» := true }) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gmul_full_64_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gmul_full_64_proof.lean
@@ -41,7 +41,7 @@ theorem mullo_thm (e e_1 : IntW 64) :
         (mul (LLVM.and e_1 (const? 64 4294967295)) (LLVM.and e (const? 64 4294967295))
           { «nsw» := false, «nuw» := true })
         (const? 64 4294967295))
-      { «disjoint» := true } := by 
+      { «disjoint» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -58,7 +58,7 @@ theorem mullo_variant3_thm (e e_1 : IntW 64) :
         (const? 64 32))
       (mul (LLVM.and e_1 (const? 64 4294967295)) (LLVM.and e (const? 64 4294967295))
         { «nsw» := false, «nuw» := true }) ⊑
-    mul e e_1 := by 
+    mul e e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gmulhpow2_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gmulhpow2_proof.lean
@@ -9,7 +9,7 @@ set_option linter.unreachableTactic false
 
 section gmulhpow2_proof
 theorem mul_selectp2_x_thm (e : IntW 8) (e_1 : IntW 1) :
-  mul (select e_1 (const? 8 2) (const? 8 4)) e ⊑ shl e (select e_1 (const? 8 1) (const? 8 2)) := by 
+  mul (select e_1 (const? 8 2) (const? 8 4)) e ⊑ shl e (select e_1 (const? 8 1) (const? 8 2)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -20,7 +20,7 @@ theorem mul_selectp2_x_thm (e : IntW 8) (e_1 : IntW 1) :
 
 theorem mul_selectp2_x_propegate_nuw_thm (e : IntW 8) (e_1 : IntW 1) :
   mul (select e_1 (const? 8 2) (const? 8 4)) e { «nsw» := true, «nuw» := true } ⊑
-    shl e (select e_1 (const? 8 1) (const? 8 2)) { «nsw» := false, «nuw» := true } := by 
+    shl e (select e_1 (const? 8 1) (const? 8 2)) { «nsw» := false, «nuw» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -30,7 +30,7 @@ theorem mul_selectp2_x_propegate_nuw_thm (e : IntW 8) (e_1 : IntW 1) :
 
 
 theorem mul_selectp2_x_non_const_thm (e e_1 : IntW 8) (e_2 : IntW 1) :
-  mul (select e_2 (const? 8 2) (shl (const? 8 1) e_1)) e ⊑ shl e (select e_2 (const? 8 1) e_1) := by 
+  mul (select e_2 (const? 8 2) (shl (const? 8 1) e_1)) e ⊑ shl e (select e_2 (const? 8 1) e_1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -41,7 +41,7 @@ theorem mul_selectp2_x_non_const_thm (e e_1 : IntW 8) (e_2 : IntW 1) :
 
 theorem mul_x_selectp2_thm (e : IntW 1) (e_1 : IntW 8) :
   mul (mul e_1 e_1) (select e (const? 8 8) (const? 8 1)) ⊑
-    shl (mul e_1 e_1) (select e (const? 8 3) (const? 8 0)) := by 
+    shl (mul e_1 e_1) (select e (const? 8 3) (const? 8 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -51,7 +51,7 @@ theorem mul_x_selectp2_thm (e : IntW 1) (e_1 : IntW 8) :
 
 
 theorem shl_add_log_may_cause_poison_pr62175_with_nuw_thm (e e_1 : IntW 8) :
-  mul e_1 (shl (const? 8 4) e { «nsw» := false, «nuw» := true }) ⊑ shl e_1 (add e (const? 8 2)) := by 
+  mul e_1 (shl (const? 8 4) e { «nsw» := false, «nuw» := true }) ⊑ shl e_1 (add e (const? 8 2)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -61,7 +61,7 @@ theorem shl_add_log_may_cause_poison_pr62175_with_nuw_thm (e e_1 : IntW 8) :
 
 
 theorem shl_add_log_may_cause_poison_pr62175_with_nsw_thm (e e_1 : IntW 8) :
-  mul e_1 (shl (const? 8 4) e { «nsw» := true, «nuw» := false }) ⊑ shl e_1 (add e (const? 8 2)) := by 
+  mul e_1 (shl (const? 8 4) e { «nsw» := true, «nuw» := false }) ⊑ shl e_1 (add e (const? 8 2)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gnarrow_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gnarrow_proof.lean
@@ -10,7 +10,7 @@ set_option linter.unreachableTactic false
 section gnarrow_proof
 theorem test1_thm (e e_1 : IntW 32) :
   trunc 1 (LLVM.and (zext 32 (icmp IntPredicate.slt e_1 e)) (zext 32 (icmp IntPredicate.sgt e_1 e))) ⊑
-    const? 1 0 := by 
+    const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -19,7 +19,7 @@ theorem test1_thm (e e_1 : IntW 32) :
     all_goals sorry
 
 
-theorem shrink_xor_thm (e : IntW 64) : trunc 32 (LLVM.xor e (const? 64 1)) ⊑ LLVM.xor (trunc 32 e) (const? 32 1) := by 
+theorem shrink_xor_thm (e : IntW 64) : trunc 32 (LLVM.xor e (const? 64 1)) ⊑ LLVM.xor (trunc 32 e) (const? 32 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -28,7 +28,7 @@ theorem shrink_xor_thm (e : IntW 64) : trunc 32 (LLVM.xor e (const? 64 1)) ⊑ L
     all_goals sorry
 
 
-theorem shrink_or_thm (e : IntW 6) : trunc 3 (LLVM.or e (const? 6 (-31))) ⊑ LLVM.or (trunc 3 e) (const? 3 1) := by 
+theorem shrink_or_thm (e : IntW 6) : trunc 3 (LLVM.or e (const? 6 (-31))) ⊑ LLVM.or (trunc 3 e) (const? 3 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -38,7 +38,7 @@ theorem shrink_or_thm (e : IntW 6) : trunc 3 (LLVM.or e (const? 6 (-31))) ⊑ LL
 
 
 theorem shrink_and_thm (e : IntW 64) :
-  trunc 31 (LLVM.and e (const? 64 42)) ⊑ trunc 31 (LLVM.and e (const? 64 42)) { «nsw» := true, «nuw» := true } := by 
+  trunc 31 (LLVM.and e (const? 64 42)) ⊑ trunc 31 (LLVM.and e (const? 64 42)) { «nsw» := true, «nuw» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gnarrowhmath_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gnarrowhmath_proof.lean
@@ -10,7 +10,7 @@ set_option linter.unreachableTactic false
 section gnarrowhmath_proof
 theorem sext_sext_add_thm (e : IntW 32) :
   add (sext 64 (ashr e (const? 32 7))) (sext 64 (ashr e (const? 32 9))) ⊑
-    sext 64 (add (ashr e (const? 32 7)) (ashr e (const? 32 9)) { «nsw» := true, «nuw» := false }) := by 
+    sext 64 (add (ashr e (const? 32 7)) (ashr e (const? 32 9)) { «nsw» := true, «nuw» := false }) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -22,7 +22,7 @@ theorem sext_sext_add_thm (e : IntW 32) :
 theorem sext_zext_add_mismatched_exts_thm (e : IntW 32) :
   add (sext 64 (ashr e (const? 32 7))) (zext 64 (lshr e (const? 32 9))) ⊑
     add (sext 64 (ashr e (const? 32 7))) (zext 64 (lshr e (const? 32 9)) { «nneg» := true })
-      { «nsw» := true, «nuw» := false } := by 
+      { «nsw» := true, «nuw» := false } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -33,7 +33,7 @@ theorem sext_zext_add_mismatched_exts_thm (e : IntW 32) :
 
 theorem sext_sext_add_mismatched_types_thm (e : IntW 32) (e_1 : IntW 16) :
   add (sext 64 (ashr e_1 (const? 16 7))) (sext 64 (ashr e (const? 32 9))) ⊑
-    add (sext 64 (ashr e_1 (const? 16 7))) (sext 64 (ashr e (const? 32 9))) { «nsw» := true, «nuw» := false } := by 
+    add (sext 64 (ashr e_1 (const? 16 7))) (sext 64 (ashr e (const? 32 9))) { «nsw» := true, «nuw» := false } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -44,7 +44,7 @@ theorem sext_sext_add_mismatched_types_thm (e : IntW 32) (e_1 : IntW 16) :
 
 theorem test5_thm (e : IntW 32) :
   add (sext 64 (ashr e (const? 32 1))) (const? 64 1073741823) ⊑
-    sext 64 (add (ashr e (const? 32 1)) (const? 32 1073741823) { «nsw» := true, «nuw» := false }) := by 
+    sext 64 (add (ashr e (const? 32 1)) (const? 32 1073741823) { «nsw» := true, «nuw» := false }) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -55,7 +55,7 @@ theorem test5_thm (e : IntW 32) :
 
 theorem test6_thm (e : IntW 32) :
   add (sext 64 (ashr e (const? 32 1))) (const? 64 (-1073741824)) ⊑
-    sext 64 (add (ashr e (const? 32 1)) (const? 32 (-1073741824)) { «nsw» := true, «nuw» := false }) := by 
+    sext 64 (add (ashr e (const? 32 1)) (const? 32 (-1073741824)) { «nsw» := true, «nuw» := false }) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -66,7 +66,7 @@ theorem test6_thm (e : IntW 32) :
 
 theorem test7_thm (e : IntW 32) :
   add (zext 64 (lshr e (const? 32 1))) (const? 64 2147483647) ⊑
-    zext 64 (add (lshr e (const? 32 1)) (const? 32 2147483647) { «nsw» := false, «nuw» := true }) := by 
+    zext 64 (add (lshr e (const? 32 1)) (const? 32 2147483647) { «nsw» := false, «nuw» := true }) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -77,7 +77,7 @@ theorem test7_thm (e : IntW 32) :
 
 theorem test8_thm (e : IntW 32) :
   mul (sext 64 (ashr e (const? 32 16))) (const? 64 32767) ⊑
-    sext 64 (mul (ashr e (const? 32 16)) (const? 32 32767) { «nsw» := true, «nuw» := false }) := by 
+    sext 64 (mul (ashr e (const? 32 16)) (const? 32 32767) { «nsw» := true, «nuw» := false }) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -88,7 +88,7 @@ theorem test8_thm (e : IntW 32) :
 
 theorem test9_thm (e : IntW 32) :
   mul (sext 64 (ashr e (const? 32 16))) (const? 64 (-32767)) ⊑
-    sext 64 (mul (ashr e (const? 32 16)) (const? 32 (-32767)) { «nsw» := true, «nuw» := false }) := by 
+    sext 64 (mul (ashr e (const? 32 16)) (const? 32 (-32767)) { «nsw» := true, «nuw» := false }) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -99,7 +99,7 @@ theorem test9_thm (e : IntW 32) :
 
 theorem test10_thm (e : IntW 32) :
   mul (zext 64 (lshr e (const? 32 16))) (const? 64 65535) ⊑
-    zext 64 (mul (lshr e (const? 32 16)) (const? 32 65535) { «nsw» := false, «nuw» := true }) := by 
+    zext 64 (mul (lshr e (const? 32 16)) (const? 32 65535) { «nsw» := false, «nuw» := true }) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -110,7 +110,7 @@ theorem test10_thm (e : IntW 32) :
 
 theorem test15_thm (e : IntW 32) :
   sub (const? 64 8) (sext 64 (ashr e (const? 32 1))) ⊑
-    sext 64 (sub (const? 32 8) (ashr e (const? 32 1)) { «nsw» := true, «nuw» := false }) := by 
+    sext 64 (sub (const? 32 8) (ashr e (const? 32 1)) { «nsw» := true, «nuw» := false }) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -121,7 +121,7 @@ theorem test15_thm (e : IntW 32) :
 
 theorem test16_thm (e : IntW 32) :
   sub (const? 64 4294967294) (zext 64 (lshr e (const? 32 1))) ⊑
-    zext 64 (sub (const? 32 (-2)) (lshr e (const? 32 1)) { «nsw» := false, «nuw» := true }) := by 
+    zext 64 (sub (const? 32 (-2)) (lshr e (const? 32 1)) { «nsw» := false, «nuw» := true }) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gnegatedhbitmask_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gnegatedhbitmask_proof.lean
@@ -9,7 +9,7 @@ set_option linter.unreachableTactic false
 
 section gnegatedhbitmask_proof
 theorem neg_mask1_lshr_thm (e : IntW 8) :
-  sub (const? 8 0) (LLVM.and (lshr e (const? 8 3)) (const? 8 1)) ⊑ ashr (shl e (const? 8 4)) (const? 8 7) := by 
+  sub (const? 8 0) (LLVM.and (lshr e (const? 8 3)) (const? 8 1)) ⊑ ashr (shl e (const? 8 4)) (const? 8 7) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -20,7 +20,7 @@ theorem neg_mask1_lshr_thm (e : IntW 8) :
 
 theorem sub_mask1_lshr_thm (e : IntW 8) :
   sub (const? 8 10) (LLVM.and (lshr e (const? 8 1)) (const? 8 1)) ⊑
-    add (ashr (shl e (const? 8 6)) (const? 8 7)) (const? 8 10) { «nsw» := true, «nuw» := false } := by 
+    add (ashr (shl e (const? 8 6)) (const? 8 7)) (const? 8 10) { «nsw» := true, «nuw» := false } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -32,7 +32,7 @@ theorem sub_mask1_lshr_thm (e : IntW 8) :
 theorem sub_mask1_trunc_lshr_thm (e : IntW 64) :
   sub (const? 8 10) (LLVM.and (trunc 8 (lshr e (const? 64 15))) (const? 8 1)) ⊑
     add (trunc 8 (ashr (shl e (const? 64 48)) (const? 64 63)) { «nsw» := true, «nuw» := false }) (const? 8 10)
-      { «nsw» := true, «nuw» := false } := by 
+      { «nsw» := true, «nuw» := false } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -45,7 +45,7 @@ theorem sub_sext_mask1_trunc_lshr_thm (e : IntW 64) :
   sub (const? 32 10) (sext 32 (LLVM.and (trunc 8 (lshr e (const? 64 15))) (const? 8 1))) ⊑
     zext 32
       (add (trunc 8 (ashr (shl e (const? 64 48)) (const? 64 63)) { «nsw» := true, «nuw» := false }) (const? 8 10)
-        { «nsw» := true, «nuw» := false }) := by 
+        { «nsw» := true, «nuw» := false }) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -57,7 +57,7 @@ theorem sub_sext_mask1_trunc_lshr_thm (e : IntW 64) :
 theorem sub_zext_trunc_lshr_thm (e : IntW 64) :
   sub (const? 32 10) (zext 32 (trunc 1 (lshr e (const? 64 15)))) ⊑
     add (ashr (shl (trunc 32 e) (const? 32 16)) (const? 32 31)) (const? 32 10)
-      { «nsw» := true, «nuw» := false } := by 
+      { «nsw» := true, «nuw» := false } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -68,7 +68,7 @@ theorem sub_zext_trunc_lshr_thm (e : IntW 64) :
 
 theorem neg_mask2_lshr_thm (e : IntW 8) :
   sub (const? 8 0) (LLVM.and (lshr e (const? 8 3)) (const? 8 2)) ⊑
-    sub (const? 8 0) (LLVM.and (lshr e (const? 8 3)) (const? 8 2)) { «nsw» := true, «nuw» := false } := by 
+    sub (const? 8 0) (LLVM.and (lshr e (const? 8 3)) (const? 8 2)) { «nsw» := true, «nuw» := false } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -78,7 +78,7 @@ theorem neg_mask2_lshr_thm (e : IntW 8) :
 
 
 theorem neg_signbit_thm (e : IntW 8) :
-  sub (const? 32 0) (zext 32 (lshr e (const? 8 7))) ⊑ sext 32 (ashr e (const? 8 7)) := by 
+  sub (const? 32 0) (zext 32 (lshr e (const? 8 7))) ⊑ sext 32 (ashr e (const? 8 7)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -88,7 +88,7 @@ theorem neg_signbit_thm (e : IntW 8) :
 
 
 theorem neg_not_signbit1_thm (e : IntW 8) :
-  sub (const? 32 1) (zext 32 (lshr e (const? 8 7))) ⊑ zext 32 (icmp IntPredicate.sgt e (const? 8 (-1))) := by 
+  sub (const? 32 1) (zext 32 (lshr e (const? 8 7))) ⊑ zext 32 (icmp IntPredicate.sgt e (const? 8 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -99,7 +99,7 @@ theorem neg_not_signbit1_thm (e : IntW 8) :
 
 theorem neg_not_signbit2_thm (e : IntW 8) :
   sub (const? 32 0) (zext 32 (lshr e (const? 8 6))) ⊑
-    sub (const? 32 0) (zext 32 (lshr e (const? 8 6)) { «nneg» := true }) { «nsw» := true, «nuw» := false } := by 
+    sub (const? 32 0) (zext 32 (lshr e (const? 8 6)) { «nneg» := true }) { «nsw» := true, «nuw» := false } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -110,7 +110,7 @@ theorem neg_not_signbit2_thm (e : IntW 8) :
 
 theorem neg_not_signbit3_thm (e : IntW 8) :
   sub (const? 32 0) (zext 32 (ashr e (const? 8 7))) ⊑
-    sub (const? 32 0) (zext 32 (ashr e (const? 8 7))) { «nsw» := true, «nuw» := false } := by 
+    sub (const? 32 0) (zext 32 (ashr e (const? 8 7))) { «nsw» := true, «nuw» := false } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -123,7 +123,7 @@ theorem neg_mask_thm (e : IntW 16) (e_1 : IntW 32) :
   LLVM.and (sub e_1 (sext 32 e) { «nsw» := true, «nuw» := false })
       (sub (const? 32 0) (zext 32 (lshr e (const? 16 15))) { «nsw» := true, «nuw» := false }) ⊑
     select (icmp IntPredicate.slt e (const? 16 0)) (sub e_1 (sext 32 e) { «nsw» := true, «nuw» := false })
-      (const? 32 0) := by 
+      (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -136,7 +136,7 @@ theorem neg_mask_const_thm (e : IntW 16) :
   LLVM.and (sub (const? 32 1000) (sext 32 e) { «nsw» := true, «nuw» := false })
       (sub (const? 32 0) (zext 32 (lshr e (const? 16 15))) { «nsw» := true, «nuw» := false }) ⊑
     select (icmp IntPredicate.slt e (const? 16 0)) (sub (const? 32 1000) (sext 32 e) { «nsw» := true, «nuw» := false })
-      (const? 32 0) := by 
+      (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gnot_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gnot_proof.lean
@@ -8,7 +8,7 @@ set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
 
 section gnot_proof
-theorem test1_thm (e : IntW 32) : LLVM.xor (LLVM.xor e (const? 32 (-1))) (const? 32 (-1)) ⊑ e := by 
+theorem test1_thm (e : IntW 32) : LLVM.xor (LLVM.xor e (const? 32 (-1))) (const? 32 (-1)) ⊑ e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -18,7 +18,7 @@ theorem test1_thm (e : IntW 32) : LLVM.xor (LLVM.xor e (const? 32 (-1))) (const?
 
 
 theorem invert_icmp_thm (e e_1 : IntW 32) :
-  LLVM.xor (icmp IntPredicate.sle e_1 e) (const? 1 1) ⊑ icmp IntPredicate.sgt e_1 e := by 
+  LLVM.xor (icmp IntPredicate.sle e_1 e) (const? 1 1) ⊑ icmp IntPredicate.sgt e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -29,7 +29,7 @@ theorem invert_icmp_thm (e e_1 : IntW 32) :
 
 theorem not_not_cmp_thm (e e_1 : IntW 32) :
   icmp IntPredicate.slt (LLVM.xor e_1 (const? 32 (-1))) (LLVM.xor e (const? 32 (-1))) ⊑
-    icmp IntPredicate.sgt e_1 e := by 
+    icmp IntPredicate.sgt e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -40,7 +40,7 @@ theorem not_not_cmp_thm (e e_1 : IntW 32) :
 
 theorem not_cmp_constant_thm (e : IntW 32) :
   icmp IntPredicate.ugt (LLVM.xor e (const? 32 (-1))) (const? 32 42) ⊑
-    icmp IntPredicate.ult e (const? 32 (-43)) := by 
+    icmp IntPredicate.ult e (const? 32 (-43)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -50,7 +50,7 @@ theorem not_cmp_constant_thm (e : IntW 32) :
 
 
 theorem not_ashr_not_thm (e e_1 : IntW 32) :
-  LLVM.xor (ashr (LLVM.xor e_1 (const? 32 (-1))) e) (const? 32 (-1)) ⊑ ashr e_1 e := by 
+  LLVM.xor (ashr (LLVM.xor e_1 (const? 32 (-1))) e) (const? 32 (-1)) ⊑ ashr e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -59,7 +59,7 @@ theorem not_ashr_not_thm (e e_1 : IntW 32) :
     all_goals sorry
 
 
-theorem not_ashr_const_thm (e : IntW 8) : LLVM.xor (ashr (const? 8 (-42)) e) (const? 8 (-1)) ⊑ lshr (const? 8 41) e := by 
+theorem not_ashr_const_thm (e : IntW 8) : LLVM.xor (ashr (const? 8 (-42)) e) (const? 8 (-1)) ⊑ lshr (const? 8 41) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -68,7 +68,7 @@ theorem not_ashr_const_thm (e : IntW 8) : LLVM.xor (ashr (const? 8 (-42)) e) (co
     all_goals sorry
 
 
-theorem not_lshr_const_thm (e : IntW 8) : LLVM.xor (lshr (const? 8 42) e) (const? 8 (-1)) ⊑ ashr (const? 8 (-43)) e := by 
+theorem not_lshr_const_thm (e : IntW 8) : LLVM.xor (lshr (const? 8 42) e) (const? 8 (-1)) ⊑ ashr (const? 8 (-43)) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -78,7 +78,7 @@ theorem not_lshr_const_thm (e : IntW 8) : LLVM.xor (lshr (const? 8 42) e) (const
 
 
 theorem not_sub_thm (e : IntW 32) :
-  LLVM.xor (sub (const? 32 123) e) (const? 32 (-1)) ⊑ add e (const? 32 (-124)) := by 
+  LLVM.xor (sub (const? 32 123) e) (const? 32 (-1)) ⊑ add e (const? 32 (-124)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -88,7 +88,7 @@ theorem not_sub_thm (e : IntW 32) :
 
 
 theorem not_add_thm (e : IntW 32) :
-  LLVM.xor (add e (const? 32 123)) (const? 32 (-1)) ⊑ sub (const? 32 (-124)) e := by 
+  LLVM.xor (add e (const? 32 123)) (const? 32 (-1)) ⊑ sub (const? 32 (-124)) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -99,7 +99,7 @@ theorem not_add_thm (e : IntW 32) :
 
 theorem not_or_neg_thm (e e_1 : IntW 8) :
   LLVM.xor (LLVM.or (sub (const? 8 0) e_1) e) (const? 8 (-1)) ⊑
-    LLVM.and (add e_1 (const? 8 (-1))) (LLVM.xor e (const? 8 (-1))) := by 
+    LLVM.and (add e_1 (const? 8 (-1))) (LLVM.xor e (const? 8 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -109,7 +109,7 @@ theorem not_or_neg_thm (e e_1 : IntW 8) :
 
 
 theorem not_select_bool_const1_thm (e e_1 : IntW 1) :
-  LLVM.xor (select e_1 e (const? 1 1)) (const? 1 1) ⊑ select e_1 (LLVM.xor e (const? 1 1)) (const? 1 0) := by 
+  LLVM.xor (select e_1 e (const? 1 1)) (const? 1 1) ⊑ select e_1 (LLVM.xor e (const? 1 1)) (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -119,7 +119,7 @@ theorem not_select_bool_const1_thm (e e_1 : IntW 1) :
 
 
 theorem not_select_bool_const4_thm (e e_1 : IntW 1) :
-  LLVM.xor (select e_1 (const? 1 0) e) (const? 1 1) ⊑ select e_1 (const? 1 1) (LLVM.xor e (const? 1 1)) := by 
+  LLVM.xor (select e_1 (const? 1 0) e) (const? 1 1) ⊑ select e_1 (const? 1 1) (LLVM.xor e (const? 1 1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -130,7 +130,7 @@ theorem not_select_bool_const4_thm (e e_1 : IntW 1) :
 
 theorem not_logicalAnd_not_op1_thm (e e_1 : IntW 1) :
   LLVM.xor (select e_1 (LLVM.xor e (const? 1 1)) (const? 1 0)) (const? 1 1) ⊑
-    select (LLVM.xor e_1 (const? 1 1)) (const? 1 1) e := by 
+    select (LLVM.xor e_1 (const? 1 1)) (const? 1 1) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -141,7 +141,7 @@ theorem not_logicalAnd_not_op1_thm (e e_1 : IntW 1) :
 
 theorem not_logicalOr_not_op1_thm (e e_1 : IntW 1) :
   LLVM.xor (select e_1 (const? 1 1) (LLVM.xor e (const? 1 1))) (const? 1 1) ⊑
-    select (LLVM.xor e_1 (const? 1 1)) e (const? 1 0) := by 
+    select (LLVM.xor e_1 (const? 1 1)) e (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -152,7 +152,7 @@ theorem not_logicalOr_not_op1_thm (e e_1 : IntW 1) :
 
 theorem invert_both_cmp_operands_add_thm (e e_1 : IntW 32) :
   icmp IntPredicate.sgt (add e_1 (LLVM.xor e (const? 32 (-1)))) (const? 32 0) ⊑
-    icmp IntPredicate.slt (sub e e_1) (const? 32 (-1)) := by 
+    icmp IntPredicate.slt (sub e e_1) (const? 32 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -163,7 +163,7 @@ theorem invert_both_cmp_operands_add_thm (e e_1 : IntW 32) :
 
 theorem invert_both_cmp_operands_sub_thm (e e_1 : IntW 32) :
   icmp IntPredicate.ult (sub (LLVM.xor e_1 (const? 32 (-1))) e) (const? 32 42) ⊑
-    icmp IntPredicate.ugt (add e_1 e) (const? 32 (-43)) := by 
+    icmp IntPredicate.ugt (add e_1 e) (const? 32 (-43)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -175,7 +175,7 @@ theorem invert_both_cmp_operands_sub_thm (e e_1 : IntW 32) :
 theorem invert_both_cmp_operands_complex_thm (e e_1 e_2 : IntW 32) (e_3 : IntW 1) :
   icmp IntPredicate.sle (select e_3 (add e_2 (LLVM.xor e_1 (const? 32 (-1)))) (LLVM.xor e (const? 32 (-1))))
       (LLVM.xor e_2 (const? 32 (-1))) ⊑
-    icmp IntPredicate.sge (select e_3 (sub e_1 e_2) e) e_2 := by 
+    icmp IntPredicate.sge (select e_3 (sub e_1 e_2) e) e_2 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -186,7 +186,7 @@ theorem invert_both_cmp_operands_complex_thm (e e_1 e_2 : IntW 32) (e_3 : IntW 1
 
 theorem test_sext_thm (e e_1 : IntW 32) :
   LLVM.xor (add e_1 (sext 32 (icmp IntPredicate.eq e (const? 32 0)))) (const? 32 (-1)) ⊑
-    sub (sext 32 (icmp IntPredicate.ne e (const? 32 0))) e_1 := by 
+    sub (sext 32 (icmp IntPredicate.ne e (const? 32 0))) e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -197,7 +197,7 @@ theorem test_sext_thm (e e_1 : IntW 32) :
 
 theorem test_zext_nneg_thm (e : IntW 64) (e_1 : IntW 32) (e_2 : IntW 64) :
   sub (add e_2 (const? 64 (-5))) (add (zext 64 (LLVM.xor e_1 (const? 32 (-1))) { «nneg» := true }) e) ⊑
-    add (add e_2 (const? 64 (-4))) (sub (sext 64 e_1) e) := by 
+    add (add e_2 (const? 64 (-4))) (sub (sext 64 e_1) e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -209,7 +209,7 @@ theorem test_zext_nneg_thm (e : IntW 64) (e_1 : IntW 32) (e_2 : IntW 64) :
 theorem test_trunc_thm (e : IntW 8) :
   LLVM.xor (trunc 8 (ashr (add (zext 32 e) (const? 32 (-1)) { «nsw» := true, «nuw» := false }) (const? 32 31)))
       (const? 8 (-1)) ⊑
-    sext 8 (icmp IntPredicate.ne e (const? 8 0)) := by 
+    sext 8 (icmp IntPredicate.ne e (const? 8 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -224,7 +224,7 @@ theorem test_invert_demorgan_or2_thm (e e_1 e_2 : IntW 64) :
         (icmp IntPredicate.ugt e (const? 64 59)))
       (const? 1 1) ⊑
     LLVM.and (LLVM.and (icmp IntPredicate.ult e_2 (const? 64 24)) (icmp IntPredicate.ult e_1 (const? 64 60)))
-      (icmp IntPredicate.ult e (const? 64 60)) := by 
+      (icmp IntPredicate.ult e (const? 64 60)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -247,7 +247,7 @@ theorem test_invert_demorgan_or3_thm (e e_1 : IntW 32) :
         (LLVM.and (icmp IntPredicate.ne e_1 (const? 32 178206))
           (icmp IntPredicate.ult (add e (const? 32 (-196608))) (const? 32 (-1506))))
         (icmp IntPredicate.ult (add e (const? 32 (-917760))) (const? 32 (-716213))))
-      (icmp IntPredicate.ult (add e (const? 32 (-1114112))) (const? 32 (-196112))) := by 
+      (icmp IntPredicate.ult (add e (const? 32 (-1114112))) (const? 32 (-196112))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -262,7 +262,7 @@ theorem test_invert_demorgan_logical_or_thm (e e_1 : IntW 64) :
         (select (icmp IntPredicate.eq e_1 (const? 64 27)) (const? 1 1) (icmp IntPredicate.eq e (const? 64 0))))
       (const? 1 1) ⊑
     LLVM.and (icmp IntPredicate.ne e_1 (const? 64 0))
-      (select (icmp IntPredicate.ne e_1 (const? 64 27)) (icmp IntPredicate.ne e (const? 64 0)) (const? 1 0)) := by 
+      (select (icmp IntPredicate.ne e_1 (const? 64 27)) (icmp IntPredicate.ne e (const? 64 0)) (const? 1 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -273,7 +273,7 @@ theorem test_invert_demorgan_logical_or_thm (e e_1 : IntW 64) :
 
 theorem test_invert_demorgan_and2_thm (e : IntW 64) :
   LLVM.xor (LLVM.and (add e (const? 64 9223372036854775807)) (const? 64 9223372036854775807)) (const? 64 (-1)) ⊑
-    LLVM.or (sub (const? 64 0) e) (const? 64 (-9223372036854775808)) := by 
+    LLVM.or (sub (const? 64 0) e) (const? 64 (-9223372036854775808)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -284,7 +284,7 @@ theorem test_invert_demorgan_and2_thm (e : IntW 64) :
 
 theorem test_invert_demorgan_and3_thm (e e_1 : IntW 32) :
   icmp IntPredicate.eq (LLVM.and (add e_1 (LLVM.xor e (const? 32 (-1)))) (const? 32 4095)) (const? 32 0) ⊑
-    icmp IntPredicate.eq (LLVM.and (sub e e_1) (const? 32 4095)) (const? 32 4095) := by 
+    icmp IntPredicate.eq (LLVM.and (sub e e_1) (const? 32 4095)) (const? 32 4095) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -299,7 +299,7 @@ theorem test_invert_demorgan_logical_and_thm (e e_1 : IntW 64) :
         (select (icmp IntPredicate.eq e_1 (const? 64 27)) (icmp IntPredicate.eq e (const? 64 0)) (const? 1 0)))
       (const? 1 1) ⊑
     LLVM.and (icmp IntPredicate.ne e_1 (const? 64 0))
-      (select (icmp IntPredicate.ne e_1 (const? 64 27)) (const? 1 1) (icmp IntPredicate.ne e (const? 64 0))) := by 
+      (select (icmp IntPredicate.ne e_1 (const? 64 27)) (const? 1 1) (icmp IntPredicate.ne e (const? 64 0))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gnothadd_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gnothadd_proof.lean
@@ -9,7 +9,7 @@ set_option linter.unreachableTactic false
 
 section gnothadd_proof
 theorem basic_thm (e e_1 : IntW 8) :
-  LLVM.xor (add (LLVM.xor e_1 (const? 8 (-1))) e) (const? 8 (-1)) ⊑ sub e_1 e := by 
+  LLVM.xor (add (LLVM.xor e_1 (const? 8 (-1))) e) (const? 8 (-1)) ⊑ sub e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -19,7 +19,7 @@ theorem basic_thm (e e_1 : IntW 8) :
 
 
 theorem basic_com_add_thm (e e_1 : IntW 8) :
-  LLVM.xor (add e_1 (LLVM.xor e (const? 8 (-1)))) (const? 8 (-1)) ⊑ sub e e_1 := by 
+  LLVM.xor (add e_1 (LLVM.xor e (const? 8 (-1)))) (const? 8 (-1)) ⊑ sub e e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -30,7 +30,7 @@ theorem basic_com_add_thm (e e_1 : IntW 8) :
 
 theorem basic_preserve_nsw_thm (e e_1 : IntW 8) :
   LLVM.xor (add (LLVM.xor e_1 (const? 8 (-1))) e { «nsw» := true, «nuw» := false }) (const? 8 (-1)) ⊑
-    sub e_1 e { «nsw» := true, «nuw» := false } := by 
+    sub e_1 e { «nsw» := true, «nuw» := false } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -41,7 +41,7 @@ theorem basic_preserve_nsw_thm (e e_1 : IntW 8) :
 
 theorem basic_preserve_nuw_thm (e e_1 : IntW 8) :
   LLVM.xor (add (LLVM.xor e_1 (const? 8 (-1))) e { «nsw» := false, «nuw» := true }) (const? 8 (-1)) ⊑
-    sub e_1 e { «nsw» := false, «nuw» := true } := by 
+    sub e_1 e { «nsw» := false, «nuw» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -52,7 +52,7 @@ theorem basic_preserve_nuw_thm (e e_1 : IntW 8) :
 
 theorem basic_preserve_nuw_nsw_thm (e e_1 : IntW 8) :
   LLVM.xor (add (LLVM.xor e_1 (const? 8 (-1))) e { «nsw» := true, «nuw» := true }) (const? 8 (-1)) ⊑
-    sub e_1 e { «nsw» := true, «nuw» := true } := by 
+    sub e_1 e { «nsw» := true, «nuw» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gomithuremhofhpowerhofhtwohorhzerohwhenhcomparinghwithhzero_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gomithuremhofhpowerhofhtwohorhzerohwhenhcomparinghwithhzero_proof.lean
@@ -10,7 +10,7 @@ set_option linter.unreachableTactic false
 section gomithuremhofhpowerhofhtwohorhzerohwhenhcomparinghwithhzero_proof
 theorem p0_scalar_urem_by_const_thm (e : IntW 32) :
   icmp IntPredicate.eq (urem (LLVM.and e (const? 32 128)) (const? 32 6)) (const? 32 0) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 32 128)) (const? 32 0) := by 
+    icmp IntPredicate.eq (LLVM.and e (const? 32 128)) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -21,7 +21,7 @@ theorem p0_scalar_urem_by_const_thm (e : IntW 32) :
 
 theorem p1_scalar_urem_by_nonconst_thm (e e_1 : IntW 32) :
   icmp IntPredicate.eq (urem (LLVM.and e_1 (const? 32 128)) (LLVM.or e (const? 32 6))) (const? 32 0) ⊑
-    icmp IntPredicate.eq (LLVM.and e_1 (const? 32 128)) (const? 32 0) := by 
+    icmp IntPredicate.eq (LLVM.and e_1 (const? 32 128)) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -33,7 +33,7 @@ theorem p1_scalar_urem_by_nonconst_thm (e e_1 : IntW 32) :
 theorem p2_scalar_shifted_urem_by_const_thm (e e_1 : IntW 32) :
   icmp IntPredicate.eq (urem (shl (LLVM.and e_1 (const? 32 1)) e) (const? 32 3)) (const? 32 0) ⊑
     icmp IntPredicate.eq (urem (shl (LLVM.and e_1 (const? 32 1)) e { «nsw» := false, «nuw» := true }) (const? 32 3))
-      (const? 32 0) := by 
+      (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gonehot_merge_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gonehot_merge_proof.lean
@@ -11,7 +11,7 @@ section gonehot_merge_proof
 theorem and_consts_thm (e : IntW 32) :
   LLVM.or (icmp IntPredicate.eq (LLVM.and (const? 32 4) e) (const? 32 0))
       (icmp IntPredicate.eq (LLVM.and (const? 32 8) e) (const? 32 0)) ⊑
-    icmp IntPredicate.ne (LLVM.and e (const? 32 12)) (const? 32 12) := by 
+    icmp IntPredicate.ne (LLVM.and e (const? 32 12)) (const? 32 12) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -23,7 +23,7 @@ theorem and_consts_thm (e : IntW 32) :
 theorem and_consts_logical_thm (e : IntW 32) :
   select (icmp IntPredicate.eq (LLVM.and (const? 32 4) e) (const? 32 0)) (const? 1 1)
       (icmp IntPredicate.eq (LLVM.and (const? 32 8) e) (const? 32 0)) ⊑
-    icmp IntPredicate.ne (LLVM.and e (const? 32 12)) (const? 32 12) := by 
+    icmp IntPredicate.ne (LLVM.and e (const? 32 12)) (const? 32 12) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -40,7 +40,7 @@ theorem foo1_and_thm (e e_1 e_2 : IntW 32) :
         (LLVM.or (shl (const? 32 1) e_2 { «nsw» := false, «nuw» := true })
           (shl (const? 32 1) e { «nsw» := false, «nuw» := true })))
       (LLVM.or (shl (const? 32 1) e_2 { «nsw» := false, «nuw» := true })
-        (shl (const? 32 1) e { «nsw» := false, «nuw» := true })) := by 
+        (shl (const? 32 1) e { «nsw» := false, «nuw» := true })) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -57,7 +57,7 @@ theorem foo1_and_commuted_thm (e e_1 e_2 : IntW 32) :
         (LLVM.or (shl (const? 32 1) e_1 { «nsw» := false, «nuw» := true })
           (shl (const? 32 1) e { «nsw» := false, «nuw» := true })))
       (LLVM.or (shl (const? 32 1) e_1 { «nsw» := false, «nuw» := true })
-        (shl (const? 32 1) e { «nsw» := false, «nuw» := true })) := by 
+        (shl (const? 32 1) e { «nsw» := false, «nuw» := true })) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -69,7 +69,7 @@ theorem foo1_and_commuted_thm (e e_1 e_2 : IntW 32) :
 theorem or_consts_thm (e : IntW 32) :
   LLVM.and (icmp IntPredicate.ne (LLVM.and (const? 32 4) e) (const? 32 0))
       (icmp IntPredicate.ne (LLVM.and (const? 32 8) e) (const? 32 0)) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 32 12)) (const? 32 12) := by 
+    icmp IntPredicate.eq (LLVM.and e (const? 32 12)) (const? 32 12) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -81,7 +81,7 @@ theorem or_consts_thm (e : IntW 32) :
 theorem or_consts_logical_thm (e : IntW 32) :
   select (icmp IntPredicate.ne (LLVM.and (const? 32 4) e) (const? 32 0))
       (icmp IntPredicate.ne (LLVM.and (const? 32 8) e) (const? 32 0)) (const? 1 0) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 32 12)) (const? 32 12) := by 
+    icmp IntPredicate.eq (LLVM.and e (const? 32 12)) (const? 32 12) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -98,7 +98,7 @@ theorem foo1_or_thm (e e_1 e_2 : IntW 32) :
         (LLVM.or (shl (const? 32 1) e_2 { «nsw» := false, «nuw» := true })
           (shl (const? 32 1) e { «nsw» := false, «nuw» := true })))
       (LLVM.or (shl (const? 32 1) e_2 { «nsw» := false, «nuw» := true })
-        (shl (const? 32 1) e { «nsw» := false, «nuw» := true })) := by 
+        (shl (const? 32 1) e { «nsw» := false, «nuw» := true })) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -115,7 +115,7 @@ theorem foo1_or_commuted_thm (e e_1 e_2 : IntW 32) :
         (LLVM.or (shl (const? 32 1) e_1 { «nsw» := false, «nuw» := true })
           (shl (const? 32 1) e { «nsw» := false, «nuw» := true })))
       (LLVM.or (shl (const? 32 1) e_1 { «nsw» := false, «nuw» := true })
-        (shl (const? 32 1) e { «nsw» := false, «nuw» := true })) := by 
+        (shl (const? 32 1) e { «nsw» := false, «nuw» := true })) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -132,7 +132,7 @@ theorem foo1_and_signbit_lshr_thm (e e_1 e_2 : IntW 32) :
         (LLVM.or (shl (const? 32 1) e_2 { «nsw» := false, «nuw» := true })
           (lshr (const? 32 (-2147483648)) e { «exact» := true })))
       (LLVM.or (shl (const? 32 1) e_2 { «nsw» := false, «nuw» := true })
-        (lshr (const? 32 (-2147483648)) e { «exact» := true })) := by 
+        (lshr (const? 32 (-2147483648)) e { «exact» := true })) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -149,7 +149,7 @@ theorem foo1_or_signbit_lshr_thm (e e_1 e_2 : IntW 32) :
         (LLVM.or (shl (const? 32 1) e_2 { «nsw» := false, «nuw» := true })
           (lshr (const? 32 (-2147483648)) e { «exact» := true })))
       (LLVM.or (shl (const? 32 1) e_2 { «nsw» := false, «nuw» := true })
-        (lshr (const? 32 (-2147483648)) e { «exact» := true })) := by 
+        (lshr (const? 32 (-2147483648)) e { «exact» := true })) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -163,7 +163,7 @@ theorem foo1_and_signbit_lshr_without_shifting_signbit_thm (e e_1 e_2 : IntW 32)
       (icmp IntPredicate.sgt (shl e_1 e) (const? 32 (-1))) ⊑
     LLVM.or
       (icmp IntPredicate.eq (LLVM.and (shl (const? 32 1) e_2 { «nsw» := false, «nuw» := true }) e_1) (const? 32 0))
-      (icmp IntPredicate.sgt (shl e_1 e) (const? 32 (-1))) := by 
+      (icmp IntPredicate.sgt (shl e_1 e) (const? 32 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -176,7 +176,7 @@ theorem foo1_and_signbit_lshr_without_shifting_signbit_logical_thm (e e_1 e_2 : 
   select (icmp IntPredicate.eq (LLVM.and (shl (const? 32 1) e_2) e_1) (const? 32 0)) (const? 1 1)
       (icmp IntPredicate.sgt (shl e_1 e) (const? 32 (-1))) ⊑
     select (icmp IntPredicate.eq (LLVM.and (shl (const? 32 1) e_2 { «nsw» := false, «nuw» := true }) e_1) (const? 32 0))
-      (const? 1 1) (icmp IntPredicate.sgt (shl e_1 e) (const? 32 (-1))) := by 
+      (const? 1 1) (icmp IntPredicate.sgt (shl e_1 e) (const? 32 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -190,7 +190,7 @@ theorem foo1_or_signbit_lshr_without_shifting_signbit_thm (e e_1 e_2 : IntW 32) 
       (icmp IntPredicate.slt (shl e_1 e) (const? 32 0)) ⊑
     LLVM.and
       (icmp IntPredicate.ne (LLVM.and (shl (const? 32 1) e_2 { «nsw» := false, «nuw» := true }) e_1) (const? 32 0))
-      (icmp IntPredicate.slt (shl e_1 e) (const? 32 0)) := by 
+      (icmp IntPredicate.slt (shl e_1 e) (const? 32 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -203,7 +203,7 @@ theorem foo1_or_signbit_lshr_without_shifting_signbit_logical_thm (e e_1 e_2 : I
   select (icmp IntPredicate.ne (LLVM.and (shl (const? 32 1) e_2) e_1) (const? 32 0))
       (icmp IntPredicate.slt (shl e_1 e) (const? 32 0)) (const? 1 0) ⊑
     select (icmp IntPredicate.ne (LLVM.and (shl (const? 32 1) e_2 { «nsw» := false, «nuw» := true }) e_1) (const? 32 0))
-      (icmp IntPredicate.slt (shl e_1 e) (const? 32 0)) (const? 1 0) := by 
+      (icmp IntPredicate.slt (shl e_1 e) (const? 32 0)) (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -214,7 +214,7 @@ theorem foo1_or_signbit_lshr_without_shifting_signbit_logical_thm (e e_1 e_2 : I
 
 theorem foo1_and_signbit_lshr_without_shifting_signbit_both_sides_thm (e e_1 e_2 : IntW 32) :
   LLVM.or (icmp IntPredicate.sgt (shl e_2 e_1) (const? 32 (-1))) (icmp IntPredicate.sgt (shl e_2 e) (const? 32 (-1))) ⊑
-    icmp IntPredicate.sgt (LLVM.and (shl e_2 e_1) (shl e_2 e)) (const? 32 (-1)) := by 
+    icmp IntPredicate.sgt (LLVM.and (shl e_2 e_1) (shl e_2 e)) (const? 32 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -225,7 +225,7 @@ theorem foo1_and_signbit_lshr_without_shifting_signbit_both_sides_thm (e e_1 e_2
 
 theorem foo1_or_signbit_lshr_without_shifting_signbit_both_sides_thm (e e_1 e_2 : IntW 32) :
   LLVM.and (icmp IntPredicate.slt (shl e_2 e_1) (const? 32 0)) (icmp IntPredicate.slt (shl e_2 e) (const? 32 0)) ⊑
-    icmp IntPredicate.slt (LLVM.and (shl e_2 e_1) (shl e_2 e)) (const? 32 0) := by 
+    icmp IntPredicate.slt (LLVM.and (shl e_2 e_1) (shl e_2 e)) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/goperandhcomplexity_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/goperandhcomplexity_proof.lean
@@ -10,7 +10,7 @@ set_option linter.unreachableTactic false
 section goperandhcomplexity_proof
 theorem neg_thm (e : IntW 8) :
   LLVM.xor (sub (const? 8 0) e) (LLVM.udiv e (const? 8 42)) ⊑
-    LLVM.xor (LLVM.udiv e (const? 8 42)) (sub (const? 8 0) e) := by 
+    LLVM.xor (LLVM.udiv e (const? 8 42)) (sub (const? 8 0) e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -21,7 +21,7 @@ theorem neg_thm (e : IntW 8) :
 
 theorem not_thm (e : IntW 8) :
   mul (LLVM.xor (const? 8 (-1)) e) (LLVM.udiv e (const? 8 42)) ⊑
-    mul (LLVM.udiv e (const? 8 42)) (LLVM.xor e (const? 8 (-1))) := by 
+    mul (LLVM.udiv e (const? 8 42)) (LLVM.xor e (const? 8 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gorhshiftedhmasks_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gorhshiftedhmasks_proof.lean
@@ -11,7 +11,7 @@ section gorhshiftedhmasks_proof
 theorem or_and_shifts1_thm (e : IntW 32) :
   LLVM.or (LLVM.and (shl e (const? 32 3)) (const? 32 15)) (LLVM.and (shl e (const? 32 5)) (const? 32 60)) ⊑
     LLVM.or (LLVM.and (shl e (const? 32 3)) (const? 32 8)) (LLVM.and (shl e (const? 32 5)) (const? 32 32))
-      { «disjoint» := true } := by 
+      { «disjoint» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -23,7 +23,7 @@ theorem or_and_shifts1_thm (e : IntW 32) :
 theorem or_and_shifts2_thm (e : IntW 32) :
   LLVM.or (LLVM.and (shl e (const? 32 3)) (const? 32 896)) (LLVM.and (lshr e (const? 32 4)) (const? 32 7)) ⊑
     LLVM.or (LLVM.and (shl e (const? 32 3)) (const? 32 896)) (LLVM.and (lshr e (const? 32 4)) (const? 32 7))
-      { «disjoint» := true } := by 
+      { «disjoint» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -34,7 +34,7 @@ theorem or_and_shifts2_thm (e : IntW 32) :
 
 theorem or_and_shift_shift_and_thm (e : IntW 32) :
   LLVM.or (shl (LLVM.and e (const? 32 7)) (const? 32 3)) (LLVM.and (shl e (const? 32 2)) (const? 32 28)) ⊑
-    LLVM.or (LLVM.and (shl e (const? 32 3)) (const? 32 56)) (LLVM.and (shl e (const? 32 2)) (const? 32 28)) := by 
+    LLVM.or (LLVM.and (shl e (const? 32 3)) (const? 32 56)) (LLVM.and (shl e (const? 32 2)) (const? 32 28)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -52,7 +52,7 @@ theorem multiuse1_thm (e : IntW 32) :
     LLVM.or
       (LLVM.or (LLVM.and (lshr e (const? 32 1)) (const? 32 1)) (LLVM.and (lshr e (const? 32 1)) (const? 32 2))
         { «disjoint» := true })
-      (LLVM.and (shl e (const? 32 6)) (const? 32 384)) { «disjoint» := true } := by 
+      (LLVM.and (shl e (const? 32 6)) (const? 32 384)) { «disjoint» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -74,7 +74,7 @@ theorem multiuse2_thm (e : IntW 32) :
         (LLVM.or (LLVM.and (shl e (const? 32 1)) (const? 32 192)) (LLVM.and (shl e (const? 32 1)) (const? 32 48))
           { «disjoint» := true })
         { «disjoint» := true })
-      { «disjoint» := true } := by 
+      { «disjoint» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -92,7 +92,7 @@ theorem multiuse3_thm (e : IntW 32) :
     LLVM.or
       (LLVM.or (LLVM.and (lshr e (const? 32 1)) (const? 32 48)) (LLVM.and (lshr e (const? 32 1)) (const? 32 15))
         { «disjoint» := true })
-      (LLVM.and (shl e (const? 32 6)) (const? 32 8064)) { «disjoint» := true } := by 
+      (LLVM.and (shl e (const? 32 6)) (const? 32 8064)) { «disjoint» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -104,7 +104,7 @@ theorem multiuse3_thm (e : IntW 32) :
 theorem shl_mask_thm (e : IntW 32) :
   LLVM.or (LLVM.and e (const? 32 255)) (shl (LLVM.and e (const? 32 255)) (const? 32 8)) ⊑
     LLVM.or (LLVM.and e (const? 32 255))
-      (shl (LLVM.and e (const? 32 255)) (const? 32 8) { «nsw» := true, «nuw» := true }) { «disjoint» := true } := by 
+      (shl (LLVM.and e (const? 32 255)) (const? 32 8) { «nsw» := true, «nuw» := true }) { «disjoint» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -116,7 +116,7 @@ theorem shl_mask_thm (e : IntW 32) :
 theorem shl_mask_wrong_shl_const_thm (e : IntW 32) :
   LLVM.or (LLVM.and e (const? 32 255)) (shl (LLVM.and e (const? 32 255)) (const? 32 7)) ⊑
     LLVM.or (LLVM.and e (const? 32 255))
-      (shl (LLVM.and e (const? 32 255)) (const? 32 7) { «nsw» := true, «nuw» := true }) := by 
+      (shl (LLVM.and e (const? 32 255)) (const? 32 7) { «nsw» := true, «nuw» := true }) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -128,7 +128,7 @@ theorem shl_mask_wrong_shl_const_thm (e : IntW 32) :
 theorem shl_mask_weird_type_thm (e : IntW 37) :
   LLVM.or (LLVM.and e (const? 37 255)) (shl (LLVM.and e (const? 37 255)) (const? 37 8)) ⊑
     LLVM.or (LLVM.and e (const? 37 255))
-      (shl (LLVM.and e (const? 37 255)) (const? 37 8) { «nsw» := true, «nuw» := true }) { «disjoint» := true } := by 
+      (shl (LLVM.and e (const? 37 255)) (const? 37 8) { «nsw» := true, «nuw» := true }) { «disjoint» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -140,7 +140,7 @@ theorem shl_mask_weird_type_thm (e : IntW 37) :
 theorem shl_mul_mask_thm (e : IntW 32) :
   LLVM.or (mul (LLVM.and e (const? 32 255)) (const? 32 65537)) (shl (LLVM.and e (const? 32 255)) (const? 32 8)) ⊑
     LLVM.or (mul (LLVM.and e (const? 32 255)) (const? 32 65537) { «nsw» := true, «nuw» := true })
-      (shl (LLVM.and e (const? 32 255)) (const? 32 8) { «nsw» := true, «nuw» := true }) := by 
+      (shl (LLVM.and e (const? 32 255)) (const? 32 8) { «nsw» := true, «nuw» := true }) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -152,7 +152,7 @@ theorem shl_mul_mask_thm (e : IntW 32) :
 theorem shl_mul_mask_wrong_mul_const_thm (e : IntW 32) :
   LLVM.or (mul (LLVM.and e (const? 32 255)) (const? 32 65535)) (shl (LLVM.and e (const? 32 255)) (const? 32 8)) ⊑
     LLVM.or (mul (LLVM.and e (const? 32 255)) (const? 32 65535) { «nsw» := true, «nuw» := true })
-      (shl (LLVM.and e (const? 32 255)) (const? 32 8) { «nsw» := true, «nuw» := true }) := by 
+      (shl (LLVM.and e (const? 32 255)) (const? 32 8) { «nsw» := true, «nuw» := true }) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gorhxor_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gorhxor_proof.lean
@@ -9,7 +9,7 @@ set_option linter.unreachableTactic false
 
 section gorhxor_proof
 theorem test1_thm (e e_1 : IntW 32) :
-  LLVM.or e_1 (LLVM.xor (LLVM.or e_1 e) (const? 32 (-1))) ⊑ LLVM.or e_1 (LLVM.xor e (const? 32 (-1))) := by 
+  LLVM.or e_1 (LLVM.xor (LLVM.or e_1 e) (const? 32 (-1))) ⊑ LLVM.or e_1 (LLVM.xor e (const? 32 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -19,7 +19,7 @@ theorem test1_thm (e e_1 : IntW 32) :
 
 
 theorem test2_thm (e e_1 : IntW 32) :
-  LLVM.or e_1 (LLVM.xor (LLVM.or e e_1) (const? 32 (-1))) ⊑ LLVM.or e_1 (LLVM.xor e (const? 32 (-1))) := by 
+  LLVM.or e_1 (LLVM.xor (LLVM.or e e_1) (const? 32 (-1))) ⊑ LLVM.or e_1 (LLVM.xor e (const? 32 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -29,7 +29,7 @@ theorem test2_thm (e e_1 : IntW 32) :
 
 
 theorem test3_thm (e e_1 : IntW 32) :
-  LLVM.or e_1 (LLVM.xor (LLVM.xor e_1 e) (const? 32 (-1))) ⊑ LLVM.or e_1 (LLVM.xor e (const? 32 (-1))) := by 
+  LLVM.or e_1 (LLVM.xor (LLVM.xor e_1 e) (const? 32 (-1))) ⊑ LLVM.or e_1 (LLVM.xor e (const? 32 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -39,7 +39,7 @@ theorem test3_thm (e e_1 : IntW 32) :
 
 
 theorem test4_thm (e e_1 : IntW 32) :
-  LLVM.or e_1 (LLVM.xor (LLVM.xor e e_1) (const? 32 (-1))) ⊑ LLVM.or e_1 (LLVM.xor e (const? 32 (-1))) := by 
+  LLVM.or e_1 (LLVM.xor (LLVM.xor e e_1) (const? 32 (-1))) ⊑ LLVM.or e_1 (LLVM.xor e (const? 32 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -49,7 +49,7 @@ theorem test4_thm (e e_1 : IntW 32) :
 
 
 theorem test5_thm (e e_1 : IntW 32) :
-  LLVM.or (LLVM.xor e_1 e) (LLVM.xor e_1 (const? 32 (-1))) ⊑ LLVM.xor (LLVM.and e_1 e) (const? 32 (-1)) := by 
+  LLVM.or (LLVM.xor e_1 e) (LLVM.xor e_1 (const? 32 (-1))) ⊑ LLVM.xor (LLVM.and e_1 e) (const? 32 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -59,7 +59,7 @@ theorem test5_thm (e e_1 : IntW 32) :
 
 
 theorem test5_commuted_x_y_thm (e e_1 : IntW 64) :
-  LLVM.or (LLVM.xor e_1 e) (LLVM.xor e (const? 64 (-1))) ⊑ LLVM.xor (LLVM.and e_1 e) (const? 64 (-1)) := by 
+  LLVM.or (LLVM.xor e_1 e) (LLVM.xor e (const? 64 (-1))) ⊑ LLVM.xor (LLVM.and e_1 e) (const? 64 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -68,7 +68,7 @@ theorem test5_commuted_x_y_thm (e e_1 : IntW 64) :
     all_goals sorry
 
 
-theorem xor_common_op_commute0_thm (e e_1 : IntW 8) : LLVM.or (LLVM.xor e_1 e) e_1 ⊑ LLVM.or e e_1 := by 
+theorem xor_common_op_commute0_thm (e e_1 : IntW 8) : LLVM.or (LLVM.xor e_1 e) e_1 ⊑ LLVM.or e e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -79,7 +79,7 @@ theorem xor_common_op_commute0_thm (e e_1 : IntW 8) : LLVM.or (LLVM.xor e_1 e) e
 
 theorem xor_common_op_commute2_thm (e e_1 : IntW 8) :
   LLVM.or (LLVM.xor e_1 (const? 8 5)) (LLVM.xor (LLVM.xor e_1 (const? 8 5)) e) ⊑
-    LLVM.or (LLVM.xor e_1 (const? 8 5)) e := by 
+    LLVM.or (LLVM.xor e_1 (const? 8 5)) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -90,7 +90,7 @@ theorem xor_common_op_commute2_thm (e e_1 : IntW 8) :
 
 theorem xor_common_op_commute3_thm (e e_1 : IntW 8) :
   LLVM.or (LLVM.xor e_1 (const? 8 5)) (LLVM.xor (mul e e) (LLVM.xor e_1 (const? 8 5))) ⊑
-    LLVM.or (LLVM.xor e_1 (const? 8 5)) (mul e e) := by 
+    LLVM.or (LLVM.xor e_1 (const? 8 5)) (mul e e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -100,7 +100,7 @@ theorem xor_common_op_commute3_thm (e e_1 : IntW 8) :
 
 
 theorem test8_thm (e e_1 : IntW 32) :
-  LLVM.or e_1 (LLVM.xor e (LLVM.xor e_1 (const? 32 (-1)))) ⊑ LLVM.or e_1 (LLVM.xor e (const? 32 (-1))) := by 
+  LLVM.or e_1 (LLVM.xor e (LLVM.xor e_1 (const? 32 (-1)))) ⊑ LLVM.or e_1 (LLVM.xor e (const? 32 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -110,7 +110,7 @@ theorem test8_thm (e e_1 : IntW 32) :
 
 
 theorem test9_thm (e e_1 : IntW 32) :
-  LLVM.or e_1 (LLVM.xor (LLVM.xor e_1 (const? 32 (-1))) e) ⊑ LLVM.or e_1 (LLVM.xor e (const? 32 (-1))) := by 
+  LLVM.or e_1 (LLVM.xor (LLVM.xor e_1 (const? 32 (-1))) e) ⊑ LLVM.or e_1 (LLVM.xor e (const? 32 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -121,7 +121,7 @@ theorem test9_thm (e e_1 : IntW 32) :
 
 theorem test10_thm (e e_1 : IntW 32) :
   LLVM.or (LLVM.xor e_1 e) (LLVM.xor (LLVM.xor e (const? 32 (-1))) e_1) ⊑
-    LLVM.or (LLVM.xor e_1 e) (LLVM.xor (LLVM.xor e e_1) (const? 32 (-1))) := by 
+    LLVM.or (LLVM.xor e_1 e) (LLVM.xor (LLVM.xor e e_1) (const? 32 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -132,7 +132,7 @@ theorem test10_thm (e e_1 : IntW 32) :
 
 theorem test10_commuted_thm (e e_1 : IntW 32) :
   LLVM.or (LLVM.xor (LLVM.xor e_1 (const? 32 (-1))) e) (LLVM.xor e e_1) ⊑
-    LLVM.or (LLVM.xor e e_1) (LLVM.xor (LLVM.xor e_1 e) (const? 32 (-1))) := by 
+    LLVM.or (LLVM.xor e e_1) (LLVM.xor (LLVM.xor e_1 e) (const? 32 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -142,7 +142,7 @@ theorem test10_commuted_thm (e e_1 : IntW 32) :
 
 
 theorem test11_thm (e e_1 : IntW 32) :
-  LLVM.and (LLVM.or e_1 e) (LLVM.xor (LLVM.xor e_1 (const? 32 (-1))) e) ⊑ LLVM.and e e_1 := by 
+  LLVM.and (LLVM.or e_1 e) (LLVM.xor (LLVM.xor e_1 (const? 32 (-1))) e) ⊑ LLVM.and e e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -152,7 +152,7 @@ theorem test11_thm (e e_1 : IntW 32) :
 
 
 theorem test12_thm (e e_1 : IntW 32) :
-  LLVM.and (LLVM.xor (LLVM.xor e_1 (const? 32 (-1))) e) (LLVM.or e_1 e) ⊑ LLVM.and e e_1 := by 
+  LLVM.and (LLVM.xor (LLVM.xor e_1 (const? 32 (-1))) e) (LLVM.or e_1 e) ⊑ LLVM.and e e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -162,7 +162,7 @@ theorem test12_thm (e e_1 : IntW 32) :
 
 
 theorem test12_commuted_thm (e e_1 : IntW 32) :
-  LLVM.and (LLVM.xor (LLVM.xor e_1 (const? 32 (-1))) e) (LLVM.or e e_1) ⊑ LLVM.and e e_1 := by 
+  LLVM.and (LLVM.xor (LLVM.xor e_1 (const? 32 (-1))) e) (LLVM.or e e_1) ⊑ LLVM.and e e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -171,7 +171,7 @@ theorem test12_commuted_thm (e e_1 : IntW 32) :
     all_goals sorry
 
 
-theorem test13_thm (e e_1 : IntW 32) : LLVM.xor (LLVM.or e_1 e) (LLVM.xor e_1 e) ⊑ LLVM.and e e_1 := by 
+theorem test13_thm (e e_1 : IntW 32) : LLVM.xor (LLVM.or e_1 e) (LLVM.xor e_1 e) ⊑ LLVM.and e e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -182,7 +182,7 @@ theorem test13_thm (e e_1 : IntW 32) : LLVM.xor (LLVM.or e_1 e) (LLVM.xor e_1 e)
 
 theorem test14_thm (e e_1 : IntW 32) :
   LLVM.xor (LLVM.or e_1 (LLVM.xor e (const? 32 (-1)))) (LLVM.or (LLVM.xor e_1 (const? 32 (-1))) e) ⊑
-    LLVM.xor e_1 e := by 
+    LLVM.xor e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -193,7 +193,7 @@ theorem test14_thm (e e_1 : IntW 32) :
 
 theorem test14_commuted_thm (e e_1 : IntW 32) :
   LLVM.xor (LLVM.or (LLVM.xor e_1 (const? 32 (-1))) e) (LLVM.or (LLVM.xor e (const? 32 (-1))) e_1) ⊑
-    LLVM.xor e e_1 := by 
+    LLVM.xor e e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -204,7 +204,7 @@ theorem test14_commuted_thm (e e_1 : IntW 32) :
 
 theorem test15_thm (e e_1 : IntW 32) :
   LLVM.xor (LLVM.and e_1 (LLVM.xor e (const? 32 (-1)))) (LLVM.and (LLVM.xor e_1 (const? 32 (-1))) e) ⊑
-    LLVM.xor e_1 e := by 
+    LLVM.xor e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -215,7 +215,7 @@ theorem test15_thm (e e_1 : IntW 32) :
 
 theorem test15_commuted_thm (e e_1 : IntW 32) :
   LLVM.xor (LLVM.and (LLVM.xor e_1 (const? 32 (-1))) e) (LLVM.and (LLVM.xor e (const? 32 (-1))) e_1) ⊑
-    LLVM.xor e e_1 := by 
+    LLVM.xor e e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -226,7 +226,7 @@ theorem test15_commuted_thm (e e_1 : IntW 32) :
 
 theorem or_and_xor_not_constant_commute0_thm (e e_1 : IntW 32) :
   LLVM.or (LLVM.and (LLVM.xor e_1 e) (const? 32 1)) (LLVM.and e (const? 32 (-2))) ⊑
-    LLVM.xor (LLVM.and e_1 (const? 32 1)) e := by 
+    LLVM.xor (LLVM.and e_1 (const? 32 1)) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -237,7 +237,7 @@ theorem or_and_xor_not_constant_commute0_thm (e e_1 : IntW 32) :
 
 theorem or_and_xor_not_constant_commute1_thm (e e_1 : IntW 9) :
   LLVM.or (LLVM.and (LLVM.xor e_1 e) (const? 9 42)) (LLVM.and e_1 (const? 9 (-43))) ⊑
-    LLVM.xor (LLVM.and e (const? 9 42)) e_1 := by 
+    LLVM.xor (LLVM.and e (const? 9 42)) e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -248,7 +248,7 @@ theorem or_and_xor_not_constant_commute1_thm (e e_1 : IntW 9) :
 
 theorem not_or_xor_thm (e : IntW 8) :
   LLVM.xor (LLVM.or (LLVM.xor e (const? 8 (-1))) (const? 8 7)) (const? 8 12) ⊑
-    LLVM.xor (LLVM.and e (const? 8 (-8))) (const? 8 (-13)) := by 
+    LLVM.xor (LLVM.and e (const? 8 (-8))) (const? 8 (-13)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -258,7 +258,7 @@ theorem not_or_xor_thm (e : IntW 8) :
 
 
 theorem xor_or_thm (e : IntW 8) :
-  LLVM.or (LLVM.xor e (const? 8 32)) (const? 8 7) ⊑ LLVM.xor (LLVM.and e (const? 8 (-8))) (const? 8 39) := by 
+  LLVM.or (LLVM.xor e (const? 8 32)) (const? 8 7) ⊑ LLVM.xor (LLVM.and e (const? 8 (-8))) (const? 8 39) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -268,7 +268,7 @@ theorem xor_or_thm (e : IntW 8) :
 
 
 theorem xor_or2_thm (e : IntW 8) :
-  LLVM.or (LLVM.xor e (const? 8 33)) (const? 8 7) ⊑ LLVM.xor (LLVM.and e (const? 8 (-8))) (const? 8 39) := by 
+  LLVM.or (LLVM.xor e (const? 8 33)) (const? 8 7) ⊑ LLVM.xor (LLVM.and e (const? 8 (-8))) (const? 8 39) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -279,7 +279,7 @@ theorem xor_or2_thm (e : IntW 8) :
 
 theorem xor_or_xor_thm (e : IntW 8) :
   LLVM.xor (LLVM.or (LLVM.xor e (const? 8 33)) (const? 8 7)) (const? 8 12) ⊑
-    LLVM.xor (LLVM.and e (const? 8 (-8))) (const? 8 43) := by 
+    LLVM.xor (LLVM.and e (const? 8 (-8))) (const? 8 43) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -290,7 +290,7 @@ theorem xor_or_xor_thm (e : IntW 8) :
 
 theorem or_xor_or_thm (e : IntW 8) :
   LLVM.or (LLVM.xor (LLVM.or e (const? 8 33)) (const? 8 12)) (const? 8 7) ⊑
-    LLVM.xor (LLVM.and e (const? 8 (-40))) (const? 8 47) := by 
+    LLVM.xor (LLVM.and e (const? 8 (-40))) (const? 8 47) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -302,7 +302,7 @@ theorem or_xor_or_thm (e : IntW 8) :
 theorem test17_thm (e e_1 : IntW 8) :
   mul (LLVM.or (LLVM.xor e_1 e) (LLVM.xor (LLVM.xor e (const? 8 33)) e_1)) (LLVM.xor (LLVM.xor e (const? 8 33)) e_1) ⊑
     mul (LLVM.or (LLVM.xor e_1 e) (LLVM.xor (LLVM.xor e e_1) (const? 8 33)))
-      (LLVM.xor (LLVM.xor e e_1) (const? 8 33)) := by 
+      (LLVM.xor (LLVM.xor e e_1) (const? 8 33)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -314,7 +314,7 @@ theorem test17_thm (e e_1 : IntW 8) :
 theorem test18_thm (e e_1 : IntW 8) :
   mul (LLVM.or (LLVM.xor (LLVM.xor e_1 (const? 8 33)) e) (LLVM.xor e e_1)) (LLVM.xor (LLVM.xor e_1 (const? 8 33)) e) ⊑
     mul (LLVM.or (LLVM.xor (LLVM.xor e_1 e) (const? 8 33)) (LLVM.xor e e_1))
-      (LLVM.xor (LLVM.xor e_1 e) (const? 8 33)) := by 
+      (LLVM.xor (LLVM.xor e_1 e) (const? 8 33)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -325,7 +325,7 @@ theorem test18_thm (e e_1 : IntW 8) :
 
 theorem test19_thm (e e_1 : IntW 32) :
   LLVM.xor (LLVM.or e_1 e) (LLVM.or (LLVM.xor e_1 (const? 32 (-1))) (LLVM.xor e (const? 32 (-1)))) ⊑
-    LLVM.xor (LLVM.xor e_1 e) (const? 32 (-1)) := by 
+    LLVM.xor (LLVM.xor e_1 e) (const? 32 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -336,7 +336,7 @@ theorem test19_thm (e e_1 : IntW 32) :
 
 theorem test20_thm (e e_1 : IntW 32) :
   LLVM.xor (LLVM.or e_1 e) (LLVM.or (LLVM.xor e (const? 32 (-1))) (LLVM.xor e_1 (const? 32 (-1)))) ⊑
-    LLVM.xor (LLVM.xor e_1 e) (const? 32 (-1)) := by 
+    LLVM.xor (LLVM.xor e_1 e) (const? 32 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -347,7 +347,7 @@ theorem test20_thm (e e_1 : IntW 32) :
 
 theorem test21_thm (e e_1 : IntW 32) :
   LLVM.xor (LLVM.or (LLVM.xor e_1 (const? 32 (-1))) (LLVM.xor e (const? 32 (-1)))) (LLVM.or e_1 e) ⊑
-    LLVM.xor (LLVM.xor e_1 e) (const? 32 (-1)) := by 
+    LLVM.xor (LLVM.xor e_1 e) (const? 32 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -358,7 +358,7 @@ theorem test21_thm (e e_1 : IntW 32) :
 
 theorem test22_thm (e e_1 : IntW 32) :
   LLVM.xor (LLVM.or (LLVM.xor e_1 (const? 32 (-1))) (LLVM.xor e (const? 32 (-1)))) (LLVM.or e e_1) ⊑
-    LLVM.xor (LLVM.xor e e_1) (const? 32 (-1)) := by 
+    LLVM.xor (LLVM.xor e e_1) (const? 32 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -369,7 +369,7 @@ theorem test22_thm (e e_1 : IntW 32) :
 
 theorem test23_thm (e : IntW 8) :
   LLVM.xor (LLVM.or (LLVM.xor (LLVM.or e (const? 8 (-2))) (const? 8 13)) (const? 8 1)) (const? 8 12) ⊑
-    const? 8 (-1) := by 
+    const? 8 (-1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -380,7 +380,7 @@ theorem test23_thm (e : IntW 8) :
 
 theorem PR45977_f1_thm (e e_1 : IntW 32) :
   LLVM.or (LLVM.xor (LLVM.or e_1 e) (const? 32 (-1))) (LLVM.and (LLVM.xor e_1 (const? 32 (-1))) e) ⊑
-    LLVM.xor e_1 (const? 32 (-1)) := by 
+    LLVM.xor e_1 (const? 32 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -390,7 +390,7 @@ theorem PR45977_f1_thm (e e_1 : IntW 32) :
 
 
 theorem PR45977_f2_thm (e e_1 : IntW 32) :
-  LLVM.xor (LLVM.or e_1 e) (LLVM.or e_1 (LLVM.xor e (const? 32 (-1)))) ⊑ LLVM.xor e_1 (const? 32 (-1)) := by 
+  LLVM.xor (LLVM.or e_1 e) (LLVM.or e_1 (LLVM.xor e (const? 32 (-1)))) ⊑ LLVM.xor e_1 (const? 32 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -400,7 +400,7 @@ theorem PR45977_f2_thm (e e_1 : IntW 32) :
 
 
 theorem or_xor_common_op_commute0_thm (e e_1 e_2 : IntW 8) :
-  LLVM.or (LLVM.or e_2 e_1) (LLVM.xor e_2 e) ⊑ LLVM.or (LLVM.or e_2 e_1) e := by 
+  LLVM.or (LLVM.or e_2 e_1) (LLVM.xor e_2 e) ⊑ LLVM.or (LLVM.or e_2 e_1) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -410,7 +410,7 @@ theorem or_xor_common_op_commute0_thm (e e_1 e_2 : IntW 8) :
 
 
 theorem or_xor_common_op_commute5_thm (e e_1 e_2 : IntW 8) :
-  LLVM.or (LLVM.xor e_2 e_1) (LLVM.or e e_2) ⊑ LLVM.or (LLVM.or e e_2) e_1 := by 
+  LLVM.or (LLVM.xor e_2 e_1) (LLVM.or e e_2) ⊑ LLVM.or (LLVM.or e e_2) e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -420,7 +420,7 @@ theorem or_xor_common_op_commute5_thm (e e_1 e_2 : IntW 8) :
 
 
 theorem or_xor_common_op_commute6_thm (e e_1 e_2 : IntW 8) :
-  LLVM.or (LLVM.xor e_2 e_1) (LLVM.or e_1 e) ⊑ LLVM.or (LLVM.or e_1 e) e_2 := by 
+  LLVM.or (LLVM.xor e_2 e_1) (LLVM.or e_1 e) ⊑ LLVM.or (LLVM.or e_1 e) e_2 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -430,7 +430,7 @@ theorem or_xor_common_op_commute6_thm (e e_1 e_2 : IntW 8) :
 
 
 theorem or_xor_common_op_commute7_thm (e e_1 e_2 : IntW 8) :
-  LLVM.or (LLVM.xor e_2 e_1) (LLVM.or e e_1) ⊑ LLVM.or (LLVM.or e e_1) e_2 := by 
+  LLVM.or (LLVM.xor e_2 e_1) (LLVM.or e e_1) ⊑ LLVM.or (LLVM.or e e_1) e_2 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -441,7 +441,7 @@ theorem or_xor_common_op_commute7_thm (e e_1 e_2 : IntW 8) :
 
 theorem or_not_xor_common_op_commute0_thm (e e_1 e_2 : IntW 4) :
   LLVM.or (LLVM.or (LLVM.xor e_2 (const? 4 (-1))) e_1) (LLVM.xor e_2 e) ⊑
-    LLVM.or e_1 (LLVM.xor (LLVM.and e_2 e) (const? 4 (-1))) := by 
+    LLVM.or e_1 (LLVM.xor (LLVM.and e_2 e) (const? 4 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -452,7 +452,7 @@ theorem or_not_xor_common_op_commute0_thm (e e_1 e_2 : IntW 4) :
 
 theorem or_not_xor_common_op_commute2_thm (e e_1 e_2 : IntW 8) :
   LLVM.or (LLVM.xor e_2 e_1) (LLVM.or (sub (const? 8 0) e) (LLVM.xor e_2 (const? 8 (-1)))) ⊑
-    LLVM.or (LLVM.xor (LLVM.and e_2 e_1) (const? 8 (-1))) (sub (const? 8 0) e) := by 
+    LLVM.or (LLVM.xor (LLVM.and e_2 e_1) (const? 8 (-1))) (sub (const? 8 0) e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -463,7 +463,7 @@ theorem or_not_xor_common_op_commute2_thm (e e_1 e_2 : IntW 8) :
 
 theorem or_not_xor_common_op_commute3_thm (e e_1 e_2 : IntW 8) :
   LLVM.or (LLVM.or (sub (const? 8 0) e_2) (LLVM.xor e_1 (const? 8 (-1)))) (LLVM.xor e_1 e) ⊑
-    LLVM.or (LLVM.xor (LLVM.and e_1 e) (const? 8 (-1))) (sub (const? 8 0) e_2) := by 
+    LLVM.or (LLVM.xor (LLVM.and e_1 e) (const? 8 (-1))) (sub (const? 8 0) e_2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -474,7 +474,7 @@ theorem or_not_xor_common_op_commute3_thm (e e_1 e_2 : IntW 8) :
 
 theorem or_not_xor_common_op_commute5_thm (e e_1 e_2 : IntW 8) :
   LLVM.or (LLVM.xor e_2 e_1) (LLVM.or (LLVM.xor e_1 (const? 8 (-1))) e) ⊑
-    LLVM.or e (LLVM.xor (LLVM.and e_2 e_1) (const? 8 (-1))) := by 
+    LLVM.or e (LLVM.xor (LLVM.and e_2 e_1) (const? 8 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -485,7 +485,7 @@ theorem or_not_xor_common_op_commute5_thm (e e_1 e_2 : IntW 8) :
 
 theorem or_not_xor_common_op_commute6_thm (e e_1 e_2 : IntW 8) :
   LLVM.or (LLVM.xor e_2 e_1) (LLVM.or (sub (const? 8 0) e) (LLVM.xor e_1 (const? 8 (-1)))) ⊑
-    LLVM.or (LLVM.xor (LLVM.and e_2 e_1) (const? 8 (-1))) (sub (const? 8 0) e) := by 
+    LLVM.or (LLVM.xor (LLVM.and e_2 e_1) (const? 8 (-1))) (sub (const? 8 0) e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -496,7 +496,7 @@ theorem or_not_xor_common_op_commute6_thm (e e_1 e_2 : IntW 8) :
 
 theorem or_not_xor_common_op_commute7_thm (e e_1 e_2 : IntW 8) :
   LLVM.or (LLVM.or (sub (const? 8 0) e_2) (LLVM.xor e_1 (const? 8 (-1)))) (LLVM.xor e e_1) ⊑
-    LLVM.or (LLVM.xor (LLVM.and e e_1) (const? 8 (-1))) (sub (const? 8 0) e_2) := by 
+    LLVM.or (LLVM.xor (LLVM.and e e_1) (const? 8 (-1))) (sub (const? 8 0) e_2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -507,7 +507,7 @@ theorem or_not_xor_common_op_commute7_thm (e e_1 e_2 : IntW 8) :
 
 theorem or_nand_xor_common_op_commute0_thm (e e_1 e_2 : IntW 4) :
   LLVM.or (LLVM.xor (LLVM.and e_2 e_1) (const? 4 (-1))) (LLVM.xor e_2 e) ⊑
-    LLVM.xor (LLVM.and (LLVM.and e_2 e_1) e) (const? 4 (-1)) := by 
+    LLVM.xor (LLVM.and (LLVM.and e_2 e_1) e) (const? 4 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -517,7 +517,7 @@ theorem or_nand_xor_common_op_commute0_thm (e e_1 e_2 : IntW 4) :
 
 
 theorem PR75692_1_thm (e : IntW 32) :
-  LLVM.or (LLVM.xor e (const? 32 4)) (LLVM.xor e (const? 32 (-5))) ⊑ const? 32 (-1) := by 
+  LLVM.or (LLVM.xor e (const? 32 4)) (LLVM.xor e (const? 32 (-5))) ⊑ const? 32 (-1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -527,7 +527,7 @@ theorem PR75692_1_thm (e : IntW 32) :
 
 
 theorem or_xor_not_thm (e e_1 : IntW 32) :
-  LLVM.or (LLVM.xor e_1 (LLVM.xor e (const? 32 (-1)))) e ⊑ LLVM.or e (LLVM.xor e_1 (const? 32 (-1))) := by 
+  LLVM.or (LLVM.xor e_1 (LLVM.xor e (const? 32 (-1)))) e ⊑ LLVM.or e (LLVM.xor e_1 (const? 32 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -538,7 +538,7 @@ theorem or_xor_not_thm (e e_1 : IntW 32) :
 
 theorem or_xor_and_commuted1_thm (e e_1 : IntW 32) :
   LLVM.or (mul e_1 e_1) (LLVM.xor (LLVM.xor (mul e_1 e_1) (const? 32 (-1))) e) ⊑
-    LLVM.or (mul e_1 e_1) (LLVM.xor e (const? 32 (-1))) := by 
+    LLVM.or (mul e_1 e_1) (LLVM.xor e (const? 32 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -549,7 +549,7 @@ theorem or_xor_and_commuted1_thm (e e_1 : IntW 32) :
 
 theorem or_xor_and_commuted2_thm (e e_1 : IntW 32) :
   LLVM.or (LLVM.xor (mul e_1 e_1) (LLVM.xor (mul e e) (const? 32 (-1)))) (mul e e) ⊑
-    LLVM.or (mul e e) (LLVM.xor (mul e_1 e_1) (const? 32 (-1))) := by 
+    LLVM.or (mul e e) (LLVM.xor (mul e_1 e_1) (const? 32 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -561,7 +561,7 @@ theorem or_xor_and_commuted2_thm (e e_1 : IntW 32) :
 theorem or_xor_tree_0000_thm (e e_1 e_2 : IntW 32) :
   LLVM.or (LLVM.xor (mul e_2 (const? 32 42)) (mul e_1 (const? 32 42)))
       (LLVM.xor (LLVM.xor (mul e_1 (const? 32 42)) (mul e (const? 32 42))) (mul e_2 (const? 32 42))) ⊑
-    LLVM.or (LLVM.xor (mul e_2 (const? 32 42)) (mul e_1 (const? 32 42))) (mul e (const? 32 42)) := by 
+    LLVM.or (LLVM.xor (mul e_2 (const? 32 42)) (mul e_1 (const? 32 42))) (mul e (const? 32 42)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -573,7 +573,7 @@ theorem or_xor_tree_0000_thm (e e_1 e_2 : IntW 32) :
 theorem or_xor_tree_0001_thm (e e_1 e_2 : IntW 32) :
   LLVM.or (LLVM.xor (mul e_2 (const? 32 42)) (mul e_1 (const? 32 42)))
       (LLVM.xor (LLVM.xor (mul e_2 (const? 32 42)) (mul e (const? 32 42))) (mul e_1 (const? 32 42))) ⊑
-    LLVM.or (LLVM.xor (mul e_2 (const? 32 42)) (mul e_1 (const? 32 42))) (mul e (const? 32 42)) := by 
+    LLVM.or (LLVM.xor (mul e_2 (const? 32 42)) (mul e_1 (const? 32 42))) (mul e (const? 32 42)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -585,7 +585,7 @@ theorem or_xor_tree_0001_thm (e e_1 e_2 : IntW 32) :
 theorem or_xor_tree_0010_thm (e e_1 e_2 : IntW 32) :
   LLVM.or (LLVM.xor (mul e_2 (const? 32 42)) (mul e_1 (const? 32 42)))
       (LLVM.xor (LLVM.xor (mul e (const? 32 42)) (mul e_1 (const? 32 42))) (mul e_2 (const? 32 42))) ⊑
-    LLVM.or (LLVM.xor (mul e_2 (const? 32 42)) (mul e_1 (const? 32 42))) (mul e (const? 32 42)) := by 
+    LLVM.or (LLVM.xor (mul e_2 (const? 32 42)) (mul e_1 (const? 32 42))) (mul e (const? 32 42)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -597,7 +597,7 @@ theorem or_xor_tree_0010_thm (e e_1 e_2 : IntW 32) :
 theorem or_xor_tree_0011_thm (e e_1 e_2 : IntW 32) :
   LLVM.or (LLVM.xor (mul e_2 (const? 32 42)) (mul e_1 (const? 32 42)))
       (LLVM.xor (LLVM.xor (mul e (const? 32 42)) (mul e_2 (const? 32 42))) (mul e_1 (const? 32 42))) ⊑
-    LLVM.or (LLVM.xor (mul e_2 (const? 32 42)) (mul e_1 (const? 32 42))) (mul e (const? 32 42)) := by 
+    LLVM.or (LLVM.xor (mul e_2 (const? 32 42)) (mul e_1 (const? 32 42))) (mul e (const? 32 42)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -609,7 +609,7 @@ theorem or_xor_tree_0011_thm (e e_1 e_2 : IntW 32) :
 theorem or_xor_tree_0100_thm (e e_1 e_2 : IntW 32) :
   LLVM.or (LLVM.xor (mul e_2 (const? 32 42)) (mul e_1 (const? 32 42)))
       (LLVM.xor (mul e_2 (const? 32 42)) (LLVM.xor (mul e_1 (const? 32 42)) (mul e (const? 32 42)))) ⊑
-    LLVM.or (LLVM.xor (mul e_2 (const? 32 42)) (mul e_1 (const? 32 42))) (mul e (const? 32 42)) := by 
+    LLVM.or (LLVM.xor (mul e_2 (const? 32 42)) (mul e_1 (const? 32 42))) (mul e (const? 32 42)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -621,7 +621,7 @@ theorem or_xor_tree_0100_thm (e e_1 e_2 : IntW 32) :
 theorem or_xor_tree_0101_thm (e e_1 e_2 : IntW 32) :
   LLVM.or (LLVM.xor (mul e_2 (const? 32 42)) (mul e_1 (const? 32 42)))
       (LLVM.xor (mul e_1 (const? 32 42)) (LLVM.xor (mul e_2 (const? 32 42)) (mul e (const? 32 42)))) ⊑
-    LLVM.or (LLVM.xor (mul e_2 (const? 32 42)) (mul e_1 (const? 32 42))) (mul e (const? 32 42)) := by 
+    LLVM.or (LLVM.xor (mul e_2 (const? 32 42)) (mul e_1 (const? 32 42))) (mul e (const? 32 42)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -633,7 +633,7 @@ theorem or_xor_tree_0101_thm (e e_1 e_2 : IntW 32) :
 theorem or_xor_tree_0110_thm (e e_1 e_2 : IntW 32) :
   LLVM.or (LLVM.xor (mul e_2 (const? 32 42)) (mul e_1 (const? 32 42)))
       (LLVM.xor (mul e_2 (const? 32 42)) (LLVM.xor (mul e (const? 32 42)) (mul e_1 (const? 32 42)))) ⊑
-    LLVM.or (LLVM.xor (mul e_2 (const? 32 42)) (mul e_1 (const? 32 42))) (mul e (const? 32 42)) := by 
+    LLVM.or (LLVM.xor (mul e_2 (const? 32 42)) (mul e_1 (const? 32 42))) (mul e (const? 32 42)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -645,7 +645,7 @@ theorem or_xor_tree_0110_thm (e e_1 e_2 : IntW 32) :
 theorem or_xor_tree_0111_thm (e e_1 e_2 : IntW 32) :
   LLVM.or (LLVM.xor (mul e_2 (const? 32 42)) (mul e_1 (const? 32 42)))
       (LLVM.xor (mul e_1 (const? 32 42)) (LLVM.xor (mul e (const? 32 42)) (mul e_2 (const? 32 42)))) ⊑
-    LLVM.or (LLVM.xor (mul e_2 (const? 32 42)) (mul e_1 (const? 32 42))) (mul e (const? 32 42)) := by 
+    LLVM.or (LLVM.xor (mul e_2 (const? 32 42)) (mul e_1 (const? 32 42))) (mul e (const? 32 42)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -657,7 +657,7 @@ theorem or_xor_tree_0111_thm (e e_1 e_2 : IntW 32) :
 theorem or_xor_tree_1000_thm (e e_1 e_2 : IntW 32) :
   LLVM.or (LLVM.xor (LLVM.xor (mul e_2 (const? 32 42)) (mul e_1 (const? 32 42))) (mul e (const? 32 42)))
       (LLVM.xor (mul e (const? 32 42)) (mul e_2 (const? 32 42))) ⊑
-    LLVM.or (LLVM.xor (mul e (const? 32 42)) (mul e_2 (const? 32 42))) (mul e_1 (const? 32 42)) := by 
+    LLVM.or (LLVM.xor (mul e (const? 32 42)) (mul e_2 (const? 32 42))) (mul e_1 (const? 32 42)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -669,7 +669,7 @@ theorem or_xor_tree_1000_thm (e e_1 e_2 : IntW 32) :
 theorem or_xor_tree_1001_thm (e e_1 e_2 : IntW 32) :
   LLVM.or (LLVM.xor (LLVM.xor (mul e_2 (const? 32 42)) (mul e_1 (const? 32 42))) (mul e (const? 32 42)))
       (LLVM.xor (mul e_2 (const? 32 42)) (mul e (const? 32 42))) ⊑
-    LLVM.or (LLVM.xor (mul e_2 (const? 32 42)) (mul e (const? 32 42))) (mul e_1 (const? 32 42)) := by 
+    LLVM.or (LLVM.xor (mul e_2 (const? 32 42)) (mul e (const? 32 42))) (mul e_1 (const? 32 42)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -681,7 +681,7 @@ theorem or_xor_tree_1001_thm (e e_1 e_2 : IntW 32) :
 theorem or_xor_tree_1010_thm (e e_1 e_2 : IntW 32) :
   LLVM.or (LLVM.xor (LLVM.xor (mul e_2 (const? 32 42)) (mul e_1 (const? 32 42))) (mul e (const? 32 42)))
       (LLVM.xor (mul e (const? 32 42)) (mul e_1 (const? 32 42))) ⊑
-    LLVM.or (LLVM.xor (mul e (const? 32 42)) (mul e_1 (const? 32 42))) (mul e_2 (const? 32 42)) := by 
+    LLVM.or (LLVM.xor (mul e (const? 32 42)) (mul e_1 (const? 32 42))) (mul e_2 (const? 32 42)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -693,7 +693,7 @@ theorem or_xor_tree_1010_thm (e e_1 e_2 : IntW 32) :
 theorem or_xor_tree_1011_thm (e e_1 e_2 : IntW 32) :
   LLVM.or (LLVM.xor (LLVM.xor (mul e_2 (const? 32 42)) (mul e_1 (const? 32 42))) (mul e (const? 32 42)))
       (LLVM.xor (mul e_1 (const? 32 42)) (mul e (const? 32 42))) ⊑
-    LLVM.or (LLVM.xor (mul e_1 (const? 32 42)) (mul e (const? 32 42))) (mul e_2 (const? 32 42)) := by 
+    LLVM.or (LLVM.xor (mul e_1 (const? 32 42)) (mul e (const? 32 42))) (mul e_2 (const? 32 42)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -705,7 +705,7 @@ theorem or_xor_tree_1011_thm (e e_1 e_2 : IntW 32) :
 theorem or_xor_tree_1100_thm (e e_1 e_2 : IntW 32) :
   LLVM.or (LLVM.xor (mul e_2 (const? 32 42)) (LLVM.xor (mul e_1 (const? 32 42)) (mul e (const? 32 42))))
       (LLVM.xor (mul e_2 (const? 32 42)) (mul e_1 (const? 32 42))) ⊑
-    LLVM.or (LLVM.xor (mul e_2 (const? 32 42)) (mul e_1 (const? 32 42))) (mul e (const? 32 42)) := by 
+    LLVM.or (LLVM.xor (mul e_2 (const? 32 42)) (mul e_1 (const? 32 42))) (mul e (const? 32 42)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -717,7 +717,7 @@ theorem or_xor_tree_1100_thm (e e_1 e_2 : IntW 32) :
 theorem or_xor_tree_1101_thm (e e_1 e_2 : IntW 32) :
   LLVM.or (LLVM.xor (mul e_2 (const? 32 42)) (LLVM.xor (mul e_1 (const? 32 42)) (mul e (const? 32 42))))
       (LLVM.xor (mul e_1 (const? 32 42)) (mul e_2 (const? 32 42))) ⊑
-    LLVM.or (LLVM.xor (mul e_1 (const? 32 42)) (mul e_2 (const? 32 42))) (mul e (const? 32 42)) := by 
+    LLVM.or (LLVM.xor (mul e_1 (const? 32 42)) (mul e_2 (const? 32 42))) (mul e (const? 32 42)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -729,7 +729,7 @@ theorem or_xor_tree_1101_thm (e e_1 e_2 : IntW 32) :
 theorem or_xor_tree_1110_thm (e e_1 e_2 : IntW 32) :
   LLVM.or (LLVM.xor (mul e_2 (const? 32 42)) (LLVM.xor (mul e_1 (const? 32 42)) (mul e (const? 32 42))))
       (LLVM.xor (mul e_2 (const? 32 42)) (mul e (const? 32 42))) ⊑
-    LLVM.or (LLVM.xor (mul e_2 (const? 32 42)) (mul e (const? 32 42))) (mul e_1 (const? 32 42)) := by 
+    LLVM.or (LLVM.xor (mul e_2 (const? 32 42)) (mul e (const? 32 42))) (mul e_1 (const? 32 42)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -741,7 +741,7 @@ theorem or_xor_tree_1110_thm (e e_1 e_2 : IntW 32) :
 theorem or_xor_tree_1111_thm (e e_1 e_2 : IntW 32) :
   LLVM.or (LLVM.xor (mul e_2 (const? 32 42)) (LLVM.xor (mul e_1 (const? 32 42)) (mul e (const? 32 42))))
       (LLVM.xor (mul e (const? 32 42)) (mul e_2 (const? 32 42))) ⊑
-    LLVM.or (LLVM.xor (mul e (const? 32 42)) (mul e_2 (const? 32 42))) (mul e_1 (const? 32 42)) := by 
+    LLVM.or (LLVM.xor (mul e (const? 32 42)) (mul e_2 (const? 32 42))) (mul e_1 (const? 32 42)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gorhxorhxor_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gorhxorhxor_proof.lean
@@ -9,7 +9,7 @@ set_option linter.unreachableTactic false
 
 section gorhxorhxor_proof
 theorem or_xor_xor_normal_variant1_thm (e e_1 : IntW 1) :
-  LLVM.or (LLVM.xor (LLVM.and e_1 e) e_1) (LLVM.xor (LLVM.and e_1 e) e) ⊑ LLVM.xor e_1 e := by 
+  LLVM.or (LLVM.xor (LLVM.and e_1 e) e_1) (LLVM.xor (LLVM.and e_1 e) e) ⊑ LLVM.xor e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -19,7 +19,7 @@ theorem or_xor_xor_normal_variant1_thm (e e_1 : IntW 1) :
 
 
 theorem or_xor_xor_normal_variant2_thm (e e_1 : IntW 8) :
-  LLVM.or (LLVM.xor (LLVM.and e_1 e) e) (LLVM.xor e_1 (LLVM.and e_1 e)) ⊑ LLVM.xor e_1 e := by 
+  LLVM.or (LLVM.xor (LLVM.and e_1 e) e) (LLVM.xor e_1 (LLVM.and e_1 e)) ⊑ LLVM.xor e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -29,7 +29,7 @@ theorem or_xor_xor_normal_variant2_thm (e e_1 : IntW 8) :
 
 
 theorem or_xor_xor_normal_variant3_thm (e e_1 : IntW 16) :
-  LLVM.or (LLVM.xor e_1 (LLVM.and e_1 e)) (LLVM.xor e (LLVM.and e_1 e)) ⊑ LLVM.xor e_1 e := by 
+  LLVM.or (LLVM.xor e_1 (LLVM.and e_1 e)) (LLVM.xor e (LLVM.and e_1 e)) ⊑ LLVM.xor e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -39,7 +39,7 @@ theorem or_xor_xor_normal_variant3_thm (e e_1 : IntW 16) :
 
 
 theorem or_xor_xor_normal_variant4_thm (e e_1 : IntW 64) :
-  LLVM.or (LLVM.xor (LLVM.and e_1 e) e_1) (LLVM.xor (LLVM.and e_1 e) e) ⊑ LLVM.xor e_1 e := by 
+  LLVM.or (LLVM.xor (LLVM.and e_1 e) e_1) (LLVM.xor (LLVM.and e_1 e) e) ⊑ LLVM.xor e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -51,7 +51,7 @@ theorem or_xor_xor_normal_variant4_thm (e e_1 : IntW 64) :
 theorem or_xor_xor_normal_binops_thm (e e_1 e_2 : IntW 32) :
   LLVM.or (LLVM.xor (LLVM.xor e_2 e_1) (LLVM.and (LLVM.xor e_2 e_1) (LLVM.xor e e_1)))
       (LLVM.xor (LLVM.xor e e_1) (LLVM.and (LLVM.xor e_2 e_1) (LLVM.xor e e_1))) ⊑
-    LLVM.xor e_2 e := by 
+    LLVM.xor e_2 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/goverflowhmul_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/goverflowhmul_proof.lean
@@ -13,7 +13,7 @@ theorem pr4917_3_thm (e e_1 : IntW 32) :
       (const? 64 111) ⊑
     select
       (icmp IntPredicate.ugt (mul (zext 64 e_1) (zext 64 e) { «nsw» := false, «nuw» := true }) (const? 64 4294967295))
-      (mul (zext 64 e_1) (zext 64 e) { «nsw» := false, «nuw» := true }) (const? 64 111) := by 
+      (mul (zext 64 e_1) (zext 64 e) { «nsw» := false, «nuw» := true }) (const? 64 111) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -24,7 +24,7 @@ theorem pr4917_3_thm (e e_1 : IntW 32) :
 
 theorem mul_may_overflow_thm (e e_1 : IntW 32) :
   zext 32 (icmp IntPredicate.ule (mul (zext 34 e_1) (zext 34 e)) (const? 34 4294967295)) ⊑
-    zext 32 (icmp IntPredicate.ult (mul (zext 34 e_1) (zext 34 e)) (const? 34 4294967296)) := by 
+    zext 32 (icmp IntPredicate.ult (mul (zext 34 e_1) (zext 34 e)) (const? 34 4294967296)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gpartallyhredundanthlefthshifthinputhmaskinghafterhtruncationhvarianthd_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gpartallyhredundanthlefthshifthinputhmaskinghafterhtruncationhvarianthd_proof.lean
@@ -10,7 +10,7 @@ set_option linter.unreachableTactic false
 section gpartallyhredundanthlefthshifthinputhmaskinghafterhtruncationhvarianthd_proof
 theorem PR51351_thm (e : IntW 64) (e_1 : IntW 32) :
   shl (trunc 32 (LLVM.and (ashr (shl (const? 64 (-1)) (zext 64 e_1)) (zext 64 e_1)) e)) (add e_1 (const? 32 (-33))) ⊑
-    shl (trunc 32 e) (add e_1 (const? 32 (-33))) := by 
+    shl (trunc 32 e) (add e_1 (const? 32 (-33))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gpr14365_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gpr14365_proof.lean
@@ -13,7 +13,7 @@ theorem test0_thm (e : IntW 32) :
       (add (LLVM.xor (LLVM.and e (const? 32 1431655765)) (const? 32 (-1))) (const? 32 1)
         { «nsw» := true, «nuw» := false })
       { «nsw» := true, «nuw» := false } ⊑
-    LLVM.and e (const? 32 (-1431655766)) := by 
+    LLVM.and e (const? 32 (-1431655766)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -27,7 +27,7 @@ theorem test1_thm (e : IntW 32) :
       (add (LLVM.xor (LLVM.and (ashr e (const? 32 1)) (const? 32 1431655765)) (const? 32 (-1))) (const? 32 1)
         { «nsw» := true, «nuw» := false })
       { «nsw» := true, «nuw» := false } ⊑
-    sub e (LLVM.and (lshr e (const? 32 1)) (const? 32 1431655765)) { «nsw» := true, «nuw» := false } := by 
+    sub e (LLVM.and (lshr e (const? 32 1)) (const? 32 1431655765)) { «nsw» := true, «nuw» := false } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gpr17827_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gpr17827_proof.lean
@@ -12,7 +12,7 @@ theorem test_shift_and_cmp_changed1_thm (e e_1 : IntW 8) :
   icmp IntPredicate.slt
       (ashr (shl (LLVM.or (LLVM.and e_1 (const? 8 8)) (LLVM.and e (const? 8 6))) (const? 8 5)) (const? 8 5))
       (const? 8 1) ⊑
-    icmp IntPredicate.slt (LLVM.and (shl e (const? 8 5)) (const? 8 (-64))) (const? 8 32) := by 
+    icmp IntPredicate.slt (LLVM.and (shl e (const? 8 5)) (const? 8 (-64))) (const? 8 32) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -23,7 +23,7 @@ theorem test_shift_and_cmp_changed1_thm (e e_1 : IntW 8) :
 
 theorem test_shift_and_cmp_changed2_thm (e : IntW 8) :
   icmp IntPredicate.ult (LLVM.and (shl e (const? 8 5)) (const? 8 (-64))) (const? 8 32) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 8 6)) (const? 8 0) := by 
+    icmp IntPredicate.eq (LLVM.and e (const? 8 6)) (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -33,7 +33,7 @@ theorem test_shift_and_cmp_changed2_thm (e : IntW 8) :
 
 
 theorem test_shift_and_cmp_changed4_thm (e : IntW 8) :
-  icmp IntPredicate.slt (LLVM.and (lshr e (const? 8 5)) (const? 8 (-64))) (const? 8 32) ⊑ const? 1 1 := by 
+  icmp IntPredicate.slt (LLVM.and (lshr e (const? 8 5)) (const? 8 (-64))) (const? 8 32) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gpr34349_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gpr34349_proof.lean
@@ -23,7 +23,7 @@ theorem fast_div_201_thm (e : IntW 8) :
         (trunc 8 (lshr (mul (zext 16 e) (const? 16 71) { «nsw» := true, «nuw» := true }) (const? 16 8))
           { «nsw» := true, «nuw» := true })
         { «nsw» := false, «nuw» := true })
-      (const? 8 7) := by 
+      (const? 8 7) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gpr49688_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gpr49688_proof.lean
@@ -11,7 +11,7 @@ section gpr49688_proof
 theorem f_thm (e : IntW 32) :
   select (icmp IntPredicate.slt e (const? 32 0)) (const? 1 1) (icmp IntPredicate.sgt e (ashr (const? 32 7) e)) ⊑
     select (icmp IntPredicate.slt e (const? 32 0)) (const? 1 1)
-      (icmp IntPredicate.sgt e (lshr (const? 32 7) e)) := by 
+      (icmp IntPredicate.sgt e (lshr (const? 32 7) e)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -26,7 +26,7 @@ theorem f2_thm (e e_1 : IntW 32) :
         (icmp IntPredicate.sgt e_1 (ashr (const? 32 7) e))) ⊑
     zext 32
       (select (icmp IntPredicate.slt e_1 (const? 32 0)) (const? 1 1)
-        (icmp IntPredicate.sgt e_1 (lshr (const? 32 7) e))) := by 
+        (icmp IntPredicate.sgt e_1 (lshr (const? 32 7) e))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gpr53357_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gpr53357_proof.lean
@@ -9,7 +9,7 @@ set_option linter.unreachableTactic false
 
 section gpr53357_proof
 theorem src_thm (e e_1 : IntW 32) :
-  add (LLVM.and e_1 e) (LLVM.xor (LLVM.or e_1 e) (const? 32 (-1))) ⊑ LLVM.xor (LLVM.xor e_1 e) (const? 32 (-1)) := by 
+  add (LLVM.and e_1 e) (LLVM.xor (LLVM.or e_1 e) (const? 32 (-1))) ⊑ LLVM.xor (LLVM.xor e_1 e) (const? 32 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -19,7 +19,7 @@ theorem src_thm (e e_1 : IntW 32) :
 
 
 theorem src2_thm (e e_1 : IntW 32) :
-  add (LLVM.and e_1 e) (LLVM.xor (LLVM.or e e_1) (const? 32 (-1))) ⊑ LLVM.xor (LLVM.xor e_1 e) (const? 32 (-1)) := by 
+  add (LLVM.and e_1 e) (LLVM.xor (LLVM.or e e_1) (const? 32 (-1))) ⊑ LLVM.xor (LLVM.xor e_1 e) (const? 32 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -30,7 +30,7 @@ theorem src2_thm (e e_1 : IntW 32) :
 
 theorem src3_thm (e e_1 : IntW 32) :
   add (LLVM.and e_1 e) (LLVM.and (LLVM.xor e (const? 32 (-1))) (LLVM.xor e_1 (const? 32 (-1)))) ⊑
-    LLVM.xor (LLVM.xor e_1 e) (const? 32 (-1)) := by 
+    LLVM.xor (LLVM.xor e_1 e) (const? 32 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -40,7 +40,7 @@ theorem src3_thm (e e_1 : IntW 32) :
 
 
 theorem src4_thm (e e_1 : IntW 32) :
-  add (LLVM.and e_1 e) (LLVM.xor (LLVM.or e e_1) (const? 32 (-1))) ⊑ LLVM.xor (LLVM.xor e_1 e) (const? 32 (-1)) := by 
+  add (LLVM.and e_1 e) (LLVM.xor (LLVM.or e e_1) (const? 32 (-1))) ⊑ LLVM.xor (LLVM.xor e_1 e) (const? 32 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -50,7 +50,7 @@ theorem src4_thm (e e_1 : IntW 32) :
 
 
 theorem src5_thm (e e_1 : IntW 32) :
-  add (LLVM.xor (LLVM.or e_1 e) (const? 32 (-1))) (LLVM.and e_1 e) ⊑ LLVM.xor (LLVM.xor e_1 e) (const? 32 (-1)) := by 
+  add (LLVM.xor (LLVM.or e_1 e) (const? 32 (-1))) (LLVM.and e_1 e) ⊑ LLVM.xor (LLVM.xor e_1 e) (const? 32 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gpr72433_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gpr72433_proof.lean
@@ -16,7 +16,7 @@ theorem widget_thm (e : IntW 32) :
     shl
       (LLVM.or (shl (const? 32 20) (zext 32 (icmp IntPredicate.ne e (const? 32 0))) { «nsw» := true, «nuw» := true })
         (zext 32 (icmp IntPredicate.ne e (const? 32 0))) { «disjoint» := true })
-      (zext 32 (icmp IntPredicate.ne e (const? 32 0))) { «nsw» := true, «nuw» := true } := by 
+      (zext 32 (icmp IntPredicate.ne e (const? 32 0))) { «nsw» := true, «nuw» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gpreservedhanalyses_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gpreservedhanalyses_proof.lean
@@ -8,7 +8,7 @@ set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
 
 section gpreservedhanalyses_proof
-theorem test_thm (e : IntW 32) : add (add e (const? 32 5)) (const? 32 (-5)) ⊑ e := by 
+theorem test_thm (e : IntW 32) : add (add e (const? 32 5)) (const? 32 (-5)) ⊑ e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gpreventhcmphmerge_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gpreventhcmphmerge_proof.lean
@@ -11,7 +11,7 @@ section gpreventhcmphmerge_proof
 theorem test1_thm (e e_1 : IntW 32) :
   LLVM.or (icmp IntPredicate.eq (LLVM.xor e_1 (const? 32 5)) (const? 32 10))
       (icmp IntPredicate.eq (LLVM.xor e_1 (const? 32 5)) e) ⊑
-    LLVM.or (icmp IntPredicate.eq e_1 (const? 32 15)) (icmp IntPredicate.eq (LLVM.xor e_1 e) (const? 32 5)) := by 
+    LLVM.or (icmp IntPredicate.eq e_1 (const? 32 15)) (icmp IntPredicate.eq (LLVM.xor e_1 e) (const? 32 5)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -24,7 +24,7 @@ theorem test1_logical_thm (e e_1 : IntW 32) :
   select (icmp IntPredicate.eq (LLVM.xor e_1 (const? 32 5)) (const? 32 10)) (const? 1 1)
       (icmp IntPredicate.eq (LLVM.xor e_1 (const? 32 5)) e) ⊑
     select (icmp IntPredicate.eq e_1 (const? 32 15)) (const? 1 1)
-      (icmp IntPredicate.eq (LLVM.xor e_1 e) (const? 32 5)) := by 
+      (icmp IntPredicate.eq (LLVM.xor e_1 e) (const? 32 5)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -36,7 +36,7 @@ theorem test1_logical_thm (e e_1 : IntW 32) :
 theorem test2_thm (e e_1 : IntW 32) :
   LLVM.xor (icmp IntPredicate.eq (LLVM.xor e_1 e) (const? 32 0))
       (icmp IntPredicate.eq (LLVM.xor e_1 e) (const? 32 32)) ⊑
-    LLVM.xor (icmp IntPredicate.eq e_1 e) (icmp IntPredicate.eq (LLVM.xor e_1 e) (const? 32 32)) := by 
+    LLVM.xor (icmp IntPredicate.eq e_1 e) (icmp IntPredicate.eq (LLVM.xor e_1 e) (const? 32 32)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -49,7 +49,7 @@ theorem test3_thm (e e_1 : IntW 32) :
   LLVM.or (icmp IntPredicate.eq (sub e_1 e { «nsw» := true, «nuw» := false }) (const? 32 0))
       (icmp IntPredicate.eq (sub e_1 e { «nsw» := true, «nuw» := false }) (const? 32 31)) ⊑
     LLVM.or (icmp IntPredicate.eq e_1 e)
-      (icmp IntPredicate.eq (sub e_1 e { «nsw» := true, «nuw» := false }) (const? 32 31)) := by 
+      (icmp IntPredicate.eq (sub e_1 e { «nsw» := true, «nuw» := false }) (const? 32 31)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -62,7 +62,7 @@ theorem test3_logical_thm (e e_1 : IntW 32) :
   select (icmp IntPredicate.eq (sub e_1 e { «nsw» := true, «nuw» := false }) (const? 32 0)) (const? 1 1)
       (icmp IntPredicate.eq (sub e_1 e { «nsw» := true, «nuw» := false }) (const? 32 31)) ⊑
     select (icmp IntPredicate.eq e_1 e) (const? 1 1)
-      (icmp IntPredicate.eq (sub e_1 e { «nsw» := true, «nuw» := false }) (const? 32 31)) := by 
+      (icmp IntPredicate.eq (sub e_1 e { «nsw» := true, «nuw» := false }) (const? 32 31)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gpullhbinophthroughhshift_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gpullhbinophthroughhshift_proof.lean
@@ -9,7 +9,7 @@ set_option linter.unreachableTactic false
 
 section gpullhbinophthroughhshift_proof
 theorem and_signbit_shl_thm (e : IntW 32) :
-  shl (LLVM.and e (const? 32 (-65536))) (const? 32 8) ⊑ LLVM.and (shl e (const? 32 8)) (const? 32 (-16777216)) := by 
+  shl (LLVM.and e (const? 32 (-65536))) (const? 32 8) ⊑ LLVM.and (shl e (const? 32 8)) (const? 32 (-16777216)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -20,7 +20,7 @@ theorem and_signbit_shl_thm (e : IntW 32) :
 
 theorem and_nosignbit_shl_thm (e : IntW 32) :
   shl (LLVM.and e (const? 32 2147418112)) (const? 32 8) ⊑
-    LLVM.and (shl e (const? 32 8)) (const? 32 (-16777216)) := by 
+    LLVM.and (shl e (const? 32 8)) (const? 32 (-16777216)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -30,7 +30,7 @@ theorem and_nosignbit_shl_thm (e : IntW 32) :
 
 
 theorem or_signbit_shl_thm (e : IntW 32) :
-  shl (LLVM.or e (const? 32 (-65536))) (const? 32 8) ⊑ LLVM.or (shl e (const? 32 8)) (const? 32 (-16777216)) := by 
+  shl (LLVM.or e (const? 32 (-65536))) (const? 32 8) ⊑ LLVM.or (shl e (const? 32 8)) (const? 32 (-16777216)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -40,7 +40,7 @@ theorem or_signbit_shl_thm (e : IntW 32) :
 
 
 theorem or_nosignbit_shl_thm (e : IntW 32) :
-  shl (LLVM.or e (const? 32 2147418112)) (const? 32 8) ⊑ LLVM.or (shl e (const? 32 8)) (const? 32 (-16777216)) := by 
+  shl (LLVM.or e (const? 32 2147418112)) (const? 32 8) ⊑ LLVM.or (shl e (const? 32 8)) (const? 32 (-16777216)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -50,7 +50,7 @@ theorem or_nosignbit_shl_thm (e : IntW 32) :
 
 
 theorem xor_signbit_shl_thm (e : IntW 32) :
-  shl (LLVM.xor e (const? 32 (-65536))) (const? 32 8) ⊑ LLVM.xor (shl e (const? 32 8)) (const? 32 (-16777216)) := by 
+  shl (LLVM.xor e (const? 32 (-65536))) (const? 32 8) ⊑ LLVM.xor (shl e (const? 32 8)) (const? 32 (-16777216)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -61,7 +61,7 @@ theorem xor_signbit_shl_thm (e : IntW 32) :
 
 theorem xor_nosignbit_shl_thm (e : IntW 32) :
   shl (LLVM.xor e (const? 32 2147418112)) (const? 32 8) ⊑
-    LLVM.xor (shl e (const? 32 8)) (const? 32 (-16777216)) := by 
+    LLVM.xor (shl e (const? 32 8)) (const? 32 (-16777216)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -71,7 +71,7 @@ theorem xor_nosignbit_shl_thm (e : IntW 32) :
 
 
 theorem add_signbit_shl_thm (e : IntW 32) :
-  shl (add e (const? 32 (-65536))) (const? 32 8) ⊑ add (shl e (const? 32 8)) (const? 32 (-16777216)) := by 
+  shl (add e (const? 32 (-65536))) (const? 32 8) ⊑ add (shl e (const? 32 8)) (const? 32 (-16777216)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -81,7 +81,7 @@ theorem add_signbit_shl_thm (e : IntW 32) :
 
 
 theorem add_nosignbit_shl_thm (e : IntW 32) :
-  shl (add e (const? 32 2147418112)) (const? 32 8) ⊑ add (shl e (const? 32 8)) (const? 32 (-16777216)) := by 
+  shl (add e (const? 32 2147418112)) (const? 32 8) ⊑ add (shl e (const? 32 8)) (const? 32 (-16777216)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -91,7 +91,7 @@ theorem add_nosignbit_shl_thm (e : IntW 32) :
 
 
 theorem and_signbit_lshr_thm (e : IntW 32) :
-  lshr (LLVM.and e (const? 32 (-65536))) (const? 32 8) ⊑ LLVM.and (lshr e (const? 32 8)) (const? 32 16776960) := by 
+  lshr (LLVM.and e (const? 32 (-65536))) (const? 32 8) ⊑ LLVM.and (lshr e (const? 32 8)) (const? 32 16776960) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -101,7 +101,7 @@ theorem and_signbit_lshr_thm (e : IntW 32) :
 
 
 theorem and_nosignbit_lshr_thm (e : IntW 32) :
-  lshr (LLVM.and e (const? 32 2147418112)) (const? 32 8) ⊑ LLVM.and (lshr e (const? 32 8)) (const? 32 8388352) := by 
+  lshr (LLVM.and e (const? 32 2147418112)) (const? 32 8) ⊑ LLVM.and (lshr e (const? 32 8)) (const? 32 8388352) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -111,7 +111,7 @@ theorem and_nosignbit_lshr_thm (e : IntW 32) :
 
 
 theorem or_signbit_lshr_thm (e : IntW 32) :
-  lshr (LLVM.or e (const? 32 (-65536))) (const? 32 8) ⊑ LLVM.or (lshr e (const? 32 8)) (const? 32 16776960) := by 
+  lshr (LLVM.or e (const? 32 (-65536))) (const? 32 8) ⊑ LLVM.or (lshr e (const? 32 8)) (const? 32 16776960) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -121,7 +121,7 @@ theorem or_signbit_lshr_thm (e : IntW 32) :
 
 
 theorem or_nosignbit_lshr_thm (e : IntW 32) :
-  lshr (LLVM.or e (const? 32 2147418112)) (const? 32 8) ⊑ LLVM.or (lshr e (const? 32 8)) (const? 32 8388352) := by 
+  lshr (LLVM.or e (const? 32 2147418112)) (const? 32 8) ⊑ LLVM.or (lshr e (const? 32 8)) (const? 32 8388352) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -131,7 +131,7 @@ theorem or_nosignbit_lshr_thm (e : IntW 32) :
 
 
 theorem xor_signbit_lshr_thm (e : IntW 32) :
-  lshr (LLVM.xor e (const? 32 (-65536))) (const? 32 8) ⊑ LLVM.xor (lshr e (const? 32 8)) (const? 32 16776960) := by 
+  lshr (LLVM.xor e (const? 32 (-65536))) (const? 32 8) ⊑ LLVM.xor (lshr e (const? 32 8)) (const? 32 16776960) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -141,7 +141,7 @@ theorem xor_signbit_lshr_thm (e : IntW 32) :
 
 
 theorem xor_nosignbit_lshr_thm (e : IntW 32) :
-  lshr (LLVM.xor e (const? 32 2147418112)) (const? 32 8) ⊑ LLVM.xor (lshr e (const? 32 8)) (const? 32 8388352) := by 
+  lshr (LLVM.xor e (const? 32 2147418112)) (const? 32 8) ⊑ LLVM.xor (lshr e (const? 32 8)) (const? 32 8388352) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -151,7 +151,7 @@ theorem xor_nosignbit_lshr_thm (e : IntW 32) :
 
 
 theorem and_signbit_ashr_thm (e : IntW 32) :
-  ashr (LLVM.and e (const? 32 (-65536))) (const? 32 8) ⊑ LLVM.and (ashr e (const? 32 8)) (const? 32 (-256)) := by 
+  ashr (LLVM.and e (const? 32 (-65536))) (const? 32 8) ⊑ LLVM.and (ashr e (const? 32 8)) (const? 32 (-256)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -161,7 +161,7 @@ theorem and_signbit_ashr_thm (e : IntW 32) :
 
 
 theorem and_nosignbit_ashr_thm (e : IntW 32) :
-  ashr (LLVM.and e (const? 32 2147418112)) (const? 32 8) ⊑ LLVM.and (lshr e (const? 32 8)) (const? 32 8388352) := by 
+  ashr (LLVM.and e (const? 32 2147418112)) (const? 32 8) ⊑ LLVM.and (lshr e (const? 32 8)) (const? 32 8388352) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -171,7 +171,7 @@ theorem and_nosignbit_ashr_thm (e : IntW 32) :
 
 
 theorem or_signbit_ashr_thm (e : IntW 32) :
-  ashr (LLVM.or e (const? 32 (-65536))) (const? 32 8) ⊑ LLVM.or (lshr e (const? 32 8)) (const? 32 (-256)) := by 
+  ashr (LLVM.or e (const? 32 (-65536))) (const? 32 8) ⊑ LLVM.or (lshr e (const? 32 8)) (const? 32 (-256)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -181,7 +181,7 @@ theorem or_signbit_ashr_thm (e : IntW 32) :
 
 
 theorem or_nosignbit_ashr_thm (e : IntW 32) :
-  ashr (LLVM.or e (const? 32 2147418112)) (const? 32 8) ⊑ LLVM.or (ashr e (const? 32 8)) (const? 32 8388352) := by 
+  ashr (LLVM.or e (const? 32 2147418112)) (const? 32 8) ⊑ LLVM.or (ashr e (const? 32 8)) (const? 32 8388352) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -191,7 +191,7 @@ theorem or_nosignbit_ashr_thm (e : IntW 32) :
 
 
 theorem xor_signbit_ashr_thm (e : IntW 32) :
-  ashr (LLVM.xor e (const? 32 (-65536))) (const? 32 8) ⊑ LLVM.xor (ashr e (const? 32 8)) (const? 32 (-256)) := by 
+  ashr (LLVM.xor e (const? 32 (-65536))) (const? 32 8) ⊑ LLVM.xor (ashr e (const? 32 8)) (const? 32 (-256)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -201,7 +201,7 @@ theorem xor_signbit_ashr_thm (e : IntW 32) :
 
 
 theorem xor_nosignbit_ashr_thm (e : IntW 32) :
-  ashr (LLVM.xor e (const? 32 2147418112)) (const? 32 8) ⊑ LLVM.xor (ashr e (const? 32 8)) (const? 32 8388352) := by 
+  ashr (LLVM.xor e (const? 32 2147418112)) (const? 32 8) ⊑ LLVM.xor (ashr e (const? 32 8)) (const? 32 8388352) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gpullhconditionalhbinophthroughhshift_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gpullhconditionalhbinophthroughhshift_proof.lean
@@ -10,7 +10,7 @@ set_option linter.unreachableTactic false
 section gpullhconditionalhbinophthroughhshift_proof
 theorem and_signbit_select_shl_thm (e : IntW 32) (e_1 : IntW 1) :
   shl (select e_1 (LLVM.and e (const? 32 (-65536))) e) (const? 32 8) ⊑
-    select e_1 (LLVM.and (shl e (const? 32 8)) (const? 32 (-16777216))) (shl e (const? 32 8)) := by 
+    select e_1 (LLVM.and (shl e (const? 32 8)) (const? 32 (-16777216))) (shl e (const? 32 8)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -21,7 +21,7 @@ theorem and_signbit_select_shl_thm (e : IntW 32) (e_1 : IntW 1) :
 
 theorem and_nosignbit_select_shl_thm (e : IntW 32) (e_1 : IntW 1) :
   shl (select e_1 (LLVM.and e (const? 32 2147418112)) e) (const? 32 8) ⊑
-    select e_1 (LLVM.and (shl e (const? 32 8)) (const? 32 (-16777216))) (shl e (const? 32 8)) := by 
+    select e_1 (LLVM.and (shl e (const? 32 8)) (const? 32 (-16777216))) (shl e (const? 32 8)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -32,7 +32,7 @@ theorem and_nosignbit_select_shl_thm (e : IntW 32) (e_1 : IntW 1) :
 
 theorem or_signbit_select_shl_thm (e : IntW 32) (e_1 : IntW 1) :
   shl (select e_1 (LLVM.or e (const? 32 (-65536))) e) (const? 32 8) ⊑
-    select e_1 (LLVM.or (shl e (const? 32 8)) (const? 32 (-16777216))) (shl e (const? 32 8)) := by 
+    select e_1 (LLVM.or (shl e (const? 32 8)) (const? 32 (-16777216))) (shl e (const? 32 8)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -43,7 +43,7 @@ theorem or_signbit_select_shl_thm (e : IntW 32) (e_1 : IntW 1) :
 
 theorem or_nosignbit_select_shl_thm (e : IntW 32) (e_1 : IntW 1) :
   shl (select e_1 (LLVM.or e (const? 32 2147418112)) e) (const? 32 8) ⊑
-    select e_1 (LLVM.or (shl e (const? 32 8)) (const? 32 (-16777216))) (shl e (const? 32 8)) := by 
+    select e_1 (LLVM.or (shl e (const? 32 8)) (const? 32 (-16777216))) (shl e (const? 32 8)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -54,7 +54,7 @@ theorem or_nosignbit_select_shl_thm (e : IntW 32) (e_1 : IntW 1) :
 
 theorem xor_signbit_select_shl_thm (e : IntW 32) (e_1 : IntW 1) :
   shl (select e_1 (LLVM.xor e (const? 32 (-65536))) e) (const? 32 8) ⊑
-    select e_1 (LLVM.xor (shl e (const? 32 8)) (const? 32 (-16777216))) (shl e (const? 32 8)) := by 
+    select e_1 (LLVM.xor (shl e (const? 32 8)) (const? 32 (-16777216))) (shl e (const? 32 8)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -65,7 +65,7 @@ theorem xor_signbit_select_shl_thm (e : IntW 32) (e_1 : IntW 1) :
 
 theorem xor_nosignbit_select_shl_thm (e : IntW 32) (e_1 : IntW 1) :
   shl (select e_1 (LLVM.xor e (const? 32 2147418112)) e) (const? 32 8) ⊑
-    select e_1 (LLVM.xor (shl e (const? 32 8)) (const? 32 (-16777216))) (shl e (const? 32 8)) := by 
+    select e_1 (LLVM.xor (shl e (const? 32 8)) (const? 32 (-16777216))) (shl e (const? 32 8)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -76,7 +76,7 @@ theorem xor_nosignbit_select_shl_thm (e : IntW 32) (e_1 : IntW 1) :
 
 theorem add_signbit_select_shl_thm (e : IntW 32) (e_1 : IntW 1) :
   shl (select e_1 (add e (const? 32 (-65536))) e) (const? 32 8) ⊑
-    select e_1 (add (shl e (const? 32 8)) (const? 32 (-16777216))) (shl e (const? 32 8)) := by 
+    select e_1 (add (shl e (const? 32 8)) (const? 32 (-16777216))) (shl e (const? 32 8)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -87,7 +87,7 @@ theorem add_signbit_select_shl_thm (e : IntW 32) (e_1 : IntW 1) :
 
 theorem add_nosignbit_select_shl_thm (e : IntW 32) (e_1 : IntW 1) :
   shl (select e_1 (add e (const? 32 2147418112)) e) (const? 32 8) ⊑
-    select e_1 (add (shl e (const? 32 8)) (const? 32 (-16777216))) (shl e (const? 32 8)) := by 
+    select e_1 (add (shl e (const? 32 8)) (const? 32 (-16777216))) (shl e (const? 32 8)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -98,7 +98,7 @@ theorem add_nosignbit_select_shl_thm (e : IntW 32) (e_1 : IntW 1) :
 
 theorem and_signbit_select_lshr_thm (e : IntW 32) (e_1 : IntW 1) :
   lshr (select e_1 (LLVM.and e (const? 32 (-65536))) e) (const? 32 8) ⊑
-    select e_1 (LLVM.and (lshr e (const? 32 8)) (const? 32 16776960)) (lshr e (const? 32 8)) := by 
+    select e_1 (LLVM.and (lshr e (const? 32 8)) (const? 32 16776960)) (lshr e (const? 32 8)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -109,7 +109,7 @@ theorem and_signbit_select_lshr_thm (e : IntW 32) (e_1 : IntW 1) :
 
 theorem and_nosignbit_select_lshr_thm (e : IntW 32) (e_1 : IntW 1) :
   lshr (select e_1 (LLVM.and e (const? 32 2147418112)) e) (const? 32 8) ⊑
-    select e_1 (LLVM.and (lshr e (const? 32 8)) (const? 32 8388352)) (lshr e (const? 32 8)) := by 
+    select e_1 (LLVM.and (lshr e (const? 32 8)) (const? 32 8388352)) (lshr e (const? 32 8)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -120,7 +120,7 @@ theorem and_nosignbit_select_lshr_thm (e : IntW 32) (e_1 : IntW 1) :
 
 theorem or_signbit_select_lshr_thm (e : IntW 32) (e_1 : IntW 1) :
   lshr (select e_1 (LLVM.or e (const? 32 (-65536))) e) (const? 32 8) ⊑
-    select e_1 (LLVM.or (lshr e (const? 32 8)) (const? 32 16776960)) (lshr e (const? 32 8)) := by 
+    select e_1 (LLVM.or (lshr e (const? 32 8)) (const? 32 16776960)) (lshr e (const? 32 8)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -131,7 +131,7 @@ theorem or_signbit_select_lshr_thm (e : IntW 32) (e_1 : IntW 1) :
 
 theorem or_nosignbit_select_lshr_thm (e : IntW 32) (e_1 : IntW 1) :
   lshr (select e_1 (LLVM.or e (const? 32 2147418112)) e) (const? 32 8) ⊑
-    select e_1 (LLVM.or (lshr e (const? 32 8)) (const? 32 8388352)) (lshr e (const? 32 8)) := by 
+    select e_1 (LLVM.or (lshr e (const? 32 8)) (const? 32 8388352)) (lshr e (const? 32 8)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -142,7 +142,7 @@ theorem or_nosignbit_select_lshr_thm (e : IntW 32) (e_1 : IntW 1) :
 
 theorem xor_signbit_select_lshr_thm (e : IntW 32) (e_1 : IntW 1) :
   lshr (select e_1 (LLVM.xor e (const? 32 (-65536))) e) (const? 32 8) ⊑
-    select e_1 (LLVM.xor (lshr e (const? 32 8)) (const? 32 16776960)) (lshr e (const? 32 8)) := by 
+    select e_1 (LLVM.xor (lshr e (const? 32 8)) (const? 32 16776960)) (lshr e (const? 32 8)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -153,7 +153,7 @@ theorem xor_signbit_select_lshr_thm (e : IntW 32) (e_1 : IntW 1) :
 
 theorem xor_nosignbit_select_lshr_thm (e : IntW 32) (e_1 : IntW 1) :
   lshr (select e_1 (LLVM.xor e (const? 32 2147418112)) e) (const? 32 8) ⊑
-    select e_1 (LLVM.xor (lshr e (const? 32 8)) (const? 32 8388352)) (lshr e (const? 32 8)) := by 
+    select e_1 (LLVM.xor (lshr e (const? 32 8)) (const? 32 8388352)) (lshr e (const? 32 8)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -164,7 +164,7 @@ theorem xor_nosignbit_select_lshr_thm (e : IntW 32) (e_1 : IntW 1) :
 
 theorem and_signbit_select_ashr_thm (e : IntW 32) (e_1 : IntW 1) :
   ashr (select e_1 (LLVM.and e (const? 32 (-65536))) e) (const? 32 8) ⊑
-    select e_1 (LLVM.and (ashr e (const? 32 8)) (const? 32 (-256))) (ashr e (const? 32 8)) := by 
+    select e_1 (LLVM.and (ashr e (const? 32 8)) (const? 32 (-256))) (ashr e (const? 32 8)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -175,7 +175,7 @@ theorem and_signbit_select_ashr_thm (e : IntW 32) (e_1 : IntW 1) :
 
 theorem and_nosignbit_select_ashr_thm (e : IntW 32) (e_1 : IntW 1) :
   ashr (select e_1 (LLVM.and e (const? 32 2147418112)) e) (const? 32 8) ⊑
-    select e_1 (LLVM.and (ashr e (const? 32 8)) (const? 32 8388352)) (ashr e (const? 32 8)) := by 
+    select e_1 (LLVM.and (ashr e (const? 32 8)) (const? 32 8388352)) (ashr e (const? 32 8)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -186,7 +186,7 @@ theorem and_nosignbit_select_ashr_thm (e : IntW 32) (e_1 : IntW 1) :
 
 theorem or_signbit_select_ashr_thm (e : IntW 32) (e_1 : IntW 1) :
   ashr (select e_1 (LLVM.or e (const? 32 (-65536))) e) (const? 32 8) ⊑
-    select e_1 (LLVM.or (ashr e (const? 32 8)) (const? 32 (-256))) (ashr e (const? 32 8)) := by 
+    select e_1 (LLVM.or (ashr e (const? 32 8)) (const? 32 (-256))) (ashr e (const? 32 8)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -197,7 +197,7 @@ theorem or_signbit_select_ashr_thm (e : IntW 32) (e_1 : IntW 1) :
 
 theorem or_nosignbit_select_ashr_thm (e : IntW 32) (e_1 : IntW 1) :
   ashr (select e_1 (LLVM.or e (const? 32 2147418112)) e) (const? 32 8) ⊑
-    select e_1 (LLVM.or (ashr e (const? 32 8)) (const? 32 8388352)) (ashr e (const? 32 8)) := by 
+    select e_1 (LLVM.or (ashr e (const? 32 8)) (const? 32 8388352)) (ashr e (const? 32 8)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -208,7 +208,7 @@ theorem or_nosignbit_select_ashr_thm (e : IntW 32) (e_1 : IntW 1) :
 
 theorem xor_signbit_select_ashr_thm (e : IntW 32) (e_1 : IntW 1) :
   ashr (select e_1 (LLVM.xor e (const? 32 (-65536))) e) (const? 32 8) ⊑
-    select e_1 (LLVM.xor (ashr e (const? 32 8)) (const? 32 (-256))) (ashr e (const? 32 8)) := by 
+    select e_1 (LLVM.xor (ashr e (const? 32 8)) (const? 32 (-256))) (ashr e (const? 32 8)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -219,7 +219,7 @@ theorem xor_signbit_select_ashr_thm (e : IntW 32) (e_1 : IntW 1) :
 
 theorem xor_nosignbit_select_ashr_thm (e : IntW 32) (e_1 : IntW 1) :
   ashr (select e_1 (LLVM.xor e (const? 32 2147418112)) e) (const? 32 8) ⊑
-    select e_1 (LLVM.xor (ashr e (const? 32 8)) (const? 32 8388352)) (ashr e (const? 32 8)) := by 
+    select e_1 (LLVM.xor (ashr e (const? 32 8)) (const? 32 8388352)) (ashr e (const? 32 8)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/grangehcheck_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/grangehcheck_proof.lean
@@ -10,7 +10,7 @@ set_option linter.unreachableTactic false
 section grangehcheck_proof
 theorem test_and1_thm (e e_1 : IntW 32) :
   LLVM.and (icmp IntPredicate.sge e_1 (const? 32 0)) (icmp IntPredicate.slt e_1 (LLVM.and e (const? 32 2147483647))) ⊑
-    icmp IntPredicate.ult e_1 (LLVM.and e (const? 32 2147483647)) := by 
+    icmp IntPredicate.ult e_1 (LLVM.and e (const? 32 2147483647)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -23,7 +23,7 @@ theorem test_and1_logical_thm (e e_1 : IntW 32) :
   select (icmp IntPredicate.sge e_1 (const? 32 0)) (icmp IntPredicate.slt e_1 (LLVM.and e (const? 32 2147483647)))
       (const? 1 0) ⊑
     select (icmp IntPredicate.sgt e_1 (const? 32 (-1))) (icmp IntPredicate.slt e_1 (LLVM.and e (const? 32 2147483647)))
-      (const? 1 0) := by 
+      (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -35,7 +35,7 @@ theorem test_and1_logical_thm (e e_1 : IntW 32) :
 theorem test_and2_thm (e e_1 : IntW 32) :
   LLVM.and (icmp IntPredicate.sgt e_1 (const? 32 (-1)))
       (icmp IntPredicate.sle e_1 (LLVM.and e (const? 32 2147483647))) ⊑
-    icmp IntPredicate.ule e_1 (LLVM.and e (const? 32 2147483647)) := by 
+    icmp IntPredicate.ule e_1 (LLVM.and e (const? 32 2147483647)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -46,7 +46,7 @@ theorem test_and2_thm (e e_1 : IntW 32) :
 
 theorem test_and3_thm (e e_1 : IntW 32) :
   LLVM.and (icmp IntPredicate.sgt (LLVM.and e_1 (const? 32 2147483647)) e) (icmp IntPredicate.sge e (const? 32 0)) ⊑
-    icmp IntPredicate.ult e (LLVM.and e_1 (const? 32 2147483647)) := by 
+    icmp IntPredicate.ult e (LLVM.and e_1 (const? 32 2147483647)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -58,7 +58,7 @@ theorem test_and3_thm (e e_1 : IntW 32) :
 theorem test_and3_logical_thm (e e_1 : IntW 32) :
   select (icmp IntPredicate.sgt (LLVM.and e_1 (const? 32 2147483647)) e) (icmp IntPredicate.sge e (const? 32 0))
       (const? 1 0) ⊑
-    icmp IntPredicate.ult e (LLVM.and e_1 (const? 32 2147483647)) := by 
+    icmp IntPredicate.ult e (LLVM.and e_1 (const? 32 2147483647)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -69,7 +69,7 @@ theorem test_and3_logical_thm (e e_1 : IntW 32) :
 
 theorem test_and4_thm (e e_1 : IntW 32) :
   LLVM.and (icmp IntPredicate.sge (LLVM.and e_1 (const? 32 2147483647)) e) (icmp IntPredicate.sge e (const? 32 0)) ⊑
-    icmp IntPredicate.ule e (LLVM.and e_1 (const? 32 2147483647)) := by 
+    icmp IntPredicate.ule e (LLVM.and e_1 (const? 32 2147483647)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -81,7 +81,7 @@ theorem test_and4_thm (e e_1 : IntW 32) :
 theorem test_and4_logical_thm (e e_1 : IntW 32) :
   select (icmp IntPredicate.sge (LLVM.and e_1 (const? 32 2147483647)) e) (icmp IntPredicate.sge e (const? 32 0))
       (const? 1 0) ⊑
-    icmp IntPredicate.ule e (LLVM.and e_1 (const? 32 2147483647)) := by 
+    icmp IntPredicate.ule e (LLVM.and e_1 (const? 32 2147483647)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -92,7 +92,7 @@ theorem test_and4_logical_thm (e e_1 : IntW 32) :
 
 theorem test_or1_thm (e e_1 : IntW 32) :
   LLVM.or (icmp IntPredicate.slt e_1 (const? 32 0)) (icmp IntPredicate.sge e_1 (LLVM.and e (const? 32 2147483647))) ⊑
-    icmp IntPredicate.uge e_1 (LLVM.and e (const? 32 2147483647)) := by 
+    icmp IntPredicate.uge e_1 (LLVM.and e (const? 32 2147483647)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -103,7 +103,7 @@ theorem test_or1_thm (e e_1 : IntW 32) :
 
 theorem test_or2_thm (e e_1 : IntW 32) :
   LLVM.or (icmp IntPredicate.sle e_1 (const? 32 (-1))) (icmp IntPredicate.sgt e_1 (LLVM.and e (const? 32 2147483647))) ⊑
-    icmp IntPredicate.ugt e_1 (LLVM.and e (const? 32 2147483647)) := by 
+    icmp IntPredicate.ugt e_1 (LLVM.and e (const? 32 2147483647)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -116,7 +116,7 @@ theorem test_or2_logical_thm (e e_1 : IntW 32) :
   select (icmp IntPredicate.sle e_1 (const? 32 (-1))) (const? 1 1)
       (icmp IntPredicate.sgt e_1 (LLVM.and e (const? 32 2147483647))) ⊑
     select (icmp IntPredicate.slt e_1 (const? 32 0)) (const? 1 1)
-      (icmp IntPredicate.sgt e_1 (LLVM.and e (const? 32 2147483647))) := by 
+      (icmp IntPredicate.sgt e_1 (LLVM.and e (const? 32 2147483647))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -127,7 +127,7 @@ theorem test_or2_logical_thm (e e_1 : IntW 32) :
 
 theorem test_or3_thm (e e_1 : IntW 32) :
   LLVM.or (icmp IntPredicate.sle (LLVM.and e_1 (const? 32 2147483647)) e) (icmp IntPredicate.slt e (const? 32 0)) ⊑
-    icmp IntPredicate.uge e (LLVM.and e_1 (const? 32 2147483647)) := by 
+    icmp IntPredicate.uge e (LLVM.and e_1 (const? 32 2147483647)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -139,7 +139,7 @@ theorem test_or3_thm (e e_1 : IntW 32) :
 theorem test_or3_logical_thm (e e_1 : IntW 32) :
   select (icmp IntPredicate.sle (LLVM.and e_1 (const? 32 2147483647)) e) (const? 1 1)
       (icmp IntPredicate.slt e (const? 32 0)) ⊑
-    icmp IntPredicate.uge e (LLVM.and e_1 (const? 32 2147483647)) := by 
+    icmp IntPredicate.uge e (LLVM.and e_1 (const? 32 2147483647)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -150,7 +150,7 @@ theorem test_or3_logical_thm (e e_1 : IntW 32) :
 
 theorem test_or4_thm (e e_1 : IntW 32) :
   LLVM.or (icmp IntPredicate.slt (LLVM.and e_1 (const? 32 2147483647)) e) (icmp IntPredicate.slt e (const? 32 0)) ⊑
-    icmp IntPredicate.ugt e (LLVM.and e_1 (const? 32 2147483647)) := by 
+    icmp IntPredicate.ugt e (LLVM.and e_1 (const? 32 2147483647)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -162,7 +162,7 @@ theorem test_or4_thm (e e_1 : IntW 32) :
 theorem test_or4_logical_thm (e e_1 : IntW 32) :
   select (icmp IntPredicate.slt (LLVM.and e_1 (const? 32 2147483647)) e) (const? 1 1)
       (icmp IntPredicate.slt e (const? 32 0)) ⊑
-    icmp IntPredicate.ugt e (LLVM.and e_1 (const? 32 2147483647)) := by 
+    icmp IntPredicate.ugt e (LLVM.and e_1 (const? 32 2147483647)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -175,7 +175,7 @@ theorem negative1_logical_thm (e e_1 : IntW 32) :
   select (icmp IntPredicate.slt e_1 (LLVM.and e (const? 32 2147483647))) (icmp IntPredicate.sgt e_1 (const? 32 0))
       (const? 1 0) ⊑
     LLVM.and (icmp IntPredicate.slt e_1 (LLVM.and e (const? 32 2147483647)))
-      (icmp IntPredicate.sgt e_1 (const? 32 0)) := by 
+      (icmp IntPredicate.sgt e_1 (const? 32 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -186,7 +186,7 @@ theorem negative1_logical_thm (e e_1 : IntW 32) :
 
 theorem negative2_thm (e e_1 : IntW 32) :
   LLVM.and (icmp IntPredicate.slt e_1 e) (icmp IntPredicate.sge e_1 (const? 32 0)) ⊑
-    LLVM.and (icmp IntPredicate.slt e_1 e) (icmp IntPredicate.sgt e_1 (const? 32 (-1))) := by 
+    LLVM.and (icmp IntPredicate.slt e_1 e) (icmp IntPredicate.sgt e_1 (const? 32 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -197,7 +197,7 @@ theorem negative2_thm (e e_1 : IntW 32) :
 
 theorem negative2_logical_thm (e e_1 : IntW 32) :
   select (icmp IntPredicate.slt e_1 e) (icmp IntPredicate.sge e_1 (const? 32 0)) (const? 1 0) ⊑
-    LLVM.and (icmp IntPredicate.slt e_1 e) (icmp IntPredicate.sgt e_1 (const? 32 (-1))) := by 
+    LLVM.and (icmp IntPredicate.slt e_1 e) (icmp IntPredicate.sgt e_1 (const? 32 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -209,7 +209,7 @@ theorem negative2_logical_thm (e e_1 : IntW 32) :
 theorem negative3_thm (e e_1 e_2 : IntW 32) :
   LLVM.and (icmp IntPredicate.slt e_2 (LLVM.and e_1 (const? 32 2147483647))) (icmp IntPredicate.sge e (const? 32 0)) ⊑
     LLVM.and (icmp IntPredicate.slt e_2 (LLVM.and e_1 (const? 32 2147483647)))
-      (icmp IntPredicate.sgt e (const? 32 (-1))) := by 
+      (icmp IntPredicate.sgt e (const? 32 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -222,7 +222,7 @@ theorem negative3_logical_thm (e e_1 e_2 : IntW 32) :
   select (icmp IntPredicate.slt e_2 (LLVM.and e_1 (const? 32 2147483647))) (icmp IntPredicate.sge e (const? 32 0))
       (const? 1 0) ⊑
     select (icmp IntPredicate.slt e_2 (LLVM.and e_1 (const? 32 2147483647))) (icmp IntPredicate.sgt e (const? 32 (-1)))
-      (const? 1 0) := by 
+      (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -234,7 +234,7 @@ theorem negative3_logical_thm (e e_1 e_2 : IntW 32) :
 theorem negative4_thm (e e_1 : IntW 32) :
   LLVM.and (icmp IntPredicate.ne e_1 (LLVM.and e (const? 32 2147483647))) (icmp IntPredicate.sge e_1 (const? 32 0)) ⊑
     LLVM.and (icmp IntPredicate.ne e_1 (LLVM.and e (const? 32 2147483647)))
-      (icmp IntPredicate.sgt e_1 (const? 32 (-1))) := by 
+      (icmp IntPredicate.sgt e_1 (const? 32 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -247,7 +247,7 @@ theorem negative4_logical_thm (e e_1 : IntW 32) :
   select (icmp IntPredicate.ne e_1 (LLVM.and e (const? 32 2147483647))) (icmp IntPredicate.sge e_1 (const? 32 0))
       (const? 1 0) ⊑
     LLVM.and (icmp IntPredicate.ne e_1 (LLVM.and e (const? 32 2147483647)))
-      (icmp IntPredicate.sgt e_1 (const? 32 (-1))) := by 
+      (icmp IntPredicate.sgt e_1 (const? 32 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -258,7 +258,7 @@ theorem negative4_logical_thm (e e_1 : IntW 32) :
 
 theorem negative5_thm (e e_1 : IntW 32) :
   LLVM.or (icmp IntPredicate.slt e_1 (LLVM.and e (const? 32 2147483647))) (icmp IntPredicate.sge e_1 (const? 32 0)) ⊑
-    const? 1 1 := by 
+    const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -270,7 +270,7 @@ theorem negative5_thm (e e_1 : IntW 32) :
 theorem negative5_logical_thm (e e_1 : IntW 32) :
   select (icmp IntPredicate.slt e_1 (LLVM.and e (const? 32 2147483647))) (const? 1 1)
       (icmp IntPredicate.sge e_1 (const? 32 0)) ⊑
-    const? 1 1 := by 
+    const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/greassociatehnuw_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/greassociatehnuw_proof.lean
@@ -10,7 +10,7 @@ set_option linter.unreachableTactic false
 section greassociatehnuw_proof
 theorem reassoc_add_nuw_thm (e : IntW 32) :
   add (add e (const? 32 4) { «nsw» := false, «nuw» := true }) (const? 32 64) { «nsw» := false, «nuw» := true } ⊑
-    add e (const? 32 68) { «nsw» := false, «nuw» := true } := by 
+    add e (const? 32 68) { «nsw» := false, «nuw» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -21,7 +21,7 @@ theorem reassoc_add_nuw_thm (e : IntW 32) :
 
 theorem reassoc_sub_nuw_thm (e : IntW 32) :
   sub (sub e (const? 32 4) { «nsw» := false, «nuw» := true }) (const? 32 64) { «nsw» := false, «nuw» := true } ⊑
-    add e (const? 32 (-68)) := by 
+    add e (const? 32 (-68)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -32,7 +32,7 @@ theorem reassoc_sub_nuw_thm (e : IntW 32) :
 
 theorem reassoc_mul_nuw_thm (e : IntW 32) :
   mul (mul e (const? 32 4) { «nsw» := false, «nuw» := true }) (const? 32 65) { «nsw» := false, «nuw» := true } ⊑
-    mul e (const? 32 260) { «nsw» := false, «nuw» := true } := by 
+    mul e (const? 32 260) { «nsw» := false, «nuw» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -42,7 +42,7 @@ theorem reassoc_mul_nuw_thm (e : IntW 32) :
 
 
 theorem no_reassoc_add_nuw_none_thm (e : IntW 32) :
-  add (add e (const? 32 4)) (const? 32 64) { «nsw» := false, «nuw» := true } ⊑ add e (const? 32 68) := by 
+  add (add e (const? 32 4)) (const? 32 64) { «nsw» := false, «nuw» := true } ⊑ add e (const? 32 68) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -52,7 +52,7 @@ theorem no_reassoc_add_nuw_none_thm (e : IntW 32) :
 
 
 theorem no_reassoc_add_none_nuw_thm (e : IntW 32) :
-  add (add e (const? 32 4) { «nsw» := false, «nuw» := true }) (const? 32 64) ⊑ add e (const? 32 68) := by 
+  add (add e (const? 32 4) { «nsw» := false, «nuw» := true }) (const? 32 64) ⊑ add e (const? 32 68) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -64,7 +64,7 @@ theorem no_reassoc_add_none_nuw_thm (e : IntW 32) :
 theorem reassoc_x2_add_nuw_thm (e e_1 : IntW 32) :
   add (add e_1 (const? 32 4) { «nsw» := false, «nuw» := true }) (add e (const? 32 8) { «nsw» := false, «nuw» := true })
       { «nsw» := false, «nuw» := true } ⊑
-    add (add e_1 e { «nsw» := false, «nuw» := true }) (const? 32 12) { «nsw» := false, «nuw» := true } := by 
+    add (add e_1 e { «nsw» := false, «nuw» := true }) (const? 32 12) { «nsw» := false, «nuw» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -76,7 +76,7 @@ theorem reassoc_x2_add_nuw_thm (e e_1 : IntW 32) :
 theorem reassoc_x2_mul_nuw_thm (e e_1 : IntW 32) :
   mul (mul e_1 (const? 32 5) { «nsw» := false, «nuw» := true }) (mul e (const? 32 9) { «nsw» := false, «nuw» := true })
       { «nsw» := false, «nuw» := true } ⊑
-    mul (mul e_1 e) (const? 32 45) { «nsw» := false, «nuw» := true } := by 
+    mul (mul e_1 e) (const? 32 45) { «nsw» := false, «nuw» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -88,7 +88,7 @@ theorem reassoc_x2_mul_nuw_thm (e e_1 : IntW 32) :
 theorem reassoc_x2_sub_nuw_thm (e e_1 : IntW 32) :
   sub (sub e_1 (const? 32 4) { «nsw» := false, «nuw» := true }) (sub e (const? 32 8) { «nsw» := false, «nuw» := true })
       { «nsw» := false, «nuw» := true } ⊑
-    add (sub e_1 e) (const? 32 4) := by 
+    add (sub e_1 e) (const? 32 4) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -99,7 +99,7 @@ theorem reassoc_x2_sub_nuw_thm (e e_1 : IntW 32) :
 
 theorem tryFactorization_add_nuw_mul_nuw_thm (e : IntW 32) :
   add (mul e (const? 32 3) { «nsw» := false, «nuw» := true }) e { «nsw» := false, «nuw» := true } ⊑
-    shl e (const? 32 2) { «nsw» := false, «nuw» := true } := by 
+    shl e (const? 32 2) { «nsw» := false, «nuw» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -110,7 +110,7 @@ theorem tryFactorization_add_nuw_mul_nuw_thm (e : IntW 32) :
 
 theorem tryFactorization_add_nuw_mul_nuw_int_max_thm (e : IntW 32) :
   add (mul e (const? 32 2147483647) { «nsw» := false, «nuw» := true }) e { «nsw» := false, «nuw» := true } ⊑
-    shl e (const? 32 31) { «nsw» := false, «nuw» := true } := by 
+    shl e (const? 32 31) { «nsw» := false, «nuw» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -120,7 +120,7 @@ theorem tryFactorization_add_nuw_mul_nuw_int_max_thm (e : IntW 32) :
 
 
 theorem tryFactorization_add_mul_nuw_thm (e : IntW 32) :
-  add (mul e (const? 32 3)) e { «nsw» := false, «nuw» := true } ⊑ shl e (const? 32 2) := by 
+  add (mul e (const? 32 3)) e { «nsw» := false, «nuw» := true } ⊑ shl e (const? 32 2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -130,7 +130,7 @@ theorem tryFactorization_add_mul_nuw_thm (e : IntW 32) :
 
 
 theorem tryFactorization_add_nuw_mul_thm (e : IntW 32) :
-  add (mul e (const? 32 3) { «nsw» := false, «nuw» := true }) e ⊑ shl e (const? 32 2) := by 
+  add (mul e (const? 32 3) { «nsw» := false, «nuw» := true }) e ⊑ shl e (const? 32 2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -142,7 +142,7 @@ theorem tryFactorization_add_nuw_mul_thm (e : IntW 32) :
 theorem tryFactorization_add_nuw_mul_nuw_mul_nuw_var_thm (e e_1 e_2 : IntW 32) :
   add (mul e_2 e_1 { «nsw» := false, «nuw» := true }) (mul e_2 e { «nsw» := false, «nuw» := true })
       { «nsw» := false, «nuw» := true } ⊑
-    mul e_2 (add e_1 e) { «nsw» := false, «nuw» := true } := by 
+    mul e_2 (add e_1 e) { «nsw» := false, «nuw» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -153,7 +153,7 @@ theorem tryFactorization_add_nuw_mul_nuw_mul_nuw_var_thm (e e_1 e_2 : IntW 32) :
 
 theorem tryFactorization_add_nuw_mul_mul_nuw_var_thm (e e_1 e_2 : IntW 32) :
   add (mul e_2 e_1) (mul e_2 e { «nsw» := false, «nuw» := true }) { «nsw» := false, «nuw» := true } ⊑
-    mul e_2 (add e_1 e) := by 
+    mul e_2 (add e_1 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -164,7 +164,7 @@ theorem tryFactorization_add_nuw_mul_mul_nuw_var_thm (e e_1 e_2 : IntW 32) :
 
 theorem tryFactorization_add_nuw_mul_nuw_mul_var_thm (e e_1 e_2 : IntW 32) :
   add (mul e_2 e_1 { «nsw» := false, «nuw» := true }) (mul e_2 e) { «nsw» := false, «nuw» := true } ⊑
-    mul e_2 (add e_1 e) := by 
+    mul e_2 (add e_1 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -175,7 +175,7 @@ theorem tryFactorization_add_nuw_mul_nuw_mul_var_thm (e e_1 e_2 : IntW 32) :
 
 theorem tryFactorization_add_mul_nuw_mul_var_thm (e e_1 e_2 : IntW 32) :
   add (mul e_2 e_1 { «nsw» := false, «nuw» := true }) (mul e_2 e { «nsw» := false, «nuw» := true }) ⊑
-    mul e_2 (add e_1 e) := by 
+    mul e_2 (add e_1 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gredundanthlefthshifthinputhmaskinghpr49778_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gredundanthlefthshifthinputhmaskinghpr49778_proof.lean
@@ -13,7 +13,7 @@ theorem src_thm (e : IntW 1) :
     shl
       (LLVM.and (LLVM.xor (shl (const? 32 (-1)) (zext 32 e) { «nsw» := true, «nuw» := false }) (const? 32 (-1)))
         (zext 32 e))
-      (zext 32 e) { «nsw» := true, «nuw» := true } := by 
+      (zext 32 e) { «nsw» := true, «nuw» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gredundanthrighthshifthinputhmasking_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gredundanthrighthshifthinputhmasking_proof.lean
@@ -10,7 +10,7 @@ set_option linter.unreachableTactic false
 section gredundanthrighthshifthinputhmasking_proof
 theorem t0_lshr_thm (e e_1 : IntW 32) :
   lshr (LLVM.and (shl (const? 32 (-1)) e_1) e) e_1 { «exact» := true } ⊑
-    lshr (LLVM.and (shl (const? 32 (-1)) e_1 { «nsw» := true, «nuw» := false }) e) e_1 { «exact» := true } := by 
+    lshr (LLVM.and (shl (const? 32 (-1)) e_1 { «nsw» := true, «nuw» := false }) e) e_1 { «exact» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -21,7 +21,7 @@ theorem t0_lshr_thm (e e_1 : IntW 32) :
 
 theorem t1_sshr_thm (e e_1 : IntW 32) :
   ashr (LLVM.and (shl (const? 32 (-1)) e_1) e) e_1 { «exact» := true } ⊑
-    ashr (LLVM.and (shl (const? 32 (-1)) e_1 { «nsw» := true, «nuw» := false }) e) e_1 { «exact» := true } := by 
+    ashr (LLVM.and (shl (const? 32 (-1)) e_1 { «nsw» := true, «nuw» := false }) e) e_1 { «exact» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -32,7 +32,7 @@ theorem t1_sshr_thm (e e_1 : IntW 32) :
 
 theorem n13_thm (e e_1 e_2 : IntW 32) :
   lshr (LLVM.and (shl (const? 32 (-1)) e_2) e_1) e ⊑
-    lshr (LLVM.and (shl (const? 32 (-1)) e_2 { «nsw» := true, «nuw» := false }) e_1) e := by 
+    lshr (LLVM.and (shl (const? 32 (-1)) e_2 { «nsw» := true, «nuw» := false }) e_1) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/grem_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/grem_proof.lean
@@ -8,7 +8,7 @@ set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
 
 section grem_proof
-theorem test1_thm (e : IntW 32) : LLVM.srem e (const? 32 1) ⊑ const? 32 0 := by 
+theorem test1_thm (e : IntW 32) : LLVM.srem e (const? 32 1) ⊑ const? 32 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -17,7 +17,7 @@ theorem test1_thm (e : IntW 32) : LLVM.srem e (const? 32 1) ⊑ const? 32 0 := b
     all_goals sorry
 
 
-theorem test3_thm (e : IntW 32) : urem e (const? 32 8) ⊑ LLVM.and e (const? 32 7) := by 
+theorem test3_thm (e : IntW 32) : urem e (const? 32 8) ⊑ LLVM.and e (const? 32 7) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -28,7 +28,7 @@ theorem test3_thm (e : IntW 32) : urem e (const? 32 8) ⊑ LLVM.and e (const? 32
 
 theorem test3a_thm (e : IntW 32) :
   icmp IntPredicate.ne (LLVM.srem e (const? 32 (-8))) (const? 32 0) ⊑
-    icmp IntPredicate.ne (LLVM.and e (const? 32 7)) (const? 32 0) := by 
+    icmp IntPredicate.ne (LLVM.and e (const? 32 7)) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -38,7 +38,7 @@ theorem test3a_thm (e : IntW 32) :
 
 
 theorem test4_thm (e : IntW 1) (e_1 : IntW 32) :
-  urem e_1 (select e (const? 32 1) (const? 32 8)) ⊑ LLVM.and e_1 (select e (const? 32 0) (const? 32 7)) := by 
+  urem e_1 (select e (const? 32 1) (const? 32 8)) ⊑ LLVM.and e_1 (select e (const? 32 0) (const? 32 7)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -51,7 +51,7 @@ theorem test5_thm (e : IntW 8) (e_1 : IntW 32) :
   urem e_1 (shl (const? 32 32) (zext 32 e)) ⊑
     LLVM.and e_1
       (add (shl (const? 32 32) (zext 32 e { «nneg» := true }) { «nsw» := false, «nuw» := true })
-        (const? 32 (-1))) := by 
+        (const? 32 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -60,7 +60,7 @@ theorem test5_thm (e : IntW 8) (e_1 : IntW 32) :
     all_goals sorry
 
 
-theorem test7_thm (e : IntW 32) : LLVM.srem (mul e (const? 32 8)) (const? 32 4) ⊑ const? 32 0 := by 
+theorem test7_thm (e : IntW 32) : LLVM.srem (mul e (const? 32 8)) (const? 32 4) ⊑ const? 32 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -69,7 +69,7 @@ theorem test7_thm (e : IntW 32) : LLVM.srem (mul e (const? 32 8)) (const? 32 4) 
     all_goals sorry
 
 
-theorem test8_thm (e : IntW 32) : LLVM.srem (shl e (const? 32 4)) (const? 32 8) ⊑ const? 32 0 := by 
+theorem test8_thm (e : IntW 32) : LLVM.srem (shl e (const? 32 4)) (const? 32 8) ⊑ const? 32 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -78,7 +78,7 @@ theorem test8_thm (e : IntW 32) : LLVM.srem (shl e (const? 32 4)) (const? 32 8) 
     all_goals sorry
 
 
-theorem test9_thm (e : IntW 32) : urem (mul e (const? 32 64)) (const? 32 32) ⊑ const? 32 0 := by 
+theorem test9_thm (e : IntW 32) : urem (mul e (const? 32 64)) (const? 32 32) ⊑ const? 32 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -88,7 +88,7 @@ theorem test9_thm (e : IntW 32) : urem (mul e (const? 32 64)) (const? 32 32) ⊑
 
 
 theorem test10_thm (e : IntW 8) :
-  trunc 32 (urem (sext 64 (mul (zext 32 e) (const? 32 4))) (const? 64 4)) ⊑ const? 32 0 := by 
+  trunc 32 (urem (sext 64 (mul (zext 32 e) (const? 32 4))) (const? 64 4)) ⊑ const? 32 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -98,7 +98,7 @@ theorem test10_thm (e : IntW 8) :
 
 
 theorem test11_thm (e : IntW 32) :
-  urem (mul (LLVM.and e (const? 32 (-2))) (const? 32 2)) (const? 32 4) ⊑ const? 32 0 := by 
+  urem (mul (LLVM.and e (const? 32 (-2))) (const? 32 2)) (const? 32 4) ⊑ const? 32 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -107,7 +107,7 @@ theorem test11_thm (e : IntW 32) :
     all_goals sorry
 
 
-theorem test12_thm (e : IntW 32) : LLVM.srem (LLVM.and e (const? 32 (-4))) (const? 32 2) ⊑ const? 32 0 := by 
+theorem test12_thm (e : IntW 32) : LLVM.srem (LLVM.and e (const? 32 (-4))) (const? 32 2) ⊑ const? 32 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -116,7 +116,7 @@ theorem test12_thm (e : IntW 32) : LLVM.srem (LLVM.and e (const? 32 (-4))) (cons
     all_goals sorry
 
 
-theorem test13_thm (e : IntW 32) : LLVM.srem e e ⊑ const? 32 0 := by 
+theorem test13_thm (e : IntW 32) : LLVM.srem e e ⊑ const? 32 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -129,7 +129,7 @@ theorem test14_thm (e : IntW 32) (e_1 : IntW 64) :
   urem e_1 (zext 64 (shl (const? 32 1) e)) ⊑
     LLVM.and e_1
       (add (zext 64 (shl (const? 32 1) e { «nsw» := false, «nuw» := true })) (const? 64 (-1))
-        { «nsw» := true, «nuw» := false }) := by 
+        { «nsw» := true, «nuw» := false }) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -141,7 +141,7 @@ theorem test14_thm (e : IntW 32) (e_1 : IntW 64) :
 theorem test15_thm (e e_1 : IntW 32) :
   urem (zext 64 e_1) (zext 64 (shl (const? 32 1) e)) ⊑
     zext 64 (LLVM.and e_1 (LLVM.xor (shl (const? 32 (-1)) e { «nsw» := true, «nuw» := false }) (const? 32 (-1))))
-      { «nneg» := true } := by 
+      { «nneg» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -153,7 +153,7 @@ theorem test15_thm (e e_1 : IntW 32) :
 theorem test16_thm (e e_1 : IntW 32) :
   urem e_1 (add (LLVM.and (lshr e (const? 32 11)) (const? 32 4)) (const? 32 4)) ⊑
     LLVM.and e_1
-      (LLVM.or (LLVM.and (lshr e (const? 32 11)) (const? 32 4)) (const? 32 3) { «disjoint» := true }) := by 
+      (LLVM.or (LLVM.and (lshr e (const? 32 11)) (const? 32 4)) (const? 32 3) { «disjoint» := true }) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -162,7 +162,7 @@ theorem test16_thm (e e_1 : IntW 32) :
     all_goals sorry
 
 
-theorem test17_thm (e : IntW 32) : urem (const? 32 1) e ⊑ zext 32 (icmp IntPredicate.ne e (const? 32 1)) := by 
+theorem test17_thm (e : IntW 32) : urem (const? 32 1) e ⊑ zext 32 (icmp IntPredicate.ne e (const? 32 1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -174,7 +174,7 @@ theorem test17_thm (e : IntW 32) : urem (const? 32 1) e ⊑ zext 32 (icmp IntPre
 theorem test18_thm (e : IntW 16) (e_1 : IntW 32) :
   urem e_1 (select (icmp IntPredicate.ne (LLVM.and e (const? 16 4)) (const? 16 0)) (const? 32 32) (const? 32 64)) ⊑
     LLVM.and e_1
-      (select (icmp IntPredicate.eq (LLVM.and e (const? 16 4)) (const? 16 0)) (const? 32 63) (const? 32 31)) := by 
+      (select (icmp IntPredicate.eq (LLVM.and e (const? 16 4)) (const? 16 0)) (const? 32 63) (const? 32 31)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -191,7 +191,7 @@ theorem test19_thm (e e_1 : IntW 32) :
           (LLVM.and (shl (const? 32 1) e { «nsw» := false, «nuw» := true })
             (shl (const? 32 1) e_1 { «nsw» := false, «nuw» := true }))
           (shl (const? 32 1) e { «nsw» := false, «nuw» := true }))
-        (const? 32 (-1))) := by 
+        (const? 32 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -208,7 +208,7 @@ theorem test19_commutative0_thm (e e_1 : IntW 32) :
           (LLVM.and (shl (const? 32 1) e_1 { «nsw» := false, «nuw» := true })
             (shl (const? 32 1) e { «nsw» := false, «nuw» := true }))
           (shl (const? 32 1) e { «nsw» := false, «nuw» := true }))
-        (const? 32 (-1))) := by 
+        (const? 32 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -224,7 +224,7 @@ theorem test19_commutative1_thm (e e_1 : IntW 32) :
         (add (shl (const? 32 1) e { «nsw» := false, «nuw» := true })
           (LLVM.and (shl (const? 32 1) e { «nsw» := false, «nuw» := true })
             (shl (const? 32 1) e_1 { «nsw» := false, «nuw» := true })))
-        (const? 32 (-1))) := by 
+        (const? 32 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -240,7 +240,7 @@ theorem test19_commutative2_thm (e e_1 : IntW 32) :
         (add (shl (const? 32 1) e { «nsw» := false, «nuw» := true })
           (LLVM.and (shl (const? 32 1) e_1 { «nsw» := false, «nuw» := true })
             (shl (const? 32 1) e { «nsw» := false, «nuw» := true })))
-        (const? 32 (-1))) := by 
+        (const? 32 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -251,7 +251,7 @@ theorem test19_commutative2_thm (e e_1 : IntW 32) :
 
 theorem test22_thm (e : IntW 32) :
   LLVM.srem (LLVM.and e (const? 32 2147483647)) (const? 32 2147483647) ⊑
-    urem (LLVM.and e (const? 32 2147483647)) (const? 32 2147483647) := by 
+    urem (LLVM.and e (const? 32 2147483647)) (const? 32 2147483647) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -262,7 +262,7 @@ theorem test22_thm (e : IntW 32) :
 
 theorem test24_thm (e : IntW 32) :
   icmp IntPredicate.ne (urem e (const? 32 (-2147483648))) (const? 32 0) ⊑
-    icmp IntPredicate.ne (LLVM.and e (const? 32 2147483647)) (const? 32 0) := by 
+    icmp IntPredicate.ne (LLVM.and e (const? 32 2147483647)) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -273,7 +273,7 @@ theorem test24_thm (e : IntW 32) :
 
 theorem test25_thm (e : IntW 32) :
   icmp IntPredicate.ne (LLVM.srem e (const? 32 (-2147483648))) (const? 32 0) ⊑
-    icmp IntPredicate.ne (LLVM.and e (const? 32 2147483647)) (const? 32 0) := by 
+    icmp IntPredicate.ne (LLVM.and e (const? 32 2147483647)) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -286,7 +286,7 @@ theorem test26_thm (e e_1 : IntW 32) :
   icmp IntPredicate.ne (LLVM.srem e_1 (shl (const? 32 1) e)) (const? 32 0) ⊑
     icmp IntPredicate.ne
       (LLVM.and e_1 (LLVM.xor (shl (const? 32 (-1)) e { «nsw» := true, «nuw» := false }) (const? 32 (-1))))
-      (const? 32 0) := by 
+      (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -297,7 +297,7 @@ theorem test26_thm (e e_1 : IntW 32) :
 
 theorem test28_thm (e : IntW 32) :
   icmp IntPredicate.eq (LLVM.srem e (const? 32 (-2147483648))) (const? 32 0) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 32 2147483647)) (const? 32 0) := by 
+    icmp IntPredicate.eq (LLVM.and e (const? 32 2147483647)) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -308,7 +308,7 @@ theorem test28_thm (e : IntW 32) :
 
 theorem positive_and_odd_eq_thm (e : IntW 32) :
   icmp IntPredicate.eq (LLVM.srem e (const? 32 2)) (const? 32 1) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 32 (-2147483647))) (const? 32 1) := by 
+    icmp IntPredicate.eq (LLVM.and e (const? 32 (-2147483647))) (const? 32 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -319,7 +319,7 @@ theorem positive_and_odd_eq_thm (e : IntW 32) :
 
 theorem positive_and_odd_ne_thm (e : IntW 32) :
   icmp IntPredicate.ne (LLVM.srem e (const? 32 2)) (const? 32 1) ⊑
-    icmp IntPredicate.ne (LLVM.and e (const? 32 (-2147483647))) (const? 32 1) := by 
+    icmp IntPredicate.ne (LLVM.and e (const? 32 (-2147483647))) (const? 32 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -329,7 +329,7 @@ theorem positive_and_odd_ne_thm (e : IntW 32) :
 
 
 theorem srem_constant_dividend_select_of_constants_divisor_thm (e : IntW 1) :
-  LLVM.srem (const? 32 42) (select e (const? 32 12) (const? 32 (-3))) ⊑ select e (const? 32 6) (const? 32 0) := by 
+  LLVM.srem (const? 32 42) (select e (const? 32 12) (const? 32 (-3))) ⊑ select e (const? 32 6) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -339,7 +339,7 @@ theorem srem_constant_dividend_select_of_constants_divisor_thm (e : IntW 1) :
 
 
 theorem srem_constant_dividend_select_of_constants_divisor_0_arm_thm (e : IntW 1) :
-  LLVM.srem (const? 32 42) (select e (const? 32 12) (const? 32 0)) ⊑ const? 32 6 := by 
+  LLVM.srem (const? 32 42) (select e (const? 32 12) (const? 32 0)) ⊑ const? 32 6 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -349,7 +349,7 @@ theorem srem_constant_dividend_select_of_constants_divisor_0_arm_thm (e : IntW 1
 
 
 theorem urem_constant_dividend_select_of_constants_divisor_thm (e : IntW 1) :
-  urem (const? 32 42) (select e (const? 32 12) (const? 32 (-3))) ⊑ select e (const? 32 6) (const? 32 42) := by 
+  urem (const? 32 42) (select e (const? 32 12) (const? 32 (-3))) ⊑ select e (const? 32 6) (const? 32 42) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -358,7 +358,7 @@ theorem urem_constant_dividend_select_of_constants_divisor_thm (e : IntW 1) :
     all_goals sorry
 
 
-theorem urem_constant_dividend_select_of_constants_divisor_0_arm_thm (e : IntW 1) : urem (const? 32 42) (select e (const? 32 12) (const? 32 0)) ⊑ const? 32 6 := by 
+theorem urem_constant_dividend_select_of_constants_divisor_0_arm_thm (e : IntW 1) : urem (const? 32 42) (select e (const? 32 12) (const? 32 0)) ⊑ const? 32 6 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/greusehconstanthfromhselecthinhicmp_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/greusehconstanthfromhselecthinhicmp_proof.lean
@@ -10,7 +10,7 @@ set_option linter.unreachableTactic false
 section greusehconstanthfromhselecthinhicmp_proof
 theorem p0_ult_65536_thm (e e_1 : IntW 32) :
   select (icmp IntPredicate.ult e_1 (const? 32 65536)) e (const? 32 65535) ⊑
-    select (icmp IntPredicate.ugt e_1 (const? 32 65535)) (const? 32 65535) e := by 
+    select (icmp IntPredicate.ugt e_1 (const? 32 65535)) (const? 32 65535) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -21,7 +21,7 @@ theorem p0_ult_65536_thm (e e_1 : IntW 32) :
 
 theorem p1_ugt_thm (e e_1 : IntW 32) :
   select (icmp IntPredicate.ugt e_1 (const? 32 65534)) e (const? 32 65535) ⊑
-    select (icmp IntPredicate.ult e_1 (const? 32 65535)) (const? 32 65535) e := by 
+    select (icmp IntPredicate.ult e_1 (const? 32 65535)) (const? 32 65535) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -32,7 +32,7 @@ theorem p1_ugt_thm (e e_1 : IntW 32) :
 
 theorem p2_slt_65536_thm (e e_1 : IntW 32) :
   select (icmp IntPredicate.slt e_1 (const? 32 65536)) e (const? 32 65535) ⊑
-    select (icmp IntPredicate.sgt e_1 (const? 32 65535)) (const? 32 65535) e := by 
+    select (icmp IntPredicate.sgt e_1 (const? 32 65535)) (const? 32 65535) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -43,7 +43,7 @@ theorem p2_slt_65536_thm (e e_1 : IntW 32) :
 
 theorem p3_sgt_thm (e e_1 : IntW 32) :
   select (icmp IntPredicate.sgt e_1 (const? 32 65534)) e (const? 32 65535) ⊑
-    select (icmp IntPredicate.slt e_1 (const? 32 65535)) (const? 32 65535) e := by 
+    select (icmp IntPredicate.slt e_1 (const? 32 65535)) (const? 32 65535) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -54,7 +54,7 @@ theorem p3_sgt_thm (e e_1 : IntW 32) :
 
 theorem p13_commutativity0_thm (e e_1 : IntW 32) :
   select (icmp IntPredicate.ult e_1 (const? 32 65536)) (const? 32 65535) e ⊑
-    select (icmp IntPredicate.ugt e_1 (const? 32 65535)) e (const? 32 65535) := by 
+    select (icmp IntPredicate.ugt e_1 (const? 32 65535)) e (const? 32 65535) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -65,7 +65,7 @@ theorem p13_commutativity0_thm (e e_1 : IntW 32) :
 
 theorem p14_commutativity1_thm (e : IntW 32) :
   select (icmp IntPredicate.ult e (const? 32 65536)) (const? 32 65535) (const? 32 42) ⊑
-    select (icmp IntPredicate.ugt e (const? 32 65535)) (const? 32 42) (const? 32 65535) := by 
+    select (icmp IntPredicate.ugt e (const? 32 65535)) (const? 32 42) (const? 32 65535) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -76,7 +76,7 @@ theorem p14_commutativity1_thm (e : IntW 32) :
 
 theorem p15_commutativity2_thm (e : IntW 32) :
   select (icmp IntPredicate.ult e (const? 32 65536)) (const? 32 42) (const? 32 65535) ⊑
-    select (icmp IntPredicate.ugt e (const? 32 65535)) (const? 32 65535) (const? 32 42) := by 
+    select (icmp IntPredicate.ugt e (const? 32 65535)) (const? 32 65535) (const? 32 42) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -87,7 +87,7 @@ theorem p15_commutativity2_thm (e : IntW 32) :
 
 theorem t22_sign_check_thm (e e_1 : IntW 32) :
   select (icmp IntPredicate.slt e_1 (const? 32 0)) (const? 32 (-1)) e ⊑
-    select (icmp IntPredicate.sgt e_1 (const? 32 (-1))) e (const? 32 (-1)) := by 
+    select (icmp IntPredicate.sgt e_1 (const? 32 (-1))) e (const? 32 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -98,7 +98,7 @@ theorem t22_sign_check_thm (e e_1 : IntW 32) :
 
 theorem t22_sign_check2_thm (e e_1 : IntW 32) :
   select (icmp IntPredicate.sgt e_1 (const? 32 (-1))) (const? 32 0) e ⊑
-    select (icmp IntPredicate.slt e_1 (const? 32 0)) e (const? 32 0) := by 
+    select (icmp IntPredicate.slt e_1 (const? 32 0)) e (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/grotate_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/grotate_proof.lean
@@ -14,7 +14,7 @@ theorem rotateleft_9_neg_mask_wide_amount_commute_thm (e : IntW 33) (e_1 : IntW 
         (lshr (zext 33 e_1) (LLVM.and (sub (const? 33 0) e) (const? 33 8)))) ⊑
     trunc 9
       (LLVM.or (shl (zext 33 e_1) (LLVM.and e (const? 33 8)) { «nsw» := true, «nuw» := true })
-        (lshr (zext 33 e_1) (LLVM.and (sub (const? 33 0) e) (const? 33 8)))) := by 
+        (lshr (zext 33 e_1) (LLVM.and (sub (const? 33 0) e) (const? 33 8)))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gsaturatinghaddhsub_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gsaturatinghaddhsub_proof.lean
@@ -10,7 +10,7 @@ set_option linter.unreachableTactic false
 section gsaturatinghaddhsub_proof
 theorem test_simplify_decrement_invalid_ne_thm (e : IntW 8) :
   select (icmp IntPredicate.ne e (const? 8 0)) (const? 8 0) (sub e (const? 8 1)) ⊑
-    sext 8 (icmp IntPredicate.eq e (const? 8 0)) := by 
+    sext 8 (icmp IntPredicate.eq e (const? 8 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -21,7 +21,7 @@ theorem test_simplify_decrement_invalid_ne_thm (e : IntW 8) :
 
 theorem test_invalid_simplify_sub2_thm (e : IntW 8) :
   select (icmp IntPredicate.eq e (const? 8 0)) (const? 8 0) (sub e (const? 8 2)) ⊑
-    select (icmp IntPredicate.eq e (const? 8 0)) (const? 8 0) (add e (const? 8 (-2))) := by 
+    select (icmp IntPredicate.eq e (const? 8 0)) (const? 8 0) (add e (const? 8 (-2))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -32,7 +32,7 @@ theorem test_invalid_simplify_sub2_thm (e : IntW 8) :
 
 theorem test_invalid_simplify_eq2_thm (e : IntW 8) :
   select (icmp IntPredicate.eq e (const? 8 2)) (const? 8 0) (sub e (const? 8 1)) ⊑
-    select (icmp IntPredicate.eq e (const? 8 2)) (const? 8 0) (add e (const? 8 (-1))) := by 
+    select (icmp IntPredicate.eq e (const? 8 2)) (const? 8 0) (add e (const? 8 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -43,7 +43,7 @@ theorem test_invalid_simplify_eq2_thm (e : IntW 8) :
 
 theorem test_invalid_simplify_select_1_thm (e : IntW 8) :
   select (icmp IntPredicate.eq e (const? 8 0)) (const? 8 1) (sub e (const? 8 1)) ⊑
-    select (icmp IntPredicate.eq e (const? 8 0)) (const? 8 1) (add e (const? 8 (-1))) := by 
+    select (icmp IntPredicate.eq e (const? 8 0)) (const? 8 1) (add e (const? 8 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -54,7 +54,7 @@ theorem test_invalid_simplify_select_1_thm (e : IntW 8) :
 
 theorem test_invalid_simplify_other_thm (e e_1 : IntW 8) :
   select (icmp IntPredicate.eq e_1 (const? 8 0)) (const? 8 0) (sub e (const? 8 1)) ⊑
-    select (icmp IntPredicate.eq e_1 (const? 8 0)) (const? 8 0) (add e (const? 8 (-1))) := by 
+    select (icmp IntPredicate.eq e_1 (const? 8 0)) (const? 8 0) (add e (const? 8 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -65,7 +65,7 @@ theorem test_invalid_simplify_other_thm (e e_1 : IntW 8) :
 
 theorem uadd_sat_flipped_wrong_bounds_thm (e : IntW 32) :
   select (icmp IntPredicate.uge e (const? 32 (-12))) (const? 32 (-1)) (add e (const? 32 9)) ⊑
-    select (icmp IntPredicate.ugt e (const? 32 (-13))) (const? 32 (-1)) (add e (const? 32 9)) := by 
+    select (icmp IntPredicate.ugt e (const? 32 (-13))) (const? 32 (-1)) (add e (const? 32 9)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -76,7 +76,7 @@ theorem uadd_sat_flipped_wrong_bounds_thm (e : IntW 32) :
 
 theorem uadd_sat_flipped_wrong_bounds4_thm (e : IntW 32) :
   select (icmp IntPredicate.uge e (const? 32 (-8))) (const? 32 (-1)) (add e (const? 32 9)) ⊑
-    select (icmp IntPredicate.ugt e (const? 32 (-9))) (const? 32 (-1)) (add e (const? 32 9)) := by 
+    select (icmp IntPredicate.ugt e (const? 32 (-9))) (const? 32 (-1)) (add e (const? 32 9)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -87,7 +87,7 @@ theorem uadd_sat_flipped_wrong_bounds4_thm (e : IntW 32) :
 
 theorem uadd_sat_flipped_wrong_bounds6_thm (e : IntW 32) :
   select (icmp IntPredicate.ule e (const? 32 (-12))) (add e (const? 32 9)) (const? 32 (-1)) ⊑
-    select (icmp IntPredicate.ult e (const? 32 (-11))) (add e (const? 32 9)) (const? 32 (-1)) := by 
+    select (icmp IntPredicate.ult e (const? 32 (-11))) (add e (const? 32 9)) (const? 32 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -98,7 +98,7 @@ theorem uadd_sat_flipped_wrong_bounds6_thm (e : IntW 32) :
 
 theorem uadd_sat_flipped_wrong_bounds7_thm (e : IntW 32) :
   select (icmp IntPredicate.ule e (const? 32 (-12))) (add e (const? 32 9)) (const? 32 (-1)) ⊑
-    select (icmp IntPredicate.ult e (const? 32 (-11))) (add e (const? 32 9)) (const? 32 (-1)) := by 
+    select (icmp IntPredicate.ult e (const? 32 (-11))) (add e (const? 32 9)) (const? 32 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -110,7 +110,7 @@ theorem uadd_sat_flipped_wrong_bounds7_thm (e : IntW 32) :
 theorem uadd_sat_canon_nuw_thm (e e_1 : IntW 32) :
   select (icmp IntPredicate.ult (add e_1 e { «nsw» := false, «nuw» := true }) e_1) (const? 32 (-1))
       (add e_1 e { «nsw» := false, «nuw» := true }) ⊑
-    add e_1 e { «nsw» := false, «nuw» := true } := by 
+    add e_1 e { «nsw» := false, «nuw» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -122,7 +122,7 @@ theorem uadd_sat_canon_nuw_thm (e e_1 : IntW 32) :
 theorem uadd_sat_canon_y_nuw_thm (e e_1 : IntW 32) :
   select (icmp IntPredicate.ult (add e_1 e { «nsw» := false, «nuw» := true }) e) (const? 32 (-1))
       (add e_1 e { «nsw» := false, «nuw» := true }) ⊑
-    add e_1 e { «nsw» := false, «nuw» := true } := by 
+    add e_1 e { «nsw» := false, «nuw» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -133,7 +133,7 @@ theorem uadd_sat_canon_y_nuw_thm (e e_1 : IntW 32) :
 
 theorem uadd_sat_via_add_nonstrict_thm (e e_1 : IntW 32) :
   select (icmp IntPredicate.ule (add e_1 e) e) (const? 32 (-1)) (add e_1 e) ⊑
-    select (icmp IntPredicate.ugt (add e_1 e) e) (add e_1 e) (const? 32 (-1)) := by 
+    select (icmp IntPredicate.ugt (add e_1 e) e) (add e_1 e) (const? 32 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -144,7 +144,7 @@ theorem uadd_sat_via_add_nonstrict_thm (e e_1 : IntW 32) :
 
 theorem uadd_sat_via_add_swapped_cmp_nonstrict_thm (e e_1 : IntW 32) :
   select (icmp IntPredicate.uge e_1 (add e e_1)) (const? 32 (-1)) (add e e_1) ⊑
-    select (icmp IntPredicate.ult e_1 (add e e_1)) (add e e_1) (const? 32 (-1)) := by 
+    select (icmp IntPredicate.ult e_1 (add e e_1)) (add e e_1) (const? 32 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gsdivh1_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gsdivh1_proof.lean
@@ -9,7 +9,7 @@ set_option linter.unreachableTactic false
 
 section gsdivh1_proof
 theorem c_thm :
-  LLVM.sdiv (sub (const? 32 0) (const? 32 (-2147483648))) (const? 32 (-3)) ⊑ const? 32 715827882 := by 
+  LLVM.sdiv (sub (const? 32 0) (const? 32 (-2147483648))) (const? 32 (-3)) ⊑ const? 32 715827882 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gsdivhcanonicalize_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gsdivhcanonicalize_proof.lean
@@ -10,7 +10,7 @@ set_option linter.unreachableTactic false
 section gsdivhcanonicalize_proof
 theorem test_sdiv_canonicalize_op0_thm (e e_1 : IntW 32) :
   LLVM.sdiv (sub (const? 32 0) e_1 { «nsw» := true, «nuw» := false }) e ⊑
-    sub (const? 32 0) (LLVM.sdiv e_1 e) { «nsw» := true, «nuw» := false } := by 
+    sub (const? 32 0) (LLVM.sdiv e_1 e) { «nsw» := true, «nuw» := false } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -21,7 +21,7 @@ theorem test_sdiv_canonicalize_op0_thm (e e_1 : IntW 32) :
 
 theorem test_sdiv_canonicalize_op0_exact_thm (e e_1 : IntW 32) :
   LLVM.sdiv (sub (const? 32 0) e_1 { «nsw» := true, «nuw» := false }) e { «exact» := true } ⊑
-    sub (const? 32 0) (LLVM.sdiv e_1 e { «exact» := true }) { «nsw» := true, «nuw» := false } := by 
+    sub (const? 32 0) (LLVM.sdiv e_1 e { «exact» := true }) { «nsw» := true, «nuw» := false } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gsdivhexacthbyhnegativehpowerhofhtwo_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gsdivhexacthbyhnegativehpowerhofhtwo_proof.lean
@@ -10,7 +10,7 @@ set_option linter.unreachableTactic false
 section gsdivhexacthbyhnegativehpowerhofhtwo_proof
 theorem t0_thm (e : IntW 8) :
   LLVM.sdiv e (const? 8 (-32)) { «exact» := true } ⊑
-    sub (const? 8 0) (ashr e (const? 8 5) { «exact» := true }) { «nsw» := true, «nuw» := false } := by 
+    sub (const? 8 0) (ashr e (const? 8 5) { «exact» := true }) { «nsw» := true, «nuw» := false } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -21,7 +21,7 @@ theorem t0_thm (e : IntW 8) :
 
 theorem prove_exact_with_high_mask_thm (e : IntW 8) :
   LLVM.sdiv (LLVM.and e (const? 8 (-32))) (const? 8 (-4)) ⊑
-    sub (const? 8 0) (LLVM.and (ashr e (const? 8 2)) (const? 8 (-8))) { «nsw» := true, «nuw» := false } := by 
+    sub (const? 8 0) (LLVM.and (ashr e (const? 8 2)) (const? 8 (-8))) { «nsw» := true, «nuw» := false } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -32,7 +32,7 @@ theorem prove_exact_with_high_mask_thm (e : IntW 8) :
 
 theorem prove_exact_with_high_mask_limit_thm (e : IntW 8) :
   LLVM.sdiv (LLVM.and e (const? 8 (-32))) (const? 8 (-32)) ⊑
-    sub (const? 8 0) (ashr e (const? 8 5)) { «nsw» := true, «nuw» := false } := by 
+    sub (const? 8 0) (ashr e (const? 8 5)) { «nsw» := true, «nuw» := false } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gsdivhexacthbyhpowerhofhtwo_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gsdivhexacthbyhpowerhofhtwo_proof.lean
@@ -9,7 +9,7 @@ set_option linter.unreachableTactic false
 
 section gsdivhexacthbyhpowerhofhtwo_proof
 theorem t0_thm (e : IntW 8) :
-  LLVM.sdiv e (const? 8 32) { «exact» := true } ⊑ ashr e (const? 8 5) { «exact» := true } := by 
+  LLVM.sdiv e (const? 8 32) { «exact» := true } ⊑ ashr e (const? 8 5) { «exact» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -19,7 +19,7 @@ theorem t0_thm (e : IntW 8) :
 
 
 theorem n2_thm (e : IntW 8) :
-  LLVM.sdiv e (const? 8 (-128)) ⊑ zext 8 (icmp IntPredicate.eq e (const? 8 (-128))) := by 
+  LLVM.sdiv e (const? 8 (-128)) ⊑ zext 8 (icmp IntPredicate.eq e (const? 8 (-128))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -30,7 +30,7 @@ theorem n2_thm (e : IntW 8) :
 
 theorem shl1_nsw_thm (e e_1 : IntW 8) :
   LLVM.sdiv e_1 (shl (const? 8 1) e { «nsw» := true, «nuw» := false }) { «exact» := true } ⊑
-    ashr e_1 e { «exact» := true } := by 
+    ashr e_1 e { «exact» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -41,7 +41,7 @@ theorem shl1_nsw_thm (e e_1 : IntW 8) :
 
 theorem shl1_nsw_not_exact_thm (e e_1 : IntW 8) :
   LLVM.sdiv e_1 (shl (const? 8 1) e { «nsw» := true, «nuw» := false }) ⊑
-    LLVM.sdiv e_1 (shl (const? 8 1) e { «nsw» := true, «nuw» := true }) := by 
+    LLVM.sdiv e_1 (shl (const? 8 1) e { «nsw» := true, «nuw» := true }) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -51,7 +51,7 @@ theorem shl1_nsw_not_exact_thm (e e_1 : IntW 8) :
 
 
 theorem prove_exact_with_high_mask_thm (e : IntW 8) :
-  LLVM.sdiv (LLVM.and e (const? 8 (-8))) (const? 8 4) ⊑ LLVM.and (ashr e (const? 8 2)) (const? 8 (-2)) := by 
+  LLVM.sdiv (LLVM.and e (const? 8 (-8))) (const? 8 4) ⊑ LLVM.and (ashr e (const? 8 2)) (const? 8 (-2)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -60,7 +60,7 @@ theorem prove_exact_with_high_mask_thm (e : IntW 8) :
     all_goals sorry
 
 
-theorem prove_exact_with_high_mask_limit_thm (e : IntW 8) : LLVM.sdiv (LLVM.and e (const? 8 (-8))) (const? 8 8) ⊑ ashr e (const? 8 3) := by 
+theorem prove_exact_with_high_mask_limit_thm (e : IntW 8) : LLVM.sdiv (LLVM.and e (const? 8 (-8))) (const? 8 8) ⊑ ashr e (const? 8 3) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gsdivhicmp_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gsdivhicmp_proof.lean
@@ -10,7 +10,7 @@ set_option linter.unreachableTactic false
 section gsdivhicmp_proof
 theorem sdiv_exact_eq_0_thm (e e_1 : IntW 8) :
   icmp IntPredicate.eq (LLVM.sdiv e_1 e { «exact» := true }) (const? 8 0) ⊑
-    icmp IntPredicate.eq e_1 (const? 8 0) := by 
+    icmp IntPredicate.eq e_1 (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -21,7 +21,7 @@ theorem sdiv_exact_eq_0_thm (e e_1 : IntW 8) :
 
 theorem udiv_exact_ne_0_thm (e e_1 : IntW 8) :
   icmp IntPredicate.ne (LLVM.udiv e_1 e { «exact» := true }) (const? 8 0) ⊑
-    icmp IntPredicate.ne e_1 (const? 8 0) := by 
+    icmp IntPredicate.ne e_1 (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -32,7 +32,7 @@ theorem udiv_exact_ne_0_thm (e e_1 : IntW 8) :
 
 theorem sdiv_exact_ne_1_thm (e e_1 : IntW 8) :
   icmp IntPredicate.eq (LLVM.sdiv e_1 e { «exact» := true }) (const? 8 0) ⊑
-    icmp IntPredicate.eq e_1 (const? 8 0) := by 
+    icmp IntPredicate.eq e_1 (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -42,7 +42,7 @@ theorem sdiv_exact_ne_1_thm (e e_1 : IntW 8) :
 
 
 theorem udiv_exact_eq_1_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.ne (LLVM.udiv e_1 e { «exact» := true }) (const? 8 1) ⊑ icmp IntPredicate.ne e_1 e := by 
+  icmp IntPredicate.ne (LLVM.udiv e_1 e { «exact» := true }) (const? 8 1) ⊑ icmp IntPredicate.ne e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -53,7 +53,7 @@ theorem udiv_exact_eq_1_thm (e e_1 : IntW 8) :
 
 theorem sdiv_exact_eq_9_no_of_thm (e e_1 : IntW 8) :
   icmp IntPredicate.eq (LLVM.sdiv e_1 (LLVM.and e (const? 8 7)) { «exact» := true }) (const? 8 9) ⊑
-    icmp IntPredicate.eq (mul (LLVM.and e (const? 8 7)) (const? 8 9) { «nsw» := true, «nuw» := true }) e_1 := by 
+    icmp IntPredicate.eq (mul (LLVM.and e (const? 8 7)) (const? 8 9) { «nsw» := true, «nuw» := true }) e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -64,7 +64,7 @@ theorem sdiv_exact_eq_9_no_of_thm (e e_1 : IntW 8) :
 
 theorem udiv_exact_ne_30_no_of_thm (e e_1 : IntW 8) :
   icmp IntPredicate.ne (LLVM.udiv e_1 (LLVM.and e (const? 8 7)) { «exact» := true }) (const? 8 30) ⊑
-    icmp IntPredicate.ne (mul (LLVM.and e (const? 8 7)) (const? 8 30) { «nsw» := false, «nuw» := true }) e_1 := by 
+    icmp IntPredicate.ne (mul (LLVM.and e (const? 8 7)) (const? 8 30) { «nsw» := false, «nuw» := true }) e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gselect_meta_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gselect_meta_proof.lean
@@ -11,7 +11,7 @@ section gselect_meta_proof
 theorem foo_thm (e : IntW 32) :
   select (icmp IntPredicate.sgt e (const? 32 2)) (add e (const? 32 20) { «nsw» := true, «nuw» := false })
       (add e (const? 32 (-20))) ⊑
-    add e (select (icmp IntPredicate.sgt e (const? 32 2)) (const? 32 20) (const? 32 (-20))) := by 
+    add e (select (icmp IntPredicate.sgt e (const? 32 2)) (const? 32 20) (const? 32 (-20))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -21,7 +21,7 @@ theorem foo_thm (e : IntW 32) :
 
 
 theorem shrink_select_thm (e : IntW 32) (e_1 : IntW 1) :
-  trunc 8 (select e_1 e (const? 32 42)) ⊑ select e_1 (trunc 8 e) (const? 8 42) := by 
+  trunc 8 (select e_1 e (const? 32 42)) ⊑ select e_1 (trunc 8 e) (const? 8 42) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -33,7 +33,7 @@ theorem shrink_select_thm (e : IntW 32) (e_1 : IntW 1) :
 theorem foo2_thm (e e_1 : IntW 32) :
   select (icmp IntPredicate.sgt e_1 (const? 32 2)) (add e_1 e { «nsw» := true, «nuw» := false })
       (sub e_1 e { «nsw» := true, «nuw» := false }) ⊑
-    add e_1 (select (icmp IntPredicate.sgt e_1 (const? 32 2)) e (sub (const? 32 0) e)) := by 
+    add e_1 (select (icmp IntPredicate.sgt e_1 (const? 32 2)) e (sub (const? 32 0) e)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -43,7 +43,7 @@ theorem foo2_thm (e e_1 : IntW 32) :
 
 
 theorem not_cond_thm (e e_1 : IntW 32) (e_2 : IntW 1) :
-  select (LLVM.xor e_2 (const? 1 1)) e_1 e ⊑ select e_2 e e_1 := by 
+  select (LLVM.xor e_2 (const? 1 1)) e_1 e ⊑ select e_2 e e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -53,7 +53,7 @@ theorem not_cond_thm (e e_1 : IntW 32) (e_2 : IntW 1) :
 
 
 theorem select_add_thm (e e_1 : IntW 64) (e_2 : IntW 1) :
-  select e_2 (add e_1 e) e_1 ⊑ add e_1 (select e_2 e (const? 64 0)) := by 
+  select e_2 (add e_1 e) e_1 ⊑ add e_1 (select e_2 e (const? 64 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -63,7 +63,7 @@ theorem select_add_thm (e e_1 : IntW 64) (e_2 : IntW 1) :
 
 
 theorem select_sub_thm (e e_1 : IntW 17) (e_2 : IntW 1) :
-  select e_2 (sub e_1 e) e_1 ⊑ sub e_1 (select e_2 e (const? 17 0)) := by 
+  select e_2 (sub e_1 e) e_1 ⊑ sub e_1 (select e_2 e (const? 17 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -73,7 +73,7 @@ theorem select_sub_thm (e e_1 : IntW 17) (e_2 : IntW 1) :
 
 
 theorem select_ashr_thm (e e_1 : IntW 128) (e_2 : IntW 1) :
-  select e_2 (ashr e_1 e) e_1 ⊑ ashr e_1 (select e_2 e (const? 128 0)) := by 
+  select e_2 (ashr e_1 e) e_1 ⊑ ashr e_1 (select e_2 e (const? 128 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gselecth2_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gselecth2_proof.lean
@@ -10,7 +10,7 @@ set_option linter.unreachableTactic false
 section gselecth2_proof
 theorem ashr_exact_poison_constant_fold_thm (e : IntW 8) (e_1 : IntW 1) :
   ashr (select e_1 e (const? 8 42)) (const? 8 3) { «exact» := true } ⊑
-    select e_1 (ashr e (const? 8 3)) (const? 8 5) := by 
+    select e_1 (ashr e (const? 8 3)) (const? 8 5) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -21,7 +21,7 @@ theorem ashr_exact_poison_constant_fold_thm (e : IntW 8) (e_1 : IntW 1) :
 
 theorem ashr_exact_thm (e : IntW 8) (e_1 : IntW 1) :
   ashr (select e_1 e (const? 8 16)) (const? 8 3) { «exact» := true } ⊑
-    select e_1 (ashr e (const? 8 3) { «exact» := true }) (const? 8 2) := by 
+    select e_1 (ashr e (const? 8 3) { «exact» := true }) (const? 8 2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -32,7 +32,7 @@ theorem ashr_exact_thm (e : IntW 8) (e_1 : IntW 1) :
 
 theorem shl_nsw_nuw_poison_constant_fold_thm (e : IntW 8) (e_1 : IntW 1) :
   shl (const? 8 16) (select e_1 (const? 8 3) e) { «nsw» := true, «nuw» := true } ⊑
-    select e_1 (const? 8 (-128)) (shl (const? 8 16) e { «nsw» := true, «nuw» := true }) := by 
+    select e_1 (const? 8 (-128)) (shl (const? 8 16) e { «nsw» := true, «nuw» := true }) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -43,7 +43,7 @@ theorem shl_nsw_nuw_poison_constant_fold_thm (e : IntW 8) (e_1 : IntW 1) :
 
 theorem shl_nsw_nuw_thm (e : IntW 8) (e_1 : IntW 1) :
   shl (const? 8 7) (select e_1 (const? 8 3) e) { «nsw» := true, «nuw» := true } ⊑
-    select e_1 (const? 8 56) (shl (const? 8 7) e { «nsw» := true, «nuw» := true }) := by 
+    select e_1 (const? 8 56) (shl (const? 8 7) e { «nsw» := true, «nuw» := true }) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -54,7 +54,7 @@ theorem shl_nsw_nuw_thm (e : IntW 8) (e_1 : IntW 1) :
 
 theorem add_nsw_poison_constant_fold_thm (e : IntW 8) (e_1 : IntW 1) :
   add (select e_1 e (const? 8 65)) (const? 8 64) { «nsw» := true, «nuw» := false } ⊑
-    select e_1 (add e (const? 8 64) { «nsw» := true, «nuw» := false }) (const? 8 (-127)) := by 
+    select e_1 (add e (const? 8 64) { «nsw» := true, «nuw» := false }) (const? 8 (-127)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -65,7 +65,7 @@ theorem add_nsw_poison_constant_fold_thm (e : IntW 8) (e_1 : IntW 1) :
 
 theorem add_nsw_thm (e : IntW 8) (e_1 : IntW 1) :
   add (select e_1 e (const? 8 7)) (const? 8 64) { «nsw» := true, «nuw» := false } ⊑
-    select e_1 (add e (const? 8 64) { «nsw» := true, «nuw» := false }) (const? 8 71) := by 
+    select e_1 (add e (const? 8 64) { «nsw» := true, «nuw» := false }) (const? 8 71) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gselecthandhor_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gselecthandhor_proof.lean
@@ -9,7 +9,7 @@ set_option linter.unreachableTactic false
 
 section gselecthandhor_proof
 theorem logical_and_not_thm (e e_1 : IntW 1) :
-  select e_1 (const? 1 0) e ⊑ select (LLVM.xor e_1 (const? 1 1)) e (const? 1 0) := by 
+  select e_1 (const? 1 0) e ⊑ select (LLVM.xor e_1 (const? 1 1)) e (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -19,7 +19,7 @@ theorem logical_and_not_thm (e e_1 : IntW 1) :
 
 
 theorem logical_or_not_thm (e e_1 : IntW 1) :
-  select e_1 e (const? 1 1) ⊑ select (LLVM.xor e_1 (const? 1 1)) (const? 1 1) e := by 
+  select e_1 e (const? 1 1) ⊑ select (LLVM.xor e_1 (const? 1 1)) (const? 1 1) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -28,7 +28,7 @@ theorem logical_or_not_thm (e e_1 : IntW 1) :
     all_goals sorry
 
 
-theorem logical_and_cond_reuse_thm (e e_1 : IntW 1) : select e_1 e e_1 ⊑ select e_1 e (const? 1 0) := by 
+theorem logical_and_cond_reuse_thm (e e_1 : IntW 1) : select e_1 e e_1 ⊑ select e_1 e (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -37,7 +37,7 @@ theorem logical_and_cond_reuse_thm (e e_1 : IntW 1) : select e_1 e e_1 ⊑ selec
     all_goals sorry
 
 
-theorem logical_or_cond_reuse_thm (e e_1 : IntW 1) : select e_1 e_1 e ⊑ select e_1 (const? 1 1) e := by 
+theorem logical_or_cond_reuse_thm (e e_1 : IntW 1) : select e_1 e_1 e ⊑ select e_1 (const? 1 1) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -47,7 +47,7 @@ theorem logical_or_cond_reuse_thm (e e_1 : IntW 1) : select e_1 e_1 e ⊑ select
 
 
 theorem logical_and_not_cond_reuse_thm (e e_1 : IntW 1) :
-  select e_1 e (LLVM.xor e_1 (const? 1 1)) ⊑ select (LLVM.xor e_1 (const? 1 1)) (const? 1 1) e := by 
+  select e_1 e (LLVM.xor e_1 (const? 1 1)) ⊑ select (LLVM.xor e_1 (const? 1 1)) (const? 1 1) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -57,7 +57,7 @@ theorem logical_and_not_cond_reuse_thm (e e_1 : IntW 1) :
 
 
 theorem logical_or_not_cond_reuse_thm (e e_1 : IntW 1) :
-  select e_1 (LLVM.xor e_1 (const? 1 1)) e ⊑ select (LLVM.xor e_1 (const? 1 1)) e (const? 1 0) := by 
+  select e_1 (LLVM.xor e_1 (const? 1 1)) e ⊑ select (LLVM.xor e_1 (const? 1 1)) e (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -68,7 +68,7 @@ theorem logical_or_not_cond_reuse_thm (e e_1 : IntW 1) :
 
 theorem logical_or_implies_thm (e : IntW 32) :
   select (icmp IntPredicate.eq e (const? 32 0)) (const? 1 1) (icmp IntPredicate.eq e (const? 32 42)) ⊑
-    LLVM.or (icmp IntPredicate.eq e (const? 32 0)) (icmp IntPredicate.eq e (const? 32 42)) := by 
+    LLVM.or (icmp IntPredicate.eq e (const? 32 0)) (icmp IntPredicate.eq e (const? 32 42)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -79,7 +79,7 @@ theorem logical_or_implies_thm (e : IntW 32) :
 
 theorem logical_or_implies_folds_thm (e : IntW 32) :
   select (icmp IntPredicate.slt e (const? 32 0)) (const? 1 1) (icmp IntPredicate.sge e (const? 32 0)) ⊑
-    const? 1 1 := by 
+    const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -90,7 +90,7 @@ theorem logical_or_implies_folds_thm (e : IntW 32) :
 
 theorem logical_and_implies_thm (e : IntW 32) :
   select (icmp IntPredicate.ne e (const? 32 0)) (icmp IntPredicate.ne e (const? 32 42)) (const? 1 0) ⊑
-    LLVM.and (icmp IntPredicate.ne e (const? 32 0)) (icmp IntPredicate.ne e (const? 32 42)) := by 
+    LLVM.and (icmp IntPredicate.ne e (const? 32 0)) (icmp IntPredicate.ne e (const? 32 42)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -101,7 +101,7 @@ theorem logical_and_implies_thm (e : IntW 32) :
 
 theorem logical_and_implies_folds_thm (e : IntW 32) :
   select (icmp IntPredicate.ugt e (const? 32 42)) (icmp IntPredicate.ne e (const? 32 0)) (const? 1 0) ⊑
-    icmp IntPredicate.ugt e (const? 32 42) := by 
+    icmp IntPredicate.ugt e (const? 32 42) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -110,7 +110,7 @@ theorem logical_and_implies_folds_thm (e : IntW 32) :
     all_goals sorry
 
 
-theorem logical_and_noundef_b_thm (e e_1 : IntW 1) : select e_1 e (const? 1 0) ⊑ LLVM.and e_1 e := by 
+theorem logical_and_noundef_b_thm (e e_1 : IntW 1) : select e_1 e (const? 1 0) ⊑ LLVM.and e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -121,7 +121,7 @@ theorem logical_and_noundef_b_thm (e e_1 : IntW 1) : select e_1 e (const? 1 0) �
 
 theorem not_not_true_thm (e e_1 : IntW 1) :
   select (LLVM.xor e_1 (const? 1 1)) (LLVM.xor e (const? 1 1)) (const? 1 1) ⊑
-    select e_1 (const? 1 1) (LLVM.xor e (const? 1 1)) := by 
+    select e_1 (const? 1 1) (LLVM.xor e (const? 1 1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -132,7 +132,7 @@ theorem not_not_true_thm (e e_1 : IntW 1) :
 
 theorem not_not_false_thm (e e_1 : IntW 1) :
   select (LLVM.xor e_1 (const? 1 1)) (LLVM.xor e (const? 1 1)) (const? 1 0) ⊑
-    LLVM.xor (select e_1 (const? 1 1) e) (const? 1 1) := by 
+    LLVM.xor (select e_1 (const? 1 1) e) (const? 1 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -143,7 +143,7 @@ theorem not_not_false_thm (e e_1 : IntW 1) :
 
 theorem not_true_not_thm (e e_1 : IntW 1) :
   select (LLVM.xor e_1 (const? 1 1)) (const? 1 1) (LLVM.xor e (const? 1 1)) ⊑
-    LLVM.xor (select e_1 e (const? 1 0)) (const? 1 1) := by 
+    LLVM.xor (select e_1 e (const? 1 0)) (const? 1 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -154,7 +154,7 @@ theorem not_true_not_thm (e e_1 : IntW 1) :
 
 theorem not_false_not_thm (e e_1 : IntW 1) :
   select (LLVM.xor e_1 (const? 1 1)) (const? 1 0) (LLVM.xor e (const? 1 1)) ⊑
-    select e_1 (LLVM.xor e (const? 1 1)) (const? 1 0) := by 
+    select e_1 (LLVM.xor e (const? 1 1)) (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -164,7 +164,7 @@ theorem not_false_not_thm (e e_1 : IntW 1) :
 
 
 theorem and_or1_thm (e e_1 e_2 : IntW 1) :
-  select (LLVM.or (LLVM.xor e_2 (const? 1 1)) e_1) e_2 e ⊑ select e_2 (select e_1 (const? 1 1) e) (const? 1 0) := by 
+  select (LLVM.or (LLVM.xor e_2 (const? 1 1)) e_1) e_2 e ⊑ select e_2 (select e_1 (const? 1 1) e) (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -174,7 +174,7 @@ theorem and_or1_thm (e e_1 e_2 : IntW 1) :
 
 
 theorem and_or2_thm (e e_1 e_2 : IntW 1) :
-  select (LLVM.and (LLVM.xor e_2 (const? 1 1)) e_1) e e_1 ⊑ select e_1 (select e_2 (const? 1 1) e) (const? 1 0) := by 
+  select (LLVM.and (LLVM.xor e_2 (const? 1 1)) e_1) e e_1 ⊑ select e_1 (select e_2 (const? 1 1) e) (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -184,7 +184,7 @@ theorem and_or2_thm (e e_1 e_2 : IntW 1) :
 
 
 theorem and_or1_commuted_thm (e e_1 e_2 : IntW 1) :
-  select (LLVM.or e_2 (LLVM.xor e_1 (const? 1 1))) e_1 e ⊑ select e_1 (select e_2 (const? 1 1) e) (const? 1 0) := by 
+  select (LLVM.or e_2 (LLVM.xor e_1 (const? 1 1))) e_1 e ⊑ select e_1 (select e_2 (const? 1 1) e) (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -194,7 +194,7 @@ theorem and_or1_commuted_thm (e e_1 e_2 : IntW 1) :
 
 
 theorem and_or2_commuted_thm (e e_1 e_2 : IntW 1) :
-  select (LLVM.and e_2 (LLVM.xor e_1 (const? 1 1))) e e_2 ⊑ select e_2 (select e_1 (const? 1 1) e) (const? 1 0) := by 
+  select (LLVM.and e_2 (LLVM.xor e_1 (const? 1 1))) e e_2 ⊑ select e_2 (select e_1 (const? 1 1) e) (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -205,7 +205,7 @@ theorem and_or2_commuted_thm (e e_1 e_2 : IntW 1) :
 
 theorem and_or1_wrong_operand_thm (e e_1 e_2 e_3 : IntW 1) :
   select (LLVM.or (LLVM.xor e_3 (const? 1 1)) e_2) e_1 e ⊑
-    select (LLVM.or e_2 (LLVM.xor e_3 (const? 1 1))) e_1 e := by 
+    select (LLVM.or e_2 (LLVM.xor e_3 (const? 1 1))) e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -216,7 +216,7 @@ theorem and_or1_wrong_operand_thm (e e_1 e_2 e_3 : IntW 1) :
 
 theorem and_or2_wrong_operand_thm (e e_1 e_2 e_3 : IntW 1) :
   select (LLVM.and (LLVM.xor e_3 (const? 1 1)) e_2) e_1 e ⊑
-    select (LLVM.and e_2 (LLVM.xor e_3 (const? 1 1))) e_1 e := by 
+    select (LLVM.and e_2 (LLVM.xor e_3 (const? 1 1))) e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -227,7 +227,7 @@ theorem and_or2_wrong_operand_thm (e e_1 e_2 e_3 : IntW 1) :
 
 theorem and_or3_thm (e : IntW 1) (e_1 e_2 : IntW 32) (e_3 : IntW 1) :
   select (LLVM.and e_3 (icmp IntPredicate.eq e_2 e_1)) e e_3 ⊑
-    select e_3 (select (icmp IntPredicate.ne e_2 e_1) (const? 1 1) e) (const? 1 0) := by 
+    select e_3 (select (icmp IntPredicate.ne e_2 e_1) (const? 1 1) e) (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -238,7 +238,7 @@ theorem and_or3_thm (e : IntW 1) (e_1 e_2 : IntW 32) (e_3 : IntW 1) :
 
 theorem and_or3_commuted_thm (e e_1 : IntW 1) (e_2 e_3 : IntW 32) :
   select (LLVM.and (icmp IntPredicate.eq e_3 e_2) e_1) e e_1 ⊑
-    select e_1 (select (icmp IntPredicate.ne e_3 e_2) (const? 1 1) e) (const? 1 0) := by 
+    select e_1 (select (icmp IntPredicate.ne e_3 e_2) (const? 1 1) e) (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -248,7 +248,7 @@ theorem and_or3_commuted_thm (e e_1 : IntW 1) (e_2 e_3 : IntW 32) :
 
 
 theorem or_and1_thm (e e_1 e_2 : IntW 1) :
-  select (LLVM.and (LLVM.xor e_2 (const? 1 1)) e_1) e e_2 ⊑ select e_2 (const? 1 1) (select e_1 e (const? 1 0)) := by 
+  select (LLVM.and (LLVM.xor e_2 (const? 1 1)) e_1) e e_2 ⊑ select e_2 (const? 1 1) (select e_1 e (const? 1 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -258,7 +258,7 @@ theorem or_and1_thm (e e_1 e_2 : IntW 1) :
 
 
 theorem or_and2_thm (e e_1 e_2 : IntW 1) :
-  select (LLVM.or (LLVM.xor e_2 (const? 1 1)) e_1) e_1 e ⊑ select e_1 (const? 1 1) (select e_2 e (const? 1 0)) := by 
+  select (LLVM.or (LLVM.xor e_2 (const? 1 1)) e_1) e_1 e ⊑ select e_1 (const? 1 1) (select e_2 e (const? 1 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -268,7 +268,7 @@ theorem or_and2_thm (e e_1 e_2 : IntW 1) :
 
 
 theorem or_and1_commuted_thm (e e_1 e_2 : IntW 1) :
-  select (LLVM.and e_2 (LLVM.xor e_1 (const? 1 1))) e e_1 ⊑ select e_1 (const? 1 1) (select e_2 e (const? 1 0)) := by 
+  select (LLVM.and e_2 (LLVM.xor e_1 (const? 1 1))) e e_1 ⊑ select e_1 (const? 1 1) (select e_2 e (const? 1 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -278,7 +278,7 @@ theorem or_and1_commuted_thm (e e_1 e_2 : IntW 1) :
 
 
 theorem or_and2_commuted_thm (e e_1 e_2 : IntW 1) :
-  select (LLVM.or e_2 (LLVM.xor e_1 (const? 1 1))) e_2 e ⊑ select e_2 (const? 1 1) (select e_1 e (const? 1 0)) := by 
+  select (LLVM.or e_2 (LLVM.xor e_1 (const? 1 1))) e_2 e ⊑ select e_2 (const? 1 1) (select e_1 e (const? 1 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -287,7 +287,7 @@ theorem or_and2_commuted_thm (e e_1 e_2 : IntW 1) :
     all_goals sorry
 
 
-theorem pr64558_thm (e e_1 : IntW 1) : select (LLVM.and (LLVM.xor e_1 (const? 1 1)) e) e e_1 ⊑ LLVM.or e_1 e := by 
+theorem pr64558_thm (e e_1 : IntW 1) : select (LLVM.and (LLVM.xor e_1 (const? 1 1)) e) e e_1 ⊑ LLVM.or e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -298,7 +298,7 @@ theorem pr64558_thm (e e_1 : IntW 1) : select (LLVM.and (LLVM.xor e_1 (const? 1 
 
 theorem or_and3_thm (e : IntW 1) (e_1 e_2 : IntW 32) (e_3 : IntW 1) :
   select (LLVM.or e_3 (icmp IntPredicate.eq e_2 e_1)) e_3 e ⊑
-    select e_3 (const? 1 1) (select (icmp IntPredicate.ne e_2 e_1) e (const? 1 0)) := by 
+    select e_3 (const? 1 1) (select (icmp IntPredicate.ne e_2 e_1) e (const? 1 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -309,7 +309,7 @@ theorem or_and3_thm (e : IntW 1) (e_1 e_2 : IntW 32) (e_3 : IntW 1) :
 
 theorem or_and3_commuted_thm (e e_1 : IntW 1) (e_2 e_3 : IntW 32) :
   select (LLVM.or (icmp IntPredicate.eq e_3 e_2) e_1) e_1 e ⊑
-    select e_1 (const? 1 1) (select (icmp IntPredicate.ne e_3 e_2) e (const? 1 0)) := by 
+    select e_1 (const? 1 1) (select (icmp IntPredicate.ne e_3 e_2) e (const? 1 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -319,7 +319,7 @@ theorem or_and3_commuted_thm (e e_1 : IntW 1) (e_2 e_3 : IntW 32) :
 
 
 theorem test_or_eq_a_b_thm (e e_1 : IntW 8) (e_2 : IntW 1) :
-  select (LLVM.or e_2 (icmp IntPredicate.eq e_1 e)) e_1 e ⊑ select e_2 e_1 e := by 
+  select (LLVM.or e_2 (icmp IntPredicate.eq e_1 e)) e_1 e ⊑ select e_2 e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -329,7 +329,7 @@ theorem test_or_eq_a_b_thm (e e_1 : IntW 8) (e_2 : IntW 1) :
 
 
 theorem test_and_ne_a_b_thm (e e_1 : IntW 8) (e_2 : IntW 1) :
-  select (LLVM.and e_2 (icmp IntPredicate.ne e_1 e)) e_1 e ⊑ select e_2 e_1 e := by 
+  select (LLVM.and e_2 (icmp IntPredicate.ne e_1 e)) e_1 e ⊑ select e_2 e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -339,7 +339,7 @@ theorem test_and_ne_a_b_thm (e e_1 : IntW 8) (e_2 : IntW 1) :
 
 
 theorem test_or_eq_a_b_commuted_thm (e e_1 : IntW 8) (e_2 : IntW 1) :
-  select (LLVM.or e_2 (icmp IntPredicate.eq e_1 e)) e e_1 ⊑ select e_2 e e_1 := by 
+  select (LLVM.or e_2 (icmp IntPredicate.eq e_1 e)) e e_1 ⊑ select e_2 e e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -349,7 +349,7 @@ theorem test_or_eq_a_b_commuted_thm (e e_1 : IntW 8) (e_2 : IntW 1) :
 
 
 theorem test_and_ne_a_b_commuted_thm (e e_1 : IntW 8) (e_2 : IntW 1) :
-  select (LLVM.and e_2 (icmp IntPredicate.ne e_1 e)) e e_1 ⊑ select e_2 e e_1 := by 
+  select (LLVM.and e_2 (icmp IntPredicate.ne e_1 e)) e e_1 ⊑ select e_2 e e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -360,7 +360,7 @@ theorem test_and_ne_a_b_commuted_thm (e e_1 : IntW 8) (e_2 : IntW 1) :
 
 theorem test_or_eq_different_operands_thm (e e_1 e_2 : IntW 8) :
   select (LLVM.or (icmp IntPredicate.eq e_2 e_1) (icmp IntPredicate.eq e e_2)) e_2 e ⊑
-    select (icmp IntPredicate.eq e_2 e_1) e_2 e := by 
+    select (icmp IntPredicate.eq e_2 e_1) e_2 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -370,7 +370,7 @@ theorem test_or_eq_different_operands_thm (e e_1 e_2 : IntW 8) :
 
 
 theorem test_or_ne_a_b_thm (e e_1 : IntW 8) (e_2 : IntW 1) :
-  select (LLVM.or e_2 (icmp IntPredicate.ne e_1 e)) e_1 e ⊑ e_1 := by 
+  select (LLVM.or e_2 (icmp IntPredicate.ne e_1 e)) e_1 e ⊑ e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -380,7 +380,7 @@ theorem test_or_ne_a_b_thm (e e_1 : IntW 8) (e_2 : IntW 1) :
 
 
 theorem test_logical_or_eq_a_b_thm (e e_1 : IntW 8) (e_2 : IntW 1) :
-  select (select e_2 (const? 1 1) (icmp IntPredicate.eq e_1 e)) e_1 e ⊑ select e_2 e_1 e := by 
+  select (select e_2 (const? 1 1) (icmp IntPredicate.eq e_1 e)) e_1 e ⊑ select e_2 e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -390,7 +390,7 @@ theorem test_logical_or_eq_a_b_thm (e e_1 : IntW 8) (e_2 : IntW 1) :
 
 
 theorem test_logical_and_ne_a_b_thm (e e_1 : IntW 8) (e_2 : IntW 1) :
-  select (select e_2 (icmp IntPredicate.ne e_1 e) (const? 1 0)) e_1 e ⊑ select e_2 e_1 e := by 
+  select (select e_2 (icmp IntPredicate.ne e_1 e) (const? 1 0)) e_1 e ⊑ select e_2 e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gselecthbinophcmp_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gselecthbinophcmp_proof.lean
@@ -10,7 +10,7 @@ set_option linter.unreachableTactic false
 section gselecthbinophcmp_proof
 theorem select_xor_icmp_thm (e e_1 e_2 : IntW 32) :
   select (icmp IntPredicate.eq e_2 (const? 32 0)) (LLVM.xor e_2 e_1) e ⊑
-    select (icmp IntPredicate.eq e_2 (const? 32 0)) e_1 e := by 
+    select (icmp IntPredicate.eq e_2 (const? 32 0)) e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -21,7 +21,7 @@ theorem select_xor_icmp_thm (e e_1 e_2 : IntW 32) :
 
 theorem select_xor_icmp2_thm (e e_1 e_2 : IntW 32) :
   select (icmp IntPredicate.ne e_2 (const? 32 0)) e_1 (LLVM.xor e_2 e) ⊑
-    select (icmp IntPredicate.eq e_2 (const? 32 0)) e e_1 := by 
+    select (icmp IntPredicate.eq e_2 (const? 32 0)) e e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -32,7 +32,7 @@ theorem select_xor_icmp2_thm (e e_1 e_2 : IntW 32) :
 
 theorem select_xor_icmp_meta_thm (e e_1 e_2 : IntW 32) :
   select (icmp IntPredicate.eq e_2 (const? 32 0)) (LLVM.xor e_2 e_1) e ⊑
-    select (icmp IntPredicate.eq e_2 (const? 32 0)) e_1 e := by 
+    select (icmp IntPredicate.eq e_2 (const? 32 0)) e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -43,7 +43,7 @@ theorem select_xor_icmp_meta_thm (e e_1 e_2 : IntW 32) :
 
 theorem select_mul_icmp_thm (e e_1 e_2 : IntW 32) :
   select (icmp IntPredicate.eq e_2 (const? 32 1)) (mul e_2 e_1) e ⊑
-    select (icmp IntPredicate.eq e_2 (const? 32 1)) e_1 e := by 
+    select (icmp IntPredicate.eq e_2 (const? 32 1)) e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -54,7 +54,7 @@ theorem select_mul_icmp_thm (e e_1 e_2 : IntW 32) :
 
 theorem select_add_icmp_thm (e e_1 e_2 : IntW 32) :
   select (icmp IntPredicate.eq e_2 (const? 32 0)) (add e_2 e_1) e ⊑
-    select (icmp IntPredicate.eq e_2 (const? 32 0)) e_1 e := by 
+    select (icmp IntPredicate.eq e_2 (const? 32 0)) e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -65,7 +65,7 @@ theorem select_add_icmp_thm (e e_1 e_2 : IntW 32) :
 
 theorem select_or_icmp_thm (e e_1 e_2 : IntW 32) :
   select (icmp IntPredicate.eq e_2 (const? 32 0)) (LLVM.or e_2 e_1) e ⊑
-    select (icmp IntPredicate.eq e_2 (const? 32 0)) e_1 e := by 
+    select (icmp IntPredicate.eq e_2 (const? 32 0)) e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -76,7 +76,7 @@ theorem select_or_icmp_thm (e e_1 e_2 : IntW 32) :
 
 theorem select_and_icmp_thm (e e_1 e_2 : IntW 32) :
   select (icmp IntPredicate.eq e_2 (const? 32 (-1))) (LLVM.and e_2 e_1) e ⊑
-    select (icmp IntPredicate.eq e_2 (const? 32 (-1))) e_1 e := by 
+    select (icmp IntPredicate.eq e_2 (const? 32 (-1))) e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -87,7 +87,7 @@ theorem select_and_icmp_thm (e e_1 e_2 : IntW 32) :
 
 theorem select_xor_inv_icmp_thm (e e_1 e_2 : IntW 32) :
   select (icmp IntPredicate.eq e_2 (const? 32 0)) (LLVM.xor e_1 e_2) e ⊑
-    select (icmp IntPredicate.eq e_2 (const? 32 0)) e_1 e := by 
+    select (icmp IntPredicate.eq e_2 (const? 32 0)) e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -98,7 +98,7 @@ theorem select_xor_inv_icmp_thm (e e_1 e_2 : IntW 32) :
 
 theorem select_sub_icmp_thm (e e_1 e_2 : IntW 32) :
   select (icmp IntPredicate.eq e_2 (const? 32 0)) (sub e_1 e_2) e ⊑
-    select (icmp IntPredicate.eq e_2 (const? 32 0)) e_1 e := by 
+    select (icmp IntPredicate.eq e_2 (const? 32 0)) e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -109,7 +109,7 @@ theorem select_sub_icmp_thm (e e_1 e_2 : IntW 32) :
 
 theorem select_lshr_icmp_thm (e e_1 e_2 : IntW 32) :
   select (icmp IntPredicate.eq e_2 (const? 32 0)) (lshr e_1 e_2) e ⊑
-    select (icmp IntPredicate.eq e_2 (const? 32 0)) e_1 e := by 
+    select (icmp IntPredicate.eq e_2 (const? 32 0)) e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -120,7 +120,7 @@ theorem select_lshr_icmp_thm (e e_1 e_2 : IntW 32) :
 
 theorem select_udiv_icmp_thm (e e_1 e_2 : IntW 32) :
   select (icmp IntPredicate.eq e_2 (const? 32 1)) (LLVM.udiv e_1 e_2) e ⊑
-    select (icmp IntPredicate.eq e_2 (const? 32 1)) e_1 e := by 
+    select (icmp IntPredicate.eq e_2 (const? 32 1)) e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -131,7 +131,7 @@ theorem select_udiv_icmp_thm (e e_1 e_2 : IntW 32) :
 
 theorem select_xor_icmp_bad_3_thm (e e_1 e_2 : IntW 32) :
   select (icmp IntPredicate.eq e_2 (const? 32 3)) (LLVM.xor e_2 e_1) e ⊑
-    select (icmp IntPredicate.eq e_2 (const? 32 3)) (LLVM.xor e_1 (const? 32 3)) e := by 
+    select (icmp IntPredicate.eq e_2 (const? 32 3)) (LLVM.xor e_1 (const? 32 3)) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -142,7 +142,7 @@ theorem select_xor_icmp_bad_3_thm (e e_1 e_2 : IntW 32) :
 
 theorem select_xor_icmp_bad_5_thm (e e_1 e_2 : IntW 32) :
   select (icmp IntPredicate.ne e_2 (const? 32 0)) (LLVM.xor e_2 e_1) e ⊑
-    select (icmp IntPredicate.eq e_2 (const? 32 0)) e (LLVM.xor e_2 e_1) := by 
+    select (icmp IntPredicate.eq e_2 (const? 32 0)) e (LLVM.xor e_2 e_1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -153,7 +153,7 @@ theorem select_xor_icmp_bad_5_thm (e e_1 e_2 : IntW 32) :
 
 theorem select_xor_icmp_bad_6_thm (e e_1 e_2 : IntW 32) :
   select (icmp IntPredicate.ne e_2 (const? 32 1)) e_1 (LLVM.xor e_2 e) ⊑
-    select (icmp IntPredicate.eq e_2 (const? 32 1)) (LLVM.xor e (const? 32 1)) e_1 := by 
+    select (icmp IntPredicate.eq e_2 (const? 32 1)) (LLVM.xor e (const? 32 1)) e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -164,7 +164,7 @@ theorem select_xor_icmp_bad_6_thm (e e_1 e_2 : IntW 32) :
 
 theorem select_mul_icmp_bad_thm (e e_1 e_2 : IntW 32) :
   select (icmp IntPredicate.eq e_2 (const? 32 3)) (mul e_2 e_1) e ⊑
-    select (icmp IntPredicate.eq e_2 (const? 32 3)) (mul e_1 (const? 32 3)) e := by 
+    select (icmp IntPredicate.eq e_2 (const? 32 3)) (mul e_1 (const? 32 3)) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -175,7 +175,7 @@ theorem select_mul_icmp_bad_thm (e e_1 e_2 : IntW 32) :
 
 theorem select_add_icmp_bad_thm (e e_1 e_2 : IntW 32) :
   select (icmp IntPredicate.eq e_2 (const? 32 1)) (add e_2 e_1) e ⊑
-    select (icmp IntPredicate.eq e_2 (const? 32 1)) (add e_1 (const? 32 1)) e := by 
+    select (icmp IntPredicate.eq e_2 (const? 32 1)) (add e_1 (const? 32 1)) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -186,7 +186,7 @@ theorem select_add_icmp_bad_thm (e e_1 e_2 : IntW 32) :
 
 theorem select_and_icmp_zero_thm (e e_1 e_2 : IntW 32) :
   select (icmp IntPredicate.eq e_2 (const? 32 0)) (LLVM.and e_2 e_1) e ⊑
-    select (icmp IntPredicate.eq e_2 (const? 32 0)) (const? 32 0) e := by 
+    select (icmp IntPredicate.eq e_2 (const? 32 0)) (const? 32 0) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -197,7 +197,7 @@ theorem select_and_icmp_zero_thm (e e_1 e_2 : IntW 32) :
 
 theorem select_or_icmp_bad_thm (e e_1 e_2 : IntW 32) :
   select (icmp IntPredicate.eq e_2 (const? 32 3)) (LLVM.or e_2 e_1) e ⊑
-    select (icmp IntPredicate.eq e_2 (const? 32 3)) (LLVM.or e_1 (const? 32 3)) e := by 
+    select (icmp IntPredicate.eq e_2 (const? 32 3)) (LLVM.or e_1 (const? 32 3)) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -207,7 +207,7 @@ theorem select_or_icmp_bad_thm (e e_1 e_2 : IntW 32) :
 
 
 theorem select_lshr_icmp_const_thm (e : IntW 32) :
-  select (icmp IntPredicate.ugt e (const? 32 31)) (lshr e (const? 32 5)) (const? 32 0) ⊑ lshr e (const? 32 5) := by 
+  select (icmp IntPredicate.ugt e (const? 32 31)) (lshr e (const? 32 5)) (const? 32 0) ⊑ lshr e (const? 32 5) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -217,7 +217,7 @@ theorem select_lshr_icmp_const_thm (e : IntW 32) :
 
 
 theorem select_lshr_icmp_const_reordered_thm (e : IntW 32) :
-  select (icmp IntPredicate.ult e (const? 32 32)) (const? 32 0) (lshr e (const? 32 5)) ⊑ lshr e (const? 32 5) := by 
+  select (icmp IntPredicate.ult e (const? 32 32)) (const? 32 0) (lshr e (const? 32 5)) ⊑ lshr e (const? 32 5) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -228,7 +228,7 @@ theorem select_lshr_icmp_const_reordered_thm (e : IntW 32) :
 
 theorem select_exact_lshr_icmp_const_thm (e : IntW 32) :
   select (icmp IntPredicate.ugt e (const? 32 31)) (lshr e (const? 32 5) { «exact» := true }) (const? 32 0) ⊑
-    lshr e (const? 32 5) := by 
+    lshr e (const? 32 5) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -239,7 +239,7 @@ theorem select_exact_lshr_icmp_const_thm (e : IntW 32) :
 
 theorem select_sub_icmp_bad_thm (e e_1 e_2 : IntW 32) :
   select (icmp IntPredicate.eq e_2 (const? 32 0)) (sub e_2 e_1) e ⊑
-    select (icmp IntPredicate.eq e_2 (const? 32 0)) (sub (const? 32 0) e_1) e := by 
+    select (icmp IntPredicate.eq e_2 (const? 32 0)) (sub (const? 32 0) e_1) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -250,7 +250,7 @@ theorem select_sub_icmp_bad_thm (e e_1 e_2 : IntW 32) :
 
 theorem select_sub_icmp_bad_2_thm (e e_1 e_2 : IntW 32) :
   select (icmp IntPredicate.eq e_2 (const? 32 1)) (sub e_1 e_2) e ⊑
-    select (icmp IntPredicate.eq e_2 (const? 32 1)) (add e_1 (const? 32 (-1))) e := by 
+    select (icmp IntPredicate.eq e_2 (const? 32 1)) (add e_1 (const? 32 (-1))) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -261,7 +261,7 @@ theorem select_sub_icmp_bad_2_thm (e e_1 e_2 : IntW 32) :
 
 theorem select_shl_icmp_bad_thm (e e_1 e_2 : IntW 32) :
   select (icmp IntPredicate.eq e_2 (const? 32 1)) (shl e_1 e_2) e ⊑
-    select (icmp IntPredicate.eq e_2 (const? 32 1)) (shl e_1 (const? 32 1)) e := by 
+    select (icmp IntPredicate.eq e_2 (const? 32 1)) (shl e_1 (const? 32 1)) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -272,7 +272,7 @@ theorem select_shl_icmp_bad_thm (e e_1 e_2 : IntW 32) :
 
 theorem select_lshr_icmp_bad_thm (e e_1 e_2 : IntW 32) :
   select (icmp IntPredicate.eq e_2 (const? 32 1)) (lshr e_1 e_2) e ⊑
-    select (icmp IntPredicate.eq e_2 (const? 32 1)) (lshr e_1 (const? 32 1)) e := by 
+    select (icmp IntPredicate.eq e_2 (const? 32 1)) (lshr e_1 (const? 32 1)) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -283,7 +283,7 @@ theorem select_lshr_icmp_bad_thm (e e_1 e_2 : IntW 32) :
 
 theorem select_ashr_icmp_bad_thm (e e_1 e_2 : IntW 32) :
   select (icmp IntPredicate.eq e_2 (const? 32 1)) (ashr e_1 e_2) e ⊑
-    select (icmp IntPredicate.eq e_2 (const? 32 1)) (ashr e_1 (const? 32 1)) e := by 
+    select (icmp IntPredicate.eq e_2 (const? 32 1)) (ashr e_1 (const? 32 1)) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -294,7 +294,7 @@ theorem select_ashr_icmp_bad_thm (e e_1 e_2 : IntW 32) :
 
 theorem select_replace_one_use_thm (e e_1 : IntW 32) :
   select (icmp IntPredicate.eq e_1 (const? 32 0)) (sub e_1 e) e ⊑
-    select (icmp IntPredicate.eq e_1 (const? 32 0)) (sub (const? 32 0) e) e := by 
+    select (icmp IntPredicate.eq e_1 (const? 32 0)) (sub (const? 32 0) e) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -305,7 +305,7 @@ theorem select_replace_one_use_thm (e e_1 : IntW 32) :
 
 theorem select_replace_nested_thm (e e_1 e_2 : IntW 32) :
   select (icmp IntPredicate.eq e_2 (const? 32 0)) (add (sub e_1 e_2) e) e_1 ⊑
-    add e_1 (select (icmp IntPredicate.eq e_2 (const? 32 0)) e (const? 32 0)) := by 
+    add e_1 (select (icmp IntPredicate.eq e_2 (const? 32 0)) e (const? 32 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -316,7 +316,7 @@ theorem select_replace_nested_thm (e e_1 e_2 : IntW 32) :
 
 theorem select_replace_nested_no_simplify_thm (e e_1 e_2 : IntW 32) :
   select (icmp IntPredicate.eq e_2 (const? 32 1)) (add (sub e_1 e_2) e) e_1 ⊑
-    select (icmp IntPredicate.eq e_2 (const? 32 1)) (add (add e_1 (const? 32 (-1))) e) e_1 := by 
+    select (icmp IntPredicate.eq e_2 (const? 32 1)) (add (add e_1 (const? 32 (-1))) e) e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -325,7 +325,7 @@ theorem select_replace_nested_no_simplify_thm (e e_1 e_2 : IntW 32) :
     all_goals sorry
 
 
-theorem select_replace_udiv_non_speculatable_thm (e e_1 : IntW 32) : select (icmp IntPredicate.eq e_1 (const? 32 0)) (LLVM.udiv e e_1) e ⊑ e := by 
+theorem select_replace_udiv_non_speculatable_thm (e e_1 : IntW 32) : select (icmp IntPredicate.eq e_1 (const? 32 0)) (LLVM.udiv e e_1) e ⊑ e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gselecthbitext_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gselecthbitext_proof.lean
@@ -9,7 +9,7 @@ set_option linter.unreachableTactic false
 
 section gselecthbitext_proof
 theorem sel_sext_constants_thm (e : IntW 1) :
-  sext 16 (select e (const? 8 (-1)) (const? 8 42)) ⊑ select e (const? 16 (-1)) (const? 16 42) := by 
+  sext 16 (select e (const? 8 (-1)) (const? 8 42)) ⊑ select e (const? 16 (-1)) (const? 16 42) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -19,7 +19,7 @@ theorem sel_sext_constants_thm (e : IntW 1) :
 
 
 theorem sel_zext_constants_thm (e : IntW 1) :
-  zext 16 (select e (const? 8 (-1)) (const? 8 42)) ⊑ select e (const? 16 255) (const? 16 42) := by 
+  zext 16 (select e (const? 8 (-1)) (const? 8 42)) ⊑ select e (const? 16 255) (const? 16 42) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -29,7 +29,7 @@ theorem sel_zext_constants_thm (e : IntW 1) :
 
 
 theorem sel_sext_thm (e : IntW 32) (e_1 : IntW 1) :
-  sext 64 (select e_1 e (const? 32 42)) ⊑ select e_1 (sext 64 e) (const? 64 42) := by 
+  sext 64 (select e_1 e (const? 32 42)) ⊑ select e_1 (sext 64 e) (const? 64 42) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -39,7 +39,7 @@ theorem sel_sext_thm (e : IntW 32) (e_1 : IntW 1) :
 
 
 theorem sel_zext_thm (e : IntW 32) (e_1 : IntW 1) :
-  zext 64 (select e_1 e (const? 32 42)) ⊑ select e_1 (zext 64 e) (const? 64 42) := by 
+  zext 64 (select e_1 e (const? 32 42)) ⊑ select e_1 (zext 64 e) (const? 64 42) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -49,7 +49,7 @@ theorem sel_zext_thm (e : IntW 32) (e_1 : IntW 1) :
 
 
 theorem trunc_sel_larger_sext_thm (e : IntW 32) (e_1 : IntW 1) :
-  sext 64 (select e_1 (trunc 16 e) (const? 16 42)) ⊑ select e_1 (sext 64 (trunc 16 e)) (const? 64 42) := by 
+  sext 64 (select e_1 (trunc 16 e) (const? 16 42)) ⊑ select e_1 (sext 64 (trunc 16 e)) (const? 64 42) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -59,7 +59,7 @@ theorem trunc_sel_larger_sext_thm (e : IntW 32) (e_1 : IntW 1) :
 
 
 theorem trunc_sel_smaller_sext_thm (e : IntW 64) (e_1 : IntW 1) :
-  sext 32 (select e_1 (trunc 16 e) (const? 16 42)) ⊑ select e_1 (sext 32 (trunc 16 e)) (const? 32 42) := by 
+  sext 32 (select e_1 (trunc 16 e) (const? 16 42)) ⊑ select e_1 (sext 32 (trunc 16 e)) (const? 32 42) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -70,7 +70,7 @@ theorem trunc_sel_smaller_sext_thm (e : IntW 64) (e_1 : IntW 1) :
 
 theorem trunc_sel_equal_sext_thm (e : IntW 32) (e_1 : IntW 1) :
   sext 32 (select e_1 (trunc 16 e) (const? 16 42)) ⊑
-    select e_1 (ashr (shl e (const? 32 16)) (const? 32 16) { «exact» := true }) (const? 32 42) := by 
+    select e_1 (ashr (shl e (const? 32 16)) (const? 32 16) { «exact» := true }) (const? 32 42) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -81,7 +81,7 @@ theorem trunc_sel_equal_sext_thm (e : IntW 32) (e_1 : IntW 1) :
 
 theorem trunc_sel_larger_zext_thm (e : IntW 32) (e_1 : IntW 1) :
   zext 64 (select e_1 (trunc 16 e) (const? 16 42)) ⊑
-    select e_1 (zext 64 (LLVM.and e (const? 32 65535)) { «nneg» := true }) (const? 64 42) := by 
+    select e_1 (zext 64 (LLVM.and e (const? 32 65535)) { «nneg» := true }) (const? 64 42) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -92,7 +92,7 @@ theorem trunc_sel_larger_zext_thm (e : IntW 32) (e_1 : IntW 1) :
 
 theorem trunc_sel_smaller_zext_thm (e : IntW 64) (e_1 : IntW 1) :
   zext 32 (select e_1 (trunc 16 e) (const? 16 42)) ⊑
-    select e_1 (LLVM.and (trunc 32 e) (const? 32 65535)) (const? 32 42) := by 
+    select e_1 (LLVM.and (trunc 32 e) (const? 32 65535)) (const? 32 42) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -102,7 +102,7 @@ theorem trunc_sel_smaller_zext_thm (e : IntW 64) (e_1 : IntW 1) :
 
 
 theorem trunc_sel_equal_zext_thm (e : IntW 32) (e_1 : IntW 1) :
-  zext 32 (select e_1 (trunc 16 e) (const? 16 42)) ⊑ select e_1 (LLVM.and e (const? 32 65535)) (const? 32 42) := by 
+  zext 32 (select e_1 (trunc 16 e) (const? 16 42)) ⊑ select e_1 (LLVM.and e (const? 32 65535)) (const? 32 42) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -112,7 +112,7 @@ theorem trunc_sel_equal_zext_thm (e : IntW 32) (e_1 : IntW 1) :
 
 
 theorem test_sext1_thm (e e_1 : IntW 1) :
-  select e_1 (sext 32 e) (const? 32 0) ⊑ sext 32 (select e_1 e (const? 1 0)) := by 
+  select e_1 (sext 32 e) (const? 32 0) ⊑ sext 32 (select e_1 e (const? 1 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -122,7 +122,7 @@ theorem test_sext1_thm (e e_1 : IntW 1) :
 
 
 theorem test_sext2_thm (e e_1 : IntW 1) :
-  select e_1 (const? 32 (-1)) (sext 32 e) ⊑ sext 32 (select e_1 (const? 1 1) e) := by 
+  select e_1 (const? 32 (-1)) (sext 32 e) ⊑ sext 32 (select e_1 (const? 1 1) e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -132,7 +132,7 @@ theorem test_sext2_thm (e e_1 : IntW 1) :
 
 
 theorem test_sext3_thm (e e_1 : IntW 1) :
-  select e_1 (const? 32 0) (sext 32 e) ⊑ sext 32 (select (LLVM.xor e_1 (const? 1 1)) e (const? 1 0)) := by 
+  select e_1 (const? 32 0) (sext 32 e) ⊑ sext 32 (select (LLVM.xor e_1 (const? 1 1)) e (const? 1 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -142,7 +142,7 @@ theorem test_sext3_thm (e e_1 : IntW 1) :
 
 
 theorem test_sext4_thm (e e_1 : IntW 1) :
-  select e_1 (sext 32 e) (const? 32 (-1)) ⊑ sext 32 (select (LLVM.xor e_1 (const? 1 1)) (const? 1 1) e) := by 
+  select e_1 (sext 32 e) (const? 32 (-1)) ⊑ sext 32 (select (LLVM.xor e_1 (const? 1 1)) (const? 1 1) e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -152,7 +152,7 @@ theorem test_sext4_thm (e e_1 : IntW 1) :
 
 
 theorem test_zext1_thm (e e_1 : IntW 1) :
-  select e_1 (zext 32 e) (const? 32 0) ⊑ zext 32 (select e_1 e (const? 1 0)) := by 
+  select e_1 (zext 32 e) (const? 32 0) ⊑ zext 32 (select e_1 e (const? 1 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -162,7 +162,7 @@ theorem test_zext1_thm (e e_1 : IntW 1) :
 
 
 theorem test_zext2_thm (e e_1 : IntW 1) :
-  select e_1 (const? 32 1) (zext 32 e) ⊑ zext 32 (select e_1 (const? 1 1) e) := by 
+  select e_1 (const? 32 1) (zext 32 e) ⊑ zext 32 (select e_1 (const? 1 1) e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -172,7 +172,7 @@ theorem test_zext2_thm (e e_1 : IntW 1) :
 
 
 theorem test_zext3_thm (e e_1 : IntW 1) :
-  select e_1 (const? 32 0) (zext 32 e) ⊑ zext 32 (select (LLVM.xor e_1 (const? 1 1)) e (const? 1 0)) := by 
+  select e_1 (const? 32 0) (zext 32 e) ⊑ zext 32 (select (LLVM.xor e_1 (const? 1 1)) e (const? 1 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -182,7 +182,7 @@ theorem test_zext3_thm (e e_1 : IntW 1) :
 
 
 theorem test_zext4_thm (e e_1 : IntW 1) :
-  select e_1 (zext 32 e) (const? 32 1) ⊑ zext 32 (select (LLVM.xor e_1 (const? 1 1)) (const? 1 1) e) := by 
+  select e_1 (zext 32 e) (const? 32 1) ⊑ zext 32 (select (LLVM.xor e_1 (const? 1 1)) (const? 1 1) e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -194,7 +194,7 @@ theorem test_zext4_thm (e e_1 : IntW 1) :
 theorem test_op_op_thm (e e_1 e_2 : IntW 32) :
   select (icmp IntPredicate.sgt e_2 (const? 32 0)) (sext 32 (icmp IntPredicate.sgt e_1 (const? 32 0)))
       (sext 32 (icmp IntPredicate.sgt e (const? 32 0))) ⊑
-    sext 32 (icmp IntPredicate.sgt (select (icmp IntPredicate.sgt e_2 (const? 32 0)) e_1 e) (const? 32 0)) := by 
+    sext 32 (icmp IntPredicate.sgt (select (icmp IntPredicate.sgt e_2 (const? 32 0)) e_1 e) (const? 32 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -204,7 +204,7 @@ theorem test_op_op_thm (e e_1 e_2 : IntW 32) :
 
 
 theorem sext_true_val_must_be_all_ones_thm (e : IntW 1) :
-  select e (sext 32 e) (const? 32 42) ⊑ select e (const? 32 (-1)) (const? 32 42) := by 
+  select e (sext 32 e) (const? 32 42) ⊑ select e (const? 32 (-1)) (const? 32 42) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -213,7 +213,7 @@ theorem sext_true_val_must_be_all_ones_thm (e : IntW 1) :
     all_goals sorry
 
 
-theorem zext_true_val_must_be_one_thm (e : IntW 1) : select e (zext 32 e) (const? 32 42) ⊑ select e (const? 32 1) (const? 32 42) := by 
+theorem zext_true_val_must_be_one_thm (e : IntW 1) : select e (zext 32 e) (const? 32 42) ⊑ select e (const? 32 1) (const? 32 42) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -222,7 +222,7 @@ theorem zext_true_val_must_be_one_thm (e : IntW 1) : select e (zext 32 e) (const
     all_goals sorry
 
 
-theorem sext_false_val_must_be_zero_thm (e : IntW 1) : select e (const? 32 42) (sext 32 e) ⊑ select e (const? 32 42) (const? 32 0) := by 
+theorem sext_false_val_must_be_zero_thm (e : IntW 1) : select e (const? 32 42) (sext 32 e) ⊑ select e (const? 32 42) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -231,7 +231,7 @@ theorem sext_false_val_must_be_zero_thm (e : IntW 1) : select e (const? 32 42) (
     all_goals sorry
 
 
-theorem zext_false_val_must_be_zero_thm (e : IntW 1) : select e (const? 32 42) (zext 32 e) ⊑ select e (const? 32 42) (const? 32 0) := by 
+theorem zext_false_val_must_be_zero_thm (e : IntW 1) : select e (const? 32 42) (zext 32 e) ⊑ select e (const? 32 42) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gselecthbitexthbitwisehops_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gselecthbitexthbitwisehops_proof.lean
@@ -11,7 +11,7 @@ section gselecthbitexthbitwisehops_proof
 theorem sel_false_val_is_a_masked_shl_of_true_val1_thm (e : IntW 64) (e_1 : IntW 32) :
   select (icmp IntPredicate.eq (LLVM.and e_1 (const? 32 15)) (const? 32 0)) e
       (ashr e (zext 64 (shl (LLVM.and e_1 (const? 32 15)) (const? 32 2) { «nsw» := true, «nuw» := true }))) ⊑
-    ashr e (zext 64 (LLVM.and (shl e_1 (const? 32 2)) (const? 32 60)) { «nneg» := true }) := by 
+    ashr e (zext 64 (LLVM.and (shl e_1 (const? 32 2)) (const? 32 60)) { «nneg» := true }) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -25,7 +25,7 @@ theorem sel_false_val_is_a_masked_shl_of_true_val2_thm (e : IntW 64) (e_1 : IntW
       (icmp IntPredicate.eq (shl (LLVM.and e_1 (const? 32 15)) (const? 32 2) { «nsw» := true, «nuw» := true })
         (const? 32 0))
       e (ashr e (zext 64 (shl (LLVM.and e_1 (const? 32 15)) (const? 32 2) { «nsw» := true, «nuw» := true }))) ⊑
-    ashr e (zext 64 (LLVM.and (shl e_1 (const? 32 2)) (const? 32 60)) { «nneg» := true }) := by 
+    ashr e (zext 64 (LLVM.and (shl e_1 (const? 32 2)) (const? 32 60)) { «nneg» := true }) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -37,7 +37,7 @@ theorem sel_false_val_is_a_masked_shl_of_true_val2_thm (e : IntW 64) (e_1 : IntW
 theorem sel_false_val_is_a_masked_lshr_of_true_val1_thm (e : IntW 64) (e_1 : IntW 32) :
   select (icmp IntPredicate.eq (LLVM.and e_1 (const? 32 60)) (const? 32 0)) e
       (ashr e (zext 64 (lshr (LLVM.and e_1 (const? 32 60)) (const? 32 2)))) ⊑
-    ashr e (zext 64 (LLVM.and (lshr e_1 (const? 32 2)) (const? 32 15)) { «nneg» := true }) := by 
+    ashr e (zext 64 (LLVM.and (lshr e_1 (const? 32 2)) (const? 32 15)) { «nneg» := true }) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -49,7 +49,7 @@ theorem sel_false_val_is_a_masked_lshr_of_true_val1_thm (e : IntW 64) (e_1 : Int
 theorem sel_false_val_is_a_masked_lshr_of_true_val2_thm (e : IntW 64) (e_1 : IntW 32) :
   select (icmp IntPredicate.eq (lshr (LLVM.and e_1 (const? 32 60)) (const? 32 2)) (const? 32 0)) e
       (ashr e (zext 64 (lshr (LLVM.and e_1 (const? 32 60)) (const? 32 2)))) ⊑
-    ashr e (zext 64 (LLVM.and (lshr e_1 (const? 32 2)) (const? 32 15)) { «nneg» := true }) := by 
+    ashr e (zext 64 (LLVM.and (lshr e_1 (const? 32 2)) (const? 32 15)) { «nneg» := true }) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -61,7 +61,7 @@ theorem sel_false_val_is_a_masked_lshr_of_true_val2_thm (e : IntW 64) (e_1 : Int
 theorem sel_false_val_is_a_masked_ashr_of_true_val1_thm (e : IntW 64) (e_1 : IntW 32) :
   select (icmp IntPredicate.eq (LLVM.and e_1 (const? 32 (-2147483588))) (const? 32 0)) e
       (ashr e (zext 64 (ashr (LLVM.and e_1 (const? 32 (-2147483588))) (const? 32 2)))) ⊑
-    ashr e (zext 64 (LLVM.and (ashr e_1 (const? 32 2)) (const? 32 (-536870897))) { «nneg» := true }) := by 
+    ashr e (zext 64 (LLVM.and (ashr e_1 (const? 32 2)) (const? 32 (-536870897))) { «nneg» := true }) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -73,7 +73,7 @@ theorem sel_false_val_is_a_masked_ashr_of_true_val1_thm (e : IntW 64) (e_1 : Int
 theorem sel_false_val_is_a_masked_ashr_of_true_val2_thm (e : IntW 64) (e_1 : IntW 32) :
   select (icmp IntPredicate.eq (ashr (LLVM.and e_1 (const? 32 (-2147483588))) (const? 32 2)) (const? 32 0)) e
       (ashr e (zext 64 (ashr (LLVM.and e_1 (const? 32 (-2147483588))) (const? 32 2)))) ⊑
-    ashr e (zext 64 (LLVM.and (ashr e_1 (const? 32 2)) (const? 32 (-536870897))) { «nneg» := true }) := by 
+    ashr e (zext 64 (LLVM.and (ashr e_1 (const? 32 2)) (const? 32 (-536870897))) { «nneg» := true }) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gselecthcmpheqhophfold_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gselecthcmpheqhophfold_proof.lean
@@ -9,7 +9,7 @@ set_option linter.unreachableTactic false
 
 section gselecthcmpheqhophfold_proof
 theorem replace_with_y_noundef_thm (e e_1 e_2 : IntW 8) :
-  select (icmp IntPredicate.eq e_2 e_1) (LLVM.and e_2 e_1) e ⊑ select (icmp IntPredicate.eq e_2 e_1) e_1 e := by 
+  select (icmp IntPredicate.eq e_2 e_1) (LLVM.and e_2 e_1) e ⊑ select (icmp IntPredicate.eq e_2 e_1) e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gselecthdivrem_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gselecthdivrem_proof.lean
@@ -9,7 +9,7 @@ set_option linter.unreachableTactic false
 
 section gselecthdivrem_proof
 theorem udiv_common_divisor_thm (e e_1 e_2 : IntW 5) (e_3 : IntW 1) :
-  select e_3 (LLVM.udiv e_2 e_1) (LLVM.udiv e e_1) ⊑ LLVM.udiv (select e_3 e_2 e) e_1 := by 
+  select e_3 (LLVM.udiv e_2 e_1) (LLVM.udiv e e_1) ⊑ LLVM.udiv (select e_3 e_2 e) e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -19,7 +19,7 @@ theorem udiv_common_divisor_thm (e e_1 e_2 : IntW 5) (e_3 : IntW 1) :
 
 
 theorem urem_common_divisor_thm (e e_1 e_2 : IntW 5) (e_3 : IntW 1) :
-  select e_3 (urem e_2 e_1) (urem e e_1) ⊑ urem (select e_3 e_2 e) e_1 := by 
+  select e_3 (urem e_2 e_1) (urem e e_1) ⊑ urem (select e_3 e_2 e) e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -29,7 +29,7 @@ theorem urem_common_divisor_thm (e e_1 e_2 : IntW 5) (e_3 : IntW 1) :
 
 
 theorem sdiv_common_divisor_defined_cond_thm (e e_1 e_2 : IntW 5) (e_3 : IntW 1) :
-  select e_3 (LLVM.sdiv e_2 e_1) (LLVM.sdiv e e_1) ⊑ LLVM.sdiv (select e_3 e_2 e) e_1 := by 
+  select e_3 (LLVM.sdiv e_2 e_1) (LLVM.sdiv e e_1) ⊑ LLVM.sdiv (select e_3 e_2 e) e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -39,7 +39,7 @@ theorem sdiv_common_divisor_defined_cond_thm (e e_1 e_2 : IntW 5) (e_3 : IntW 1)
 
 
 theorem srem_common_divisor_defined_cond_thm (e e_1 e_2 : IntW 5) (e_3 : IntW 1) :
-  select e_3 (LLVM.srem e_2 e_1) (LLVM.srem e e_1) ⊑ LLVM.srem (select e_3 e_2 e) e_1 := by 
+  select e_3 (LLVM.srem e_2 e_1) (LLVM.srem e e_1) ⊑ LLVM.srem (select e_3 e_2 e) e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -49,7 +49,7 @@ theorem srem_common_divisor_defined_cond_thm (e e_1 e_2 : IntW 5) (e_3 : IntW 1)
 
 
 theorem udiv_common_divisor_defined_cond_thm (e e_1 e_2 : IntW 5) (e_3 : IntW 1) :
-  select e_3 (LLVM.udiv e_2 e_1) (LLVM.udiv e e_1) ⊑ LLVM.udiv (select e_3 e_2 e) e_1 := by 
+  select e_3 (LLVM.udiv e_2 e_1) (LLVM.udiv e e_1) ⊑ LLVM.udiv (select e_3 e_2 e) e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -59,7 +59,7 @@ theorem udiv_common_divisor_defined_cond_thm (e e_1 e_2 : IntW 5) (e_3 : IntW 1)
 
 
 theorem urem_common_divisor_defined_cond_thm (e e_1 e_2 : IntW 5) (e_3 : IntW 1) :
-  select e_3 (urem e_2 e_1) (urem e e_1) ⊑ urem (select e_3 e_2 e) e_1 := by 
+  select e_3 (urem e_2 e_1) (urem e e_1) ⊑ urem (select e_3 e_2 e) e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -69,7 +69,7 @@ theorem urem_common_divisor_defined_cond_thm (e e_1 e_2 : IntW 5) (e_3 : IntW 1)
 
 
 theorem sdiv_common_dividend_defined_cond_thm (e e_1 e_2 : IntW 5) (e_3 : IntW 1) :
-  select e_3 (LLVM.sdiv e_2 e_1) (LLVM.sdiv e_2 e) ⊑ LLVM.sdiv e_2 (select e_3 e_1 e) := by 
+  select e_3 (LLVM.sdiv e_2 e_1) (LLVM.sdiv e_2 e) ⊑ LLVM.sdiv e_2 (select e_3 e_1 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -79,7 +79,7 @@ theorem sdiv_common_dividend_defined_cond_thm (e e_1 e_2 : IntW 5) (e_3 : IntW 1
 
 
 theorem srem_common_dividend_defined_cond_thm (e e_1 e_2 : IntW 5) (e_3 : IntW 1) :
-  select e_3 (LLVM.srem e_2 e_1) (LLVM.srem e_2 e) ⊑ LLVM.srem e_2 (select e_3 e_1 e) := by 
+  select e_3 (LLVM.srem e_2 e_1) (LLVM.srem e_2 e) ⊑ LLVM.srem e_2 (select e_3 e_1 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -89,7 +89,7 @@ theorem srem_common_dividend_defined_cond_thm (e e_1 e_2 : IntW 5) (e_3 : IntW 1
 
 
 theorem udiv_common_dividend_defined_cond_thm (e e_1 e_2 : IntW 5) (e_3 : IntW 1) :
-  select e_3 (LLVM.udiv e_2 e_1) (LLVM.udiv e_2 e) ⊑ LLVM.udiv e_2 (select e_3 e_1 e) := by 
+  select e_3 (LLVM.udiv e_2 e_1) (LLVM.udiv e_2 e) ⊑ LLVM.udiv e_2 (select e_3 e_1 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -99,7 +99,7 @@ theorem udiv_common_dividend_defined_cond_thm (e e_1 e_2 : IntW 5) (e_3 : IntW 1
 
 
 theorem urem_common_dividend_defined_cond_thm (e e_1 e_2 : IntW 5) (e_3 : IntW 1) :
-  select e_3 (urem e_2 e_1) (urem e_2 e) ⊑ urem e_2 (select e_3 e_1 e) := by 
+  select e_3 (urem e_2 e_1) (urem e_2 e) ⊑ urem e_2 (select e_3 e_1 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -111,7 +111,7 @@ theorem urem_common_dividend_defined_cond_thm (e e_1 e_2 : IntW 5) (e_3 : IntW 1
 theorem rem_euclid_1_thm (e : IntW 32) :
   select (icmp IntPredicate.slt (LLVM.srem e (const? 32 8)) (const? 32 0))
       (add (LLVM.srem e (const? 32 8)) (const? 32 8)) (LLVM.srem e (const? 32 8)) ⊑
-    LLVM.and e (const? 32 7) := by 
+    LLVM.and e (const? 32 7) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -123,7 +123,7 @@ theorem rem_euclid_1_thm (e : IntW 32) :
 theorem rem_euclid_2_thm (e : IntW 32) :
   select (icmp IntPredicate.sgt (LLVM.srem e (const? 32 8)) (const? 32 (-1))) (LLVM.srem e (const? 32 8))
       (add (LLVM.srem e (const? 32 8)) (const? 32 8)) ⊑
-    LLVM.and e (const? 32 7) := by 
+    LLVM.and e (const? 32 7) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -137,7 +137,7 @@ theorem rem_euclid_wrong_sign_test_thm (e : IntW 32) :
       (add (LLVM.srem e (const? 32 8)) (const? 32 8)) (LLVM.srem e (const? 32 8)) ⊑
     select (icmp IntPredicate.sgt (LLVM.srem e (const? 32 8)) (const? 32 0))
       (add (LLVM.srem e (const? 32 8)) (const? 32 8) { «nsw» := true, «nuw» := false })
-      (LLVM.srem e (const? 32 8)) := by 
+      (LLVM.srem e (const? 32 8)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -151,7 +151,7 @@ theorem rem_euclid_add_different_const_thm (e : IntW 32) :
       (add (LLVM.srem e (const? 32 8)) (const? 32 9)) (LLVM.srem e (const? 32 8)) ⊑
     select (icmp IntPredicate.slt (LLVM.srem e (const? 32 8)) (const? 32 0))
       (add (LLVM.srem e (const? 32 8)) (const? 32 9) { «nsw» := true, «nuw» := false })
-      (LLVM.srem e (const? 32 8)) := by 
+      (LLVM.srem e (const? 32 8)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -164,7 +164,7 @@ theorem rem_euclid_wrong_operands_select_thm (e : IntW 32) :
   select (icmp IntPredicate.slt (LLVM.srem e (const? 32 8)) (const? 32 0)) (LLVM.srem e (const? 32 8))
       (add (LLVM.srem e (const? 32 8)) (const? 32 8)) ⊑
     select (icmp IntPredicate.slt (LLVM.srem e (const? 32 8)) (const? 32 0)) (LLVM.srem e (const? 32 8))
-      (add (LLVM.srem e (const? 32 8)) (const? 32 8) { «nsw» := true, «nuw» := false }) := by 
+      (add (LLVM.srem e (const? 32 8)) (const? 32 8) { «nsw» := true, «nuw» := false }) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -176,7 +176,7 @@ theorem rem_euclid_wrong_operands_select_thm (e : IntW 32) :
 theorem rem_euclid_i128_thm (e : IntW 128) :
   select (icmp IntPredicate.slt (LLVM.srem e (const? 128 8)) (const? 128 0))
       (add (LLVM.srem e (const? 128 8)) (const? 128 8)) (LLVM.srem e (const? 128 8)) ⊑
-    LLVM.and e (const? 128 7) := by 
+    LLVM.and e (const? 128 7) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -188,7 +188,7 @@ theorem rem_euclid_i128_thm (e : IntW 128) :
 theorem rem_euclid_non_const_pow2_thm (e e_1 : IntW 8) :
   select (icmp IntPredicate.slt (LLVM.srem e_1 (shl (const? 8 1) e)) (const? 8 0))
       (add (LLVM.srem e_1 (shl (const? 8 1) e)) (shl (const? 8 1) e)) (LLVM.srem e_1 (shl (const? 8 1) e)) ⊑
-    LLVM.and e_1 (LLVM.xor (shl (const? 8 (-1)) e { «nsw» := true, «nuw» := false }) (const? 8 (-1))) := by 
+    LLVM.and e_1 (LLVM.xor (shl (const? 8 (-1)) e { «nsw» := true, «nuw» := false }) (const? 8 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -199,7 +199,7 @@ theorem rem_euclid_non_const_pow2_thm (e e_1 : IntW 8) :
 
 theorem rem_euclid_pow2_true_arm_folded_thm (e : IntW 32) :
   select (icmp IntPredicate.slt (LLVM.srem e (const? 32 2)) (const? 32 0)) (const? 32 1) (LLVM.srem e (const? 32 2)) ⊑
-    LLVM.and e (const? 32 1) := by 
+    LLVM.and e (const? 32 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -210,7 +210,7 @@ theorem rem_euclid_pow2_true_arm_folded_thm (e : IntW 32) :
 
 theorem rem_euclid_pow2_false_arm_folded_thm (e : IntW 32) :
   select (icmp IntPredicate.sge (LLVM.srem e (const? 32 2)) (const? 32 0)) (LLVM.srem e (const? 32 2)) (const? 32 1) ⊑
-    LLVM.and e (const? 32 1) := by 
+    LLVM.and e (const? 32 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -227,7 +227,7 @@ theorem pr89516_thm (e e_1 : IntW 8) :
     add (LLVM.srem (const? 8 1) (shl (const? 8 1) e { «nsw» := false, «nuw» := true }))
       (select (icmp IntPredicate.slt e_1 (const? 8 0)) (shl (const? 8 1) e { «nsw» := false, «nuw» := true })
         (const? 8 0))
-      { «nsw» := false, «nuw» := true } := by 
+      { «nsw» := false, «nuw» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gselecthfactorize_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gselecthfactorize_proof.lean
@@ -10,7 +10,7 @@ set_option linter.unreachableTactic false
 section gselecthfactorize_proof
 theorem logic_and_logic_or_1_thm (e e_1 e_2 : IntW 1) :
   select (select e_2 e_1 (const? 1 0)) (const? 1 1) (select e_2 e (const? 1 0)) ⊑
-    select e_2 (select e_1 (const? 1 1) e) (const? 1 0) := by 
+    select e_2 (select e_1 (const? 1 1) e) (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -21,7 +21,7 @@ theorem logic_and_logic_or_1_thm (e e_1 e_2 : IntW 1) :
 
 theorem logic_and_logic_or_2_thm (e e_1 e_2 : IntW 1) :
   select (select e_2 e_1 (const? 1 0)) (const? 1 1) (select e_1 e (const? 1 0)) ⊑
-    select e_1 (select e_2 (const? 1 1) e) (const? 1 0) := by 
+    select e_1 (select e_2 (const? 1 1) e) (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -32,7 +32,7 @@ theorem logic_and_logic_or_2_thm (e e_1 e_2 : IntW 1) :
 
 theorem logic_and_logic_or_3_thm (e e_1 e_2 : IntW 1) :
   select (select e_2 e_1 (const? 1 0)) (const? 1 1) (select e e_1 (const? 1 0)) ⊑
-    select (select e_2 (const? 1 1) e) e_1 (const? 1 0) := by 
+    select (select e_2 (const? 1 1) e) e_1 (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -43,7 +43,7 @@ theorem logic_and_logic_or_3_thm (e e_1 e_2 : IntW 1) :
 
 theorem logic_and_logic_or_4_thm (e e_1 e_2 : IntW 1) :
   select (select e_2 e_1 (const? 1 0)) (const? 1 1) (select e e_2 (const? 1 0)) ⊑
-    select e_2 (select e_1 (const? 1 1) e) (const? 1 0) := by 
+    select e_2 (select e_1 (const? 1 1) e) (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -54,7 +54,7 @@ theorem logic_and_logic_or_4_thm (e e_1 e_2 : IntW 1) :
 
 theorem logic_and_logic_or_5_thm (e e_1 e_2 : IntW 1) :
   select (select e_2 e_1 (const? 1 0)) (const? 1 1) (select e_2 e (const? 1 0)) ⊑
-    select e_2 (select e_1 (const? 1 1) e) (const? 1 0) := by 
+    select e_2 (select e_1 (const? 1 1) e) (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -65,7 +65,7 @@ theorem logic_and_logic_or_5_thm (e e_1 e_2 : IntW 1) :
 
 theorem logic_and_logic_or_6_thm (e e_1 e_2 : IntW 1) :
   select (select e_2 e_1 (const? 1 0)) (const? 1 1) (select e e_2 (const? 1 0)) ⊑
-    select e_2 (select e_1 (const? 1 1) e) (const? 1 0) := by 
+    select e_2 (select e_1 (const? 1 1) e) (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -76,7 +76,7 @@ theorem logic_and_logic_or_6_thm (e e_1 e_2 : IntW 1) :
 
 theorem logic_and_logic_or_7_thm (e e_1 e_2 : IntW 1) :
   select (select e_2 e_1 (const? 1 0)) (const? 1 1) (select e e_1 (const? 1 0)) ⊑
-    select (select e_2 (const? 1 1) e) e_1 (const? 1 0) := by 
+    select (select e_2 (const? 1 1) e) e_1 (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -87,7 +87,7 @@ theorem logic_and_logic_or_7_thm (e e_1 e_2 : IntW 1) :
 
 theorem logic_and_logic_or_8_thm (e e_1 e_2 : IntW 1) :
   select (select e_2 e_1 (const? 1 0)) (const? 1 1) (select e_1 e (const? 1 0)) ⊑
-    select e_1 (select e_2 (const? 1 1) e) (const? 1 0) := by 
+    select e_1 (select e_2 (const? 1 1) e) (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -98,7 +98,7 @@ theorem logic_and_logic_or_8_thm (e e_1 e_2 : IntW 1) :
 
 theorem and_logic_and_logic_or_1_thm (e e_1 e_2 : IntW 1) :
   select (LLVM.and e_2 e_1) (const? 1 1) (select e_2 e (const? 1 0)) ⊑
-    select e_2 (select e_1 (const? 1 1) e) (const? 1 0) := by 
+    select e_2 (select e_1 (const? 1 1) e) (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -109,7 +109,7 @@ theorem and_logic_and_logic_or_1_thm (e e_1 e_2 : IntW 1) :
 
 theorem and_logic_and_logic_or_2_thm (e e_1 e_2 : IntW 1) :
   select (LLVM.and e_2 e_1) (const? 1 1) (select e e_2 (const? 1 0)) ⊑
-    select e_2 (select e_1 (const? 1 1) e) (const? 1 0) := by 
+    select e_2 (select e_1 (const? 1 1) e) (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -120,7 +120,7 @@ theorem and_logic_and_logic_or_2_thm (e e_1 e_2 : IntW 1) :
 
 theorem and_logic_and_logic_or_3_thm (e e_1 e_2 : IntW 1) :
   select (LLVM.and e_2 e_1) (const? 1 1) (select e_1 e (const? 1 0)) ⊑
-    select e_1 (select e_2 (const? 1 1) e) (const? 1 0) := by 
+    select e_1 (select e_2 (const? 1 1) e) (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -131,7 +131,7 @@ theorem and_logic_and_logic_or_3_thm (e e_1 e_2 : IntW 1) :
 
 theorem and_logic_and_logic_or_4_thm (e e_1 e_2 : IntW 1) :
   select (LLVM.and e_2 e_1) (const? 1 1) (select e e_1 (const? 1 0)) ⊑
-    select e_1 (select e_2 (const? 1 1) e) (const? 1 0) := by 
+    select e_1 (select e_2 (const? 1 1) e) (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -142,7 +142,7 @@ theorem and_logic_and_logic_or_4_thm (e e_1 e_2 : IntW 1) :
 
 theorem and_logic_and_logic_or_5_thm (e e_1 e_2 : IntW 1) :
   select (select e_2 e_1 (const? 1 0)) (const? 1 1) (LLVM.and e_2 e) ⊑
-    select e_2 (select e_1 (const? 1 1) e) (const? 1 0) := by 
+    select e_2 (select e_1 (const? 1 1) e) (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -152,7 +152,7 @@ theorem and_logic_and_logic_or_5_thm (e e_1 e_2 : IntW 1) :
 
 
 theorem and_logic_and_logic_or_6_thm (e e_1 e_2 : IntW 1) :
-  select (select e_2 e_1 (const? 1 0)) (const? 1 1) (LLVM.and e_1 e) ⊑ LLVM.and e_1 (select e_2 (const? 1 1) e) := by 
+  select (select e_2 e_1 (const? 1 0)) (const? 1 1) (LLVM.and e_1 e) ⊑ LLVM.and e_1 (select e_2 (const? 1 1) e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -163,7 +163,7 @@ theorem and_logic_and_logic_or_6_thm (e e_1 e_2 : IntW 1) :
 
 theorem and_logic_and_logic_or_7_thm (e e_1 e_2 : IntW 1) :
   select (select e_2 e_1 (const? 1 0)) (const? 1 1) (LLVM.and e e_2) ⊑
-    select e_2 (select e_1 (const? 1 1) e) (const? 1 0) := by 
+    select e_2 (select e_1 (const? 1 1) e) (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -173,7 +173,7 @@ theorem and_logic_and_logic_or_7_thm (e e_1 e_2 : IntW 1) :
 
 
 theorem and_logic_and_logic_or_8_thm (e e_1 e_2 : IntW 1) :
-  select (select e_2 e_1 (const? 1 0)) (const? 1 1) (LLVM.and e e_1) ⊑ LLVM.and e_1 (select e_2 (const? 1 1) e) := by 
+  select (select e_2 e_1 (const? 1 0)) (const? 1 1) (LLVM.and e e_1) ⊑ LLVM.and e_1 (select e_2 (const? 1 1) e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -183,7 +183,7 @@ theorem and_logic_and_logic_or_8_thm (e e_1 e_2 : IntW 1) :
 
 
 theorem and_and_logic_or_1_thm (e e_1 e_2 : IntW 1) :
-  select (LLVM.and e_2 e_1) (const? 1 1) (LLVM.and e_2 e) ⊑ LLVM.and e_2 (select e_1 (const? 1 1) e) := by 
+  select (LLVM.and e_2 e_1) (const? 1 1) (LLVM.and e_2 e) ⊑ LLVM.and e_2 (select e_1 (const? 1 1) e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -193,7 +193,7 @@ theorem and_and_logic_or_1_thm (e e_1 e_2 : IntW 1) :
 
 
 theorem and_and_logic_or_2_thm (e e_1 e_2 : IntW 1) :
-  select (LLVM.and e_2 e_1) (const? 1 1) (LLVM.and e e_2) ⊑ LLVM.and e_2 (select e_1 (const? 1 1) e) := by 
+  select (LLVM.and e_2 e_1) (const? 1 1) (LLVM.and e e_2) ⊑ LLVM.and e_2 (select e_1 (const? 1 1) e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -204,7 +204,7 @@ theorem and_and_logic_or_2_thm (e e_1 e_2 : IntW 1) :
 
 theorem logic_or_logic_and_1_thm (e e_1 e_2 : IntW 1) :
   select (select e_2 (const? 1 1) e_1) (select e_2 (const? 1 1) e) (const? 1 0) ⊑
-    select e_2 (const? 1 1) (select e_1 e (const? 1 0)) := by 
+    select e_2 (const? 1 1) (select e_1 e (const? 1 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -215,7 +215,7 @@ theorem logic_or_logic_and_1_thm (e e_1 e_2 : IntW 1) :
 
 theorem logic_or_logic_and_2_thm (e e_1 e_2 : IntW 1) :
   select (select e_2 (const? 1 1) e_1) (select e_1 (const? 1 1) e) (const? 1 0) ⊑
-    select e_1 (const? 1 1) (select e_2 e (const? 1 0)) := by 
+    select e_1 (const? 1 1) (select e_2 e (const? 1 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -226,7 +226,7 @@ theorem logic_or_logic_and_2_thm (e e_1 e_2 : IntW 1) :
 
 theorem logic_or_logic_and_3_thm (e e_1 e_2 : IntW 1) :
   select (select e_2 (const? 1 1) e_1) (select e (const? 1 1) e_1) (const? 1 0) ⊑
-    select (select e_2 e (const? 1 0)) (const? 1 1) e_1 := by 
+    select (select e_2 e (const? 1 0)) (const? 1 1) e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -237,7 +237,7 @@ theorem logic_or_logic_and_3_thm (e e_1 e_2 : IntW 1) :
 
 theorem logic_or_logic_and_4_thm (e e_1 e_2 : IntW 1) :
   select (select e_2 (const? 1 1) e_1) (select e (const? 1 1) e_2) (const? 1 0) ⊑
-    select e_2 (const? 1 1) (select e_1 e (const? 1 0)) := by 
+    select e_2 (const? 1 1) (select e_1 e (const? 1 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -248,7 +248,7 @@ theorem logic_or_logic_and_4_thm (e e_1 e_2 : IntW 1) :
 
 theorem logic_or_logic_and_5_thm (e e_1 e_2 : IntW 1) :
   select (select e_2 (const? 1 1) e_1) (select e_2 (const? 1 1) e) (const? 1 0) ⊑
-    select e_2 (const? 1 1) (select e_1 e (const? 1 0)) := by 
+    select e_2 (const? 1 1) (select e_1 e (const? 1 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -259,7 +259,7 @@ theorem logic_or_logic_and_5_thm (e e_1 e_2 : IntW 1) :
 
 theorem logic_or_logic_and_6_thm (e e_1 e_2 : IntW 1) :
   select (select e_2 (const? 1 1) e_1) (select e (const? 1 1) e_2) (const? 1 0) ⊑
-    select e_2 (const? 1 1) (select e_1 e (const? 1 0)) := by 
+    select e_2 (const? 1 1) (select e_1 e (const? 1 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -270,7 +270,7 @@ theorem logic_or_logic_and_6_thm (e e_1 e_2 : IntW 1) :
 
 theorem logic_or_logic_and_7_thm (e e_1 e_2 : IntW 1) :
   select (select e_2 (const? 1 1) e_1) (select e (const? 1 1) e_1) (const? 1 0) ⊑
-    select (select e_2 e (const? 1 0)) (const? 1 1) e_1 := by 
+    select (select e_2 e (const? 1 0)) (const? 1 1) e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -281,7 +281,7 @@ theorem logic_or_logic_and_7_thm (e e_1 e_2 : IntW 1) :
 
 theorem logic_or_logic_and_8_thm (e e_1 e_2 : IntW 1) :
   select (select e_2 (const? 1 1) e_1) (select e_1 (const? 1 1) e) (const? 1 0) ⊑
-    select e_1 (const? 1 1) (select e_2 e (const? 1 0)) := by 
+    select e_1 (const? 1 1) (select e_2 e (const? 1 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -292,7 +292,7 @@ theorem logic_or_logic_and_8_thm (e e_1 e_2 : IntW 1) :
 
 theorem or_logic_or_logic_and_1_thm (e e_1 e_2 : IntW 1) :
   select (LLVM.or e_2 e_1) (select e_2 (const? 1 1) e) (const? 1 0) ⊑
-    select e_2 (const? 1 1) (select e_1 e (const? 1 0)) := by 
+    select e_2 (const? 1 1) (select e_1 e (const? 1 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -303,7 +303,7 @@ theorem or_logic_or_logic_and_1_thm (e e_1 e_2 : IntW 1) :
 
 theorem or_logic_or_logic_and_2_thm (e e_1 e_2 : IntW 1) :
   select (LLVM.or e_2 e_1) (select e (const? 1 1) e_2) (const? 1 0) ⊑
-    select e_2 (const? 1 1) (select e_1 e (const? 1 0)) := by 
+    select e_2 (const? 1 1) (select e_1 e (const? 1 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -314,7 +314,7 @@ theorem or_logic_or_logic_and_2_thm (e e_1 e_2 : IntW 1) :
 
 theorem or_logic_or_logic_and_3_thm (e e_1 e_2 : IntW 1) :
   select (select e_2 (const? 1 1) e_1) (LLVM.or e_2 e) (const? 1 0) ⊑
-    select e_2 (const? 1 1) (select e_1 e (const? 1 0)) := by 
+    select e_2 (const? 1 1) (select e_1 e (const? 1 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -324,7 +324,7 @@ theorem or_logic_or_logic_and_3_thm (e e_1 e_2 : IntW 1) :
 
 
 theorem or_logic_or_logic_and_4_thm (e e_1 e_2 : IntW 1) :
-  select (select e_2 (const? 1 1) e_1) (LLVM.or e_1 e) (const? 1 0) ⊑ LLVM.or e_1 (select e_2 e (const? 1 0)) := by 
+  select (select e_2 (const? 1 1) e_1) (LLVM.or e_1 e) (const? 1 0) ⊑ LLVM.or e_1 (select e_2 e (const? 1 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -335,7 +335,7 @@ theorem or_logic_or_logic_and_4_thm (e e_1 e_2 : IntW 1) :
 
 theorem or_logic_or_logic_and_5_thm (e e_1 e_2 : IntW 1) :
   select (LLVM.or e_2 e_1) (select e_1 (const? 1 1) e) (const? 1 0) ⊑
-    select e_1 (const? 1 1) (select e_2 e (const? 1 0)) := by 
+    select e_1 (const? 1 1) (select e_2 e (const? 1 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -346,7 +346,7 @@ theorem or_logic_or_logic_and_5_thm (e e_1 e_2 : IntW 1) :
 
 theorem or_logic_or_logic_and_6_thm (e e_1 e_2 : IntW 1) :
   select (LLVM.or e_2 e_1) (select e (const? 1 1) e_1) (const? 1 0) ⊑
-    select e_1 (const? 1 1) (select e_2 e (const? 1 0)) := by 
+    select e_1 (const? 1 1) (select e_2 e (const? 1 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -357,7 +357,7 @@ theorem or_logic_or_logic_and_6_thm (e e_1 e_2 : IntW 1) :
 
 theorem or_logic_or_logic_and_7_thm (e e_1 e_2 : IntW 1) :
   select (select e_2 (const? 1 1) e_1) (LLVM.or e e_2) (const? 1 0) ⊑
-    select e_2 (const? 1 1) (select e_1 e (const? 1 0)) := by 
+    select e_2 (const? 1 1) (select e_1 e (const? 1 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -367,7 +367,7 @@ theorem or_logic_or_logic_and_7_thm (e e_1 e_2 : IntW 1) :
 
 
 theorem or_logic_or_logic_and_8_thm (e e_1 e_2 : IntW 1) :
-  select (select e_2 (const? 1 1) e_1) (LLVM.or e e_1) (const? 1 0) ⊑ LLVM.or e_1 (select e_2 e (const? 1 0)) := by 
+  select (select e_2 (const? 1 1) e_1) (LLVM.or e e_1) (const? 1 0) ⊑ LLVM.or e_1 (select e_2 e (const? 1 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -377,7 +377,7 @@ theorem or_logic_or_logic_and_8_thm (e e_1 e_2 : IntW 1) :
 
 
 theorem or_or_logic_and_1_thm (e e_1 e_2 : IntW 1) :
-  select (LLVM.or e_2 e_1) (LLVM.or e e_2) (const? 1 0) ⊑ LLVM.or e_2 (select e_1 e (const? 1 0)) := by 
+  select (LLVM.or e_2 e_1) (LLVM.or e e_2) (const? 1 0) ⊑ LLVM.or e_2 (select e_1 e (const? 1 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -387,7 +387,7 @@ theorem or_or_logic_and_1_thm (e e_1 e_2 : IntW 1) :
 
 
 theorem or_or_logic_and_2_thm (e e_1 e_2 : IntW 1) :
-  select (LLVM.or e_2 e_1) (LLVM.or e_1 e) (const? 1 0) ⊑ LLVM.or e_1 (select e_2 e (const? 1 0)) := by 
+  select (LLVM.or e_2 e_1) (LLVM.or e_1 e) (const? 1 0) ⊑ LLVM.or e_1 (select e_2 e (const? 1 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gselecthicmphand_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gselecthicmphand_proof.lean
@@ -10,7 +10,7 @@ set_option linter.unreachableTactic false
 section gselecthicmphand_proof
 theorem test5_thm (e : IntW 41) :
   select (icmp IntPredicate.ne (LLVM.and e (const? 41 32)) (const? 41 0)) (const? 41 32) (const? 41 0) ⊑
-    LLVM.and e (const? 41 32) := by 
+    LLVM.and e (const? 41 32) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -21,7 +21,7 @@ theorem test5_thm (e : IntW 41) :
 
 theorem test6_thm (e : IntW 1023) :
   select (icmp IntPredicate.ne (LLVM.and e (const? 1023 64)) (const? 1023 0)) (const? 1023 64) (const? 1023 0) ⊑
-    LLVM.and e (const? 1023 64) := by 
+    LLVM.and e (const? 1023 64) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -32,7 +32,7 @@ theorem test6_thm (e : IntW 1023) :
 
 theorem test35_thm (e : IntW 32) :
   select (icmp IntPredicate.sge e (const? 32 0)) (const? 32 60) (const? 32 100) ⊑
-    select (icmp IntPredicate.sgt e (const? 32 (-1))) (const? 32 60) (const? 32 100) := by 
+    select (icmp IntPredicate.sgt e (const? 32 (-1))) (const? 32 60) (const? 32 100) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -44,7 +44,7 @@ theorem test35_thm (e : IntW 32) :
 theorem test35_with_trunc_thm (e : IntW 64) :
   select (icmp IntPredicate.sge (trunc 32 e) (const? 32 0)) (const? 32 60) (const? 32 100) ⊑
     select (icmp IntPredicate.eq (LLVM.and e (const? 64 2147483648)) (const? 64 0)) (const? 32 60)
-      (const? 32 100) := by 
+      (const? 32 100) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -55,7 +55,7 @@ theorem test35_with_trunc_thm (e : IntW 64) :
 
 theorem test65_thm (e : IntW 64) :
   select (icmp IntPredicate.ne (LLVM.and e (const? 64 16)) (const? 64 0)) (const? 32 40) (const? 32 42) ⊑
-    select (icmp IntPredicate.eq (LLVM.and e (const? 64 16)) (const? 64 0)) (const? 32 42) (const? 32 40) := by 
+    select (icmp IntPredicate.eq (LLVM.and e (const? 64 16)) (const? 64 0)) (const? 32 42) (const? 32 40) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -67,7 +67,7 @@ theorem test65_thm (e : IntW 64) :
 theorem test66_thm (e : IntW 64) :
   select (icmp IntPredicate.ne (LLVM.and e (const? 64 4294967296)) (const? 64 0)) (const? 32 40) (const? 32 42) ⊑
     select (icmp IntPredicate.eq (LLVM.and e (const? 64 4294967296)) (const? 64 0)) (const? 32 42)
-      (const? 32 40) := by 
+      (const? 32 40) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -78,7 +78,7 @@ theorem test66_thm (e : IntW 64) :
 
 theorem test67_thm (e : IntW 16) :
   select (icmp IntPredicate.ne (LLVM.and e (const? 16 4)) (const? 16 0)) (const? 32 40) (const? 32 42) ⊑
-    select (icmp IntPredicate.eq (LLVM.and e (const? 16 4)) (const? 16 0)) (const? 32 42) (const? 32 40) := by 
+    select (icmp IntPredicate.eq (LLVM.and e (const? 16 4)) (const? 16 0)) (const? 32 42) (const? 32 40) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -89,7 +89,7 @@ theorem test67_thm (e : IntW 16) :
 
 theorem test71_thm (e : IntW 32) :
   select (icmp IntPredicate.ne (LLVM.and e (const? 32 128)) (const? 32 0)) (const? 32 40) (const? 32 42) ⊑
-    select (icmp IntPredicate.eq (LLVM.and e (const? 32 128)) (const? 32 0)) (const? 32 42) (const? 32 40) := by 
+    select (icmp IntPredicate.eq (LLVM.and e (const? 32 128)) (const? 32 0)) (const? 32 42) (const? 32 40) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -100,7 +100,7 @@ theorem test71_thm (e : IntW 32) :
 
 theorem test73_thm (e : IntW 32) :
   select (icmp IntPredicate.sgt (trunc 8 e) (const? 8 (-1))) (const? 32 40) (const? 32 42) ⊑
-    select (icmp IntPredicate.eq (LLVM.and e (const? 32 128)) (const? 32 0)) (const? 32 40) (const? 32 42) := by 
+    select (icmp IntPredicate.eq (LLVM.and e (const? 32 128)) (const? 32 0)) (const? 32 40) (const? 32 42) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -111,7 +111,7 @@ theorem test73_thm (e : IntW 32) :
 
 theorem test15a_thm (e : IntW 32) :
   select (icmp IntPredicate.eq (LLVM.and e (const? 32 16)) (const? 32 0)) (const? 32 0) (const? 32 16) ⊑
-    LLVM.and e (const? 32 16) := by 
+    LLVM.and e (const? 32 16) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -122,7 +122,7 @@ theorem test15a_thm (e : IntW 32) :
 
 theorem test15b_thm (e : IntW 32) :
   select (icmp IntPredicate.eq (LLVM.and e (const? 32 32)) (const? 32 0)) (const? 32 32) (const? 32 0) ⊑
-    LLVM.xor (LLVM.and e (const? 32 32)) (const? 32 32) := by 
+    LLVM.xor (LLVM.and e (const? 32 32)) (const? 32 32) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -133,7 +133,7 @@ theorem test15b_thm (e : IntW 32) :
 
 theorem test15c_thm (e : IntW 32) :
   select (icmp IntPredicate.eq (LLVM.and e (const? 32 16)) (const? 32 16)) (const? 32 16) (const? 32 0) ⊑
-    LLVM.and e (const? 32 16) := by 
+    LLVM.and e (const? 32 16) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -144,7 +144,7 @@ theorem test15c_thm (e : IntW 32) :
 
 theorem test15d_thm (e : IntW 32) :
   select (icmp IntPredicate.ne (LLVM.and e (const? 32 16)) (const? 32 0)) (const? 32 16) (const? 32 0) ⊑
-    LLVM.and e (const? 32 16) := by 
+    LLVM.and e (const? 32 16) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -155,7 +155,7 @@ theorem test15d_thm (e : IntW 32) :
 
 theorem test15e_thm (e : IntW 32) :
   select (icmp IntPredicate.ne (LLVM.and e (const? 32 128)) (const? 32 0)) (const? 32 256) (const? 32 0) ⊑
-    LLVM.and (shl e (const? 32 1)) (const? 32 256) := by 
+    LLVM.and (shl e (const? 32 1)) (const? 32 256) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -166,7 +166,7 @@ theorem test15e_thm (e : IntW 32) :
 
 theorem test15f_thm (e : IntW 32) :
   select (icmp IntPredicate.ne (LLVM.and e (const? 32 128)) (const? 32 0)) (const? 32 0) (const? 32 256) ⊑
-    LLVM.xor (LLVM.and (shl e (const? 32 1)) (const? 32 256)) (const? 32 256) := by 
+    LLVM.xor (LLVM.and (shl e (const? 32 1)) (const? 32 256)) (const? 32 256) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -177,7 +177,7 @@ theorem test15f_thm (e : IntW 32) :
 
 theorem test15g_thm (e : IntW 32) :
   select (icmp IntPredicate.ne (LLVM.and e (const? 32 8)) (const? 32 0)) (const? 32 (-1)) (const? 32 (-9)) ⊑
-    LLVM.or e (const? 32 (-9)) := by 
+    LLVM.or e (const? 32 (-9)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -188,7 +188,7 @@ theorem test15g_thm (e : IntW 32) :
 
 theorem test15h_thm (e : IntW 32) :
   select (icmp IntPredicate.ne (LLVM.and e (const? 32 8)) (const? 32 0)) (const? 32 (-9)) (const? 32 (-1)) ⊑
-    LLVM.xor (LLVM.and e (const? 32 8)) (const? 32 (-1)) := by 
+    LLVM.xor (LLVM.and e (const? 32 8)) (const? 32 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -199,7 +199,7 @@ theorem test15h_thm (e : IntW 32) :
 
 theorem test15i_thm (e : IntW 32) :
   select (icmp IntPredicate.ne (LLVM.and e (const? 32 2)) (const? 32 0)) (const? 32 577) (const? 32 1089) ⊑
-    select (icmp IntPredicate.eq (LLVM.and e (const? 32 2)) (const? 32 0)) (const? 32 1089) (const? 32 577) := by 
+    select (icmp IntPredicate.eq (LLVM.and e (const? 32 2)) (const? 32 0)) (const? 32 1089) (const? 32 577) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -210,7 +210,7 @@ theorem test15i_thm (e : IntW 32) :
 
 theorem test15j_thm (e : IntW 32) :
   select (icmp IntPredicate.ne (LLVM.and e (const? 32 2)) (const? 32 0)) (const? 32 1089) (const? 32 577) ⊑
-    select (icmp IntPredicate.eq (LLVM.and e (const? 32 2)) (const? 32 0)) (const? 32 577) (const? 32 1089) := by 
+    select (icmp IntPredicate.eq (LLVM.and e (const? 32 2)) (const? 32 0)) (const? 32 577) (const? 32 1089) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -221,7 +221,7 @@ theorem test15j_thm (e : IntW 32) :
 
 theorem clear_to_set_decomposebittest_thm (e : IntW 8) :
   select (icmp IntPredicate.sgt e (const? 8 (-1))) (const? 8 (-125)) (const? 8 3) ⊑
-    LLVM.xor (LLVM.and e (const? 8 (-128))) (const? 8 (-125)) := by 
+    LLVM.xor (LLVM.and e (const? 8 (-128))) (const? 8 (-125)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -232,7 +232,7 @@ theorem clear_to_set_decomposebittest_thm (e : IntW 8) :
 
 theorem clear_to_clear_decomposebittest_thm (e : IntW 8) :
   select (icmp IntPredicate.sgt e (const? 8 (-1))) (const? 8 3) (const? 8 (-125)) ⊑
-    LLVM.or (LLVM.and e (const? 8 (-128))) (const? 8 3) { «disjoint» := true } := by 
+    LLVM.or (LLVM.and e (const? 8 (-128))) (const? 8 3) { «disjoint» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -243,7 +243,7 @@ theorem clear_to_clear_decomposebittest_thm (e : IntW 8) :
 
 theorem set_to_set_decomposebittest_thm (e : IntW 8) :
   select (icmp IntPredicate.slt e (const? 8 0)) (const? 8 (-125)) (const? 8 3) ⊑
-    LLVM.or (LLVM.and e (const? 8 (-128))) (const? 8 3) { «disjoint» := true } := by 
+    LLVM.or (LLVM.and e (const? 8 (-128))) (const? 8 3) { «disjoint» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -254,7 +254,7 @@ theorem set_to_set_decomposebittest_thm (e : IntW 8) :
 
 theorem set_to_clear_decomposebittest_thm (e : IntW 8) :
   select (icmp IntPredicate.slt e (const? 8 0)) (const? 8 3) (const? 8 (-125)) ⊑
-    LLVM.xor (LLVM.and e (const? 8 (-128))) (const? 8 (-125)) := by 
+    LLVM.xor (LLVM.and e (const? 8 (-128))) (const? 8 (-125)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -265,7 +265,7 @@ theorem set_to_clear_decomposebittest_thm (e : IntW 8) :
 
 theorem select_bittest_to_add_thm (e : IntW 32) :
   select (icmp IntPredicate.eq (LLVM.and e (const? 32 1)) (const? 32 0)) (const? 32 3) (const? 32 4) ⊑
-    add (LLVM.and e (const? 32 1)) (const? 32 3) { «nsw» := true, «nuw» := true } := by 
+    add (LLVM.and e (const? 32 1)) (const? 32 3) { «nsw» := true, «nuw» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -276,7 +276,7 @@ theorem select_bittest_to_add_thm (e : IntW 32) :
 
 theorem select_bittest_to_sub_thm (e : IntW 32) :
   select (icmp IntPredicate.eq (LLVM.and e (const? 32 1)) (const? 32 0)) (const? 32 4) (const? 32 3) ⊑
-    sub (const? 32 4) (LLVM.and e (const? 32 1)) { «nsw» := true, «nuw» := true } := by 
+    sub (const? 32 4) (LLVM.and e (const? 32 1)) { «nsw» := true, «nuw» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -288,7 +288,7 @@ theorem select_bittest_to_sub_thm (e : IntW 32) :
 theorem select_bittest_to_shl_negative_test_thm (e : IntW 32) :
   add (select (icmp IntPredicate.eq (LLVM.and e (const? 32 1)) (const? 32 0)) (const? 32 2) (const? 32 4)) (const? 32 2)
       { «nsw» := true, «nuw» := true } ⊑
-    select (icmp IntPredicate.eq (LLVM.and e (const? 32 1)) (const? 32 0)) (const? 32 4) (const? 32 6) := by 
+    select (icmp IntPredicate.eq (LLVM.and e (const? 32 1)) (const? 32 0)) (const? 32 4) (const? 32 6) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gselecthicmphandhzerohshl_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gselecthicmphandhzerohshl_proof.lean
@@ -10,7 +10,7 @@ set_option linter.unreachableTactic false
 section gselecthicmphandhzerohshl_proof
 theorem test_eq_thm (e : IntW 32) :
   select (icmp IntPredicate.eq (LLVM.and e (const? 32 1073741823)) (const? 32 0)) (const? 32 0) (shl e (const? 32 2)) ⊑
-    shl e (const? 32 2) := by 
+    shl e (const? 32 2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -21,7 +21,7 @@ theorem test_eq_thm (e : IntW 32) :
 
 theorem test_ne_thm (e : IntW 32) :
   select (icmp IntPredicate.ne (LLVM.and e (const? 32 1073741823)) (const? 32 0)) (shl e (const? 32 2)) (const? 32 0) ⊑
-    shl e (const? 32 2) := by 
+    shl e (const? 32 2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -33,7 +33,7 @@ theorem test_ne_thm (e : IntW 32) :
 theorem test_nuw_dropped_thm (e : IntW 32) :
   select (icmp IntPredicate.eq (LLVM.and e (const? 32 1073741823)) (const? 32 0)) (const? 32 0)
       (shl e (const? 32 2) { «nsw» := false, «nuw» := true }) ⊑
-    shl e (const? 32 2) := by 
+    shl e (const? 32 2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -45,7 +45,7 @@ theorem test_nuw_dropped_thm (e : IntW 32) :
 theorem test_nsw_dropped_thm (e : IntW 32) :
   select (icmp IntPredicate.eq (LLVM.and e (const? 32 1073741823)) (const? 32 0)) (const? 32 0)
       (shl e (const? 32 2) { «nsw» := true, «nuw» := false }) ⊑
-    shl e (const? 32 2) := by 
+    shl e (const? 32 2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -56,7 +56,7 @@ theorem test_nsw_dropped_thm (e : IntW 32) :
 
 theorem neg_test_icmp_non_equality_thm (e : IntW 32) :
   select (icmp IntPredicate.slt (LLVM.and e (const? 32 1073741823)) (const? 32 0)) (const? 32 0) (shl e (const? 32 2)) ⊑
-    shl e (const? 32 2) := by 
+    shl e (const? 32 2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gselecthicmphxor_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gselecthicmphxor_proof.lean
@@ -10,7 +10,7 @@ set_option linter.unreachableTactic false
 section gselecthicmphxor_proof
 theorem select_icmp_eq_pow2_thm (e : IntW 8) :
   select (icmp IntPredicate.eq (LLVM.and e (const? 8 4)) (const? 8 0)) e (LLVM.xor e (const? 8 4)) ⊑
-    LLVM.and e (const? 8 (-5)) := by 
+    LLVM.and e (const? 8 (-5)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -21,7 +21,7 @@ theorem select_icmp_eq_pow2_thm (e : IntW 8) :
 
 theorem select_icmp_eq_pow2_flipped_thm (e : IntW 8) :
   select (icmp IntPredicate.eq (LLVM.and e (const? 8 4)) (const? 8 0)) (LLVM.xor e (const? 8 4)) e ⊑
-    LLVM.or e (const? 8 4) := by 
+    LLVM.or e (const? 8 4) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -32,7 +32,7 @@ theorem select_icmp_eq_pow2_flipped_thm (e : IntW 8) :
 
 theorem select_icmp_ne_pow2_thm (e : IntW 8) :
   select (icmp IntPredicate.ne (LLVM.and e (const? 8 4)) (const? 8 0)) (LLVM.xor e (const? 8 4)) e ⊑
-    LLVM.and e (const? 8 (-5)) := by 
+    LLVM.and e (const? 8 (-5)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -43,7 +43,7 @@ theorem select_icmp_ne_pow2_thm (e : IntW 8) :
 
 theorem select_icmp_ne_pow2_flipped_thm (e : IntW 8) :
   select (icmp IntPredicate.ne (LLVM.and e (const? 8 4)) (const? 8 0)) e (LLVM.xor e (const? 8 4)) ⊑
-    LLVM.or e (const? 8 4) := by 
+    LLVM.or e (const? 8 4) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -54,7 +54,7 @@ theorem select_icmp_ne_pow2_flipped_thm (e : IntW 8) :
 
 theorem select_icmp_ne_not_pow2_thm (e : IntW 8) :
   select (icmp IntPredicate.ne (LLVM.and e (const? 8 5)) (const? 8 0)) (LLVM.xor e (const? 8 5)) e ⊑
-    select (icmp IntPredicate.eq (LLVM.and e (const? 8 5)) (const? 8 0)) e (LLVM.xor e (const? 8 5)) := by 
+    select (icmp IntPredicate.eq (LLVM.and e (const? 8 5)) (const? 8 0)) e (LLVM.xor e (const? 8 5)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -64,7 +64,7 @@ theorem select_icmp_ne_not_pow2_thm (e : IntW 8) :
 
 
 theorem select_icmp_slt_zero_smin_thm (e : IntW 8) :
-  select (icmp IntPredicate.slt e (const? 8 0)) e (LLVM.xor e (const? 8 (-128))) ⊑ LLVM.or e (const? 8 (-128)) := by 
+  select (icmp IntPredicate.slt e (const? 8 0)) e (LLVM.xor e (const? 8 (-128))) ⊑ LLVM.or e (const? 8 (-128)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -74,7 +74,7 @@ theorem select_icmp_slt_zero_smin_thm (e : IntW 8) :
 
 
 theorem select_icmp_slt_zero_smin_flipped_thm (e : IntW 8) :
-  select (icmp IntPredicate.slt e (const? 8 0)) (LLVM.xor e (const? 8 (-128))) e ⊑ LLVM.and e (const? 8 127) := by 
+  select (icmp IntPredicate.slt e (const? 8 0)) (LLVM.xor e (const? 8 (-128))) e ⊑ LLVM.and e (const? 8 127) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -84,7 +84,7 @@ theorem select_icmp_slt_zero_smin_flipped_thm (e : IntW 8) :
 
 
 theorem select_icmp_sgt_allones_smin_thm (e : IntW 8) :
-  select (icmp IntPredicate.sgt e (const? 8 (-1))) e (LLVM.xor e (const? 8 (-128))) ⊑ LLVM.and e (const? 8 127) := by 
+  select (icmp IntPredicate.sgt e (const? 8 (-1))) e (LLVM.xor e (const? 8 (-128))) ⊑ LLVM.and e (const? 8 127) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -95,7 +95,7 @@ theorem select_icmp_sgt_allones_smin_thm (e : IntW 8) :
 
 theorem select_icmp_sgt_allones_smin_flipped_thm (e : IntW 8) :
   select (icmp IntPredicate.sgt e (const? 8 (-1))) (LLVM.xor e (const? 8 (-128))) e ⊑
-    LLVM.or e (const? 8 (-128)) := by 
+    LLVM.or e (const? 8 (-128)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -106,7 +106,7 @@ theorem select_icmp_sgt_allones_smin_flipped_thm (e : IntW 8) :
 
 theorem select_icmp_sgt_not_smin_thm (e : IntW 8) :
   select (icmp IntPredicate.sgt e (const? 8 (-1))) e (LLVM.xor e (const? 8 (-127))) ⊑
-    select (icmp IntPredicate.slt e (const? 8 0)) (LLVM.xor e (const? 8 (-127))) e := by 
+    select (icmp IntPredicate.slt e (const? 8 0)) (LLVM.xor e (const? 8 (-127))) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gselecthimmhcanon_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gselecthimmhcanon_proof.lean
@@ -10,7 +10,7 @@ set_option linter.unreachableTactic false
 section gselecthimmhcanon_proof
 theorem thisdoesnotloop_thm (e e_1 : IntW 32) :
   trunc 8 (select (icmp IntPredicate.slt e_1 (const? 32 (-128))) (const? 32 128) e) ⊑
-    select (icmp IntPredicate.slt e_1 (const? 32 (-128))) (const? 8 (-128)) (trunc 8 e) := by 
+    select (icmp IntPredicate.slt e_1 (const? 32 (-128))) (const? 8 (-128)) (trunc 8 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gselecthobohpeohops_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gselecthobohpeohops_proof.lean
@@ -11,7 +11,7 @@ section gselecthobohpeohops_proof
 theorem test_shl_nuw_nsw__all_are_safe_thm (e : IntW 64) (e_1 : IntW 32) :
   select (icmp IntPredicate.eq (LLVM.and e_1 (const? 32 15)) (const? 32 0)) e
       (ashr e (zext 64 (shl (LLVM.and e_1 (const? 32 15)) (const? 32 2) { «nsw» := true, «nuw» := true }))) ⊑
-    ashr e (zext 64 (LLVM.and (shl e_1 (const? 32 2)) (const? 32 60)) { «nneg» := true }) := by 
+    ashr e (zext 64 (LLVM.and (shl e_1 (const? 32 2)) (const? 32 60)) { «nneg» := true }) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -23,7 +23,7 @@ theorem test_shl_nuw_nsw__all_are_safe_thm (e : IntW 64) (e_1 : IntW 32) :
 theorem test_shl_nuw__all_are_safe_thm (e : IntW 64) (e_1 : IntW 32) :
   select (icmp IntPredicate.eq (LLVM.and e_1 (const? 32 15)) (const? 32 0)) e
       (ashr e (zext 64 (shl (LLVM.and e_1 (const? 32 15)) (const? 32 2) { «nsw» := false, «nuw» := true }))) ⊑
-    ashr e (zext 64 (LLVM.and (shl e_1 (const? 32 2)) (const? 32 60)) { «nneg» := true }) := by 
+    ashr e (zext 64 (LLVM.and (shl e_1 (const? 32 2)) (const? 32 60)) { «nneg» := true }) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -35,7 +35,7 @@ theorem test_shl_nuw__all_are_safe_thm (e : IntW 64) (e_1 : IntW 32) :
 theorem test_shl_nsw__all_are_safe_thm (e : IntW 64) (e_1 : IntW 32) :
   select (icmp IntPredicate.eq (LLVM.and e_1 (const? 32 15)) (const? 32 0)) e
       (ashr e (zext 64 (shl (LLVM.and e_1 (const? 32 15)) (const? 32 2) { «nsw» := true, «nuw» := false }))) ⊑
-    ashr e (zext 64 (LLVM.and (shl e_1 (const? 32 2)) (const? 32 60)) { «nneg» := true }) := by 
+    ashr e (zext 64 (LLVM.and (shl e_1 (const? 32 2)) (const? 32 60)) { «nneg» := true }) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -47,7 +47,7 @@ theorem test_shl_nsw__all_are_safe_thm (e : IntW 64) (e_1 : IntW 32) :
 theorem test_shl__all_are_safe_thm (e : IntW 64) (e_1 : IntW 32) :
   select (icmp IntPredicate.eq (LLVM.and e_1 (const? 32 15)) (const? 32 0)) e
       (ashr e (zext 64 (shl (LLVM.and e_1 (const? 32 15)) (const? 32 2)))) ⊑
-    ashr e (zext 64 (LLVM.and (shl e_1 (const? 32 2)) (const? 32 60)) { «nneg» := true }) := by 
+    ashr e (zext 64 (LLVM.and (shl e_1 (const? 32 2)) (const? 32 60)) { «nneg» := true }) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -59,7 +59,7 @@ theorem test_shl__all_are_safe_thm (e : IntW 64) (e_1 : IntW 32) :
 theorem test_shl_nuw_nsw__nuw_is_safe_thm (e : IntW 64) (e_1 : IntW 32) :
   select (icmp IntPredicate.eq (LLVM.and e_1 (const? 32 1073741822)) (const? 32 0)) e
       (ashr e (zext 64 (shl (LLVM.and e_1 (const? 32 1073741822)) (const? 32 2) { «nsw» := true, «nuw» := true }))) ⊑
-    ashr e (zext 64 (LLVM.and (shl e_1 (const? 32 2)) (const? 32 (-8))) { «nneg» := true }) := by 
+    ashr e (zext 64 (LLVM.and (shl e_1 (const? 32 2)) (const? 32 (-8))) { «nneg» := true }) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -71,7 +71,7 @@ theorem test_shl_nuw_nsw__nuw_is_safe_thm (e : IntW 64) (e_1 : IntW 32) :
 theorem test_shl_nuw__nuw_is_safe_thm (e : IntW 64) (e_1 : IntW 32) :
   select (icmp IntPredicate.eq (LLVM.and e_1 (const? 32 1073741822)) (const? 32 0)) e
       (ashr e (zext 64 (shl (LLVM.and e_1 (const? 32 1073741822)) (const? 32 2) { «nsw» := false, «nuw» := true }))) ⊑
-    ashr e (zext 64 (LLVM.and (shl e_1 (const? 32 2)) (const? 32 (-8))) { «nneg» := true }) := by 
+    ashr e (zext 64 (LLVM.and (shl e_1 (const? 32 2)) (const? 32 (-8))) { «nneg» := true }) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -83,7 +83,7 @@ theorem test_shl_nuw__nuw_is_safe_thm (e : IntW 64) (e_1 : IntW 32) :
 theorem test_shl_nsw__nuw_is_safe_thm (e : IntW 64) (e_1 : IntW 32) :
   select (icmp IntPredicate.eq (LLVM.and e_1 (const? 32 1073741822)) (const? 32 0)) e
       (ashr e (zext 64 (shl (LLVM.and e_1 (const? 32 1073741822)) (const? 32 2) { «nsw» := true, «nuw» := false }))) ⊑
-    ashr e (zext 64 (LLVM.and (shl e_1 (const? 32 2)) (const? 32 (-8))) { «nneg» := true }) := by 
+    ashr e (zext 64 (LLVM.and (shl e_1 (const? 32 2)) (const? 32 (-8))) { «nneg» := true }) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -95,7 +95,7 @@ theorem test_shl_nsw__nuw_is_safe_thm (e : IntW 64) (e_1 : IntW 32) :
 theorem test_shl__nuw_is_safe_thm (e : IntW 64) (e_1 : IntW 32) :
   select (icmp IntPredicate.eq (LLVM.and e_1 (const? 32 1073741822)) (const? 32 0)) e
       (ashr e (zext 64 (shl (LLVM.and e_1 (const? 32 1073741822)) (const? 32 2)))) ⊑
-    ashr e (zext 64 (LLVM.and (shl e_1 (const? 32 2)) (const? 32 (-8))) { «nneg» := true }) := by 
+    ashr e (zext 64 (LLVM.and (shl e_1 (const? 32 2)) (const? 32 (-8))) { «nneg» := true }) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -112,7 +112,7 @@ theorem test_shl_nuw_nsw__nsw_is_safe_thm (e : IntW 32) :
           (shl (LLVM.or e (const? 32 (-83886080))) (const? 32 2) { «nsw» := true, «nuw» := true }))
         (LLVM.or e (const? 32 (-83886080))))
       (shl (LLVM.or e (const? 32 (-83886080))) (const? 32 2) { «nsw» := true, «nuw» := true }) ⊑
-    const? 32 0 := by 
+    const? 32 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -129,7 +129,7 @@ theorem test_shl_nuw__nsw_is_safe_thm (e : IntW 32) :
           (shl (LLVM.or e (const? 32 (-83886080))) (const? 32 2) { «nsw» := false, «nuw» := true }))
         (LLVM.or e (const? 32 (-83886080))))
       (shl (LLVM.or e (const? 32 (-83886080))) (const? 32 2) { «nsw» := false, «nuw» := true }) ⊑
-    const? 32 0 := by 
+    const? 32 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -149,7 +149,7 @@ theorem test_shl_nsw__nsw_is_safe_thm (e : IntW 32) :
     mul
       (mul (shl (LLVM.or e (const? 32 (-83886080))) (const? 32 2) { «nsw» := true, «nuw» := false })
         (LLVM.or e (const? 32 (-83886080))))
-      (shl (LLVM.or e (const? 32 (-83886080))) (const? 32 2) { «nsw» := true, «nuw» := false }) := by 
+      (shl (LLVM.or e (const? 32 (-83886080))) (const? 32 2) { «nsw» := true, «nuw» := false }) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -168,7 +168,7 @@ theorem test_shl__nsw_is_safe_thm (e : IntW 32) :
     mul
       (mul (shl (LLVM.or e (const? 32 (-83886080))) (const? 32 2) { «nsw» := true, «nuw» := false })
         (LLVM.or e (const? 32 (-83886080))))
-      (shl (LLVM.or e (const? 32 (-83886080))) (const? 32 2) { «nsw» := true, «nuw» := false }) := by 
+      (shl (LLVM.or e (const? 32 (-83886080))) (const? 32 2) { «nsw» := true, «nuw» := false }) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -180,7 +180,7 @@ theorem test_shl__nsw_is_safe_thm (e : IntW 32) :
 theorem test_shl_nuw_nsw__none_are_safe_thm (e : IntW 64) (e_1 : IntW 32) :
   select (icmp IntPredicate.eq (LLVM.and e_1 (const? 32 (-2))) (const? 32 0)) e
       (ashr e (zext 64 (shl (LLVM.and e_1 (const? 32 (-2))) (const? 32 2) { «nsw» := true, «nuw» := true }))) ⊑
-    ashr e (zext 64 (LLVM.and (shl e_1 (const? 32 2)) (const? 32 (-8))) { «nneg» := true }) := by 
+    ashr e (zext 64 (LLVM.and (shl e_1 (const? 32 2)) (const? 32 (-8))) { «nneg» := true }) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -192,7 +192,7 @@ theorem test_shl_nuw_nsw__none_are_safe_thm (e : IntW 64) (e_1 : IntW 32) :
 theorem test_shl_nuw__none_are_safe_thm (e : IntW 64) (e_1 : IntW 32) :
   select (icmp IntPredicate.eq (LLVM.and e_1 (const? 32 (-2))) (const? 32 0)) e
       (ashr e (zext 64 (shl (LLVM.and e_1 (const? 32 (-2))) (const? 32 2) { «nsw» := false, «nuw» := true }))) ⊑
-    ashr e (zext 64 (LLVM.and (shl e_1 (const? 32 2)) (const? 32 (-8))) { «nneg» := true }) := by 
+    ashr e (zext 64 (LLVM.and (shl e_1 (const? 32 2)) (const? 32 (-8))) { «nneg» := true }) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -204,7 +204,7 @@ theorem test_shl_nuw__none_are_safe_thm (e : IntW 64) (e_1 : IntW 32) :
 theorem test_shl_nsw__none_are_safe_thm (e : IntW 64) (e_1 : IntW 32) :
   select (icmp IntPredicate.eq (LLVM.and e_1 (const? 32 (-2))) (const? 32 0)) e
       (ashr e (zext 64 (shl (LLVM.and e_1 (const? 32 (-2))) (const? 32 2) { «nsw» := true, «nuw» := false }))) ⊑
-    ashr e (zext 64 (LLVM.and (shl e_1 (const? 32 2)) (const? 32 (-8))) { «nneg» := true }) := by 
+    ashr e (zext 64 (LLVM.and (shl e_1 (const? 32 2)) (const? 32 (-8))) { «nneg» := true }) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -216,7 +216,7 @@ theorem test_shl_nsw__none_are_safe_thm (e : IntW 64) (e_1 : IntW 32) :
 theorem test_shl__none_are_safe_thm (e : IntW 64) (e_1 : IntW 32) :
   select (icmp IntPredicate.eq (LLVM.and e_1 (const? 32 (-2))) (const? 32 0)) e
       (ashr e (zext 64 (shl (LLVM.and e_1 (const? 32 (-2))) (const? 32 2)))) ⊑
-    ashr e (zext 64 (LLVM.and (shl e_1 (const? 32 2)) (const? 32 (-8))) { «nneg» := true }) := by 
+    ashr e (zext 64 (LLVM.and (shl e_1 (const? 32 2)) (const? 32 (-8))) { «nneg» := true }) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -228,7 +228,7 @@ theorem test_shl__none_are_safe_thm (e : IntW 64) (e_1 : IntW 32) :
 theorem test_lshr_exact__exact_is_safe_thm (e : IntW 64) (e_1 : IntW 32) :
   select (icmp IntPredicate.eq (LLVM.and e_1 (const? 32 60)) (const? 32 0)) e
       (ashr e (zext 64 (lshr (LLVM.and e_1 (const? 32 60)) (const? 32 2) { «exact» := true }))) ⊑
-    ashr e (zext 64 (LLVM.and (lshr e_1 (const? 32 2)) (const? 32 15)) { «nneg» := true }) := by 
+    ashr e (zext 64 (LLVM.and (lshr e_1 (const? 32 2)) (const? 32 15)) { «nneg» := true }) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -240,7 +240,7 @@ theorem test_lshr_exact__exact_is_safe_thm (e : IntW 64) (e_1 : IntW 32) :
 theorem test_lshr__exact_is_safe_thm (e : IntW 64) (e_1 : IntW 32) :
   select (icmp IntPredicate.eq (LLVM.and e_1 (const? 32 60)) (const? 32 0)) e
       (ashr e (zext 64 (lshr (LLVM.and e_1 (const? 32 60)) (const? 32 2)))) ⊑
-    ashr e (zext 64 (LLVM.and (lshr e_1 (const? 32 2)) (const? 32 15)) { «nneg» := true }) := by 
+    ashr e (zext 64 (LLVM.and (lshr e_1 (const? 32 2)) (const? 32 15)) { «nneg» := true }) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -252,7 +252,7 @@ theorem test_lshr__exact_is_safe_thm (e : IntW 64) (e_1 : IntW 32) :
 theorem test_lshr_exact__exact_is_unsafe_thm (e : IntW 64) (e_1 : IntW 32) :
   select (icmp IntPredicate.eq (LLVM.and e_1 (const? 32 63)) (const? 32 0)) e
       (ashr e (zext 64 (lshr (LLVM.and e_1 (const? 32 63)) (const? 32 2) { «exact» := true }))) ⊑
-    ashr e (zext 64 (LLVM.and (lshr e_1 (const? 32 2)) (const? 32 15)) { «nneg» := true }) := by 
+    ashr e (zext 64 (LLVM.and (lshr e_1 (const? 32 2)) (const? 32 15)) { «nneg» := true }) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -264,7 +264,7 @@ theorem test_lshr_exact__exact_is_unsafe_thm (e : IntW 64) (e_1 : IntW 32) :
 theorem test_lshr__exact_is_unsafe_thm (e : IntW 64) (e_1 : IntW 32) :
   select (icmp IntPredicate.eq (LLVM.and e_1 (const? 32 63)) (const? 32 0)) e
       (ashr e (zext 64 (lshr (LLVM.and e_1 (const? 32 63)) (const? 32 2)))) ⊑
-    ashr e (zext 64 (LLVM.and (lshr e_1 (const? 32 2)) (const? 32 15)) { «nneg» := true }) := by 
+    ashr e (zext 64 (LLVM.and (lshr e_1 (const? 32 2)) (const? 32 15)) { «nneg» := true }) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -276,7 +276,7 @@ theorem test_lshr__exact_is_unsafe_thm (e : IntW 64) (e_1 : IntW 32) :
 theorem test_ashr_exact__exact_is_safe_thm (e : IntW 64) (e_1 : IntW 32) :
   select (icmp IntPredicate.eq (LLVM.and e_1 (const? 32 (-2147483588))) (const? 32 0)) e
       (ashr e (zext 64 (ashr (LLVM.and e_1 (const? 32 (-2147483588))) (const? 32 2) { «exact» := true }))) ⊑
-    ashr e (zext 64 (LLVM.and (ashr e_1 (const? 32 2)) (const? 32 (-536870897))) { «nneg» := true }) := by 
+    ashr e (zext 64 (LLVM.and (ashr e_1 (const? 32 2)) (const? 32 (-536870897))) { «nneg» := true }) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -288,7 +288,7 @@ theorem test_ashr_exact__exact_is_safe_thm (e : IntW 64) (e_1 : IntW 32) :
 theorem test_ashr__exact_is_safe_thm (e : IntW 64) (e_1 : IntW 32) :
   select (icmp IntPredicate.eq (LLVM.and e_1 (const? 32 (-2147483588))) (const? 32 0)) e
       (ashr e (zext 64 (ashr (LLVM.and e_1 (const? 32 (-2147483588))) (const? 32 2)))) ⊑
-    ashr e (zext 64 (LLVM.and (ashr e_1 (const? 32 2)) (const? 32 (-536870897))) { «nneg» := true }) := by 
+    ashr e (zext 64 (LLVM.and (ashr e_1 (const? 32 2)) (const? 32 (-536870897))) { «nneg» := true }) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -300,7 +300,7 @@ theorem test_ashr__exact_is_safe_thm (e : IntW 64) (e_1 : IntW 32) :
 theorem test_ashr_exact__exact_is_unsafe_thm (e : IntW 64) (e_1 : IntW 32) :
   select (icmp IntPredicate.eq (LLVM.and e_1 (const? 32 (-2147483585))) (const? 32 0)) e
       (ashr e (zext 64 (ashr (LLVM.and e_1 (const? 32 (-2147483585))) (const? 32 2) { «exact» := true }))) ⊑
-    ashr e (zext 64 (LLVM.and (ashr e_1 (const? 32 2)) (const? 32 (-536870897))) { «nneg» := true }) := by 
+    ashr e (zext 64 (LLVM.and (ashr e_1 (const? 32 2)) (const? 32 (-536870897))) { «nneg» := true }) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -312,7 +312,7 @@ theorem test_ashr_exact__exact_is_unsafe_thm (e : IntW 64) (e_1 : IntW 32) :
 theorem test_ashr__exact_is_unsafe_thm (e : IntW 64) (e_1 : IntW 32) :
   select (icmp IntPredicate.eq (LLVM.and e_1 (const? 32 (-2147483585))) (const? 32 0)) e
       (ashr e (zext 64 (ashr (LLVM.and e_1 (const? 32 (-2147483585))) (const? 32 2)))) ⊑
-    ashr e (zext 64 (LLVM.and (ashr e_1 (const? 32 2)) (const? 32 (-536870897))) { «nneg» := true }) := by 
+    ashr e (zext 64 (LLVM.and (ashr e_1 (const? 32 2)) (const? 32 (-536870897))) { «nneg» := true }) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -324,7 +324,7 @@ theorem test_ashr__exact_is_unsafe_thm (e : IntW 64) (e_1 : IntW 32) :
 theorem test_add_nuw_nsw__all_are_safe_thm (e : IntW 32) :
   select (icmp IntPredicate.eq (LLVM.and e (const? 32 1073741823)) (const? 32 3)) (const? 32 4)
       (add (LLVM.and e (const? 32 1073741823)) (const? 32 1) { «nsw» := true, «nuw» := true }) ⊑
-    add (LLVM.and e (const? 32 1073741823)) (const? 32 1) { «nsw» := true, «nuw» := true } := by 
+    add (LLVM.and e (const? 32 1073741823)) (const? 32 1) { «nsw» := true, «nuw» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -336,7 +336,7 @@ theorem test_add_nuw_nsw__all_are_safe_thm (e : IntW 32) :
 theorem test_add_nuw__all_are_safe_thm (e : IntW 32) :
   select (icmp IntPredicate.eq (LLVM.and e (const? 32 1073741823)) (const? 32 3)) (const? 32 4)
       (add (LLVM.and e (const? 32 1073741823)) (const? 32 1) { «nsw» := false, «nuw» := true }) ⊑
-    add (LLVM.and e (const? 32 1073741823)) (const? 32 1) { «nsw» := true, «nuw» := true } := by 
+    add (LLVM.and e (const? 32 1073741823)) (const? 32 1) { «nsw» := true, «nuw» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -348,7 +348,7 @@ theorem test_add_nuw__all_are_safe_thm (e : IntW 32) :
 theorem test_add_nsw__all_are_safe_thm (e : IntW 32) :
   select (icmp IntPredicate.eq (LLVM.and e (const? 32 1073741823)) (const? 32 3)) (const? 32 4)
       (add (LLVM.and e (const? 32 1073741823)) (const? 32 1) { «nsw» := true, «nuw» := false }) ⊑
-    add (LLVM.and e (const? 32 1073741823)) (const? 32 1) { «nsw» := true, «nuw» := true } := by 
+    add (LLVM.and e (const? 32 1073741823)) (const? 32 1) { «nsw» := true, «nuw» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -360,7 +360,7 @@ theorem test_add_nsw__all_are_safe_thm (e : IntW 32) :
 theorem test_add__all_are_safe_thm (e : IntW 32) :
   select (icmp IntPredicate.eq (LLVM.and e (const? 32 1073741823)) (const? 32 3)) (const? 32 4)
       (add (LLVM.and e (const? 32 1073741823)) (const? 32 1)) ⊑
-    add (LLVM.and e (const? 32 1073741823)) (const? 32 1) { «nsw» := true, «nuw» := true } := by 
+    add (LLVM.and e (const? 32 1073741823)) (const? 32 1) { «nsw» := true, «nuw» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -372,7 +372,7 @@ theorem test_add__all_are_safe_thm (e : IntW 32) :
 theorem test_add_nuw_nsw__nuw_is_safe_thm (e : IntW 32) :
   select (icmp IntPredicate.eq (LLVM.and e (const? 32 2147483647)) (const? 32 2147483647)) (const? 32 (-2147483648))
       (add (LLVM.and e (const? 32 2147483647)) (const? 32 1) { «nsw» := true, «nuw» := true }) ⊑
-    add (LLVM.and e (const? 32 2147483647)) (const? 32 1) { «nsw» := false, «nuw» := true } := by 
+    add (LLVM.and e (const? 32 2147483647)) (const? 32 1) { «nsw» := false, «nuw» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -384,7 +384,7 @@ theorem test_add_nuw_nsw__nuw_is_safe_thm (e : IntW 32) :
 theorem test_add_nuw__nuw_is_safe_thm (e : IntW 32) :
   select (icmp IntPredicate.eq (LLVM.and e (const? 32 2147483647)) (const? 32 2147483647)) (const? 32 (-2147483648))
       (add (LLVM.and e (const? 32 2147483647)) (const? 32 1) { «nsw» := false, «nuw» := true }) ⊑
-    add (LLVM.and e (const? 32 2147483647)) (const? 32 1) { «nsw» := false, «nuw» := true } := by 
+    add (LLVM.and e (const? 32 2147483647)) (const? 32 1) { «nsw» := false, «nuw» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -396,7 +396,7 @@ theorem test_add_nuw__nuw_is_safe_thm (e : IntW 32) :
 theorem test_add_nsw__nuw_is_safe_thm (e : IntW 32) :
   select (icmp IntPredicate.eq (LLVM.and e (const? 32 2147483647)) (const? 32 2147483647)) (const? 32 (-2147483648))
       (add (LLVM.and e (const? 32 2147483647)) (const? 32 1) { «nsw» := true, «nuw» := false }) ⊑
-    add (LLVM.and e (const? 32 2147483647)) (const? 32 1) { «nsw» := false, «nuw» := true } := by 
+    add (LLVM.and e (const? 32 2147483647)) (const? 32 1) { «nsw» := false, «nuw» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -408,7 +408,7 @@ theorem test_add_nsw__nuw_is_safe_thm (e : IntW 32) :
 theorem test_add__nuw_is_safe_thm (e : IntW 32) :
   select (icmp IntPredicate.eq (LLVM.and e (const? 32 2147483647)) (const? 32 2147483647)) (const? 32 (-2147483648))
       (add (LLVM.and e (const? 32 2147483647)) (const? 32 1)) ⊑
-    add (LLVM.and e (const? 32 2147483647)) (const? 32 1) { «nsw» := false, «nuw» := true } := by 
+    add (LLVM.and e (const? 32 2147483647)) (const? 32 1) { «nsw» := false, «nuw» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -420,7 +420,7 @@ theorem test_add__nuw_is_safe_thm (e : IntW 32) :
 theorem test_add_nuw_nsw__nsw_is_safe_thm (e : IntW 32) :
   select (icmp IntPredicate.eq (LLVM.or e (const? 32 (-2147483648))) (const? 32 (-1))) (const? 32 0)
       (add (LLVM.or e (const? 32 (-2147483648))) (const? 32 1) { «nsw» := true, «nuw» := true }) ⊑
-    add (LLVM.or e (const? 32 (-2147483648))) (const? 32 1) { «nsw» := true, «nuw» := false } := by 
+    add (LLVM.or e (const? 32 (-2147483648))) (const? 32 1) { «nsw» := true, «nuw» := false } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -432,7 +432,7 @@ theorem test_add_nuw_nsw__nsw_is_safe_thm (e : IntW 32) :
 theorem test_add_nuw__nsw_is_safe_thm (e : IntW 32) :
   select (icmp IntPredicate.eq (LLVM.or e (const? 32 (-2147483648))) (const? 32 (-1))) (const? 32 0)
       (add (LLVM.or e (const? 32 (-2147483648))) (const? 32 1) { «nsw» := false, «nuw» := true }) ⊑
-    add (LLVM.or e (const? 32 (-2147483648))) (const? 32 1) { «nsw» := true, «nuw» := false } := by 
+    add (LLVM.or e (const? 32 (-2147483648))) (const? 32 1) { «nsw» := true, «nuw» := false } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -444,7 +444,7 @@ theorem test_add_nuw__nsw_is_safe_thm (e : IntW 32) :
 theorem test_add_nsw__nsw_is_safe_thm (e : IntW 32) :
   select (icmp IntPredicate.eq (LLVM.or e (const? 32 (-2147483648))) (const? 32 (-1))) (const? 32 0)
       (add (LLVM.or e (const? 32 (-2147483648))) (const? 32 1) { «nsw» := true, «nuw» := false }) ⊑
-    add (LLVM.or e (const? 32 (-2147483648))) (const? 32 1) { «nsw» := true, «nuw» := false } := by 
+    add (LLVM.or e (const? 32 (-2147483648))) (const? 32 1) { «nsw» := true, «nuw» := false } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -456,7 +456,7 @@ theorem test_add_nsw__nsw_is_safe_thm (e : IntW 32) :
 theorem test_add__nsw_is_safe_thm (e : IntW 32) :
   select (icmp IntPredicate.eq (LLVM.or e (const? 32 (-2147483648))) (const? 32 (-1))) (const? 32 0)
       (add (LLVM.or e (const? 32 (-2147483648))) (const? 32 1)) ⊑
-    add (LLVM.or e (const? 32 (-2147483648))) (const? 32 1) { «nsw» := true, «nuw» := false } := by 
+    add (LLVM.or e (const? 32 (-2147483648))) (const? 32 1) { «nsw» := true, «nuw» := false } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -467,7 +467,7 @@ theorem test_add__nsw_is_safe_thm (e : IntW 32) :
 
 theorem test_add_nuw_nsw__none_are_safe_thm (e : IntW 32) :
   select (icmp IntPredicate.eq e (const? 32 3)) (const? 32 4) (add e (const? 32 1) { «nsw» := true, «nuw» := true }) ⊑
-    add e (const? 32 1) := by 
+    add e (const? 32 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -478,7 +478,7 @@ theorem test_add_nuw_nsw__none_are_safe_thm (e : IntW 32) :
 
 theorem test_add_nuw__none_are_safe_thm (e : IntW 32) :
   select (icmp IntPredicate.eq e (const? 32 3)) (const? 32 4) (add e (const? 32 1) { «nsw» := false, «nuw» := true }) ⊑
-    add e (const? 32 1) := by 
+    add e (const? 32 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -489,7 +489,7 @@ theorem test_add_nuw__none_are_safe_thm (e : IntW 32) :
 
 theorem test_add_nsw__none_are_safe_thm (e : IntW 32) :
   select (icmp IntPredicate.eq e (const? 32 3)) (const? 32 4) (add e (const? 32 1) { «nsw» := true, «nuw» := false }) ⊑
-    add e (const? 32 1) := by 
+    add e (const? 32 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -499,7 +499,7 @@ theorem test_add_nsw__none_are_safe_thm (e : IntW 32) :
 
 
 theorem test_add__none_are_safe_thm (e : IntW 32) :
-  select (icmp IntPredicate.eq e (const? 32 3)) (const? 32 4) (add e (const? 32 1)) ⊑ add e (const? 32 1) := by 
+  select (icmp IntPredicate.eq e (const? 32 3)) (const? 32 4) (add e (const? 32 1)) ⊑ add e (const? 32 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -511,7 +511,7 @@ theorem test_add__none_are_safe_thm (e : IntW 32) :
 theorem test_sub_nuw_nsw__all_are_safe_thm (e : IntW 32) :
   select (icmp IntPredicate.eq (LLVM.and e (const? 32 255)) (const? 32 6)) (const? 32 (-260))
       (sub (const? 32 (-254)) (LLVM.and e (const? 32 255)) { «nsw» := true, «nuw» := true }) ⊑
-    sub (const? 32 (-254)) (LLVM.and e (const? 32 255)) { «nsw» := true, «nuw» := true } := by 
+    sub (const? 32 (-254)) (LLVM.and e (const? 32 255)) { «nsw» := true, «nuw» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -523,7 +523,7 @@ theorem test_sub_nuw_nsw__all_are_safe_thm (e : IntW 32) :
 theorem test_sub_nuw__all_are_safe_thm (e : IntW 32) :
   select (icmp IntPredicate.eq (LLVM.and e (const? 32 255)) (const? 32 6)) (const? 32 (-260))
       (sub (const? 32 (-254)) (LLVM.and e (const? 32 255)) { «nsw» := false, «nuw» := true }) ⊑
-    sub (const? 32 (-254)) (LLVM.and e (const? 32 255)) { «nsw» := true, «nuw» := true } := by 
+    sub (const? 32 (-254)) (LLVM.and e (const? 32 255)) { «nsw» := true, «nuw» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -535,7 +535,7 @@ theorem test_sub_nuw__all_are_safe_thm (e : IntW 32) :
 theorem test_sub_nsw__all_are_safe_thm (e : IntW 32) :
   select (icmp IntPredicate.eq (LLVM.and e (const? 32 255)) (const? 32 6)) (const? 32 (-260))
       (sub (const? 32 (-254)) (LLVM.and e (const? 32 255)) { «nsw» := true, «nuw» := false }) ⊑
-    sub (const? 32 (-254)) (LLVM.and e (const? 32 255)) { «nsw» := true, «nuw» := true } := by 
+    sub (const? 32 (-254)) (LLVM.and e (const? 32 255)) { «nsw» := true, «nuw» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -547,7 +547,7 @@ theorem test_sub_nsw__all_are_safe_thm (e : IntW 32) :
 theorem test_sub__all_are_safe_thm (e : IntW 32) :
   select (icmp IntPredicate.eq (LLVM.and e (const? 32 255)) (const? 32 6)) (const? 32 (-260))
       (sub (const? 32 (-254)) (LLVM.and e (const? 32 255))) ⊑
-    sub (const? 32 (-254)) (LLVM.and e (const? 32 255)) { «nsw» := true, «nuw» := true } := by 
+    sub (const? 32 (-254)) (LLVM.and e (const? 32 255)) { «nsw» := true, «nuw» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -559,7 +559,7 @@ theorem test_sub__all_are_safe_thm (e : IntW 32) :
 theorem test_sub_nuw_nsw__nuw_is_safe_thm (e : IntW 32) :
   select (icmp IntPredicate.eq (LLVM.and e (const? 32 2147483647)) (const? 32 1073741824)) (const? 32 1073741824)
       (sub (const? 32 (-2147483648)) (LLVM.and e (const? 32 2147483647)) { «nsw» := true, «nuw» := true }) ⊑
-    sub (const? 32 (-2147483648)) (LLVM.and e (const? 32 2147483647)) { «nsw» := false, «nuw» := true } := by 
+    sub (const? 32 (-2147483648)) (LLVM.and e (const? 32 2147483647)) { «nsw» := false, «nuw» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -571,7 +571,7 @@ theorem test_sub_nuw_nsw__nuw_is_safe_thm (e : IntW 32) :
 theorem test_sub_nuw__nuw_is_safe_thm (e : IntW 32) :
   select (icmp IntPredicate.eq (LLVM.and e (const? 32 2147483647)) (const? 32 1073741824)) (const? 32 1073741824)
       (sub (const? 32 (-2147483648)) (LLVM.and e (const? 32 2147483647)) { «nsw» := false, «nuw» := true }) ⊑
-    sub (const? 32 (-2147483648)) (LLVM.and e (const? 32 2147483647)) { «nsw» := false, «nuw» := true } := by 
+    sub (const? 32 (-2147483648)) (LLVM.and e (const? 32 2147483647)) { «nsw» := false, «nuw» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -583,7 +583,7 @@ theorem test_sub_nuw__nuw_is_safe_thm (e : IntW 32) :
 theorem test_sub_nsw__nuw_is_safe_thm (e : IntW 32) :
   select (icmp IntPredicate.eq (LLVM.and e (const? 32 2147483647)) (const? 32 1073741824)) (const? 32 1073741824)
       (sub (const? 32 (-2147483648)) (LLVM.and e (const? 32 2147483647)) { «nsw» := true, «nuw» := false }) ⊑
-    sub (const? 32 (-2147483648)) (LLVM.and e (const? 32 2147483647)) { «nsw» := false, «nuw» := true } := by 
+    sub (const? 32 (-2147483648)) (LLVM.and e (const? 32 2147483647)) { «nsw» := false, «nuw» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -595,7 +595,7 @@ theorem test_sub_nsw__nuw_is_safe_thm (e : IntW 32) :
 theorem test_sub__nuw_is_safe_thm (e : IntW 32) :
   select (icmp IntPredicate.eq (LLVM.and e (const? 32 2147483647)) (const? 32 1073741824)) (const? 32 1073741824)
       (sub (const? 32 (-2147483648)) (LLVM.and e (const? 32 2147483647))) ⊑
-    sub (const? 32 (-2147483648)) (LLVM.and e (const? 32 2147483647)) { «nsw» := false, «nuw» := true } := by 
+    sub (const? 32 (-2147483648)) (LLVM.and e (const? 32 2147483647)) { «nsw» := false, «nuw» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -607,7 +607,7 @@ theorem test_sub__nuw_is_safe_thm (e : IntW 32) :
 theorem test_sub_nuw_nsw__nsw_is_safe_thm (e : IntW 32) :
   select (icmp IntPredicate.eq (LLVM.or e (const? 32 (-2147483648))) (const? 32 (-2147483647))) (const? 32 (-1))
       (sub (const? 32 (-2147483648)) (LLVM.or e (const? 32 (-2147483648))) { «nsw» := true, «nuw» := true }) ⊑
-    sub (const? 32 (-2147483648)) (LLVM.or e (const? 32 (-2147483648))) { «nsw» := true, «nuw» := false } := by 
+    sub (const? 32 (-2147483648)) (LLVM.or e (const? 32 (-2147483648))) { «nsw» := true, «nuw» := false } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -619,7 +619,7 @@ theorem test_sub_nuw_nsw__nsw_is_safe_thm (e : IntW 32) :
 theorem test_sub_nuw__nsw_is_safe_thm (e : IntW 32) :
   select (icmp IntPredicate.eq (LLVM.or e (const? 32 (-2147483648))) (const? 32 (-2147483647))) (const? 32 (-1))
       (sub (const? 32 (-2147483648)) (LLVM.or e (const? 32 (-2147483648))) { «nsw» := false, «nuw» := true }) ⊑
-    sub (const? 32 (-2147483648)) (LLVM.or e (const? 32 (-2147483648))) { «nsw» := true, «nuw» := false } := by 
+    sub (const? 32 (-2147483648)) (LLVM.or e (const? 32 (-2147483648))) { «nsw» := true, «nuw» := false } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -631,7 +631,7 @@ theorem test_sub_nuw__nsw_is_safe_thm (e : IntW 32) :
 theorem test_sub_nsw__nsw_is_safe_thm (e : IntW 32) :
   select (icmp IntPredicate.eq (LLVM.or e (const? 32 (-2147483648))) (const? 32 (-2147483647))) (const? 32 (-1))
       (sub (const? 32 (-2147483648)) (LLVM.or e (const? 32 (-2147483648))) { «nsw» := true, «nuw» := false }) ⊑
-    sub (const? 32 (-2147483648)) (LLVM.or e (const? 32 (-2147483648))) { «nsw» := true, «nuw» := false } := by 
+    sub (const? 32 (-2147483648)) (LLVM.or e (const? 32 (-2147483648))) { «nsw» := true, «nuw» := false } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -643,7 +643,7 @@ theorem test_sub_nsw__nsw_is_safe_thm (e : IntW 32) :
 theorem test_sub__nsw_is_safe_thm (e : IntW 32) :
   select (icmp IntPredicate.eq (LLVM.or e (const? 32 (-2147483648))) (const? 32 (-2147483647))) (const? 32 (-1))
       (sub (const? 32 (-2147483648)) (LLVM.or e (const? 32 (-2147483648)))) ⊑
-    sub (const? 32 (-2147483648)) (LLVM.or e (const? 32 (-2147483648))) { «nsw» := true, «nuw» := false } := by 
+    sub (const? 32 (-2147483648)) (LLVM.or e (const? 32 (-2147483648))) { «nsw» := true, «nuw» := false } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -655,7 +655,7 @@ theorem test_sub__nsw_is_safe_thm (e : IntW 32) :
 theorem test_sub_nuw_nsw__none_are_safe_thm (e : IntW 32) :
   select (icmp IntPredicate.eq e (const? 32 1)) (const? 32 2147483647)
       (sub (const? 32 (-2147483648)) e { «nsw» := true, «nuw» := true }) ⊑
-    sub (const? 32 (-2147483648)) e := by 
+    sub (const? 32 (-2147483648)) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -667,7 +667,7 @@ theorem test_sub_nuw_nsw__none_are_safe_thm (e : IntW 32) :
 theorem test_sub_nuw__none_are_safe_thm (e : IntW 32) :
   select (icmp IntPredicate.eq e (const? 32 1)) (const? 32 2147483647)
       (sub (const? 32 (-2147483648)) e { «nsw» := false, «nuw» := true }) ⊑
-    sub (const? 32 (-2147483648)) e := by 
+    sub (const? 32 (-2147483648)) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -679,7 +679,7 @@ theorem test_sub_nuw__none_are_safe_thm (e : IntW 32) :
 theorem test_sub_nsw__none_are_safe_thm (e : IntW 32) :
   select (icmp IntPredicate.eq e (const? 32 1)) (const? 32 2147483647)
       (sub (const? 32 (-2147483648)) e { «nsw» := true, «nuw» := false }) ⊑
-    sub (const? 32 (-2147483648)) e := by 
+    sub (const? 32 (-2147483648)) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -690,7 +690,7 @@ theorem test_sub_nsw__none_are_safe_thm (e : IntW 32) :
 
 theorem test_sub__none_are_safe_thm (e : IntW 32) :
   select (icmp IntPredicate.eq e (const? 32 1)) (const? 32 2147483647) (sub (const? 32 (-2147483648)) e) ⊑
-    sub (const? 32 (-2147483648)) e := by 
+    sub (const? 32 (-2147483648)) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -702,7 +702,7 @@ theorem test_sub__none_are_safe_thm (e : IntW 32) :
 theorem test_mul_nuw_nsw__all_are_safe_thm (e : IntW 32) :
   select (icmp IntPredicate.eq (LLVM.and e (const? 32 255)) (const? 32 17)) (const? 32 153)
       (mul (LLVM.and e (const? 32 255)) (const? 32 9) { «nsw» := true, «nuw» := true }) ⊑
-    mul (LLVM.and e (const? 32 255)) (const? 32 9) { «nsw» := true, «nuw» := true } := by 
+    mul (LLVM.and e (const? 32 255)) (const? 32 9) { «nsw» := true, «nuw» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -714,7 +714,7 @@ theorem test_mul_nuw_nsw__all_are_safe_thm (e : IntW 32) :
 theorem test_mul_nuw__all_are_safe_thm (e : IntW 32) :
   select (icmp IntPredicate.eq (LLVM.and e (const? 32 255)) (const? 32 17)) (const? 32 153)
       (mul (LLVM.and e (const? 32 255)) (const? 32 9) { «nsw» := false, «nuw» := true }) ⊑
-    mul (LLVM.and e (const? 32 255)) (const? 32 9) { «nsw» := true, «nuw» := true } := by 
+    mul (LLVM.and e (const? 32 255)) (const? 32 9) { «nsw» := true, «nuw» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -726,7 +726,7 @@ theorem test_mul_nuw__all_are_safe_thm (e : IntW 32) :
 theorem test_mul_nsw__all_are_safe_thm (e : IntW 32) :
   select (icmp IntPredicate.eq (LLVM.and e (const? 32 255)) (const? 32 17)) (const? 32 153)
       (mul (LLVM.and e (const? 32 255)) (const? 32 9) { «nsw» := true, «nuw» := false }) ⊑
-    mul (LLVM.and e (const? 32 255)) (const? 32 9) { «nsw» := true, «nuw» := true } := by 
+    mul (LLVM.and e (const? 32 255)) (const? 32 9) { «nsw» := true, «nuw» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -738,7 +738,7 @@ theorem test_mul_nsw__all_are_safe_thm (e : IntW 32) :
 theorem test_mul__all_are_safe_thm (e : IntW 32) :
   select (icmp IntPredicate.eq (LLVM.and e (const? 32 255)) (const? 32 17)) (const? 32 153)
       (mul (LLVM.and e (const? 32 255)) (const? 32 9)) ⊑
-    mul (LLVM.and e (const? 32 255)) (const? 32 9) { «nsw» := true, «nuw» := true } := by 
+    mul (LLVM.and e (const? 32 255)) (const? 32 9) { «nsw» := true, «nuw» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -750,7 +750,7 @@ theorem test_mul__all_are_safe_thm (e : IntW 32) :
 theorem test_mul_nuw_nsw__nuw_is_safe_thm (e : IntW 32) :
   select (icmp IntPredicate.eq (LLVM.and e (const? 32 268435457)) (const? 32 268435456)) (const? 32 (-1879048192))
       (mul (LLVM.and e (const? 32 268435457)) (const? 32 9) { «nsw» := true, «nuw» := true }) ⊑
-    mul (LLVM.and e (const? 32 268435457)) (const? 32 9) { «nsw» := false, «nuw» := true } := by 
+    mul (LLVM.and e (const? 32 268435457)) (const? 32 9) { «nsw» := false, «nuw» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -762,7 +762,7 @@ theorem test_mul_nuw_nsw__nuw_is_safe_thm (e : IntW 32) :
 theorem test_mul_nuw__nuw_is_safe_thm (e : IntW 32) :
   select (icmp IntPredicate.eq (LLVM.and e (const? 32 268435457)) (const? 32 268435456)) (const? 32 (-1879048192))
       (mul (LLVM.and e (const? 32 268435457)) (const? 32 9) { «nsw» := false, «nuw» := true }) ⊑
-    mul (LLVM.and e (const? 32 268435457)) (const? 32 9) { «nsw» := false, «nuw» := true } := by 
+    mul (LLVM.and e (const? 32 268435457)) (const? 32 9) { «nsw» := false, «nuw» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -774,7 +774,7 @@ theorem test_mul_nuw__nuw_is_safe_thm (e : IntW 32) :
 theorem test_mul_nsw__nuw_is_safe_thm (e : IntW 32) :
   select (icmp IntPredicate.eq (LLVM.and e (const? 32 268435457)) (const? 32 268435456)) (const? 32 (-1879048192))
       (mul (LLVM.and e (const? 32 268435457)) (const? 32 9) { «nsw» := true, «nuw» := false }) ⊑
-    mul (LLVM.and e (const? 32 268435457)) (const? 32 9) { «nsw» := false, «nuw» := true } := by 
+    mul (LLVM.and e (const? 32 268435457)) (const? 32 9) { «nsw» := false, «nuw» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -786,7 +786,7 @@ theorem test_mul_nsw__nuw_is_safe_thm (e : IntW 32) :
 theorem test_mul__nuw_is_safe_thm (e : IntW 32) :
   select (icmp IntPredicate.eq (LLVM.and e (const? 32 268435457)) (const? 32 268435456)) (const? 32 (-1879048192))
       (mul (LLVM.and e (const? 32 268435457)) (const? 32 9)) ⊑
-    mul (LLVM.and e (const? 32 268435457)) (const? 32 9) { «nsw» := false, «nuw» := true } := by 
+    mul (LLVM.and e (const? 32 268435457)) (const? 32 9) { «nsw» := false, «nuw» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -798,7 +798,7 @@ theorem test_mul__nuw_is_safe_thm (e : IntW 32) :
 theorem test_mul_nuw_nsw__nsw_is_safe_thm (e : IntW 32) :
   select (icmp IntPredicate.eq (LLVM.or e (const? 32 (-83886080))) (const? 32 (-83886079))) (const? 32 (-754974711))
       (mul (LLVM.or e (const? 32 (-83886080))) (const? 32 9) { «nsw» := true, «nuw» := true }) ⊑
-    mul (LLVM.or e (const? 32 (-83886080))) (const? 32 9) { «nsw» := true, «nuw» := false } := by 
+    mul (LLVM.or e (const? 32 (-83886080))) (const? 32 9) { «nsw» := true, «nuw» := false } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -810,7 +810,7 @@ theorem test_mul_nuw_nsw__nsw_is_safe_thm (e : IntW 32) :
 theorem test_mul_nuw__nsw_is_safe_thm (e : IntW 32) :
   select (icmp IntPredicate.eq (LLVM.or e (const? 32 (-83886080))) (const? 32 (-83886079))) (const? 32 (-754974711))
       (mul (LLVM.or e (const? 32 (-83886080))) (const? 32 9) { «nsw» := false, «nuw» := true }) ⊑
-    mul (LLVM.or e (const? 32 (-83886080))) (const? 32 9) { «nsw» := true, «nuw» := false } := by 
+    mul (LLVM.or e (const? 32 (-83886080))) (const? 32 9) { «nsw» := true, «nuw» := false } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -822,7 +822,7 @@ theorem test_mul_nuw__nsw_is_safe_thm (e : IntW 32) :
 theorem test_mul_nsw__nsw_is_safe_thm (e : IntW 32) :
   select (icmp IntPredicate.eq (LLVM.or e (const? 32 (-83886080))) (const? 32 (-83886079))) (const? 32 (-754974711))
       (mul (LLVM.or e (const? 32 (-83886080))) (const? 32 9) { «nsw» := true, «nuw» := false }) ⊑
-    mul (LLVM.or e (const? 32 (-83886080))) (const? 32 9) { «nsw» := true, «nuw» := false } := by 
+    mul (LLVM.or e (const? 32 (-83886080))) (const? 32 9) { «nsw» := true, «nuw» := false } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -834,7 +834,7 @@ theorem test_mul_nsw__nsw_is_safe_thm (e : IntW 32) :
 theorem test_mul__nsw_is_safe_thm (e : IntW 32) :
   select (icmp IntPredicate.eq (LLVM.or e (const? 32 (-83886080))) (const? 32 (-83886079))) (const? 32 (-754974711))
       (mul (LLVM.or e (const? 32 (-83886080))) (const? 32 9)) ⊑
-    mul (LLVM.or e (const? 32 (-83886080))) (const? 32 9) { «nsw» := true, «nuw» := false } := by 
+    mul (LLVM.or e (const? 32 (-83886080))) (const? 32 9) { «nsw» := true, «nuw» := false } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -846,7 +846,7 @@ theorem test_mul__nsw_is_safe_thm (e : IntW 32) :
 theorem test_mul_nuw_nsw__none_are_safe_thm (e : IntW 32) :
   select (icmp IntPredicate.eq e (const? 32 805306368)) (const? 32 (-1342177280))
       (mul e (const? 32 9) { «nsw» := true, «nuw» := true }) ⊑
-    mul e (const? 32 9) := by 
+    mul e (const? 32 9) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -858,7 +858,7 @@ theorem test_mul_nuw_nsw__none_are_safe_thm (e : IntW 32) :
 theorem test_mul_nuw__none_are_safe_thm (e : IntW 32) :
   select (icmp IntPredicate.eq e (const? 32 805306368)) (const? 32 (-1342177280))
       (mul e (const? 32 9) { «nsw» := false, «nuw» := true }) ⊑
-    mul e (const? 32 9) := by 
+    mul e (const? 32 9) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -870,7 +870,7 @@ theorem test_mul_nuw__none_are_safe_thm (e : IntW 32) :
 theorem test_mul_nsw__none_are_safe_thm (e : IntW 32) :
   select (icmp IntPredicate.eq e (const? 32 805306368)) (const? 32 (-1342177280))
       (mul e (const? 32 9) { «nsw» := true, «nuw» := false }) ⊑
-    mul e (const? 32 9) := by 
+    mul e (const? 32 9) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -881,7 +881,7 @@ theorem test_mul_nsw__none_are_safe_thm (e : IntW 32) :
 
 theorem test_mul__none_are_safe_thm (e : IntW 32) :
   select (icmp IntPredicate.eq e (const? 32 805306368)) (const? 32 (-1342177280)) (mul e (const? 32 9)) ⊑
-    mul e (const? 32 9) := by 
+    mul e (const? 32 9) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gselecthofhbittest_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gselecthofhbittest_proof.lean
@@ -11,7 +11,7 @@ section gselecthofhbittest_proof
 theorem and_lshr_and_thm (e : IntW 32) :
   select (icmp IntPredicate.eq (LLVM.and e (const? 32 1)) (const? 32 0)) (LLVM.and (lshr e (const? 32 1)) (const? 32 1))
       (const? 32 1) ⊑
-    zext 32 (icmp IntPredicate.ne (LLVM.and e (const? 32 3)) (const? 32 0)) := by 
+    zext 32 (icmp IntPredicate.ne (LLVM.and e (const? 32 3)) (const? 32 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -22,7 +22,7 @@ theorem and_lshr_and_thm (e : IntW 32) :
 
 theorem and_and_thm (e : IntW 32) :
   select (icmp IntPredicate.eq (LLVM.and e (const? 32 2)) (const? 32 0)) (LLVM.and e (const? 32 1)) (const? 32 1) ⊑
-    zext 32 (icmp IntPredicate.ne (LLVM.and e (const? 32 3)) (const? 32 0)) := by 
+    zext 32 (icmp IntPredicate.ne (LLVM.and e (const? 32 3)) (const? 32 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -34,7 +34,7 @@ theorem and_and_thm (e : IntW 32) :
 theorem f_var0_thm (e e_1 : IntW 32) :
   select (icmp IntPredicate.eq (LLVM.and e_1 e) (const? 32 0)) (LLVM.and (lshr e_1 (const? 32 1)) (const? 32 1))
       (const? 32 1) ⊑
-    zext 32 (icmp IntPredicate.ne (LLVM.and e_1 (LLVM.or e (const? 32 2))) (const? 32 0)) := by 
+    zext 32 (icmp IntPredicate.ne (LLVM.and e_1 (LLVM.or e (const? 32 2))) (const? 32 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -46,7 +46,7 @@ theorem f_var0_thm (e e_1 : IntW 32) :
 theorem f_var0_commutative_and_thm (e e_1 : IntW 32) :
   select (icmp IntPredicate.eq (LLVM.and e_1 e) (const? 32 0)) (LLVM.and (lshr e (const? 32 1)) (const? 32 1))
       (const? 32 1) ⊑
-    zext 32 (icmp IntPredicate.ne (LLVM.and e (LLVM.or e_1 (const? 32 2))) (const? 32 0)) := by 
+    zext 32 (icmp IntPredicate.ne (LLVM.and e (LLVM.or e_1 (const? 32 2))) (const? 32 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -57,7 +57,7 @@ theorem f_var0_commutative_and_thm (e e_1 : IntW 32) :
 
 theorem f_var1_thm (e e_1 : IntW 32) :
   select (icmp IntPredicate.eq (LLVM.and e_1 e) (const? 32 0)) (LLVM.and e_1 (const? 32 1)) (const? 32 1) ⊑
-    zext 32 (icmp IntPredicate.ne (LLVM.and e_1 (LLVM.or e (const? 32 1))) (const? 32 0)) := by 
+    zext 32 (icmp IntPredicate.ne (LLVM.and e_1 (LLVM.or e (const? 32 1))) (const? 32 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -68,7 +68,7 @@ theorem f_var1_thm (e e_1 : IntW 32) :
 
 theorem f_var1_commutative_and_thm (e e_1 : IntW 32) :
   select (icmp IntPredicate.eq (LLVM.and e_1 e) (const? 32 0)) (LLVM.and e (const? 32 1)) (const? 32 1) ⊑
-    zext 32 (icmp IntPredicate.ne (LLVM.and e (LLVM.or e_1 (const? 32 1))) (const? 32 0)) := by 
+    zext 32 (icmp IntPredicate.ne (LLVM.and e (LLVM.or e_1 (const? 32 1))) (const? 32 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -79,7 +79,7 @@ theorem f_var1_commutative_and_thm (e e_1 : IntW 32) :
 
 theorem n5_thm (e : IntW 32) :
   select (icmp IntPredicate.eq (LLVM.and e (const? 32 2)) (const? 32 0)) (LLVM.and e (const? 32 2)) (const? 32 1) ⊑
-    LLVM.and (lshr e (const? 32 1)) (const? 32 1) := by 
+    LLVM.and (lshr e (const? 32 1)) (const? 32 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -92,7 +92,7 @@ theorem n6_thm (e : IntW 32) :
   select (icmp IntPredicate.ne (LLVM.and e (const? 32 1)) (const? 32 0)) (LLVM.and (lshr e (const? 32 2)) (const? 32 1))
       (const? 32 1) ⊑
     select (icmp IntPredicate.eq (LLVM.and e (const? 32 1)) (const? 32 0)) (const? 32 1)
-      (LLVM.and (lshr e (const? 32 2)) (const? 32 1)) := by 
+      (LLVM.and (lshr e (const? 32 2)) (const? 32 1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -104,7 +104,7 @@ theorem n6_thm (e : IntW 32) :
 theorem n7_thm (e : IntW 32) :
   select (icmp IntPredicate.ne (LLVM.and e (const? 32 2)) (const? 32 0)) (LLVM.and e (const? 32 1)) (const? 32 1) ⊑
     select (icmp IntPredicate.eq (LLVM.and e (const? 32 2)) (const? 32 0)) (const? 32 1)
-      (LLVM.and e (const? 32 1)) := by 
+      (LLVM.and e (const? 32 1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -117,7 +117,7 @@ theorem n8_thm (e : IntW 32) :
   select (icmp IntPredicate.eq (LLVM.and e (const? 32 1)) (const? 32 1)) (LLVM.and (lshr e (const? 32 2)) (const? 32 1))
       (const? 32 1) ⊑
     select (icmp IntPredicate.eq (LLVM.and e (const? 32 1)) (const? 32 0)) (const? 32 1)
-      (LLVM.and (lshr e (const? 32 2)) (const? 32 1)) := by 
+      (LLVM.and (lshr e (const? 32 2)) (const? 32 1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gselecthofhsymmetrichselects_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gselecthofhsymmetrichselects_proof.lean
@@ -9,7 +9,7 @@ set_option linter.unreachableTactic false
 
 section gselecthofhsymmetrichselects_proof
 theorem select_of_symmetric_selects_thm (e e_1 : IntW 32) (e_2 e_3 : IntW 1) :
-  select e_3 (select e_2 e_1 e) (select e_2 e e_1) ⊑ select (LLVM.xor e_2 e_3) e e_1 := by 
+  select e_3 (select e_2 e_1 e) (select e_2 e e_1) ⊑ select (LLVM.xor e_2 e_3) e e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -19,7 +19,7 @@ theorem select_of_symmetric_selects_thm (e e_1 : IntW 32) (e_2 e_3 : IntW 1) :
 
 
 theorem select_of_symmetric_selects_negative1_thm (e e_1 : IntW 32) (e_2 e_3 : IntW 1) :
-  select e_3 (select e_2 e_1 e) (select e_3 e e_1) ⊑ select e_3 (select e_2 e_1 e) e_1 := by 
+  select e_3 (select e_2 e_1 e) (select e_3 e e_1) ⊑ select e_3 (select e_2 e_1 e) e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -29,7 +29,7 @@ theorem select_of_symmetric_selects_negative1_thm (e e_1 : IntW 32) (e_2 e_3 : I
 
 
 theorem select_of_symmetric_selects_commuted_thm (e e_1 : IntW 32) (e_2 e_3 : IntW 1) :
-  select e_3 (select e_2 e_1 e) (select e_2 e e_1) ⊑ select (LLVM.xor e_2 e_3) e e_1 := by 
+  select e_3 (select e_2 e_1 e) (select e_2 e e_1) ⊑ select (LLVM.xor e_2 e_3) e e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gselecthsafehboolhtransforms_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gselecthsafehboolhtransforms_proof.lean
@@ -9,7 +9,7 @@ set_option linter.unreachableTactic false
 
 section gselecthsafehboolhtransforms_proof
 theorem land_land_left1_thm (e e_1 : IntW 1) :
-  select (select e_1 e (const? 1 0)) e_1 (const? 1 0) ⊑ select e_1 e (const? 1 0) := by 
+  select (select e_1 e (const? 1 0)) e_1 (const? 1 0) ⊑ select e_1 e (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -19,7 +19,7 @@ theorem land_land_left1_thm (e e_1 : IntW 1) :
 
 
 theorem land_land_left2_thm (e e_1 : IntW 1) :
-  select (select e_1 e (const? 1 0)) e (const? 1 0) ⊑ select e_1 e (const? 1 0) := by 
+  select (select e_1 e (const? 1 0)) e (const? 1 0) ⊑ select e_1 e (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -28,7 +28,7 @@ theorem land_land_left2_thm (e e_1 : IntW 1) :
     all_goals sorry
 
 
-theorem land_band_left1_thm (e e_1 : IntW 1) : LLVM.and (select e_1 e (const? 1 0)) e_1 ⊑ select e_1 e (const? 1 0) := by 
+theorem land_band_left1_thm (e e_1 : IntW 1) : LLVM.and (select e_1 e (const? 1 0)) e_1 ⊑ select e_1 e (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -37,7 +37,7 @@ theorem land_band_left1_thm (e e_1 : IntW 1) : LLVM.and (select e_1 e (const? 1 
     all_goals sorry
 
 
-theorem land_band_left2_thm (e e_1 : IntW 1) : LLVM.and (select e_1 e (const? 1 0)) e ⊑ select e_1 e (const? 1 0) := by 
+theorem land_band_left2_thm (e e_1 : IntW 1) : LLVM.and (select e_1 e (const? 1 0)) e ⊑ select e_1 e (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -46,7 +46,7 @@ theorem land_band_left2_thm (e e_1 : IntW 1) : LLVM.and (select e_1 e (const? 1 
     all_goals sorry
 
 
-theorem land_lor_left1_thm (e e_1 : IntW 1) : select (select e_1 e (const? 1 0)) (const? 1 1) e_1 ⊑ e_1 := by 
+theorem land_lor_left1_thm (e e_1 : IntW 1) : select (select e_1 e (const? 1 0)) (const? 1 1) e_1 ⊑ e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -55,7 +55,7 @@ theorem land_lor_left1_thm (e e_1 : IntW 1) : select (select e_1 e (const? 1 0))
     all_goals sorry
 
 
-theorem land_lor_left2_thm (e e_1 : IntW 1) : select (select e_1 e (const? 1 0)) (const? 1 1) e ⊑ e := by 
+theorem land_lor_left2_thm (e e_1 : IntW 1) : select (select e_1 e (const? 1 0)) (const? 1 1) e ⊑ e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -64,7 +64,7 @@ theorem land_lor_left2_thm (e e_1 : IntW 1) : select (select e_1 e (const? 1 0))
     all_goals sorry
 
 
-theorem land_bor_left1_thm (e e_1 : IntW 1) : LLVM.or (select e_1 e (const? 1 0)) e_1 ⊑ e_1 := by 
+theorem land_bor_left1_thm (e e_1 : IntW 1) : LLVM.or (select e_1 e (const? 1 0)) e_1 ⊑ e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -73,7 +73,7 @@ theorem land_bor_left1_thm (e e_1 : IntW 1) : LLVM.or (select e_1 e (const? 1 0)
     all_goals sorry
 
 
-theorem land_bor_left2_thm (e e_1 : IntW 1) : LLVM.or (select e_1 e (const? 1 0)) e ⊑ e := by 
+theorem land_bor_left2_thm (e e_1 : IntW 1) : LLVM.or (select e_1 e (const? 1 0)) e ⊑ e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -82,7 +82,7 @@ theorem land_bor_left2_thm (e e_1 : IntW 1) : LLVM.or (select e_1 e (const? 1 0)
     all_goals sorry
 
 
-theorem band_land_left1_thm (e e_1 : IntW 1) : select (LLVM.and e_1 e) e_1 (const? 1 0) ⊑ LLVM.and e_1 e := by 
+theorem band_land_left1_thm (e e_1 : IntW 1) : select (LLVM.and e_1 e) e_1 (const? 1 0) ⊑ LLVM.and e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -91,7 +91,7 @@ theorem band_land_left1_thm (e e_1 : IntW 1) : select (LLVM.and e_1 e) e_1 (cons
     all_goals sorry
 
 
-theorem band_land_left2_thm (e e_1 : IntW 1) : select (LLVM.and e_1 e) e (const? 1 0) ⊑ LLVM.and e_1 e := by 
+theorem band_land_left2_thm (e e_1 : IntW 1) : select (LLVM.and e_1 e) e (const? 1 0) ⊑ LLVM.and e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -100,7 +100,7 @@ theorem band_land_left2_thm (e e_1 : IntW 1) : select (LLVM.and e_1 e) e (const?
     all_goals sorry
 
 
-theorem band_lor_left1_thm (e e_1 : IntW 1) : select (LLVM.and e_1 e) (const? 1 1) e_1 ⊑ e_1 := by 
+theorem band_lor_left1_thm (e e_1 : IntW 1) : select (LLVM.and e_1 e) (const? 1 1) e_1 ⊑ e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -109,7 +109,7 @@ theorem band_lor_left1_thm (e e_1 : IntW 1) : select (LLVM.and e_1 e) (const? 1 
     all_goals sorry
 
 
-theorem band_lor_left2_thm (e e_1 : IntW 1) : select (LLVM.and e_1 e) (const? 1 1) e ⊑ e := by 
+theorem band_lor_left2_thm (e e_1 : IntW 1) : select (LLVM.and e_1 e) (const? 1 1) e ⊑ e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -118,7 +118,7 @@ theorem band_lor_left2_thm (e e_1 : IntW 1) : select (LLVM.and e_1 e) (const? 1 
     all_goals sorry
 
 
-theorem lor_land_left1_thm (e e_1 : IntW 1) : select (select e_1 (const? 1 1) e) e_1 (const? 1 0) ⊑ e_1 := by 
+theorem lor_land_left1_thm (e e_1 : IntW 1) : select (select e_1 (const? 1 1) e) e_1 (const? 1 0) ⊑ e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -127,7 +127,7 @@ theorem lor_land_left1_thm (e e_1 : IntW 1) : select (select e_1 (const? 1 1) e)
     all_goals sorry
 
 
-theorem lor_land_left2_thm (e e_1 : IntW 1) : select (select e_1 (const? 1 1) e) e (const? 1 0) ⊑ e := by 
+theorem lor_land_left2_thm (e e_1 : IntW 1) : select (select e_1 (const? 1 1) e) e (const? 1 0) ⊑ e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -136,7 +136,7 @@ theorem lor_land_left2_thm (e e_1 : IntW 1) : select (select e_1 (const? 1 1) e)
     all_goals sorry
 
 
-theorem lor_band_left1_thm (e e_1 : IntW 1) : LLVM.and (select e_1 (const? 1 1) e) e_1 ⊑ e_1 := by 
+theorem lor_band_left1_thm (e e_1 : IntW 1) : LLVM.and (select e_1 (const? 1 1) e) e_1 ⊑ e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -145,7 +145,7 @@ theorem lor_band_left1_thm (e e_1 : IntW 1) : LLVM.and (select e_1 (const? 1 1) 
     all_goals sorry
 
 
-theorem lor_band_left2_thm (e e_1 : IntW 1) : LLVM.and (select e_1 (const? 1 1) e) e ⊑ e := by 
+theorem lor_band_left2_thm (e e_1 : IntW 1) : LLVM.and (select e_1 (const? 1 1) e) e ⊑ e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -155,7 +155,7 @@ theorem lor_band_left2_thm (e e_1 : IntW 1) : LLVM.and (select e_1 (const? 1 1) 
 
 
 theorem lor_lor_left1_thm (e e_1 : IntW 1) :
-  select (select e_1 (const? 1 1) e) (const? 1 1) e_1 ⊑ select e_1 (const? 1 1) e := by 
+  select (select e_1 (const? 1 1) e) (const? 1 1) e_1 ⊑ select e_1 (const? 1 1) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -165,7 +165,7 @@ theorem lor_lor_left1_thm (e e_1 : IntW 1) :
 
 
 theorem lor_lor_left2_thm (e e_1 : IntW 1) :
-  select (select e_1 (const? 1 1) e) (const? 1 1) e ⊑ select e_1 (const? 1 1) e := by 
+  select (select e_1 (const? 1 1) e) (const? 1 1) e ⊑ select e_1 (const? 1 1) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -174,7 +174,7 @@ theorem lor_lor_left2_thm (e e_1 : IntW 1) :
     all_goals sorry
 
 
-theorem lor_bor_left1_thm (e e_1 : IntW 1) : LLVM.or (select e_1 (const? 1 1) e) e_1 ⊑ select e_1 (const? 1 1) e := by 
+theorem lor_bor_left1_thm (e e_1 : IntW 1) : LLVM.or (select e_1 (const? 1 1) e) e_1 ⊑ select e_1 (const? 1 1) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -183,7 +183,7 @@ theorem lor_bor_left1_thm (e e_1 : IntW 1) : LLVM.or (select e_1 (const? 1 1) e)
     all_goals sorry
 
 
-theorem lor_bor_left2_thm (e e_1 : IntW 1) : LLVM.or (select e_1 (const? 1 1) e) e ⊑ select e_1 (const? 1 1) e := by 
+theorem lor_bor_left2_thm (e e_1 : IntW 1) : LLVM.or (select e_1 (const? 1 1) e) e ⊑ select e_1 (const? 1 1) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -192,7 +192,7 @@ theorem lor_bor_left2_thm (e e_1 : IntW 1) : LLVM.or (select e_1 (const? 1 1) e)
     all_goals sorry
 
 
-theorem bor_land_left1_thm (e e_1 : IntW 1) : select (LLVM.or e_1 e) e_1 (const? 1 0) ⊑ e_1 := by 
+theorem bor_land_left1_thm (e e_1 : IntW 1) : select (LLVM.or e_1 e) e_1 (const? 1 0) ⊑ e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -201,7 +201,7 @@ theorem bor_land_left1_thm (e e_1 : IntW 1) : select (LLVM.or e_1 e) e_1 (const?
     all_goals sorry
 
 
-theorem bor_land_left2_thm (e e_1 : IntW 1) : select (LLVM.or e_1 e) e (const? 1 0) ⊑ e := by 
+theorem bor_land_left2_thm (e e_1 : IntW 1) : select (LLVM.or e_1 e) e (const? 1 0) ⊑ e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -210,7 +210,7 @@ theorem bor_land_left2_thm (e e_1 : IntW 1) : select (LLVM.or e_1 e) e (const? 1
     all_goals sorry
 
 
-theorem bor_lor_left1_thm (e e_1 : IntW 1) : select (LLVM.or e_1 e) (const? 1 1) e_1 ⊑ LLVM.or e_1 e := by 
+theorem bor_lor_left1_thm (e e_1 : IntW 1) : select (LLVM.or e_1 e) (const? 1 1) e_1 ⊑ LLVM.or e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -219,7 +219,7 @@ theorem bor_lor_left1_thm (e e_1 : IntW 1) : select (LLVM.or e_1 e) (const? 1 1)
     all_goals sorry
 
 
-theorem bor_lor_left2_thm (e e_1 : IntW 1) : select (LLVM.or e_1 e) (const? 1 1) e ⊑ LLVM.or e_1 e := by 
+theorem bor_lor_left2_thm (e e_1 : IntW 1) : select (LLVM.or e_1 e) (const? 1 1) e ⊑ LLVM.or e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -229,7 +229,7 @@ theorem bor_lor_left2_thm (e e_1 : IntW 1) : select (LLVM.or e_1 e) (const? 1 1)
 
 
 theorem land_land_right1_thm (e e_1 : IntW 1) :
-  select e_1 (select e_1 e (const? 1 0)) (const? 1 0) ⊑ select e_1 e (const? 1 0) := by 
+  select e_1 (select e_1 e (const? 1 0)) (const? 1 0) ⊑ select e_1 e (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -239,7 +239,7 @@ theorem land_land_right1_thm (e e_1 : IntW 1) :
 
 
 theorem land_land_right2_thm (e e_1 : IntW 1) :
-  select e_1 (select e e_1 (const? 1 0)) (const? 1 0) ⊑ select e_1 e (const? 1 0) := by 
+  select e_1 (select e e_1 (const? 1 0)) (const? 1 0) ⊑ select e_1 e (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -248,7 +248,7 @@ theorem land_land_right2_thm (e e_1 : IntW 1) :
     all_goals sorry
 
 
-theorem land_band_right1_thm (e e_1 : IntW 1) : LLVM.and e_1 (select e_1 e (const? 1 0)) ⊑ select e_1 e (const? 1 0) := by 
+theorem land_band_right1_thm (e e_1 : IntW 1) : LLVM.and e_1 (select e_1 e (const? 1 0)) ⊑ select e_1 e (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -257,7 +257,7 @@ theorem land_band_right1_thm (e e_1 : IntW 1) : LLVM.and e_1 (select e_1 e (cons
     all_goals sorry
 
 
-theorem land_band_right2_thm (e e_1 : IntW 1) : LLVM.and e_1 (select e e_1 (const? 1 0)) ⊑ select e e_1 (const? 1 0) := by 
+theorem land_band_right2_thm (e e_1 : IntW 1) : LLVM.and e_1 (select e e_1 (const? 1 0)) ⊑ select e e_1 (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -266,7 +266,7 @@ theorem land_band_right2_thm (e e_1 : IntW 1) : LLVM.and e_1 (select e e_1 (cons
     all_goals sorry
 
 
-theorem land_lor_right1_thm (e e_1 : IntW 1) : select e_1 (const? 1 1) (select e_1 e (const? 1 0)) ⊑ e_1 := by 
+theorem land_lor_right1_thm (e e_1 : IntW 1) : select e_1 (const? 1 1) (select e_1 e (const? 1 0)) ⊑ e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -275,7 +275,7 @@ theorem land_lor_right1_thm (e e_1 : IntW 1) : select e_1 (const? 1 1) (select e
     all_goals sorry
 
 
-theorem land_lor_right2_thm (e e_1 : IntW 1) : select e_1 (const? 1 1) (select e e_1 (const? 1 0)) ⊑ e_1 := by 
+theorem land_lor_right2_thm (e e_1 : IntW 1) : select e_1 (const? 1 1) (select e e_1 (const? 1 0)) ⊑ e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -284,7 +284,7 @@ theorem land_lor_right2_thm (e e_1 : IntW 1) : select e_1 (const? 1 1) (select e
     all_goals sorry
 
 
-theorem land_bor_right1_thm (e e_1 : IntW 1) : LLVM.or e_1 (select e_1 e (const? 1 0)) ⊑ e_1 := by 
+theorem land_bor_right1_thm (e e_1 : IntW 1) : LLVM.or e_1 (select e_1 e (const? 1 0)) ⊑ e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -293,7 +293,7 @@ theorem land_bor_right1_thm (e e_1 : IntW 1) : LLVM.or e_1 (select e_1 e (const?
     all_goals sorry
 
 
-theorem land_bor_right2_thm (e e_1 : IntW 1) : LLVM.or e_1 (select e e_1 (const? 1 0)) ⊑ e_1 := by 
+theorem land_bor_right2_thm (e e_1 : IntW 1) : LLVM.or e_1 (select e e_1 (const? 1 0)) ⊑ e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -302,7 +302,7 @@ theorem land_bor_right2_thm (e e_1 : IntW 1) : LLVM.or e_1 (select e e_1 (const?
     all_goals sorry
 
 
-theorem band_land_right1_thm (e e_1 : IntW 1) : select e_1 (LLVM.and e_1 e) (const? 1 0) ⊑ select e_1 e (const? 1 0) := by 
+theorem band_land_right1_thm (e e_1 : IntW 1) : select e_1 (LLVM.and e_1 e) (const? 1 0) ⊑ select e_1 e (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -311,7 +311,7 @@ theorem band_land_right1_thm (e e_1 : IntW 1) : select e_1 (LLVM.and e_1 e) (con
     all_goals sorry
 
 
-theorem band_land_right2_thm (e e_1 : IntW 1) : select e_1 (LLVM.and e e_1) (const? 1 0) ⊑ select e_1 e (const? 1 0) := by 
+theorem band_land_right2_thm (e e_1 : IntW 1) : select e_1 (LLVM.and e e_1) (const? 1 0) ⊑ select e_1 e (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -320,7 +320,7 @@ theorem band_land_right2_thm (e e_1 : IntW 1) : select e_1 (LLVM.and e e_1) (con
     all_goals sorry
 
 
-theorem band_lor_right1_thm (e e_1 : IntW 1) : select e_1 (const? 1 1) (LLVM.and e_1 e) ⊑ e_1 := by 
+theorem band_lor_right1_thm (e e_1 : IntW 1) : select e_1 (const? 1 1) (LLVM.and e_1 e) ⊑ e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -329,7 +329,7 @@ theorem band_lor_right1_thm (e e_1 : IntW 1) : select e_1 (const? 1 1) (LLVM.and
     all_goals sorry
 
 
-theorem band_lor_right2_thm (e e_1 : IntW 1) : select e_1 (const? 1 1) (LLVM.and e e_1) ⊑ e_1 := by 
+theorem band_lor_right2_thm (e e_1 : IntW 1) : select e_1 (const? 1 1) (LLVM.and e e_1) ⊑ e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -338,7 +338,7 @@ theorem band_lor_right2_thm (e e_1 : IntW 1) : select e_1 (const? 1 1) (LLVM.and
     all_goals sorry
 
 
-theorem lor_land_right1_thm (e e_1 : IntW 1) : select e_1 (select e_1 (const? 1 1) e) (const? 1 0) ⊑ e_1 := by 
+theorem lor_land_right1_thm (e e_1 : IntW 1) : select e_1 (select e_1 (const? 1 1) e) (const? 1 0) ⊑ e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -347,7 +347,7 @@ theorem lor_land_right1_thm (e e_1 : IntW 1) : select e_1 (select e_1 (const? 1 
     all_goals sorry
 
 
-theorem lor_land_right2_thm (e e_1 : IntW 1) : select e_1 (select e (const? 1 1) e_1) (const? 1 0) ⊑ e_1 := by 
+theorem lor_land_right2_thm (e e_1 : IntW 1) : select e_1 (select e (const? 1 1) e_1) (const? 1 0) ⊑ e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -356,7 +356,7 @@ theorem lor_land_right2_thm (e e_1 : IntW 1) : select e_1 (select e (const? 1 1)
     all_goals sorry
 
 
-theorem lor_band_right1_thm (e e_1 : IntW 1) : LLVM.and e_1 (select e_1 (const? 1 1) e) ⊑ e_1 := by 
+theorem lor_band_right1_thm (e e_1 : IntW 1) : LLVM.and e_1 (select e_1 (const? 1 1) e) ⊑ e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -365,7 +365,7 @@ theorem lor_band_right1_thm (e e_1 : IntW 1) : LLVM.and e_1 (select e_1 (const? 
     all_goals sorry
 
 
-theorem lor_band_right2_thm (e e_1 : IntW 1) : LLVM.and e_1 (select e (const? 1 1) e_1) ⊑ e_1 := by 
+theorem lor_band_right2_thm (e e_1 : IntW 1) : LLVM.and e_1 (select e (const? 1 1) e_1) ⊑ e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -375,7 +375,7 @@ theorem lor_band_right2_thm (e e_1 : IntW 1) : LLVM.and e_1 (select e (const? 1 
 
 
 theorem lor_lor_right1_thm (e e_1 : IntW 1) :
-  select e_1 (const? 1 1) (select e_1 (const? 1 1) e) ⊑ select e_1 (const? 1 1) e := by 
+  select e_1 (const? 1 1) (select e_1 (const? 1 1) e) ⊑ select e_1 (const? 1 1) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -385,7 +385,7 @@ theorem lor_lor_right1_thm (e e_1 : IntW 1) :
 
 
 theorem lor_lor_right2_thm (e e_1 : IntW 1) :
-  select e_1 (const? 1 1) (select e (const? 1 1) e_1) ⊑ select e_1 (const? 1 1) e := by 
+  select e_1 (const? 1 1) (select e (const? 1 1) e_1) ⊑ select e_1 (const? 1 1) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -394,7 +394,7 @@ theorem lor_lor_right2_thm (e e_1 : IntW 1) :
     all_goals sorry
 
 
-theorem lor_bor_right1_thm (e e_1 : IntW 1) : LLVM.or e_1 (select e_1 (const? 1 1) e) ⊑ select e_1 (const? 1 1) e := by 
+theorem lor_bor_right1_thm (e e_1 : IntW 1) : LLVM.or e_1 (select e_1 (const? 1 1) e) ⊑ select e_1 (const? 1 1) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -403,7 +403,7 @@ theorem lor_bor_right1_thm (e e_1 : IntW 1) : LLVM.or e_1 (select e_1 (const? 1 
     all_goals sorry
 
 
-theorem lor_bor_right2_thm (e e_1 : IntW 1) : LLVM.or e_1 (select e (const? 1 1) e_1) ⊑ select e (const? 1 1) e_1 := by 
+theorem lor_bor_right2_thm (e e_1 : IntW 1) : LLVM.or e_1 (select e (const? 1 1) e_1) ⊑ select e (const? 1 1) e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -412,7 +412,7 @@ theorem lor_bor_right2_thm (e e_1 : IntW 1) : LLVM.or e_1 (select e (const? 1 1)
     all_goals sorry
 
 
-theorem bor_land_right1_thm (e e_1 : IntW 1) : select e_1 (LLVM.or e_1 e) (const? 1 0) ⊑ e_1 := by 
+theorem bor_land_right1_thm (e e_1 : IntW 1) : select e_1 (LLVM.or e_1 e) (const? 1 0) ⊑ e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -421,7 +421,7 @@ theorem bor_land_right1_thm (e e_1 : IntW 1) : select e_1 (LLVM.or e_1 e) (const
     all_goals sorry
 
 
-theorem bor_land_right2_thm (e e_1 : IntW 1) : select e_1 (LLVM.or e e_1) (const? 1 0) ⊑ e_1 := by 
+theorem bor_land_right2_thm (e e_1 : IntW 1) : select e_1 (LLVM.or e e_1) (const? 1 0) ⊑ e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -430,7 +430,7 @@ theorem bor_land_right2_thm (e e_1 : IntW 1) : select e_1 (LLVM.or e e_1) (const
     all_goals sorry
 
 
-theorem bor_lor_right1_thm (e e_1 : IntW 1) : select e_1 (const? 1 1) (LLVM.or e_1 e) ⊑ select e_1 (const? 1 1) e := by 
+theorem bor_lor_right1_thm (e e_1 : IntW 1) : select e_1 (const? 1 1) (LLVM.or e_1 e) ⊑ select e_1 (const? 1 1) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -439,7 +439,7 @@ theorem bor_lor_right1_thm (e e_1 : IntW 1) : select e_1 (const? 1 1) (LLVM.or e
     all_goals sorry
 
 
-theorem bor_lor_right2_thm (e e_1 : IntW 1) : select e_1 (const? 1 1) (LLVM.or e e_1) ⊑ select e_1 (const? 1 1) e := by 
+theorem bor_lor_right2_thm (e e_1 : IntW 1) : select e_1 (const? 1 1) (LLVM.or e e_1) ⊑ select e_1 (const? 1 1) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gselecthsafehimpliedcondhtransforms_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gselecthsafehimpliedcondhtransforms_proof.lean
@@ -11,7 +11,7 @@ section gselecthsafehimpliedcondhtransforms_proof
 theorem a_true_implies_b_true_thm (e e_1 : IntW 1) (e_2 : IntW 8) :
   select (icmp IntPredicate.ugt e_2 (const? 8 20)) (select (icmp IntPredicate.ugt e_2 (const? 8 10)) e_1 e)
       (const? 1 0) ⊑
-    select (icmp IntPredicate.ugt e_2 (const? 8 20)) e_1 (const? 1 0) := by 
+    select (icmp IntPredicate.ugt e_2 (const? 8 20)) e_1 (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -22,7 +22,7 @@ theorem a_true_implies_b_true_thm (e e_1 : IntW 1) (e_2 : IntW 8) :
 
 theorem a_true_implies_b_true2_thm (e e_1 : IntW 1) (e_2 : IntW 8) :
   LLVM.and (icmp IntPredicate.ugt e_2 (const? 8 20)) (select (icmp IntPredicate.ugt e_2 (const? 8 10)) e_1 e) ⊑
-    select (icmp IntPredicate.ugt e_2 (const? 8 20)) e_1 (const? 1 0) := by 
+    select (icmp IntPredicate.ugt e_2 (const? 8 20)) e_1 (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -33,7 +33,7 @@ theorem a_true_implies_b_true2_thm (e e_1 : IntW 1) (e_2 : IntW 8) :
 
 theorem a_true_implies_b_true2_comm_thm (e e_1 : IntW 1) (e_2 : IntW 8) :
   LLVM.and (select (icmp IntPredicate.ugt e_2 (const? 8 10)) e_1 e) (icmp IntPredicate.ugt e_2 (const? 8 20)) ⊑
-    select (icmp IntPredicate.ugt e_2 (const? 8 20)) e_1 (const? 1 0) := by 
+    select (icmp IntPredicate.ugt e_2 (const? 8 20)) e_1 (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -45,7 +45,7 @@ theorem a_true_implies_b_true2_comm_thm (e e_1 : IntW 1) (e_2 : IntW 8) :
 theorem a_true_implies_b_false_thm (e e_1 : IntW 1) (e_2 : IntW 8) :
   select (icmp IntPredicate.ugt e_2 (const? 8 20)) (select (icmp IntPredicate.ult e_2 (const? 8 10)) e_1 e)
       (const? 1 0) ⊑
-    select (icmp IntPredicate.ugt e_2 (const? 8 20)) e (const? 1 0) := by 
+    select (icmp IntPredicate.ugt e_2 (const? 8 20)) e (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -56,7 +56,7 @@ theorem a_true_implies_b_false_thm (e e_1 : IntW 1) (e_2 : IntW 8) :
 
 theorem a_true_implies_b_false2_thm (e e_1 : IntW 1) (e_2 : IntW 8) :
   LLVM.and (icmp IntPredicate.ugt e_2 (const? 8 20)) (select (icmp IntPredicate.eq e_2 (const? 8 10)) e_1 e) ⊑
-    select (icmp IntPredicate.ugt e_2 (const? 8 20)) e (const? 1 0) := by 
+    select (icmp IntPredicate.ugt e_2 (const? 8 20)) e (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -67,7 +67,7 @@ theorem a_true_implies_b_false2_thm (e e_1 : IntW 1) (e_2 : IntW 8) :
 
 theorem a_true_implies_b_false2_comm_thm (e e_1 : IntW 1) (e_2 : IntW 8) :
   LLVM.and (select (icmp IntPredicate.eq e_2 (const? 8 10)) e_1 e) (icmp IntPredicate.ugt e_2 (const? 8 20)) ⊑
-    select (icmp IntPredicate.ugt e_2 (const? 8 20)) e (const? 1 0) := by 
+    select (icmp IntPredicate.ugt e_2 (const? 8 20)) e (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -79,7 +79,7 @@ theorem a_true_implies_b_false2_comm_thm (e e_1 : IntW 1) (e_2 : IntW 8) :
 theorem a_false_implies_b_true_thm (e e_1 : IntW 1) (e_2 : IntW 8) :
   select (icmp IntPredicate.ugt e_2 (const? 8 10)) (const? 1 1)
       (select (icmp IntPredicate.ult e_2 (const? 8 20)) e_1 e) ⊑
-    select (icmp IntPredicate.ugt e_2 (const? 8 10)) (const? 1 1) e_1 := by 
+    select (icmp IntPredicate.ugt e_2 (const? 8 10)) (const? 1 1) e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -90,7 +90,7 @@ theorem a_false_implies_b_true_thm (e e_1 : IntW 1) (e_2 : IntW 8) :
 
 theorem a_false_implies_b_true2_thm (e e_1 : IntW 1) (e_2 : IntW 8) :
   LLVM.or (icmp IntPredicate.ugt e_2 (const? 8 10)) (select (icmp IntPredicate.ult e_2 (const? 8 20)) e_1 e) ⊑
-    select (icmp IntPredicate.ugt e_2 (const? 8 10)) (const? 1 1) e_1 := by 
+    select (icmp IntPredicate.ugt e_2 (const? 8 10)) (const? 1 1) e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -101,7 +101,7 @@ theorem a_false_implies_b_true2_thm (e e_1 : IntW 1) (e_2 : IntW 8) :
 
 theorem a_false_implies_b_true2_comm_thm (e e_1 : IntW 1) (e_2 : IntW 8) :
   LLVM.or (select (icmp IntPredicate.ult e_2 (const? 8 20)) e_1 e) (icmp IntPredicate.ugt e_2 (const? 8 10)) ⊑
-    select (icmp IntPredicate.ugt e_2 (const? 8 10)) (const? 1 1) e_1 := by 
+    select (icmp IntPredicate.ugt e_2 (const? 8 10)) (const? 1 1) e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -113,7 +113,7 @@ theorem a_false_implies_b_true2_comm_thm (e e_1 : IntW 1) (e_2 : IntW 8) :
 theorem a_false_implies_b_false_thm (e e_1 : IntW 1) (e_2 : IntW 8) :
   select (icmp IntPredicate.ugt e_2 (const? 8 10)) (const? 1 1)
       (select (icmp IntPredicate.ugt e_2 (const? 8 20)) e_1 e) ⊑
-    select (icmp IntPredicate.ugt e_2 (const? 8 10)) (const? 1 1) e := by 
+    select (icmp IntPredicate.ugt e_2 (const? 8 10)) (const? 1 1) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -124,7 +124,7 @@ theorem a_false_implies_b_false_thm (e e_1 : IntW 1) (e_2 : IntW 8) :
 
 theorem a_false_implies_b_false2_thm (e e_1 : IntW 1) (e_2 : IntW 8) :
   LLVM.or (icmp IntPredicate.ugt e_2 (const? 8 10)) (select (icmp IntPredicate.ugt e_2 (const? 8 20)) e_1 e) ⊑
-    select (icmp IntPredicate.ugt e_2 (const? 8 10)) (const? 1 1) e := by 
+    select (icmp IntPredicate.ugt e_2 (const? 8 10)) (const? 1 1) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -135,7 +135,7 @@ theorem a_false_implies_b_false2_thm (e e_1 : IntW 1) (e_2 : IntW 8) :
 
 theorem a_false_implies_b_false2_comm_thm (e e_1 : IntW 1) (e_2 : IntW 8) :
   LLVM.or (select (icmp IntPredicate.ugt e_2 (const? 8 20)) e_1 e) (icmp IntPredicate.ugt e_2 (const? 8 10)) ⊑
-    select (icmp IntPredicate.ugt e_2 (const? 8 10)) (const? 1 1) e := by 
+    select (icmp IntPredicate.ugt e_2 (const? 8 10)) (const? 1 1) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gselecthsafehtransforms_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gselecthsafehtransforms_proof.lean
@@ -10,7 +10,7 @@ set_option linter.unreachableTactic false
 section gselecthsafehtransforms_proof
 theorem cond_eq_and_const_thm (e e_1 : IntW 8) :
   select (icmp IntPredicate.eq e_1 (const? 8 10)) (icmp IntPredicate.ult e_1 e) (const? 1 0) ⊑
-    select (icmp IntPredicate.eq e_1 (const? 8 10)) (icmp IntPredicate.ugt e (const? 8 10)) (const? 1 0) := by 
+    select (icmp IntPredicate.eq e_1 (const? 8 10)) (icmp IntPredicate.ugt e (const? 8 10)) (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -21,7 +21,7 @@ theorem cond_eq_and_const_thm (e e_1 : IntW 8) :
 
 theorem cond_eq_or_const_thm (e e_1 : IntW 8) :
   select (icmp IntPredicate.ne e_1 (const? 8 10)) (const? 1 1) (icmp IntPredicate.ult e_1 e) ⊑
-    select (icmp IntPredicate.ne e_1 (const? 8 10)) (const? 1 1) (icmp IntPredicate.ugt e (const? 8 10)) := by 
+    select (icmp IntPredicate.ne e_1 (const? 8 10)) (const? 1 1) (icmp IntPredicate.ugt e (const? 8 10)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -32,7 +32,7 @@ theorem cond_eq_or_const_thm (e e_1 : IntW 8) :
 
 theorem xor_and_thm (e e_1 : IntW 32) (e_2 : IntW 1) :
   LLVM.xor (select e_2 (icmp IntPredicate.ult e_1 e) (const? 1 0)) (const? 1 1) ⊑
-    select (LLVM.xor e_2 (const? 1 1)) (const? 1 1) (icmp IntPredicate.uge e_1 e) := by 
+    select (LLVM.xor e_2 (const? 1 1)) (const? 1 1) (icmp IntPredicate.uge e_1 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -43,7 +43,7 @@ theorem xor_and_thm (e e_1 : IntW 32) (e_2 : IntW 1) :
 
 theorem xor_or_thm (e e_1 : IntW 32) (e_2 : IntW 1) :
   LLVM.xor (select e_2 (const? 1 1) (icmp IntPredicate.ult e_1 e)) (const? 1 1) ⊑
-    select (LLVM.xor e_2 (const? 1 1)) (icmp IntPredicate.uge e_1 e) (const? 1 0) := by 
+    select (LLVM.xor e_2 (const? 1 1)) (icmp IntPredicate.uge e_1 e) (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -54,7 +54,7 @@ theorem xor_or_thm (e e_1 : IntW 32) (e_2 : IntW 1) :
 
 theorem and_orn_cmp_1_logical_thm (e : IntW 1) (e_1 e_2 : IntW 32) :
   select (icmp IntPredicate.sgt e_2 e_1) (select e (const? 1 1) (icmp IntPredicate.sle e_2 e_1)) (const? 1 0) ⊑
-    select (icmp IntPredicate.sgt e_2 e_1) e (const? 1 0) := by 
+    select (icmp IntPredicate.sgt e_2 e_1) e (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -65,7 +65,7 @@ theorem and_orn_cmp_1_logical_thm (e : IntW 1) (e_1 e_2 : IntW 32) :
 
 theorem andn_or_cmp_2_logical_thm (e e_1 : IntW 16) (e_2 : IntW 1) :
   select (select e_2 (const? 1 1) (icmp IntPredicate.sge e_1 e)) (icmp IntPredicate.slt e_1 e) (const? 1 0) ⊑
-    select e_2 (icmp IntPredicate.slt e_1 e) (const? 1 0) := by 
+    select e_2 (icmp IntPredicate.slt e_1 e) (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -76,7 +76,7 @@ theorem andn_or_cmp_2_logical_thm (e e_1 : IntW 16) (e_2 : IntW 1) :
 
 theorem andn_or_cmp_2_partial_logical_thm (e : IntW 1) (e_1 e_2 : IntW 16) :
   select (LLVM.or (icmp IntPredicate.sge e_2 e_1) e) (icmp IntPredicate.slt e_2 e_1) (const? 1 0) ⊑
-    LLVM.and e (icmp IntPredicate.slt e_2 e_1) := by 
+    LLVM.and e (icmp IntPredicate.slt e_2 e_1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -87,7 +87,7 @@ theorem andn_or_cmp_2_partial_logical_thm (e : IntW 1) (e_1 e_2 : IntW 16) :
 
 theorem bools_logical_commute0_thm (e e_1 e_2 : IntW 1) :
   select (select (LLVM.xor e_2 (const? 1 1)) e_1 (const? 1 0)) (const? 1 1) (select e_2 e (const? 1 0)) ⊑
-    select e_2 e e_1 := by 
+    select e_2 e e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -97,7 +97,7 @@ theorem bools_logical_commute0_thm (e e_1 e_2 : IntW 1) :
 
 
 theorem bools_logical_commute0_and1_thm (e e_1 e_2 : IntW 1) :
-  select (LLVM.and (LLVM.xor e_2 (const? 1 1)) e_1) (const? 1 1) (select e_2 e (const? 1 0)) ⊑ select e_2 e e_1 := by 
+  select (LLVM.and (LLVM.xor e_2 (const? 1 1)) e_1) (const? 1 1) (select e_2 e (const? 1 0)) ⊑ select e_2 e e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -107,7 +107,7 @@ theorem bools_logical_commute0_and1_thm (e e_1 e_2 : IntW 1) :
 
 
 theorem bools_logical_commute0_and2_thm (e e_1 e_2 : IntW 1) :
-  select (select (LLVM.xor e_2 (const? 1 1)) e_1 (const? 1 0)) (const? 1 1) (LLVM.and e_2 e) ⊑ select e_2 e e_1 := by 
+  select (select (LLVM.xor e_2 (const? 1 1)) e_1 (const? 1 0)) (const? 1 1) (LLVM.and e_2 e) ⊑ select e_2 e e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -117,7 +117,7 @@ theorem bools_logical_commute0_and2_thm (e e_1 e_2 : IntW 1) :
 
 
 theorem bools_logical_commute0_and1_and2_thm (e e_1 e_2 : IntW 1) :
-  select (LLVM.and (LLVM.xor e_2 (const? 1 1)) e_1) (const? 1 1) (LLVM.and e_2 e) ⊑ select e_2 e e_1 := by 
+  select (LLVM.and (LLVM.xor e_2 (const? 1 1)) e_1) (const? 1 1) (LLVM.and e_2 e) ⊑ select e_2 e e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -128,7 +128,7 @@ theorem bools_logical_commute0_and1_and2_thm (e e_1 e_2 : IntW 1) :
 
 theorem bools_logical_commute1_thm (e e_1 e_2 : IntW 1) :
   select (select e_2 (LLVM.xor e_1 (const? 1 1)) (const? 1 0)) (const? 1 1) (select e_1 e (const? 1 0)) ⊑
-    select e_1 e e_2 := by 
+    select e_1 e e_2 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -138,7 +138,7 @@ theorem bools_logical_commute1_thm (e e_1 e_2 : IntW 1) :
 
 
 theorem bools_logical_commute1_and2_thm (e e_1 e_2 : IntW 1) :
-  select (select e_2 (LLVM.xor e_1 (const? 1 1)) (const? 1 0)) (const? 1 1) (LLVM.and e_1 e) ⊑ select e_1 e e_2 := by 
+  select (select e_2 (LLVM.xor e_1 (const? 1 1)) (const? 1 0)) (const? 1 1) (LLVM.and e_1 e) ⊑ select e_1 e e_2 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -148,7 +148,7 @@ theorem bools_logical_commute1_and2_thm (e e_1 e_2 : IntW 1) :
 
 
 theorem bools_logical_commute3_and2_thm (e e_1 e_2 : IntW 1) :
-  select (select e_2 (LLVM.xor e_1 (const? 1 1)) (const? 1 0)) (const? 1 1) (LLVM.and e e_1) ⊑ select e_1 e e_2 := by 
+  select (select e_2 (LLVM.xor e_1 (const? 1 1)) (const? 1 0)) (const? 1 1) (LLVM.and e e_1) ⊑ select e_1 e e_2 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -159,7 +159,7 @@ theorem bools_logical_commute3_and2_thm (e e_1 e_2 : IntW 1) :
 
 theorem bools2_logical_commute0_thm (e e_1 e_2 : IntW 1) :
   select (select e_2 e_1 (const? 1 0)) (const? 1 1) (select (LLVM.xor e_2 (const? 1 1)) e (const? 1 0)) ⊑
-    select e_2 e_1 e := by 
+    select e_2 e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -169,7 +169,7 @@ theorem bools2_logical_commute0_thm (e e_1 e_2 : IntW 1) :
 
 
 theorem bools2_logical_commute0_and1_thm (e e_1 e_2 : IntW 1) :
-  select (LLVM.and e_2 e_1) (const? 1 1) (select (LLVM.xor e_2 (const? 1 1)) e (const? 1 0)) ⊑ select e_2 e_1 e := by 
+  select (LLVM.and e_2 e_1) (const? 1 1) (select (LLVM.xor e_2 (const? 1 1)) e (const? 1 0)) ⊑ select e_2 e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -179,7 +179,7 @@ theorem bools2_logical_commute0_and1_thm (e e_1 e_2 : IntW 1) :
 
 
 theorem bools2_logical_commute0_and2_thm (e e_1 e_2 : IntW 1) :
-  select (select e_2 e_1 (const? 1 0)) (const? 1 1) (LLVM.and (LLVM.xor e_2 (const? 1 1)) e) ⊑ select e_2 e_1 e := by 
+  select (select e_2 e_1 (const? 1 0)) (const? 1 1) (LLVM.and (LLVM.xor e_2 (const? 1 1)) e) ⊑ select e_2 e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -189,7 +189,7 @@ theorem bools2_logical_commute0_and2_thm (e e_1 e_2 : IntW 1) :
 
 
 theorem bools2_logical_commute0_and1_and2_thm (e e_1 e_2 : IntW 1) :
-  select (LLVM.and e_2 e_1) (const? 1 1) (LLVM.and (LLVM.xor e_2 (const? 1 1)) e) ⊑ select e_2 e_1 e := by 
+  select (LLVM.and e_2 e_1) (const? 1 1) (LLVM.and (LLVM.xor e_2 (const? 1 1)) e) ⊑ select e_2 e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -200,7 +200,7 @@ theorem bools2_logical_commute0_and1_and2_thm (e e_1 e_2 : IntW 1) :
 
 theorem bools2_logical_commute1_thm (e e_1 e_2 : IntW 1) :
   select (select e_2 e_1 (const? 1 0)) (const? 1 1) (select (LLVM.xor e_1 (const? 1 1)) e (const? 1 0)) ⊑
-    select e_1 e_2 e := by 
+    select e_1 e_2 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -210,7 +210,7 @@ theorem bools2_logical_commute1_thm (e e_1 e_2 : IntW 1) :
 
 
 theorem bools2_logical_commute1_and1_thm (e e_1 e_2 : IntW 1) :
-  select (LLVM.and e_2 e_1) (const? 1 1) (select (LLVM.xor e_1 (const? 1 1)) e (const? 1 0)) ⊑ select e_1 e_2 e := by 
+  select (LLVM.and e_2 e_1) (const? 1 1) (select (LLVM.xor e_1 (const? 1 1)) e (const? 1 0)) ⊑ select e_1 e_2 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -220,7 +220,7 @@ theorem bools2_logical_commute1_and1_thm (e e_1 e_2 : IntW 1) :
 
 
 theorem bools2_logical_commute1_and2_thm (e e_1 e_2 : IntW 1) :
-  select (select e_2 e_1 (const? 1 0)) (const? 1 1) (LLVM.and (LLVM.xor e_1 (const? 1 1)) e) ⊑ select e_1 e_2 e := by 
+  select (select e_2 e_1 (const? 1 0)) (const? 1 1) (LLVM.and (LLVM.xor e_1 (const? 1 1)) e) ⊑ select e_1 e_2 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -230,7 +230,7 @@ theorem bools2_logical_commute1_and2_thm (e e_1 e_2 : IntW 1) :
 
 
 theorem bools2_logical_commute1_and1_and2_thm (e e_1 e_2 : IntW 1) :
-  select (LLVM.and e_2 e_1) (const? 1 1) (LLVM.and (LLVM.xor e_1 (const? 1 1)) e) ⊑ select e_1 e_2 e := by 
+  select (LLVM.and e_2 e_1) (const? 1 1) (LLVM.and (LLVM.xor e_1 (const? 1 1)) e) ⊑ select e_1 e_2 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -241,7 +241,7 @@ theorem bools2_logical_commute1_and1_and2_thm (e e_1 e_2 : IntW 1) :
 
 theorem bools2_logical_commute2_thm (e e_1 e_2 : IntW 1) :
   select (select e_2 e_1 (const? 1 0)) (const? 1 1) (select e (LLVM.xor e_2 (const? 1 1)) (const? 1 0)) ⊑
-    select e_2 e_1 e := by 
+    select e_2 e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -251,7 +251,7 @@ theorem bools2_logical_commute2_thm (e e_1 e_2 : IntW 1) :
 
 
 theorem bools2_logical_commute2_and1_thm (e e_1 e_2 : IntW 1) :
-  select (LLVM.and e_2 e_1) (const? 1 1) (select e (LLVM.xor e_2 (const? 1 1)) (const? 1 0)) ⊑ select e_2 e_1 e := by 
+  select (LLVM.and e_2 e_1) (const? 1 1) (select e (LLVM.xor e_2 (const? 1 1)) (const? 1 0)) ⊑ select e_2 e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -261,7 +261,7 @@ theorem bools2_logical_commute2_and1_thm (e e_1 e_2 : IntW 1) :
 
 
 theorem bools2_logical_commute3_and1_thm (e e_1 e_2 : IntW 1) :
-  select (LLVM.and e_2 e_1) (const? 1 1) (select e (LLVM.xor e_1 (const? 1 1)) (const? 1 0)) ⊑ select e_1 e_2 e := by 
+  select (LLVM.and e_2 e_1) (const? 1 1) (select e (LLVM.xor e_1 (const? 1 1)) (const? 1 0)) ⊑ select e_1 e_2 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -272,7 +272,7 @@ theorem bools2_logical_commute3_and1_thm (e e_1 e_2 : IntW 1) :
 
 theorem orn_and_cmp_1_logical_thm (e : IntW 1) (e_1 e_2 : IntW 37) :
   select (icmp IntPredicate.sle e_2 e_1) (const? 1 1) (select e (icmp IntPredicate.sgt e_2 e_1) (const? 1 0)) ⊑
-    select (icmp IntPredicate.sle e_2 e_1) (const? 1 1) e := by 
+    select (icmp IntPredicate.sle e_2 e_1) (const? 1 1) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -283,7 +283,7 @@ theorem orn_and_cmp_1_logical_thm (e : IntW 1) (e_1 e_2 : IntW 37) :
 
 theorem orn_and_cmp_2_logical_thm (e e_1 : IntW 16) (e_2 : IntW 1) :
   select (select e_2 (icmp IntPredicate.sge e_1 e) (const? 1 0)) (const? 1 1) (icmp IntPredicate.slt e_1 e) ⊑
-    select e_2 (const? 1 1) (icmp IntPredicate.slt e_1 e) := by 
+    select e_2 (const? 1 1) (icmp IntPredicate.slt e_1 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -294,7 +294,7 @@ theorem orn_and_cmp_2_logical_thm (e e_1 : IntW 16) (e_2 : IntW 1) :
 
 theorem orn_and_cmp_2_partial_logical_thm (e : IntW 1) (e_1 e_2 : IntW 16) :
   select (LLVM.and (icmp IntPredicate.sge e_2 e_1) e) (const? 1 1) (icmp IntPredicate.slt e_2 e_1) ⊑
-    LLVM.or e (icmp IntPredicate.slt e_2 e_1) := by 
+    LLVM.or e (icmp IntPredicate.slt e_2 e_1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gselecthwithhbitwisehops_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gselecthwithhbitwisehops_proof.lean
@@ -10,7 +10,7 @@ set_option linter.unreachableTactic false
 section gselecthwithhbitwisehops_proof
 theorem select_icmp_eq_and_1_0_or_2_thm (e e_1 : IntW 32) :
   select (icmp IntPredicate.eq (LLVM.and e_1 (const? 32 1)) (const? 32 0)) e (LLVM.or e (const? 32 2)) ⊑
-    LLVM.or e (LLVM.and (shl e_1 (const? 32 1)) (const? 32 2)) := by 
+    LLVM.or e (LLVM.and (shl e_1 (const? 32 1)) (const? 32 2)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -21,7 +21,7 @@ theorem select_icmp_eq_and_1_0_or_2_thm (e e_1 : IntW 32) :
 
 theorem select_icmp_eq_and_1_0_xor_2_thm (e e_1 : IntW 32) :
   select (icmp IntPredicate.eq (LLVM.and e_1 (const? 32 1)) (const? 32 0)) e (LLVM.xor e (const? 32 2)) ⊑
-    LLVM.xor e (LLVM.and (shl e_1 (const? 32 1)) (const? 32 2)) := by 
+    LLVM.xor e (LLVM.and (shl e_1 (const? 32 1)) (const? 32 2)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -32,7 +32,7 @@ theorem select_icmp_eq_and_1_0_xor_2_thm (e e_1 : IntW 32) :
 
 theorem select_icmp_eq_and_32_0_or_8_thm (e e_1 : IntW 32) :
   select (icmp IntPredicate.eq (LLVM.and e_1 (const? 32 32)) (const? 32 0)) e (LLVM.or e (const? 32 8)) ⊑
-    LLVM.or e (LLVM.and (lshr e_1 (const? 32 2)) (const? 32 8)) := by 
+    LLVM.or e (LLVM.and (lshr e_1 (const? 32 2)) (const? 32 8)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -43,7 +43,7 @@ theorem select_icmp_eq_and_32_0_or_8_thm (e e_1 : IntW 32) :
 
 theorem select_icmp_eq_and_32_0_xor_8_thm (e e_1 : IntW 32) :
   select (icmp IntPredicate.eq (LLVM.and e_1 (const? 32 32)) (const? 32 0)) e (LLVM.xor e (const? 32 8)) ⊑
-    LLVM.xor e (LLVM.and (lshr e_1 (const? 32 2)) (const? 32 8)) := by 
+    LLVM.xor e (LLVM.and (lshr e_1 (const? 32 2)) (const? 32 8)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -54,7 +54,7 @@ theorem select_icmp_eq_and_32_0_xor_8_thm (e e_1 : IntW 32) :
 
 theorem select_icmp_ne_0_and_4096_or_4096_thm (e e_1 : IntW 32) :
   select (icmp IntPredicate.ne (const? 32 0) (LLVM.and e_1 (const? 32 4096))) e (LLVM.or e (const? 32 4096)) ⊑
-    LLVM.or e (LLVM.xor (LLVM.and e_1 (const? 32 4096)) (const? 32 4096)) := by 
+    LLVM.or e (LLVM.xor (LLVM.and e_1 (const? 32 4096)) (const? 32 4096)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -65,7 +65,7 @@ theorem select_icmp_ne_0_and_4096_or_4096_thm (e e_1 : IntW 32) :
 
 theorem select_icmp_ne_0_and_4096_xor_4096_thm (e e_1 : IntW 32) :
   select (icmp IntPredicate.ne (const? 32 0) (LLVM.and e_1 (const? 32 4096))) e (LLVM.xor e (const? 32 4096)) ⊑
-    LLVM.xor (LLVM.xor (LLVM.and e_1 (const? 32 4096)) e) (const? 32 4096) := by 
+    LLVM.xor (LLVM.xor (LLVM.and e_1 (const? 32 4096)) e) (const? 32 4096) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -77,7 +77,7 @@ theorem select_icmp_ne_0_and_4096_xor_4096_thm (e e_1 : IntW 32) :
 theorem select_icmp_ne_0_and_4096_and_not_4096_thm (e e_1 : IntW 32) :
   select (icmp IntPredicate.ne (const? 32 0) (LLVM.and e_1 (const? 32 4096))) e (LLVM.and e (const? 32 (-4097))) ⊑
     select (icmp IntPredicate.eq (LLVM.and e_1 (const? 32 4096)) (const? 32 0)) (LLVM.and e (const? 32 (-4097)))
-      e := by 
+      e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -88,7 +88,7 @@ theorem select_icmp_ne_0_and_4096_and_not_4096_thm (e e_1 : IntW 32) :
 
 theorem select_icmp_eq_and_4096_0_or_4096_thm (e e_1 : IntW 32) :
   select (icmp IntPredicate.eq (LLVM.and e_1 (const? 32 4096)) (const? 32 0)) e (LLVM.or e (const? 32 4096)) ⊑
-    LLVM.or e (LLVM.and e_1 (const? 32 4096)) := by 
+    LLVM.or e (LLVM.and e_1 (const? 32 4096)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -99,7 +99,7 @@ theorem select_icmp_eq_and_4096_0_or_4096_thm (e e_1 : IntW 32) :
 
 theorem select_icmp_eq_and_4096_0_xor_4096_thm (e e_1 : IntW 32) :
   select (icmp IntPredicate.eq (LLVM.and e_1 (const? 32 4096)) (const? 32 0)) e (LLVM.xor e (const? 32 4096)) ⊑
-    LLVM.xor e (LLVM.and e_1 (const? 32 4096)) := by 
+    LLVM.xor e (LLVM.and e_1 (const? 32 4096)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -110,7 +110,7 @@ theorem select_icmp_eq_and_4096_0_xor_4096_thm (e e_1 : IntW 32) :
 
 theorem select_icmp_eq_0_and_1_or_1_thm (e : IntW 32) (e_1 : IntW 64) :
   select (icmp IntPredicate.eq (LLVM.and e_1 (const? 64 1)) (const? 64 0)) e (LLVM.or e (const? 32 1)) ⊑
-    LLVM.or e (LLVM.and (trunc 32 e_1) (const? 32 1)) := by 
+    LLVM.or e (LLVM.and (trunc 32 e_1) (const? 32 1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -121,7 +121,7 @@ theorem select_icmp_eq_0_and_1_or_1_thm (e : IntW 32) (e_1 : IntW 64) :
 
 theorem select_icmp_eq_0_and_1_xor_1_thm (e : IntW 32) (e_1 : IntW 64) :
   select (icmp IntPredicate.eq (LLVM.and e_1 (const? 64 1)) (const? 64 0)) e (LLVM.xor e (const? 32 1)) ⊑
-    LLVM.xor e (LLVM.and (trunc 32 e_1) (const? 32 1)) := by 
+    LLVM.xor e (LLVM.and (trunc 32 e_1) (const? 32 1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -132,7 +132,7 @@ theorem select_icmp_eq_0_and_1_xor_1_thm (e : IntW 32) (e_1 : IntW 64) :
 
 theorem select_icmp_ne_0_and_4096_or_32_thm (e e_1 : IntW 32) :
   select (icmp IntPredicate.ne (const? 32 0) (LLVM.and e_1 (const? 32 4096))) e (LLVM.or e (const? 32 32)) ⊑
-    LLVM.or e (LLVM.xor (LLVM.and (lshr e_1 (const? 32 7)) (const? 32 32)) (const? 32 32)) := by 
+    LLVM.or e (LLVM.xor (LLVM.and (lshr e_1 (const? 32 7)) (const? 32 32)) (const? 32 32)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -143,7 +143,7 @@ theorem select_icmp_ne_0_and_4096_or_32_thm (e e_1 : IntW 32) :
 
 theorem select_icmp_ne_0_and_4096_xor_32_thm (e e_1 : IntW 32) :
   select (icmp IntPredicate.ne (const? 32 0) (LLVM.and e_1 (const? 32 4096))) e (LLVM.xor e (const? 32 32)) ⊑
-    LLVM.xor (LLVM.xor (LLVM.and (lshr e_1 (const? 32 7)) (const? 32 32)) e) (const? 32 32) := by 
+    LLVM.xor (LLVM.xor (LLVM.and (lshr e_1 (const? 32 7)) (const? 32 32)) e) (const? 32 32) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -155,7 +155,7 @@ theorem select_icmp_ne_0_and_4096_xor_32_thm (e e_1 : IntW 32) :
 theorem select_icmp_ne_0_and_4096_and_not_32_thm (e e_1 : IntW 32) :
   select (icmp IntPredicate.ne (const? 32 0) (LLVM.and e_1 (const? 32 4096))) e (LLVM.and e (const? 32 (-33))) ⊑
     select (icmp IntPredicate.eq (LLVM.and e_1 (const? 32 4096)) (const? 32 0)) (LLVM.and e (const? 32 (-33)))
-      e := by 
+      e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -166,7 +166,7 @@ theorem select_icmp_ne_0_and_4096_and_not_32_thm (e e_1 : IntW 32) :
 
 theorem select_icmp_ne_0_and_32_or_4096_thm (e e_1 : IntW 32) :
   select (icmp IntPredicate.ne (const? 32 0) (LLVM.and e_1 (const? 32 32))) e (LLVM.or e (const? 32 4096)) ⊑
-    LLVM.or e (LLVM.xor (LLVM.and (shl e_1 (const? 32 7)) (const? 32 4096)) (const? 32 4096)) := by 
+    LLVM.or e (LLVM.xor (LLVM.and (shl e_1 (const? 32 7)) (const? 32 4096)) (const? 32 4096)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -177,7 +177,7 @@ theorem select_icmp_ne_0_and_32_or_4096_thm (e e_1 : IntW 32) :
 
 theorem select_icmp_ne_0_and_32_xor_4096_thm (e e_1 : IntW 32) :
   select (icmp IntPredicate.ne (const? 32 0) (LLVM.and e_1 (const? 32 32))) e (LLVM.xor e (const? 32 4096)) ⊑
-    LLVM.xor (LLVM.xor (LLVM.and (shl e_1 (const? 32 7)) (const? 32 4096)) e) (const? 32 4096) := by 
+    LLVM.xor (LLVM.xor (LLVM.and (shl e_1 (const? 32 7)) (const? 32 4096)) e) (const? 32 4096) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -189,7 +189,7 @@ theorem select_icmp_ne_0_and_32_xor_4096_thm (e e_1 : IntW 32) :
 theorem select_icmp_ne_0_and_32_and_not_4096_thm (e e_1 : IntW 32) :
   select (icmp IntPredicate.ne (const? 32 0) (LLVM.and e_1 (const? 32 32))) e (LLVM.and e (const? 32 (-4097))) ⊑
     select (icmp IntPredicate.eq (LLVM.and e_1 (const? 32 32)) (const? 32 0)) (LLVM.and e (const? 32 (-4097)))
-      e := by 
+      e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -201,7 +201,7 @@ theorem select_icmp_ne_0_and_32_and_not_4096_thm (e e_1 : IntW 32) :
 theorem select_icmp_ne_0_and_1073741824_or_8_thm (e : IntW 8) (e_1 : IntW 32) :
   select (icmp IntPredicate.ne (const? 32 0) (LLVM.and e_1 (const? 32 1073741824))) e (LLVM.or e (const? 8 8)) ⊑
     select (icmp IntPredicate.eq (LLVM.and e_1 (const? 32 1073741824)) (const? 32 0)) (LLVM.or e (const? 8 8))
-      e := by 
+      e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -213,7 +213,7 @@ theorem select_icmp_ne_0_and_1073741824_or_8_thm (e : IntW 8) (e_1 : IntW 32) :
 theorem select_icmp_ne_0_and_1073741824_xor_8_thm (e : IntW 8) (e_1 : IntW 32) :
   select (icmp IntPredicate.ne (const? 32 0) (LLVM.and e_1 (const? 32 1073741824))) e (LLVM.xor e (const? 8 8)) ⊑
     select (icmp IntPredicate.eq (LLVM.and e_1 (const? 32 1073741824)) (const? 32 0)) (LLVM.xor e (const? 8 8))
-      e := by 
+      e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -225,7 +225,7 @@ theorem select_icmp_ne_0_and_1073741824_xor_8_thm (e : IntW 8) (e_1 : IntW 32) :
 theorem select_icmp_ne_0_and_1073741824_and_not_8_thm (e : IntW 8) (e_1 : IntW 32) :
   select (icmp IntPredicate.ne (const? 32 0) (LLVM.and e_1 (const? 32 1073741824))) e (LLVM.and e (const? 8 (-9))) ⊑
     select (icmp IntPredicate.eq (LLVM.and e_1 (const? 32 1073741824)) (const? 32 0)) (LLVM.and e (const? 8 (-9)))
-      e := by 
+      e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -236,7 +236,7 @@ theorem select_icmp_ne_0_and_1073741824_and_not_8_thm (e : IntW 8) (e_1 : IntW 3
 
 theorem select_icmp_ne_0_and_8_or_1073741824_thm (e : IntW 32) (e_1 : IntW 8) :
   select (icmp IntPredicate.ne (const? 8 0) (LLVM.and e_1 (const? 8 8))) e (LLVM.or e (const? 32 1073741824)) ⊑
-    select (icmp IntPredicate.eq (LLVM.and e_1 (const? 8 8)) (const? 8 0)) (LLVM.or e (const? 32 1073741824)) e := by 
+    select (icmp IntPredicate.eq (LLVM.and e_1 (const? 8 8)) (const? 8 0)) (LLVM.or e (const? 32 1073741824)) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -248,7 +248,7 @@ theorem select_icmp_ne_0_and_8_or_1073741824_thm (e : IntW 32) (e_1 : IntW 8) :
 theorem select_icmp_ne_0_and_8_xor_1073741824_thm (e : IntW 32) (e_1 : IntW 8) :
   select (icmp IntPredicate.ne (const? 8 0) (LLVM.and e_1 (const? 8 8))) e (LLVM.xor e (const? 32 1073741824)) ⊑
     select (icmp IntPredicate.eq (LLVM.and e_1 (const? 8 8)) (const? 8 0)) (LLVM.xor e (const? 32 1073741824))
-      e := by 
+      e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -260,7 +260,7 @@ theorem select_icmp_ne_0_and_8_xor_1073741824_thm (e : IntW 32) (e_1 : IntW 8) :
 theorem select_icmp_ne_0_and_8_and_not_1073741824_thm (e : IntW 32) (e_1 : IntW 8) :
   select (icmp IntPredicate.ne (const? 8 0) (LLVM.and e_1 (const? 8 8))) e (LLVM.and e (const? 32 (-1073741825))) ⊑
     select (icmp IntPredicate.eq (LLVM.and e_1 (const? 8 8)) (const? 8 0)) (LLVM.and e (const? 32 (-1073741825)))
-      e := by 
+      e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -271,7 +271,7 @@ theorem select_icmp_ne_0_and_8_and_not_1073741824_thm (e : IntW 32) (e_1 : IntW 
 
 theorem select_icmp_and_8_ne_0_xor_8_thm (e : IntW 32) :
   select (icmp IntPredicate.eq (LLVM.and e (const? 32 8)) (const? 32 0)) e (LLVM.xor e (const? 32 8)) ⊑
-    LLVM.and e (const? 32 (-9)) := by 
+    LLVM.and e (const? 32 (-9)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -282,7 +282,7 @@ theorem select_icmp_and_8_ne_0_xor_8_thm (e : IntW 32) :
 
 theorem select_icmp_and_8_eq_0_xor_8_thm (e : IntW 32) :
   select (icmp IntPredicate.eq (LLVM.and e (const? 32 8)) (const? 32 0)) (LLVM.xor e (const? 32 8)) e ⊑
-    LLVM.or e (const? 32 8) := by 
+    LLVM.or e (const? 32 8) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -293,7 +293,7 @@ theorem select_icmp_and_8_eq_0_xor_8_thm (e : IntW 32) :
 
 theorem select_icmp_x_and_8_eq_0_y_xor_8_thm (e : IntW 64) (e_1 : IntW 32) :
   select (icmp IntPredicate.eq (LLVM.and e_1 (const? 32 8)) (const? 32 0)) e (LLVM.xor e (const? 64 8)) ⊑
-    LLVM.xor e (zext 64 (LLVM.and e_1 (const? 32 8)) { «nneg» := true }) := by 
+    LLVM.xor e (zext 64 (LLVM.and e_1 (const? 32 8)) { «nneg» := true }) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -304,7 +304,7 @@ theorem select_icmp_x_and_8_eq_0_y_xor_8_thm (e : IntW 64) (e_1 : IntW 32) :
 
 theorem select_icmp_x_and_8_ne_0_y_xor_8_thm (e : IntW 64) (e_1 : IntW 32) :
   select (icmp IntPredicate.eq (LLVM.and e_1 (const? 32 8)) (const? 32 0)) (LLVM.xor e (const? 64 8)) e ⊑
-    LLVM.xor e (zext 64 (LLVM.xor (LLVM.and e_1 (const? 32 8)) (const? 32 8)) { «nneg» := true }) := by 
+    LLVM.xor e (zext 64 (LLVM.xor (LLVM.and e_1 (const? 32 8)) (const? 32 8)) { «nneg» := true }) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -315,7 +315,7 @@ theorem select_icmp_x_and_8_ne_0_y_xor_8_thm (e : IntW 64) (e_1 : IntW 32) :
 
 theorem select_icmp_x_and_8_ne_0_y_or_8_thm (e : IntW 64) (e_1 : IntW 32) :
   select (icmp IntPredicate.eq (LLVM.and e_1 (const? 32 8)) (const? 32 0)) (LLVM.or e (const? 64 8)) e ⊑
-    LLVM.or e (zext 64 (LLVM.xor (LLVM.and e_1 (const? 32 8)) (const? 32 8)) { «nneg» := true }) := by 
+    LLVM.or e (zext 64 (LLVM.xor (LLVM.and e_1 (const? 32 8)) (const? 32 8)) { «nneg» := true }) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -327,7 +327,7 @@ theorem select_icmp_x_and_8_ne_0_y_or_8_thm (e : IntW 64) (e_1 : IntW 32) :
 theorem select_icmp_and_2147483648_ne_0_xor_2147483648_thm (e : IntW 32) :
   select (icmp IntPredicate.eq (LLVM.and e (const? 32 (-2147483648))) (const? 32 0)) e
       (LLVM.xor e (const? 32 (-2147483648))) ⊑
-    LLVM.and e (const? 32 2147483647) := by 
+    LLVM.and e (const? 32 2147483647) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -339,7 +339,7 @@ theorem select_icmp_and_2147483648_ne_0_xor_2147483648_thm (e : IntW 32) :
 theorem select_icmp_and_2147483648_eq_0_xor_2147483648_thm (e : IntW 32) :
   select (icmp IntPredicate.eq (LLVM.and e (const? 32 (-2147483648))) (const? 32 0))
       (LLVM.xor e (const? 32 (-2147483648))) e ⊑
-    LLVM.or e (const? 32 (-2147483648)) := by 
+    LLVM.or e (const? 32 (-2147483648)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -351,7 +351,7 @@ theorem select_icmp_and_2147483648_eq_0_xor_2147483648_thm (e : IntW 32) :
 theorem select_icmp_x_and_2147483648_ne_0_or_2147483648_thm (e : IntW 32) :
   select (icmp IntPredicate.eq (LLVM.and e (const? 32 (-2147483648))) (const? 32 0))
       (LLVM.or e (const? 32 (-2147483648))) e ⊑
-    LLVM.or e (const? 32 (-2147483648)) := by 
+    LLVM.or e (const? 32 (-2147483648)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -362,7 +362,7 @@ theorem select_icmp_x_and_2147483648_ne_0_or_2147483648_thm (e : IntW 32) :
 
 theorem test68_thm (e e_1 : IntW 32) :
   select (icmp IntPredicate.eq (LLVM.and e_1 (const? 32 128)) (const? 32 0)) e (LLVM.or e (const? 32 2)) ⊑
-    LLVM.or e (LLVM.and (lshr e_1 (const? 32 6)) (const? 32 2)) := by 
+    LLVM.or e (LLVM.and (lshr e_1 (const? 32 6)) (const? 32 2)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -373,7 +373,7 @@ theorem test68_thm (e e_1 : IntW 32) :
 
 theorem test68_xor_thm (e e_1 : IntW 32) :
   select (icmp IntPredicate.eq (LLVM.and e_1 (const? 32 128)) (const? 32 0)) e (LLVM.xor e (const? 32 2)) ⊑
-    LLVM.xor e (LLVM.and (lshr e_1 (const? 32 6)) (const? 32 2)) := by 
+    LLVM.xor e (LLVM.and (lshr e_1 (const? 32 6)) (const? 32 2)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -384,7 +384,7 @@ theorem test68_xor_thm (e e_1 : IntW 32) :
 
 theorem test69_thm (e e_1 : IntW 32) :
   select (icmp IntPredicate.ne (LLVM.and e_1 (const? 32 128)) (const? 32 0)) e (LLVM.or e (const? 32 2)) ⊑
-    LLVM.or e (LLVM.xor (LLVM.and (lshr e_1 (const? 32 6)) (const? 32 2)) (const? 32 2)) := by 
+    LLVM.or e (LLVM.xor (LLVM.and (lshr e_1 (const? 32 6)) (const? 32 2)) (const? 32 2)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -395,7 +395,7 @@ theorem test69_thm (e e_1 : IntW 32) :
 
 theorem test69_xor_thm (e e_1 : IntW 32) :
   select (icmp IntPredicate.ne (LLVM.and e_1 (const? 32 128)) (const? 32 0)) e (LLVM.xor e (const? 32 2)) ⊑
-    LLVM.xor (LLVM.xor (LLVM.and (lshr e_1 (const? 32 6)) (const? 32 2)) e) (const? 32 2) := by 
+    LLVM.xor (LLVM.xor (LLVM.and (lshr e_1 (const? 32 6)) (const? 32 2)) e) (const? 32 2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -406,7 +406,7 @@ theorem test69_xor_thm (e e_1 : IntW 32) :
 
 theorem test69_and_thm (e e_1 : IntW 32) :
   select (icmp IntPredicate.ne (LLVM.and e_1 (const? 32 128)) (const? 32 0)) e (LLVM.and e (const? 32 2)) ⊑
-    select (icmp IntPredicate.eq (LLVM.and e_1 (const? 32 128)) (const? 32 0)) (LLVM.and e (const? 32 2)) e := by 
+    select (icmp IntPredicate.eq (LLVM.and e_1 (const? 32 128)) (const? 32 0)) (LLVM.and e (const? 32 2)) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -417,7 +417,7 @@ theorem test69_and_thm (e e_1 : IntW 32) :
 
 theorem test70_thm (e e_1 : IntW 8) :
   select (icmp IntPredicate.slt e_1 (const? 8 0)) (LLVM.or e (const? 8 2)) e ⊑
-    LLVM.or e (LLVM.and (lshr e_1 (const? 8 6)) (const? 8 2)) := by 
+    LLVM.or e (LLVM.and (lshr e_1 (const? 8 6)) (const? 8 2)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -429,7 +429,7 @@ theorem test70_thm (e e_1 : IntW 8) :
 theorem shift_no_xor_multiuse_or_thm (e e_1 : IntW 32) :
   mul (select (icmp IntPredicate.eq (LLVM.and e_1 (const? 32 1)) (const? 32 0)) e (LLVM.or e (const? 32 2)))
       (LLVM.or e (const? 32 2)) ⊑
-    mul (LLVM.or e (LLVM.and (shl e_1 (const? 32 1)) (const? 32 2))) (LLVM.or e (const? 32 2)) := by 
+    mul (LLVM.or e (LLVM.and (shl e_1 (const? 32 1)) (const? 32 2))) (LLVM.or e (const? 32 2)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -441,7 +441,7 @@ theorem shift_no_xor_multiuse_or_thm (e e_1 : IntW 32) :
 theorem shift_no_xor_multiuse_xor_thm (e e_1 : IntW 32) :
   mul (select (icmp IntPredicate.eq (LLVM.and e_1 (const? 32 1)) (const? 32 0)) e (LLVM.xor e (const? 32 2)))
       (LLVM.xor e (const? 32 2)) ⊑
-    mul (LLVM.xor e (LLVM.and (shl e_1 (const? 32 1)) (const? 32 2))) (LLVM.xor e (const? 32 2)) := by 
+    mul (LLVM.xor e (LLVM.and (shl e_1 (const? 32 1)) (const? 32 2))) (LLVM.xor e (const? 32 2)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -453,7 +453,7 @@ theorem shift_no_xor_multiuse_xor_thm (e e_1 : IntW 32) :
 theorem no_shift_no_xor_multiuse_or_thm (e e_1 : IntW 32) :
   mul (select (icmp IntPredicate.eq (LLVM.and e_1 (const? 32 4096)) (const? 32 0)) e (LLVM.or e (const? 32 4096)))
       (LLVM.or e (const? 32 4096)) ⊑
-    mul (LLVM.or e (LLVM.and e_1 (const? 32 4096))) (LLVM.or e (const? 32 4096)) := by 
+    mul (LLVM.or e (LLVM.and e_1 (const? 32 4096))) (LLVM.or e (const? 32 4096)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -465,7 +465,7 @@ theorem no_shift_no_xor_multiuse_or_thm (e e_1 : IntW 32) :
 theorem no_shift_no_xor_multiuse_xor_thm (e e_1 : IntW 32) :
   mul (select (icmp IntPredicate.eq (LLVM.and e_1 (const? 32 4096)) (const? 32 0)) e (LLVM.xor e (const? 32 4096)))
       (LLVM.xor e (const? 32 4096)) ⊑
-    mul (LLVM.xor e (LLVM.and e_1 (const? 32 4096))) (LLVM.xor e (const? 32 4096)) := by 
+    mul (LLVM.xor e (LLVM.and e_1 (const? 32 4096))) (LLVM.xor e (const? 32 4096)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -477,7 +477,7 @@ theorem no_shift_no_xor_multiuse_xor_thm (e e_1 : IntW 32) :
 theorem no_shift_xor_multiuse_or_thm (e e_1 : IntW 32) :
   mul (select (icmp IntPredicate.ne (const? 32 0) (LLVM.and e_1 (const? 32 4096))) e (LLVM.or e (const? 32 4096)))
       (LLVM.or e (const? 32 4096)) ⊑
-    mul (LLVM.or e (LLVM.xor (LLVM.and e_1 (const? 32 4096)) (const? 32 4096))) (LLVM.or e (const? 32 4096)) := by 
+    mul (LLVM.or e (LLVM.xor (LLVM.and e_1 (const? 32 4096)) (const? 32 4096))) (LLVM.or e (const? 32 4096)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -489,7 +489,7 @@ theorem no_shift_xor_multiuse_or_thm (e e_1 : IntW 32) :
 theorem no_shift_xor_multiuse_xor_thm (e e_1 : IntW 32) :
   mul (select (icmp IntPredicate.ne (const? 32 0) (LLVM.and e_1 (const? 32 4096))) e (LLVM.xor e (const? 32 4096)))
       (LLVM.xor e (const? 32 4096)) ⊑
-    mul (LLVM.xor (LLVM.xor (LLVM.and e_1 (const? 32 4096)) e) (const? 32 4096)) (LLVM.xor e (const? 32 4096)) := by 
+    mul (LLVM.xor (LLVM.xor (LLVM.and e_1 (const? 32 4096)) e) (const? 32 4096)) (LLVM.xor e (const? 32 4096)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -502,7 +502,7 @@ theorem no_shift_xor_multiuse_and_thm (e e_1 : IntW 32) :
   mul (select (icmp IntPredicate.ne (const? 32 0) (LLVM.and e_1 (const? 32 4096))) e (LLVM.and e (const? 32 (-4097))))
       (LLVM.and e (const? 32 (-4097))) ⊑
     mul (select (icmp IntPredicate.eq (LLVM.and e_1 (const? 32 4096)) (const? 32 0)) (LLVM.and e (const? 32 (-4097))) e)
-      (LLVM.and e (const? 32 (-4097))) := by 
+      (LLVM.and e (const? 32 (-4097))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -515,7 +515,7 @@ theorem shift_xor_multiuse_or_thm (e e_1 : IntW 32) :
   mul (select (icmp IntPredicate.ne (const? 32 0) (LLVM.and e_1 (const? 32 4096))) e (LLVM.or e (const? 32 2048)))
       (LLVM.or e (const? 32 2048)) ⊑
     mul (select (icmp IntPredicate.eq (LLVM.and e_1 (const? 32 4096)) (const? 32 0)) (LLVM.or e (const? 32 2048)) e)
-      (LLVM.or e (const? 32 2048)) := by 
+      (LLVM.or e (const? 32 2048)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -528,7 +528,7 @@ theorem shift_xor_multiuse_xor_thm (e e_1 : IntW 32) :
   mul (select (icmp IntPredicate.ne (const? 32 0) (LLVM.and e_1 (const? 32 4096))) e (LLVM.xor e (const? 32 2048)))
       (LLVM.xor e (const? 32 2048)) ⊑
     mul (select (icmp IntPredicate.eq (LLVM.and e_1 (const? 32 4096)) (const? 32 0)) (LLVM.xor e (const? 32 2048)) e)
-      (LLVM.xor e (const? 32 2048)) := by 
+      (LLVM.xor e (const? 32 2048)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -541,7 +541,7 @@ theorem shift_xor_multiuse_and_thm (e e_1 : IntW 32) :
   mul (select (icmp IntPredicate.ne (const? 32 0) (LLVM.and e_1 (const? 32 4096))) e (LLVM.and e (const? 32 (-2049))))
       (LLVM.and e (const? 32 (-2049))) ⊑
     mul (select (icmp IntPredicate.eq (LLVM.and e_1 (const? 32 4096)) (const? 32 0)) (LLVM.and e (const? 32 (-2049))) e)
-      (LLVM.and e (const? 32 (-2049))) := by 
+      (LLVM.and e (const? 32 (-2049))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -554,7 +554,7 @@ theorem shift_no_xor_multiuse_cmp_thm (e e_1 e_2 e_3 : IntW 32) :
   mul (select (icmp IntPredicate.eq (LLVM.and e_3 (const? 32 1)) (const? 32 0)) e_2 (LLVM.or e_2 (const? 32 2)))
       (select (icmp IntPredicate.eq (LLVM.and e_3 (const? 32 1)) (const? 32 0)) e_1 e) ⊑
     mul (LLVM.or e_2 (shl (LLVM.and e_3 (const? 32 1)) (const? 32 1) { «nsw» := true, «nuw» := true }))
-      (select (icmp IntPredicate.eq (LLVM.and e_3 (const? 32 1)) (const? 32 0)) e_1 e) := by 
+      (select (icmp IntPredicate.eq (LLVM.and e_3 (const? 32 1)) (const? 32 0)) e_1 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -567,7 +567,7 @@ theorem shift_no_xor_multiuse_cmp_with_xor_thm (e e_1 e_2 e_3 : IntW 32) :
   mul (select (icmp IntPredicate.eq (LLVM.and e_3 (const? 32 1)) (const? 32 0)) e_2 (LLVM.xor e_2 (const? 32 2)))
       (select (icmp IntPredicate.eq (LLVM.and e_3 (const? 32 1)) (const? 32 0)) e_1 e) ⊑
     mul (LLVM.xor e_2 (shl (LLVM.and e_3 (const? 32 1)) (const? 32 1) { «nsw» := true, «nuw» := true }))
-      (select (icmp IntPredicate.eq (LLVM.and e_3 (const? 32 1)) (const? 32 0)) e_1 e) := by 
+      (select (icmp IntPredicate.eq (LLVM.and e_3 (const? 32 1)) (const? 32 0)) e_1 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -580,7 +580,7 @@ theorem no_shift_no_xor_multiuse_cmp_thm (e e_1 e_2 e_3 : IntW 32) :
   mul (select (icmp IntPredicate.eq (LLVM.and e_3 (const? 32 4096)) (const? 32 0)) e_2 (LLVM.or e_2 (const? 32 4096)))
       (select (icmp IntPredicate.eq (LLVM.and e_3 (const? 32 4096)) (const? 32 0)) e_1 e) ⊑
     mul (LLVM.or e_2 (LLVM.and e_3 (const? 32 4096)))
-      (select (icmp IntPredicate.eq (LLVM.and e_3 (const? 32 4096)) (const? 32 0)) e_1 e) := by 
+      (select (icmp IntPredicate.eq (LLVM.and e_3 (const? 32 4096)) (const? 32 0)) e_1 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -593,7 +593,7 @@ theorem no_shift_no_xor_multiuse_cmp_with_xor_thm (e e_1 e_2 e_3 : IntW 32) :
   mul (select (icmp IntPredicate.eq (LLVM.and e_3 (const? 32 4096)) (const? 32 0)) e_2 (LLVM.xor e_2 (const? 32 4096)))
       (select (icmp IntPredicate.eq (LLVM.and e_3 (const? 32 4096)) (const? 32 0)) e_1 e) ⊑
     mul (LLVM.xor e_2 (LLVM.and e_3 (const? 32 4096)))
-      (select (icmp IntPredicate.eq (LLVM.and e_3 (const? 32 4096)) (const? 32 0)) e_1 e) := by 
+      (select (icmp IntPredicate.eq (LLVM.and e_3 (const? 32 4096)) (const? 32 0)) e_1 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -606,7 +606,7 @@ theorem no_shift_xor_multiuse_cmp_thm (e e_1 e_2 e_3 : IntW 32) :
   mul (select (icmp IntPredicate.ne (const? 32 0) (LLVM.and e_3 (const? 32 4096))) e_2 (LLVM.or e_2 (const? 32 4096)))
       (select (icmp IntPredicate.ne (const? 32 0) (LLVM.and e_3 (const? 32 4096))) e_1 e) ⊑
     mul (LLVM.or e_2 (LLVM.xor (LLVM.and e_3 (const? 32 4096)) (const? 32 4096)))
-      (select (icmp IntPredicate.eq (LLVM.and e_3 (const? 32 4096)) (const? 32 0)) e e_1) := by 
+      (select (icmp IntPredicate.eq (LLVM.and e_3 (const? 32 4096)) (const? 32 0)) e e_1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -619,7 +619,7 @@ theorem no_shift_xor_multiuse_cmp_with_xor_thm (e e_1 e_2 e_3 : IntW 32) :
   mul (select (icmp IntPredicate.ne (const? 32 0) (LLVM.and e_3 (const? 32 4096))) e_2 (LLVM.xor e_2 (const? 32 4096)))
       (select (icmp IntPredicate.ne (const? 32 0) (LLVM.and e_3 (const? 32 4096))) e_1 e) ⊑
     mul (LLVM.xor (LLVM.xor (LLVM.and e_3 (const? 32 4096)) e_2) (const? 32 4096))
-      (select (icmp IntPredicate.eq (LLVM.and e_3 (const? 32 4096)) (const? 32 0)) e e_1) := by 
+      (select (icmp IntPredicate.eq (LLVM.and e_3 (const? 32 4096)) (const? 32 0)) e e_1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -636,7 +636,7 @@ theorem no_shift_xor_multiuse_cmp_with_and_thm (e e_1 e_2 e_3 : IntW 32) :
     mul
       (select (icmp IntPredicate.eq (LLVM.and e_3 (const? 32 4096)) (const? 32 0)) (LLVM.and e_2 (const? 32 (-4097)))
         e_2)
-      (select (icmp IntPredicate.eq (LLVM.and e_3 (const? 32 4096)) (const? 32 0)) e e_1) := by 
+      (select (icmp IntPredicate.eq (LLVM.and e_3 (const? 32 4096)) (const? 32 0)) e e_1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -649,7 +649,7 @@ theorem shift_xor_multiuse_cmp_thm (e e_1 e_2 e_3 : IntW 32) :
   mul (select (icmp IntPredicate.ne (const? 32 0) (LLVM.and e_3 (const? 32 4096))) e_2 (LLVM.or e_2 (const? 32 2048)))
       (select (icmp IntPredicate.ne (const? 32 0) (LLVM.and e_3 (const? 32 4096))) e_1 e) ⊑
     mul (select (icmp IntPredicate.eq (LLVM.and e_3 (const? 32 4096)) (const? 32 0)) (LLVM.or e_2 (const? 32 2048)) e_2)
-      (select (icmp IntPredicate.eq (LLVM.and e_3 (const? 32 4096)) (const? 32 0)) e e_1) := by 
+      (select (icmp IntPredicate.eq (LLVM.and e_3 (const? 32 4096)) (const? 32 0)) e e_1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -663,7 +663,7 @@ theorem shift_xor_multiuse_cmp_with_xor_thm (e e_1 e_2 e_3 : IntW 32) :
       (select (icmp IntPredicate.ne (const? 32 0) (LLVM.and e_3 (const? 32 4096))) e_1 e) ⊑
     mul
       (select (icmp IntPredicate.eq (LLVM.and e_3 (const? 32 4096)) (const? 32 0)) (LLVM.xor e_2 (const? 32 2048)) e_2)
-      (select (icmp IntPredicate.eq (LLVM.and e_3 (const? 32 4096)) (const? 32 0)) e e_1) := by 
+      (select (icmp IntPredicate.eq (LLVM.and e_3 (const? 32 4096)) (const? 32 0)) e e_1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -680,7 +680,7 @@ theorem shift_xor_multiuse_cmp_with_and_thm (e e_1 e_2 e_3 : IntW 32) :
     mul
       (select (icmp IntPredicate.eq (LLVM.and e_3 (const? 32 4096)) (const? 32 0)) (LLVM.and e_2 (const? 32 (-2049)))
         e_2)
-      (select (icmp IntPredicate.eq (LLVM.and e_3 (const? 32 4096)) (const? 32 0)) e e_1) := by 
+      (select (icmp IntPredicate.eq (LLVM.and e_3 (const? 32 4096)) (const? 32 0)) e e_1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -698,7 +698,7 @@ theorem no_shift_no_xor_multiuse_cmp_or_thm (e e_1 e_2 e_3 : IntW 32) :
     mul
       (mul (LLVM.or e_2 (LLVM.and e_3 (const? 32 4096)))
         (select (icmp IntPredicate.eq (LLVM.and e_3 (const? 32 4096)) (const? 32 0)) e_1 e))
-      (LLVM.or e_2 (const? 32 4096)) := by 
+      (LLVM.or e_2 (const? 32 4096)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -717,7 +717,7 @@ theorem no_shift_no_xor_multiuse_cmp_xor_thm (e e_1 e_2 e_3 : IntW 32) :
     mul
       (mul (LLVM.xor e_2 (LLVM.and e_3 (const? 32 4096)))
         (select (icmp IntPredicate.eq (LLVM.and e_3 (const? 32 4096)) (const? 32 0)) e_1 e))
-      (LLVM.xor e_2 (const? 32 4096)) := by 
+      (LLVM.xor e_2 (const? 32 4096)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -736,7 +736,7 @@ theorem no_shift_xor_multiuse_cmp_or_thm (e e_1 e_2 e_3 : IntW 32) :
       (mul
         (select (icmp IntPredicate.eq (LLVM.and e_3 (const? 32 4096)) (const? 32 0)) (LLVM.or e_2 (const? 32 4096)) e_2)
         (select (icmp IntPredicate.eq (LLVM.and e_3 (const? 32 4096)) (const? 32 0)) e e_1))
-      (LLVM.or e_2 (const? 32 4096)) := by 
+      (LLVM.or e_2 (const? 32 4096)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -757,7 +757,7 @@ theorem no_shift_xor_multiuse_cmp_xor_thm (e e_1 e_2 e_3 : IntW 32) :
         (select (icmp IntPredicate.eq (LLVM.and e_3 (const? 32 4096)) (const? 32 0)) (LLVM.xor e_2 (const? 32 4096))
           e_2)
         (select (icmp IntPredicate.eq (LLVM.and e_3 (const? 32 4096)) (const? 32 0)) e e_1))
-      (LLVM.xor e_2 (const? 32 4096)) := by 
+      (LLVM.xor e_2 (const? 32 4096)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -778,7 +778,7 @@ theorem no_shift_xor_multiuse_cmp_and_thm (e e_1 e_2 e_3 : IntW 32) :
         (select (icmp IntPredicate.eq (LLVM.and e_3 (const? 32 4096)) (const? 32 0)) (LLVM.and e_2 (const? 32 (-4097)))
           e_2)
         (select (icmp IntPredicate.eq (LLVM.and e_3 (const? 32 4096)) (const? 32 0)) e e_1))
-      (LLVM.and e_2 (const? 32 (-4097))) := by 
+      (LLVM.and e_2 (const? 32 (-4097))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -797,7 +797,7 @@ theorem shift_xor_multiuse_cmp_or_thm (e e_1 e_2 e_3 : IntW 32) :
       (mul
         (select (icmp IntPredicate.eq (LLVM.and e_3 (const? 32 4096)) (const? 32 0)) (LLVM.or e_2 (const? 32 2048)) e_2)
         (select (icmp IntPredicate.eq (LLVM.and e_3 (const? 32 4096)) (const? 32 0)) e e_1))
-      (LLVM.or e_2 (const? 32 2048)) := by 
+      (LLVM.or e_2 (const? 32 2048)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -818,7 +818,7 @@ theorem shift_xor_multiuse_cmp_xor_thm (e e_1 e_2 e_3 : IntW 32) :
         (select (icmp IntPredicate.eq (LLVM.and e_3 (const? 32 4096)) (const? 32 0)) (LLVM.xor e_2 (const? 32 2048))
           e_2)
         (select (icmp IntPredicate.eq (LLVM.and e_3 (const? 32 4096)) (const? 32 0)) e e_1))
-      (LLVM.xor e_2 (const? 32 2048)) := by 
+      (LLVM.xor e_2 (const? 32 2048)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -839,7 +839,7 @@ theorem shift_xor_multiuse_cmp_and_thm (e e_1 e_2 e_3 : IntW 32) :
         (select (icmp IntPredicate.eq (LLVM.and e_3 (const? 32 4096)) (const? 32 0)) (LLVM.and e_2 (const? 32 2048))
           e_2)
         (select (icmp IntPredicate.eq (LLVM.and e_3 (const? 32 4096)) (const? 32 0)) e e_1))
-      (LLVM.and e_2 (const? 32 2048)) := by 
+      (LLVM.and e_2 (const? 32 2048)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -850,7 +850,7 @@ theorem shift_xor_multiuse_cmp_and_thm (e e_1 e_2 e_3 : IntW 32) :
 
 theorem set_bits_thm (e : IntW 8) (e_1 : IntW 1) :
   select e_1 (LLVM.or e (const? 8 5)) (LLVM.and e (const? 8 (-6))) ⊑
-    LLVM.or (LLVM.and e (const? 8 (-6))) (select e_1 (const? 8 5) (const? 8 0)) { «disjoint» := true } := by 
+    LLVM.or (LLVM.and e (const? 8 (-6))) (select e_1 (const? 8 5) (const? 8 0)) { «disjoint» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -862,7 +862,7 @@ theorem set_bits_thm (e : IntW 8) (e_1 : IntW 1) :
 theorem xor_i8_to_i64_shl_save_and_ne_thm (e : IntW 64) (e_1 : IntW 8) :
   select (icmp IntPredicate.ne (LLVM.and e_1 (const? 8 1)) (const? 8 0)) (LLVM.xor e (const? 64 (-9223372036854775808)))
       e ⊑
-    LLVM.xor e (shl (zext 64 e_1) (const? 64 63)) := by 
+    LLVM.xor e (shl (zext 64 e_1) (const? 64 63)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -873,7 +873,7 @@ theorem xor_i8_to_i64_shl_save_and_ne_thm (e : IntW 64) (e_1 : IntW 8) :
 
 theorem select_icmp_eq_and_1_0_lshr_fv_thm (e e_1 : IntW 8) :
   select (icmp IntPredicate.eq (LLVM.and e_1 (const? 8 1)) (const? 8 0)) e (lshr e (const? 8 2)) ⊑
-    lshr e (LLVM.and (shl e_1 (const? 8 1)) (const? 8 2)) := by 
+    lshr e (LLVM.and (shl e_1 (const? 8 1)) (const? 8 2)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -884,7 +884,7 @@ theorem select_icmp_eq_and_1_0_lshr_fv_thm (e e_1 : IntW 8) :
 
 theorem select_icmp_eq_and_1_0_lshr_tv_thm (e e_1 : IntW 8) :
   select (icmp IntPredicate.ne (LLVM.and e_1 (const? 8 1)) (const? 8 0)) (lshr e (const? 8 2)) e ⊑
-    lshr e (LLVM.and (shl e_1 (const? 8 1)) (const? 8 2)) := by 
+    lshr e (LLVM.and (shl e_1 (const? 8 1)) (const? 8 2)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gset_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gset_proof.lean
@@ -8,7 +8,7 @@ set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
 
 section gset_proof
-theorem test3_thm (e : IntW 32) : icmp IntPredicate.slt e e ⊑ const? 1 0 := by 
+theorem test3_thm (e : IntW 32) : icmp IntPredicate.slt e e ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -17,7 +17,7 @@ theorem test3_thm (e : IntW 32) : icmp IntPredicate.slt e e ⊑ const? 1 0 := by
     all_goals sorry
 
 
-theorem test4_thm (e : IntW 32) : icmp IntPredicate.sgt e e ⊑ const? 1 0 := by 
+theorem test4_thm (e : IntW 32) : icmp IntPredicate.sgt e e ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -26,7 +26,7 @@ theorem test4_thm (e : IntW 32) : icmp IntPredicate.sgt e e ⊑ const? 1 0 := by
     all_goals sorry
 
 
-theorem test5_thm (e : IntW 32) : icmp IntPredicate.sle e e ⊑ const? 1 1 := by 
+theorem test5_thm (e : IntW 32) : icmp IntPredicate.sle e e ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -35,7 +35,7 @@ theorem test5_thm (e : IntW 32) : icmp IntPredicate.sle e e ⊑ const? 1 1 := by
     all_goals sorry
 
 
-theorem test6_thm (e : IntW 32) : icmp IntPredicate.sge e e ⊑ const? 1 1 := by 
+theorem test6_thm (e : IntW 32) : icmp IntPredicate.sge e e ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -44,7 +44,7 @@ theorem test6_thm (e : IntW 32) : icmp IntPredicate.sge e e ⊑ const? 1 1 := by
     all_goals sorry
 
 
-theorem test7_thm (e : IntW 32) : icmp IntPredicate.uge e (const? 32 0) ⊑ const? 1 1 := by 
+theorem test7_thm (e : IntW 32) : icmp IntPredicate.uge e (const? 32 0) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -53,7 +53,7 @@ theorem test7_thm (e : IntW 32) : icmp IntPredicate.uge e (const? 32 0) ⊑ cons
     all_goals sorry
 
 
-theorem test8_thm (e : IntW 32) : icmp IntPredicate.ult e (const? 32 0) ⊑ const? 1 0 := by 
+theorem test8_thm (e : IntW 32) : icmp IntPredicate.ult e (const? 32 0) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -62,7 +62,7 @@ theorem test8_thm (e : IntW 32) : icmp IntPredicate.ult e (const? 32 0) ⊑ cons
     all_goals sorry
 
 
-theorem test9_thm (e : IntW 1) : icmp IntPredicate.ult e (const? 1 0) ⊑ const? 1 0 := by 
+theorem test9_thm (e : IntW 1) : icmp IntPredicate.ult e (const? 1 0) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -71,7 +71,7 @@ theorem test9_thm (e : IntW 1) : icmp IntPredicate.ult e (const? 1 0) ⊑ const?
     all_goals sorry
 
 
-theorem test10_thm (e : IntW 1) : icmp IntPredicate.ugt e (const? 1 1) ⊑ const? 1 0 := by 
+theorem test10_thm (e : IntW 1) : icmp IntPredicate.ugt e (const? 1 1) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -80,7 +80,7 @@ theorem test10_thm (e : IntW 1) : icmp IntPredicate.ugt e (const? 1 1) ⊑ const
     all_goals sorry
 
 
-theorem test11_thm (e : IntW 1) : icmp IntPredicate.ule e (const? 1 1) ⊑ const? 1 1 := by 
+theorem test11_thm (e : IntW 1) : icmp IntPredicate.ule e (const? 1 1) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -89,7 +89,7 @@ theorem test11_thm (e : IntW 1) : icmp IntPredicate.ule e (const? 1 1) ⊑ const
     all_goals sorry
 
 
-theorem test12_thm (e : IntW 1) : icmp IntPredicate.uge e (const? 1 0) ⊑ const? 1 1 := by 
+theorem test12_thm (e : IntW 1) : icmp IntPredicate.uge e (const? 1 0) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -98,7 +98,7 @@ theorem test12_thm (e : IntW 1) : icmp IntPredicate.uge e (const? 1 0) ⊑ const
     all_goals sorry
 
 
-theorem test13_thm (e e_1 : IntW 1) : icmp IntPredicate.uge e_1 e ⊑ LLVM.or e_1 (LLVM.xor e (const? 1 1)) := by 
+theorem test13_thm (e e_1 : IntW 1) : icmp IntPredicate.uge e_1 e ⊑ LLVM.or e_1 (LLVM.xor e (const? 1 1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -107,7 +107,7 @@ theorem test13_thm (e e_1 : IntW 1) : icmp IntPredicate.uge e_1 e ⊑ LLVM.or e_
     all_goals sorry
 
 
-theorem test14_thm (e e_1 : IntW 1) : icmp IntPredicate.eq e_1 e ⊑ LLVM.xor (LLVM.xor e_1 e) (const? 1 1) := by 
+theorem test14_thm (e e_1 : IntW 1) : icmp IntPredicate.eq e_1 e ⊑ LLVM.xor (LLVM.xor e_1 e) (const? 1 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -119,7 +119,7 @@ theorem test14_thm (e e_1 : IntW 1) : icmp IntPredicate.eq e_1 e ⊑ LLVM.xor (L
 theorem bool_eq0_thm (e : IntW 64) :
   LLVM.and (icmp IntPredicate.sgt e (const? 64 0))
       (icmp IntPredicate.eq (icmp IntPredicate.eq e (const? 64 1)) (const? 1 0)) ⊑
-    icmp IntPredicate.sgt e (const? 64 1) := by 
+    icmp IntPredicate.sgt e (const? 64 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -131,7 +131,7 @@ theorem bool_eq0_thm (e : IntW 64) :
 theorem bool_eq0_logical_thm (e : IntW 64) :
   select (icmp IntPredicate.sgt e (const? 64 0))
       (icmp IntPredicate.eq (icmp IntPredicate.eq e (const? 64 1)) (const? 1 0)) (const? 1 0) ⊑
-    icmp IntPredicate.sgt e (const? 64 1) := by 
+    icmp IntPredicate.sgt e (const? 64 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -142,7 +142,7 @@ theorem bool_eq0_logical_thm (e : IntW 64) :
 
 theorem xor_of_icmps_thm (e : IntW 64) :
   LLVM.xor (icmp IntPredicate.eq e (const? 64 1)) (icmp IntPredicate.sgt e (const? 64 0)) ⊑
-    icmp IntPredicate.sgt e (const? 64 1) := by 
+    icmp IntPredicate.sgt e (const? 64 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -153,7 +153,7 @@ theorem xor_of_icmps_thm (e : IntW 64) :
 
 theorem xor_of_icmps_commute_thm (e : IntW 64) :
   LLVM.xor (icmp IntPredicate.sgt e (const? 64 0)) (icmp IntPredicate.eq e (const? 64 1)) ⊑
-    icmp IntPredicate.sgt e (const? 64 1) := by 
+    icmp IntPredicate.sgt e (const? 64 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -164,7 +164,7 @@ theorem xor_of_icmps_commute_thm (e : IntW 64) :
 
 theorem xor_of_icmps_to_ne_thm (e : IntW 64) :
   LLVM.xor (icmp IntPredicate.sgt e (const? 64 4)) (icmp IntPredicate.slt e (const? 64 6)) ⊑
-    icmp IntPredicate.ne e (const? 64 5) := by 
+    icmp IntPredicate.ne e (const? 64 5) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -175,7 +175,7 @@ theorem xor_of_icmps_to_ne_thm (e : IntW 64) :
 
 theorem xor_of_icmps_to_ne_commute_thm (e : IntW 64) :
   LLVM.xor (icmp IntPredicate.slt e (const? 64 6)) (icmp IntPredicate.sgt e (const? 64 4)) ⊑
-    icmp IntPredicate.ne e (const? 64 5) := by 
+    icmp IntPredicate.ne e (const? 64 5) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -186,7 +186,7 @@ theorem xor_of_icmps_to_ne_commute_thm (e : IntW 64) :
 
 theorem xor_of_icmps_neg_to_ne_thm (e : IntW 64) :
   LLVM.xor (icmp IntPredicate.sgt e (const? 64 (-6))) (icmp IntPredicate.slt e (const? 64 (-4))) ⊑
-    icmp IntPredicate.ne e (const? 64 (-5)) := by 
+    icmp IntPredicate.ne e (const? 64 (-5)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -197,7 +197,7 @@ theorem xor_of_icmps_neg_to_ne_thm (e : IntW 64) :
 
 theorem xor_of_icmps_to_eq_thm (e : IntW 8) :
   LLVM.xor (icmp IntPredicate.slt e (const? 8 (-128))) (icmp IntPredicate.sgt e (const? 8 126)) ⊑
-    icmp IntPredicate.eq e (const? 8 127) := by 
+    icmp IntPredicate.eq e (const? 8 127) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -210,7 +210,7 @@ theorem PR2844_thm (e : IntW 32) :
   select (LLVM.or (icmp IntPredicate.eq e (const? 32 0)) (icmp IntPredicate.slt e (const? 32 (-638208501))))
       (const? 32 0) (const? 32 1) ⊑
     zext 32
-      (LLVM.and (icmp IntPredicate.ne e (const? 32 0)) (icmp IntPredicate.sgt e (const? 32 (-638208502)))) := by 
+      (LLVM.and (icmp IntPredicate.ne e (const? 32 0)) (icmp IntPredicate.sgt e (const? 32 (-638208502)))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -223,7 +223,7 @@ theorem PR2844_logical_thm (e : IntW 32) :
   select (select (icmp IntPredicate.eq e (const? 32 0)) (const? 1 1) (icmp IntPredicate.slt e (const? 32 (-638208501))))
       (const? 32 0) (const? 32 1) ⊑
     zext 32
-      (LLVM.and (icmp IntPredicate.ne e (const? 32 0)) (icmp IntPredicate.sgt e (const? 32 (-638208502)))) := by 
+      (LLVM.and (icmp IntPredicate.ne e (const? 32 0)) (icmp IntPredicate.sgt e (const? 32 (-638208502)))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -232,7 +232,7 @@ theorem PR2844_logical_thm (e : IntW 32) :
     all_goals sorry
 
 
-theorem test16_thm (e : IntW 32) : icmp IntPredicate.eq (LLVM.and e (const? 32 5)) (const? 32 8) ⊑ const? 1 0 := by 
+theorem test16_thm (e : IntW 32) : icmp IntPredicate.eq (LLVM.and e (const? 32 5)) (const? 32 8) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -241,7 +241,7 @@ theorem test16_thm (e : IntW 32) : icmp IntPredicate.eq (LLVM.and e (const? 32 5
     all_goals sorry
 
 
-theorem test17_thm (e : IntW 8) : icmp IntPredicate.eq (LLVM.or e (const? 8 1)) (const? 8 2) ⊑ const? 1 0 := by 
+theorem test17_thm (e : IntW 8) : icmp IntPredicate.eq (LLVM.or e (const? 8 1)) (const? 8 2) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -251,7 +251,7 @@ theorem test17_thm (e : IntW 8) : icmp IntPredicate.eq (LLVM.or e (const? 8 1)) 
 
 
 theorem test19_thm (e e_1 : IntW 1) :
-  icmp IntPredicate.eq (zext 32 e_1) (zext 32 e) ⊑ LLVM.xor (LLVM.xor e_1 e) (const? 1 1) := by 
+  icmp IntPredicate.eq (zext 32 e_1) (zext 32 e) ⊑ LLVM.xor (LLVM.xor e_1 e) (const? 1 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -261,7 +261,7 @@ theorem test19_thm (e e_1 : IntW 1) :
 
 
 theorem test20_thm (e : IntW 32) :
-  zext 32 (icmp IntPredicate.ne (LLVM.and e (const? 32 1)) (const? 32 0)) ⊑ LLVM.and e (const? 32 1) := by 
+  zext 32 (icmp IntPredicate.ne (LLVM.and e (const? 32 1)) (const? 32 0)) ⊑ LLVM.and e (const? 32 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -272,7 +272,7 @@ theorem test20_thm (e : IntW 32) :
 
 theorem test21_thm (e : IntW 32) :
   zext 32 (icmp IntPredicate.ne (LLVM.and e (const? 32 4)) (const? 32 0)) ⊑
-    LLVM.and (lshr e (const? 32 2)) (const? 32 1) := by 
+    LLVM.and (lshr e (const? 32 2)) (const? 32 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -284,7 +284,7 @@ theorem test21_thm (e : IntW 32) :
 theorem test22_thm (e e_1 : IntW 32) :
   LLVM.or (icmp IntPredicate.ult (LLVM.and e_1 (const? 32 100663295)) (const? 32 268435456))
       (icmp IntPredicate.sgt (LLVM.and e (const? 32 7)) (const? 32 (-1))) ⊑
-    const? 1 1 := by 
+    const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -296,7 +296,7 @@ theorem test22_thm (e e_1 : IntW 32) :
 theorem test22_logical_thm (e e_1 : IntW 32) :
   select (icmp IntPredicate.ult (LLVM.and e_1 (const? 32 100663295)) (const? 32 268435456)) (const? 1 1)
       (icmp IntPredicate.sgt (LLVM.and e (const? 32 7)) (const? 32 (-1))) ⊑
-    const? 1 1 := by 
+    const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -307,7 +307,7 @@ theorem test22_logical_thm (e e_1 : IntW 32) :
 
 theorem test23_thm (e : IntW 32) :
   zext 32 (icmp IntPredicate.eq (LLVM.and e (const? 32 1)) (const? 32 0)) ⊑
-    LLVM.xor (LLVM.and e (const? 32 1)) (const? 32 1) := by 
+    LLVM.xor (LLVM.and e (const? 32 1)) (const? 32 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -318,7 +318,7 @@ theorem test23_thm (e : IntW 32) :
 
 theorem test24_thm (e : IntW 32) :
   zext 32 (icmp IntPredicate.eq (lshr (LLVM.and e (const? 32 4)) (const? 32 2)) (const? 32 0)) ⊑
-    LLVM.xor (LLVM.and (lshr e (const? 32 2)) (const? 32 1)) (const? 32 1) := by 
+    LLVM.xor (LLVM.and (lshr e (const? 32 2)) (const? 32 1)) (const? 32 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -327,7 +327,7 @@ theorem test24_thm (e : IntW 32) :
     all_goals sorry
 
 
-theorem test25_thm (e : IntW 32) : icmp IntPredicate.ugt (LLVM.and e (const? 32 2)) (const? 32 2) ⊑ const? 1 0 := by 
+theorem test25_thm (e : IntW 32) : icmp IntPredicate.ugt (LLVM.and e (const? 32 2)) (const? 32 2) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gsetcchstrengthhreduce_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gsetcchstrengthhreduce_proof.lean
@@ -9,7 +9,7 @@ set_option linter.unreachableTactic false
 
 section gsetcchstrengthhreduce_proof
 theorem test1_thm (e : IntW 32) :
-  icmp IntPredicate.uge e (const? 32 1) ⊑ icmp IntPredicate.ne e (const? 32 0) := by 
+  icmp IntPredicate.uge e (const? 32 1) ⊑ icmp IntPredicate.ne e (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -19,7 +19,7 @@ theorem test1_thm (e : IntW 32) :
 
 
 theorem test2_thm (e : IntW 32) :
-  icmp IntPredicate.ugt e (const? 32 0) ⊑ icmp IntPredicate.ne e (const? 32 0) := by 
+  icmp IntPredicate.ugt e (const? 32 0) ⊑ icmp IntPredicate.ne e (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -29,7 +29,7 @@ theorem test2_thm (e : IntW 32) :
 
 
 theorem test3_thm (e : IntW 8) :
-  icmp IntPredicate.sge e (const? 8 (-127)) ⊑ icmp IntPredicate.ne e (const? 8 (-128)) := by 
+  icmp IntPredicate.sge e (const? 8 (-127)) ⊑ icmp IntPredicate.ne e (const? 8 (-128)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -39,7 +39,7 @@ theorem test3_thm (e : IntW 8) :
 
 
 theorem test4_thm (e : IntW 8) :
-  icmp IntPredicate.sle e (const? 8 126) ⊑ icmp IntPredicate.ne e (const? 8 127) := by 
+  icmp IntPredicate.sle e (const? 8 126) ⊑ icmp IntPredicate.ne e (const? 8 127) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -49,7 +49,7 @@ theorem test4_thm (e : IntW 8) :
 
 
 theorem test5_thm (e : IntW 8) :
-  icmp IntPredicate.slt e (const? 8 127) ⊑ icmp IntPredicate.ne e (const? 8 127) := by 
+  icmp IntPredicate.slt e (const? 8 127) ⊑ icmp IntPredicate.ne e (const? 8 127) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gsethlowbitshmaskhcanonicalize_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gsethlowbitshmaskhcanonicalize_proof.lean
@@ -10,7 +10,7 @@ set_option linter.unreachableTactic false
 section gsethlowbitshmaskhcanonicalize_proof
 theorem shl_add_thm (e : IntW 32) :
   add (shl (const? 32 1) e) (const? 32 (-1)) ⊑
-    LLVM.xor (shl (const? 32 (-1)) e { «nsw» := true, «nuw» := false }) (const? 32 (-1)) := by 
+    LLVM.xor (shl (const? 32 (-1)) e { «nsw» := true, «nuw» := false }) (const? 32 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -21,7 +21,7 @@ theorem shl_add_thm (e : IntW 32) :
 
 theorem shl_add_nsw_thm (e : IntW 32) :
   add (shl (const? 32 1) e) (const? 32 (-1)) { «nsw» := true, «nuw» := false } ⊑
-    LLVM.xor (shl (const? 32 (-1)) e { «nsw» := true, «nuw» := false }) (const? 32 (-1)) := by 
+    LLVM.xor (shl (const? 32 (-1)) e { «nsw» := true, «nuw» := false }) (const? 32 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -31,7 +31,7 @@ theorem shl_add_nsw_thm (e : IntW 32) :
 
 
 theorem shl_add_nuw_thm (e : IntW 32) :
-  add (shl (const? 32 1) e) (const? 32 (-1)) { «nsw» := false, «nuw» := true } ⊑ const? 32 (-1) := by 
+  add (shl (const? 32 1) e) (const? 32 (-1)) { «nsw» := false, «nuw» := true } ⊑ const? 32 (-1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -41,7 +41,7 @@ theorem shl_add_nuw_thm (e : IntW 32) :
 
 
 theorem shl_add_nsw_nuw_thm (e : IntW 32) :
-  add (shl (const? 32 1) e) (const? 32 (-1)) { «nsw» := true, «nuw» := true } ⊑ const? 32 (-1) := by 
+  add (shl (const? 32 1) e) (const? 32 (-1)) { «nsw» := true, «nuw» := true } ⊑ const? 32 (-1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -52,7 +52,7 @@ theorem shl_add_nsw_nuw_thm (e : IntW 32) :
 
 theorem shl_nsw_add_thm (e : IntW 32) :
   add (shl (const? 32 1) e { «nsw» := true, «nuw» := false }) (const? 32 (-1)) ⊑
-    LLVM.xor (shl (const? 32 (-1)) e { «nsw» := true, «nuw» := false }) (const? 32 (-1)) := by 
+    LLVM.xor (shl (const? 32 (-1)) e { «nsw» := true, «nuw» := false }) (const? 32 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -63,7 +63,7 @@ theorem shl_nsw_add_thm (e : IntW 32) :
 
 theorem shl_nsw_add_nsw_thm (e : IntW 32) :
   add (shl (const? 32 1) e { «nsw» := true, «nuw» := false }) (const? 32 (-1)) { «nsw» := true, «nuw» := false } ⊑
-    LLVM.xor (shl (const? 32 (-1)) e { «nsw» := true, «nuw» := false }) (const? 32 (-1)) := by 
+    LLVM.xor (shl (const? 32 (-1)) e { «nsw» := true, «nuw» := false }) (const? 32 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -74,7 +74,7 @@ theorem shl_nsw_add_nsw_thm (e : IntW 32) :
 
 theorem shl_nsw_add_nuw_thm (e : IntW 32) :
   add (shl (const? 32 1) e { «nsw» := true, «nuw» := false }) (const? 32 (-1)) { «nsw» := false, «nuw» := true } ⊑
-    const? 32 (-1) := by 
+    const? 32 (-1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -85,7 +85,7 @@ theorem shl_nsw_add_nuw_thm (e : IntW 32) :
 
 theorem shl_nsw_add_nsw_nuw_thm (e : IntW 32) :
   add (shl (const? 32 1) e { «nsw» := true, «nuw» := false }) (const? 32 (-1)) { «nsw» := true, «nuw» := true } ⊑
-    const? 32 (-1) := by 
+    const? 32 (-1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -96,7 +96,7 @@ theorem shl_nsw_add_nsw_nuw_thm (e : IntW 32) :
 
 theorem shl_nuw_add_thm (e : IntW 32) :
   add (shl (const? 32 1) e { «nsw» := false, «nuw» := true }) (const? 32 (-1)) ⊑
-    LLVM.xor (shl (const? 32 (-1)) e { «nsw» := true, «nuw» := false }) (const? 32 (-1)) := by 
+    LLVM.xor (shl (const? 32 (-1)) e { «nsw» := true, «nuw» := false }) (const? 32 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -107,7 +107,7 @@ theorem shl_nuw_add_thm (e : IntW 32) :
 
 theorem shl_nuw_add_nsw_thm (e : IntW 32) :
   add (shl (const? 32 1) e { «nsw» := false, «nuw» := true }) (const? 32 (-1)) { «nsw» := true, «nuw» := false } ⊑
-    LLVM.xor (shl (const? 32 (-1)) e { «nsw» := true, «nuw» := false }) (const? 32 (-1)) := by 
+    LLVM.xor (shl (const? 32 (-1)) e { «nsw» := true, «nuw» := false }) (const? 32 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -118,7 +118,7 @@ theorem shl_nuw_add_nsw_thm (e : IntW 32) :
 
 theorem shl_nuw_add_nuw_thm (e : IntW 32) :
   add (shl (const? 32 1) e { «nsw» := false, «nuw» := true }) (const? 32 (-1)) { «nsw» := false, «nuw» := true } ⊑
-    const? 32 (-1) := by 
+    const? 32 (-1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -129,7 +129,7 @@ theorem shl_nuw_add_nuw_thm (e : IntW 32) :
 
 theorem shl_nuw_add_nsw_nuw_thm (e : IntW 32) :
   add (shl (const? 32 1) e { «nsw» := false, «nuw» := true }) (const? 32 (-1)) { «nsw» := true, «nuw» := true } ⊑
-    const? 32 (-1) := by 
+    const? 32 (-1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -140,7 +140,7 @@ theorem shl_nuw_add_nsw_nuw_thm (e : IntW 32) :
 
 theorem shl_nsw_nuw_add_thm (e : IntW 32) :
   add (shl (const? 32 1) e { «nsw» := true, «nuw» := true }) (const? 32 (-1)) ⊑
-    LLVM.xor (shl (const? 32 (-1)) e { «nsw» := true, «nuw» := false }) (const? 32 (-1)) := by 
+    LLVM.xor (shl (const? 32 (-1)) e { «nsw» := true, «nuw» := false }) (const? 32 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -151,7 +151,7 @@ theorem shl_nsw_nuw_add_thm (e : IntW 32) :
 
 theorem shl_nsw_nuw_add_nsw_thm (e : IntW 32) :
   add (shl (const? 32 1) e { «nsw» := true, «nuw» := true }) (const? 32 (-1)) { «nsw» := true, «nuw» := false } ⊑
-    LLVM.xor (shl (const? 32 (-1)) e { «nsw» := true, «nuw» := false }) (const? 32 (-1)) := by 
+    LLVM.xor (shl (const? 32 (-1)) e { «nsw» := true, «nuw» := false }) (const? 32 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -162,7 +162,7 @@ theorem shl_nsw_nuw_add_nsw_thm (e : IntW 32) :
 
 theorem shl_nsw_nuw_add_nuw_thm (e : IntW 32) :
   add (shl (const? 32 1) e { «nsw» := true, «nuw» := true }) (const? 32 (-1)) { «nsw» := false, «nuw» := true } ⊑
-    const? 32 (-1) := by 
+    const? 32 (-1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -173,7 +173,7 @@ theorem shl_nsw_nuw_add_nuw_thm (e : IntW 32) :
 
 theorem shl_nsw_nuw_add_nsw_nuw_thm (e : IntW 32) :
   add (shl (const? 32 1) e { «nsw» := true, «nuw» := true }) (const? 32 (-1)) { «nsw» := true, «nuw» := true } ⊑
-    const? 32 (-1) := by 
+    const? 32 (-1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -183,7 +183,7 @@ theorem shl_nsw_nuw_add_nsw_nuw_thm (e : IntW 32) :
 
 
 theorem bad_add0_thm (e e_1 : IntW 32) :
-  add (shl (const? 32 1) e_1) e ⊑ add (shl (const? 32 1) e_1 { «nsw» := false, «nuw» := true }) e := by 
+  add (shl (const? 32 1) e_1) e ⊑ add (shl (const? 32 1) e_1 { «nsw» := false, «nuw» := true }) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -194,7 +194,7 @@ theorem bad_add0_thm (e e_1 : IntW 32) :
 
 theorem bad_add1_thm (e : IntW 32) :
   add (shl (const? 32 1) e) (const? 32 1) ⊑
-    add (shl (const? 32 1) e { «nsw» := false, «nuw» := true }) (const? 32 1) { «nsw» := false, «nuw» := true } := by 
+    add (shl (const? 32 1) e { «nsw» := false, «nuw» := true }) (const? 32 1) { «nsw» := false, «nuw» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -205,7 +205,7 @@ theorem bad_add1_thm (e : IntW 32) :
 
 theorem bad_add2_thm (e : IntW 32) :
   add (shl (const? 32 1) e) (const? 32 (-2)) ⊑
-    add (shl (const? 32 1) e { «nsw» := false, «nuw» := true }) (const? 32 (-2)) := by 
+    add (shl (const? 32 1) e { «nsw» := false, «nuw» := true }) (const? 32 (-2)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gsext_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gsext_proof.lean
@@ -9,7 +9,7 @@ set_option linter.unreachableTactic false
 
 section gsext_proof
 theorem test4_thm (e : IntW 32) :
-  sext 64 (LLVM.udiv e (const? 32 3)) ⊑ zext 64 (LLVM.udiv e (const? 32 3)) { «nneg» := true } := by 
+  sext 64 (LLVM.udiv e (const? 32 3)) ⊑ zext 64 (LLVM.udiv e (const? 32 3)) { «nneg» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -19,7 +19,7 @@ theorem test4_thm (e : IntW 32) :
 
 
 theorem test5_thm (e : IntW 32) :
-  sext 64 (urem e (const? 32 30000)) ⊑ zext 64 (urem e (const? 32 30000)) { «nneg» := true } := by 
+  sext 64 (urem e (const? 32 30000)) ⊑ zext 64 (urem e (const? 32 30000)) { «nneg» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -30,7 +30,7 @@ theorem test5_thm (e : IntW 32) :
 
 theorem test6_thm (e : IntW 32) :
   sext 64 (mul (lshr e (const? 32 3)) (const? 32 3)) ⊑
-    zext 64 (mul (lshr e (const? 32 3)) (const? 32 3) { «nsw» := true, «nuw» := true }) { «nneg» := true } := by 
+    zext 64 (mul (lshr e (const? 32 3)) (const? 32 3) { «nsw» := true, «nuw» := true }) { «nneg» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -42,7 +42,7 @@ theorem test6_thm (e : IntW 32) :
 theorem test7_thm (e : IntW 32) :
   sext 64 (sub (const? 32 20000) (LLVM.and e (const? 32 511))) ⊑
     zext 64 (sub (const? 32 20000) (LLVM.and e (const? 32 511)) { «nsw» := true, «nuw» := true })
-      { «nneg» := true } := by 
+      { «nneg» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -53,7 +53,7 @@ theorem test7_thm (e : IntW 32) :
 
 theorem test10_thm (e : IntW 32) :
   sext 32 (ashr (shl (trunc 8 e) (const? 8 6)) (const? 8 6)) ⊑
-    ashr (shl e (const? 32 30)) (const? 32 30) { «exact» := true } := by 
+    ashr (shl e (const? 32 30)) (const? 32 30) { «exact» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -64,7 +64,7 @@ theorem test10_thm (e : IntW 32) :
 
 theorem test13_thm (e : IntW 32) :
   sext 32 (icmp IntPredicate.eq (LLVM.and e (const? 32 8)) (const? 32 0)) ⊑
-    add (LLVM.and (lshr e (const? 32 3)) (const? 32 1)) (const? 32 (-1)) { «nsw» := true, «nuw» := false } := by 
+    add (LLVM.and (lshr e (const? 32 3)) (const? 32 1)) (const? 32 (-1)) { «nsw» := true, «nuw» := false } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -76,7 +76,7 @@ theorem test13_thm (e : IntW 32) :
 theorem test14_thm (e : IntW 16) :
   sext 32 (icmp IntPredicate.ne (LLVM.and e (const? 16 16)) (const? 16 16)) ⊑
     sext 32
-      (add (LLVM.and (lshr e (const? 16 4)) (const? 16 1)) (const? 16 (-1)) { «nsw» := true, «nuw» := false }) := by 
+      (add (LLVM.and (lshr e (const? 16 4)) (const? 16 1)) (const? 16 (-1)) { «nsw» := true, «nuw» := false }) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -87,7 +87,7 @@ theorem test14_thm (e : IntW 16) :
 
 theorem test15_thm (e : IntW 32) :
   sext 32 (icmp IntPredicate.ne (LLVM.and e (const? 32 16)) (const? 32 0)) ⊑
-    ashr (shl e (const? 32 27)) (const? 32 31) := by 
+    ashr (shl e (const? 32 27)) (const? 32 31) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -98,7 +98,7 @@ theorem test15_thm (e : IntW 32) :
 
 theorem test16_thm (e : IntW 16) :
   sext 32 (icmp IntPredicate.eq (LLVM.and e (const? 16 8)) (const? 16 8)) ⊑
-    sext 32 (ashr (shl e (const? 16 12)) (const? 16 15)) := by 
+    sext 32 (ashr (shl e (const? 16 12)) (const? 16 15)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -107,7 +107,7 @@ theorem test16_thm (e : IntW 16) :
     all_goals sorry
 
 
-theorem test17_thm (e : IntW 1) : sub (const? 32 0) (sext 32 e) ⊑ zext 32 e := by 
+theorem test17_thm (e : IntW 1) : sub (const? 32 0) (sext 32 e) ⊑ zext 32 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -118,7 +118,7 @@ theorem test17_thm (e : IntW 1) : sub (const? 32 0) (sext 32 e) ⊑ zext 32 e :=
 
 theorem test19_thm (e : IntW 10) :
   sext 10 (ashr (shl (trunc 3 e) (const? 3 2)) (const? 3 2)) ⊑
-    sext 10 (sub (const? 3 0) (LLVM.and (trunc 3 e) (const? 3 1)) { «nsw» := true, «nuw» := false }) := by 
+    sext 10 (sub (const? 3 0) (LLVM.and (trunc 3 e) (const? 3 1)) { «nsw» := true, «nuw» := false }) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -128,7 +128,7 @@ theorem test19_thm (e : IntW 10) :
 
 
 theorem smear_set_bit_thm (e : IntW 32) :
-  sext 32 (ashr (trunc 8 e) (const? 8 7)) ⊑ ashr (shl e (const? 32 24)) (const? 32 31) := by 
+  sext 32 (ashr (trunc 8 e) (const? 8 7)) ⊑ ashr (shl e (const? 32 24)) (const? 32 31) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -139,7 +139,7 @@ theorem smear_set_bit_thm (e : IntW 32) :
 
 theorem smear_set_bit_different_dest_type_thm (e : IntW 32) :
   sext 16 (ashr (trunc 8 e) (const? 8 7)) ⊑
-    trunc 16 (ashr (shl e (const? 32 24)) (const? 32 31)) { «nsw» := true, «nuw» := false } := by 
+    trunc 16 (ashr (shl e (const? 32 24)) (const? 32 31)) { «nsw» := true, «nuw» := false } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -149,7 +149,7 @@ theorem smear_set_bit_different_dest_type_thm (e : IntW 32) :
 
 
 theorem smear_set_bit_different_dest_type_wider_dst_thm (e : IntW 32) :
-  sext 64 (ashr (trunc 8 e) (const? 8 7)) ⊑ sext 64 (ashr (shl e (const? 32 24)) (const? 32 31)) := by 
+  sext 64 (ashr (trunc 8 e) (const? 8 7)) ⊑ sext 64 (ashr (shl e (const? 32 24)) (const? 32 31)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gsexthand_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gsexthand_proof.lean
@@ -10,7 +10,7 @@ set_option linter.unreachableTactic false
 section gsexthand_proof
 theorem fold_sext_to_and_thm (e : IntW 8) :
   icmp IntPredicate.eq (LLVM.and (sext 32 e) (const? 32 (-2147483647))) (const? 32 1) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 8 (-127))) (const? 8 1) := by 
+    icmp IntPredicate.eq (LLVM.and e (const? 8 (-127))) (const? 8 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -21,7 +21,7 @@ theorem fold_sext_to_and_thm (e : IntW 8) :
 
 theorem fold_sext_to_and1_thm (e : IntW 8) :
   icmp IntPredicate.ne (LLVM.and (sext 32 e) (const? 32 (-2147483647))) (const? 32 1) ⊑
-    icmp IntPredicate.ne (LLVM.and e (const? 8 (-127))) (const? 8 1) := by 
+    icmp IntPredicate.ne (LLVM.and e (const? 8 (-127))) (const? 8 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -32,7 +32,7 @@ theorem fold_sext_to_and1_thm (e : IntW 8) :
 
 theorem fold_sext_to_and2_thm (e : IntW 8) :
   icmp IntPredicate.eq (LLVM.and (sext 32 e) (const? 32 1073741826)) (const? 32 2) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 8 (-126))) (const? 8 2) := by 
+    icmp IntPredicate.eq (LLVM.and e (const? 8 (-126))) (const? 8 2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -43,7 +43,7 @@ theorem fold_sext_to_and2_thm (e : IntW 8) :
 
 theorem fold_sext_to_and3_thm (e : IntW 8) :
   icmp IntPredicate.ne (LLVM.and (sext 32 e) (const? 32 1073741826)) (const? 32 2) ⊑
-    icmp IntPredicate.ne (LLVM.and e (const? 8 (-126))) (const? 8 2) := by 
+    icmp IntPredicate.ne (LLVM.and e (const? 8 (-126))) (const? 8 2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -53,7 +53,7 @@ theorem fold_sext_to_and3_thm (e : IntW 8) :
 
 
 theorem fold_sext_to_and_wrong_thm (e : IntW 8) :
-  icmp IntPredicate.eq (LLVM.and (sext 32 e) (const? 32 (-2147483647))) (const? 32 (-1)) ⊑ const? 1 0 := by 
+  icmp IntPredicate.eq (LLVM.and (sext 32 e) (const? 32 (-2147483647))) (const? 32 (-1)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -63,7 +63,7 @@ theorem fold_sext_to_and_wrong_thm (e : IntW 8) :
 
 
 theorem fold_sext_to_and_wrong2_thm (e : IntW 8) :
-  icmp IntPredicate.eq (LLVM.and (sext 32 e) (const? 32 (-2147483647))) (const? 32 128) ⊑ const? 1 0 := by 
+  icmp IntPredicate.eq (LLVM.and (sext 32 e) (const? 32 (-2147483647))) (const? 32 128) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -73,7 +73,7 @@ theorem fold_sext_to_and_wrong2_thm (e : IntW 8) :
 
 
 theorem fold_sext_to_and_wrong3_thm (e : IntW 8) :
-  icmp IntPredicate.eq (LLVM.and (sext 32 e) (const? 32 128)) (const? 32 (-2147483648)) ⊑ const? 1 0 := by 
+  icmp IntPredicate.eq (LLVM.and (sext 32 e) (const? 32 128)) (const? 32 (-2147483648)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -83,7 +83,7 @@ theorem fold_sext_to_and_wrong3_thm (e : IntW 8) :
 
 
 theorem fold_sext_to_and_wrong4_thm (e : IntW 8) :
-  icmp IntPredicate.eq (LLVM.and (sext 32 e) (const? 32 128)) (const? 32 1) ⊑ const? 1 0 := by 
+  icmp IntPredicate.eq (LLVM.and (sext 32 e) (const? 32 128)) (const? 32 1) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -93,7 +93,7 @@ theorem fold_sext_to_and_wrong4_thm (e : IntW 8) :
 
 
 theorem fold_sext_to_and_wrong5_thm (e : IntW 8) :
-  icmp IntPredicate.eq (LLVM.and (sext 32 e) (const? 32 (-256))) (const? 32 1) ⊑ const? 1 0 := by 
+  icmp IntPredicate.eq (LLVM.and (sext 32 e) (const? 32 (-256))) (const? 32 1) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -103,7 +103,7 @@ theorem fold_sext_to_and_wrong5_thm (e : IntW 8) :
 
 
 theorem fold_sext_to_and_wrong6_thm (e : IntW 8) :
-  icmp IntPredicate.ne (LLVM.and (sext 32 e) (const? 32 (-2147483647))) (const? 32 (-1)) ⊑ const? 1 1 := by 
+  icmp IntPredicate.ne (LLVM.and (sext 32 e) (const? 32 (-2147483647))) (const? 32 (-1)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -113,7 +113,7 @@ theorem fold_sext_to_and_wrong6_thm (e : IntW 8) :
 
 
 theorem fold_sext_to_and_wrong7_thm (e : IntW 8) :
-  icmp IntPredicate.ne (LLVM.and (sext 32 e) (const? 32 (-2147483647))) (const? 32 128) ⊑ const? 1 1 := by 
+  icmp IntPredicate.ne (LLVM.and (sext 32 e) (const? 32 (-2147483647))) (const? 32 128) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -123,7 +123,7 @@ theorem fold_sext_to_and_wrong7_thm (e : IntW 8) :
 
 
 theorem fold_sext_to_and_wrong8_thm (e : IntW 8) :
-  icmp IntPredicate.ne (LLVM.and (sext 32 e) (const? 32 128)) (const? 32 (-2147483648)) ⊑ const? 1 1 := by 
+  icmp IntPredicate.ne (LLVM.and (sext 32 e) (const? 32 128)) (const? 32 (-2147483648)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -133,7 +133,7 @@ theorem fold_sext_to_and_wrong8_thm (e : IntW 8) :
 
 
 theorem fold_sext_to_and_wrong9_thm (e : IntW 8) :
-  icmp IntPredicate.ne (LLVM.and (sext 32 e) (const? 32 128)) (const? 32 1) ⊑ const? 1 1 := by 
+  icmp IntPredicate.ne (LLVM.and (sext 32 e) (const? 32 128)) (const? 32 1) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -143,7 +143,7 @@ theorem fold_sext_to_and_wrong9_thm (e : IntW 8) :
 
 
 theorem fold_sext_to_and_wrong10_thm (e : IntW 8) :
-  icmp IntPredicate.ne (LLVM.and (sext 32 e) (const? 32 (-256))) (const? 32 1) ⊑ const? 1 1 := by 
+  icmp IntPredicate.ne (LLVM.and (sext 32 e) (const? 32 (-256))) (const? 32 1) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gsexthofhtrunchnsw_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gsexthofhtrunchnsw_proof.lean
@@ -10,7 +10,7 @@ set_option linter.unreachableTactic false
 section gsexthofhtrunchnsw_proof
 theorem narrow_source_matching_signbits_thm (e : IntW 32) :
   sext 64 (trunc 8 (shl (const? 32 (-1)) (LLVM.and e (const? 32 7)) { «nsw» := true, «nuw» := false })) ⊑
-    sext 64 (shl (const? 32 (-1)) (LLVM.and e (const? 32 7)) { «nsw» := true, «nuw» := false }) := by 
+    sext 64 (shl (const? 32 (-1)) (LLVM.and e (const? 32 7)) { «nsw» := true, «nuw» := false }) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -22,7 +22,7 @@ theorem narrow_source_matching_signbits_thm (e : IntW 32) :
 theorem wide_source_matching_signbits_thm (e : IntW 32) :
   sext 24 (trunc 8 (shl (const? 32 (-1)) (LLVM.and e (const? 32 7)) { «nsw» := true, «nuw» := false })) ⊑
     trunc 24 (shl (const? 32 (-1)) (LLVM.and e (const? 32 7)) { «nsw» := true, «nuw» := false })
-      { «nsw» := true, «nuw» := false } := by 
+      { «nsw» := true, «nuw» := false } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -33,7 +33,7 @@ theorem wide_source_matching_signbits_thm (e : IntW 32) :
 
 theorem same_source_matching_signbits_thm (e : IntW 32) :
   sext 32 (trunc 8 (shl (const? 32 (-1)) (LLVM.and e (const? 32 7)) { «nsw» := true, «nuw» := false })) ⊑
-    shl (const? 32 (-1)) (LLVM.and e (const? 32 7)) { «nsw» := true, «nuw» := false } := by 
+    shl (const? 32 (-1)) (LLVM.and e (const? 32 7)) { «nsw» := true, «nuw» := false } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -44,7 +44,7 @@ theorem same_source_matching_signbits_thm (e : IntW 32) :
 
 theorem same_source_not_matching_signbits_thm (e : IntW 32) :
   sext 32 (trunc 8 (shl (const? 32 (-1)) (LLVM.and e (const? 32 8)) { «nsw» := true, «nuw» := false })) ⊑
-    ashr (shl (const? 32 (-16777216)) (LLVM.and e (const? 32 8))) (const? 32 24) { «exact» := true } := by 
+    ashr (shl (const? 32 (-16777216)) (LLVM.and e (const? 32 8))) (const? 32 24) { «exact» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gshifthadd_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gshifthadd_proof.lean
@@ -9,7 +9,7 @@ set_option linter.unreachableTactic false
 
 section gshifthadd_proof
 theorem shl_C1_add_A_C2_i32_thm (e : IntW 16) :
-  shl (const? 32 6) (add (zext 32 e) (const? 32 5)) ⊑ shl (const? 32 192) (zext 32 e { «nneg» := true }) := by 
+  shl (const? 32 6) (add (zext 32 e) (const? 32 5)) ⊑ shl (const? 32 192) (zext 32 e { «nneg» := true }) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -19,7 +19,7 @@ theorem shl_C1_add_A_C2_i32_thm (e : IntW 16) :
 
 
 theorem ashr_C1_add_A_C2_i32_thm (e : IntW 32) :
-  ashr (const? 32 6) (add (LLVM.and e (const? 32 65535)) (const? 32 5)) ⊑ const? 32 0 := by 
+  ashr (const? 32 6) (add (LLVM.and e (const? 32 65535)) (const? 32 5)) ⊑ const? 32 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -30,7 +30,7 @@ theorem ashr_C1_add_A_C2_i32_thm (e : IntW 32) :
 
 theorem lshr_C1_add_A_C2_i32_thm (e : IntW 32) :
   shl (const? 32 6) (add (LLVM.and e (const? 32 65535)) (const? 32 5)) ⊑
-    shl (const? 32 192) (LLVM.and e (const? 32 65535)) := by 
+    shl (const? 32 192) (LLVM.and e (const? 32 65535)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -40,7 +40,7 @@ theorem lshr_C1_add_A_C2_i32_thm (e : IntW 32) :
 
 
 theorem shl_add_nuw_thm (e : IntW 32) :
-  shl (const? 32 6) (add e (const? 32 5) { «nsw» := false, «nuw» := true }) ⊑ shl (const? 32 192) e := by 
+  shl (const? 32 6) (add e (const? 32 5) { «nsw» := false, «nuw» := true }) ⊑ shl (const? 32 192) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -51,7 +51,7 @@ theorem shl_add_nuw_thm (e : IntW 32) :
 
 theorem shl_nuw_add_nuw_thm (e : IntW 32) :
   shl (const? 32 1) (add e (const? 32 1) { «nsw» := false, «nuw» := true }) { «nsw» := false, «nuw» := true } ⊑
-    shl (const? 32 2) e { «nsw» := false, «nuw» := true } := by 
+    shl (const? 32 2) e { «nsw» := false, «nuw» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -62,7 +62,7 @@ theorem shl_nuw_add_nuw_thm (e : IntW 32) :
 
 theorem shl_nsw_add_nuw_thm (e : IntW 32) :
   shl (const? 32 (-1)) (add e (const? 32 1) { «nsw» := false, «nuw» := true }) { «nsw» := true, «nuw» := false } ⊑
-    shl (const? 32 (-2)) e { «nsw» := true, «nuw» := false } := by 
+    shl (const? 32 (-2)) e { «nsw» := true, «nuw» := false } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -73,7 +73,7 @@ theorem shl_nsw_add_nuw_thm (e : IntW 32) :
 
 theorem lshr_exact_add_nuw_thm (e : IntW 32) :
   lshr (const? 32 4) (add e (const? 32 1) { «nsw» := false, «nuw» := true }) { «exact» := true } ⊑
-    lshr (const? 32 2) e { «exact» := true } := by 
+    lshr (const? 32 2) e { «exact» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -84,7 +84,7 @@ theorem lshr_exact_add_nuw_thm (e : IntW 32) :
 
 theorem ashr_exact_add_nuw_thm (e : IntW 32) :
   ashr (const? 32 (-4)) (add e (const? 32 1) { «nsw» := false, «nuw» := true }) { «exact» := true } ⊑
-    ashr (const? 32 (-2)) e { «exact» := true } := by 
+    ashr (const? 32 (-2)) e { «exact» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -94,7 +94,7 @@ theorem ashr_exact_add_nuw_thm (e : IntW 32) :
 
 
 theorem lshr_exact_add_negative_shift_positive_thm (e : IntW 32) :
-  lshr (const? 32 2) (add e (const? 32 (-1))) { «exact» := true } ⊑ lshr (const? 32 4) e { «exact» := true } := by 
+  lshr (const? 32 2) (add e (const? 32 (-1))) { «exact» := true } ⊑ lshr (const? 32 4) e { «exact» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -105,7 +105,7 @@ theorem lshr_exact_add_negative_shift_positive_thm (e : IntW 32) :
 
 theorem ashr_exact_add_negative_shift_negative_thm (e : IntW 32) :
   ashr (const? 32 (-2)) (add e (const? 32 (-1))) { «exact» := true } ⊑
-    ashr (const? 32 (-4)) e { «exact» := true } := by 
+    ashr (const? 32 (-4)) e { «exact» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -116,7 +116,7 @@ theorem ashr_exact_add_negative_shift_negative_thm (e : IntW 32) :
 
 theorem shl_nsw_add_negative_thm (e : IntW 32) :
   shl (const? 32 2) (add e (const? 32 (-1))) { «nsw» := true, «nuw» := false } ⊑
-    shl (const? 32 1) e { «nsw» := false, «nuw» := true } := by 
+    shl (const? 32 1) e { «nsw» := false, «nuw» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -127,7 +127,7 @@ theorem shl_nsw_add_negative_thm (e : IntW 32) :
 
 theorem shl_nsw_add_negative_invalid_constant3_thm (e : IntW 4) :
   shl (const? 4 2) (add e (const? 4 (-8))) { «nsw» := true, «nuw» := false } ⊑
-    shl (const? 4 2) (LLVM.xor e (const? 4 (-8))) { «nsw» := true, «nuw» := false } := by 
+    shl (const? 4 2) (LLVM.xor e (const? 4 (-8))) { «nsw» := true, «nuw» := false } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -137,7 +137,7 @@ theorem shl_nsw_add_negative_invalid_constant3_thm (e : IntW 4) :
 
 
 theorem lshr_2_add_zext_basic_thm (e e_1 : IntW 1) :
-  lshr (add (zext 2 e_1) (zext 2 e)) (const? 2 1) ⊑ zext 2 (LLVM.and e_1 e) := by 
+  lshr (add (zext 2 e_1) (zext 2 e)) (const? 2 1) ⊑ zext 2 (LLVM.and e_1 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -148,7 +148,7 @@ theorem lshr_2_add_zext_basic_thm (e e_1 : IntW 1) :
 
 theorem ashr_2_add_zext_basic_thm (e e_1 : IntW 1) :
   ashr (add (zext 2 e_1) (zext 2 e)) (const? 2 1) ⊑
-    ashr (add (zext 2 e_1) (zext 2 e) { «nsw» := false, «nuw» := true }) (const? 2 1) := by 
+    ashr (add (zext 2 e_1) (zext 2 e) { «nsw» := false, «nuw» := true }) (const? 2 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -159,7 +159,7 @@ theorem ashr_2_add_zext_basic_thm (e e_1 : IntW 1) :
 
 theorem lshr_16_add_zext_basic_thm (e e_1 : IntW 16) :
   lshr (add (zext 32 e_1) (zext 32 e)) (const? 32 16) ⊑
-    zext 32 (icmp IntPredicate.ugt e (LLVM.xor e_1 (const? 16 (-1)))) := by 
+    zext 32 (icmp IntPredicate.ugt e (LLVM.xor e_1 (const? 16 (-1)))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -171,7 +171,7 @@ theorem lshr_16_add_zext_basic_thm (e e_1 : IntW 16) :
 theorem lshr_16_add_zext_basic_multiuse_thm (e e_1 : IntW 16) :
   LLVM.or (lshr (add (zext 32 e_1) (zext 32 e)) (const? 32 16)) (zext 32 e_1) ⊑
     LLVM.or (lshr (add (zext 32 e_1) (zext 32 e) { «nsw» := true, «nuw» := true }) (const? 32 16))
-      (zext 32 e_1) := by 
+      (zext 32 e_1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -183,7 +183,7 @@ theorem lshr_16_add_zext_basic_multiuse_thm (e e_1 : IntW 16) :
 theorem lshr_16_add_known_16_leading_zeroes_thm (e e_1 : IntW 32) :
   lshr (add (LLVM.and e_1 (const? 32 65535)) (LLVM.and e (const? 32 65535))) (const? 32 16) ⊑
     lshr (add (LLVM.and e_1 (const? 32 65535)) (LLVM.and e (const? 32 65535)) { «nsw» := true, «nuw» := true })
-      (const? 32 16) := by 
+      (const? 32 16) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -195,7 +195,7 @@ theorem lshr_16_add_known_16_leading_zeroes_thm (e e_1 : IntW 32) :
 theorem lshr_16_add_not_known_16_leading_zeroes_thm (e e_1 : IntW 32) :
   lshr (add (LLVM.and e_1 (const? 32 131071)) (LLVM.and e (const? 32 65535))) (const? 32 16) ⊑
     lshr (add (LLVM.and e_1 (const? 32 131071)) (LLVM.and e (const? 32 65535)) { «nsw» := true, «nuw» := true })
-      (const? 32 16) := by 
+      (const? 32 16) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -206,7 +206,7 @@ theorem lshr_16_add_not_known_16_leading_zeroes_thm (e e_1 : IntW 32) :
 
 theorem lshr_32_add_zext_basic_thm (e e_1 : IntW 32) :
   lshr (add (zext 64 e_1) (zext 64 e)) (const? 64 32) ⊑
-    zext 64 (icmp IntPredicate.ugt e (LLVM.xor e_1 (const? 32 (-1)))) := by 
+    zext 64 (icmp IntPredicate.ugt e (LLVM.xor e_1 (const? 32 (-1)))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -217,7 +217,7 @@ theorem lshr_32_add_zext_basic_thm (e e_1 : IntW 32) :
 
 theorem lshr_32_add_zext_basic_multiuse_thm (e e_1 : IntW 32) :
   LLVM.or (lshr (add (zext 64 e_1) (zext 64 e)) (const? 64 32)) (zext 64 e) ⊑
-    LLVM.or (lshr (add (zext 64 e_1) (zext 64 e) { «nsw» := true, «nuw» := true }) (const? 64 32)) (zext 64 e) := by 
+    LLVM.or (lshr (add (zext 64 e_1) (zext 64 e) { «nsw» := true, «nuw» := true }) (const? 64 32)) (zext 64 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -228,7 +228,7 @@ theorem lshr_32_add_zext_basic_multiuse_thm (e e_1 : IntW 32) :
 
 theorem lshr_31_i32_add_zext_basic_thm (e e_1 : IntW 32) :
   lshr (add (zext 64 e_1) (zext 64 e)) (const? 64 31) ⊑
-    lshr (add (zext 64 e_1) (zext 64 e) { «nsw» := true, «nuw» := true }) (const? 64 31) := by 
+    lshr (add (zext 64 e_1) (zext 64 e) { «nsw» := true, «nuw» := true }) (const? 64 31) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -237,7 +237,7 @@ theorem lshr_31_i32_add_zext_basic_thm (e e_1 : IntW 32) :
     all_goals sorry
 
 
-theorem lshr_33_i32_add_zext_basic_thm (e e_1 : IntW 32) : lshr (add (zext 64 e_1) (zext 64 e)) (const? 64 33) ⊑ const? 64 0 := by 
+theorem lshr_33_i32_add_zext_basic_thm (e e_1 : IntW 32) : lshr (add (zext 64 e_1) (zext 64 e)) (const? 64 33) ⊑ const? 64 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -248,7 +248,7 @@ theorem lshr_33_i32_add_zext_basic_thm (e e_1 : IntW 32) : lshr (add (zext 64 e_
 
 theorem lshr_16_to_64_add_zext_basic_thm (e e_1 : IntW 16) :
   lshr (add (zext 64 e_1) (zext 64 e)) (const? 64 16) ⊑
-    zext 64 (icmp IntPredicate.ugt e (LLVM.xor e_1 (const? 16 (-1)))) := by 
+    zext 64 (icmp IntPredicate.ugt e (LLVM.xor e_1 (const? 16 (-1)))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -261,7 +261,7 @@ theorem lshr_32_add_known_32_leading_zeroes_thm (e e_1 : IntW 64) :
   lshr (add (LLVM.and e_1 (const? 64 4294967295)) (LLVM.and e (const? 64 4294967295))) (const? 64 32) ⊑
     lshr
       (add (LLVM.and e_1 (const? 64 4294967295)) (LLVM.and e (const? 64 4294967295)) { «nsw» := true, «nuw» := true })
-      (const? 64 32) := by 
+      (const? 64 32) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -274,7 +274,7 @@ theorem lshr_32_add_not_known_32_leading_zeroes_thm (e e_1 : IntW 64) :
   lshr (add (LLVM.and e_1 (const? 64 8589934591)) (LLVM.and e (const? 64 4294967295))) (const? 64 32) ⊑
     lshr
       (add (LLVM.and e_1 (const? 64 8589934591)) (LLVM.and e (const? 64 4294967295)) { «nsw» := true, «nuw» := true })
-      (const? 64 32) := by 
+      (const? 64 32) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -285,7 +285,7 @@ theorem lshr_32_add_not_known_32_leading_zeroes_thm (e e_1 : IntW 64) :
 
 theorem ashr_16_add_zext_basic_thm (e e_1 : IntW 16) :
   lshr (add (zext 32 e_1) (zext 32 e)) (const? 32 16) ⊑
-    zext 32 (icmp IntPredicate.ugt e (LLVM.xor e_1 (const? 16 (-1)))) := by 
+    zext 32 (icmp IntPredicate.ugt e (LLVM.xor e_1 (const? 16 (-1)))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -296,7 +296,7 @@ theorem ashr_16_add_zext_basic_thm (e e_1 : IntW 16) :
 
 theorem ashr_32_add_zext_basic_thm (e e_1 : IntW 32) :
   ashr (add (zext 64 e_1) (zext 64 e)) (const? 64 32) ⊑
-    zext 64 (icmp IntPredicate.ugt e (LLVM.xor e_1 (const? 32 (-1)))) := by 
+    zext 64 (icmp IntPredicate.ugt e (LLVM.xor e_1 (const? 32 (-1)))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -307,7 +307,7 @@ theorem ashr_32_add_zext_basic_thm (e e_1 : IntW 32) :
 
 theorem ashr_16_to_64_add_zext_basic_thm (e e_1 : IntW 16) :
   ashr (add (zext 64 e_1) (zext 64 e)) (const? 64 16) ⊑
-    zext 64 (icmp IntPredicate.ugt e (LLVM.xor e_1 (const? 16 (-1)))) := by 
+    zext 64 (icmp IntPredicate.ugt e (LLVM.xor e_1 (const? 16 (-1)))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -318,7 +318,7 @@ theorem ashr_16_to_64_add_zext_basic_thm (e e_1 : IntW 16) :
 
 theorem lshr_32_add_zext_trunc_thm (e e_1 : IntW 32) :
   add (trunc 32 (add (zext 64 e_1) (zext 64 e))) (trunc 32 (lshr (add (zext 64 e_1) (zext 64 e)) (const? 64 32))) ⊑
-    add (add e_1 e) (zext 32 (icmp IntPredicate.ult (add e_1 e) e_1)) := by 
+    add (add e_1 e) (zext 32 (icmp IntPredicate.ult (add e_1 e) e_1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -328,7 +328,7 @@ theorem lshr_32_add_zext_trunc_thm (e e_1 : IntW 32) :
 
 
 theorem shl_fold_or_disjoint_cnt_thm (e : IntW 8) :
-  shl (const? 8 2) (LLVM.or e (const? 8 3) { «disjoint» := true }) ⊑ shl (const? 8 16) e := by 
+  shl (const? 8 2) (LLVM.or e (const? 8 3) { «disjoint» := true }) ⊑ shl (const? 8 16) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gshifthaddhinseltpoison_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gshifthaddhinseltpoison_proof.lean
@@ -9,7 +9,7 @@ set_option linter.unreachableTactic false
 
 section gshifthaddhinseltpoison_proof
 theorem shl_C1_add_A_C2_i32_thm (e : IntW 16) :
-  shl (const? 32 6) (add (zext 32 e) (const? 32 5)) ⊑ shl (const? 32 192) (zext 32 e { «nneg» := true }) := by 
+  shl (const? 32 6) (add (zext 32 e) (const? 32 5)) ⊑ shl (const? 32 192) (zext 32 e { «nneg» := true }) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -19,7 +19,7 @@ theorem shl_C1_add_A_C2_i32_thm (e : IntW 16) :
 
 
 theorem ashr_C1_add_A_C2_i32_thm (e : IntW 32) :
-  ashr (const? 32 6) (add (LLVM.and e (const? 32 65535)) (const? 32 5)) ⊑ const? 32 0 := by 
+  ashr (const? 32 6) (add (LLVM.and e (const? 32 65535)) (const? 32 5)) ⊑ const? 32 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -30,7 +30,7 @@ theorem ashr_C1_add_A_C2_i32_thm (e : IntW 32) :
 
 theorem lshr_C1_add_A_C2_i32_thm (e : IntW 32) :
   shl (const? 32 6) (add (LLVM.and e (const? 32 65535)) (const? 32 5)) ⊑
-    shl (const? 32 192) (LLVM.and e (const? 32 65535)) := by 
+    shl (const? 32 192) (LLVM.and e (const? 32 65535)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gshifthamounthreassociation_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gshifthamounthreassociation_proof.lean
@@ -9,7 +9,7 @@ set_option linter.unreachableTactic false
 
 section gshifthamounthreassociation_proof
 theorem t0_thm (e e_1 : IntW 32) :
-  lshr (lshr e_1 (sub (const? 32 32) e)) (add e (const? 32 (-2))) { «exact» := true } ⊑ lshr e_1 (const? 32 30) := by 
+  lshr (lshr e_1 (sub (const? 32 32) e)) (add e (const? 32 (-2))) { «exact» := true } ⊑ lshr e_1 (const? 32 30) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -21,7 +21,7 @@ theorem t0_thm (e e_1 : IntW 32) :
 theorem t6_shl_thm (e e_1 : IntW 32) :
   shl (shl e_1 (sub (const? 32 32) e) { «nsw» := false, «nuw» := true }) (add e (const? 32 (-2)))
       { «nsw» := true, «nuw» := false } ⊑
-    shl e_1 (const? 32 30) := by 
+    shl e_1 (const? 32 30) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -31,7 +31,7 @@ theorem t6_shl_thm (e e_1 : IntW 32) :
 
 
 theorem t7_ashr_thm (e e_1 : IntW 32) :
-  ashr (ashr e_1 (sub (const? 32 32) e) { «exact» := true }) (add e (const? 32 (-2))) ⊑ ashr e_1 (const? 32 30) := by 
+  ashr (ashr e_1 (sub (const? 32 32) e) { «exact» := true }) (add e (const? 32 (-2))) ⊑ ashr e_1 (const? 32 30) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -42,7 +42,7 @@ theorem t7_ashr_thm (e e_1 : IntW 32) :
 
 theorem t8_lshr_exact_flag_preservation_thm (e e_1 : IntW 32) :
   lshr (lshr e_1 (sub (const? 32 32) e) { «exact» := true }) (add e (const? 32 (-2))) { «exact» := true } ⊑
-    lshr e_1 (const? 32 30) { «exact» := true } := by 
+    lshr e_1 (const? 32 30) { «exact» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -53,7 +53,7 @@ theorem t8_lshr_exact_flag_preservation_thm (e e_1 : IntW 32) :
 
 theorem t9_ashr_exact_flag_preservation_thm (e e_1 : IntW 32) :
   ashr (ashr e_1 (sub (const? 32 32) e) { «exact» := true }) (add e (const? 32 (-2))) { «exact» := true } ⊑
-    ashr e_1 (const? 32 30) { «exact» := true } := by 
+    ashr e_1 (const? 32 30) { «exact» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -65,7 +65,7 @@ theorem t9_ashr_exact_flag_preservation_thm (e e_1 : IntW 32) :
 theorem t10_shl_nuw_flag_preservation_thm (e e_1 : IntW 32) :
   shl (shl e_1 (sub (const? 32 32) e) { «nsw» := false, «nuw» := true }) (add e (const? 32 (-2)))
       { «nsw» := true, «nuw» := true } ⊑
-    shl e_1 (const? 32 30) { «nsw» := false, «nuw» := true } := by 
+    shl e_1 (const? 32 30) { «nsw» := false, «nuw» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -77,7 +77,7 @@ theorem t10_shl_nuw_flag_preservation_thm (e e_1 : IntW 32) :
 theorem t11_shl_nsw_flag_preservation_thm (e e_1 : IntW 32) :
   shl (shl e_1 (sub (const? 32 32) e) { «nsw» := true, «nuw» := false }) (add e (const? 32 (-2)))
       { «nsw» := true, «nuw» := true } ⊑
-    shl e_1 (const? 32 30) { «nsw» := true, «nuw» := false } := by 
+    shl e_1 (const? 32 30) { «nsw» := true, «nuw» := false } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gshifthamounthreassociationhinhbittest_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gshifthamounthreassociationhinhbittest_proof.lean
@@ -10,7 +10,7 @@ set_option linter.unreachableTactic false
 section gshifthamounthreassociationhinhbittest_proof
 theorem t0_const_lshr_shl_ne_thm (e e_1 : IntW 32) :
   icmp IntPredicate.ne (LLVM.and (shl e_1 (const? 32 1)) (lshr e (const? 32 1))) (const? 32 0) ⊑
-    icmp IntPredicate.ne (LLVM.and (lshr e (const? 32 2)) e_1) (const? 32 0) := by 
+    icmp IntPredicate.ne (LLVM.and (lshr e (const? 32 2)) e_1) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -21,7 +21,7 @@ theorem t0_const_lshr_shl_ne_thm (e e_1 : IntW 32) :
 
 theorem t1_const_shl_lshr_ne_thm (e e_1 : IntW 32) :
   icmp IntPredicate.ne (LLVM.and (lshr e_1 (const? 32 1)) (shl e (const? 32 1))) (const? 32 0) ⊑
-    icmp IntPredicate.ne (LLVM.and (lshr e_1 (const? 32 2)) e) (const? 32 0) := by 
+    icmp IntPredicate.ne (LLVM.and (lshr e_1 (const? 32 2)) e) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -32,7 +32,7 @@ theorem t1_const_shl_lshr_ne_thm (e e_1 : IntW 32) :
 
 theorem t2_const_lshr_shl_eq_thm (e e_1 : IntW 32) :
   icmp IntPredicate.eq (LLVM.and (shl e_1 (const? 32 1)) (lshr e (const? 32 1))) (const? 32 0) ⊑
-    icmp IntPredicate.eq (LLVM.and (lshr e (const? 32 2)) e_1) (const? 32 0) := by 
+    icmp IntPredicate.eq (LLVM.and (lshr e (const? 32 2)) e_1) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -43,7 +43,7 @@ theorem t2_const_lshr_shl_eq_thm (e e_1 : IntW 32) :
 
 theorem t3_const_after_fold_lshr_shl_ne_thm (e e_1 e_2 : IntW 32) :
   icmp IntPredicate.ne (LLVM.and (lshr e_2 (sub (const? 32 32) e_1)) (shl e (add e_1 (const? 32 (-1))))) (const? 32 0) ⊑
-    icmp IntPredicate.ne (LLVM.and (lshr e_2 (const? 32 31)) e) (const? 32 0) := by 
+    icmp IntPredicate.ne (LLVM.and (lshr e_2 (const? 32 31)) e) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -54,7 +54,7 @@ theorem t3_const_after_fold_lshr_shl_ne_thm (e e_1 e_2 : IntW 32) :
 
 theorem t4_const_after_fold_lshr_shl_ne_thm (e e_1 e_2 : IntW 32) :
   icmp IntPredicate.ne (LLVM.and (shl e_2 (sub (const? 32 32) e_1)) (lshr e (add e_1 (const? 32 (-1))))) (const? 32 0) ⊑
-    icmp IntPredicate.ne (LLVM.and (lshr e (const? 32 31)) e_2) (const? 32 0) := by 
+    icmp IntPredicate.ne (LLVM.and (lshr e (const? 32 31)) e_2) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gshifthamounthreassociationhinhbittesthwithhtruncationhlshr_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gshifthamounthreassociationhinhbittesthwithhtruncationhlshr_proof.lean
@@ -15,7 +15,7 @@ theorem n0_thm (e : IntW 64) (e_1 e_2 : IntW 32) :
     icmp IntPredicate.ne
       (LLVM.and (shl e_2 (sub (const? 32 32) e_1))
         (trunc 32 (lshr e (zext 64 (add e_1 (const? 32 (-16))) { «nneg» := true }))))
-      (const? 32 0) := by 
+      (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -29,7 +29,7 @@ theorem t1_thm (e : IntW 64) (e_1 : IntW 32) :
       (LLVM.and (shl (const? 32 65535) (sub (const? 32 32) e_1))
         (trunc 32 (lshr e (zext 64 (add e_1 (const? 32 (-16)))))))
       (const? 32 0) ⊑
-    icmp IntPredicate.ne (LLVM.and e (const? 64 4294901760)) (const? 64 0) := by 
+    icmp IntPredicate.ne (LLVM.and e (const? 64 4294901760)) (const? 64 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -43,7 +43,7 @@ theorem t1_single_bit_thm (e : IntW 64) (e_1 : IntW 32) :
       (LLVM.and (shl (const? 32 32768) (sub (const? 32 32) e_1))
         (trunc 32 (lshr e (zext 64 (add e_1 (const? 32 (-16)))))))
       (const? 32 0) ⊑
-    icmp IntPredicate.ne (LLVM.and e (const? 64 2147483648)) (const? 64 0) := by 
+    icmp IntPredicate.ne (LLVM.and e (const? 64 2147483648)) (const? 64 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -60,7 +60,7 @@ theorem n2_thm (e : IntW 64) (e_1 : IntW 32) :
     icmp IntPredicate.ne
       (LLVM.and (shl (const? 32 131071) (sub (const? 32 32) e_1))
         (trunc 32 (lshr e (zext 64 (add e_1 (const? 32 (-16))) { «nneg» := true }))))
-      (const? 32 0) := by 
+      (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -74,7 +74,7 @@ theorem t3_thm (e e_1 : IntW 32) :
       (LLVM.and (shl e_1 (sub (const? 32 32) e))
         (trunc 32 (lshr (const? 64 131071) (zext 64 (add e (const? 32 (-16)))))))
       (const? 32 0) ⊑
-    icmp IntPredicate.ne (LLVM.and e_1 (const? 32 1)) (const? 32 0) := by 
+    icmp IntPredicate.ne (LLVM.and e_1 (const? 32 1)) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -88,7 +88,7 @@ theorem t3_singlebit_thm (e e_1 : IntW 32) :
       (LLVM.and (shl e_1 (sub (const? 32 32) e))
         (trunc 32 (lshr (const? 64 65536) (zext 64 (add e (const? 32 (-16)))))))
       (const? 32 0) ⊑
-    icmp IntPredicate.ne (LLVM.and e_1 (const? 32 1)) (const? 32 0) := by 
+    icmp IntPredicate.ne (LLVM.and e_1 (const? 32 1)) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -106,7 +106,7 @@ theorem n4_thm (e e_1 : IntW 32) :
       (LLVM.and (shl e_1 (sub (const? 32 32) e))
         (trunc 32 (lshr (const? 64 262143) (zext 64 (add e (const? 32 (-16))) { «nneg» := true }))
           { «nsw» := true, «nuw» := true }))
-      (const? 32 0) := by 
+      (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -119,7 +119,7 @@ theorem t9_highest_bit_thm (e : IntW 64) (e_1 e_2 : IntW 32) :
   icmp IntPredicate.ne
       (LLVM.and (shl e_2 (sub (const? 32 64) e_1)) (trunc 32 (lshr e (zext 64 (add e_1 (const? 32 (-1)))))))
       (const? 32 0) ⊑
-    icmp IntPredicate.ne (LLVM.and (lshr e (const? 64 63)) (zext 64 e_2)) (const? 64 0) := by 
+    icmp IntPredicate.ne (LLVM.and (lshr e (const? 64 63)) (zext 64 e_2)) (const? 64 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -135,7 +135,7 @@ theorem t10_almost_highest_bit_thm (e : IntW 64) (e_1 e_2 : IntW 32) :
     icmp IntPredicate.ne
       (LLVM.and (shl e_2 (sub (const? 32 64) e_1))
         (trunc 32 (lshr e (zext 64 (add e_1 (const? 32 (-2))) { «nneg» := true }))))
-      (const? 32 0) := by 
+      (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -148,7 +148,7 @@ theorem t11_no_shift_thm (e : IntW 64) (e_1 e_2 : IntW 32) :
   icmp IntPredicate.ne
       (LLVM.and (shl e_2 (sub (const? 32 64) e_1)) (trunc 32 (lshr e (zext 64 (add e_1 (const? 32 (-64)))))))
       (const? 32 0) ⊑
-    icmp IntPredicate.ne (LLVM.and e (zext 64 e_2)) (const? 64 0) := by 
+    icmp IntPredicate.ne (LLVM.and e (zext 64 e_2)) (const? 64 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -164,7 +164,7 @@ theorem t10_shift_by_one_thm (e : IntW 64) (e_1 e_2 : IntW 32) :
     icmp IntPredicate.ne
       (LLVM.and (shl e_2 (sub (const? 32 64) e_1))
         (trunc 32 (lshr e (zext 64 (add e_1 (const? 32 (-63))) { «nneg» := true }))))
-      (const? 32 0) := by 
+      (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -177,7 +177,7 @@ theorem t13_x_is_one_thm (e : IntW 64) (e_1 : IntW 32) :
   icmp IntPredicate.ne
       (LLVM.and (shl (const? 32 1) (sub (const? 32 32) e_1)) (trunc 32 (lshr e (zext 64 (add e_1 (const? 32 (-16)))))))
       (const? 32 0) ⊑
-    icmp IntPredicate.ne (LLVM.and e (const? 64 65536)) (const? 64 0) := by 
+    icmp IntPredicate.ne (LLVM.and e (const? 64 65536)) (const? 64 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -190,7 +190,7 @@ theorem t14_x_is_one_thm (e e_1 : IntW 32) :
   icmp IntPredicate.ne
       (LLVM.and (shl e_1 (sub (const? 32 32) e)) (trunc 32 (lshr (const? 64 1) (zext 64 (add e (const? 32 (-16)))))))
       (const? 32 0) ⊑
-    const? 1 0 := by 
+    const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -204,7 +204,7 @@ theorem rawspeed_signbit_thm (e : IntW 64) (e_1 : IntW 32) :
       (LLVM.and (shl (const? 32 1) (add e_1 (const? 32 (-1)) { «nsw» := true, «nuw» := false }))
         (trunc 32 (lshr e (zext 64 (sub (const? 32 64) e_1 { «nsw» := true, «nuw» := false })))))
       (const? 32 0) ⊑
-    icmp IntPredicate.sgt e (const? 64 (-1)) := by 
+    icmp IntPredicate.sgt e (const? 64 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gshifthamounthreassociationhinhbittesthwithhtruncationhshl_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gshifthamounthreassociationhinhbittesthwithhtruncationhshl_proof.lean
@@ -12,7 +12,7 @@ theorem t0_const_after_fold_lshr_shl_ne_thm (e : IntW 64) (e_1 e_2 : IntW 32) :
   icmp IntPredicate.ne
       (LLVM.and (lshr e_2 (sub (const? 32 32) e_1)) (trunc 32 (shl e (zext 64 (add e_1 (const? 32 (-1)))))))
       (const? 32 0) ⊑
-    icmp IntPredicate.ne (LLVM.and e (zext 64 (lshr e_2 (const? 32 31)) { «nneg» := true })) (const? 64 0) := by 
+    icmp IntPredicate.ne (LLVM.and e (zext 64 (lshr e_2 (const? 32 31)) { «nneg» := true })) (const? 64 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -23,7 +23,7 @@ theorem t0_const_after_fold_lshr_shl_ne_thm (e : IntW 64) (e_1 e_2 : IntW 32) :
 
 theorem t10_constants_thm (e : IntW 64) (e_1 : IntW 32) :
   icmp IntPredicate.ne (LLVM.and (lshr e_1 (const? 32 12)) (trunc 32 (shl e (const? 64 14)))) (const? 32 0) ⊑
-    icmp IntPredicate.ne (LLVM.and (lshr e_1 (const? 32 26)) (trunc 32 e)) (const? 32 0) := by 
+    icmp IntPredicate.ne (LLVM.and (lshr e_1 (const? 32 26)) (trunc 32 e)) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -39,7 +39,7 @@ theorem n13_overshift_thm (e : IntW 64) (e_1 e_2 : IntW 32) :
     icmp IntPredicate.ne
       (LLVM.and (lshr e_2 (sub (const? 32 32) e_1))
         (trunc 32 (shl e (zext 64 (add e_1 (const? 32 32)) { «nneg» := true }))))
-      (const? 32 0) := by 
+      (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -55,7 +55,7 @@ theorem n14_trunc_of_lshr_thm (e e_1 : IntW 32) (e_2 : IntW 64) :
     icmp IntPredicate.ne
       (LLVM.and (shl e (add e_1 (const? 32 (-1))))
         (trunc 32 (lshr e_2 (zext 64 (sub (const? 32 32) e_1) { «nneg» := true }))))
-      (const? 32 0) := by 
+      (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -66,7 +66,7 @@ theorem n14_trunc_of_lshr_thm (e e_1 : IntW 32) (e_2 : IntW 64) :
 
 theorem n15_variable_shamts_thm (e e_1 : IntW 32) (e_2 e_3 : IntW 64) :
   icmp IntPredicate.ne (LLVM.and (trunc 32 (shl e_3 e_2)) (lshr e_1 e)) (const? 32 0) ⊑
-    icmp IntPredicate.ne (LLVM.and (lshr e_1 e) (trunc 32 (shl e_3 e_2))) (const? 32 0) := by 
+    icmp IntPredicate.ne (LLVM.and (lshr e_1 e) (trunc 32 (shl e_3 e_2))) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gshifthamounthreassociationhwithhtruncationhashr_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gshifthamounthreassociationhwithhtruncationhashr_proof.lean
@@ -10,7 +10,7 @@ set_option linter.unreachableTactic false
 section gshifthamounthreassociationhwithhtruncationhashr_proof
 theorem t0_thm (e : IntW 16) (e_1 : IntW 32) :
   ashr (trunc 16 (ashr e_1 (zext 32 (sub (const? 16 32) e)))) (add e (const? 16 (-1))) ⊑
-    trunc 16 (ashr e_1 (const? 32 31)) { «nsw» := true, «nuw» := false } := by 
+    trunc 16 (ashr e_1 (const? 32 31)) { «nsw» := true, «nuw» := false } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -21,7 +21,7 @@ theorem t0_thm (e : IntW 16) (e_1 : IntW 32) :
 
 theorem t9_ashr_thm (e : IntW 16) (e_1 : IntW 32) :
   ashr (trunc 16 (ashr e_1 (zext 32 (sub (const? 16 32) e)))) (add e (const? 16 (-2))) ⊑
-    ashr (trunc 16 (ashr e_1 (zext 32 (sub (const? 16 32) e) { «nneg» := true }))) (add e (const? 16 (-2))) := by 
+    ashr (trunc 16 (ashr e_1 (zext 32 (sub (const? 16 32) e) { «nneg» := true }))) (add e (const? 16 (-2))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -32,7 +32,7 @@ theorem t9_ashr_thm (e : IntW 16) (e_1 : IntW 32) :
 
 theorem n10_lshr_ashr_thm (e : IntW 16) (e_1 : IntW 32) :
   ashr (trunc 16 (lshr e_1 (zext 32 (sub (const? 16 32) e)))) (add e (const? 16 (-1))) ⊑
-    ashr (trunc 16 (lshr e_1 (zext 32 (sub (const? 16 32) e) { «nneg» := true }))) (add e (const? 16 (-1))) := by 
+    ashr (trunc 16 (lshr e_1 (zext 32 (sub (const? 16 32) e) { «nneg» := true }))) (add e (const? 16 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gshifthamounthreassociationhwithhtruncationhlshr_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gshifthamounthreassociationhwithhtruncationhlshr_proof.lean
@@ -10,7 +10,7 @@ set_option linter.unreachableTactic false
 section gshifthamounthreassociationhwithhtruncationhlshr_proof
 theorem t0_thm (e : IntW 16) (e_1 : IntW 32) :
   lshr (trunc 16 (lshr e_1 (zext 32 (sub (const? 16 32) e)))) (add e (const? 16 (-1))) ⊑
-    trunc 16 (lshr e_1 (const? 32 31)) { «nsw» := true, «nuw» := true } := by 
+    trunc 16 (lshr e_1 (const? 32 31)) { «nsw» := true, «nuw» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -21,7 +21,7 @@ theorem t0_thm (e : IntW 16) (e_1 : IntW 32) :
 
 theorem t9_lshr_thm (e : IntW 16) (e_1 : IntW 32) :
   lshr (trunc 16 (lshr e_1 (zext 32 (sub (const? 16 32) e)))) (add e (const? 16 (-2))) ⊑
-    lshr (trunc 16 (lshr e_1 (zext 32 (sub (const? 16 32) e) { «nneg» := true }))) (add e (const? 16 (-2))) := by 
+    lshr (trunc 16 (lshr e_1 (zext 32 (sub (const? 16 32) e) { «nneg» := true }))) (add e (const? 16 (-2))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -32,7 +32,7 @@ theorem t9_lshr_thm (e : IntW 16) (e_1 : IntW 32) :
 
 theorem n10_ashr_lshr_thm (e : IntW 16) (e_1 : IntW 32) :
   lshr (trunc 16 (ashr e_1 (zext 32 (sub (const? 16 32) e)))) (add e (const? 16 (-1))) ⊑
-    lshr (trunc 16 (ashr e_1 (zext 32 (sub (const? 16 32) e) { «nneg» := true }))) (add e (const? 16 (-1))) := by 
+    lshr (trunc 16 (ashr e_1 (zext 32 (sub (const? 16 32) e) { «nneg» := true }))) (add e (const? 16 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gshifthamounthreassociationhwithhtruncationhshl_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gshifthamounthreassociationhwithhtruncationhshl_proof.lean
@@ -10,7 +10,7 @@ set_option linter.unreachableTactic false
 section gshifthamounthreassociationhwithhtruncationhshl_proof
 theorem t0_thm (e : IntW 16) (e_1 : IntW 32) :
   shl (trunc 16 (shl e_1 (zext 32 (sub (const? 16 32) e)))) (add e (const? 16 (-24))) ⊑
-    shl (trunc 16 e_1) (const? 16 8) := by 
+    shl (trunc 16 e_1) (const? 16 8) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -21,7 +21,7 @@ theorem t0_thm (e : IntW 16) (e_1 : IntW 32) :
 
 theorem n11_thm (e : IntW 16) (e_1 : IntW 32) :
   shl (trunc 16 (shl e_1 (zext 32 (sub (const? 16 30) e)))) (add e (const? 16 (-31))) ⊑
-    shl (trunc 16 (shl e_1 (zext 32 (sub (const? 16 30) e) { «nneg» := true }))) (add e (const? 16 (-31))) := by 
+    shl (trunc 16 (shl e_1 (zext 32 (sub (const? 16 30) e) { «nneg» := true }))) (add e (const? 16 (-31))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gshifthbyhsignext_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gshifthbyhsignext_proof.lean
@@ -8,7 +8,7 @@ set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
 
 section gshifthbyhsignext_proof
-theorem t0_shl_thm (e : IntW 8) (e_1 : IntW 32) : shl e_1 (sext 32 e) ⊑ shl e_1 (zext 32 e { «nneg» := true }) := by 
+theorem t0_shl_thm (e : IntW 8) (e_1 : IntW 32) : shl e_1 (sext 32 e) ⊑ shl e_1 (zext 32 e { «nneg» := true }) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -18,7 +18,7 @@ theorem t0_shl_thm (e : IntW 8) (e_1 : IntW 32) : shl e_1 (sext 32 e) ⊑ shl e_
 
 
 theorem t1_lshr_thm (e : IntW 8) (e_1 : IntW 32) :
-  lshr e_1 (sext 32 e) ⊑ lshr e_1 (zext 32 e { «nneg» := true }) := by 
+  lshr e_1 (sext 32 e) ⊑ lshr e_1 (zext 32 e { «nneg» := true }) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -28,7 +28,7 @@ theorem t1_lshr_thm (e : IntW 8) (e_1 : IntW 32) :
 
 
 theorem t2_ashr_thm (e : IntW 8) (e_1 : IntW 32) :
-  ashr e_1 (sext 32 e) ⊑ ashr e_1 (zext 32 e { «nneg» := true }) := by 
+  ashr e_1 (sext 32 e) ⊑ ashr e_1 (zext 32 e { «nneg» := true }) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gshifthdirectionhinhbithtest_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gshifthdirectionhinhbithtest_proof.lean
@@ -11,7 +11,7 @@ section gshifthdirectionhinhbithtest_proof
 theorem t7_twoshifts2_thm (e e_1 e_2 : IntW 32) :
   icmp IntPredicate.eq (LLVM.and (shl e_2 e_1) (shl (const? 32 1) e)) (const? 32 0) ⊑
     icmp IntPredicate.eq (LLVM.and (shl e_2 e_1) (shl (const? 32 1) e { «nsw» := false, «nuw» := true }))
-      (const? 32 0) := by 
+      (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -23,7 +23,7 @@ theorem t7_twoshifts2_thm (e e_1 e_2 : IntW 32) :
 theorem t8_twoshifts3_thm (e e_1 e_2 : IntW 32) :
   icmp IntPredicate.eq (LLVM.and (shl (const? 32 1) e_2) (shl e_1 e)) (const? 32 0) ⊑
     icmp IntPredicate.eq (LLVM.and (shl (const? 32 1) e_2 { «nsw» := false, «nuw» := true }) (shl e_1 e))
-      (const? 32 0) := by 
+      (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -34,7 +34,7 @@ theorem t8_twoshifts3_thm (e e_1 e_2 : IntW 32) :
 
 theorem t12_shift_of_const0_thm (e e_1 : IntW 32) :
   icmp IntPredicate.eq (LLVM.and (shl (const? 32 1) e_1) e) (const? 32 0) ⊑
-    icmp IntPredicate.eq (LLVM.and (shl (const? 32 1) e_1 { «nsw» := false, «nuw» := true }) e) (const? 32 0) := by 
+    icmp IntPredicate.eq (LLVM.and (shl (const? 32 1) e_1 { «nsw» := false, «nuw» := true }) e) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -45,7 +45,7 @@ theorem t12_shift_of_const0_thm (e e_1 : IntW 32) :
 
 theorem t14_and_with_const0_thm (e e_1 : IntW 32) :
   icmp IntPredicate.eq (LLVM.and (shl e_1 e) (const? 32 1)) (const? 32 0) ⊑
-    icmp IntPredicate.eq (LLVM.and e_1 (lshr (const? 32 1) e)) (const? 32 0) := by 
+    icmp IntPredicate.eq (LLVM.and e_1 (lshr (const? 32 1) e)) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -56,7 +56,7 @@ theorem t14_and_with_const0_thm (e e_1 : IntW 32) :
 
 theorem t15_and_with_const1_thm (e e_1 : IntW 32) :
   icmp IntPredicate.eq (LLVM.and (lshr e_1 e) (const? 32 1)) (const? 32 0) ⊑
-    icmp IntPredicate.eq (LLVM.and e_1 (shl (const? 32 1) e { «nsw» := false, «nuw» := true })) (const? 32 0) := by 
+    icmp IntPredicate.eq (LLVM.and e_1 (shl (const? 32 1) e { «nsw» := false, «nuw» := true })) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gshifthflags_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gshifthflags_proof.lean
@@ -10,7 +10,7 @@ set_option linter.unreachableTactic false
 section gshifthflags_proof
 theorem shl_add_nuw_thm (e e_1 : IntW 8) :
   shl (LLVM.and e_1 (const? 8 63)) (LLVM.and e (const? 8 2)) ⊑
-    shl (LLVM.and e_1 (const? 8 63)) (LLVM.and e (const? 8 2)) { «nsw» := false, «nuw» := true } := by 
+    shl (LLVM.and e_1 (const? 8 63)) (LLVM.and e (const? 8 2)) { «nsw» := false, «nuw» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -21,7 +21,7 @@ theorem shl_add_nuw_thm (e e_1 : IntW 8) :
 
 theorem shl_add_nuw_and_nsw_thm (e e_1 : IntW 8) :
   shl (LLVM.and e_1 (const? 8 31)) (LLVM.and e (const? 8 2)) ⊑
-    shl (LLVM.and e_1 (const? 8 31)) (LLVM.and e (const? 8 2)) { «nsw» := true, «nuw» := true } := by 
+    shl (LLVM.and e_1 (const? 8 31)) (LLVM.and e (const? 8 2)) { «nsw» := true, «nuw» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -32,7 +32,7 @@ theorem shl_add_nuw_and_nsw_thm (e e_1 : IntW 8) :
 
 theorem shl_add_nsw_thm (e e_1 : IntW 8) :
   shl (LLVM.or e_1 (const? 8 (-32))) (LLVM.and e (const? 8 2)) ⊑
-    shl (LLVM.or e_1 (const? 8 (-32))) (LLVM.and e (const? 8 2)) { «nsw» := true, «nuw» := false } := by 
+    shl (LLVM.or e_1 (const? 8 (-32))) (LLVM.and e (const? 8 2)) { «nsw» := true, «nuw» := false } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -43,7 +43,7 @@ theorem shl_add_nsw_thm (e e_1 : IntW 8) :
 
 theorem lshr_add_exact_thm (e e_1 : IntW 8) :
   lshr (LLVM.and e_1 (const? 8 (-4))) (LLVM.and e (const? 8 2)) ⊑
-    lshr (LLVM.and e_1 (const? 8 (-4))) (LLVM.and e (const? 8 2)) { «exact» := true } := by 
+    lshr (LLVM.and e_1 (const? 8 (-4))) (LLVM.and e (const? 8 2)) { «exact» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -54,7 +54,7 @@ theorem lshr_add_exact_thm (e e_1 : IntW 8) :
 
 theorem ashr_add_exact_thm (e e_1 : IntW 8) :
   ashr (LLVM.and e_1 (const? 8 (-14))) (LLVM.and e (const? 8 1)) ⊑
-    ashr (LLVM.and e_1 (const? 8 (-14))) (LLVM.and e (const? 8 1)) { «exact» := true } := by 
+    ashr (LLVM.and e_1 (const? 8 (-14))) (LLVM.and e (const? 8 1)) { «exact» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gshifthlogic_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gshifthlogic_proof.lean
@@ -9,7 +9,7 @@ set_option linter.unreachableTactic false
 
 section gshifthlogic_proof
 theorem shl_and_thm (e e_1 : IntW 8) :
-  shl (LLVM.and (shl e_1 (const? 8 3)) e) (const? 8 2) ⊑ LLVM.and (shl e_1 (const? 8 5)) (shl e (const? 8 2)) := by 
+  shl (LLVM.and (shl e_1 (const? 8 3)) e) (const? 8 2) ⊑ LLVM.and (shl e_1 (const? 8 5)) (shl e (const? 8 2)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -21,7 +21,7 @@ theorem shl_and_thm (e e_1 : IntW 8) :
 theorem shl_or_thm (e e_1 : IntW 16) :
   shl (LLVM.or (LLVM.srem e_1 (const? 16 42)) (shl e (const? 16 5))) (const? 16 7) ⊑
     LLVM.or (shl e (const? 16 12))
-      (shl (LLVM.srem e_1 (const? 16 42)) (const? 16 7) { «nsw» := true, «nuw» := false }) := by 
+      (shl (LLVM.srem e_1 (const? 16 42)) (const? 16 7) { «nsw» := true, «nuw» := false }) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -32,7 +32,7 @@ theorem shl_or_thm (e e_1 : IntW 16) :
 
 theorem shl_xor_thm (e e_1 : IntW 32) :
   shl (LLVM.xor (shl e_1 (const? 32 5)) e) (const? 32 7) ⊑
-    LLVM.xor (shl e_1 (const? 32 12)) (shl e (const? 32 7)) := by 
+    LLVM.xor (shl e_1 (const? 32 12)) (shl e (const? 32 7)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -43,7 +43,7 @@ theorem shl_xor_thm (e e_1 : IntW 32) :
 
 theorem lshr_and_thm (e e_1 : IntW 64) :
   lshr (LLVM.and (LLVM.srem e_1 (const? 64 42)) (lshr e (const? 64 5))) (const? 64 7) ⊑
-    LLVM.and (lshr e (const? 64 12)) (lshr (LLVM.srem e_1 (const? 64 42)) (const? 64 7)) := by 
+    LLVM.and (lshr e (const? 64 12)) (lshr (LLVM.srem e_1 (const? 64 42)) (const? 64 7)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -54,7 +54,7 @@ theorem lshr_and_thm (e e_1 : IntW 64) :
 
 theorem ashr_xor_thm (e e_1 : IntW 32) :
   ashr (LLVM.xor (LLVM.srem e_1 (const? 32 42)) (ashr e (const? 32 5))) (const? 32 7) ⊑
-    LLVM.xor (ashr e (const? 32 12)) (ashr (LLVM.srem e_1 (const? 32 42)) (const? 32 7)) := by 
+    LLVM.xor (ashr e (const? 32 12)) (ashr (LLVM.srem e_1 (const? 32 42)) (const? 32 7)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -65,7 +65,7 @@ theorem ashr_xor_thm (e e_1 : IntW 32) :
 
 theorem lshr_mul_thm (e : IntW 64) :
   lshr (mul e (const? 64 52) { «nsw» := false, «nuw» := true }) (const? 64 2) ⊑
-    mul e (const? 64 13) { «nsw» := true, «nuw» := true } := by 
+    mul e (const? 64 13) { «nsw» := true, «nuw» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -76,7 +76,7 @@ theorem lshr_mul_thm (e : IntW 64) :
 
 theorem lshr_mul_nuw_nsw_thm (e : IntW 64) :
   lshr (mul e (const? 64 52) { «nsw» := true, «nuw» := true }) (const? 64 2) ⊑
-    mul e (const? 64 13) { «nsw» := true, «nuw» := true } := by 
+    mul e (const? 64 13) { «nsw» := true, «nuw» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -86,7 +86,7 @@ theorem lshr_mul_nuw_nsw_thm (e : IntW 64) :
 
 
 theorem lshr_mul_negative_nonuw_thm (e : IntW 64) :
-  lshr (mul e (const? 64 52)) (const? 64 2) ⊑ lshr (mul e (const? 64 52)) (const? 64 2) { «exact» := true } := by 
+  lshr (mul e (const? 64 52)) (const? 64 2) ⊑ lshr (mul e (const? 64 52)) (const? 64 2) { «exact» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -97,7 +97,7 @@ theorem lshr_mul_negative_nonuw_thm (e : IntW 64) :
 
 theorem lshr_mul_negative_nsw_thm (e : IntW 64) :
   lshr (mul e (const? 64 52) { «nsw» := true, «nuw» := false }) (const? 64 2) ⊑
-    lshr (mul e (const? 64 52) { «nsw» := true, «nuw» := false }) (const? 64 2) { «exact» := true } := by 
+    lshr (mul e (const? 64 52) { «nsw» := true, «nuw» := false }) (const? 64 2) { «exact» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -107,7 +107,7 @@ theorem lshr_mul_negative_nsw_thm (e : IntW 64) :
 
 
 theorem shl_add_thm (e e_1 : IntW 8) :
-  shl (add (shl e_1 (const? 8 3)) e) (const? 8 2) ⊑ add (shl e_1 (const? 8 5)) (shl e (const? 8 2)) := by 
+  shl (add (shl e_1 (const? 8 3)) e) (const? 8 2) ⊑ add (shl e_1 (const? 8 5)) (shl e (const? 8 2)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -117,7 +117,7 @@ theorem shl_add_thm (e e_1 : IntW 8) :
 
 
 theorem shl_sub_thm (e e_1 : IntW 8) :
-  shl (sub (shl e_1 (const? 8 3)) e) (const? 8 2) ⊑ sub (shl e_1 (const? 8 5)) (shl e (const? 8 2)) := by 
+  shl (sub (shl e_1 (const? 8 3)) e) (const? 8 2) ⊑ sub (shl e_1 (const? 8 5)) (shl e (const? 8 2)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -127,7 +127,7 @@ theorem shl_sub_thm (e e_1 : IntW 8) :
 
 
 theorem shl_sub_no_commute_thm (e e_1 : IntW 8) :
-  shl (sub e_1 (shl e (const? 8 3))) (const? 8 2) ⊑ sub (shl e_1 (const? 8 2)) (shl e (const? 8 5)) := by 
+  shl (sub e_1 (shl e (const? 8 3))) (const? 8 2) ⊑ sub (shl e_1 (const? 8 2)) (shl e (const? 8 5)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gshifthshift_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gshifthshift_proof.lean
@@ -8,7 +8,7 @@ set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
 
 section gshifthshift_proof
-theorem shl_shl_thm (e : IntW 32) : shl (shl e (const? 32 6)) (const? 32 28) ⊑ const? 32 0 := by 
+theorem shl_shl_thm (e : IntW 32) : shl (shl e (const? 32 6)) (const? 32 28) ⊑ const? 32 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -17,7 +17,7 @@ theorem shl_shl_thm (e : IntW 32) : shl (shl e (const? 32 6)) (const? 32 28) ⊑
     all_goals sorry
 
 
-theorem lshr_lshr_thm (e : IntW 232) : lshr (lshr e (const? 232 231)) (const? 232 1) ⊑ const? 232 0 := by 
+theorem lshr_lshr_thm (e : IntW 232) : lshr (lshr e (const? 232 231)) (const? 232 1) ⊑ const? 232 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -27,7 +27,7 @@ theorem lshr_lshr_thm (e : IntW 232) : lshr (lshr e (const? 232 231)) (const? 23
 
 
 theorem shl_trunc_bigger_lshr_thm (e : IntW 32) :
-  shl (trunc 8 (lshr e (const? 32 5))) (const? 8 3) ⊑ LLVM.and (trunc 8 (lshr e (const? 32 2))) (const? 8 (-8)) := by 
+  shl (trunc 8 (lshr e (const? 32 5))) (const? 8 3) ⊑ LLVM.and (trunc 8 (lshr e (const? 32 2))) (const? 8 (-8)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -37,7 +37,7 @@ theorem shl_trunc_bigger_lshr_thm (e : IntW 32) :
 
 
 theorem shl_trunc_smaller_lshr_thm (e : IntW 32) :
-  shl (trunc 8 (lshr e (const? 32 3))) (const? 8 5) ⊑ LLVM.and (shl (trunc 8 e) (const? 8 2)) (const? 8 (-32)) := by 
+  shl (trunc 8 (lshr e (const? 32 3))) (const? 8 5) ⊑ LLVM.and (shl (trunc 8 e) (const? 8 2)) (const? 8 (-32)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -48,7 +48,7 @@ theorem shl_trunc_smaller_lshr_thm (e : IntW 32) :
 
 theorem shl_trunc_bigger_ashr_thm (e : IntW 32) :
   shl (trunc 24 (ashr e (const? 32 12))) (const? 24 3) ⊑
-    LLVM.and (trunc 24 (ashr e (const? 32 9)) { «nsw» := true, «nuw» := false }) (const? 24 (-8)) := by 
+    LLVM.and (trunc 24 (ashr e (const? 32 9)) { «nsw» := true, «nuw» := false }) (const? 24 (-8)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -59,7 +59,7 @@ theorem shl_trunc_bigger_ashr_thm (e : IntW 32) :
 
 theorem shl_trunc_smaller_ashr_thm (e : IntW 32) :
   shl (trunc 24 (ashr e (const? 32 10))) (const? 24 13) ⊑
-    LLVM.and (shl (trunc 24 e) (const? 24 3)) (const? 24 (-8192)) := by 
+    LLVM.and (shl (trunc 24 e) (const? 24 3)) (const? 24 (-8192)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -69,7 +69,7 @@ theorem shl_trunc_smaller_ashr_thm (e : IntW 32) :
 
 
 theorem shl_trunc_bigger_shl_thm (e : IntW 32) :
-  shl (trunc 8 (shl e (const? 32 4))) (const? 8 2) ⊑ shl (trunc 8 e) (const? 8 6) := by 
+  shl (trunc 8 (shl e (const? 32 4))) (const? 8 2) ⊑ shl (trunc 8 e) (const? 8 6) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -79,7 +79,7 @@ theorem shl_trunc_bigger_shl_thm (e : IntW 32) :
 
 
 theorem shl_trunc_smaller_shl_thm (e : IntW 32) :
-  shl (trunc 8 (shl e (const? 32 2))) (const? 8 4) ⊑ shl (trunc 8 e) (const? 8 6) := by 
+  shl (trunc 8 (shl e (const? 32 2))) (const? 8 4) ⊑ shl (trunc 8 e) (const? 8 6) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -89,7 +89,7 @@ theorem shl_trunc_smaller_shl_thm (e : IntW 32) :
 
 
 theorem shl_shl_constants_div_thm (e e_1 : IntW 32) :
-  LLVM.udiv e_1 (shl (shl (const? 32 1) e) (const? 32 2)) ⊑ lshr e_1 (add e (const? 32 2)) := by 
+  LLVM.udiv e_1 (shl (shl (const? 32 1) e) (const? 32 2)) ⊑ lshr e_1 (add e (const? 32 2)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -100,7 +100,7 @@ theorem shl_shl_constants_div_thm (e e_1 : IntW 32) :
 
 theorem ashr_shl_constants_thm (e : IntW 32) :
   shl (ashr (const? 32 (-33)) e) (const? 32 3) ⊑
-    shl (ashr (const? 32 (-33)) e) (const? 32 3) { «nsw» := true, «nuw» := false } := by 
+    shl (ashr (const? 32 (-33)) e) (const? 32 3) { «nsw» := true, «nuw» := false } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -111,7 +111,7 @@ theorem ashr_shl_constants_thm (e : IntW 32) :
 
 theorem shl_lshr_demand1_thm (e : IntW 8) :
   LLVM.or (lshr (shl (const? 8 40) e) (const? 8 3)) (const? 8 (-32)) ⊑
-    LLVM.or (shl (const? 8 5) e) (const? 8 (-32)) := by 
+    LLVM.or (shl (const? 8 5) e) (const? 8 (-32)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -123,7 +123,7 @@ theorem shl_lshr_demand1_thm (e : IntW 8) :
 theorem shl_lshr_demand3_thm (e : IntW 8) :
   LLVM.or (lshr (shl (const? 8 40) e) (const? 8 3)) (const? 8 (-64)) ⊑
     LLVM.or (lshr (shl (const? 8 40) e) (const? 8 3) { «exact» := true }) (const? 8 (-64))
-      { «disjoint» := true } := by 
+      { «disjoint» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -134,7 +134,7 @@ theorem shl_lshr_demand3_thm (e : IntW 8) :
 
 theorem shl_lshr_demand4_thm (e : IntW 8) :
   LLVM.or (lshr (shl (const? 8 44) e) (const? 8 3)) (const? 8 (-32)) ⊑
-    LLVM.or (lshr (shl (const? 8 44) e) (const? 8 3)) (const? 8 (-32)) { «disjoint» := true } := by 
+    LLVM.or (lshr (shl (const? 8 44) e) (const? 8 3)) (const? 8 (-32)) { «disjoint» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -145,7 +145,7 @@ theorem shl_lshr_demand4_thm (e : IntW 8) :
 
 theorem shl_lshr_demand6_thm (e : IntW 16) :
   LLVM.and (lshr (shl (const? 16 (-32624)) e) (const? 16 4)) (const? 16 4094) ⊑
-    LLVM.and (shl (const? 16 2057) e) (const? 16 4094) := by 
+    LLVM.and (shl (const? 16 2057) e) (const? 16 4094) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -156,7 +156,7 @@ theorem shl_lshr_demand6_thm (e : IntW 16) :
 
 theorem lshr_shl_demand1_thm (e : IntW 8) :
   LLVM.or (shl (lshr (const? 8 28) e) (const? 8 3)) (const? 8 7) ⊑
-    LLVM.or (lshr (const? 8 (-32)) e) (const? 8 7) := by 
+    LLVM.or (lshr (const? 8 (-32)) e) (const? 8 7) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -168,7 +168,7 @@ theorem lshr_shl_demand1_thm (e : IntW 8) :
 theorem lshr_shl_demand3_thm (e : IntW 8) :
   LLVM.or (shl (lshr (const? 8 28) e) (const? 8 3)) (const? 8 3) ⊑
     LLVM.or (shl (lshr (const? 8 28) e) (const? 8 3) { «nsw» := false, «nuw» := true }) (const? 8 3)
-      { «disjoint» := true } := by 
+      { «disjoint» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -179,7 +179,7 @@ theorem lshr_shl_demand3_thm (e : IntW 8) :
 
 theorem lshr_shl_demand4_thm (e : IntW 8) :
   LLVM.or (shl (lshr (const? 8 60) e) (const? 8 3)) (const? 8 7) ⊑
-    LLVM.or (shl (lshr (const? 8 60) e) (const? 8 3)) (const? 8 7) { «disjoint» := true } := by 
+    LLVM.or (shl (lshr (const? 8 60) e) (const? 8 3)) (const? 8 7) { «disjoint» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gshifthsra_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gshifthsra_proof.lean
@@ -10,7 +10,7 @@ set_option linter.unreachableTactic false
 section gshifthsra_proof
 theorem test1_thm (e : IntW 8) (e_1 : IntW 32) :
   LLVM.and (ashr e_1 (zext 32 e)) (const? 32 1) ⊑
-    LLVM.and (lshr e_1 (zext 32 e { «nneg» := true })) (const? 32 1) := by 
+    LLVM.and (lshr e_1 (zext 32 e { «nneg» := true })) (const? 32 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -21,7 +21,7 @@ theorem test1_thm (e : IntW 8) (e_1 : IntW 32) :
 
 theorem test2_thm (e : IntW 8) :
   ashr (add (zext 32 e) (const? 32 7)) (const? 32 3) ⊑
-    lshr (add (zext 32 e) (const? 32 7) { «nsw» := true, «nuw» := true }) (const? 32 3) := by 
+    lshr (add (zext 32 e) (const? 32 7) { «nsw» := true, «nuw» := true }) (const? 32 3) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -30,7 +30,7 @@ theorem test2_thm (e : IntW 8) :
     all_goals sorry
 
 
-theorem ashr_ashr_thm (e : IntW 32) : ashr (ashr e (const? 32 5)) (const? 32 7) ⊑ ashr e (const? 32 12) := by 
+theorem ashr_ashr_thm (e : IntW 32) : ashr (ashr e (const? 32 5)) (const? 32 7) ⊑ ashr e (const? 32 12) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -39,7 +39,7 @@ theorem ashr_ashr_thm (e : IntW 32) : ashr (ashr e (const? 32 5)) (const? 32 7) 
     all_goals sorry
 
 
-theorem ashr_overshift_thm (e : IntW 32) : ashr (ashr e (const? 32 15)) (const? 32 17) ⊑ ashr e (const? 32 31) := by 
+theorem ashr_overshift_thm (e : IntW 32) : ashr (ashr e (const? 32 15)) (const? 32 17) ⊑ ashr e (const? 32 31) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -48,7 +48,7 @@ theorem ashr_overshift_thm (e : IntW 32) : ashr (ashr e (const? 32 15)) (const? 
     all_goals sorry
 
 
-theorem hoist_ashr_ahead_of_sext_1_thm (e : IntW 8) : ashr (sext 32 e) (const? 32 3) ⊑ sext 32 (ashr e (const? 8 3)) := by 
+theorem hoist_ashr_ahead_of_sext_1_thm (e : IntW 8) : ashr (sext 32 e) (const? 32 3) ⊑ sext 32 (ashr e (const? 8 3)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -57,7 +57,7 @@ theorem hoist_ashr_ahead_of_sext_1_thm (e : IntW 8) : ashr (sext 32 e) (const? 3
     all_goals sorry
 
 
-theorem hoist_ashr_ahead_of_sext_2_thm (e : IntW 8) : ashr (sext 32 e) (const? 32 8) ⊑ sext 32 (ashr e (const? 8 7)) := by 
+theorem hoist_ashr_ahead_of_sext_2_thm (e : IntW 8) : ashr (sext 32 e) (const? 32 8) ⊑ sext 32 (ashr e (const? 8 7)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gshlhandhnegChicmpeqhzero_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gshlhandhnegChicmpeqhzero_proof.lean
@@ -10,7 +10,7 @@ set_option linter.unreachableTactic false
 section gshlhandhnegChicmpeqhzero_proof
 theorem scalar_i8_shl_and_negC_eq_thm (e e_1 : IntW 8) :
   icmp IntPredicate.eq (LLVM.and (shl e_1 e) (const? 8 (-4))) (const? 8 0) ⊑
-    icmp IntPredicate.ult (shl e_1 e) (const? 8 4) := by 
+    icmp IntPredicate.ult (shl e_1 e) (const? 8 4) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -21,7 +21,7 @@ theorem scalar_i8_shl_and_negC_eq_thm (e e_1 : IntW 8) :
 
 theorem scalar_i16_shl_and_negC_eq_thm (e e_1 : IntW 16) :
   icmp IntPredicate.eq (LLVM.and (shl e_1 e) (const? 16 (-128))) (const? 16 0) ⊑
-    icmp IntPredicate.ult (shl e_1 e) (const? 16 128) := by 
+    icmp IntPredicate.ult (shl e_1 e) (const? 16 128) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -32,7 +32,7 @@ theorem scalar_i16_shl_and_negC_eq_thm (e e_1 : IntW 16) :
 
 theorem scalar_i32_shl_and_negC_eq_thm (e e_1 : IntW 32) :
   icmp IntPredicate.eq (LLVM.and (shl e_1 e) (const? 32 (-262144))) (const? 32 0) ⊑
-    icmp IntPredicate.ult (shl e_1 e) (const? 32 262144) := by 
+    icmp IntPredicate.ult (shl e_1 e) (const? 32 262144) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -43,7 +43,7 @@ theorem scalar_i32_shl_and_negC_eq_thm (e e_1 : IntW 32) :
 
 theorem scalar_i64_shl_and_negC_eq_thm (e e_1 : IntW 64) :
   icmp IntPredicate.eq (LLVM.and (shl e_1 e) (const? 64 (-8589934592))) (const? 64 0) ⊑
-    icmp IntPredicate.ult (shl e_1 e) (const? 64 8589934592) := by 
+    icmp IntPredicate.ult (shl e_1 e) (const? 64 8589934592) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -54,7 +54,7 @@ theorem scalar_i64_shl_and_negC_eq_thm (e e_1 : IntW 64) :
 
 theorem scalar_i32_shl_and_negC_ne_thm (e e_1 : IntW 32) :
   icmp IntPredicate.ne (LLVM.and (shl e_1 e) (const? 32 (-262144))) (const? 32 0) ⊑
-    icmp IntPredicate.ugt (shl e_1 e) (const? 32 262143) := by 
+    icmp IntPredicate.ugt (shl e_1 e) (const? 32 262143) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -65,7 +65,7 @@ theorem scalar_i32_shl_and_negC_ne_thm (e e_1 : IntW 32) :
 
 theorem scalar_i32_shl_and_negC_eq_X_is_constant1_thm (e : IntW 32) :
   icmp IntPredicate.eq (LLVM.and (shl (const? 32 12345) e) (const? 32 (-8))) (const? 32 0) ⊑
-    icmp IntPredicate.ult (shl (const? 32 12345) e) (const? 32 8) := by 
+    icmp IntPredicate.ult (shl (const? 32 12345) e) (const? 32 8) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -76,7 +76,7 @@ theorem scalar_i32_shl_and_negC_eq_X_is_constant1_thm (e : IntW 32) :
 
 theorem scalar_i32_shl_and_negC_eq_X_is_constant2_thm (e : IntW 32) :
   icmp IntPredicate.eq (LLVM.and (shl (const? 32 1) e) (const? 32 (-8))) (const? 32 0) ⊑
-    icmp IntPredicate.ult e (const? 32 3) := by 
+    icmp IntPredicate.ult e (const? 32 3) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -87,7 +87,7 @@ theorem scalar_i32_shl_and_negC_eq_X_is_constant2_thm (e : IntW 32) :
 
 theorem scalar_i32_shl_and_negC_slt_thm (e e_1 : IntW 32) :
   icmp IntPredicate.slt (LLVM.and (shl e_1 e) (const? 32 (-8))) (const? 32 0) ⊑
-    icmp IntPredicate.slt (shl e_1 e) (const? 32 0) := by 
+    icmp IntPredicate.slt (shl e_1 e) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -97,7 +97,7 @@ theorem scalar_i32_shl_and_negC_slt_thm (e e_1 : IntW 32) :
 
 
 theorem scalar_i32_shl_and_negC_eq_nonzero_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.eq (LLVM.and (shl e_1 e) (const? 32 (-8))) (const? 32 1) ⊑ const? 1 0 := by 
+  icmp IntPredicate.eq (LLVM.and (shl e_1 e) (const? 32 (-8))) (const? 32 1) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gshlhandhsignbithicmpeqhzero_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gshlhandhsignbithicmpeqhzero_proof.lean
@@ -10,7 +10,7 @@ set_option linter.unreachableTactic false
 section gshlhandhsignbithicmpeqhzero_proof
 theorem scalar_i8_shl_and_signbit_eq_thm (e e_1 : IntW 8) :
   icmp IntPredicate.eq (LLVM.and (shl e_1 e) (const? 8 (-128))) (const? 8 0) ⊑
-    icmp IntPredicate.sgt (shl e_1 e) (const? 8 (-1)) := by 
+    icmp IntPredicate.sgt (shl e_1 e) (const? 8 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -21,7 +21,7 @@ theorem scalar_i8_shl_and_signbit_eq_thm (e e_1 : IntW 8) :
 
 theorem scalar_i16_shl_and_signbit_eq_thm (e e_1 : IntW 16) :
   icmp IntPredicate.eq (LLVM.and (shl e_1 e) (const? 16 (-32768))) (const? 16 0) ⊑
-    icmp IntPredicate.sgt (shl e_1 e) (const? 16 (-1)) := by 
+    icmp IntPredicate.sgt (shl e_1 e) (const? 16 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -32,7 +32,7 @@ theorem scalar_i16_shl_and_signbit_eq_thm (e e_1 : IntW 16) :
 
 theorem scalar_i32_shl_and_signbit_eq_thm (e e_1 : IntW 32) :
   icmp IntPredicate.eq (LLVM.and (shl e_1 e) (const? 32 (-2147483648))) (const? 32 0) ⊑
-    icmp IntPredicate.sgt (shl e_1 e) (const? 32 (-1)) := by 
+    icmp IntPredicate.sgt (shl e_1 e) (const? 32 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -43,7 +43,7 @@ theorem scalar_i32_shl_and_signbit_eq_thm (e e_1 : IntW 32) :
 
 theorem scalar_i64_shl_and_signbit_eq_thm (e e_1 : IntW 64) :
   icmp IntPredicate.eq (LLVM.and (shl e_1 e) (const? 64 (-9223372036854775808))) (const? 64 0) ⊑
-    icmp IntPredicate.sgt (shl e_1 e) (const? 64 (-1)) := by 
+    icmp IntPredicate.sgt (shl e_1 e) (const? 64 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -54,7 +54,7 @@ theorem scalar_i64_shl_and_signbit_eq_thm (e e_1 : IntW 64) :
 
 theorem scalar_i32_shl_and_signbit_ne_thm (e e_1 : IntW 32) :
   icmp IntPredicate.ne (LLVM.and (shl e_1 e) (const? 32 (-2147483648))) (const? 32 0) ⊑
-    icmp IntPredicate.slt (shl e_1 e) (const? 32 0) := by 
+    icmp IntPredicate.slt (shl e_1 e) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -65,7 +65,7 @@ theorem scalar_i32_shl_and_signbit_ne_thm (e e_1 : IntW 32) :
 
 theorem scalar_i32_shl_and_signbit_eq_X_is_constant1_thm (e : IntW 32) :
   icmp IntPredicate.eq (LLVM.and (shl (const? 32 12345) e) (const? 32 (-2147483648))) (const? 32 0) ⊑
-    icmp IntPredicate.sgt (shl (const? 32 12345) e) (const? 32 (-1)) := by 
+    icmp IntPredicate.sgt (shl (const? 32 12345) e) (const? 32 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -76,7 +76,7 @@ theorem scalar_i32_shl_and_signbit_eq_X_is_constant1_thm (e : IntW 32) :
 
 theorem scalar_i32_shl_and_signbit_eq_X_is_constant2_thm (e : IntW 32) :
   icmp IntPredicate.eq (LLVM.and (shl (const? 32 1) e) (const? 32 (-2147483648))) (const? 32 0) ⊑
-    icmp IntPredicate.ne e (const? 32 31) := by 
+    icmp IntPredicate.ne e (const? 32 31) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -87,7 +87,7 @@ theorem scalar_i32_shl_and_signbit_eq_X_is_constant2_thm (e : IntW 32) :
 
 theorem scalar_i32_shl_and_signbit_slt_thm (e e_1 : IntW 32) :
   icmp IntPredicate.slt (LLVM.and (shl e_1 e) (const? 32 (-2147483648))) (const? 32 0) ⊑
-    icmp IntPredicate.slt (shl e_1 e) (const? 32 0) := by 
+    icmp IntPredicate.slt (shl e_1 e) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -97,7 +97,7 @@ theorem scalar_i32_shl_and_signbit_slt_thm (e e_1 : IntW 32) :
 
 
 theorem scalar_i32_shl_and_signbit_eq_nonzero_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.eq (LLVM.and (shl e_1 e) (const? 32 (-2147483648))) (const? 32 1) ⊑ const? 1 0 := by 
+  icmp IntPredicate.eq (LLVM.and (shl e_1 e) (const? 32 (-2147483648))) (const? 32 1) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gshlhbo_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gshlhbo_proof.lean
@@ -10,7 +10,7 @@ set_option linter.unreachableTactic false
 section gshlhbo_proof
 theorem lshr_add_thm (e e_1 : IntW 8) :
   shl (add (lshr e_1 (const? 8 5)) (LLVM.srem e (const? 8 42))) (const? 8 5) ⊑
-    LLVM.and (add e_1 (shl (LLVM.srem e (const? 8 42)) (const? 8 5))) (const? 8 (-32)) := by 
+    LLVM.and (add e_1 (shl (LLVM.srem e (const? 8 42)) (const? 8 5))) (const? 8 (-32)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -22,7 +22,7 @@ theorem lshr_add_thm (e e_1 : IntW 8) :
 theorem lshr_sub_thm (e e_1 : IntW 8) :
   shl (sub (LLVM.srem e_1 (const? 8 42)) (lshr e (const? 8 3))) (const? 8 3) ⊑
     shl (sub (LLVM.srem e_1 (const? 8 42)) (lshr e (const? 8 3)) { «nsw» := true, «nuw» := false })
-      (const? 8 3) := by 
+      (const? 8 3) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -33,7 +33,7 @@ theorem lshr_sub_thm (e e_1 : IntW 8) :
 
 theorem lshr_and_thm (e e_1 : IntW 8) :
   shl (LLVM.and (lshr e_1 (const? 8 6)) (LLVM.srem e (const? 8 42))) (const? 8 6) ⊑
-    LLVM.and e_1 (shl (LLVM.srem e (const? 8 42)) (const? 8 6)) := by 
+    LLVM.and e_1 (shl (LLVM.srem e (const? 8 42)) (const? 8 6)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -44,7 +44,7 @@ theorem lshr_and_thm (e e_1 : IntW 8) :
 
 theorem lshr_or_thm (e e_1 : IntW 8) :
   shl (LLVM.or (LLVM.srem e_1 (const? 8 42)) (lshr e (const? 8 4))) (const? 8 4) ⊑
-    LLVM.or (LLVM.and e (const? 8 (-16))) (shl (LLVM.srem e_1 (const? 8 42)) (const? 8 4)) := by 
+    LLVM.or (LLVM.and e (const? 8 (-16))) (shl (LLVM.srem e_1 (const? 8 42)) (const? 8 4)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -55,7 +55,7 @@ theorem lshr_or_thm (e e_1 : IntW 8) :
 
 theorem lshr_xor_thm (e e_1 : IntW 8) :
   shl (LLVM.xor (lshr e_1 (const? 8 3)) (LLVM.srem e (const? 8 42))) (const? 8 3) ⊑
-    LLVM.xor (LLVM.and e_1 (const? 8 (-8))) (shl (LLVM.srem e (const? 8 42)) (const? 8 3)) := by 
+    LLVM.xor (LLVM.and e_1 (const? 8 (-8))) (shl (LLVM.srem e (const? 8 42)) (const? 8 3)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -66,7 +66,7 @@ theorem lshr_xor_thm (e e_1 : IntW 8) :
 
 theorem lshr_and_add_thm (e e_1 : IntW 8) :
   shl (add (LLVM.srem e_1 (const? 8 42)) (LLVM.and (lshr e (const? 8 3)) (const? 8 12))) (const? 8 3) ⊑
-    add (LLVM.and e (const? 8 96)) (shl (LLVM.srem e_1 (const? 8 42)) (const? 8 3)) := by 
+    add (LLVM.and e (const? 8 96)) (shl (LLVM.srem e_1 (const? 8 42)) (const? 8 3)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -80,7 +80,7 @@ theorem lshr_and_sub_thm (e e_1 : IntW 8) :
     shl
       (sub (LLVM.srem e_1 (const? 8 42)) (LLVM.and (lshr e (const? 8 2)) (const? 8 13))
         { «nsw» := true, «nuw» := false })
-      (const? 8 2) := by 
+      (const? 8 2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -91,7 +91,7 @@ theorem lshr_and_sub_thm (e e_1 : IntW 8) :
 
 theorem lshr_and_and_thm (e e_1 : IntW 8) :
   shl (LLVM.and (LLVM.and (lshr e_1 (const? 8 2)) (const? 8 13)) (LLVM.srem e (const? 8 42))) (const? 8 2) ⊑
-    LLVM.and (LLVM.and e_1 (const? 8 52)) (shl (LLVM.srem e (const? 8 42)) (const? 8 2)) := by 
+    LLVM.and (LLVM.and e_1 (const? 8 52)) (shl (LLVM.srem e (const? 8 42)) (const? 8 2)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -102,7 +102,7 @@ theorem lshr_and_and_thm (e e_1 : IntW 8) :
 
 theorem lshr_and_or_thm (e e_1 : IntW 8) :
   shl (LLVM.or (LLVM.srem e_1 (const? 8 42)) (LLVM.and (lshr e (const? 8 2)) (const? 8 13))) (const? 8 2) ⊑
-    LLVM.or (LLVM.and e (const? 8 52)) (shl (LLVM.srem e_1 (const? 8 42)) (const? 8 2)) := by 
+    LLVM.or (LLVM.and e (const? 8 52)) (shl (LLVM.srem e_1 (const? 8 42)) (const? 8 2)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -114,7 +114,7 @@ theorem lshr_and_or_thm (e e_1 : IntW 8) :
 theorem lshr_and_or_disjoint_thm (e e_1 : IntW 8) :
   shl (LLVM.or (LLVM.srem e_1 (const? 8 42)) (LLVM.and (lshr e (const? 8 2)) (const? 8 13)) { «disjoint» := true })
       (const? 8 2) ⊑
-    LLVM.or (LLVM.and e (const? 8 52)) (shl (LLVM.srem e_1 (const? 8 42)) (const? 8 2)) { «disjoint» := true } := by 
+    LLVM.or (LLVM.and e (const? 8 52)) (shl (LLVM.srem e_1 (const? 8 42)) (const? 8 2)) { «disjoint» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -126,7 +126,7 @@ theorem lshr_and_or_disjoint_thm (e e_1 : IntW 8) :
 theorem ashr_and_or_disjoint_thm (e e_1 : IntW 8) :
   shl (LLVM.or (LLVM.srem e_1 (const? 8 42)) (LLVM.and (ashr e (const? 8 2)) (const? 8 13)) { «disjoint» := true })
       (const? 8 2) ⊑
-    LLVM.or (LLVM.and e (const? 8 52)) (shl (LLVM.srem e_1 (const? 8 42)) (const? 8 2)) { «disjoint» := true } := by 
+    LLVM.or (LLVM.and e (const? 8 52)) (shl (LLVM.srem e_1 (const? 8 42)) (const? 8 2)) { «disjoint» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -137,7 +137,7 @@ theorem ashr_and_or_disjoint_thm (e e_1 : IntW 8) :
 
 theorem lshr_and_xor_thm (e e_1 : IntW 8) :
   shl (LLVM.xor (LLVM.and (lshr e_1 (const? 8 2)) (const? 8 13)) (LLVM.srem e (const? 8 42))) (const? 8 2) ⊑
-    LLVM.xor (LLVM.and e_1 (const? 8 52)) (shl (LLVM.srem e (const? 8 42)) (const? 8 2)) := by 
+    LLVM.xor (LLVM.and e_1 (const? 8 52)) (shl (LLVM.srem e (const? 8 42)) (const? 8 2)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -148,7 +148,7 @@ theorem lshr_and_xor_thm (e e_1 : IntW 8) :
 
 theorem lshr_add_and_shl_thm (e e_1 : IntW 32) :
   shl (add e_1 (LLVM.and (lshr e (const? 32 5)) (const? 32 127))) (const? 32 5) ⊑
-    add (LLVM.and e (const? 32 4064)) (shl e_1 (const? 32 5)) := by 
+    add (LLVM.and e (const? 32 4064)) (shl e_1 (const? 32 5)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -159,7 +159,7 @@ theorem lshr_add_and_shl_thm (e e_1 : IntW 32) :
 
 theorem shl_add_and_lshr_thm (e e_1 : IntW 32) :
   shl (add (LLVM.and (lshr e_1 (const? 32 4)) (const? 32 8)) e) (const? 32 4) ⊑
-    add (LLVM.and e_1 (const? 32 128)) (shl e (const? 32 4)) := by 
+    add (LLVM.and e_1 (const? 32 128)) (shl e (const? 32 4)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gshlhdemand_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gshlhdemand_proof.lean
@@ -10,7 +10,7 @@ set_option linter.unreachableTactic false
 section gshlhdemand_proof
 theorem src_srem_shl_demand_max_signbit_thm (e : IntW 32) :
   LLVM.and (shl (LLVM.srem e (const? 32 2)) (const? 32 30)) (const? 32 (-2147483648)) ⊑
-    LLVM.and (LLVM.srem e (const? 32 2)) (const? 32 (-2147483648)) := by 
+    LLVM.and (LLVM.srem e (const? 32 2)) (const? 32 (-2147483648)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -21,7 +21,7 @@ theorem src_srem_shl_demand_max_signbit_thm (e : IntW 32) :
 
 theorem src_srem_shl_demand_min_signbit_thm (e : IntW 32) :
   LLVM.and (shl (LLVM.srem e (const? 32 1073741823)) (const? 32 1)) (const? 32 (-2147483648)) ⊑
-    LLVM.and (LLVM.srem e (const? 32 1073741823)) (const? 32 (-2147483648)) := by 
+    LLVM.and (LLVM.srem e (const? 32 1073741823)) (const? 32 (-2147483648)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -32,7 +32,7 @@ theorem src_srem_shl_demand_min_signbit_thm (e : IntW 32) :
 
 theorem src_srem_shl_demand_max_mask_thm (e : IntW 32) :
   LLVM.and (shl (LLVM.srem e (const? 32 2)) (const? 32 1)) (const? 32 (-4)) ⊑
-    LLVM.and (LLVM.srem e (const? 32 2)) (const? 32 (-4)) := by 
+    LLVM.and (LLVM.srem e (const? 32 2)) (const? 32 (-4)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -44,7 +44,7 @@ theorem src_srem_shl_demand_max_mask_thm (e : IntW 32) :
 theorem src_srem_shl_demand_max_signbit_mask_hit_first_demand_thm (e : IntW 32) :
   LLVM.and (shl (LLVM.srem e (const? 32 4)) (const? 32 29)) (const? 32 (-1073741824)) ⊑
     LLVM.and (shl (LLVM.srem e (const? 32 4)) (const? 32 29) { «nsw» := true, «nuw» := false })
-      (const? 32 (-1073741824)) := by 
+      (const? 32 (-1073741824)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -56,7 +56,7 @@ theorem src_srem_shl_demand_max_signbit_mask_hit_first_demand_thm (e : IntW 32) 
 theorem src_srem_shl_demand_min_signbit_mask_hit_last_demand_thm (e : IntW 32) :
   LLVM.and (shl (LLVM.srem e (const? 32 536870912)) (const? 32 1)) (const? 32 (-1073741822)) ⊑
     LLVM.and (shl (LLVM.srem e (const? 32 536870912)) (const? 32 1) { «nsw» := true, «nuw» := false })
-      (const? 32 (-1073741822)) := by 
+      (const? 32 (-1073741822)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -68,7 +68,7 @@ theorem src_srem_shl_demand_min_signbit_mask_hit_last_demand_thm (e : IntW 32) :
 theorem src_srem_shl_demand_eliminate_signbit_thm (e : IntW 32) :
   LLVM.and (shl (LLVM.srem e (const? 32 1073741824)) (const? 32 1)) (const? 32 2) ⊑
     LLVM.and (shl (LLVM.srem e (const? 32 1073741824)) (const? 32 1) { «nsw» := true, «nuw» := false })
-      (const? 32 2) := by 
+      (const? 32 2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -79,7 +79,7 @@ theorem src_srem_shl_demand_eliminate_signbit_thm (e : IntW 32) :
 
 theorem src_srem_shl_demand_max_mask_hit_demand_thm (e : IntW 32) :
   LLVM.and (shl (LLVM.srem e (const? 32 4)) (const? 32 1)) (const? 32 (-4)) ⊑
-    LLVM.and (shl (LLVM.srem e (const? 32 4)) (const? 32 1) { «nsw» := true, «nuw» := false }) (const? 32 (-4)) := by 
+    LLVM.and (shl (LLVM.srem e (const? 32 4)) (const? 32 1) { «nsw» := true, «nuw» := false }) (const? 32 (-4)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -89,7 +89,7 @@ theorem src_srem_shl_demand_max_mask_hit_demand_thm (e : IntW 32) :
 
 
 theorem sext_shl_trunc_same_size_thm (e : IntW 32) (e_1 : IntW 16) :
-  trunc 16 (shl (sext 32 e_1) e) ⊑ trunc 16 (shl (zext 32 e_1) e) := by 
+  trunc 16 (shl (sext 32 e_1) e) ⊑ trunc 16 (shl (zext 32 e_1) e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -99,7 +99,7 @@ theorem sext_shl_trunc_same_size_thm (e : IntW 32) (e_1 : IntW 16) :
 
 
 theorem sext_shl_trunc_smaller_thm (e : IntW 32) (e_1 : IntW 16) :
-  trunc 5 (shl (sext 32 e_1) e) ⊑ trunc 5 (shl (zext 32 e_1) e) := by 
+  trunc 5 (shl (sext 32 e_1) e) ⊑ trunc 5 (shl (zext 32 e_1) e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -109,7 +109,7 @@ theorem sext_shl_trunc_smaller_thm (e : IntW 32) (e_1 : IntW 16) :
 
 
 theorem sext_shl_mask_thm (e : IntW 32) (e_1 : IntW 16) :
-  LLVM.and (shl (sext 32 e_1) e) (const? 32 65535) ⊑ LLVM.and (shl (zext 32 e_1) e) (const? 32 65535) := by 
+  LLVM.and (shl (sext 32 e_1) e) (const? 32 65535) ⊑ LLVM.and (shl (zext 32 e_1) e) (const? 32 65535) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -120,7 +120,7 @@ theorem sext_shl_mask_thm (e : IntW 32) (e_1 : IntW 16) :
 
 theorem set_shl_mask_thm (e e_1 : IntW 32) :
   LLVM.and (shl (LLVM.or e_1 (const? 32 196609)) e) (const? 32 65536) ⊑
-    LLVM.and (shl (LLVM.or e_1 (const? 32 65537)) e) (const? 32 65536) := by 
+    LLVM.and (shl (LLVM.or e_1 (const? 32 65537)) e) (const? 32 65536) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -130,7 +130,7 @@ theorem set_shl_mask_thm (e e_1 : IntW 32) :
 
 
 theorem must_drop_poison_thm (e e_1 : IntW 32) :
-  trunc 8 (shl (LLVM.and e_1 (const? 32 255)) e { «nsw» := true, «nuw» := true }) ⊑ trunc 8 (shl e_1 e) := by 
+  trunc 8 (shl (LLVM.and e_1 (const? 32 255)) e { «nsw» := true, «nuw» := true }) ⊑ trunc 8 (shl e_1 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -141,7 +141,7 @@ theorem must_drop_poison_thm (e e_1 : IntW 32) :
 
 theorem f_t15_t01_t09_thm (e : IntW 40) :
   shl (trunc 32 (ashr e (const? 40 31))) (const? 32 16) ⊑
-    LLVM.and (trunc 32 (ashr e (const? 40 15)) { «nsw» := true, «nuw» := false }) (const? 32 (-65536)) := by 
+    LLVM.and (trunc 32 (ashr e (const? 40 15)) { «nsw» := true, «nuw» := false }) (const? 32 (-65536)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gshlhfactor_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gshlhfactor_proof.lean
@@ -8,7 +8,7 @@ set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
 
 section gshlhfactor_proof
-theorem add_shl_same_amount_thm (e e_1 e_2 : IntW 6) : add (shl e_2 e_1) (shl e e_1) ⊑ shl (add e_2 e) e_1 := by 
+theorem add_shl_same_amount_thm (e e_1 e_2 : IntW 6) : add (shl e_2 e_1) (shl e e_1) ⊑ shl (add e_2 e) e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -20,7 +20,7 @@ theorem add_shl_same_amount_thm (e e_1 e_2 : IntW 6) : add (shl e_2 e_1) (shl e 
 theorem add_shl_same_amount_nuw_thm (e e_1 e_2 : IntW 64) :
   add (shl e_2 e_1 { «nsw» := false, «nuw» := true }) (shl e e_1 { «nsw» := false, «nuw» := true })
       { «nsw» := false, «nuw» := true } ⊑
-    shl (add e_2 e { «nsw» := false, «nuw» := true }) e_1 { «nsw» := false, «nuw» := true } := by 
+    shl (add e_2 e { «nsw» := false, «nuw» := true }) e_1 { «nsw» := false, «nuw» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -31,7 +31,7 @@ theorem add_shl_same_amount_nuw_thm (e e_1 e_2 : IntW 64) :
 
 theorem add_shl_same_amount_partial_nsw1_thm (e e_1 e_2 : IntW 6) :
   add (shl e_2 e_1 { «nsw» := true, «nuw» := false }) (shl e e_1 { «nsw» := true, «nuw» := false }) ⊑
-    shl (add e_2 e) e_1 := by 
+    shl (add e_2 e) e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -42,7 +42,7 @@ theorem add_shl_same_amount_partial_nsw1_thm (e e_1 e_2 : IntW 6) :
 
 theorem add_shl_same_amount_partial_nsw2_thm (e e_1 e_2 : IntW 6) :
   add (shl e_2 e_1) (shl e e_1 { «nsw» := true, «nuw» := false }) { «nsw» := true, «nuw» := false } ⊑
-    shl (add e_2 e) e_1 := by 
+    shl (add e_2 e) e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -53,7 +53,7 @@ theorem add_shl_same_amount_partial_nsw2_thm (e e_1 e_2 : IntW 6) :
 
 theorem add_shl_same_amount_partial_nuw1_thm (e e_1 e_2 : IntW 6) :
   add (shl e_2 e_1 { «nsw» := false, «nuw» := true }) (shl e e_1 { «nsw» := false, «nuw» := true }) ⊑
-    shl (add e_2 e) e_1 := by 
+    shl (add e_2 e) e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -64,7 +64,7 @@ theorem add_shl_same_amount_partial_nuw1_thm (e e_1 e_2 : IntW 6) :
 
 theorem add_shl_same_amount_partial_nuw2_thm (e e_1 e_2 : IntW 6) :
   add (shl e_2 e_1 { «nsw» := false, «nuw» := true }) (shl e e_1) { «nsw» := false, «nuw» := true } ⊑
-    shl (add e_2 e) e_1 := by 
+    shl (add e_2 e) e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -73,7 +73,7 @@ theorem add_shl_same_amount_partial_nuw2_thm (e e_1 e_2 : IntW 6) :
     all_goals sorry
 
 
-theorem sub_shl_same_amount_thm (e e_1 e_2 : IntW 6) : sub (shl e_2 e_1) (shl e e_1) ⊑ shl (sub e_2 e) e_1 := by 
+theorem sub_shl_same_amount_thm (e e_1 e_2 : IntW 6) : sub (shl e_2 e_1) (shl e e_1) ⊑ shl (sub e_2 e) e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -85,7 +85,7 @@ theorem sub_shl_same_amount_thm (e e_1 e_2 : IntW 6) : sub (shl e_2 e_1) (shl e 
 theorem sub_shl_same_amount_nuw_thm (e e_1 e_2 : IntW 64) :
   sub (shl e_2 e_1 { «nsw» := false, «nuw» := true }) (shl e e_1 { «nsw» := false, «nuw» := true })
       { «nsw» := false, «nuw» := true } ⊑
-    shl (sub e_2 e { «nsw» := false, «nuw» := true }) e_1 { «nsw» := false, «nuw» := true } := by 
+    shl (sub e_2 e { «nsw» := false, «nuw» := true }) e_1 { «nsw» := false, «nuw» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -96,7 +96,7 @@ theorem sub_shl_same_amount_nuw_thm (e e_1 e_2 : IntW 64) :
 
 theorem sub_shl_same_amount_partial_nsw1_thm (e e_1 e_2 : IntW 6) :
   sub (shl e_2 e_1 { «nsw» := true, «nuw» := false }) (shl e e_1 { «nsw» := true, «nuw» := false }) ⊑
-    shl (sub e_2 e) e_1 := by 
+    shl (sub e_2 e) e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -107,7 +107,7 @@ theorem sub_shl_same_amount_partial_nsw1_thm (e e_1 e_2 : IntW 6) :
 
 theorem sub_shl_same_amount_partial_nsw2_thm (e e_1 e_2 : IntW 6) :
   sub (shl e_2 e_1) (shl e e_1 { «nsw» := true, «nuw» := false }) { «nsw» := true, «nuw» := false } ⊑
-    shl (sub e_2 e) e_1 := by 
+    shl (sub e_2 e) e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -118,7 +118,7 @@ theorem sub_shl_same_amount_partial_nsw2_thm (e e_1 e_2 : IntW 6) :
 
 theorem sub_shl_same_amount_partial_nuw1_thm (e e_1 e_2 : IntW 6) :
   sub (shl e_2 e_1 { «nsw» := false, «nuw» := true }) (shl e e_1 { «nsw» := false, «nuw» := true }) ⊑
-    shl (sub e_2 e) e_1 := by 
+    shl (sub e_2 e) e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -129,7 +129,7 @@ theorem sub_shl_same_amount_partial_nuw1_thm (e e_1 e_2 : IntW 6) :
 
 theorem sub_shl_same_amount_partial_nuw2_thm (e e_1 e_2 : IntW 6) :
   sub (shl e_2 e_1 { «nsw» := false, «nuw» := true }) (shl e e_1) { «nsw» := false, «nuw» := true } ⊑
-    shl (sub e_2 e) e_1 := by 
+    shl (sub e_2 e) e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -138,7 +138,7 @@ theorem sub_shl_same_amount_partial_nuw2_thm (e e_1 e_2 : IntW 6) :
     all_goals sorry
 
 
-theorem add_shl_same_amount_constants_thm (e : IntW 8) : add (shl (const? 8 4) e) (shl (const? 8 3) e) ⊑ shl (const? 8 7) e := by 
+theorem add_shl_same_amount_constants_thm (e : IntW 8) : add (shl (const? 8 4) e) (shl (const? 8 3) e) ⊑ shl (const? 8 7) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gshlhsub_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gshlhsub_proof.lean
@@ -9,7 +9,7 @@ set_option linter.unreachableTactic false
 
 section gshlhsub_proof
 theorem shl_sub_i32_thm (e : IntW 32) :
-  shl (const? 32 1) (sub (const? 32 31) e) ⊑ lshr (const? 32 (-2147483648)) e { «exact» := true } := by 
+  shl (const? 32 1) (sub (const? 32 31) e) ⊑ lshr (const? 32 (-2147483648)) e { «exact» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -19,7 +19,7 @@ theorem shl_sub_i32_thm (e : IntW 32) :
 
 
 theorem shl_sub_i8_thm (e : IntW 8) :
-  shl (const? 8 1) (sub (const? 8 7) e) ⊑ lshr (const? 8 (-128)) e { «exact» := true } := by 
+  shl (const? 8 1) (sub (const? 8 7) e) ⊑ lshr (const? 8 (-128)) e { «exact» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -29,7 +29,7 @@ theorem shl_sub_i8_thm (e : IntW 8) :
 
 
 theorem shl_sub_i64_thm (e : IntW 64) :
-  shl (const? 64 1) (sub (const? 64 63) e) ⊑ lshr (const? 64 (-9223372036854775808)) e { «exact» := true } := by 
+  shl (const? 64 1) (sub (const? 64 63) e) ⊑ lshr (const? 64 (-9223372036854775808)) e { «exact» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -40,7 +40,7 @@ theorem shl_sub_i64_thm (e : IntW 64) :
 
 theorem shl_bad_sub_i32_thm (e : IntW 32) :
   shl (const? 32 1) (sub (const? 32 32) e) ⊑
-    shl (const? 32 1) (sub (const? 32 32) e) { «nsw» := false, «nuw» := true } := by 
+    shl (const? 32 1) (sub (const? 32 32) e) { «nsw» := false, «nuw» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -51,7 +51,7 @@ theorem shl_bad_sub_i32_thm (e : IntW 32) :
 
 theorem shl_bad_sub2_i32_thm (e : IntW 32) :
   shl (const? 32 1) (sub e (const? 32 31)) ⊑
-    shl (const? 32 1) (add e (const? 32 (-31))) { «nsw» := false, «nuw» := true } := by 
+    shl (const? 32 1) (add e (const? 32 (-31))) { «nsw» := false, «nuw» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -62,7 +62,7 @@ theorem shl_bad_sub2_i32_thm (e : IntW 32) :
 
 theorem bad_shl2_sub_i32_thm (e : IntW 32) :
   shl (const? 32 1) (sub e (const? 32 31)) ⊑
-    shl (const? 32 1) (add e (const? 32 (-31))) { «nsw» := false, «nuw» := true } := by 
+    shl (const? 32 1) (add e (const? 32 (-31))) { «nsw» := false, «nuw» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -73,7 +73,7 @@ theorem bad_shl2_sub_i32_thm (e : IntW 32) :
 
 theorem shl_bad_sub_i8_thm (e : IntW 8) :
   shl (const? 8 1) (sub (const? 8 4) e) ⊑
-    shl (const? 8 1) (sub (const? 8 4) e) { «nsw» := false, «nuw» := true } := by 
+    shl (const? 8 1) (sub (const? 8 4) e) { «nsw» := false, «nuw» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -84,7 +84,7 @@ theorem shl_bad_sub_i8_thm (e : IntW 8) :
 
 theorem shl_bad_sub_i64_thm (e : IntW 64) :
   shl (const? 64 1) (sub (const? 64 67) e) ⊑
-    shl (const? 64 1) (sub (const? 64 67) e) { «nsw» := false, «nuw» := true } := by 
+    shl (const? 64 1) (sub (const? 64 67) e) { «nsw» := false, «nuw» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -94,7 +94,7 @@ theorem shl_bad_sub_i64_thm (e : IntW 64) :
 
 
 theorem shl_const_op1_sub_const_op0_thm (e : IntW 32) :
-  shl (sub (const? 32 42) e) (const? 32 3) ⊑ sub (const? 32 336) (shl e (const? 32 3)) := by 
+  shl (sub (const? 32 42) e) (const? 32 3) ⊑ sub (const? 32 336) (shl e (const? 32 3)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gshlhunsignedhcmphconst_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gshlhunsignedhcmphconst_proof.lean
@@ -10,7 +10,7 @@ set_option linter.unreachableTactic false
 section gshlhunsignedhcmphconst_proof
 theorem scalar_i8_shl_ult_const_1_thm (e : IntW 8) :
   icmp IntPredicate.ult (shl e (const? 8 5)) (const? 8 64) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 8 6)) (const? 8 0) := by 
+    icmp IntPredicate.eq (LLVM.and e (const? 8 6)) (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -21,7 +21,7 @@ theorem scalar_i8_shl_ult_const_1_thm (e : IntW 8) :
 
 theorem scalar_i8_shl_ult_const_2_thm (e : IntW 8) :
   icmp IntPredicate.ult (shl e (const? 8 6)) (const? 8 64) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 8 3)) (const? 8 0) := by 
+    icmp IntPredicate.eq (LLVM.and e (const? 8 3)) (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -32,7 +32,7 @@ theorem scalar_i8_shl_ult_const_2_thm (e : IntW 8) :
 
 theorem scalar_i8_shl_ult_const_3_thm (e : IntW 8) :
   icmp IntPredicate.ult (shl e (const? 8 7)) (const? 8 64) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 8 1)) (const? 8 0) := by 
+    icmp IntPredicate.eq (LLVM.and e (const? 8 1)) (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -43,7 +43,7 @@ theorem scalar_i8_shl_ult_const_3_thm (e : IntW 8) :
 
 theorem scalar_i16_shl_ult_const_thm (e : IntW 16) :
   icmp IntPredicate.ult (shl e (const? 16 8)) (const? 16 1024) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 16 252)) (const? 16 0) := by 
+    icmp IntPredicate.eq (LLVM.and e (const? 16 252)) (const? 16 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -54,7 +54,7 @@ theorem scalar_i16_shl_ult_const_thm (e : IntW 16) :
 
 theorem scalar_i32_shl_ult_const_thm (e : IntW 32) :
   icmp IntPredicate.ult (shl e (const? 32 11)) (const? 32 131072) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 32 2097088)) (const? 32 0) := by 
+    icmp IntPredicate.eq (LLVM.and e (const? 32 2097088)) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -65,7 +65,7 @@ theorem scalar_i32_shl_ult_const_thm (e : IntW 32) :
 
 theorem scalar_i64_shl_ult_const_thm (e : IntW 64) :
   icmp IntPredicate.ult (shl e (const? 64 25)) (const? 64 8589934592) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 64 549755813632)) (const? 64 0) := by 
+    icmp IntPredicate.eq (LLVM.and e (const? 64 549755813632)) (const? 64 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -76,7 +76,7 @@ theorem scalar_i64_shl_ult_const_thm (e : IntW 64) :
 
 theorem scalar_i8_shl_uge_const_thm (e : IntW 8) :
   icmp IntPredicate.uge (shl e (const? 8 5)) (const? 8 64) ⊑
-    icmp IntPredicate.ne (LLVM.and e (const? 8 6)) (const? 8 0) := by 
+    icmp IntPredicate.ne (LLVM.and e (const? 8 6)) (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -87,7 +87,7 @@ theorem scalar_i8_shl_uge_const_thm (e : IntW 8) :
 
 theorem scalar_i8_shl_ule_const_thm (e : IntW 8) :
   icmp IntPredicate.ule (shl e (const? 8 5)) (const? 8 63) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 8 6)) (const? 8 0) := by 
+    icmp IntPredicate.eq (LLVM.and e (const? 8 6)) (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -98,7 +98,7 @@ theorem scalar_i8_shl_ule_const_thm (e : IntW 8) :
 
 theorem scalar_i8_shl_ugt_const_thm (e : IntW 8) :
   icmp IntPredicate.ugt (shl e (const? 8 5)) (const? 8 63) ⊑
-    icmp IntPredicate.ne (LLVM.and e (const? 8 6)) (const? 8 0) := by 
+    icmp IntPredicate.ne (LLVM.and e (const? 8 6)) (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gshouldhchangehtype_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gshouldhchangehtype_proof.lean
@@ -8,7 +8,7 @@ set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
 
 section gshouldhchangehtype_proof
-theorem test1_thm (e e_1 : IntW 8) : trunc 8 (add (zext 64 e_1) (zext 64 e)) ⊑ add e_1 e := by 
+theorem test1_thm (e e_1 : IntW 8) : trunc 8 (add (zext 64 e_1) (zext 64 e)) ⊑ add e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -17,7 +17,7 @@ theorem test1_thm (e e_1 : IntW 8) : trunc 8 (add (zext 64 e_1) (zext 64 e)) ⊑
     all_goals sorry
 
 
-theorem test2_thm (e e_1 : IntW 16) : trunc 16 (add (zext 64 e_1) (zext 64 e)) ⊑ add e_1 e := by 
+theorem test2_thm (e e_1 : IntW 16) : trunc 16 (add (zext 64 e_1) (zext 64 e)) ⊑ add e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -26,7 +26,7 @@ theorem test2_thm (e e_1 : IntW 16) : trunc 16 (add (zext 64 e_1) (zext 64 e)) �
     all_goals sorry
 
 
-theorem test3_thm (e e_1 : IntW 32) : trunc 32 (add (zext 64 e_1) (zext 64 e)) ⊑ add e_1 e := by 
+theorem test3_thm (e e_1 : IntW 32) : trunc 32 (add (zext 64 e_1) (zext 64 e)) ⊑ add e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -37,7 +37,7 @@ theorem test3_thm (e e_1 : IntW 32) : trunc 32 (add (zext 64 e_1) (zext 64 e)) �
 
 theorem test4_thm (e e_1 : IntW 9) :
   trunc 9 (add (zext 64 e_1) (zext 64 e)) ⊑
-    trunc 9 (add (zext 64 e_1) (zext 64 e) { «nsw» := true, «nuw» := true }) := by 
+    trunc 9 (add (zext 64 e_1) (zext 64 e) { «nsw» := true, «nuw» := true }) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gsignbithlshrhandhicmpeqhzero_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gsignbithlshrhandhicmpeqhzero_proof.lean
@@ -10,7 +10,7 @@ set_option linter.unreachableTactic false
 section gsignbithlshrhandhicmpeqhzero_proof
 theorem scalar_i8_signbit_lshr_and_eq_thm (e e_1 : IntW 8) :
   icmp IntPredicate.eq (LLVM.and (lshr (const? 8 (-128)) e_1) e) (const? 8 0) ⊑
-    icmp IntPredicate.eq (LLVM.and (lshr (const? 8 (-128)) e_1 { «exact» := true }) e) (const? 8 0) := by 
+    icmp IntPredicate.eq (LLVM.and (lshr (const? 8 (-128)) e_1 { «exact» := true }) e) (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -21,7 +21,7 @@ theorem scalar_i8_signbit_lshr_and_eq_thm (e e_1 : IntW 8) :
 
 theorem scalar_i16_signbit_lshr_and_eq_thm (e e_1 : IntW 16) :
   icmp IntPredicate.eq (LLVM.and (lshr (const? 16 (-32768)) e_1) e) (const? 16 0) ⊑
-    icmp IntPredicate.eq (LLVM.and (lshr (const? 16 (-32768)) e_1 { «exact» := true }) e) (const? 16 0) := by 
+    icmp IntPredicate.eq (LLVM.and (lshr (const? 16 (-32768)) e_1 { «exact» := true }) e) (const? 16 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -32,7 +32,7 @@ theorem scalar_i16_signbit_lshr_and_eq_thm (e e_1 : IntW 16) :
 
 theorem scalar_i32_signbit_lshr_and_eq_thm (e e_1 : IntW 32) :
   icmp IntPredicate.eq (LLVM.and (lshr (const? 32 (-2147483648)) e_1) e) (const? 32 0) ⊑
-    icmp IntPredicate.eq (LLVM.and (lshr (const? 32 (-2147483648)) e_1 { «exact» := true }) e) (const? 32 0) := by 
+    icmp IntPredicate.eq (LLVM.and (lshr (const? 32 (-2147483648)) e_1 { «exact» := true }) e) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -44,7 +44,7 @@ theorem scalar_i32_signbit_lshr_and_eq_thm (e e_1 : IntW 32) :
 theorem scalar_i64_signbit_lshr_and_eq_thm (e e_1 : IntW 64) :
   icmp IntPredicate.eq (LLVM.and (lshr (const? 64 (-9223372036854775808)) e_1) e) (const? 64 0) ⊑
     icmp IntPredicate.eq (LLVM.and (lshr (const? 64 (-9223372036854775808)) e_1 { «exact» := true }) e)
-      (const? 64 0) := by 
+      (const? 64 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -55,7 +55,7 @@ theorem scalar_i64_signbit_lshr_and_eq_thm (e e_1 : IntW 64) :
 
 theorem scalar_i32_signbit_lshr_and_ne_thm (e e_1 : IntW 32) :
   icmp IntPredicate.ne (LLVM.and (lshr (const? 32 (-2147483648)) e_1) e) (const? 32 0) ⊑
-    icmp IntPredicate.ne (LLVM.and (lshr (const? 32 (-2147483648)) e_1 { «exact» := true }) e) (const? 32 0) := by 
+    icmp IntPredicate.ne (LLVM.and (lshr (const? 32 (-2147483648)) e_1 { «exact» := true }) e) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -67,7 +67,7 @@ theorem scalar_i32_signbit_lshr_and_ne_thm (e e_1 : IntW 32) :
 theorem scalar_i32_signbit_lshr_and_eq_X_is_constant1_thm (e : IntW 32) :
   icmp IntPredicate.eq (LLVM.and (lshr (const? 32 (-2147483648)) e) (const? 32 12345)) (const? 32 0) ⊑
     icmp IntPredicate.eq (LLVM.and (lshr (const? 32 (-2147483648)) e { «exact» := true }) (const? 32 12345))
-      (const? 32 0) := by 
+      (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -78,7 +78,7 @@ theorem scalar_i32_signbit_lshr_and_eq_X_is_constant1_thm (e : IntW 32) :
 
 theorem scalar_i32_signbit_lshr_and_eq_X_is_constant2_thm (e : IntW 32) :
   icmp IntPredicate.eq (LLVM.and (lshr (const? 32 (-2147483648)) e) (const? 32 1)) (const? 32 0) ⊑
-    icmp IntPredicate.ne e (const? 32 31) := by 
+    icmp IntPredicate.ne e (const? 32 31) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -89,7 +89,7 @@ theorem scalar_i32_signbit_lshr_and_eq_X_is_constant2_thm (e : IntW 32) :
 
 theorem scalar_i32_signbit_lshr_and_slt_thm (e e_1 : IntW 32) :
   icmp IntPredicate.slt (LLVM.and (lshr (const? 32 (-2147483648)) e_1) e) (const? 32 0) ⊑
-    icmp IntPredicate.slt (LLVM.and (lshr (const? 32 (-2147483648)) e_1 { «exact» := true }) e) (const? 32 0) := by 
+    icmp IntPredicate.slt (LLVM.and (lshr (const? 32 (-2147483648)) e_1 { «exact» := true }) e) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -100,7 +100,7 @@ theorem scalar_i32_signbit_lshr_and_slt_thm (e e_1 : IntW 32) :
 
 theorem scalar_i32_signbit_lshr_and_eq_nonzero_thm (e e_1 : IntW 32) :
   icmp IntPredicate.eq (LLVM.and (lshr (const? 32 (-2147483648)) e_1) e) (const? 32 1) ⊑
-    icmp IntPredicate.eq (LLVM.and (lshr (const? 32 (-2147483648)) e_1 { «exact» := true }) e) (const? 32 1) := by 
+    icmp IntPredicate.eq (LLVM.and (lshr (const? 32 (-2147483648)) e_1 { «exact» := true }) e) (const? 32 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gsignbithshlhandhicmpeqhzero_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gsignbithshlhandhicmpeqhzero_proof.lean
@@ -10,7 +10,7 @@ set_option linter.unreachableTactic false
 section gsignbithshlhandhicmpeqhzero_proof
 theorem scalar_i32_signbit_shl_and_eq_X_is_constant1_thm (e : IntW 32) :
   icmp IntPredicate.eq (LLVM.and (shl (const? 32 (-2147483648)) e) (const? 32 12345)) (const? 32 0) ⊑
-    const? 1 1 := by 
+    const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -20,7 +20,7 @@ theorem scalar_i32_signbit_shl_and_eq_X_is_constant1_thm (e : IntW 32) :
 
 
 theorem scalar_i32_signbit_shl_and_eq_X_is_constant2_thm (e : IntW 32) :
-  icmp IntPredicate.eq (LLVM.and (shl (const? 32 (-2147483648)) e) (const? 32 1)) (const? 32 0) ⊑ const? 1 1 := by 
+  icmp IntPredicate.eq (LLVM.and (shl (const? 32 (-2147483648)) e) (const? 32 1)) (const? 32 0) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -31,7 +31,7 @@ theorem scalar_i32_signbit_shl_and_eq_X_is_constant2_thm (e : IntW 32) :
 
 theorem scalar_i32_signbit_shl_and_slt_thm (e e_1 : IntW 32) :
   icmp IntPredicate.slt (LLVM.and (shl (const? 32 (-2147483648)) e_1) e) (const? 32 0) ⊑
-    icmp IntPredicate.ne (LLVM.and (shl (const? 32 (-2147483648)) e_1) e) (const? 32 0) := by 
+    icmp IntPredicate.ne (LLVM.and (shl (const? 32 (-2147483648)) e_1) e) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -41,7 +41,7 @@ theorem scalar_i32_signbit_shl_and_slt_thm (e e_1 : IntW 32) :
 
 
 theorem scalar_i32_signbit_shl_and_eq_nonzero_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.eq (LLVM.and (shl (const? 32 (-2147483648)) e_1) e) (const? 32 1) ⊑ const? 1 0 := by 
+  icmp IntPredicate.eq (LLVM.and (shl (const? 32 (-2147483648)) e_1) e) (const? 32 1) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gsignedhcomparison_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gsignedhcomparison_proof.lean
@@ -9,7 +9,7 @@ set_option linter.unreachableTactic false
 
 section gsignedhcomparison_proof
 theorem scalar_zext_slt_thm (e : IntW 16) :
-  icmp IntPredicate.slt (zext 32 e) (const? 32 500) ⊑ icmp IntPredicate.ult e (const? 16 500) := by 
+  icmp IntPredicate.slt (zext 32 e) (const? 32 500) ⊑ icmp IntPredicate.ult e (const? 16 500) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gsignedhtruncationhcheck_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gsignedhtruncationhcheck_proof.lean
@@ -10,7 +10,7 @@ set_option linter.unreachableTactic false
 section gsignedhtruncationhcheck_proof
 theorem positive_with_signbit_thm (e : IntW 32) :
   LLVM.and (icmp IntPredicate.sgt e (const? 32 (-1))) (icmp IntPredicate.ult (add e (const? 32 128)) (const? 32 256)) ⊑
-    icmp IntPredicate.ult e (const? 32 128) := by 
+    icmp IntPredicate.ult e (const? 32 128) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -22,7 +22,7 @@ theorem positive_with_signbit_thm (e : IntW 32) :
 theorem positive_with_signbit_logical_thm (e : IntW 32) :
   select (icmp IntPredicate.sgt e (const? 32 (-1))) (icmp IntPredicate.ult (add e (const? 32 128)) (const? 32 256))
       (const? 1 0) ⊑
-    icmp IntPredicate.ult e (const? 32 128) := by 
+    icmp IntPredicate.ult e (const? 32 128) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -34,7 +34,7 @@ theorem positive_with_signbit_logical_thm (e : IntW 32) :
 theorem positive_with_mask_thm (e : IntW 32) :
   LLVM.and (icmp IntPredicate.eq (LLVM.and e (const? 32 1107296256)) (const? 32 0))
       (icmp IntPredicate.ult (add e (const? 32 128)) (const? 32 256)) ⊑
-    icmp IntPredicate.ult e (const? 32 128) := by 
+    icmp IntPredicate.ult e (const? 32 128) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -46,7 +46,7 @@ theorem positive_with_mask_thm (e : IntW 32) :
 theorem positive_with_mask_logical_thm (e : IntW 32) :
   select (icmp IntPredicate.eq (LLVM.and e (const? 32 1107296256)) (const? 32 0))
       (icmp IntPredicate.ult (add e (const? 32 128)) (const? 32 256)) (const? 1 0) ⊑
-    icmp IntPredicate.ult e (const? 32 128) := by 
+    icmp IntPredicate.ult e (const? 32 128) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -57,7 +57,7 @@ theorem positive_with_mask_logical_thm (e : IntW 32) :
 
 theorem positive_with_icmp_thm (e : IntW 32) :
   LLVM.and (icmp IntPredicate.ult e (const? 32 512)) (icmp IntPredicate.ult (add e (const? 32 128)) (const? 32 256)) ⊑
-    icmp IntPredicate.ult e (const? 32 128) := by 
+    icmp IntPredicate.ult e (const? 32 128) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -69,7 +69,7 @@ theorem positive_with_icmp_thm (e : IntW 32) :
 theorem positive_with_icmp_logical_thm (e : IntW 32) :
   select (icmp IntPredicate.ult e (const? 32 512)) (icmp IntPredicate.ult (add e (const? 32 128)) (const? 32 256))
       (const? 1 0) ⊑
-    icmp IntPredicate.ult e (const? 32 128) := by 
+    icmp IntPredicate.ult e (const? 32 128) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -80,7 +80,7 @@ theorem positive_with_icmp_logical_thm (e : IntW 32) :
 
 theorem positive_with_aggressive_icmp_thm (e : IntW 32) :
   LLVM.and (icmp IntPredicate.ult e (const? 32 128)) (icmp IntPredicate.ult (add e (const? 32 256)) (const? 32 512)) ⊑
-    icmp IntPredicate.ult e (const? 32 128) := by 
+    icmp IntPredicate.ult e (const? 32 128) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -92,7 +92,7 @@ theorem positive_with_aggressive_icmp_thm (e : IntW 32) :
 theorem positive_with_aggressive_icmp_logical_thm (e : IntW 32) :
   select (icmp IntPredicate.ult e (const? 32 128)) (icmp IntPredicate.ult (add e (const? 32 256)) (const? 32 512))
       (const? 1 0) ⊑
-    icmp IntPredicate.ult e (const? 32 128) := by 
+    icmp IntPredicate.ult e (const? 32 128) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -104,7 +104,7 @@ theorem positive_with_aggressive_icmp_logical_thm (e : IntW 32) :
 theorem positive_with_extra_and_thm (e : IntW 1) (e_1 : IntW 32) :
   LLVM.and (icmp IntPredicate.ult (add e_1 (const? 32 128)) (const? 32 256))
       (LLVM.and (icmp IntPredicate.sgt e_1 (const? 32 (-1))) e) ⊑
-    LLVM.and (icmp IntPredicate.ult e_1 (const? 32 128)) e := by 
+    LLVM.and (icmp IntPredicate.ult e_1 (const? 32 128)) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -116,7 +116,7 @@ theorem positive_with_extra_and_thm (e : IntW 1) (e_1 : IntW 32) :
 theorem positive_with_extra_and_logical_thm (e : IntW 1) (e_1 : IntW 32) :
   select (icmp IntPredicate.ult (add e_1 (const? 32 128)) (const? 32 256))
       (select (icmp IntPredicate.sgt e_1 (const? 32 (-1))) e (const? 1 0)) (const? 1 0) ⊑
-    select (icmp IntPredicate.ult e_1 (const? 32 128)) e (const? 1 0) := by 
+    select (icmp IntPredicate.ult e_1 (const? 32 128)) e (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -128,7 +128,7 @@ theorem positive_with_extra_and_logical_thm (e : IntW 1) (e_1 : IntW 32) :
 theorem positive_trunc_signbit_thm (e : IntW 32) :
   LLVM.and (icmp IntPredicate.sgt (trunc 8 e) (const? 8 (-1)))
       (icmp IntPredicate.ult (add e (const? 32 128)) (const? 32 256)) ⊑
-    icmp IntPredicate.ult e (const? 32 128) := by 
+    icmp IntPredicate.ult e (const? 32 128) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -140,7 +140,7 @@ theorem positive_trunc_signbit_thm (e : IntW 32) :
 theorem positive_trunc_signbit_logical_thm (e : IntW 32) :
   select (icmp IntPredicate.sgt (trunc 8 e) (const? 8 (-1)))
       (icmp IntPredicate.ult (add e (const? 32 128)) (const? 32 256)) (const? 1 0) ⊑
-    icmp IntPredicate.ult e (const? 32 128) := by 
+    icmp IntPredicate.ult e (const? 32 128) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -152,7 +152,7 @@ theorem positive_trunc_signbit_logical_thm (e : IntW 32) :
 theorem positive_trunc_base_thm (e : IntW 32) :
   LLVM.and (icmp IntPredicate.sgt (trunc 16 e) (const? 16 (-1)))
       (icmp IntPredicate.ult (add (trunc 16 e) (const? 16 128)) (const? 16 256)) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 32 65408)) (const? 32 0) := by 
+    icmp IntPredicate.eq (LLVM.and e (const? 32 65408)) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -164,7 +164,7 @@ theorem positive_trunc_base_thm (e : IntW 32) :
 theorem positive_trunc_base_logical_thm (e : IntW 32) :
   select (icmp IntPredicate.sgt (trunc 16 e) (const? 16 (-1)))
       (icmp IntPredicate.ult (add (trunc 16 e) (const? 16 128)) (const? 16 256)) (const? 1 0) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 32 65408)) (const? 32 0) := by 
+    icmp IntPredicate.eq (LLVM.and e (const? 32 65408)) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -177,7 +177,7 @@ theorem positive_different_trunc_both_thm (e : IntW 32) :
   LLVM.and (icmp IntPredicate.sgt (trunc 15 e) (const? 15 (-1)))
       (icmp IntPredicate.ult (add (trunc 16 e) (const? 16 128)) (const? 16 256)) ⊑
     LLVM.and (icmp IntPredicate.eq (LLVM.and e (const? 32 16384)) (const? 32 0))
-      (icmp IntPredicate.ult (add (trunc 16 e) (const? 16 128)) (const? 16 256)) := by 
+      (icmp IntPredicate.ult (add (trunc 16 e) (const? 16 128)) (const? 16 256)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -190,7 +190,7 @@ theorem positive_different_trunc_both_logical_thm (e : IntW 32) :
   select (icmp IntPredicate.sgt (trunc 15 e) (const? 15 (-1)))
       (icmp IntPredicate.ult (add (trunc 16 e) (const? 16 128)) (const? 16 256)) (const? 1 0) ⊑
     select (icmp IntPredicate.eq (LLVM.and e (const? 32 16384)) (const? 32 0))
-      (icmp IntPredicate.ult (add (trunc 16 e) (const? 16 128)) (const? 16 256)) (const? 1 0) := by 
+      (icmp IntPredicate.ult (add (trunc 16 e) (const? 16 128)) (const? 16 256)) (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -203,7 +203,7 @@ theorem negative_trunc_not_arg_thm (e e_1 : IntW 32) :
   LLVM.and (icmp IntPredicate.sgt (trunc 8 e_1) (const? 8 (-1)))
       (icmp IntPredicate.ult (add e (const? 32 128)) (const? 32 256)) ⊑
     LLVM.and (icmp IntPredicate.eq (LLVM.and e_1 (const? 32 128)) (const? 32 0))
-      (icmp IntPredicate.ult (add e (const? 32 128)) (const? 32 256)) := by 
+      (icmp IntPredicate.ult (add e (const? 32 128)) (const? 32 256)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -216,7 +216,7 @@ theorem negative_trunc_not_arg_logical_thm (e e_1 : IntW 32) :
   select (icmp IntPredicate.sgt (trunc 8 e_1) (const? 8 (-1)))
       (icmp IntPredicate.ult (add e (const? 32 128)) (const? 32 256)) (const? 1 0) ⊑
     select (icmp IntPredicate.eq (LLVM.and e_1 (const? 32 128)) (const? 32 0))
-      (icmp IntPredicate.ult (add e (const? 32 128)) (const? 32 256)) (const? 1 0) := by 
+      (icmp IntPredicate.ult (add e (const? 32 128)) (const? 32 256)) (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -229,7 +229,7 @@ theorem negative_with_nonuniform_bad_mask_logical_thm (e : IntW 32) :
   select (icmp IntPredicate.eq (LLVM.and e (const? 32 1711276033)) (const? 32 0))
       (icmp IntPredicate.ult (add e (const? 32 128)) (const? 32 256)) (const? 1 0) ⊑
     LLVM.and (icmp IntPredicate.eq (LLVM.and e (const? 32 1711276033)) (const? 32 0))
-      (icmp IntPredicate.ult (add e (const? 32 128)) (const? 32 256)) := by 
+      (icmp IntPredicate.ult (add e (const? 32 128)) (const? 32 256)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -242,7 +242,7 @@ theorem negative_with_uniform_bad_mask_logical_thm (e : IntW 32) :
   select (icmp IntPredicate.eq (LLVM.and e (const? 32 (-16777152))) (const? 32 0))
       (icmp IntPredicate.ult (add e (const? 32 128)) (const? 32 256)) (const? 1 0) ⊑
     LLVM.and (icmp IntPredicate.eq (LLVM.and e (const? 32 (-16777152))) (const? 32 0))
-      (icmp IntPredicate.ult (add e (const? 32 128)) (const? 32 256)) := by 
+      (icmp IntPredicate.ult (add e (const? 32 128)) (const? 32 256)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -255,7 +255,7 @@ theorem negative_with_wrong_mask_logical_thm (e : IntW 32) :
   select (icmp IntPredicate.eq (LLVM.and e (const? 32 1)) (const? 32 0))
       (icmp IntPredicate.ult (add e (const? 32 128)) (const? 32 256)) (const? 1 0) ⊑
     LLVM.and (icmp IntPredicate.eq (LLVM.and e (const? 32 1)) (const? 32 0))
-      (icmp IntPredicate.ult (add e (const? 32 128)) (const? 32 256)) := by 
+      (icmp IntPredicate.ult (add e (const? 32 128)) (const? 32 256)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -266,7 +266,7 @@ theorem negative_with_wrong_mask_logical_thm (e : IntW 32) :
 
 theorem negative_not_less_than_thm (e : IntW 32) :
   LLVM.and (icmp IntPredicate.sgt e (const? 32 (-1))) (icmp IntPredicate.ult (add e (const? 32 256)) (const? 32 256)) ⊑
-    const? 1 0 := by 
+    const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -278,7 +278,7 @@ theorem negative_not_less_than_thm (e : IntW 32) :
 theorem negative_not_less_than_logical_thm (e : IntW 32) :
   select (icmp IntPredicate.sgt e (const? 32 (-1))) (icmp IntPredicate.ult (add e (const? 32 256)) (const? 32 256))
       (const? 1 0) ⊑
-    const? 1 0 := by 
+    const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -289,7 +289,7 @@ theorem negative_not_less_than_logical_thm (e : IntW 32) :
 
 theorem negative_not_power_of_two_thm (e : IntW 32) :
   LLVM.and (icmp IntPredicate.sgt e (const? 32 (-1))) (icmp IntPredicate.ult (add e (const? 32 255)) (const? 32 256)) ⊑
-    icmp IntPredicate.eq e (const? 32 0) := by 
+    icmp IntPredicate.eq e (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -301,7 +301,7 @@ theorem negative_not_power_of_two_thm (e : IntW 32) :
 theorem negative_not_power_of_two_logical_thm (e : IntW 32) :
   select (icmp IntPredicate.sgt e (const? 32 (-1))) (icmp IntPredicate.ult (add e (const? 32 255)) (const? 32 256))
       (const? 1 0) ⊑
-    icmp IntPredicate.eq e (const? 32 0) := by 
+    icmp IntPredicate.eq e (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -312,7 +312,7 @@ theorem negative_not_power_of_two_logical_thm (e : IntW 32) :
 
 theorem negative_not_next_power_of_two_thm (e : IntW 32) :
   LLVM.and (icmp IntPredicate.sgt e (const? 32 (-1))) (icmp IntPredicate.ult (add e (const? 32 64)) (const? 32 256)) ⊑
-    icmp IntPredicate.ult e (const? 32 192) := by 
+    icmp IntPredicate.ult e (const? 32 192) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -324,7 +324,7 @@ theorem negative_not_next_power_of_two_thm (e : IntW 32) :
 theorem negative_not_next_power_of_two_logical_thm (e : IntW 32) :
   select (icmp IntPredicate.sgt e (const? 32 (-1))) (icmp IntPredicate.ult (add e (const? 32 64)) (const? 32 256))
       (const? 1 0) ⊑
-    icmp IntPredicate.ult e (const? 32 192) := by 
+    icmp IntPredicate.ult e (const? 32 192) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -336,7 +336,7 @@ theorem negative_not_next_power_of_two_logical_thm (e : IntW 32) :
 theorem two_signed_truncation_checks_thm (e : IntW 32) :
   LLVM.and (icmp IntPredicate.ult (add e (const? 32 512)) (const? 32 1024))
       (icmp IntPredicate.ult (add e (const? 32 128)) (const? 32 256)) ⊑
-    icmp IntPredicate.ult (add e (const? 32 128)) (const? 32 256) := by 
+    icmp IntPredicate.ult (add e (const? 32 128)) (const? 32 256) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -348,7 +348,7 @@ theorem two_signed_truncation_checks_thm (e : IntW 32) :
 theorem two_signed_truncation_checks_logical_thm (e : IntW 32) :
   select (icmp IntPredicate.ult (add e (const? 32 512)) (const? 32 1024))
       (icmp IntPredicate.ult (add e (const? 32 128)) (const? 32 256)) (const? 1 0) ⊑
-    icmp IntPredicate.ult (add e (const? 32 128)) (const? 32 256) := by 
+    icmp IntPredicate.ult (add e (const? 32 128)) (const? 32 256) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gsignext_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gsignext_proof.lean
@@ -10,7 +10,7 @@ set_option linter.unreachableTactic false
 section gsignext_proof
 theorem sextinreg_thm (e : IntW 32) :
   add (LLVM.xor (LLVM.and e (const? 32 65535)) (const? 32 (-32768))) (const? 32 32768) ⊑
-    ashr (shl e (const? 32 16)) (const? 32 16) { «exact» := true } := by 
+    ashr (shl e (const? 32 16)) (const? 32 16) { «exact» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -21,7 +21,7 @@ theorem sextinreg_thm (e : IntW 32) :
 
 theorem sextinreg_alt_thm (e : IntW 32) :
   add (LLVM.xor (LLVM.and e (const? 32 65535)) (const? 32 32768)) (const? 32 (-32768)) ⊑
-    ashr (shl e (const? 32 16)) (const? 32 16) { «exact» := true } := by 
+    ashr (shl e (const? 32 16)) (const? 32 16) { «exact» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -31,7 +31,7 @@ theorem sextinreg_alt_thm (e : IntW 32) :
 
 
 theorem sext_thm (e : IntW 16) :
-  add (LLVM.xor (zext 32 e) (const? 32 32768)) (const? 32 (-32768)) ⊑ sext 32 e := by 
+  add (LLVM.xor (zext 32 e) (const? 32 32768)) (const? 32 (-32768)) ⊑ sext 32 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -42,7 +42,7 @@ theorem sext_thm (e : IntW 16) :
 
 theorem sextinreg2_thm (e : IntW 32) :
   add (LLVM.xor (LLVM.and e (const? 32 255)) (const? 32 128)) (const? 32 (-128)) ⊑
-    ashr (shl e (const? 32 24)) (const? 32 24) { «exact» := true } := by 
+    ashr (shl e (const? 32 24)) (const? 32 24) { «exact» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -52,7 +52,7 @@ theorem sextinreg2_thm (e : IntW 32) :
 
 
 theorem test5_thm (e : IntW 32) :
-  ashr (shl e (const? 32 16)) (const? 32 16) ⊑ ashr (shl e (const? 32 16)) (const? 32 16) { «exact» := true } := by 
+  ashr (shl e (const? 32 16)) (const? 32 16) ⊑ ashr (shl e (const? 32 16)) (const? 32 16) { «exact» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -61,7 +61,7 @@ theorem test5_thm (e : IntW 32) :
     all_goals sorry
 
 
-theorem test6_thm (e : IntW 16) : ashr (shl (zext 32 e) (const? 32 16)) (const? 32 16) ⊑ sext 32 e := by 
+theorem test6_thm (e : IntW 16) : ashr (shl (zext 32 e) (const? 32 16)) (const? 32 16) ⊑ sext 32 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -71,7 +71,7 @@ theorem test6_thm (e : IntW 16) : ashr (shl (zext 32 e) (const? 32 16)) (const? 
 
 
 theorem ashr_thm (e : IntW 32) :
-  add (LLVM.xor (lshr e (const? 32 5)) (const? 32 67108864)) (const? 32 (-67108864)) ⊑ ashr e (const? 32 5) := by 
+  add (LLVM.xor (lshr e (const? 32 5)) (const? 32 67108864)) (const? 32 (-67108864)) ⊑ ashr e (const? 32 5) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gsignhbithtesthviahrighthshiftinghallhotherhbits_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gsignhbithtesthviahrighthshiftinghallhotherhbits_proof.lean
@@ -9,7 +9,7 @@ set_option linter.unreachableTactic false
 
 section gsignhbithtesthviahrighthshiftinghallhotherhbits_proof
 theorem unsigned_sign_bit_extract_thm (e : IntW 32) :
-  icmp IntPredicate.ne (lshr e (const? 32 31)) (const? 32 0) ⊑ icmp IntPredicate.slt e (const? 32 0) := by 
+  icmp IntPredicate.ne (lshr e (const? 32 31)) (const? 32 0) ⊑ icmp IntPredicate.slt e (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -19,7 +19,7 @@ theorem unsigned_sign_bit_extract_thm (e : IntW 32) :
 
 
 theorem signed_sign_bit_extract_thm (e : IntW 32) :
-  icmp IntPredicate.ne (ashr e (const? 32 31)) (const? 32 0) ⊑ icmp IntPredicate.slt e (const? 32 0) := by 
+  icmp IntPredicate.ne (ashr e (const? 32 31)) (const? 32 0) ⊑ icmp IntPredicate.slt e (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -29,7 +29,7 @@ theorem signed_sign_bit_extract_thm (e : IntW 32) :
 
 
 theorem unsigned_sign_bit_extract_with_trunc_thm (e : IntW 64) :
-  icmp IntPredicate.ne (trunc 32 (lshr e (const? 64 63))) (const? 32 0) ⊑ icmp IntPredicate.slt e (const? 64 0) := by 
+  icmp IntPredicate.ne (trunc 32 (lshr e (const? 64 63))) (const? 32 0) ⊑ icmp IntPredicate.slt e (const? 64 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -39,7 +39,7 @@ theorem unsigned_sign_bit_extract_with_trunc_thm (e : IntW 64) :
 
 
 theorem signed_sign_bit_extract_trunc_thm (e : IntW 64) :
-  icmp IntPredicate.ne (trunc 32 (ashr e (const? 64 63))) (const? 32 0) ⊑ icmp IntPredicate.slt e (const? 64 0) := by 
+  icmp IntPredicate.ne (trunc 32 (ashr e (const? 64 63))) (const? 32 0) ⊑ icmp IntPredicate.slt e (const? 64 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gsignhtesthandhor_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gsignhtesthandhor_proof.lean
@@ -10,7 +10,7 @@ set_option linter.unreachableTactic false
 section gsignhtesthandhor_proof
 theorem test1_thm (e e_1 : IntW 32) :
   LLVM.or (icmp IntPredicate.slt e_1 (const? 32 0)) (icmp IntPredicate.slt e (const? 32 0)) ⊑
-    icmp IntPredicate.slt (LLVM.or e_1 e) (const? 32 0) := by 
+    icmp IntPredicate.slt (LLVM.or e_1 e) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -21,7 +21,7 @@ theorem test1_thm (e e_1 : IntW 32) :
 
 theorem test2_thm (e e_1 : IntW 32) :
   LLVM.or (icmp IntPredicate.sgt e_1 (const? 32 (-1))) (icmp IntPredicate.sgt e (const? 32 (-1))) ⊑
-    icmp IntPredicate.sgt (LLVM.and e_1 e) (const? 32 (-1)) := by 
+    icmp IntPredicate.sgt (LLVM.and e_1 e) (const? 32 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -32,7 +32,7 @@ theorem test2_thm (e e_1 : IntW 32) :
 
 theorem test3_thm (e e_1 : IntW 32) :
   LLVM.and (icmp IntPredicate.slt e_1 (const? 32 0)) (icmp IntPredicate.slt e (const? 32 0)) ⊑
-    icmp IntPredicate.slt (LLVM.and e_1 e) (const? 32 0) := by 
+    icmp IntPredicate.slt (LLVM.and e_1 e) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -43,7 +43,7 @@ theorem test3_thm (e e_1 : IntW 32) :
 
 theorem test4_thm (e e_1 : IntW 32) :
   LLVM.and (icmp IntPredicate.sgt e_1 (const? 32 (-1))) (icmp IntPredicate.sgt e (const? 32 (-1))) ⊑
-    icmp IntPredicate.sgt (LLVM.or e_1 e) (const? 32 (-1)) := by 
+    icmp IntPredicate.sgt (LLVM.or e_1 e) (const? 32 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -55,7 +55,7 @@ theorem test4_thm (e e_1 : IntW 32) :
 theorem test9_thm (e : IntW 32) :
   LLVM.and (icmp IntPredicate.ne (LLVM.and e (const? 32 1073741824)) (const? 32 0))
       (icmp IntPredicate.sgt e (const? 32 (-1))) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 32 (-1073741824))) (const? 32 1073741824) := by 
+    icmp IntPredicate.eq (LLVM.and e (const? 32 (-1073741824))) (const? 32 1073741824) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -67,7 +67,7 @@ theorem test9_thm (e : IntW 32) :
 theorem test9_logical_thm (e : IntW 32) :
   select (icmp IntPredicate.ne (LLVM.and e (const? 32 1073741824)) (const? 32 0))
       (icmp IntPredicate.sgt e (const? 32 (-1))) (const? 1 0) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 32 (-1073741824))) (const? 32 1073741824) := by 
+    icmp IntPredicate.eq (LLVM.and e (const? 32 (-1073741824))) (const? 32 1073741824) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -78,7 +78,7 @@ theorem test9_logical_thm (e : IntW 32) :
 
 theorem test10_thm (e : IntW 32) :
   LLVM.and (icmp IntPredicate.eq (LLVM.and e (const? 32 2)) (const? 32 0)) (icmp IntPredicate.ult e (const? 32 4)) ⊑
-    icmp IntPredicate.ult e (const? 32 2) := by 
+    icmp IntPredicate.ult e (const? 32 2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -90,7 +90,7 @@ theorem test10_thm (e : IntW 32) :
 theorem test10_logical_thm (e : IntW 32) :
   select (icmp IntPredicate.eq (LLVM.and e (const? 32 2)) (const? 32 0)) (icmp IntPredicate.ult e (const? 32 4))
       (const? 1 0) ⊑
-    icmp IntPredicate.ult e (const? 32 2) := by 
+    icmp IntPredicate.ult e (const? 32 2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -101,7 +101,7 @@ theorem test10_logical_thm (e : IntW 32) :
 
 theorem test11_thm (e : IntW 32) :
   LLVM.or (icmp IntPredicate.ne (LLVM.and e (const? 32 2)) (const? 32 0)) (icmp IntPredicate.ugt e (const? 32 3)) ⊑
-    icmp IntPredicate.ugt e (const? 32 1) := by 
+    icmp IntPredicate.ugt e (const? 32 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -113,7 +113,7 @@ theorem test11_thm (e : IntW 32) :
 theorem test11_logical_thm (e : IntW 32) :
   select (icmp IntPredicate.ne (LLVM.and e (const? 32 2)) (const? 32 0)) (const? 1 1)
       (icmp IntPredicate.ugt e (const? 32 3)) ⊑
-    icmp IntPredicate.ugt e (const? 32 1) := by 
+    icmp IntPredicate.ugt e (const? 32 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gsignmaskhofhsexthvshofhshlhofhzext_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gsignmaskhofhsexthvshofhshlhofhzext_proof.lean
@@ -10,7 +10,7 @@ set_option linter.unreachableTactic false
 section gsignmaskhofhsexthvshofhshlhofhzext_proof
 theorem t0_thm (e : IntW 16) :
   LLVM.and (shl (zext 32 e) (const? 32 16)) (const? 32 (-2147483648)) ⊑
-    LLVM.and (sext 32 e) (const? 32 (-2147483648)) := by 
+    LLVM.and (sext 32 e) (const? 32 (-2147483648)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -21,7 +21,7 @@ theorem t0_thm (e : IntW 16) :
 
 theorem t1_thm (e : IntW 8) :
   LLVM.and (shl (zext 32 e) (const? 32 24)) (const? 32 (-2147483648)) ⊑
-    LLVM.and (sext 32 e) (const? 32 (-2147483648)) := by 
+    LLVM.and (sext 32 e) (const? 32 (-2147483648)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -31,7 +31,7 @@ theorem t1_thm (e : IntW 8) :
 
 
 theorem n2_thm (e : IntW 16) :
-  LLVM.and (shl (zext 32 e) (const? 32 15)) (const? 32 (-2147483648)) ⊑ const? 32 0 := by 
+  LLVM.and (shl (zext 32 e) (const? 32 15)) (const? 32 (-2147483648)) ⊑ const? 32 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -42,7 +42,7 @@ theorem n2_thm (e : IntW 16) :
 
 theorem n4_thm (e : IntW 16) :
   LLVM.and (shl (zext 32 e) (const? 32 16)) (const? 32 (-1073741824)) ⊑
-    LLVM.and (shl (zext 32 e) (const? 32 16) { «nsw» := false, «nuw» := true }) (const? 32 (-1073741824)) := by 
+    LLVM.and (shl (zext 32 e) (const? 32 16) { «nsw» := false, «nuw» := true }) (const? 32 (-1073741824)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gsinkhnothintohand_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gsinkhnothintohand_proof.lean
@@ -10,7 +10,7 @@ set_option linter.unreachableTactic false
 section gsinkhnothintohand_proof
 theorem t0_thm (e e_1 e_2 e_3 : IntW 32) :
   LLVM.xor (LLVM.and (icmp IntPredicate.eq e_3 e_2) (icmp IntPredicate.eq e_1 e)) (const? 1 1) ⊑
-    LLVM.or (icmp IntPredicate.ne e_3 e_2) (icmp IntPredicate.ne e_1 e) := by 
+    LLVM.or (icmp IntPredicate.ne e_3 e_2) (icmp IntPredicate.ne e_1 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gsinkhnothintohanotherhhandhofhand_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gsinkhnothintohanotherhhandhofhand_proof.lean
@@ -10,7 +10,7 @@ set_option linter.unreachableTactic false
 section gsinkhnothintohanotherhhandhofhand_proof
 theorem t0_thm (e e_1 e_2 e_3 : IntW 8) (e_4 : IntW 1) :
   select (LLVM.and (LLVM.xor e_4 (const? 1 1)) (icmp IntPredicate.eq e_3 e_2)) e_1 e ⊑
-    select (LLVM.or (icmp IntPredicate.ne e_3 e_2) e_4) e e_1 := by 
+    select (LLVM.or (icmp IntPredicate.ne e_3 e_2) e_4) e e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -21,7 +21,7 @@ theorem t0_thm (e e_1 e_2 e_3 : IntW 8) (e_4 : IntW 1) :
 
 theorem n2_thm (e e_1 : IntW 8) (e_2 : IntW 1) :
   LLVM.and (LLVM.xor e_2 (const? 1 1)) (icmp IntPredicate.eq e_1 e) ⊑
-    LLVM.and (icmp IntPredicate.eq e_1 e) (LLVM.xor e_2 (const? 1 1)) := by 
+    LLVM.and (icmp IntPredicate.eq e_1 e) (LLVM.xor e_2 (const? 1 1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gsinkhnothintohanotherhhandhofhlogicalhand_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gsinkhnothintohanotherhhandhofhlogicalhand_proof.lean
@@ -10,7 +10,7 @@ set_option linter.unreachableTactic false
 section gsinkhnothintohanotherhhandhofhlogicalhand_proof
 theorem t0_thm (e e_1 e_2 e_3 : IntW 8) (e_4 : IntW 1) :
   select (select (LLVM.xor e_4 (const? 1 1)) (icmp IntPredicate.eq e_3 e_2) (const? 1 0)) e_1 e ⊑
-    select (select e_4 (const? 1 1) (icmp IntPredicate.ne e_3 e_2)) e e_1 := by 
+    select (select e_4 (const? 1 1) (icmp IntPredicate.ne e_3 e_2)) e e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -21,7 +21,7 @@ theorem t0_thm (e e_1 e_2 e_3 : IntW 8) (e_4 : IntW 1) :
 
 theorem t0_commutative_thm (e e_1 : IntW 8) (e_2 : IntW 1) (e_3 e_4 : IntW 8) :
   select (select (icmp IntPredicate.eq e_4 e_3) (LLVM.xor e_2 (const? 1 1)) (const? 1 0)) e_1 e ⊑
-    select (select (icmp IntPredicate.ne e_4 e_3) (const? 1 1) e_2) e e_1 := by 
+    select (select (icmp IntPredicate.ne e_4 e_3) (const? 1 1) e_2) e e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gsinkhnothintohanotherhhandhofhlogicalhor_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gsinkhnothintohanotherhhandhofhlogicalhor_proof.lean
@@ -10,7 +10,7 @@ set_option linter.unreachableTactic false
 section gsinkhnothintohanotherhhandhofhlogicalhor_proof
 theorem t0_thm (e e_1 e_2 e_3 : IntW 8) (e_4 : IntW 1) :
   select (select (LLVM.xor e_4 (const? 1 1)) (const? 1 1) (icmp IntPredicate.eq e_3 e_2)) e_1 e ⊑
-    select (select e_4 (icmp IntPredicate.ne e_3 e_2) (const? 1 0)) e e_1 := by 
+    select (select e_4 (icmp IntPredicate.ne e_3 e_2) (const? 1 0)) e e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -21,7 +21,7 @@ theorem t0_thm (e e_1 e_2 e_3 : IntW 8) (e_4 : IntW 1) :
 
 theorem t0_commutative_thm (e e_1 : IntW 8) (e_2 : IntW 1) (e_3 e_4 : IntW 8) :
   select (select (icmp IntPredicate.eq e_4 e_3) (const? 1 1) (LLVM.xor e_2 (const? 1 1))) e_1 e ⊑
-    select (select (icmp IntPredicate.ne e_4 e_3) e_2 (const? 1 0)) e e_1 := by 
+    select (select (icmp IntPredicate.ne e_4 e_3) e_2 (const? 1 0)) e e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gsinkhnothintohanotherhhandhofhor_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gsinkhnothintohanotherhhandhofhor_proof.lean
@@ -10,7 +10,7 @@ set_option linter.unreachableTactic false
 section gsinkhnothintohanotherhhandhofhor_proof
 theorem t0_thm (e e_1 e_2 e_3 : IntW 8) (e_4 : IntW 1) :
   select (LLVM.or (LLVM.xor e_4 (const? 1 1)) (icmp IntPredicate.eq e_3 e_2)) e_1 e ⊑
-    select (LLVM.and (icmp IntPredicate.ne e_3 e_2) e_4) e e_1 := by 
+    select (LLVM.and (icmp IntPredicate.ne e_3 e_2) e_4) e e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -21,7 +21,7 @@ theorem t0_thm (e e_1 e_2 e_3 : IntW 8) (e_4 : IntW 1) :
 
 theorem n2_thm (e e_1 : IntW 8) (e_2 : IntW 1) :
   LLVM.or (LLVM.xor e_2 (const? 1 1)) (icmp IntPredicate.eq e_1 e) ⊑
-    LLVM.or (icmp IntPredicate.eq e_1 e) (LLVM.xor e_2 (const? 1 1)) := by 
+    LLVM.or (icmp IntPredicate.eq e_1 e) (LLVM.xor e_2 (const? 1 1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gsinkhnothintohlogicalhand_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gsinkhnothintohlogicalhand_proof.lean
@@ -10,7 +10,7 @@ set_option linter.unreachableTactic false
 section gsinkhnothintohlogicalhand_proof
 theorem t0_thm (e e_1 e_2 e_3 : IntW 32) :
   LLVM.xor (select (icmp IntPredicate.eq e_3 e_2) (icmp IntPredicate.eq e_1 e) (const? 1 0)) (const? 1 1) ⊑
-    select (icmp IntPredicate.ne e_3 e_2) (const? 1 1) (icmp IntPredicate.ne e_1 e) := by 
+    select (icmp IntPredicate.ne e_3 e_2) (const? 1 1) (icmp IntPredicate.ne e_1 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -21,7 +21,7 @@ theorem t0_thm (e e_1 e_2 e_3 : IntW 32) :
 
 theorem n2_thm (e e_1 : IntW 32) (e_2 : IntW 1) :
   LLVM.xor (select e_2 (icmp IntPredicate.eq e_1 e) (const? 1 0)) (const? 1 1) ⊑
-    select (LLVM.xor e_2 (const? 1 1)) (const? 1 1) (icmp IntPredicate.ne e_1 e) := by 
+    select (LLVM.xor e_2 (const? 1 1)) (const? 1 1) (icmp IntPredicate.ne e_1 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gsinkhnothintohlogicalhor_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gsinkhnothintohlogicalhor_proof.lean
@@ -10,7 +10,7 @@ set_option linter.unreachableTactic false
 section gsinkhnothintohlogicalhor_proof
 theorem t0_thm (e e_1 e_2 e_3 : IntW 32) :
   LLVM.xor (select (icmp IntPredicate.eq e_3 e_2) (const? 1 1) (icmp IntPredicate.eq e_1 e)) (const? 1 1) ⊑
-    select (icmp IntPredicate.ne e_3 e_2) (icmp IntPredicate.ne e_1 e) (const? 1 0) := by 
+    select (icmp IntPredicate.ne e_3 e_2) (icmp IntPredicate.ne e_1 e) (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -21,7 +21,7 @@ theorem t0_thm (e e_1 e_2 e_3 : IntW 32) :
 
 theorem n2_thm (e e_1 : IntW 32) (e_2 : IntW 1) :
   LLVM.xor (select e_2 (const? 1 1) (icmp IntPredicate.eq e_1 e)) (const? 1 1) ⊑
-    select (LLVM.xor e_2 (const? 1 1)) (icmp IntPredicate.ne e_1 e) (const? 1 0) := by 
+    select (LLVM.xor e_2 (const? 1 1)) (icmp IntPredicate.ne e_1 e) (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gsinkhnothintohor_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gsinkhnothintohor_proof.lean
@@ -10,7 +10,7 @@ set_option linter.unreachableTactic false
 section gsinkhnothintohor_proof
 theorem t0_thm (e e_1 e_2 e_3 : IntW 32) :
   LLVM.xor (LLVM.or (icmp IntPredicate.eq e_3 e_2) (icmp IntPredicate.eq e_1 e)) (const? 1 1) ⊑
-    LLVM.and (icmp IntPredicate.ne e_3 e_2) (icmp IntPredicate.ne e_1 e) := by 
+    LLVM.and (icmp IntPredicate.ne e_3 e_2) (icmp IntPredicate.ne e_1 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gsmaxhicmp_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gsmaxhicmp_proof.lean
@@ -9,7 +9,7 @@ set_option linter.unreachableTactic false
 
 section gsmaxhicmp_proof
 theorem eq_smax1_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.eq (select (icmp IntPredicate.sgt e_1 e) e_1 e) e_1 ⊑ icmp IntPredicate.sge e_1 e := by 
+  icmp IntPredicate.eq (select (icmp IntPredicate.sgt e_1 e) e_1 e) e_1 ⊑ icmp IntPredicate.sge e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -19,7 +19,7 @@ theorem eq_smax1_thm (e e_1 : IntW 32) :
 
 
 theorem eq_smax2_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.eq (select (icmp IntPredicate.sgt e_1 e) e_1 e) e ⊑ icmp IntPredicate.sge e e_1 := by 
+  icmp IntPredicate.eq (select (icmp IntPredicate.sgt e_1 e) e_1 e) e ⊑ icmp IntPredicate.sge e e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -31,7 +31,7 @@ theorem eq_smax2_thm (e e_1 : IntW 32) :
 theorem eq_smax3_thm (e e_1 : IntW 32) :
   icmp IntPredicate.eq (add e_1 (const? 32 3))
       (select (icmp IntPredicate.sgt (add e_1 (const? 32 3)) e) (add e_1 (const? 32 3)) e) ⊑
-    icmp IntPredicate.sge (add e_1 (const? 32 3)) e := by 
+    icmp IntPredicate.sge (add e_1 (const? 32 3)) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -43,7 +43,7 @@ theorem eq_smax3_thm (e e_1 : IntW 32) :
 theorem eq_smax4_thm (e e_1 : IntW 32) :
   icmp IntPredicate.eq (add e_1 (const? 32 3))
       (select (icmp IntPredicate.sgt e (add e_1 (const? 32 3))) e (add e_1 (const? 32 3))) ⊑
-    icmp IntPredicate.sge (add e_1 (const? 32 3)) e := by 
+    icmp IntPredicate.sge (add e_1 (const? 32 3)) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -53,7 +53,7 @@ theorem eq_smax4_thm (e e_1 : IntW 32) :
 
 
 theorem sle_smax1_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.sle (select (icmp IntPredicate.sgt e_1 e) e_1 e) e_1 ⊑ icmp IntPredicate.sle e e_1 := by 
+  icmp IntPredicate.sle (select (icmp IntPredicate.sgt e_1 e) e_1 e) e_1 ⊑ icmp IntPredicate.sle e e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -63,7 +63,7 @@ theorem sle_smax1_thm (e e_1 : IntW 32) :
 
 
 theorem sle_smax2_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.sle (select (icmp IntPredicate.sgt e_1 e) e_1 e) e ⊑ icmp IntPredicate.sle e_1 e := by 
+  icmp IntPredicate.sle (select (icmp IntPredicate.sgt e_1 e) e_1 e) e ⊑ icmp IntPredicate.sle e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -75,7 +75,7 @@ theorem sle_smax2_thm (e e_1 : IntW 32) :
 theorem sle_smax3_thm (e e_1 : IntW 32) :
   icmp IntPredicate.sge (add e_1 (const? 32 3))
       (select (icmp IntPredicate.sgt (add e_1 (const? 32 3)) e) (add e_1 (const? 32 3)) e) ⊑
-    icmp IntPredicate.sle e (add e_1 (const? 32 3)) := by 
+    icmp IntPredicate.sle e (add e_1 (const? 32 3)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -87,7 +87,7 @@ theorem sle_smax3_thm (e e_1 : IntW 32) :
 theorem sle_smax4_thm (e e_1 : IntW 32) :
   icmp IntPredicate.sge (add e_1 (const? 32 3))
       (select (icmp IntPredicate.sgt e (add e_1 (const? 32 3))) e (add e_1 (const? 32 3))) ⊑
-    icmp IntPredicate.sle e (add e_1 (const? 32 3)) := by 
+    icmp IntPredicate.sle e (add e_1 (const? 32 3)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -97,7 +97,7 @@ theorem sle_smax4_thm (e e_1 : IntW 32) :
 
 
 theorem ne_smax1_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.ne (select (icmp IntPredicate.sgt e_1 e) e_1 e) e_1 ⊑ icmp IntPredicate.slt e_1 e := by 
+  icmp IntPredicate.ne (select (icmp IntPredicate.sgt e_1 e) e_1 e) e_1 ⊑ icmp IntPredicate.slt e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -107,7 +107,7 @@ theorem ne_smax1_thm (e e_1 : IntW 32) :
 
 
 theorem ne_smax2_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.ne (select (icmp IntPredicate.sgt e_1 e) e_1 e) e ⊑ icmp IntPredicate.slt e e_1 := by 
+  icmp IntPredicate.ne (select (icmp IntPredicate.sgt e_1 e) e_1 e) e ⊑ icmp IntPredicate.slt e e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -119,7 +119,7 @@ theorem ne_smax2_thm (e e_1 : IntW 32) :
 theorem ne_smax3_thm (e e_1 : IntW 32) :
   icmp IntPredicate.ne (add e_1 (const? 32 3))
       (select (icmp IntPredicate.sgt (add e_1 (const? 32 3)) e) (add e_1 (const? 32 3)) e) ⊑
-    icmp IntPredicate.slt (add e_1 (const? 32 3)) e := by 
+    icmp IntPredicate.slt (add e_1 (const? 32 3)) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -131,7 +131,7 @@ theorem ne_smax3_thm (e e_1 : IntW 32) :
 theorem ne_smax4_thm (e e_1 : IntW 32) :
   icmp IntPredicate.ne (add e_1 (const? 32 3))
       (select (icmp IntPredicate.sgt e (add e_1 (const? 32 3))) e (add e_1 (const? 32 3))) ⊑
-    icmp IntPredicate.slt (add e_1 (const? 32 3)) e := by 
+    icmp IntPredicate.slt (add e_1 (const? 32 3)) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -141,7 +141,7 @@ theorem ne_smax4_thm (e e_1 : IntW 32) :
 
 
 theorem sgt_smax1_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.sgt (select (icmp IntPredicate.sgt e_1 e) e_1 e) e_1 ⊑ icmp IntPredicate.sgt e e_1 := by 
+  icmp IntPredicate.sgt (select (icmp IntPredicate.sgt e_1 e) e_1 e) e_1 ⊑ icmp IntPredicate.sgt e e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -151,7 +151,7 @@ theorem sgt_smax1_thm (e e_1 : IntW 32) :
 
 
 theorem sgt_smax2_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.sgt (select (icmp IntPredicate.sgt e_1 e) e_1 e) e ⊑ icmp IntPredicate.sgt e_1 e := by 
+  icmp IntPredicate.sgt (select (icmp IntPredicate.sgt e_1 e) e_1 e) e ⊑ icmp IntPredicate.sgt e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -163,7 +163,7 @@ theorem sgt_smax2_thm (e e_1 : IntW 32) :
 theorem sgt_smax3_thm (e e_1 : IntW 32) :
   icmp IntPredicate.slt (add e_1 (const? 32 3))
       (select (icmp IntPredicate.sgt (add e_1 (const? 32 3)) e) (add e_1 (const? 32 3)) e) ⊑
-    icmp IntPredicate.sgt e (add e_1 (const? 32 3)) := by 
+    icmp IntPredicate.sgt e (add e_1 (const? 32 3)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -175,7 +175,7 @@ theorem sgt_smax3_thm (e e_1 : IntW 32) :
 theorem sgt_smax4_thm (e e_1 : IntW 32) :
   icmp IntPredicate.slt (add e_1 (const? 32 3))
       (select (icmp IntPredicate.sgt e (add e_1 (const? 32 3))) e (add e_1 (const? 32 3))) ⊑
-    icmp IntPredicate.sgt e (add e_1 (const? 32 3)) := by 
+    icmp IntPredicate.sgt e (add e_1 (const? 32 3)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gsminhicmp_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gsminhicmp_proof.lean
@@ -9,7 +9,7 @@ set_option linter.unreachableTactic false
 
 section gsminhicmp_proof
 theorem eq_smin1_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.eq (select (icmp IntPredicate.slt e_1 e) e_1 e) e_1 ⊑ icmp IntPredicate.sle e_1 e := by 
+  icmp IntPredicate.eq (select (icmp IntPredicate.slt e_1 e) e_1 e) e_1 ⊑ icmp IntPredicate.sle e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -19,7 +19,7 @@ theorem eq_smin1_thm (e e_1 : IntW 32) :
 
 
 theorem eq_smin2_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.eq (select (icmp IntPredicate.slt e_1 e) e_1 e) e ⊑ icmp IntPredicate.sle e e_1 := by 
+  icmp IntPredicate.eq (select (icmp IntPredicate.slt e_1 e) e_1 e) e ⊑ icmp IntPredicate.sle e e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -31,7 +31,7 @@ theorem eq_smin2_thm (e e_1 : IntW 32) :
 theorem eq_smin3_thm (e e_1 : IntW 32) :
   icmp IntPredicate.eq (add e_1 (const? 32 3))
       (select (icmp IntPredicate.slt (add e_1 (const? 32 3)) e) (add e_1 (const? 32 3)) e) ⊑
-    icmp IntPredicate.sle (add e_1 (const? 32 3)) e := by 
+    icmp IntPredicate.sle (add e_1 (const? 32 3)) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -43,7 +43,7 @@ theorem eq_smin3_thm (e e_1 : IntW 32) :
 theorem eq_smin4_thm (e e_1 : IntW 32) :
   icmp IntPredicate.eq (add e_1 (const? 32 3))
       (select (icmp IntPredicate.slt e (add e_1 (const? 32 3))) e (add e_1 (const? 32 3))) ⊑
-    icmp IntPredicate.sle (add e_1 (const? 32 3)) e := by 
+    icmp IntPredicate.sle (add e_1 (const? 32 3)) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -53,7 +53,7 @@ theorem eq_smin4_thm (e e_1 : IntW 32) :
 
 
 theorem sge_smin1_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.sge (select (icmp IntPredicate.slt e_1 e) e_1 e) e_1 ⊑ icmp IntPredicate.sge e e_1 := by 
+  icmp IntPredicate.sge (select (icmp IntPredicate.slt e_1 e) e_1 e) e_1 ⊑ icmp IntPredicate.sge e e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -63,7 +63,7 @@ theorem sge_smin1_thm (e e_1 : IntW 32) :
 
 
 theorem sge_smin2_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.sge (select (icmp IntPredicate.slt e_1 e) e_1 e) e ⊑ icmp IntPredicate.sge e_1 e := by 
+  icmp IntPredicate.sge (select (icmp IntPredicate.slt e_1 e) e_1 e) e ⊑ icmp IntPredicate.sge e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -75,7 +75,7 @@ theorem sge_smin2_thm (e e_1 : IntW 32) :
 theorem sge_smin3_thm (e e_1 : IntW 32) :
   icmp IntPredicate.sle (add e_1 (const? 32 3))
       (select (icmp IntPredicate.slt (add e_1 (const? 32 3)) e) (add e_1 (const? 32 3)) e) ⊑
-    icmp IntPredicate.sge e (add e_1 (const? 32 3)) := by 
+    icmp IntPredicate.sge e (add e_1 (const? 32 3)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -87,7 +87,7 @@ theorem sge_smin3_thm (e e_1 : IntW 32) :
 theorem sge_smin4_thm (e e_1 : IntW 32) :
   icmp IntPredicate.sle (add e_1 (const? 32 3))
       (select (icmp IntPredicate.slt e (add e_1 (const? 32 3))) e (add e_1 (const? 32 3))) ⊑
-    icmp IntPredicate.sge e (add e_1 (const? 32 3)) := by 
+    icmp IntPredicate.sge e (add e_1 (const? 32 3)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -97,7 +97,7 @@ theorem sge_smin4_thm (e e_1 : IntW 32) :
 
 
 theorem ne_smin1_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.ne (select (icmp IntPredicate.slt e_1 e) e_1 e) e_1 ⊑ icmp IntPredicate.sgt e_1 e := by 
+  icmp IntPredicate.ne (select (icmp IntPredicate.slt e_1 e) e_1 e) e_1 ⊑ icmp IntPredicate.sgt e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -107,7 +107,7 @@ theorem ne_smin1_thm (e e_1 : IntW 32) :
 
 
 theorem ne_smin2_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.ne (select (icmp IntPredicate.slt e_1 e) e_1 e) e ⊑ icmp IntPredicate.sgt e e_1 := by 
+  icmp IntPredicate.ne (select (icmp IntPredicate.slt e_1 e) e_1 e) e ⊑ icmp IntPredicate.sgt e e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -119,7 +119,7 @@ theorem ne_smin2_thm (e e_1 : IntW 32) :
 theorem ne_smin3_thm (e e_1 : IntW 32) :
   icmp IntPredicate.ne (add e_1 (const? 32 3))
       (select (icmp IntPredicate.slt (add e_1 (const? 32 3)) e) (add e_1 (const? 32 3)) e) ⊑
-    icmp IntPredicate.sgt (add e_1 (const? 32 3)) e := by 
+    icmp IntPredicate.sgt (add e_1 (const? 32 3)) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -131,7 +131,7 @@ theorem ne_smin3_thm (e e_1 : IntW 32) :
 theorem ne_smin4_thm (e e_1 : IntW 32) :
   icmp IntPredicate.ne (add e_1 (const? 32 3))
       (select (icmp IntPredicate.slt e (add e_1 (const? 32 3))) e (add e_1 (const? 32 3))) ⊑
-    icmp IntPredicate.sgt (add e_1 (const? 32 3)) e := by 
+    icmp IntPredicate.sgt (add e_1 (const? 32 3)) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -141,7 +141,7 @@ theorem ne_smin4_thm (e e_1 : IntW 32) :
 
 
 theorem slt_smin1_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.slt (select (icmp IntPredicate.slt e_1 e) e_1 e) e_1 ⊑ icmp IntPredicate.slt e e_1 := by 
+  icmp IntPredicate.slt (select (icmp IntPredicate.slt e_1 e) e_1 e) e_1 ⊑ icmp IntPredicate.slt e e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -151,7 +151,7 @@ theorem slt_smin1_thm (e e_1 : IntW 32) :
 
 
 theorem slt_smin2_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.slt (select (icmp IntPredicate.slt e_1 e) e_1 e) e ⊑ icmp IntPredicate.slt e_1 e := by 
+  icmp IntPredicate.slt (select (icmp IntPredicate.slt e_1 e) e_1 e) e ⊑ icmp IntPredicate.slt e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -163,7 +163,7 @@ theorem slt_smin2_thm (e e_1 : IntW 32) :
 theorem slt_smin3_thm (e e_1 : IntW 32) :
   icmp IntPredicate.sgt (add e_1 (const? 32 3))
       (select (icmp IntPredicate.slt (add e_1 (const? 32 3)) e) (add e_1 (const? 32 3)) e) ⊑
-    icmp IntPredicate.slt e (add e_1 (const? 32 3)) := by 
+    icmp IntPredicate.slt e (add e_1 (const? 32 3)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -175,7 +175,7 @@ theorem slt_smin3_thm (e e_1 : IntW 32) :
 theorem slt_smin4_thm (e e_1 : IntW 32) :
   icmp IntPredicate.sgt (add e_1 (const? 32 3))
       (select (icmp IntPredicate.slt e (add e_1 (const? 32 3))) e (add e_1 (const? 32 3))) ⊑
-    icmp IntPredicate.slt e (add e_1 (const? 32 3)) := by 
+    icmp IntPredicate.slt e (add e_1 (const? 32 3)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -185,7 +185,7 @@ theorem slt_smin4_thm (e e_1 : IntW 32) :
 
 
 theorem sle_smin1_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.sle (select (icmp IntPredicate.slt e_1 e) e_1 e) e_1 ⊑ const? 1 1 := by 
+  icmp IntPredicate.sle (select (icmp IntPredicate.slt e_1 e) e_1 e) e_1 ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -195,7 +195,7 @@ theorem sle_smin1_thm (e e_1 : IntW 32) :
 
 
 theorem sle_smin2_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.sle (select (icmp IntPredicate.slt e_1 e) e_1 e) e ⊑ const? 1 1 := by 
+  icmp IntPredicate.sle (select (icmp IntPredicate.slt e_1 e) e_1 e) e ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -207,7 +207,7 @@ theorem sle_smin2_thm (e e_1 : IntW 32) :
 theorem sle_smin3_thm (e e_1 : IntW 32) :
   icmp IntPredicate.sge (add e_1 (const? 32 3))
       (select (icmp IntPredicate.slt (add e_1 (const? 32 3)) e) (add e_1 (const? 32 3)) e) ⊑
-    const? 1 1 := by 
+    const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -219,7 +219,7 @@ theorem sle_smin3_thm (e e_1 : IntW 32) :
 theorem sle_smin4_thm (e e_1 : IntW 32) :
   icmp IntPredicate.sge (add e_1 (const? 32 3))
       (select (icmp IntPredicate.slt e (add e_1 (const? 32 3))) e (add e_1 (const? 32 3))) ⊑
-    const? 1 1 := by 
+    const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -229,7 +229,7 @@ theorem sle_smin4_thm (e e_1 : IntW 32) :
 
 
 theorem sgt_smin1_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.sgt (select (icmp IntPredicate.slt e_1 e) e_1 e) e_1 ⊑ const? 1 0 := by 
+  icmp IntPredicate.sgt (select (icmp IntPredicate.slt e_1 e) e_1 e) e_1 ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -239,7 +239,7 @@ theorem sgt_smin1_thm (e e_1 : IntW 32) :
 
 
 theorem sgt_smin2_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.sgt (select (icmp IntPredicate.slt e_1 e) e_1 e) e ⊑ const? 1 0 := by 
+  icmp IntPredicate.sgt (select (icmp IntPredicate.slt e_1 e) e_1 e) e ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -251,7 +251,7 @@ theorem sgt_smin2_thm (e e_1 : IntW 32) :
 theorem sgt_smin3_thm (e e_1 : IntW 32) :
   icmp IntPredicate.slt (add e_1 (const? 32 3))
       (select (icmp IntPredicate.slt (add e_1 (const? 32 3)) e) (add e_1 (const? 32 3)) e) ⊑
-    const? 1 0 := by 
+    const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -263,7 +263,7 @@ theorem sgt_smin3_thm (e e_1 : IntW 32) :
 theorem sgt_smin4_thm (e e_1 : IntW 32) :
   icmp IntPredicate.slt (add e_1 (const? 32 3))
       (select (icmp IntPredicate.slt e (add e_1 (const? 32 3))) e (add e_1 (const? 32 3))) ⊑
-    const? 1 0 := by 
+    const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gsremhcanonicalize_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gsremhcanonicalize_proof.lean
@@ -10,7 +10,7 @@ set_option linter.unreachableTactic false
 section gsremhcanonicalize_proof
 theorem test_srem_canonicalize_op0_thm (e e_1 : IntW 32) :
   LLVM.srem (sub (const? 32 0) e_1 { «nsw» := true, «nuw» := false }) e ⊑
-    sub (const? 32 0) (LLVM.srem e_1 e) { «nsw» := true, «nuw» := false } := by 
+    sub (const? 32 0) (LLVM.srem e_1 e) { «nsw» := true, «nuw» := false } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gsremhsimplifyhbug_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gsremhsimplifyhbug_proof.lean
@@ -9,7 +9,7 @@ set_option linter.unreachableTactic false
 
 section gsremhsimplifyhbug_proof
 theorem f_thm (e : IntW 32) :
-  icmp IntPredicate.ne (LLVM.srem (LLVM.or e (const? 32 1)) (const? 32 1)) (const? 32 0) ⊑ const? 1 0 := by 
+  icmp IntPredicate.ne (LLVM.srem (LLVM.or e (const? 32 1)) (const? 32 1)) (const? 32 0) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gsubhandhorhneghxor_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gsubhandhorhneghxor_proof.lean
@@ -9,7 +9,7 @@ set_option linter.unreachableTactic false
 
 section gsubhandhorhneghxor_proof
 theorem sub_to_xor_thm (e e_1 : IntW 32) :
-  sub (LLVM.and e_1 e) (LLVM.or e_1 e) ⊑ sub (const? 32 0) (LLVM.xor e_1 e) := by 
+  sub (LLVM.and e_1 e) (LLVM.or e_1 e) ⊑ sub (const? 32 0) (LLVM.xor e_1 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -19,7 +19,7 @@ theorem sub_to_xor_thm (e e_1 : IntW 32) :
 
 
 theorem sub_to_xor_or_commuted_thm (e e_1 : IntW 32) :
-  sub (LLVM.and e_1 e) (LLVM.or e e_1) ⊑ sub (const? 32 0) (LLVM.xor e_1 e) := by 
+  sub (LLVM.and e_1 e) (LLVM.or e e_1) ⊑ sub (const? 32 0) (LLVM.xor e_1 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -29,7 +29,7 @@ theorem sub_to_xor_or_commuted_thm (e e_1 : IntW 32) :
 
 
 theorem sub_to_xor_and_commuted_thm (e e_1 : IntW 32) :
-  sub (LLVM.and e_1 e) (LLVM.or e e_1) ⊑ sub (const? 32 0) (LLVM.xor e_1 e) := by 
+  sub (LLVM.and e_1 e) (LLVM.or e e_1) ⊑ sub (const? 32 0) (LLVM.xor e_1 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gsubhashrhandhtohicmphselect_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gsubhashrhandhtohicmphselect_proof.lean
@@ -10,7 +10,7 @@ set_option linter.unreachableTactic false
 section gsubhashrhandhtohicmphselect_proof
 theorem sub_ashr_and_i8_thm (e e_1 : IntW 8) :
   LLVM.and (ashr (sub e_1 e { «nsw» := true, «nuw» := false }) (const? 8 7)) e ⊑
-    select (icmp IntPredicate.slt e_1 e) e (const? 8 0) := by 
+    select (icmp IntPredicate.slt e_1 e) e (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -21,7 +21,7 @@ theorem sub_ashr_and_i8_thm (e e_1 : IntW 8) :
 
 theorem sub_ashr_and_i16_thm (e e_1 : IntW 16) :
   LLVM.and (ashr (sub e_1 e { «nsw» := true, «nuw» := false }) (const? 16 15)) e ⊑
-    select (icmp IntPredicate.slt e_1 e) e (const? 16 0) := by 
+    select (icmp IntPredicate.slt e_1 e) e (const? 16 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -32,7 +32,7 @@ theorem sub_ashr_and_i16_thm (e e_1 : IntW 16) :
 
 theorem sub_ashr_and_i32_thm (e e_1 : IntW 32) :
   LLVM.and (ashr (sub e_1 e { «nsw» := true, «nuw» := false }) (const? 32 31)) e ⊑
-    select (icmp IntPredicate.slt e_1 e) e (const? 32 0) := by 
+    select (icmp IntPredicate.slt e_1 e) e (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -43,7 +43,7 @@ theorem sub_ashr_and_i32_thm (e e_1 : IntW 32) :
 
 theorem sub_ashr_and_i64_thm (e e_1 : IntW 64) :
   LLVM.and (ashr (sub e_1 e { «nsw» := true, «nuw» := false }) (const? 64 63)) e ⊑
-    select (icmp IntPredicate.slt e_1 e) e (const? 64 0) := by 
+    select (icmp IntPredicate.slt e_1 e) e (const? 64 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -54,7 +54,7 @@ theorem sub_ashr_and_i64_thm (e e_1 : IntW 64) :
 
 theorem sub_ashr_and_i32_nuw_nsw_thm (e e_1 : IntW 32) :
   LLVM.and (ashr (sub e_1 e { «nsw» := true, «nuw» := true }) (const? 32 31)) e ⊑
-    select (icmp IntPredicate.slt e_1 e) e (const? 32 0) := by 
+    select (icmp IntPredicate.slt e_1 e) e (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -65,7 +65,7 @@ theorem sub_ashr_and_i32_nuw_nsw_thm (e e_1 : IntW 32) :
 
 theorem sub_ashr_and_i32_commute_thm (e e_1 : IntW 32) :
   LLVM.and e_1 (ashr (sub e e_1 { «nsw» := true, «nuw» := false }) (const? 32 31)) ⊑
-    select (icmp IntPredicate.slt e e_1) e_1 (const? 32 0) := by 
+    select (icmp IntPredicate.slt e e_1) e_1 (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gsubhashrhorhtohicmphselect_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gsubhashrhorhtohicmphselect_proof.lean
@@ -10,7 +10,7 @@ set_option linter.unreachableTactic false
 section gsubhashrhorhtohicmphselect_proof
 theorem sub_ashr_or_i8_thm (e e_1 : IntW 8) :
   LLVM.or (ashr (sub e_1 e { «nsw» := true, «nuw» := false }) (const? 8 7)) e ⊑
-    select (icmp IntPredicate.slt e_1 e) (const? 8 (-1)) e := by 
+    select (icmp IntPredicate.slt e_1 e) (const? 8 (-1)) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -21,7 +21,7 @@ theorem sub_ashr_or_i8_thm (e e_1 : IntW 8) :
 
 theorem sub_ashr_or_i16_thm (e e_1 : IntW 16) :
   LLVM.or (ashr (sub e_1 e { «nsw» := true, «nuw» := false }) (const? 16 15)) e ⊑
-    select (icmp IntPredicate.slt e_1 e) (const? 16 (-1)) e := by 
+    select (icmp IntPredicate.slt e_1 e) (const? 16 (-1)) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -32,7 +32,7 @@ theorem sub_ashr_or_i16_thm (e e_1 : IntW 16) :
 
 theorem sub_ashr_or_i32_thm (e e_1 : IntW 32) :
   LLVM.or (ashr (sub e_1 e { «nsw» := true, «nuw» := false }) (const? 32 31)) e ⊑
-    select (icmp IntPredicate.slt e_1 e) (const? 32 (-1)) e := by 
+    select (icmp IntPredicate.slt e_1 e) (const? 32 (-1)) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -43,7 +43,7 @@ theorem sub_ashr_or_i32_thm (e e_1 : IntW 32) :
 
 theorem sub_ashr_or_i64_thm (e e_1 : IntW 64) :
   LLVM.or (ashr (sub e_1 e { «nsw» := true, «nuw» := false }) (const? 64 63)) e ⊑
-    select (icmp IntPredicate.slt e_1 e) (const? 64 (-1)) e := by 
+    select (icmp IntPredicate.slt e_1 e) (const? 64 (-1)) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -53,7 +53,7 @@ theorem sub_ashr_or_i64_thm (e e_1 : IntW 64) :
 
 
 theorem neg_or_ashr_i32_thm (e : IntW 32) :
-  ashr (LLVM.or (sub (const? 32 0) e) e) (const? 32 31) ⊑ sext 32 (icmp IntPredicate.ne e (const? 32 0)) := by 
+  ashr (LLVM.or (sub (const? 32 0) e) e) (const? 32 31) ⊑ sext 32 (icmp IntPredicate.ne e (const? 32 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -64,7 +64,7 @@ theorem neg_or_ashr_i32_thm (e : IntW 32) :
 
 theorem sub_ashr_or_i32_nuw_nsw_thm (e e_1 : IntW 32) :
   LLVM.or (ashr (sub e_1 e { «nsw» := true, «nuw» := true }) (const? 32 31)) e ⊑
-    select (icmp IntPredicate.slt e_1 e) (const? 32 (-1)) e := by 
+    select (icmp IntPredicate.slt e_1 e) (const? 32 (-1)) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -75,7 +75,7 @@ theorem sub_ashr_or_i32_nuw_nsw_thm (e e_1 : IntW 32) :
 
 theorem sub_ashr_or_i32_commute_thm (e e_1 : IntW 32) :
   LLVM.or e_1 (ashr (sub e e_1 { «nsw» := true, «nuw» := false }) (const? 32 31)) ⊑
-    select (icmp IntPredicate.slt e e_1) (const? 32 (-1)) e_1 := by 
+    select (icmp IntPredicate.slt e e_1) (const? 32 (-1)) e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -86,7 +86,7 @@ theorem sub_ashr_or_i32_commute_thm (e e_1 : IntW 32) :
 
 theorem neg_or_ashr_i32_commute_thm (e : IntW 32) :
   ashr (LLVM.or (LLVM.sdiv (const? 32 42) e) (sub (const? 32 0) (LLVM.sdiv (const? 32 42) e))) (const? 32 31) ⊑
-    sext 32 (icmp IntPredicate.ne (LLVM.sdiv (const? 32 42) e) (const? 32 0)) := by 
+    sext 32 (icmp IntPredicate.ne (LLVM.sdiv (const? 32 42) e) (const? 32 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gsubhfromhsub_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gsubhfromhsub_proof.lean
@@ -8,7 +8,7 @@ set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
 
 section gsubhfromhsub_proof
-theorem t0_thm (e e_1 e_2 : IntW 8) : sub (sub e_2 e_1) e ⊑ sub e_2 (add e_1 e) := by 
+theorem t0_thm (e e_1 e_2 : IntW 8) : sub (sub e_2 e_1) e ⊑ sub e_2 (add e_1 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -19,7 +19,7 @@ theorem t0_thm (e e_1 e_2 : IntW 8) : sub (sub e_2 e_1) e ⊑ sub e_2 (add e_1 e
 
 theorem t1_flags_thm (e e_1 e_2 : IntW 8) :
   sub (sub e_2 e_1 { «nsw» := true, «nuw» := true }) e { «nsw» := true, «nuw» := true } ⊑
-    sub e_2 (add e_1 e { «nsw» := true, «nuw» := true }) { «nsw» := true, «nuw» := true } := by 
+    sub e_2 (add e_1 e { «nsw» := true, «nuw» := true }) { «nsw» := true, «nuw» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -30,7 +30,7 @@ theorem t1_flags_thm (e e_1 e_2 : IntW 8) :
 
 theorem t1_flags_nuw_only_thm (e e_1 e_2 : IntW 8) :
   sub (sub e_2 e_1 { «nsw» := false, «nuw» := true }) e { «nsw» := false, «nuw» := true } ⊑
-    sub e_2 (add e_1 e { «nsw» := false, «nuw» := true }) { «nsw» := false, «nuw» := true } := by 
+    sub e_2 (add e_1 e { «nsw» := false, «nuw» := true }) { «nsw» := false, «nuw» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -40,7 +40,7 @@ theorem t1_flags_nuw_only_thm (e e_1 e_2 : IntW 8) :
 
 
 theorem t1_flags_sub_nsw_sub_thm (e e_1 e_2 : IntW 8) :
-  sub (sub e_2 e_1 { «nsw» := true, «nuw» := false }) e ⊑ sub e_2 (add e_1 e) := by 
+  sub (sub e_2 e_1 { «nsw» := true, «nuw» := false }) e ⊑ sub e_2 (add e_1 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -50,7 +50,7 @@ theorem t1_flags_sub_nsw_sub_thm (e e_1 e_2 : IntW 8) :
 
 
 theorem t1_flags_nuw_first_thm (e e_1 e_2 : IntW 8) :
-  sub (sub e_2 e_1 { «nsw» := false, «nuw» := true }) e ⊑ sub e_2 (add e_1 e) := by 
+  sub (sub e_2 e_1 { «nsw» := false, «nuw» := true }) e ⊑ sub e_2 (add e_1 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -60,7 +60,7 @@ theorem t1_flags_nuw_first_thm (e e_1 e_2 : IntW 8) :
 
 
 theorem t1_flags_nuw_second_thm (e e_1 e_2 : IntW 8) :
-  sub (sub e_2 e_1) e { «nsw» := false, «nuw» := true } ⊑ sub e_2 (add e_1 e) := by 
+  sub (sub e_2 e_1) e { «nsw» := false, «nuw» := true } ⊑ sub e_2 (add e_1 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -70,7 +70,7 @@ theorem t1_flags_nuw_second_thm (e e_1 e_2 : IntW 8) :
 
 
 theorem t1_flags_nuw_nsw_first_thm (e e_1 e_2 : IntW 8) :
-  sub (sub e_2 e_1 { «nsw» := true, «nuw» := true }) e ⊑ sub e_2 (add e_1 e) := by 
+  sub (sub e_2 e_1 { «nsw» := true, «nuw» := true }) e ⊑ sub e_2 (add e_1 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -80,7 +80,7 @@ theorem t1_flags_nuw_nsw_first_thm (e e_1 e_2 : IntW 8) :
 
 
 theorem t1_flags_nuw_nsw_second_thm (e e_1 e_2 : IntW 8) :
-  sub (sub e_2 e_1) e { «nsw» := true, «nuw» := true } ⊑ sub e_2 (add e_1 e) := by 
+  sub (sub e_2 e_1) e { «nsw» := true, «nuw» := true } ⊑ sub e_2 (add e_1 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -89,7 +89,7 @@ theorem t1_flags_nuw_nsw_second_thm (e e_1 e_2 : IntW 8) :
     all_goals sorry
 
 
-theorem t3_c0_thm (e e_1 : IntW 8) : sub (sub (const? 8 42) e_1) e ⊑ sub (const? 8 42) (add e_1 e) := by 
+theorem t3_c0_thm (e e_1 : IntW 8) : sub (sub (const? 8 42) e_1) e ⊑ sub (const? 8 42) (add e_1 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -98,7 +98,7 @@ theorem t3_c0_thm (e e_1 : IntW 8) : sub (sub (const? 8 42) e_1) e ⊑ sub (cons
     all_goals sorry
 
 
-theorem t4_c1_thm (e e_1 : IntW 8) : sub (sub e_1 (const? 8 42)) e ⊑ sub (add e_1 (const? 8 (-42))) e := by 
+theorem t4_c1_thm (e e_1 : IntW 8) : sub (sub e_1 (const? 8 42)) e ⊑ sub (add e_1 (const? 8 (-42))) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -107,7 +107,7 @@ theorem t4_c1_thm (e e_1 : IntW 8) : sub (sub e_1 (const? 8 42)) e ⊑ sub (add 
     all_goals sorry
 
 
-theorem t5_c2_thm (e e_1 : IntW 8) : sub (sub e_1 e) (const? 8 42) ⊑ add (sub e_1 e) (const? 8 (-42)) := by 
+theorem t5_c2_thm (e e_1 : IntW 8) : sub (sub e_1 e) (const? 8 42) ⊑ add (sub e_1 e) (const? 8 (-42)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -116,7 +116,7 @@ theorem t5_c2_thm (e e_1 : IntW 8) : sub (sub e_1 e) (const? 8 42) ⊑ add (sub 
     all_goals sorry
 
 
-theorem t9_c0_c2_thm (e : IntW 8) : sub (sub (const? 8 42) e) (const? 8 24) ⊑ sub (const? 8 18) e := by 
+theorem t9_c0_c2_thm (e : IntW 8) : sub (sub (const? 8 42) e) (const? 8 24) ⊑ sub (const? 8 18) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -125,7 +125,7 @@ theorem t9_c0_c2_thm (e : IntW 8) : sub (sub (const? 8 42) e) (const? 8 24) ⊑ 
     all_goals sorry
 
 
-theorem t10_c1_c2_thm (e : IntW 8) : sub (sub e (const? 8 42)) (const? 8 24) ⊑ add e (const? 8 (-66)) := by 
+theorem t10_c1_c2_thm (e : IntW 8) : sub (sub e (const? 8 42)) (const? 8 24) ⊑ add e (const? 8 (-66)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gsubhlshrhorhtohicmphselect_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gsubhlshrhorhtohicmphselect_proof.lean
@@ -9,7 +9,7 @@ set_option linter.unreachableTactic false
 
 section gsubhlshrhorhtohicmphselect_proof
 theorem neg_or_lshr_i32_thm (e : IntW 32) :
-  lshr (LLVM.or (sub (const? 32 0) e) e) (const? 32 31) ⊑ zext 32 (icmp IntPredicate.ne e (const? 32 0)) := by 
+  lshr (LLVM.or (sub (const? 32 0) e) e) (const? 32 31) ⊑ zext 32 (icmp IntPredicate.ne e (const? 32 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -20,7 +20,7 @@ theorem neg_or_lshr_i32_thm (e : IntW 32) :
 
 theorem neg_or_lshr_i32_commute_thm (e : IntW 32) :
   lshr (LLVM.or (LLVM.sdiv (const? 32 42) e) (sub (const? 32 0) (LLVM.sdiv (const? 32 42) e))) (const? 32 31) ⊑
-    zext 32 (icmp IntPredicate.ne (LLVM.sdiv (const? 32 42) e) (const? 32 0)) := by 
+    zext 32 (icmp IntPredicate.ne (LLVM.sdiv (const? 32 42) e) (const? 32 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gsubhnot_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gsubhnot_proof.lean
@@ -9,7 +9,7 @@ set_option linter.unreachableTactic false
 
 section gsubhnot_proof
 theorem sub_not_thm (e e_1 : IntW 8) :
-  LLVM.xor (sub e_1 e) (const? 8 (-1)) ⊑ add e (LLVM.xor e_1 (const? 8 (-1))) := by 
+  LLVM.xor (sub e_1 e) (const? 8 (-1)) ⊑ add e (LLVM.xor e_1 (const? 8 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -18,7 +18,7 @@ theorem sub_not_thm (e e_1 : IntW 8) :
     all_goals sorry
 
 
-theorem dec_sub_thm (e e_1 : IntW 8) : add (sub e_1 e) (const? 8 (-1)) ⊑ add e_1 (LLVM.xor e (const? 8 (-1))) := by 
+theorem dec_sub_thm (e e_1 : IntW 8) : add (sub e_1 e) (const? 8 (-1)) ⊑ add e_1 (LLVM.xor e (const? 8 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -27,7 +27,7 @@ theorem dec_sub_thm (e e_1 : IntW 8) : add (sub e_1 e) (const? 8 (-1)) ⊑ add e
     all_goals sorry
 
 
-theorem sub_inc_thm (e e_1 : IntW 8) : sub e_1 (add e (const? 8 1)) ⊑ add e_1 (LLVM.xor e (const? 8 (-1))) := by 
+theorem sub_inc_thm (e e_1 : IntW 8) : sub e_1 (add e (const? 8 1)) ⊑ add e_1 (LLVM.xor e (const? 8 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -36,7 +36,7 @@ theorem sub_inc_thm (e e_1 : IntW 8) : sub e_1 (add e (const? 8 1)) ⊑ add e_1 
     all_goals sorry
 
 
-theorem sub_dec_thm (e e_1 : IntW 8) : sub (add e_1 (const? 8 (-1))) e ⊑ add e_1 (LLVM.xor e (const? 8 (-1))) := by 
+theorem sub_dec_thm (e e_1 : IntW 8) : sub (add e_1 (const? 8 (-1))) e ⊑ add e_1 (LLVM.xor e (const? 8 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gsubhofhnegatible_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gsubhofhnegatible_proof.lean
@@ -8,7 +8,7 @@ set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
 
 section gsubhofhnegatible_proof
-theorem t0_thm (e : IntW 8) : sub e (const? 8 (-42)) ⊑ add e (const? 8 42) := by 
+theorem t0_thm (e : IntW 8) : sub e (const? 8 (-42)) ⊑ add e (const? 8 42) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -17,7 +17,7 @@ theorem t0_thm (e : IntW 8) : sub e (const? 8 (-42)) ⊑ add e (const? 8 42) := 
     all_goals sorry
 
 
-theorem t2_thm (e e_1 : IntW 8) : sub e_1 (shl (const? 8 (-42)) e) ⊑ add (shl (const? 8 42) e) e_1 := by 
+theorem t2_thm (e e_1 : IntW 8) : sub e_1 (shl (const? 8 (-42)) e) ⊑ add (shl (const? 8 42) e) e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -27,7 +27,7 @@ theorem t2_thm (e e_1 : IntW 8) : sub e_1 (shl (const? 8 (-42)) e) ⊑ add (shl 
 
 
 theorem t4_thm (e : IntW 1) (e_1 : IntW 8) :
-  sub e_1 (select e (const? 8 (-42)) (const? 8 44)) ⊑ add (select e (const? 8 42) (const? 8 (-44))) e_1 := by 
+  sub e_1 (select e (const? 8 (-42)) (const? 8 44)) ⊑ add (select e (const? 8 42) (const? 8 (-44))) e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -39,7 +39,7 @@ theorem t4_thm (e : IntW 1) (e_1 : IntW 8) :
 theorem PR52261_thm (e : IntW 1) :
   LLVM.and (select e (const? 32 2) (const? 32 (-2)))
       (sub (const? 32 0) (select e (const? 32 2) (const? 32 (-2))) { «nsw» := true, «nuw» := false }) ⊑
-    const? 32 2 := by 
+    const? 32 2 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -50,7 +50,7 @@ theorem PR52261_thm (e : IntW 1) :
 
 theorem t7_thm (e : IntW 8) (e_1 : IntW 1) (e_2 : IntW 8) :
   sub e_2 (select e_1 (const? 8 0) (shl (const? 8 1) e)) ⊑
-    add (select e_1 (const? 8 0) (shl (const? 8 (-1)) e { «nsw» := true, «nuw» := false })) e_2 := by 
+    add (select e_1 (const? 8 0) (shl (const? 8 (-1)) e { «nsw» := true, «nuw» := false })) e_2 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -59,7 +59,7 @@ theorem t7_thm (e : IntW 8) (e_1 : IntW 1) (e_2 : IntW 8) :
     all_goals sorry
 
 
-theorem t9_thm (e e_1 : IntW 8) : sub (const? 8 0) (sub e_1 e) ⊑ sub e e_1 := by 
+theorem t9_thm (e e_1 : IntW 8) : sub (const? 8 0) (sub e_1 e) ⊑ sub e e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -68,7 +68,7 @@ theorem t9_thm (e e_1 : IntW 8) : sub (const? 8 0) (sub e_1 e) ⊑ sub e e_1 := 
     all_goals sorry
 
 
-theorem neg_of_sub_from_constant_thm (e : IntW 8) : sub (const? 8 0) (sub (const? 8 42) e) ⊑ add e (const? 8 (-42)) := by 
+theorem neg_of_sub_from_constant_thm (e : IntW 8) : sub (const? 8 0) (sub (const? 8 42) e) ⊑ add e (const? 8 (-42)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -77,7 +77,7 @@ theorem neg_of_sub_from_constant_thm (e : IntW 8) : sub (const? 8 0) (sub (const
     all_goals sorry
 
 
-theorem sub_from_constant_of_sub_from_constant_thm (e : IntW 8) : sub (const? 8 11) (sub (const? 8 42) e) ⊑ add e (const? 8 (-31)) := by 
+theorem sub_from_constant_of_sub_from_constant_thm (e : IntW 8) : sub (const? 8 11) (sub (const? 8 42) e) ⊑ add e (const? 8 (-31)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -86,7 +86,7 @@ theorem sub_from_constant_of_sub_from_constant_thm (e : IntW 8) : sub (const? 8 
     all_goals sorry
 
 
-theorem sub_from_variable_of_sub_from_constant_thm (e e_1 : IntW 8) : sub e_1 (sub (const? 8 42) e) ⊑ add (add e (const? 8 (-42))) e_1 := by 
+theorem sub_from_variable_of_sub_from_constant_thm (e e_1 : IntW 8) : sub e_1 (sub (const? 8 42) e) ⊑ add (add e (const? 8 (-42))) e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -95,7 +95,7 @@ theorem sub_from_variable_of_sub_from_constant_thm (e e_1 : IntW 8) : sub e_1 (s
     all_goals sorry
 
 
-theorem neg_of_add_with_constant_thm (e : IntW 8) : sub (const? 8 0) (add e (const? 8 42)) ⊑ sub (const? 8 (-42)) e := by 
+theorem neg_of_add_with_constant_thm (e : IntW 8) : sub (const? 8 0) (add e (const? 8 42)) ⊑ sub (const? 8 (-42)) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -104,7 +104,7 @@ theorem neg_of_add_with_constant_thm (e : IntW 8) : sub (const? 8 0) (add e (con
     all_goals sorry
 
 
-theorem sub_from_constant_of_add_with_constant_thm (e : IntW 8) : sub (const? 8 11) (add e (const? 8 42)) ⊑ sub (const? 8 (-31)) e := by 
+theorem sub_from_constant_of_add_with_constant_thm (e : IntW 8) : sub (const? 8 11) (add e (const? 8 42)) ⊑ sub (const? 8 (-31)) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -114,7 +114,7 @@ theorem sub_from_constant_of_add_with_constant_thm (e : IntW 8) : sub (const? 8 
 
 
 theorem t20_thm (e : IntW 16) (e_1 : IntW 8) :
-  sub e_1 (trunc 8 (shl (const? 16 (-42)) e)) ⊑ add e_1 (trunc 8 (shl (const? 16 42) e)) := by 
+  sub e_1 (trunc 8 (shl (const? 16 (-42)) e)) ⊑ add e_1 (trunc 8 (shl (const? 16 42) e)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -124,7 +124,7 @@ theorem t20_thm (e : IntW 16) (e_1 : IntW 8) :
 
 
 theorem negate_xor_thm (e : IntW 4) :
-  sub (const? 4 0) (LLVM.xor e (const? 4 5)) ⊑ add (LLVM.xor e (const? 4 (-6))) (const? 4 1) := by 
+  sub (const? 4 0) (LLVM.xor e (const? 4 5)) ⊑ add (LLVM.xor e (const? 4 (-6))) (const? 4 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -135,7 +135,7 @@ theorem negate_xor_thm (e : IntW 4) :
 
 theorem negate_shl_xor_thm (e e_1 : IntW 4) :
   sub (const? 4 0) (shl (LLVM.xor e_1 (const? 4 5)) e) ⊑
-    shl (add (LLVM.xor e_1 (const? 4 (-6))) (const? 4 1)) e := by 
+    shl (add (LLVM.xor e_1 (const? 4 (-6))) (const? 4 1)) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -145,7 +145,7 @@ theorem negate_shl_xor_thm (e e_1 : IntW 4) :
 
 
 theorem negate_sdiv_thm (e e_1 : IntW 8) :
-  sub e_1 (LLVM.sdiv e (const? 8 42)) ⊑ add (LLVM.sdiv e (const? 8 (-42))) e_1 := by 
+  sub e_1 (LLVM.sdiv e (const? 8 42)) ⊑ add (LLVM.sdiv e (const? 8 (-42))) e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -154,7 +154,7 @@ theorem negate_sdiv_thm (e e_1 : IntW 8) :
     all_goals sorry
 
 
-theorem negate_ashr_thm (e e_1 : IntW 8) : sub e_1 (ashr e (const? 8 7)) ⊑ add (lshr e (const? 8 7)) e_1 := by 
+theorem negate_ashr_thm (e e_1 : IntW 8) : sub e_1 (ashr e (const? 8 7)) ⊑ add (lshr e (const? 8 7)) e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -163,7 +163,7 @@ theorem negate_ashr_thm (e e_1 : IntW 8) : sub e_1 (ashr e (const? 8 7)) ⊑ add
     all_goals sorry
 
 
-theorem negate_lshr_thm (e e_1 : IntW 8) : sub e_1 (lshr e (const? 8 7)) ⊑ add (ashr e (const? 8 7)) e_1 := by 
+theorem negate_lshr_thm (e e_1 : IntW 8) : sub e_1 (lshr e (const? 8 7)) ⊑ add (ashr e (const? 8 7)) e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -172,7 +172,7 @@ theorem negate_lshr_thm (e e_1 : IntW 8) : sub e_1 (lshr e (const? 8 7)) ⊑ add
     all_goals sorry
 
 
-theorem negate_sext_thm (e : IntW 1) (e_1 : IntW 8) : sub e_1 (sext 8 e) ⊑ add e_1 (zext 8 e) := by 
+theorem negate_sext_thm (e : IntW 1) (e_1 : IntW 8) : sub e_1 (sext 8 e) ⊑ add e_1 (zext 8 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -181,7 +181,7 @@ theorem negate_sext_thm (e : IntW 1) (e_1 : IntW 8) : sub e_1 (sext 8 e) ⊑ add
     all_goals sorry
 
 
-theorem negate_zext_thm (e : IntW 1) (e_1 : IntW 8) : sub e_1 (zext 8 e) ⊑ add e_1 (sext 8 e) := by 
+theorem negate_zext_thm (e : IntW 1) (e_1 : IntW 8) : sub e_1 (zext 8 e) ⊑ add e_1 (sext 8 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -191,7 +191,7 @@ theorem negate_zext_thm (e : IntW 1) (e_1 : IntW 8) : sub e_1 (zext 8 e) ⊑ add
 
 
 theorem negation_of_increment_via_or_with_no_common_bits_set_thm (e e_1 : IntW 8) :
-  sub e_1 (LLVM.or (shl e (const? 8 1)) (const? 8 1)) ⊑ add e_1 (LLVM.xor (shl e (const? 8 1)) (const? 8 (-1))) := by 
+  sub e_1 (LLVM.or (shl e (const? 8 1)) (const? 8 1)) ⊑ add e_1 (LLVM.xor (shl e (const? 8 1)) (const? 8 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -201,7 +201,7 @@ theorem negation_of_increment_via_or_with_no_common_bits_set_thm (e e_1 : IntW 8
 
 
 theorem negation_of_increment_via_or_disjoint_thm (e e_1 : IntW 8) :
-  sub e_1 (LLVM.or e (const? 8 1) { «disjoint» := true }) ⊑ add e_1 (LLVM.xor e (const? 8 (-1))) := by 
+  sub e_1 (LLVM.or e (const? 8 1) { «disjoint» := true }) ⊑ add e_1 (LLVM.xor e (const? 8 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -210,7 +210,7 @@ theorem negation_of_increment_via_or_disjoint_thm (e e_1 : IntW 8) :
     all_goals sorry
 
 
-theorem negate_add_with_single_negatible_operand_thm (e : IntW 8) : sub (const? 8 0) (add e (const? 8 42)) ⊑ sub (const? 8 (-42)) e := by 
+theorem negate_add_with_single_negatible_operand_thm (e : IntW 8) : sub (const? 8 0) (add e (const? 8 42)) ⊑ sub (const? 8 (-42)) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -220,7 +220,7 @@ theorem negate_add_with_single_negatible_operand_thm (e : IntW 8) : sub (const? 
 
 
 theorem negate_add_with_single_negatible_operand_depth2_thm (e e_1 : IntW 8) :
-  sub (const? 8 0) (mul (add e_1 (const? 8 21)) e) ⊑ mul (sub (const? 8 (-21)) e_1) e := by 
+  sub (const? 8 0) (mul (add e_1 (const? 8 21)) e) ⊑ mul (sub (const? 8 (-21)) e_1) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -231,7 +231,7 @@ theorem negate_add_with_single_negatible_operand_depth2_thm (e e_1 : IntW 8) :
 
 theorem negate_select_of_op_vs_negated_op_nsw_thm (e : IntW 8) (e_1 : IntW 1) (e_2 : IntW 8) :
   sub e_2 (select e_1 (sub (const? 8 0) e { «nsw» := true, «nuw» := false }) e) ⊑
-    add (select e_1 e (sub (const? 8 0) e)) e_2 := by 
+    add (select e_1 e (sub (const? 8 0) e)) e_2 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -242,7 +242,7 @@ theorem negate_select_of_op_vs_negated_op_nsw_thm (e : IntW 8) (e_1 : IntW 1) (e
 
 theorem negate_select_of_op_vs_negated_op_nsw_commuted_thm (e : IntW 8) (e_1 : IntW 1) (e_2 : IntW 8) :
   sub e_2 (select e_1 e (sub (const? 8 0) e { «nsw» := true, «nuw» := false })) ⊑
-    add (select e_1 (sub (const? 8 0) e) e) e_2 := by 
+    add (select e_1 (sub (const? 8 0) e) e) e_2 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -253,7 +253,7 @@ theorem negate_select_of_op_vs_negated_op_nsw_commuted_thm (e : IntW 8) (e_1 : I
 
 theorem negate_select_of_op_vs_negated_op_nsw_xyyx_thm (e e_1 : IntW 8) (e_2 : IntW 1) (e_3 : IntW 8) :
   sub e_3 (select e_2 (sub e_1 e { «nsw» := true, «nuw» := false }) (sub e e_1 { «nsw» := true, «nuw» := false })) ⊑
-    add (select e_2 (sub e e_1) (sub e_1 e)) e_3 := by 
+    add (select e_2 (sub e e_1) (sub e_1 e)) e_3 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gsubhofhnegatiblehinseltpoison_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gsubhofhnegatiblehinseltpoison_proof.lean
@@ -8,7 +8,7 @@ set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
 
 section gsubhofhnegatiblehinseltpoison_proof
-theorem t0_thm (e : IntW 8) : sub e (const? 8 (-42)) ⊑ add e (const? 8 42) := by 
+theorem t0_thm (e : IntW 8) : sub e (const? 8 (-42)) ⊑ add e (const? 8 42) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -17,7 +17,7 @@ theorem t0_thm (e : IntW 8) : sub e (const? 8 (-42)) ⊑ add e (const? 8 42) := 
     all_goals sorry
 
 
-theorem t2_thm (e e_1 : IntW 8) : sub e_1 (shl (const? 8 (-42)) e) ⊑ add (shl (const? 8 42) e) e_1 := by 
+theorem t2_thm (e e_1 : IntW 8) : sub e_1 (shl (const? 8 (-42)) e) ⊑ add (shl (const? 8 42) e) e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -27,7 +27,7 @@ theorem t2_thm (e e_1 : IntW 8) : sub e_1 (shl (const? 8 (-42)) e) ⊑ add (shl 
 
 
 theorem t4_thm (e : IntW 1) (e_1 : IntW 8) :
-  sub e_1 (select e (const? 8 (-42)) (const? 8 44)) ⊑ add (select e (const? 8 42) (const? 8 (-44))) e_1 := by 
+  sub e_1 (select e (const? 8 (-42)) (const? 8 44)) ⊑ add (select e (const? 8 42) (const? 8 (-44))) e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -38,7 +38,7 @@ theorem t4_thm (e : IntW 1) (e_1 : IntW 8) :
 
 theorem t7_thm (e : IntW 8) (e_1 : IntW 1) (e_2 : IntW 8) :
   sub e_2 (select e_1 (const? 8 0) (shl (const? 8 1) e)) ⊑
-    add (select e_1 (const? 8 0) (shl (const? 8 (-1)) e { «nsw» := true, «nuw» := false })) e_2 := by 
+    add (select e_1 (const? 8 0) (shl (const? 8 (-1)) e { «nsw» := true, «nuw» := false })) e_2 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -47,7 +47,7 @@ theorem t7_thm (e : IntW 8) (e_1 : IntW 1) (e_2 : IntW 8) :
     all_goals sorry
 
 
-theorem t9_thm (e e_1 : IntW 8) : sub (const? 8 0) (sub e_1 e) ⊑ sub e e_1 := by 
+theorem t9_thm (e e_1 : IntW 8) : sub (const? 8 0) (sub e_1 e) ⊑ sub e e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -56,7 +56,7 @@ theorem t9_thm (e e_1 : IntW 8) : sub (const? 8 0) (sub e_1 e) ⊑ sub e e_1 := 
     all_goals sorry
 
 
-theorem neg_of_sub_from_constant_thm (e : IntW 8) : sub (const? 8 0) (sub (const? 8 42) e) ⊑ add e (const? 8 (-42)) := by 
+theorem neg_of_sub_from_constant_thm (e : IntW 8) : sub (const? 8 0) (sub (const? 8 42) e) ⊑ add e (const? 8 (-42)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -65,7 +65,7 @@ theorem neg_of_sub_from_constant_thm (e : IntW 8) : sub (const? 8 0) (sub (const
     all_goals sorry
 
 
-theorem sub_from_constant_of_sub_from_constant_thm (e : IntW 8) : sub (const? 8 11) (sub (const? 8 42) e) ⊑ add e (const? 8 (-31)) := by 
+theorem sub_from_constant_of_sub_from_constant_thm (e : IntW 8) : sub (const? 8 11) (sub (const? 8 42) e) ⊑ add e (const? 8 (-31)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -74,7 +74,7 @@ theorem sub_from_constant_of_sub_from_constant_thm (e : IntW 8) : sub (const? 8 
     all_goals sorry
 
 
-theorem sub_from_variable_of_sub_from_constant_thm (e e_1 : IntW 8) : sub e_1 (sub (const? 8 42) e) ⊑ add (add e (const? 8 (-42))) e_1 := by 
+theorem sub_from_variable_of_sub_from_constant_thm (e e_1 : IntW 8) : sub e_1 (sub (const? 8 42) e) ⊑ add (add e (const? 8 (-42))) e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -83,7 +83,7 @@ theorem sub_from_variable_of_sub_from_constant_thm (e e_1 : IntW 8) : sub e_1 (s
     all_goals sorry
 
 
-theorem neg_of_add_with_constant_thm (e : IntW 8) : sub (const? 8 0) (add e (const? 8 42)) ⊑ sub (const? 8 (-42)) e := by 
+theorem neg_of_add_with_constant_thm (e : IntW 8) : sub (const? 8 0) (add e (const? 8 42)) ⊑ sub (const? 8 (-42)) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -92,7 +92,7 @@ theorem neg_of_add_with_constant_thm (e : IntW 8) : sub (const? 8 0) (add e (con
     all_goals sorry
 
 
-theorem sub_from_constant_of_add_with_constant_thm (e : IntW 8) : sub (const? 8 11) (add e (const? 8 42)) ⊑ sub (const? 8 (-31)) e := by 
+theorem sub_from_constant_of_add_with_constant_thm (e : IntW 8) : sub (const? 8 11) (add e (const? 8 42)) ⊑ sub (const? 8 (-31)) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -102,7 +102,7 @@ theorem sub_from_constant_of_add_with_constant_thm (e : IntW 8) : sub (const? 8 
 
 
 theorem t20_thm (e : IntW 16) (e_1 : IntW 8) :
-  sub e_1 (trunc 8 (shl (const? 16 (-42)) e)) ⊑ add e_1 (trunc 8 (shl (const? 16 42) e)) := by 
+  sub e_1 (trunc 8 (shl (const? 16 (-42)) e)) ⊑ add e_1 (trunc 8 (shl (const? 16 42) e)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -112,7 +112,7 @@ theorem t20_thm (e : IntW 16) (e_1 : IntW 8) :
 
 
 theorem negate_xor_thm (e : IntW 4) :
-  sub (const? 4 0) (LLVM.xor e (const? 4 5)) ⊑ add (LLVM.xor e (const? 4 (-6))) (const? 4 1) := by 
+  sub (const? 4 0) (LLVM.xor e (const? 4 5)) ⊑ add (LLVM.xor e (const? 4 (-6))) (const? 4 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -123,7 +123,7 @@ theorem negate_xor_thm (e : IntW 4) :
 
 theorem negate_shl_xor_thm (e e_1 : IntW 4) :
   sub (const? 4 0) (shl (LLVM.xor e_1 (const? 4 5)) e) ⊑
-    shl (add (LLVM.xor e_1 (const? 4 (-6))) (const? 4 1)) e := by 
+    shl (add (LLVM.xor e_1 (const? 4 (-6))) (const? 4 1)) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -133,7 +133,7 @@ theorem negate_shl_xor_thm (e e_1 : IntW 4) :
 
 
 theorem negate_sdiv_thm (e e_1 : IntW 8) :
-  sub e_1 (LLVM.sdiv e (const? 8 42)) ⊑ add (LLVM.sdiv e (const? 8 (-42))) e_1 := by 
+  sub e_1 (LLVM.sdiv e (const? 8 42)) ⊑ add (LLVM.sdiv e (const? 8 (-42))) e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -142,7 +142,7 @@ theorem negate_sdiv_thm (e e_1 : IntW 8) :
     all_goals sorry
 
 
-theorem negate_ashr_thm (e e_1 : IntW 8) : sub e_1 (ashr e (const? 8 7)) ⊑ add (lshr e (const? 8 7)) e_1 := by 
+theorem negate_ashr_thm (e e_1 : IntW 8) : sub e_1 (ashr e (const? 8 7)) ⊑ add (lshr e (const? 8 7)) e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -151,7 +151,7 @@ theorem negate_ashr_thm (e e_1 : IntW 8) : sub e_1 (ashr e (const? 8 7)) ⊑ add
     all_goals sorry
 
 
-theorem negate_lshr_thm (e e_1 : IntW 8) : sub e_1 (lshr e (const? 8 7)) ⊑ add (ashr e (const? 8 7)) e_1 := by 
+theorem negate_lshr_thm (e e_1 : IntW 8) : sub e_1 (lshr e (const? 8 7)) ⊑ add (ashr e (const? 8 7)) e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -160,7 +160,7 @@ theorem negate_lshr_thm (e e_1 : IntW 8) : sub e_1 (lshr e (const? 8 7)) ⊑ add
     all_goals sorry
 
 
-theorem negate_sext_thm (e : IntW 1) (e_1 : IntW 8) : sub e_1 (sext 8 e) ⊑ add e_1 (zext 8 e) := by 
+theorem negate_sext_thm (e : IntW 1) (e_1 : IntW 8) : sub e_1 (sext 8 e) ⊑ add e_1 (zext 8 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -169,7 +169,7 @@ theorem negate_sext_thm (e : IntW 1) (e_1 : IntW 8) : sub e_1 (sext 8 e) ⊑ add
     all_goals sorry
 
 
-theorem negate_zext_thm (e : IntW 1) (e_1 : IntW 8) : sub e_1 (zext 8 e) ⊑ add e_1 (sext 8 e) := by 
+theorem negate_zext_thm (e : IntW 1) (e_1 : IntW 8) : sub e_1 (zext 8 e) ⊑ add e_1 (sext 8 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -179,7 +179,7 @@ theorem negate_zext_thm (e : IntW 1) (e_1 : IntW 8) : sub e_1 (zext 8 e) ⊑ add
 
 
 theorem negation_of_increment_via_or_with_no_common_bits_set_thm (e e_1 : IntW 8) :
-  sub e_1 (LLVM.or (shl e (const? 8 1)) (const? 8 1)) ⊑ add e_1 (LLVM.xor (shl e (const? 8 1)) (const? 8 (-1))) := by 
+  sub e_1 (LLVM.or (shl e (const? 8 1)) (const? 8 1)) ⊑ add e_1 (LLVM.xor (shl e (const? 8 1)) (const? 8 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -188,7 +188,7 @@ theorem negation_of_increment_via_or_with_no_common_bits_set_thm (e e_1 : IntW 8
     all_goals sorry
 
 
-theorem negate_add_with_single_negatible_operand_thm (e : IntW 8) : sub (const? 8 0) (add e (const? 8 42)) ⊑ sub (const? 8 (-42)) e := by 
+theorem negate_add_with_single_negatible_operand_thm (e : IntW 8) : sub (const? 8 0) (add e (const? 8 42)) ⊑ sub (const? 8 (-42)) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -198,7 +198,7 @@ theorem negate_add_with_single_negatible_operand_thm (e : IntW 8) : sub (const? 
 
 
 theorem negate_add_with_single_negatible_operand_depth2_thm (e e_1 : IntW 8) :
-  sub (const? 8 0) (mul (add e_1 (const? 8 21)) e) ⊑ mul (sub (const? 8 (-21)) e_1) e := by 
+  sub (const? 8 0) (mul (add e_1 (const? 8 21)) e) ⊑ mul (sub (const? 8 (-21)) e_1) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gsubhorhandhxor_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gsubhorhandhxor_proof.lean
@@ -8,7 +8,7 @@ set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
 
 section gsubhorhandhxor_proof
-theorem sub_to_xor_thm (e e_1 : IntW 32) : sub (LLVM.or e_1 e) (LLVM.and e_1 e) ⊑ LLVM.xor e_1 e := by 
+theorem sub_to_xor_thm (e e_1 : IntW 32) : sub (LLVM.or e_1 e) (LLVM.and e_1 e) ⊑ LLVM.xor e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -17,7 +17,7 @@ theorem sub_to_xor_thm (e e_1 : IntW 32) : sub (LLVM.or e_1 e) (LLVM.and e_1 e) 
     all_goals sorry
 
 
-theorem sub_to_xor_or_commuted_thm (e e_1 : IntW 32) : sub (LLVM.or e_1 e) (LLVM.and e e_1) ⊑ LLVM.xor e e_1 := by 
+theorem sub_to_xor_or_commuted_thm (e e_1 : IntW 32) : sub (LLVM.or e_1 e) (LLVM.and e e_1) ⊑ LLVM.xor e e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -26,7 +26,7 @@ theorem sub_to_xor_or_commuted_thm (e e_1 : IntW 32) : sub (LLVM.or e_1 e) (LLVM
     all_goals sorry
 
 
-theorem sub_to_xor_and_commuted_thm (e e_1 : IntW 32) : sub (LLVM.or e_1 e) (LLVM.and e e_1) ⊑ LLVM.xor e e_1 := by 
+theorem sub_to_xor_and_commuted_thm (e e_1 : IntW 32) : sub (LLVM.or e_1 e) (LLVM.and e e_1) ⊑ LLVM.xor e e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gsubhxor_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gsubhxor_proof.lean
@@ -9,7 +9,7 @@ set_option linter.unreachableTactic false
 
 section gsubhxor_proof
 theorem low_mask_nsw_nuw_thm (e : IntW 32) :
-  sub (const? 32 63) (LLVM.and e (const? 32 31)) ⊑ LLVM.xor (LLVM.and e (const? 32 31)) (const? 32 63) := by 
+  sub (const? 32 63) (LLVM.and e (const? 32 31)) ⊑ LLVM.xor (LLVM.and e (const? 32 31)) (const? 32 63) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -20,7 +20,7 @@ theorem low_mask_nsw_nuw_thm (e : IntW 32) :
 
 theorem arbitrary_mask_sub_i8_thm (e : IntW 8) :
   sub (const? 8 11) (LLVM.and e (const? 8 10)) ⊑
-    sub (const? 8 11) (LLVM.and e (const? 8 10)) { «nsw» := true, «nuw» := true } := by 
+    sub (const? 8 11) (LLVM.and e (const? 8 10)) { «nsw» := true, «nuw» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -31,7 +31,7 @@ theorem arbitrary_mask_sub_i8_thm (e : IntW 8) :
 
 theorem not_masked_sub_i8_thm (e : IntW 8) :
   sub (const? 8 11) (LLVM.and e (const? 8 7)) ⊑
-    sub (const? 8 11) (LLVM.and e (const? 8 7)) { «nsw» := true, «nuw» := true } := by 
+    sub (const? 8 11) (LLVM.and e (const? 8 7)) { «nsw» := true, «nuw» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -42,7 +42,7 @@ theorem not_masked_sub_i8_thm (e : IntW 8) :
 
 theorem xor_add_thm (e : IntW 32) :
   add (LLVM.xor (LLVM.and e (const? 32 31)) (const? 32 31)) (const? 32 42) ⊑
-    sub (const? 32 73) (LLVM.and e (const? 32 31)) { «nsw» := true, «nuw» := true } := by 
+    sub (const? 32 73) (LLVM.and e (const? 32 31)) { «nsw» := true, «nuw» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gsubhxorhcmp_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gsubhxorhcmp_proof.lean
@@ -9,7 +9,7 @@ set_option linter.unreachableTactic false
 
 section gsubhxorhcmp_proof
 theorem sext_xor_sub_thm (e : IntW 1) (e_1 : IntW 64) :
-  sub (LLVM.xor e_1 (sext 64 e)) (sext 64 e) ⊑ select e (sub (const? 64 0) e_1) e_1 := by 
+  sub (LLVM.xor e_1 (sext 64 e)) (sext 64 e) ⊑ select e (sub (const? 64 0) e_1) e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -19,7 +19,7 @@ theorem sext_xor_sub_thm (e : IntW 1) (e_1 : IntW 64) :
 
 
 theorem sext_xor_sub_1_thm (e : IntW 64) (e_1 : IntW 1) :
-  sub (LLVM.xor (sext 64 e_1) e) (sext 64 e_1) ⊑ select e_1 (sub (const? 64 0) e) e := by 
+  sub (LLVM.xor (sext 64 e_1) e) (sext 64 e_1) ⊑ select e_1 (sub (const? 64 0) e) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -29,7 +29,7 @@ theorem sext_xor_sub_1_thm (e : IntW 64) (e_1 : IntW 1) :
 
 
 theorem sext_xor_sub_2_thm (e : IntW 64) (e_1 : IntW 1) :
-  sub (sext 64 e_1) (LLVM.xor e (sext 64 e_1)) ⊑ select e_1 e (sub (const? 64 0) e) := by 
+  sub (sext 64 e_1) (LLVM.xor e (sext 64 e_1)) ⊑ select e_1 e (sub (const? 64 0) e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -39,7 +39,7 @@ theorem sext_xor_sub_2_thm (e : IntW 64) (e_1 : IntW 1) :
 
 
 theorem sext_xor_sub_3_thm (e : IntW 64) (e_1 : IntW 1) :
-  sub (sext 64 e_1) (LLVM.xor (sext 64 e_1) e) ⊑ select e_1 e (sub (const? 64 0) e) := by 
+  sub (sext 64 e_1) (LLVM.xor (sext 64 e_1) e) ⊑ select e_1 e (sub (const? 64 0) e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -49,7 +49,7 @@ theorem sext_xor_sub_3_thm (e : IntW 64) (e_1 : IntW 1) :
 
 
 theorem sext_non_bool_xor_sub_1_thm (e : IntW 64) (e_1 : IntW 8) :
-  sub (LLVM.xor (sext 64 e_1) e) (sext 64 e_1) ⊑ sub (LLVM.xor e (sext 64 e_1)) (sext 64 e_1) := by 
+  sub (LLVM.xor (sext 64 e_1) e) (sext 64 e_1) ⊑ sub (LLVM.xor e (sext 64 e_1)) (sext 64 e_1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -59,7 +59,7 @@ theorem sext_non_bool_xor_sub_1_thm (e : IntW 64) (e_1 : IntW 8) :
 
 
 theorem sext_diff_i1_xor_sub_thm (e e_1 : IntW 1) :
-  sub (sext 64 e_1) (sext 64 e) ⊑ add (zext 64 e) (sext 64 e_1) { «nsw» := true, «nuw» := false } := by 
+  sub (sext 64 e_1) (sext 64 e) ⊑ add (zext 64 e) (sext 64 e_1) { «nsw» := true, «nuw» := false } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -69,7 +69,7 @@ theorem sext_diff_i1_xor_sub_thm (e e_1 : IntW 1) :
 
 
 theorem sext_diff_i1_xor_sub_1_thm (e e_1 : IntW 1) :
-  sub (sext 64 e_1) (sext 64 e) ⊑ add (zext 64 e) (sext 64 e_1) { «nsw» := true, «nuw» := false } := by 
+  sub (sext 64 e_1) (sext 64 e) ⊑ add (zext 64 e) (sext 64 e_1) { «nsw» := true, «nuw» := false } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -80,7 +80,7 @@ theorem sext_diff_i1_xor_sub_1_thm (e e_1 : IntW 1) :
 
 theorem sext_multi_uses_thm (e : IntW 64) (e_1 : IntW 1) (e_2 : IntW 64) :
   add (mul e_2 (sext 64 e_1)) (sub (LLVM.xor e (sext 64 e_1)) (sext 64 e_1)) ⊑
-    select e_1 (sub (const? 64 0) (add e_2 e)) e := by 
+    select e_1 (sub (const? 64 0) (add e_2 e)) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -91,7 +91,7 @@ theorem sext_multi_uses_thm (e : IntW 64) (e_1 : IntW 1) (e_2 : IntW 64) :
 
 theorem absdiff_thm (e e_1 : IntW 64) :
   sub (LLVM.xor (sext 64 (icmp IntPredicate.ult e_1 e)) (sub e_1 e)) (sext 64 (icmp IntPredicate.ult e_1 e)) ⊑
-    select (icmp IntPredicate.ult e_1 e) (sub (const? 64 0) (sub e_1 e)) (sub e_1 e) := by 
+    select (icmp IntPredicate.ult e_1 e) (sub (const? 64 0) (sub e_1 e)) (sub e_1 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -102,7 +102,7 @@ theorem absdiff_thm (e e_1 : IntW 64) :
 
 theorem absdiff1_thm (e e_1 : IntW 64) :
   sub (LLVM.xor (sub e_1 e) (sext 64 (icmp IntPredicate.ult e_1 e))) (sext 64 (icmp IntPredicate.ult e_1 e)) ⊑
-    select (icmp IntPredicate.ult e_1 e) (sub (const? 64 0) (sub e_1 e)) (sub e_1 e) := by 
+    select (icmp IntPredicate.ult e_1 e) (sub (const? 64 0) (sub e_1 e)) (sub e_1 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -113,7 +113,7 @@ theorem absdiff1_thm (e e_1 : IntW 64) :
 
 theorem absdiff2_thm (e e_1 : IntW 64) :
   sub (LLVM.xor (sub e_1 e) (sext 64 (icmp IntPredicate.ugt e e_1))) (sext 64 (icmp IntPredicate.ugt e e_1)) ⊑
-    select (icmp IntPredicate.ugt e e_1) (sub (const? 64 0) (sub e_1 e)) (sub e_1 e) := by 
+    select (icmp IntPredicate.ugt e e_1) (sub (const? 64 0) (sub e_1 e)) (sub e_1 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gsubhxorhorhneghand_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gsubhxorhorhneghand_proof.lean
@@ -9,7 +9,7 @@ set_option linter.unreachableTactic false
 
 section gsubhxorhorhneghand_proof
 theorem sub_to_and_thm (e e_1 : IntW 32) :
-  sub (LLVM.xor e_1 e) (LLVM.or e_1 e) ⊑ sub (const? 32 0) (LLVM.and e_1 e) := by 
+  sub (LLVM.xor e_1 e) (LLVM.or e_1 e) ⊑ sub (const? 32 0) (LLVM.and e_1 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -19,7 +19,7 @@ theorem sub_to_and_thm (e e_1 : IntW 32) :
 
 
 theorem sub_to_and_or_commuted_thm (e e_1 : IntW 32) :
-  sub (LLVM.xor e_1 e) (LLVM.or e e_1) ⊑ sub (const? 32 0) (LLVM.and e_1 e) := by 
+  sub (LLVM.xor e_1 e) (LLVM.or e e_1) ⊑ sub (const? 32 0) (LLVM.and e_1 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -29,7 +29,7 @@ theorem sub_to_and_or_commuted_thm (e e_1 : IntW 32) :
 
 
 theorem sub_to_and_and_commuted_thm (e e_1 : IntW 32) :
-  sub (LLVM.xor e_1 e) (LLVM.or e e_1) ⊑ sub (const? 32 0) (LLVM.and e_1 e) := by 
+  sub (LLVM.xor e_1 e) (LLVM.or e e_1) ⊑ sub (const? 32 0) (LLVM.and e_1 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gsubtracthfromhonehhandhofhselect_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gsubtracthfromhonehhandhofhselect_proof.lean
@@ -9,7 +9,7 @@ set_option linter.unreachableTactic false
 
 section gsubtracthfromhonehhandhofhselect_proof
 theorem t0_sub_from_trueval_thm (e : IntW 8) (e_1 : IntW 1) (e_2 : IntW 8) :
-  sub e_2 (select e_1 e_2 e) ⊑ select e_1 (const? 8 0) (sub e_2 e) := by 
+  sub e_2 (select e_1 e_2 e) ⊑ select e_1 (const? 8 0) (sub e_2 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -19,7 +19,7 @@ theorem t0_sub_from_trueval_thm (e : IntW 8) (e_1 : IntW 1) (e_2 : IntW 8) :
 
 
 theorem t1_sub_from_falseval_thm (e : IntW 8) (e_1 : IntW 1) (e_2 : IntW 8) :
-  sub e_2 (select e_1 e e_2) ⊑ select e_1 (sub e_2 e) (const? 8 0) := by 
+  sub e_2 (select e_1 e e_2) ⊑ select e_1 (sub e_2 e) (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gsubtracthofhonehhandhofhselect_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gsubtracthofhonehhandhofhselect_proof.lean
@@ -9,7 +9,7 @@ set_option linter.unreachableTactic false
 
 section gsubtracthofhonehhandhofhselect_proof
 theorem t0_sub_of_trueval_thm (e e_1 : IntW 8) (e_2 : IntW 1) :
-  sub (select e_2 e_1 e) e_1 ⊑ select e_2 (const? 8 0) (sub e e_1) := by 
+  sub (select e_2 e_1 e) e_1 ⊑ select e_2 (const? 8 0) (sub e e_1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -19,7 +19,7 @@ theorem t0_sub_of_trueval_thm (e e_1 : IntW 8) (e_2 : IntW 1) :
 
 
 theorem t1_sub_of_falseval_thm (e e_1 : IntW 8) (e_2 : IntW 1) :
-  sub (select e_2 e_1 e) e ⊑ select e_2 (sub e_1 e) (const? 8 0) := by 
+  sub (select e_2 e_1 e) e ⊑ select e_2 (sub e_1 e) (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gtrunc_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gtrunc_proof.lean
@@ -8,7 +8,7 @@ set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
 
 section gtrunc_proof
-theorem test5_thm (e : IntW 32) : trunc 32 (lshr (zext 128 e) (const? 128 16)) ⊑ lshr e (const? 32 16) := by 
+theorem test5_thm (e : IntW 32) : trunc 32 (lshr (zext 128 e) (const? 128 16)) ⊑ lshr e (const? 32 16) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -19,7 +19,7 @@ theorem test5_thm (e : IntW 32) : trunc 32 (lshr (zext 128 e) (const? 128 16)) �
 
 theorem test6_thm (e : IntW 64) :
   trunc 32 (lshr (zext 128 e) (const? 128 32)) ⊑
-    trunc 32 (lshr e (const? 64 32)) { «nsw» := false, «nuw» := true } := by 
+    trunc 32 (lshr e (const? 64 32)) { «nsw» := false, «nuw» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -30,7 +30,7 @@ theorem test6_thm (e : IntW 64) :
 
 theorem ashr_mul_sign_bits_thm (e e_1 : IntW 8) :
   trunc 16 (ashr (mul (sext 32 e_1) (sext 32 e)) (const? 32 3)) ⊑
-    ashr (mul (sext 16 e_1) (sext 16 e) { «nsw» := true, «nuw» := false }) (const? 16 3) := by 
+    ashr (mul (sext 16 e_1) (sext 16 e) { «nsw» := true, «nuw» := false }) (const? 16 3) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -41,7 +41,7 @@ theorem ashr_mul_sign_bits_thm (e e_1 : IntW 8) :
 
 theorem ashr_mul_thm (e e_1 : IntW 8) :
   trunc 16 (ashr (mul (sext 20 e_1) (sext 20 e)) (const? 20 8)) ⊑
-    ashr (mul (sext 16 e_1) (sext 16 e) { «nsw» := true, «nuw» := false }) (const? 16 8) := by 
+    ashr (mul (sext 16 e_1) (sext 16 e) { «nsw» := true, «nuw» := false }) (const? 16 8) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -52,7 +52,7 @@ theorem ashr_mul_thm (e e_1 : IntW 8) :
 
 theorem trunc_ashr_thm (e : IntW 32) :
   trunc 32 (ashr (LLVM.or (zext 36 e) (const? 36 (-2147483648))) (const? 36 8)) ⊑
-    LLVM.or (lshr e (const? 32 8)) (const? 32 (-8388608)) := by 
+    LLVM.or (lshr e (const? 32 8)) (const? 32 (-8388608)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -62,7 +62,7 @@ theorem trunc_ashr_thm (e : IntW 32) :
 
 
 theorem test7_thm (e : IntW 64) :
-  trunc 92 (lshr (zext 128 e) (const? 128 32)) ⊑ zext 92 (lshr e (const? 64 32)) { «nneg» := true } := by 
+  trunc 92 (lshr (zext 128 e) (const? 128 32)) ⊑ zext 92 (lshr e (const? 64 32)) { «nneg» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -74,7 +74,7 @@ theorem test7_thm (e : IntW 64) :
 theorem test8_thm (e e_1 : IntW 32) :
   trunc 64 (LLVM.or (shl (zext 128 e_1) (const? 128 32)) (zext 128 e)) ⊑
     LLVM.or (shl (zext 64 e_1) (const? 64 32) { «nsw» := false, «nuw» := true }) (zext 64 e)
-      { «disjoint» := true } := by 
+      { «disjoint» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -83,7 +83,7 @@ theorem test8_thm (e e_1 : IntW 32) :
     all_goals sorry
 
 
-theorem test9_thm (e : IntW 32) : trunc 8 (LLVM.and e (const? 32 42)) ⊑ LLVM.and (trunc 8 e) (const? 8 42) := by 
+theorem test9_thm (e : IntW 32) : trunc 8 (LLVM.and e (const? 32 42)) ⊑ LLVM.and (trunc 8 e) (const? 8 42) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -94,7 +94,7 @@ theorem test9_thm (e : IntW 32) : trunc 8 (LLVM.and e (const? 32 42)) ⊑ LLVM.a
 
 theorem test11_thm (e e_1 : IntW 32) :
   trunc 64 (shl (zext 128 e_1) (LLVM.and (zext 128 e) (const? 128 31))) ⊑
-    shl (zext 64 e_1) (zext 64 (LLVM.and e (const? 32 31)) { «nneg» := true }) { «nsw» := true, «nuw» := true } := by 
+    shl (zext 64 e_1) (zext 64 (LLVM.and e (const? 32 31)) { «nneg» := true }) { «nsw» := true, «nuw» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -105,7 +105,7 @@ theorem test11_thm (e e_1 : IntW 32) :
 
 theorem test12_thm (e e_1 : IntW 32) :
   trunc 64 (lshr (zext 128 e_1) (LLVM.and (zext 128 e) (const? 128 31))) ⊑
-    lshr (zext 64 e_1) (zext 64 (LLVM.and e (const? 32 31)) { «nneg» := true }) := by 
+    lshr (zext 64 e_1) (zext 64 (LLVM.and e (const? 32 31)) { «nneg» := true }) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -116,7 +116,7 @@ theorem test12_thm (e e_1 : IntW 32) :
 
 theorem test13_thm (e e_1 : IntW 32) :
   trunc 64 (ashr (sext 128 e_1) (LLVM.and (zext 128 e) (const? 128 31))) ⊑
-    ashr (sext 64 e_1) (zext 64 (LLVM.and e (const? 32 31)) { «nneg» := true }) := by 
+    ashr (sext 64 e_1) (zext 64 (LLVM.and e (const? 32 31)) { «nneg» := true }) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -125,7 +125,7 @@ theorem test13_thm (e e_1 : IntW 32) :
     all_goals sorry
 
 
-theorem trunc_shl_31_i32_i64_thm (e : IntW 64) : trunc 32 (shl e (const? 64 31)) ⊑ shl (trunc 32 e) (const? 32 31) := by 
+theorem trunc_shl_31_i32_i64_thm (e : IntW 64) : trunc 32 (shl e (const? 64 31)) ⊑ shl (trunc 32 e) (const? 32 31) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -135,7 +135,7 @@ theorem trunc_shl_31_i32_i64_thm (e : IntW 64) : trunc 32 (shl e (const? 64 31))
 
 
 theorem trunc_shl_nsw_31_i32_i64_thm (e : IntW 64) :
-  trunc 32 (shl e (const? 64 31) { «nsw» := true, «nuw» := false }) ⊑ shl (trunc 32 e) (const? 32 31) := by 
+  trunc 32 (shl e (const? 64 31) { «nsw» := true, «nuw» := false }) ⊑ shl (trunc 32 e) (const? 32 31) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -145,7 +145,7 @@ theorem trunc_shl_nsw_31_i32_i64_thm (e : IntW 64) :
 
 
 theorem trunc_shl_nuw_31_i32_i64_thm (e : IntW 64) :
-  trunc 32 (shl e (const? 64 31) { «nsw» := false, «nuw» := true }) ⊑ shl (trunc 32 e) (const? 32 31) := by 
+  trunc 32 (shl e (const? 64 31) { «nsw» := false, «nuw» := true }) ⊑ shl (trunc 32 e) (const? 32 31) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -155,7 +155,7 @@ theorem trunc_shl_nuw_31_i32_i64_thm (e : IntW 64) :
 
 
 theorem trunc_shl_nsw_nuw_31_i32_i64_thm (e : IntW 64) :
-  trunc 32 (shl e (const? 64 31) { «nsw» := true, «nuw» := true }) ⊑ shl (trunc 32 e) (const? 32 31) := by 
+  trunc 32 (shl e (const? 64 31) { «nsw» := true, «nuw» := true }) ⊑ shl (trunc 32 e) (const? 32 31) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -164,7 +164,7 @@ theorem trunc_shl_nsw_nuw_31_i32_i64_thm (e : IntW 64) :
     all_goals sorry
 
 
-theorem trunc_shl_15_i16_i64_thm (e : IntW 64) : trunc 16 (shl e (const? 64 15)) ⊑ shl (trunc 16 e) (const? 16 15) := by 
+theorem trunc_shl_15_i16_i64_thm (e : IntW 64) : trunc 16 (shl e (const? 64 15)) ⊑ shl (trunc 16 e) (const? 16 15) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -173,7 +173,7 @@ theorem trunc_shl_15_i16_i64_thm (e : IntW 64) : trunc 16 (shl e (const? 64 15))
     all_goals sorry
 
 
-theorem trunc_shl_15_i16_i32_thm (e : IntW 32) : trunc 16 (shl e (const? 32 15)) ⊑ shl (trunc 16 e) (const? 16 15) := by 
+theorem trunc_shl_15_i16_i32_thm (e : IntW 32) : trunc 16 (shl e (const? 32 15)) ⊑ shl (trunc 16 e) (const? 16 15) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -182,7 +182,7 @@ theorem trunc_shl_15_i16_i32_thm (e : IntW 32) : trunc 16 (shl e (const? 32 15))
     all_goals sorry
 
 
-theorem trunc_shl_7_i8_i64_thm (e : IntW 64) : trunc 8 (shl e (const? 64 7)) ⊑ shl (trunc 8 e) (const? 8 7) := by 
+theorem trunc_shl_7_i8_i64_thm (e : IntW 64) : trunc 8 (shl e (const? 64 7)) ⊑ shl (trunc 8 e) (const? 8 7) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -191,7 +191,7 @@ theorem trunc_shl_7_i8_i64_thm (e : IntW 64) : trunc 8 (shl e (const? 64 7)) ⊑
     all_goals sorry
 
 
-theorem trunc_shl_1_i32_i64_thm (e : IntW 64) : trunc 32 (shl e (const? 64 1)) ⊑ shl (trunc 32 e) (const? 32 1) := by 
+theorem trunc_shl_1_i32_i64_thm (e : IntW 64) : trunc 32 (shl e (const? 64 1)) ⊑ shl (trunc 32 e) (const? 32 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -200,7 +200,7 @@ theorem trunc_shl_1_i32_i64_thm (e : IntW 64) : trunc 32 (shl e (const? 64 1)) �
     all_goals sorry
 
 
-theorem trunc_shl_16_i32_i64_thm (e : IntW 64) : trunc 32 (shl e (const? 64 16)) ⊑ shl (trunc 32 e) (const? 32 16) := by 
+theorem trunc_shl_16_i32_i64_thm (e : IntW 64) : trunc 32 (shl e (const? 64 16)) ⊑ shl (trunc 32 e) (const? 32 16) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -209,7 +209,7 @@ theorem trunc_shl_16_i32_i64_thm (e : IntW 64) : trunc 32 (shl e (const? 64 16))
     all_goals sorry
 
 
-theorem trunc_shl_33_i32_i64_thm (e : IntW 64) : trunc 32 (shl e (const? 64 33)) ⊑ const? 32 0 := by 
+theorem trunc_shl_33_i32_i64_thm (e : IntW 64) : trunc 32 (shl e (const? 64 33)) ⊑ const? 32 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -218,7 +218,7 @@ theorem trunc_shl_33_i32_i64_thm (e : IntW 64) : trunc 32 (shl e (const? 64 33))
     all_goals sorry
 
 
-theorem trunc_shl_32_i32_i64_thm (e : IntW 64) : trunc 32 (shl e (const? 64 32)) ⊑ const? 32 0 := by 
+theorem trunc_shl_32_i32_i64_thm (e : IntW 64) : trunc 32 (shl e (const? 64 32)) ⊑ const? 32 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -229,7 +229,7 @@ theorem trunc_shl_32_i32_i64_thm (e : IntW 64) : trunc 32 (shl e (const? 64 32))
 
 theorem trunc_shl_lshr_infloop_thm (e : IntW 64) :
   trunc 32 (shl (lshr e (const? 64 1)) (const? 64 2)) ⊑
-    LLVM.and (shl (trunc 32 e) (const? 32 1)) (const? 32 (-4)) := by 
+    LLVM.and (shl (trunc 32 e) (const? 32 1)) (const? 32 (-4)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -240,7 +240,7 @@ theorem trunc_shl_lshr_infloop_thm (e : IntW 64) :
 
 theorem trunc_shl_ashr_infloop_thm (e : IntW 64) :
   trunc 32 (shl (ashr e (const? 64 3)) (const? 64 2)) ⊑
-    LLVM.and (trunc 32 (lshr e (const? 64 1))) (const? 32 (-4)) := by 
+    LLVM.and (trunc 32 (lshr e (const? 64 1))) (const? 32 (-4)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -250,7 +250,7 @@ theorem trunc_shl_ashr_infloop_thm (e : IntW 64) :
 
 
 theorem trunc_shl_shl_infloop_thm (e : IntW 64) :
-  trunc 32 (shl (shl e (const? 64 1)) (const? 64 2)) ⊑ shl (trunc 32 e) (const? 32 3) := by 
+  trunc 32 (shl (shl e (const? 64 1)) (const? 64 2)) ⊑ shl (trunc 32 e) (const? 32 3) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -260,7 +260,7 @@ theorem trunc_shl_shl_infloop_thm (e : IntW 64) :
 
 
 theorem trunc_shl_lshr_var_thm (e e_1 : IntW 64) :
-  trunc 32 (shl (lshr e_1 e) (const? 64 2)) ⊑ shl (trunc 32 (lshr e_1 e)) (const? 32 2) := by 
+  trunc 32 (shl (lshr e_1 e) (const? 64 2)) ⊑ shl (trunc 32 (lshr e_1 e)) (const? 32 2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -270,7 +270,7 @@ theorem trunc_shl_lshr_var_thm (e e_1 : IntW 64) :
 
 
 theorem trunc_shl_ashr_var_thm (e e_1 : IntW 64) :
-  trunc 32 (shl (ashr e_1 e) (const? 64 2)) ⊑ shl (trunc 32 (ashr e_1 e)) (const? 32 2) := by 
+  trunc 32 (shl (ashr e_1 e) (const? 64 2)) ⊑ shl (trunc 32 (ashr e_1 e)) (const? 32 2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -280,7 +280,7 @@ theorem trunc_shl_ashr_var_thm (e e_1 : IntW 64) :
 
 
 theorem trunc_shl_shl_var_thm (e e_1 : IntW 64) :
-  trunc 32 (shl (shl e_1 e) (const? 64 2)) ⊑ shl (trunc 32 (shl e_1 e)) (const? 32 2) := by 
+  trunc 32 (shl (shl e_1 e) (const? 64 2)) ⊑ shl (trunc 32 (shl e_1 e)) (const? 32 2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -295,7 +295,7 @@ theorem PR44545_thm (e e_1 : IntW 32) :
         (select (icmp IntPredicate.eq e_1 (const? 32 0)) (const? 32 0)
           (add e (const? 32 1) { «nsw» := true, «nuw» := true })))
       (const? 16 (-1)) { «nsw» := true, «nuw» := false } ⊑
-    select (icmp IntPredicate.eq e_1 (const? 32 0)) (const? 16 (-1)) (trunc 16 e) := by 
+    select (icmp IntPredicate.eq e_1 (const? 32 0)) (const? 16 (-1)) (trunc 16 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -306,7 +306,7 @@ theorem PR44545_thm (e e_1 : IntW 32) :
 
 theorem drop_nsw_trunc_thm (e e_1 : IntW 16) :
   trunc 8 (LLVM.and (LLVM.and e_1 (const? 16 255)) e) { «nsw» := true, «nuw» := false } ⊑
-    trunc 8 (LLVM.and e_1 e) := by 
+    trunc 8 (LLVM.and e_1 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -317,7 +317,7 @@ theorem drop_nsw_trunc_thm (e e_1 : IntW 16) :
 
 theorem drop_nuw_trunc_thm (e e_1 : IntW 16) :
   trunc 8 (LLVM.and (LLVM.and e_1 (const? 16 255)) e) { «nsw» := false, «nuw» := true } ⊑
-    trunc 8 (LLVM.and e_1 e) := by 
+    trunc 8 (LLVM.and e_1 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -328,7 +328,7 @@ theorem drop_nuw_trunc_thm (e e_1 : IntW 16) :
 
 theorem drop_both_trunc_thm (e e_1 : IntW 16) :
   trunc 8 (LLVM.and (LLVM.and e_1 (const? 16 255)) e) { «nsw» := true, «nuw» := true } ⊑
-    trunc 8 (LLVM.and e_1 e) := by 
+    trunc 8 (LLVM.and e_1 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -338,7 +338,7 @@ theorem drop_both_trunc_thm (e e_1 : IntW 16) :
 
 
 theorem trunc_nuw_xor_thm (e e_1 : IntW 8) :
-  trunc 1 (LLVM.xor e_1 e) { «nsw» := false, «nuw» := true } ⊑ icmp IntPredicate.ne e_1 e := by 
+  trunc 1 (LLVM.xor e_1 e) { «nsw» := false, «nuw» := true } ⊑ icmp IntPredicate.ne e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -348,7 +348,7 @@ theorem trunc_nuw_xor_thm (e e_1 : IntW 8) :
 
 
 theorem trunc_nsw_xor_thm (e e_1 : IntW 8) :
-  trunc 1 (LLVM.xor e_1 e) { «nsw» := true, «nuw» := false } ⊑ icmp IntPredicate.ne e_1 e := by 
+  trunc 1 (LLVM.xor e_1 e) { «nsw» := true, «nuw» := false } ⊑ icmp IntPredicate.ne e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gtruncatinghsaturate_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gtruncatinghsaturate_proof.lean
@@ -12,7 +12,7 @@ theorem testtrunclowhigh_thm (e e_1 : IntW 16) (e_2 : IntW 32) :
   select (icmp IntPredicate.ult (add e_2 (const? 32 128)) (const? 32 256)) (trunc 16 e_2)
       (select (icmp IntPredicate.sgt e_2 (const? 32 (-1))) e_1 e) ⊑
     select (icmp IntPredicate.ult (add e_2 (const? 32 128)) (const? 32 256)) (trunc 16 e_2)
-      (select (icmp IntPredicate.slt e_2 (const? 32 0)) e e_1) := by 
+      (select (icmp IntPredicate.slt e_2 (const? 32 0)) e e_1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -25,7 +25,7 @@ theorem testi32i8_thm (e : IntW 32) :
   select (icmp IntPredicate.eq (ashr (trunc 8 e) (const? 8 7)) (trunc 8 (lshr e (const? 32 8)))) (trunc 8 e)
       (LLVM.xor (trunc 8 (ashr e (const? 32 15))) (const? 8 127)) ⊑
     select (icmp IntPredicate.eq (ashr (trunc 8 e) (const? 8 7)) (trunc 8 (lshr e (const? 32 8)))) (trunc 8 e)
-      (LLVM.xor (trunc 8 (lshr e (const? 32 15))) (const? 8 127)) := by 
+      (LLVM.xor (trunc 8 (lshr e (const? 32 15))) (const? 8 127)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -38,7 +38,7 @@ theorem differentconsts_thm (e : IntW 32) :
   select (icmp IntPredicate.ult (add e (const? 32 16)) (const? 32 144)) (trunc 16 e)
       (select (icmp IntPredicate.slt e (const? 32 128)) (const? 16 256) (const? 16 (-1))) ⊑
     select (icmp IntPredicate.sgt e (const? 32 127)) (const? 16 (-1))
-      (select (icmp IntPredicate.slt e (const? 32 (-16))) (const? 16 256) (trunc 16 e)) := by 
+      (select (icmp IntPredicate.slt e (const? 32 (-16))) (const? 16 256) (trunc 16 e)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -53,7 +53,7 @@ theorem badimm1_thm (e : IntW 16) :
     select
       (icmp IntPredicate.eq (ashr (trunc 8 e) (const? 8 7))
         (trunc 8 (lshr e (const? 16 9)) { «nsw» := true, «nuw» := true }))
-      (trunc 8 e) (select (icmp IntPredicate.sgt e (const? 16 (-1))) (const? 8 127) (const? 8 (-128))) := by 
+      (trunc 8 e) (select (icmp IntPredicate.sgt e (const? 16 (-1))) (const? 8 127) (const? 8 (-128))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -68,7 +68,7 @@ theorem badimm2_thm (e : IntW 16) :
     select
       (icmp IntPredicate.eq (ashr (trunc 8 e) (const? 8 6))
         (trunc 8 (lshr e (const? 16 8)) { «nsw» := false, «nuw» := true }))
-      (trunc 8 e) (select (icmp IntPredicate.sgt e (const? 16 (-1))) (const? 8 127) (const? 8 (-128))) := by 
+      (trunc 8 e) (select (icmp IntPredicate.sgt e (const? 16 (-1))) (const? 8 127) (const? 8 (-128))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -81,7 +81,7 @@ theorem badimm3_thm (e : IntW 16) :
   select (icmp IntPredicate.eq (ashr (trunc 8 e) (const? 8 7)) (trunc 8 (lshr e (const? 16 8)))) (trunc 8 e)
       (LLVM.xor (trunc 8 (ashr e (const? 16 14))) (const? 8 127)) ⊑
     select (icmp IntPredicate.ult (add e (const? 16 128)) (const? 16 256)) (trunc 8 e)
-      (LLVM.xor (trunc 8 (ashr e (const? 16 14)) { «nsw» := true, «nuw» := false }) (const? 8 127)) := by 
+      (LLVM.xor (trunc 8 (ashr e (const? 16 14)) { «nsw» := true, «nuw» := false }) (const? 8 127)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -94,7 +94,7 @@ theorem badimm4_thm (e : IntW 16) :
   select (icmp IntPredicate.eq (ashr (trunc 8 e) (const? 8 7)) (trunc 8 (lshr e (const? 16 8)))) (trunc 8 e)
       (LLVM.xor (trunc 8 (ashr e (const? 16 15))) (const? 8 126)) ⊑
     select (icmp IntPredicate.sgt e (const? 16 127)) (const? 8 126)
-      (select (icmp IntPredicate.slt e (const? 16 (-128))) (const? 8 (-127)) (trunc 8 e)) := by 
+      (select (icmp IntPredicate.slt e (const? 16 (-128))) (const? 8 (-127)) (trunc 8 e)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -106,7 +106,7 @@ theorem badimm4_thm (e : IntW 16) :
 theorem C0zero_thm (e e_1 e_2 : IntW 8) :
   select (icmp IntPredicate.ult (add e_2 (const? 8 10)) (const? 8 0)) e_2
       (select (icmp IntPredicate.slt e_2 (const? 8 (-10))) e_1 e) ⊑
-    select (icmp IntPredicate.slt e_2 (const? 8 (-10))) e_1 e := by 
+    select (icmp IntPredicate.slt e_2 (const? 8 (-10))) e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gtrunchbinophext_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gtrunchbinophext_proof.lean
@@ -9,7 +9,7 @@ set_option linter.unreachableTactic false
 
 section gtrunchbinophext_proof
 theorem narrow_sext_and_thm (e : IntW 32) (e_1 : IntW 16) :
-  trunc 16 (LLVM.and (sext 32 e_1) e) ⊑ LLVM.and e_1 (trunc 16 e) := by 
+  trunc 16 (LLVM.and (sext 32 e_1) e) ⊑ LLVM.and e_1 (trunc 16 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -19,7 +19,7 @@ theorem narrow_sext_and_thm (e : IntW 32) (e_1 : IntW 16) :
 
 
 theorem narrow_zext_and_thm (e : IntW 32) (e_1 : IntW 16) :
-  trunc 16 (LLVM.and (zext 32 e_1) e) ⊑ LLVM.and e_1 (trunc 16 e) := by 
+  trunc 16 (LLVM.and (zext 32 e_1) e) ⊑ LLVM.and e_1 (trunc 16 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -29,7 +29,7 @@ theorem narrow_zext_and_thm (e : IntW 32) (e_1 : IntW 16) :
 
 
 theorem narrow_sext_or_thm (e : IntW 32) (e_1 : IntW 16) :
-  trunc 16 (LLVM.or (sext 32 e_1) e) ⊑ LLVM.or e_1 (trunc 16 e) := by 
+  trunc 16 (LLVM.or (sext 32 e_1) e) ⊑ LLVM.or e_1 (trunc 16 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -39,7 +39,7 @@ theorem narrow_sext_or_thm (e : IntW 32) (e_1 : IntW 16) :
 
 
 theorem narrow_zext_or_thm (e : IntW 32) (e_1 : IntW 16) :
-  trunc 16 (LLVM.or (zext 32 e_1) e) ⊑ LLVM.or e_1 (trunc 16 e) := by 
+  trunc 16 (LLVM.or (zext 32 e_1) e) ⊑ LLVM.or e_1 (trunc 16 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -49,7 +49,7 @@ theorem narrow_zext_or_thm (e : IntW 32) (e_1 : IntW 16) :
 
 
 theorem narrow_sext_xor_thm (e : IntW 32) (e_1 : IntW 16) :
-  trunc 16 (LLVM.xor (sext 32 e_1) e) ⊑ LLVM.xor e_1 (trunc 16 e) := by 
+  trunc 16 (LLVM.xor (sext 32 e_1) e) ⊑ LLVM.xor e_1 (trunc 16 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -59,7 +59,7 @@ theorem narrow_sext_xor_thm (e : IntW 32) (e_1 : IntW 16) :
 
 
 theorem narrow_zext_xor_thm (e : IntW 32) (e_1 : IntW 16) :
-  trunc 16 (LLVM.xor (zext 32 e_1) e) ⊑ LLVM.xor e_1 (trunc 16 e) := by 
+  trunc 16 (LLVM.xor (zext 32 e_1) e) ⊑ LLVM.xor e_1 (trunc 16 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -68,7 +68,7 @@ theorem narrow_zext_xor_thm (e : IntW 32) (e_1 : IntW 16) :
     all_goals sorry
 
 
-theorem narrow_sext_add_thm (e : IntW 32) (e_1 : IntW 16) : trunc 16 (add (sext 32 e_1) e) ⊑ add e_1 (trunc 16 e) := by 
+theorem narrow_sext_add_thm (e : IntW 32) (e_1 : IntW 16) : trunc 16 (add (sext 32 e_1) e) ⊑ add e_1 (trunc 16 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -77,7 +77,7 @@ theorem narrow_sext_add_thm (e : IntW 32) (e_1 : IntW 16) : trunc 16 (add (sext 
     all_goals sorry
 
 
-theorem narrow_zext_add_thm (e : IntW 32) (e_1 : IntW 16) : trunc 16 (add (zext 32 e_1) e) ⊑ add e_1 (trunc 16 e) := by 
+theorem narrow_zext_add_thm (e : IntW 32) (e_1 : IntW 16) : trunc 16 (add (zext 32 e_1) e) ⊑ add e_1 (trunc 16 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -86,7 +86,7 @@ theorem narrow_zext_add_thm (e : IntW 32) (e_1 : IntW 16) : trunc 16 (add (zext 
     all_goals sorry
 
 
-theorem narrow_sext_sub_thm (e : IntW 32) (e_1 : IntW 16) : trunc 16 (sub (sext 32 e_1) e) ⊑ sub e_1 (trunc 16 e) := by 
+theorem narrow_sext_sub_thm (e : IntW 32) (e_1 : IntW 16) : trunc 16 (sub (sext 32 e_1) e) ⊑ sub e_1 (trunc 16 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -95,7 +95,7 @@ theorem narrow_sext_sub_thm (e : IntW 32) (e_1 : IntW 16) : trunc 16 (sub (sext 
     all_goals sorry
 
 
-theorem narrow_zext_sub_thm (e : IntW 32) (e_1 : IntW 16) : trunc 16 (sub (zext 32 e_1) e) ⊑ sub e_1 (trunc 16 e) := by 
+theorem narrow_zext_sub_thm (e : IntW 32) (e_1 : IntW 16) : trunc 16 (sub (zext 32 e_1) e) ⊑ sub e_1 (trunc 16 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -104,7 +104,7 @@ theorem narrow_zext_sub_thm (e : IntW 32) (e_1 : IntW 16) : trunc 16 (sub (zext 
     all_goals sorry
 
 
-theorem narrow_sext_mul_thm (e : IntW 32) (e_1 : IntW 16) : trunc 16 (mul (sext 32 e_1) e) ⊑ mul e_1 (trunc 16 e) := by 
+theorem narrow_sext_mul_thm (e : IntW 32) (e_1 : IntW 16) : trunc 16 (mul (sext 32 e_1) e) ⊑ mul e_1 (trunc 16 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -113,7 +113,7 @@ theorem narrow_sext_mul_thm (e : IntW 32) (e_1 : IntW 16) : trunc 16 (mul (sext 
     all_goals sorry
 
 
-theorem narrow_zext_mul_thm (e : IntW 32) (e_1 : IntW 16) : trunc 16 (mul (zext 32 e_1) e) ⊑ mul e_1 (trunc 16 e) := by 
+theorem narrow_zext_mul_thm (e : IntW 32) (e_1 : IntW 16) : trunc 16 (mul (zext 32 e_1) e) ⊑ mul e_1 (trunc 16 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -124,7 +124,7 @@ theorem narrow_zext_mul_thm (e : IntW 32) (e_1 : IntW 16) : trunc 16 (mul (zext 
 
 theorem narrow_zext_ashr_keep_trunc_thm (e e_1 : IntW 8) :
   trunc 8 (ashr (add (sext 32 e_1) (sext 32 e) { «nsw» := true, «nuw» := false }) (const? 32 1)) ⊑
-    trunc 8 (lshr (add (sext 16 e_1) (sext 16 e) { «nsw» := true, «nuw» := false }) (const? 16 1)) := by 
+    trunc 8 (lshr (add (sext 16 e_1) (sext 16 e) { «nsw» := true, «nuw» := false }) (const? 16 1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -135,7 +135,7 @@ theorem narrow_zext_ashr_keep_trunc_thm (e e_1 : IntW 8) :
 
 theorem narrow_zext_ashr_keep_trunc2_thm (e e_1 : IntW 9) :
   trunc 8 (ashr (add (sext 64 e_1) (sext 64 e) { «nsw» := true, «nuw» := false }) (const? 64 1)) ⊑
-    trunc 8 (lshr (add (zext 16 e_1) (zext 16 e) { «nsw» := true, «nuw» := true }) (const? 16 1)) := by 
+    trunc 8 (lshr (add (zext 16 e_1) (zext 16 e) { «nsw» := true, «nuw» := true }) (const? 16 1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -146,7 +146,7 @@ theorem narrow_zext_ashr_keep_trunc2_thm (e e_1 : IntW 9) :
 
 theorem narrow_zext_ashr_keep_trunc3_thm (e e_1 : IntW 8) :
   trunc 7 (ashr (add (sext 64 e_1) (sext 64 e) { «nsw» := true, «nuw» := false }) (const? 64 1)) ⊑
-    trunc 7 (lshr (add (zext 14 e_1) (zext 14 e) { «nsw» := true, «nuw» := true }) (const? 14 1)) := by 
+    trunc 7 (lshr (add (zext 14 e_1) (zext 14 e) { «nsw» := true, «nuw» := true }) (const? 14 1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -157,7 +157,7 @@ theorem narrow_zext_ashr_keep_trunc3_thm (e e_1 : IntW 8) :
 
 theorem dont_narrow_zext_ashr_keep_trunc_thm (e e_1 : IntW 8) :
   trunc 8 (ashr (add (sext 16 e_1) (sext 16 e) { «nsw» := true, «nuw» := false }) (const? 16 1)) ⊑
-    trunc 8 (lshr (add (sext 16 e_1) (sext 16 e) { «nsw» := true, «nuw» := false }) (const? 16 1)) := by 
+    trunc 8 (lshr (add (sext 16 e_1) (sext 16 e) { «nsw» := true, «nuw» := false }) (const? 16 1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gtrunchdemand_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gtrunchdemand_proof.lean
@@ -10,7 +10,7 @@ set_option linter.unreachableTactic false
 section gtrunchdemand_proof
 theorem trunc_lshr_thm (e : IntW 8) :
   LLVM.and (trunc 6 (lshr e (const? 8 2))) (const? 6 14) ⊑
-    LLVM.and (lshr (trunc 6 e) (const? 6 2)) (const? 6 14) := by 
+    LLVM.and (lshr (trunc 6 e) (const? 6 2)) (const? 6 14) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -20,7 +20,7 @@ theorem trunc_lshr_thm (e : IntW 8) :
 
 
 theorem trunc_lshr_exact_mask_thm (e : IntW 8) :
-  LLVM.and (trunc 6 (lshr e (const? 8 2))) (const? 6 15) ⊑ lshr (trunc 6 e) (const? 6 2) := by 
+  LLVM.and (trunc 6 (lshr e (const? 8 2))) (const? 6 15) ⊑ lshr (trunc 6 e) (const? 6 2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -31,7 +31,7 @@ theorem trunc_lshr_exact_mask_thm (e : IntW 8) :
 
 theorem trunc_lshr_big_mask_thm (e : IntW 8) :
   LLVM.and (trunc 6 (lshr e (const? 8 2))) (const? 6 31) ⊑
-    LLVM.and (trunc 6 (lshr e (const? 8 2)) { «nsw» := false, «nuw» := true }) (const? 6 31) := by 
+    LLVM.and (trunc 6 (lshr e (const? 8 2)) { «nsw» := false, «nuw» := true }) (const? 6 31) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -42,7 +42,7 @@ theorem trunc_lshr_big_mask_thm (e : IntW 8) :
 
 theorem or_trunc_lshr_thm (e : IntW 8) :
   LLVM.or (trunc 6 (lshr e (const? 8 1))) (const? 6 (-32)) ⊑
-    LLVM.or (lshr (trunc 6 e) (const? 6 1)) (const? 6 (-32)) { «disjoint» := true } := by 
+    LLVM.or (lshr (trunc 6 e) (const? 6 1)) (const? 6 (-32)) { «disjoint» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -53,7 +53,7 @@ theorem or_trunc_lshr_thm (e : IntW 8) :
 
 theorem or_trunc_lshr_more_thm (e : IntW 8) :
   LLVM.or (trunc 6 (lshr e (const? 8 4))) (const? 6 (-4)) ⊑
-    LLVM.or (lshr (trunc 6 e) (const? 6 4)) (const? 6 (-4)) { «disjoint» := true } := by 
+    LLVM.or (lshr (trunc 6 e) (const? 6 4)) (const? 6 (-4)) { «disjoint» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -64,7 +64,7 @@ theorem or_trunc_lshr_more_thm (e : IntW 8) :
 
 theorem or_trunc_lshr_small_mask_thm (e : IntW 8) :
   LLVM.or (trunc 6 (lshr e (const? 8 4))) (const? 6 (-8)) ⊑
-    LLVM.or (trunc 6 (lshr e (const? 8 4)) { «nsw» := true, «nuw» := true }) (const? 6 (-8)) := by 
+    LLVM.or (trunc 6 (lshr e (const? 8 4)) { «nsw» := true, «nuw» := true }) (const? 6 (-8)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gtrunchinseltpoison_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gtrunchinseltpoison_proof.lean
@@ -8,7 +8,7 @@ set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
 
 section gtrunchinseltpoison_proof
-theorem test5_thm (e : IntW 32) : trunc 32 (lshr (zext 128 e) (const? 128 16)) ⊑ lshr e (const? 32 16) := by 
+theorem test5_thm (e : IntW 32) : trunc 32 (lshr (zext 128 e) (const? 128 16)) ⊑ lshr e (const? 32 16) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -19,7 +19,7 @@ theorem test5_thm (e : IntW 32) : trunc 32 (lshr (zext 128 e) (const? 128 16)) �
 
 theorem test6_thm (e : IntW 64) :
   trunc 32 (lshr (zext 128 e) (const? 128 32)) ⊑
-    trunc 32 (lshr e (const? 64 32)) { «nsw» := false, «nuw» := true } := by 
+    trunc 32 (lshr e (const? 64 32)) { «nsw» := false, «nuw» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -30,7 +30,7 @@ theorem test6_thm (e : IntW 64) :
 
 theorem ashr_mul_sign_bits_thm (e e_1 : IntW 8) :
   trunc 16 (ashr (mul (sext 32 e_1) (sext 32 e)) (const? 32 3)) ⊑
-    ashr (mul (sext 16 e_1) (sext 16 e) { «nsw» := true, «nuw» := false }) (const? 16 3) := by 
+    ashr (mul (sext 16 e_1) (sext 16 e) { «nsw» := true, «nuw» := false }) (const? 16 3) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -41,7 +41,7 @@ theorem ashr_mul_sign_bits_thm (e e_1 : IntW 8) :
 
 theorem ashr_mul_thm (e e_1 : IntW 8) :
   trunc 16 (ashr (mul (sext 20 e_1) (sext 20 e)) (const? 20 8)) ⊑
-    ashr (mul (sext 16 e_1) (sext 16 e) { «nsw» := true, «nuw» := false }) (const? 16 8) := by 
+    ashr (mul (sext 16 e_1) (sext 16 e) { «nsw» := true, «nuw» := false }) (const? 16 8) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -52,7 +52,7 @@ theorem ashr_mul_thm (e e_1 : IntW 8) :
 
 theorem trunc_ashr_thm (e : IntW 32) :
   trunc 32 (ashr (LLVM.or (zext 36 e) (const? 36 (-2147483648))) (const? 36 8)) ⊑
-    LLVM.or (lshr e (const? 32 8)) (const? 32 (-8388608)) := by 
+    LLVM.or (lshr e (const? 32 8)) (const? 32 (-8388608)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -62,7 +62,7 @@ theorem trunc_ashr_thm (e : IntW 32) :
 
 
 theorem test7_thm (e : IntW 64) :
-  trunc 92 (lshr (zext 128 e) (const? 128 32)) ⊑ zext 92 (lshr e (const? 64 32)) { «nneg» := true } := by 
+  trunc 92 (lshr (zext 128 e) (const? 128 32)) ⊑ zext 92 (lshr e (const? 64 32)) { «nneg» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -74,7 +74,7 @@ theorem test7_thm (e : IntW 64) :
 theorem test8_thm (e e_1 : IntW 32) :
   trunc 64 (LLVM.or (shl (zext 128 e_1) (const? 128 32)) (zext 128 e)) ⊑
     LLVM.or (shl (zext 64 e_1) (const? 64 32) { «nsw» := false, «nuw» := true }) (zext 64 e)
-      { «disjoint» := true } := by 
+      { «disjoint» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -83,7 +83,7 @@ theorem test8_thm (e e_1 : IntW 32) :
     all_goals sorry
 
 
-theorem test9_thm (e : IntW 32) : trunc 8 (LLVM.and e (const? 32 42)) ⊑ LLVM.and (trunc 8 e) (const? 8 42) := by 
+theorem test9_thm (e : IntW 32) : trunc 8 (LLVM.and e (const? 32 42)) ⊑ LLVM.and (trunc 8 e) (const? 8 42) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -94,7 +94,7 @@ theorem test9_thm (e : IntW 32) : trunc 8 (LLVM.and e (const? 32 42)) ⊑ LLVM.a
 
 theorem test11_thm (e e_1 : IntW 32) :
   trunc 64 (shl (zext 128 e_1) (LLVM.and (zext 128 e) (const? 128 31))) ⊑
-    shl (zext 64 e_1) (zext 64 (LLVM.and e (const? 32 31)) { «nneg» := true }) { «nsw» := true, «nuw» := true } := by 
+    shl (zext 64 e_1) (zext 64 (LLVM.and e (const? 32 31)) { «nneg» := true }) { «nsw» := true, «nuw» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -105,7 +105,7 @@ theorem test11_thm (e e_1 : IntW 32) :
 
 theorem test12_thm (e e_1 : IntW 32) :
   trunc 64 (lshr (zext 128 e_1) (LLVM.and (zext 128 e) (const? 128 31))) ⊑
-    lshr (zext 64 e_1) (zext 64 (LLVM.and e (const? 32 31)) { «nneg» := true }) := by 
+    lshr (zext 64 e_1) (zext 64 (LLVM.and e (const? 32 31)) { «nneg» := true }) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -116,7 +116,7 @@ theorem test12_thm (e e_1 : IntW 32) :
 
 theorem test13_thm (e e_1 : IntW 32) :
   trunc 64 (ashr (sext 128 e_1) (LLVM.and (zext 128 e) (const? 128 31))) ⊑
-    ashr (sext 64 e_1) (zext 64 (LLVM.and e (const? 32 31)) { «nneg» := true }) := by 
+    ashr (sext 64 e_1) (zext 64 (LLVM.and e (const? 32 31)) { «nneg» := true }) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -125,7 +125,7 @@ theorem test13_thm (e e_1 : IntW 32) :
     all_goals sorry
 
 
-theorem trunc_shl_31_i32_i64_thm (e : IntW 64) : trunc 32 (shl e (const? 64 31)) ⊑ shl (trunc 32 e) (const? 32 31) := by 
+theorem trunc_shl_31_i32_i64_thm (e : IntW 64) : trunc 32 (shl e (const? 64 31)) ⊑ shl (trunc 32 e) (const? 32 31) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -135,7 +135,7 @@ theorem trunc_shl_31_i32_i64_thm (e : IntW 64) : trunc 32 (shl e (const? 64 31))
 
 
 theorem trunc_shl_nsw_31_i32_i64_thm (e : IntW 64) :
-  trunc 32 (shl e (const? 64 31) { «nsw» := true, «nuw» := false }) ⊑ shl (trunc 32 e) (const? 32 31) := by 
+  trunc 32 (shl e (const? 64 31) { «nsw» := true, «nuw» := false }) ⊑ shl (trunc 32 e) (const? 32 31) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -145,7 +145,7 @@ theorem trunc_shl_nsw_31_i32_i64_thm (e : IntW 64) :
 
 
 theorem trunc_shl_nuw_31_i32_i64_thm (e : IntW 64) :
-  trunc 32 (shl e (const? 64 31) { «nsw» := false, «nuw» := true }) ⊑ shl (trunc 32 e) (const? 32 31) := by 
+  trunc 32 (shl e (const? 64 31) { «nsw» := false, «nuw» := true }) ⊑ shl (trunc 32 e) (const? 32 31) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -155,7 +155,7 @@ theorem trunc_shl_nuw_31_i32_i64_thm (e : IntW 64) :
 
 
 theorem trunc_shl_nsw_nuw_31_i32_i64_thm (e : IntW 64) :
-  trunc 32 (shl e (const? 64 31) { «nsw» := true, «nuw» := true }) ⊑ shl (trunc 32 e) (const? 32 31) := by 
+  trunc 32 (shl e (const? 64 31) { «nsw» := true, «nuw» := true }) ⊑ shl (trunc 32 e) (const? 32 31) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -164,7 +164,7 @@ theorem trunc_shl_nsw_nuw_31_i32_i64_thm (e : IntW 64) :
     all_goals sorry
 
 
-theorem trunc_shl_15_i16_i64_thm (e : IntW 64) : trunc 16 (shl e (const? 64 15)) ⊑ shl (trunc 16 e) (const? 16 15) := by 
+theorem trunc_shl_15_i16_i64_thm (e : IntW 64) : trunc 16 (shl e (const? 64 15)) ⊑ shl (trunc 16 e) (const? 16 15) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -173,7 +173,7 @@ theorem trunc_shl_15_i16_i64_thm (e : IntW 64) : trunc 16 (shl e (const? 64 15))
     all_goals sorry
 
 
-theorem trunc_shl_15_i16_i32_thm (e : IntW 32) : trunc 16 (shl e (const? 32 15)) ⊑ shl (trunc 16 e) (const? 16 15) := by 
+theorem trunc_shl_15_i16_i32_thm (e : IntW 32) : trunc 16 (shl e (const? 32 15)) ⊑ shl (trunc 16 e) (const? 16 15) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -182,7 +182,7 @@ theorem trunc_shl_15_i16_i32_thm (e : IntW 32) : trunc 16 (shl e (const? 32 15))
     all_goals sorry
 
 
-theorem trunc_shl_7_i8_i64_thm (e : IntW 64) : trunc 8 (shl e (const? 64 7)) ⊑ shl (trunc 8 e) (const? 8 7) := by 
+theorem trunc_shl_7_i8_i64_thm (e : IntW 64) : trunc 8 (shl e (const? 64 7)) ⊑ shl (trunc 8 e) (const? 8 7) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -191,7 +191,7 @@ theorem trunc_shl_7_i8_i64_thm (e : IntW 64) : trunc 8 (shl e (const? 64 7)) ⊑
     all_goals sorry
 
 
-theorem trunc_shl_1_i32_i64_thm (e : IntW 64) : trunc 32 (shl e (const? 64 1)) ⊑ shl (trunc 32 e) (const? 32 1) := by 
+theorem trunc_shl_1_i32_i64_thm (e : IntW 64) : trunc 32 (shl e (const? 64 1)) ⊑ shl (trunc 32 e) (const? 32 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -200,7 +200,7 @@ theorem trunc_shl_1_i32_i64_thm (e : IntW 64) : trunc 32 (shl e (const? 64 1)) �
     all_goals sorry
 
 
-theorem trunc_shl_16_i32_i64_thm (e : IntW 64) : trunc 32 (shl e (const? 64 16)) ⊑ shl (trunc 32 e) (const? 32 16) := by 
+theorem trunc_shl_16_i32_i64_thm (e : IntW 64) : trunc 32 (shl e (const? 64 16)) ⊑ shl (trunc 32 e) (const? 32 16) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -209,7 +209,7 @@ theorem trunc_shl_16_i32_i64_thm (e : IntW 64) : trunc 32 (shl e (const? 64 16))
     all_goals sorry
 
 
-theorem trunc_shl_33_i32_i64_thm (e : IntW 64) : trunc 32 (shl e (const? 64 33)) ⊑ const? 32 0 := by 
+theorem trunc_shl_33_i32_i64_thm (e : IntW 64) : trunc 32 (shl e (const? 64 33)) ⊑ const? 32 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -218,7 +218,7 @@ theorem trunc_shl_33_i32_i64_thm (e : IntW 64) : trunc 32 (shl e (const? 64 33))
     all_goals sorry
 
 
-theorem trunc_shl_32_i32_i64_thm (e : IntW 64) : trunc 32 (shl e (const? 64 32)) ⊑ const? 32 0 := by 
+theorem trunc_shl_32_i32_i64_thm (e : IntW 64) : trunc 32 (shl e (const? 64 32)) ⊑ const? 32 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -229,7 +229,7 @@ theorem trunc_shl_32_i32_i64_thm (e : IntW 64) : trunc 32 (shl e (const? 64 32))
 
 theorem trunc_shl_lshr_infloop_thm (e : IntW 64) :
   trunc 32 (shl (lshr e (const? 64 1)) (const? 64 2)) ⊑
-    LLVM.and (shl (trunc 32 e) (const? 32 1)) (const? 32 (-4)) := by 
+    LLVM.and (shl (trunc 32 e) (const? 32 1)) (const? 32 (-4)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -240,7 +240,7 @@ theorem trunc_shl_lshr_infloop_thm (e : IntW 64) :
 
 theorem trunc_shl_ashr_infloop_thm (e : IntW 64) :
   trunc 32 (shl (ashr e (const? 64 3)) (const? 64 2)) ⊑
-    LLVM.and (trunc 32 (lshr e (const? 64 1))) (const? 32 (-4)) := by 
+    LLVM.and (trunc 32 (lshr e (const? 64 1))) (const? 32 (-4)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -250,7 +250,7 @@ theorem trunc_shl_ashr_infloop_thm (e : IntW 64) :
 
 
 theorem trunc_shl_shl_infloop_thm (e : IntW 64) :
-  trunc 32 (shl (shl e (const? 64 1)) (const? 64 2)) ⊑ shl (trunc 32 e) (const? 32 3) := by 
+  trunc 32 (shl (shl e (const? 64 1)) (const? 64 2)) ⊑ shl (trunc 32 e) (const? 32 3) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -260,7 +260,7 @@ theorem trunc_shl_shl_infloop_thm (e : IntW 64) :
 
 
 theorem trunc_shl_lshr_var_thm (e e_1 : IntW 64) :
-  trunc 32 (shl (lshr e_1 e) (const? 64 2)) ⊑ shl (trunc 32 (lshr e_1 e)) (const? 32 2) := by 
+  trunc 32 (shl (lshr e_1 e) (const? 64 2)) ⊑ shl (trunc 32 (lshr e_1 e)) (const? 32 2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -270,7 +270,7 @@ theorem trunc_shl_lshr_var_thm (e e_1 : IntW 64) :
 
 
 theorem trunc_shl_ashr_var_thm (e e_1 : IntW 64) :
-  trunc 32 (shl (ashr e_1 e) (const? 64 2)) ⊑ shl (trunc 32 (ashr e_1 e)) (const? 32 2) := by 
+  trunc 32 (shl (ashr e_1 e) (const? 64 2)) ⊑ shl (trunc 32 (ashr e_1 e)) (const? 32 2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -280,7 +280,7 @@ theorem trunc_shl_ashr_var_thm (e e_1 : IntW 64) :
 
 
 theorem trunc_shl_shl_var_thm (e e_1 : IntW 64) :
-  trunc 32 (shl (shl e_1 e) (const? 64 2)) ⊑ shl (trunc 32 (shl e_1 e)) (const? 32 2) := by 
+  trunc 32 (shl (shl e_1 e) (const? 64 2)) ⊑ shl (trunc 32 (shl e_1 e)) (const? 32 2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -295,7 +295,7 @@ theorem PR44545_thm (e e_1 : IntW 32) :
         (select (icmp IntPredicate.eq e_1 (const? 32 0)) (const? 32 0)
           (add e (const? 32 1) { «nsw» := true, «nuw» := true })))
       (const? 16 (-1)) { «nsw» := true, «nuw» := false } ⊑
-    select (icmp IntPredicate.eq e_1 (const? 32 0)) (const? 16 (-1)) (trunc 16 e) := by 
+    select (icmp IntPredicate.eq e_1 (const? 32 0)) (const? 16 (-1)) (trunc 16 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gtrunchshifthtrunc_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gtrunchshifthtrunc_proof.lean
@@ -8,7 +8,7 @@ set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
 
 section gtrunchshifthtrunc_proof
-theorem trunc_lshr_trunc_thm (e : IntW 64) : trunc 8 (lshr (trunc 32 e) (const? 32 8)) ⊑ trunc 8 (lshr e (const? 64 8)) := by 
+theorem trunc_lshr_trunc_thm (e : IntW 64) : trunc 8 (lshr (trunc 32 e) (const? 32 8)) ⊑ trunc 8 (lshr e (const? 64 8)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -19,7 +19,7 @@ theorem trunc_lshr_trunc_thm (e : IntW 64) : trunc 8 (lshr (trunc 32 e) (const? 
 
 theorem trunc_lshr_trunc_outofrange_thm (e : IntW 64) :
   trunc 8 (lshr (trunc 32 e) (const? 32 25)) ⊑
-    trunc 8 (lshr (trunc 32 e) (const? 32 25)) { «nsw» := true, «nuw» := true } := by 
+    trunc 8 (lshr (trunc 32 e) (const? 32 25)) { «nsw» := true, «nuw» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -28,7 +28,7 @@ theorem trunc_lshr_trunc_outofrange_thm (e : IntW 64) :
     all_goals sorry
 
 
-theorem trunc_ashr_trunc_thm (e : IntW 64) : trunc 8 (ashr (trunc 32 e) (const? 32 8)) ⊑ trunc 8 (lshr e (const? 64 8)) := by 
+theorem trunc_ashr_trunc_thm (e : IntW 64) : trunc 8 (ashr (trunc 32 e) (const? 32 8)) ⊑ trunc 8 (lshr e (const? 64 8)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -39,7 +39,7 @@ theorem trunc_ashr_trunc_thm (e : IntW 64) : trunc 8 (ashr (trunc 32 e) (const? 
 
 theorem trunc_ashr_trunc_exact_thm (e : IntW 64) :
   trunc 8 (ashr (trunc 32 e) (const? 32 8) { «exact» := true }) ⊑
-    trunc 8 (lshr e (const? 64 8) { «exact» := true }) := by 
+    trunc 8 (lshr e (const? 64 8) { «exact» := true }) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -50,7 +50,7 @@ theorem trunc_ashr_trunc_exact_thm (e : IntW 64) :
 
 theorem trunc_ashr_trunc_outofrange_thm (e : IntW 64) :
   trunc 8 (ashr (trunc 32 e) (const? 32 25)) ⊑
-    trunc 8 (ashr (trunc 32 e) (const? 32 25)) { «nsw» := true, «nuw» := false } := by 
+    trunc 8 (ashr (trunc 32 e) (const? 32 25)) { «nsw» := true, «nuw» := false } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gtrunchshlhzext_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gtrunchshlhzext_proof.lean
@@ -9,7 +9,7 @@ set_option linter.unreachableTactic false
 
 section gtrunchshlhzext_proof
 theorem trunc_shl_zext_32_thm (e : IntW 32) :
-  zext 32 (shl (trunc 16 e) (const? 16 4)) ⊑ LLVM.and (shl e (const? 32 4)) (const? 32 65520) := by 
+  zext 32 (shl (trunc 16 e) (const? 16 4)) ⊑ LLVM.and (shl e (const? 32 4)) (const? 32 65520) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -19,7 +19,7 @@ theorem trunc_shl_zext_32_thm (e : IntW 32) :
 
 
 theorem trunc_shl_zext_64_thm (e : IntW 64) :
-  zext 64 (shl (trunc 8 e) (const? 8 7)) ⊑ LLVM.and (shl e (const? 64 7)) (const? 64 128) := by 
+  zext 64 (shl (trunc 8 e) (const? 8 7)) ⊑ LLVM.and (shl e (const? 64 7)) (const? 64 128) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/guaddo_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/guaddo_proof.lean
@@ -10,7 +10,7 @@ set_option linter.unreachableTactic false
 section guaddo_proof
 theorem uaddo_commute3_thm (e e_1 e_2 : IntW 32) :
   select (icmp IntPredicate.ult (LLVM.xor e_2 (const? 32 (-1))) e_1) e (add e_1 e_2) ⊑
-    select (icmp IntPredicate.ugt e_1 (LLVM.xor e_2 (const? 32 (-1)))) e (add e_1 e_2) := by 
+    select (icmp IntPredicate.ugt e_1 (LLVM.xor e_2 (const? 32 (-1)))) e (add e_1 e_2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -21,7 +21,7 @@ theorem uaddo_commute3_thm (e e_1 e_2 : IntW 32) :
 
 theorem uaddo_commute4_thm (e e_1 e_2 : IntW 32) :
   select (icmp IntPredicate.ult (LLVM.xor e_2 (const? 32 (-1))) e_1) e (add e_2 e_1) ⊑
-    select (icmp IntPredicate.ugt e_1 (LLVM.xor e_2 (const? 32 (-1)))) e (add e_2 e_1) := by 
+    select (icmp IntPredicate.ugt e_1 (LLVM.xor e_2 (const? 32 (-1)))) e (add e_2 e_1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -32,7 +32,7 @@ theorem uaddo_commute4_thm (e e_1 e_2 : IntW 32) :
 
 theorem uaddo_commute7_thm (e e_1 e_2 : IntW 32) :
   select (icmp IntPredicate.ult (LLVM.xor e_2 (const? 32 (-1))) e_1) (add e_1 e_2) e ⊑
-    select (icmp IntPredicate.ugt e_1 (LLVM.xor e_2 (const? 32 (-1)))) (add e_1 e_2) e := by 
+    select (icmp IntPredicate.ugt e_1 (LLVM.xor e_2 (const? 32 (-1)))) (add e_1 e_2) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -43,7 +43,7 @@ theorem uaddo_commute7_thm (e e_1 e_2 : IntW 32) :
 
 theorem uaddo_commute8_thm (e e_1 e_2 : IntW 32) :
   select (icmp IntPredicate.ult (LLVM.xor e_2 (const? 32 (-1))) e_1) (add e_2 e_1) e ⊑
-    select (icmp IntPredicate.ugt e_1 (LLVM.xor e_2 (const? 32 (-1)))) (add e_2 e_1) e := by 
+    select (icmp IntPredicate.ugt e_1 (LLVM.xor e_2 (const? 32 (-1)))) (add e_2 e_1) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -54,7 +54,7 @@ theorem uaddo_commute8_thm (e e_1 e_2 : IntW 32) :
 
 theorem uaddo_wrong_pred2_thm (e e_1 e_2 : IntW 32) :
   select (icmp IntPredicate.uge e_2 (LLVM.xor e_1 (const? 32 (-1)))) e (add e_2 e_1) ⊑
-    select (icmp IntPredicate.ult e_2 (LLVM.xor e_1 (const? 32 (-1)))) (add e_2 e_1) e := by 
+    select (icmp IntPredicate.ult e_2 (LLVM.xor e_1 (const? 32 (-1)))) (add e_2 e_1) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gudiv_select_to_select_shift_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gudiv_select_to_select_shift_proof.lean
@@ -10,7 +10,7 @@ set_option linter.unreachableTactic false
 section gudiv_select_to_select_shift_proof
 theorem test_thm (e : IntW 1) (e_1 : IntW 64) :
   add (LLVM.udiv e_1 (select e (const? 64 16) (const? 64 8))) (LLVM.udiv e_1 (select e (const? 64 8) (const? 64 0))) ⊑
-    add (lshr e_1 (const? 64 4)) (lshr e_1 (const? 64 3)) { «nsw» := true, «nuw» := true } := by 
+    add (lshr e_1 (const? 64 4)) (lshr e_1 (const? 64 3)) { «nsw» := true, «nuw» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gudivremhchangehwidth_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gudivremhchangehwidth_proof.lean
@@ -8,7 +8,7 @@ set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
 
 section gudivremhchangehwidth_proof
-theorem udiv_i8_thm (e e_1 : IntW 8) : trunc 8 (LLVM.udiv (zext 32 e_1) (zext 32 e)) ⊑ LLVM.udiv e_1 e := by 
+theorem udiv_i8_thm (e e_1 : IntW 8) : trunc 8 (LLVM.udiv (zext 32 e_1) (zext 32 e)) ⊑ LLVM.udiv e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -17,7 +17,7 @@ theorem udiv_i8_thm (e e_1 : IntW 8) : trunc 8 (LLVM.udiv (zext 32 e_1) (zext 32
     all_goals sorry
 
 
-theorem urem_i8_thm (e e_1 : IntW 8) : trunc 8 (urem (zext 32 e_1) (zext 32 e)) ⊑ urem e_1 e := by 
+theorem urem_i8_thm (e e_1 : IntW 8) : trunc 8 (urem (zext 32 e_1) (zext 32 e)) ⊑ urem e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -26,7 +26,7 @@ theorem urem_i8_thm (e e_1 : IntW 8) : trunc 8 (urem (zext 32 e_1) (zext 32 e)) 
     all_goals sorry
 
 
-theorem udiv_i32_thm (e e_1 : IntW 8) : LLVM.udiv (zext 32 e_1) (zext 32 e) ⊑ zext 32 (LLVM.udiv e_1 e) := by 
+theorem udiv_i32_thm (e e_1 : IntW 8) : LLVM.udiv (zext 32 e_1) (zext 32 e) ⊑ zext 32 (LLVM.udiv e_1 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -38,7 +38,7 @@ theorem udiv_i32_thm (e e_1 : IntW 8) : LLVM.udiv (zext 32 e_1) (zext 32 e) ⊑ 
 theorem udiv_i32_multiuse_thm (e e_1 : IntW 8) :
   mul (LLVM.udiv (zext 32 e_1) (zext 32 e)) (add (zext 32 e_1) (zext 32 e)) ⊑
     mul (LLVM.udiv (zext 32 e_1) (zext 32 e)) (add (zext 32 e_1) (zext 32 e) { «nsw» := true, «nuw» := true })
-      { «nsw» := true, «nuw» := true } := by 
+      { «nsw» := true, «nuw» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -47,7 +47,7 @@ theorem udiv_i32_multiuse_thm (e e_1 : IntW 8) :
     all_goals sorry
 
 
-theorem udiv_illegal_type_thm (e e_1 : IntW 9) : LLVM.udiv (zext 32 e_1) (zext 32 e) ⊑ zext 32 (LLVM.udiv e_1 e) := by 
+theorem udiv_illegal_type_thm (e e_1 : IntW 9) : LLVM.udiv (zext 32 e_1) (zext 32 e) ⊑ zext 32 (LLVM.udiv e_1 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -56,7 +56,7 @@ theorem udiv_illegal_type_thm (e e_1 : IntW 9) : LLVM.udiv (zext 32 e_1) (zext 3
     all_goals sorry
 
 
-theorem urem_i32_thm (e e_1 : IntW 8) : urem (zext 32 e_1) (zext 32 e) ⊑ zext 32 (urem e_1 e) := by 
+theorem urem_i32_thm (e e_1 : IntW 8) : urem (zext 32 e_1) (zext 32 e) ⊑ zext 32 (urem e_1 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -68,7 +68,7 @@ theorem urem_i32_thm (e e_1 : IntW 8) : urem (zext 32 e_1) (zext 32 e) ⊑ zext 
 theorem urem_i32_multiuse_thm (e e_1 : IntW 8) :
   mul (urem (zext 32 e_1) (zext 32 e)) (add (zext 32 e_1) (zext 32 e)) ⊑
     mul (urem (zext 32 e_1) (zext 32 e)) (add (zext 32 e_1) (zext 32 e) { «nsw» := true, «nuw» := true })
-      { «nsw» := true, «nuw» := true } := by 
+      { «nsw» := true, «nuw» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -77,7 +77,7 @@ theorem urem_i32_multiuse_thm (e e_1 : IntW 8) :
     all_goals sorry
 
 
-theorem urem_illegal_type_thm (e e_1 : IntW 9) : urem (zext 32 e_1) (zext 32 e) ⊑ zext 32 (urem e_1 e) := by 
+theorem urem_illegal_type_thm (e e_1 : IntW 9) : urem (zext 32 e_1) (zext 32 e) ⊑ zext 32 (urem e_1 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -87,7 +87,7 @@ theorem urem_illegal_type_thm (e e_1 : IntW 9) : urem (zext 32 e_1) (zext 32 e) 
 
 
 theorem udiv_i32_c_thm (e : IntW 8) :
-  LLVM.udiv (zext 32 e) (const? 32 10) ⊑ zext 32 (LLVM.udiv e (const? 8 10)) { «nneg» := true } := by 
+  LLVM.udiv (zext 32 e) (const? 32 10) ⊑ zext 32 (LLVM.udiv e (const? 8 10)) { «nneg» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -98,7 +98,7 @@ theorem udiv_i32_c_thm (e : IntW 8) :
 
 theorem udiv_i32_c_multiuse_thm (e : IntW 8) :
   add (zext 32 e) (LLVM.udiv (zext 32 e) (const? 32 10)) ⊑
-    add (LLVM.udiv (zext 32 e) (const? 32 10)) (zext 32 e) { «nsw» := true, «nuw» := true } := by 
+    add (LLVM.udiv (zext 32 e) (const? 32 10)) (zext 32 e) { «nsw» := true, «nuw» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -108,7 +108,7 @@ theorem udiv_i32_c_multiuse_thm (e : IntW 8) :
 
 
 theorem udiv_illegal_type_c_thm (e : IntW 9) :
-  LLVM.udiv (zext 32 e) (const? 32 10) ⊑ zext 32 (LLVM.udiv e (const? 9 10)) { «nneg» := true } := by 
+  LLVM.udiv (zext 32 e) (const? 32 10) ⊑ zext 32 (LLVM.udiv e (const? 9 10)) { «nneg» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -118,7 +118,7 @@ theorem udiv_illegal_type_c_thm (e : IntW 9) :
 
 
 theorem urem_i32_c_thm (e : IntW 8) :
-  urem (zext 32 e) (const? 32 10) ⊑ zext 32 (urem e (const? 8 10)) { «nneg» := true } := by 
+  urem (zext 32 e) (const? 32 10) ⊑ zext 32 (urem e (const? 8 10)) { «nneg» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -129,7 +129,7 @@ theorem urem_i32_c_thm (e : IntW 8) :
 
 theorem urem_i32_c_multiuse_thm (e : IntW 8) :
   add (zext 32 e) (urem (zext 32 e) (const? 32 10)) ⊑
-    add (urem (zext 32 e) (const? 32 10)) (zext 32 e) { «nsw» := true, «nuw» := true } := by 
+    add (urem (zext 32 e) (const? 32 10)) (zext 32 e) { «nsw» := true, «nuw» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -139,7 +139,7 @@ theorem urem_i32_c_multiuse_thm (e : IntW 8) :
 
 
 theorem urem_illegal_type_c_thm (e : IntW 9) :
-  urem (zext 32 e) (const? 32 10) ⊑ zext 32 (urem e (const? 9 10)) { «nneg» := true } := by 
+  urem (zext 32 e) (const? 32 10) ⊑ zext 32 (urem e (const? 9 10)) { «nneg» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -149,7 +149,7 @@ theorem urem_illegal_type_c_thm (e : IntW 9) :
 
 
 theorem udiv_c_i32_thm (e : IntW 8) :
-  LLVM.udiv (const? 32 10) (zext 32 e) ⊑ zext 32 (LLVM.udiv (const? 8 10) e) { «nneg» := true } := by 
+  LLVM.udiv (const? 32 10) (zext 32 e) ⊑ zext 32 (LLVM.udiv (const? 8 10) e) { «nneg» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -159,7 +159,7 @@ theorem udiv_c_i32_thm (e : IntW 8) :
 
 
 theorem urem_c_i32_thm (e : IntW 8) :
-  urem (const? 32 10) (zext 32 e) ⊑ zext 32 (urem (const? 8 10) e) { «nneg» := true } := by 
+  urem (const? 32 10) (zext 32 e) ⊑ zext 32 (urem (const? 8 10) e) { «nneg» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gumaxhicmp_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gumaxhicmp_proof.lean
@@ -9,7 +9,7 @@ set_option linter.unreachableTactic false
 
 section gumaxhicmp_proof
 theorem eq_umax1_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.eq (select (icmp IntPredicate.ugt e_1 e) e_1 e) e_1 ⊑ icmp IntPredicate.uge e_1 e := by 
+  icmp IntPredicate.eq (select (icmp IntPredicate.ugt e_1 e) e_1 e) e_1 ⊑ icmp IntPredicate.uge e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -19,7 +19,7 @@ theorem eq_umax1_thm (e e_1 : IntW 32) :
 
 
 theorem eq_umax2_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.eq (select (icmp IntPredicate.ugt e_1 e) e_1 e) e ⊑ icmp IntPredicate.uge e e_1 := by 
+  icmp IntPredicate.eq (select (icmp IntPredicate.ugt e_1 e) e_1 e) e ⊑ icmp IntPredicate.uge e e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -31,7 +31,7 @@ theorem eq_umax2_thm (e e_1 : IntW 32) :
 theorem eq_umax3_thm (e e_1 : IntW 32) :
   icmp IntPredicate.eq (add e_1 (const? 32 3))
       (select (icmp IntPredicate.ugt (add e_1 (const? 32 3)) e) (add e_1 (const? 32 3)) e) ⊑
-    icmp IntPredicate.uge (add e_1 (const? 32 3)) e := by 
+    icmp IntPredicate.uge (add e_1 (const? 32 3)) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -43,7 +43,7 @@ theorem eq_umax3_thm (e e_1 : IntW 32) :
 theorem eq_umax4_thm (e e_1 : IntW 32) :
   icmp IntPredicate.eq (add e_1 (const? 32 3))
       (select (icmp IntPredicate.ugt e (add e_1 (const? 32 3))) e (add e_1 (const? 32 3))) ⊑
-    icmp IntPredicate.uge (add e_1 (const? 32 3)) e := by 
+    icmp IntPredicate.uge (add e_1 (const? 32 3)) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -53,7 +53,7 @@ theorem eq_umax4_thm (e e_1 : IntW 32) :
 
 
 theorem ule_umax1_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.ule (select (icmp IntPredicate.ugt e_1 e) e_1 e) e_1 ⊑ icmp IntPredicate.ule e e_1 := by 
+  icmp IntPredicate.ule (select (icmp IntPredicate.ugt e_1 e) e_1 e) e_1 ⊑ icmp IntPredicate.ule e e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -63,7 +63,7 @@ theorem ule_umax1_thm (e e_1 : IntW 32) :
 
 
 theorem ule_umax2_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.ule (select (icmp IntPredicate.ugt e_1 e) e_1 e) e ⊑ icmp IntPredicate.ule e_1 e := by 
+  icmp IntPredicate.ule (select (icmp IntPredicate.ugt e_1 e) e_1 e) e ⊑ icmp IntPredicate.ule e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -75,7 +75,7 @@ theorem ule_umax2_thm (e e_1 : IntW 32) :
 theorem ule_umax3_thm (e e_1 : IntW 32) :
   icmp IntPredicate.uge (add e_1 (const? 32 3))
       (select (icmp IntPredicate.ugt (add e_1 (const? 32 3)) e) (add e_1 (const? 32 3)) e) ⊑
-    icmp IntPredicate.ule e (add e_1 (const? 32 3)) := by 
+    icmp IntPredicate.ule e (add e_1 (const? 32 3)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -87,7 +87,7 @@ theorem ule_umax3_thm (e e_1 : IntW 32) :
 theorem ule_umax4_thm (e e_1 : IntW 32) :
   icmp IntPredicate.uge (add e_1 (const? 32 3))
       (select (icmp IntPredicate.ugt e (add e_1 (const? 32 3))) e (add e_1 (const? 32 3))) ⊑
-    icmp IntPredicate.ule e (add e_1 (const? 32 3)) := by 
+    icmp IntPredicate.ule e (add e_1 (const? 32 3)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -97,7 +97,7 @@ theorem ule_umax4_thm (e e_1 : IntW 32) :
 
 
 theorem ne_umax1_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.ne (select (icmp IntPredicate.ugt e_1 e) e_1 e) e_1 ⊑ icmp IntPredicate.ult e_1 e := by 
+  icmp IntPredicate.ne (select (icmp IntPredicate.ugt e_1 e) e_1 e) e_1 ⊑ icmp IntPredicate.ult e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -107,7 +107,7 @@ theorem ne_umax1_thm (e e_1 : IntW 32) :
 
 
 theorem ne_umax2_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.ne (select (icmp IntPredicate.ugt e_1 e) e_1 e) e ⊑ icmp IntPredicate.ult e e_1 := by 
+  icmp IntPredicate.ne (select (icmp IntPredicate.ugt e_1 e) e_1 e) e ⊑ icmp IntPredicate.ult e e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -119,7 +119,7 @@ theorem ne_umax2_thm (e e_1 : IntW 32) :
 theorem ne_umax3_thm (e e_1 : IntW 32) :
   icmp IntPredicate.ne (add e_1 (const? 32 3))
       (select (icmp IntPredicate.ugt (add e_1 (const? 32 3)) e) (add e_1 (const? 32 3)) e) ⊑
-    icmp IntPredicate.ult (add e_1 (const? 32 3)) e := by 
+    icmp IntPredicate.ult (add e_1 (const? 32 3)) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -131,7 +131,7 @@ theorem ne_umax3_thm (e e_1 : IntW 32) :
 theorem ne_umax4_thm (e e_1 : IntW 32) :
   icmp IntPredicate.ne (add e_1 (const? 32 3))
       (select (icmp IntPredicate.ugt e (add e_1 (const? 32 3))) e (add e_1 (const? 32 3))) ⊑
-    icmp IntPredicate.ult (add e_1 (const? 32 3)) e := by 
+    icmp IntPredicate.ult (add e_1 (const? 32 3)) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -141,7 +141,7 @@ theorem ne_umax4_thm (e e_1 : IntW 32) :
 
 
 theorem ugt_umax1_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.ugt (select (icmp IntPredicate.ugt e_1 e) e_1 e) e_1 ⊑ icmp IntPredicate.ugt e e_1 := by 
+  icmp IntPredicate.ugt (select (icmp IntPredicate.ugt e_1 e) e_1 e) e_1 ⊑ icmp IntPredicate.ugt e e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -151,7 +151,7 @@ theorem ugt_umax1_thm (e e_1 : IntW 32) :
 
 
 theorem ugt_umax2_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.ugt (select (icmp IntPredicate.ugt e_1 e) e_1 e) e ⊑ icmp IntPredicate.ugt e_1 e := by 
+  icmp IntPredicate.ugt (select (icmp IntPredicate.ugt e_1 e) e_1 e) e ⊑ icmp IntPredicate.ugt e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -163,7 +163,7 @@ theorem ugt_umax2_thm (e e_1 : IntW 32) :
 theorem ugt_umax3_thm (e e_1 : IntW 32) :
   icmp IntPredicate.ult (add e_1 (const? 32 3))
       (select (icmp IntPredicate.ugt (add e_1 (const? 32 3)) e) (add e_1 (const? 32 3)) e) ⊑
-    icmp IntPredicate.ugt e (add e_1 (const? 32 3)) := by 
+    icmp IntPredicate.ugt e (add e_1 (const? 32 3)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -175,7 +175,7 @@ theorem ugt_umax3_thm (e e_1 : IntW 32) :
 theorem ugt_umax4_thm (e e_1 : IntW 32) :
   icmp IntPredicate.ult (add e_1 (const? 32 3))
       (select (icmp IntPredicate.ugt e (add e_1 (const? 32 3))) e (add e_1 (const? 32 3))) ⊑
-    icmp IntPredicate.ugt e (add e_1 (const? 32 3)) := by 
+    icmp IntPredicate.ugt e (add e_1 (const? 32 3)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/guminhicmp_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/guminhicmp_proof.lean
@@ -9,7 +9,7 @@ set_option linter.unreachableTactic false
 
 section guminhicmp_proof
 theorem eq_umin1_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.eq (select (icmp IntPredicate.ult e_1 e) e_1 e) e_1 ⊑ icmp IntPredicate.ule e_1 e := by 
+  icmp IntPredicate.eq (select (icmp IntPredicate.ult e_1 e) e_1 e) e_1 ⊑ icmp IntPredicate.ule e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -19,7 +19,7 @@ theorem eq_umin1_thm (e e_1 : IntW 32) :
 
 
 theorem eq_umin2_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.eq (select (icmp IntPredicate.ult e_1 e) e_1 e) e ⊑ icmp IntPredicate.ule e e_1 := by 
+  icmp IntPredicate.eq (select (icmp IntPredicate.ult e_1 e) e_1 e) e ⊑ icmp IntPredicate.ule e e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -31,7 +31,7 @@ theorem eq_umin2_thm (e e_1 : IntW 32) :
 theorem eq_umin3_thm (e e_1 : IntW 32) :
   icmp IntPredicate.eq (add e_1 (const? 32 3))
       (select (icmp IntPredicate.ult (add e_1 (const? 32 3)) e) (add e_1 (const? 32 3)) e) ⊑
-    icmp IntPredicate.ule (add e_1 (const? 32 3)) e := by 
+    icmp IntPredicate.ule (add e_1 (const? 32 3)) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -43,7 +43,7 @@ theorem eq_umin3_thm (e e_1 : IntW 32) :
 theorem eq_umin4_thm (e e_1 : IntW 32) :
   icmp IntPredicate.eq (add e_1 (const? 32 3))
       (select (icmp IntPredicate.ult e (add e_1 (const? 32 3))) e (add e_1 (const? 32 3))) ⊑
-    icmp IntPredicate.ule (add e_1 (const? 32 3)) e := by 
+    icmp IntPredicate.ule (add e_1 (const? 32 3)) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -53,7 +53,7 @@ theorem eq_umin4_thm (e e_1 : IntW 32) :
 
 
 theorem uge_umin1_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.uge (select (icmp IntPredicate.ult e_1 e) e_1 e) e_1 ⊑ icmp IntPredicate.uge e e_1 := by 
+  icmp IntPredicate.uge (select (icmp IntPredicate.ult e_1 e) e_1 e) e_1 ⊑ icmp IntPredicate.uge e e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -63,7 +63,7 @@ theorem uge_umin1_thm (e e_1 : IntW 32) :
 
 
 theorem uge_umin2_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.uge (select (icmp IntPredicate.ult e_1 e) e_1 e) e ⊑ icmp IntPredicate.uge e_1 e := by 
+  icmp IntPredicate.uge (select (icmp IntPredicate.ult e_1 e) e_1 e) e ⊑ icmp IntPredicate.uge e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -75,7 +75,7 @@ theorem uge_umin2_thm (e e_1 : IntW 32) :
 theorem uge_umin3_thm (e e_1 : IntW 32) :
   icmp IntPredicate.ule (add e_1 (const? 32 3))
       (select (icmp IntPredicate.ult (add e_1 (const? 32 3)) e) (add e_1 (const? 32 3)) e) ⊑
-    icmp IntPredicate.uge e (add e_1 (const? 32 3)) := by 
+    icmp IntPredicate.uge e (add e_1 (const? 32 3)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -87,7 +87,7 @@ theorem uge_umin3_thm (e e_1 : IntW 32) :
 theorem uge_umin4_thm (e e_1 : IntW 32) :
   icmp IntPredicate.ule (add e_1 (const? 32 3))
       (select (icmp IntPredicate.ult e (add e_1 (const? 32 3))) e (add e_1 (const? 32 3))) ⊑
-    icmp IntPredicate.uge e (add e_1 (const? 32 3)) := by 
+    icmp IntPredicate.uge e (add e_1 (const? 32 3)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -97,7 +97,7 @@ theorem uge_umin4_thm (e e_1 : IntW 32) :
 
 
 theorem ne_umin1_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.ne (select (icmp IntPredicate.ult e_1 e) e_1 e) e_1 ⊑ icmp IntPredicate.ugt e_1 e := by 
+  icmp IntPredicate.ne (select (icmp IntPredicate.ult e_1 e) e_1 e) e_1 ⊑ icmp IntPredicate.ugt e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -107,7 +107,7 @@ theorem ne_umin1_thm (e e_1 : IntW 32) :
 
 
 theorem ne_umin2_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.ne (select (icmp IntPredicate.ult e_1 e) e_1 e) e ⊑ icmp IntPredicate.ugt e e_1 := by 
+  icmp IntPredicate.ne (select (icmp IntPredicate.ult e_1 e) e_1 e) e ⊑ icmp IntPredicate.ugt e e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -119,7 +119,7 @@ theorem ne_umin2_thm (e e_1 : IntW 32) :
 theorem ne_umin3_thm (e e_1 : IntW 32) :
   icmp IntPredicate.ne (add e_1 (const? 32 3))
       (select (icmp IntPredicate.ult (add e_1 (const? 32 3)) e) (add e_1 (const? 32 3)) e) ⊑
-    icmp IntPredicate.ugt (add e_1 (const? 32 3)) e := by 
+    icmp IntPredicate.ugt (add e_1 (const? 32 3)) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -131,7 +131,7 @@ theorem ne_umin3_thm (e e_1 : IntW 32) :
 theorem ne_umin4_thm (e e_1 : IntW 32) :
   icmp IntPredicate.ne (add e_1 (const? 32 3))
       (select (icmp IntPredicate.ult e (add e_1 (const? 32 3))) e (add e_1 (const? 32 3))) ⊑
-    icmp IntPredicate.ugt (add e_1 (const? 32 3)) e := by 
+    icmp IntPredicate.ugt (add e_1 (const? 32 3)) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -141,7 +141,7 @@ theorem ne_umin4_thm (e e_1 : IntW 32) :
 
 
 theorem ult_umin1_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.ult (select (icmp IntPredicate.ult e_1 e) e_1 e) e_1 ⊑ icmp IntPredicate.ult e e_1 := by 
+  icmp IntPredicate.ult (select (icmp IntPredicate.ult e_1 e) e_1 e) e_1 ⊑ icmp IntPredicate.ult e e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -151,7 +151,7 @@ theorem ult_umin1_thm (e e_1 : IntW 32) :
 
 
 theorem ult_umin2_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.ult (select (icmp IntPredicate.ult e_1 e) e_1 e) e ⊑ icmp IntPredicate.ult e_1 e := by 
+  icmp IntPredicate.ult (select (icmp IntPredicate.ult e_1 e) e_1 e) e ⊑ icmp IntPredicate.ult e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -163,7 +163,7 @@ theorem ult_umin2_thm (e e_1 : IntW 32) :
 theorem ult_umin3_thm (e e_1 : IntW 32) :
   icmp IntPredicate.ugt (add e_1 (const? 32 3))
       (select (icmp IntPredicate.ult (add e_1 (const? 32 3)) e) (add e_1 (const? 32 3)) e) ⊑
-    icmp IntPredicate.ult e (add e_1 (const? 32 3)) := by 
+    icmp IntPredicate.ult e (add e_1 (const? 32 3)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -175,7 +175,7 @@ theorem ult_umin3_thm (e e_1 : IntW 32) :
 theorem ult_umin4_thm (e e_1 : IntW 32) :
   icmp IntPredicate.ugt (add e_1 (const? 32 3))
       (select (icmp IntPredicate.ult e (add e_1 (const? 32 3))) e (add e_1 (const? 32 3))) ⊑
-    icmp IntPredicate.ult e (add e_1 (const? 32 3)) := by 
+    icmp IntPredicate.ult e (add e_1 (const? 32 3)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gunfoldhmaskedhmergehwithhconsthmaskhscalar_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gunfoldhmaskedhmergehwithhconsthmaskhscalar_proof.lean
@@ -10,7 +10,7 @@ set_option linter.unreachableTactic false
 section gunfoldhmaskedhmergehwithhconsthmaskhscalar_proof
 theorem scalar0_thm (e e_1 : IntW 4) :
   LLVM.xor (LLVM.and (LLVM.xor e_1 e) (const? 4 1)) e ⊑
-    LLVM.or (LLVM.and e_1 (const? 4 1)) (LLVM.and e (const? 4 (-2))) { «disjoint» := true } := by 
+    LLVM.or (LLVM.and e_1 (const? 4 1)) (LLVM.and e (const? 4 (-2))) { «disjoint» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -21,7 +21,7 @@ theorem scalar0_thm (e e_1 : IntW 4) :
 
 theorem scalar1_thm (e e_1 : IntW 4) :
   LLVM.xor (LLVM.and (LLVM.xor e_1 e) (const? 4 (-2))) e ⊑
-    LLVM.or (LLVM.and e_1 (const? 4 (-2))) (LLVM.and e (const? 4 1)) { «disjoint» := true } := by 
+    LLVM.or (LLVM.and e_1 (const? 4 (-2))) (LLVM.and e (const? 4 1)) { «disjoint» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -31,7 +31,7 @@ theorem scalar1_thm (e e_1 : IntW 4) :
 
 
 theorem in_constant_varx_mone_thm (e : IntW 4) :
-  LLVM.xor (LLVM.and (LLVM.xor e (const? 4 (-1))) (const? 4 1)) (const? 4 (-1)) ⊑ LLVM.or e (const? 4 (-2)) := by 
+  LLVM.xor (LLVM.and (LLVM.xor e (const? 4 (-1))) (const? 4 1)) (const? 4 (-1)) ⊑ LLVM.or e (const? 4 (-2)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -41,7 +41,7 @@ theorem in_constant_varx_mone_thm (e : IntW 4) :
 
 
 theorem in_constant_varx_14_thm (e : IntW 4) :
-  LLVM.xor (LLVM.and (LLVM.xor e (const? 4 (-2))) (const? 4 1)) (const? 4 (-2)) ⊑ LLVM.or e (const? 4 (-2)) := by 
+  LLVM.xor (LLVM.and (LLVM.xor e (const? 4 (-2))) (const? 4 1)) (const? 4 (-2)) ⊑ LLVM.or e (const? 4 (-2)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -51,7 +51,7 @@ theorem in_constant_varx_14_thm (e : IntW 4) :
 
 
 theorem in_constant_mone_vary_thm (e : IntW 4) :
-  LLVM.xor (LLVM.and (LLVM.xor e (const? 4 (-1))) (const? 4 1)) e ⊑ LLVM.or e (const? 4 1) := by 
+  LLVM.xor (LLVM.and (LLVM.xor e (const? 4 (-1))) (const? 4 1)) e ⊑ LLVM.or e (const? 4 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -61,7 +61,7 @@ theorem in_constant_mone_vary_thm (e : IntW 4) :
 
 
 theorem in_constant_14_vary_thm (e : IntW 4) :
-  LLVM.xor (LLVM.and (LLVM.xor e (const? 4 (-2))) (const? 4 1)) e ⊑ LLVM.and e (const? 4 (-2)) := by 
+  LLVM.xor (LLVM.and (LLVM.xor e (const? 4 (-2))) (const? 4 1)) e ⊑ LLVM.and e (const? 4 (-2)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -72,7 +72,7 @@ theorem in_constant_14_vary_thm (e : IntW 4) :
 
 theorem c_1_0_0_thm (e e_1 : IntW 4) :
   LLVM.xor (LLVM.and (LLVM.xor e_1 e) (const? 4 (-2))) e_1 ⊑
-    LLVM.or (LLVM.and e (const? 4 (-2))) (LLVM.and e_1 (const? 4 1)) { «disjoint» := true } := by 
+    LLVM.or (LLVM.and e (const? 4 (-2))) (LLVM.and e_1 (const? 4 1)) { «disjoint» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -83,7 +83,7 @@ theorem c_1_0_0_thm (e e_1 : IntW 4) :
 
 theorem c_0_1_0_thm (e e_1 : IntW 4) :
   LLVM.xor (LLVM.and (LLVM.xor e_1 e) (const? 4 (-2))) e_1 ⊑
-    LLVM.or (LLVM.and e (const? 4 (-2))) (LLVM.and e_1 (const? 4 1)) { «disjoint» := true } := by 
+    LLVM.or (LLVM.and e (const? 4 (-2))) (LLVM.and e_1 (const? 4 1)) { «disjoint» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -94,7 +94,7 @@ theorem c_0_1_0_thm (e e_1 : IntW 4) :
 
 theorem c_1_1_0_thm (e e_1 : IntW 4) :
   LLVM.xor (LLVM.and (LLVM.xor e_1 e) (const? 4 (-2))) e ⊑
-    LLVM.or (LLVM.and e_1 (const? 4 (-2))) (LLVM.and e (const? 4 1)) { «disjoint» := true } := by 
+    LLVM.or (LLVM.and e_1 (const? 4 (-2))) (LLVM.and e (const? 4 1)) { «disjoint» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -104,7 +104,7 @@ theorem c_1_1_0_thm (e e_1 : IntW 4) :
 
 
 theorem commutativity_constant_14_vary_thm (e : IntW 4) :
-  LLVM.xor e (LLVM.and (LLVM.xor e (const? 4 (-2))) (const? 4 1)) ⊑ LLVM.and e (const? 4 (-2)) := by 
+  LLVM.xor e (LLVM.and (LLVM.xor e (const? 4 (-2))) (const? 4 1)) ⊑ LLVM.and e (const? 4 (-2)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gunsigned_saturated_sub_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gunsigned_saturated_sub_proof.lean
@@ -9,7 +9,7 @@ set_option linter.unreachableTactic false
 
 section gunsigned_saturated_sub_proof
 theorem max_sub_ugt_c0_thm (e : IntW 32) :
-  select (icmp IntPredicate.ugt e (const? 32 (-1))) (add e (const? 32 0)) (const? 32 0) ⊑ const? 32 0 := by 
+  select (icmp IntPredicate.ugt e (const? 32 (-1))) (add e (const? 32 0)) (const? 32 0) ⊑ const? 32 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -20,7 +20,7 @@ theorem max_sub_ugt_c0_thm (e : IntW 32) :
 
 theorem max_sub_ult_c1_thm (e : IntW 32) :
   select (icmp IntPredicate.ult e (const? 32 1)) (add e (const? 32 (-1))) (const? 32 0) ⊑
-    sext 32 (icmp IntPredicate.eq e (const? 32 0)) := by 
+    sext 32 (icmp IntPredicate.eq e (const? 32 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -31,7 +31,7 @@ theorem max_sub_ult_c1_thm (e : IntW 32) :
 
 theorem max_sub_ugt_c32_thm (e : IntW 32) :
   select (icmp IntPredicate.ugt (const? 32 3) e) (add e (const? 32 (-2))) (const? 32 0) ⊑
-    select (icmp IntPredicate.ult e (const? 32 3)) (add e (const? 32 (-2))) (const? 32 0) := by 
+    select (icmp IntPredicate.ult e (const? 32 3)) (add e (const? 32 (-2))) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -42,7 +42,7 @@ theorem max_sub_ugt_c32_thm (e : IntW 32) :
 
 theorem max_sub_uge_c32_thm (e : IntW 32) :
   select (icmp IntPredicate.uge (const? 32 2) e) (add e (const? 32 (-2))) (const? 32 0) ⊑
-    select (icmp IntPredicate.ult e (const? 32 3)) (add e (const? 32 (-2))) (const? 32 0) := by 
+    select (icmp IntPredicate.ult e (const? 32 3)) (add e (const? 32 (-2))) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -53,7 +53,7 @@ theorem max_sub_uge_c32_thm (e : IntW 32) :
 
 theorem max_sub_ult_c12_thm (e : IntW 32) :
   select (icmp IntPredicate.ult e (const? 32 1)) (add e (const? 32 (-2))) (const? 32 0) ⊑
-    select (icmp IntPredicate.eq e (const? 32 0)) (const? 32 (-2)) (const? 32 0) := by 
+    select (icmp IntPredicate.eq e (const? 32 0)) (const? 32 (-2)) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -63,7 +63,7 @@ theorem max_sub_ult_c12_thm (e : IntW 32) :
 
 
 theorem max_sub_ult_c0_thm (e : IntW 32) :
-  select (icmp IntPredicate.ult e (const? 32 0)) (add e (const? 32 (-1))) (const? 32 0) ⊑ const? 32 0 := by 
+  select (icmp IntPredicate.ult e (const? 32 0)) (add e (const? 32 (-1))) (const? 32 0) ⊑ const? 32 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gunsignedhaddhlackhofhoverflowhcheck_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gunsignedhaddhlackhofhoverflowhcheck_proof.lean
@@ -9,7 +9,7 @@ set_option linter.unreachableTactic false
 
 section gunsignedhaddhlackhofhoverflowhcheck_proof
 theorem t0_basic_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.uge (add e_1 e) e ⊑ icmp IntPredicate.ule e_1 (LLVM.xor e (const? 8 (-1))) := by 
+  icmp IntPredicate.uge (add e_1 e) e ⊑ icmp IntPredicate.ule e_1 (LLVM.xor e (const? 8 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -19,7 +19,7 @@ theorem t0_basic_thm (e e_1 : IntW 8) :
 
 
 theorem t2_symmetry_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.uge (add e_1 e) e_1 ⊑ icmp IntPredicate.ule e (LLVM.xor e_1 (const? 8 (-1))) := by 
+  icmp IntPredicate.uge (add e_1 e) e_1 ⊑ icmp IntPredicate.ule e (LLVM.xor e_1 (const? 8 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -29,7 +29,7 @@ theorem t2_symmetry_thm (e e_1 : IntW 8) :
 
 
 theorem t4_commutative_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.ule e_1 (add e e_1) ⊑ icmp IntPredicate.ule e (LLVM.xor e_1 (const? 8 (-1))) := by 
+  icmp IntPredicate.ule e_1 (add e e_1) ⊑ icmp IntPredicate.ule e (LLVM.xor e_1 (const? 8 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -39,7 +39,7 @@ theorem t4_commutative_thm (e e_1 : IntW 8) :
 
 
 theorem n10_wrong_pred2_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.eq (add e_1 e) e ⊑ icmp IntPredicate.eq e_1 (const? 8 0) := by 
+  icmp IntPredicate.eq (add e_1 e) e ⊑ icmp IntPredicate.eq e_1 (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -49,7 +49,7 @@ theorem n10_wrong_pred2_thm (e e_1 : IntW 8) :
 
 
 theorem n11_wrong_pred3_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.ne (add e_1 e) e ⊑ icmp IntPredicate.ne e_1 (const? 8 0) := by 
+  icmp IntPredicate.ne (add e_1 e) e ⊑ icmp IntPredicate.ne e_1 (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -59,7 +59,7 @@ theorem n11_wrong_pred3_thm (e e_1 : IntW 8) :
 
 
 theorem low_bitmask_ult_thm (e : IntW 8) :
-  icmp IntPredicate.ult (LLVM.and (add e (const? 8 31)) (const? 8 31)) e ⊑ icmp IntPredicate.ne e (const? 8 0) := by 
+  icmp IntPredicate.ult (LLVM.and (add e (const? 8 31)) (const? 8 31)) e ⊑ icmp IntPredicate.ne e (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -70,7 +70,7 @@ theorem low_bitmask_ult_thm (e : IntW 8) :
 
 theorem low_bitmask_ugt_thm (e : IntW 8) :
   icmp IntPredicate.ugt (mul e e) (LLVM.and (add (mul e e) (const? 8 127)) (const? 8 127)) ⊑
-    icmp IntPredicate.ne (mul e e) (const? 8 0) := by 
+    icmp IntPredicate.ne (mul e e) (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gunsignedhaddhlackhofhoverflowhcheckhviahadd_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gunsignedhaddhlackhofhoverflowhcheckhviahadd_proof.lean
@@ -9,7 +9,7 @@ set_option linter.unreachableTactic false
 
 section gunsignedhaddhlackhofhoverflowhcheckhviahadd_proof
 theorem t6_no_extrause_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.uge (add e_1 e) e ⊑ icmp IntPredicate.ule e_1 (LLVM.xor e (const? 8 (-1))) := by 
+  icmp IntPredicate.uge (add e_1 e) e ⊑ icmp IntPredicate.ule e_1 (LLVM.xor e (const? 8 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gunsignedhaddhlackhofhoverflowhcheckhviahxor_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gunsignedhaddhlackhofhoverflowhcheckhviahxor_proof.lean
@@ -10,7 +10,7 @@ set_option linter.unreachableTactic false
 section gunsignedhaddhlackhofhoverflowhcheckhviahxor_proof
 theorem t3_no_extrause_thm (e e_1 : IntW 8) :
   icmp IntPredicate.uge (LLVM.xor e_1 (const? 8 (-1))) e ⊑
-    icmp IntPredicate.ule e (LLVM.xor e_1 (const? 8 (-1))) := by 
+    icmp IntPredicate.ule e (LLVM.xor e_1 (const? 8 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gunsignedhaddhoverflowhcheck_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gunsignedhaddhoverflowhcheck_proof.lean
@@ -9,7 +9,7 @@ set_option linter.unreachableTactic false
 
 section gunsignedhaddhoverflowhcheck_proof
 theorem t0_basic_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.ult (add e_1 e) e ⊑ icmp IntPredicate.ugt e_1 (LLVM.xor e (const? 8 (-1))) := by 
+  icmp IntPredicate.ult (add e_1 e) e ⊑ icmp IntPredicate.ugt e_1 (LLVM.xor e (const? 8 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -19,7 +19,7 @@ theorem t0_basic_thm (e e_1 : IntW 8) :
 
 
 theorem t2_symmetry_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.ult (add e_1 e) e_1 ⊑ icmp IntPredicate.ugt e (LLVM.xor e_1 (const? 8 (-1))) := by 
+  icmp IntPredicate.ult (add e_1 e) e_1 ⊑ icmp IntPredicate.ugt e (LLVM.xor e_1 (const? 8 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -29,7 +29,7 @@ theorem t2_symmetry_thm (e e_1 : IntW 8) :
 
 
 theorem t4_commutative_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.ugt e_1 (add e e_1) ⊑ icmp IntPredicate.ugt e (LLVM.xor e_1 (const? 8 (-1))) := by 
+  icmp IntPredicate.ugt e_1 (add e e_1) ⊑ icmp IntPredicate.ugt e (LLVM.xor e_1 (const? 8 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -39,7 +39,7 @@ theorem t4_commutative_thm (e e_1 : IntW 8) :
 
 
 theorem n10_wrong_pred2_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.eq (add e_1 e) e ⊑ icmp IntPredicate.eq e_1 (const? 8 0) := by 
+  icmp IntPredicate.eq (add e_1 e) e ⊑ icmp IntPredicate.eq e_1 (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -49,7 +49,7 @@ theorem n10_wrong_pred2_thm (e e_1 : IntW 8) :
 
 
 theorem n11_wrong_pred3_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.ne (add e_1 e) e ⊑ icmp IntPredicate.ne e_1 (const? 8 0) := by 
+  icmp IntPredicate.ne (add e_1 e) e ⊑ icmp IntPredicate.ne e_1 (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gunsignedhaddhoverflowhcheckhviahadd_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gunsignedhaddhoverflowhcheckhviahadd_proof.lean
@@ -9,7 +9,7 @@ set_option linter.unreachableTactic false
 
 section gunsignedhaddhoverflowhcheckhviahadd_proof
 theorem t6_no_extrause_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.ult (add e_1 e) e ⊑ icmp IntPredicate.ugt e_1 (LLVM.xor e (const? 8 (-1))) := by 
+  icmp IntPredicate.ult (add e_1 e) e ⊑ icmp IntPredicate.ugt e_1 (LLVM.xor e (const? 8 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gunsignedhaddhoverflowhcheckhviahxor_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gunsignedhaddhoverflowhcheckhviahxor_proof.lean
@@ -10,7 +10,7 @@ set_option linter.unreachableTactic false
 section gunsignedhaddhoverflowhcheckhviahxor_proof
 theorem t3_no_extrause_thm (e e_1 : IntW 8) :
   icmp IntPredicate.ult (LLVM.xor e_1 (const? 8 (-1))) e ⊑
-    icmp IntPredicate.ugt e (LLVM.xor e_1 (const? 8 (-1))) := by 
+    icmp IntPredicate.ugt e (LLVM.xor e_1 (const? 8 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gunsignedhsubhlackhofhoverflowhcheck_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gunsignedhsubhlackhofhoverflowhcheck_proof.lean
@@ -8,7 +8,7 @@ set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
 
 section gunsignedhsubhlackhofhoverflowhcheck_proof
-theorem t0_basic_thm (e e_1 : IntW 8) : icmp IntPredicate.ule (sub e_1 e) e_1 ⊑ icmp IntPredicate.ule e e_1 := by 
+theorem t0_basic_thm (e e_1 : IntW 8) : icmp IntPredicate.ule (sub e_1 e) e_1 ⊑ icmp IntPredicate.ule e e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -17,7 +17,7 @@ theorem t0_basic_thm (e e_1 : IntW 8) : icmp IntPredicate.ule (sub e_1 e) e_1 �
     all_goals sorry
 
 
-theorem t2_commutative_thm (e e_1 : IntW 8) : icmp IntPredicate.uge e_1 (sub e_1 e) ⊑ icmp IntPredicate.uge e_1 e := by 
+theorem t2_commutative_thm (e e_1 : IntW 8) : icmp IntPredicate.uge e_1 (sub e_1 e) ⊑ icmp IntPredicate.uge e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -27,7 +27,7 @@ theorem t2_commutative_thm (e e_1 : IntW 8) : icmp IntPredicate.uge e_1 (sub e_1
 
 
 theorem n7_wrong_pred2_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.eq (sub e_1 e) e_1 ⊑ icmp IntPredicate.eq e (const? 8 0) := by 
+  icmp IntPredicate.eq (sub e_1 e) e_1 ⊑ icmp IntPredicate.eq e (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -37,7 +37,7 @@ theorem n7_wrong_pred2_thm (e e_1 : IntW 8) :
 
 
 theorem n8_wrong_pred3_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.ne (sub e_1 e) e_1 ⊑ icmp IntPredicate.ne e (const? 8 0) := by 
+  icmp IntPredicate.ne (sub e_1 e) e_1 ⊑ icmp IntPredicate.ne e (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gunsignedhsubhoverflowhcheck_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gunsignedhsubhoverflowhcheck_proof.lean
@@ -8,7 +8,7 @@ set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
 
 section gunsignedhsubhoverflowhcheck_proof
-theorem t0_basic_thm (e e_1 : IntW 8) : icmp IntPredicate.ugt (sub e_1 e) e_1 ⊑ icmp IntPredicate.ugt e e_1 := by 
+theorem t0_basic_thm (e e_1 : IntW 8) : icmp IntPredicate.ugt (sub e_1 e) e_1 ⊑ icmp IntPredicate.ugt e e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -17,7 +17,7 @@ theorem t0_basic_thm (e e_1 : IntW 8) : icmp IntPredicate.ugt (sub e_1 e) e_1 �
     all_goals sorry
 
 
-theorem t2_commutative_thm (e e_1 : IntW 8) : icmp IntPredicate.ult e_1 (sub e_1 e) ⊑ icmp IntPredicate.ult e_1 e := by 
+theorem t2_commutative_thm (e e_1 : IntW 8) : icmp IntPredicate.ult e_1 (sub e_1 e) ⊑ icmp IntPredicate.ult e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -27,7 +27,7 @@ theorem t2_commutative_thm (e e_1 : IntW 8) : icmp IntPredicate.ult e_1 (sub e_1
 
 
 theorem n7_wrong_pred2_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.eq (sub e_1 e) e_1 ⊑ icmp IntPredicate.eq e (const? 8 0) := by 
+  icmp IntPredicate.eq (sub e_1 e) e_1 ⊑ icmp IntPredicate.eq e (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -37,7 +37,7 @@ theorem n7_wrong_pred2_thm (e e_1 : IntW 8) :
 
 
 theorem n8_wrong_pred3_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.ne (sub e_1 e) e_1 ⊑ icmp IntPredicate.ne e (const? 8 0) := by 
+  icmp IntPredicate.ne (sub e_1 e) e_1 ⊑ icmp IntPredicate.ne e (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gxor2_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gxor2_proof.lean
@@ -10,7 +10,7 @@ set_option linter.unreachableTactic false
 section gxor2_proof
 theorem test0_thm (e : IntW 32) :
   icmp IntPredicate.sgt (LLVM.xor e (const? 32 (-2147483648))) (const? 32 (-1)) ⊑
-    icmp IntPredicate.slt e (const? 32 0) := by 
+    icmp IntPredicate.slt e (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -20,7 +20,7 @@ theorem test0_thm (e : IntW 32) :
 
 
 theorem test1_thm (e : IntW 32) :
-  icmp IntPredicate.slt (LLVM.xor e (const? 32 12345)) (const? 32 0) ⊑ icmp IntPredicate.slt e (const? 32 0) := by 
+  icmp IntPredicate.slt (LLVM.xor e (const? 32 12345)) (const? 32 0) ⊑ icmp IntPredicate.slt e (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -31,7 +31,7 @@ theorem test1_thm (e : IntW 32) :
 
 theorem test2_thm (e : IntW 32) :
   LLVM.xor (add (LLVM.and e (const? 32 32)) (const? 32 145)) (const? 32 153) ⊑
-    LLVM.or (LLVM.and e (const? 32 32)) (const? 32 8) { «disjoint» := true } := by 
+    LLVM.or (LLVM.and e (const? 32 32)) (const? 32 8) { «disjoint» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -42,7 +42,7 @@ theorem test2_thm (e : IntW 32) :
 
 theorem test3_thm (e : IntW 32) :
   LLVM.xor (LLVM.and (LLVM.or e (const? 32 145)) (const? 32 177)) (const? 32 153) ⊑
-    LLVM.or (LLVM.and e (const? 32 32)) (const? 32 8) { «disjoint» := true } := by 
+    LLVM.or (LLVM.and e (const? 32 32)) (const? 32 8) { «disjoint» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -53,7 +53,7 @@ theorem test3_thm (e : IntW 32) :
 
 theorem test5_thm (e : IntW 32) :
   add (LLVM.xor (lshr (LLVM.xor e (const? 32 1234)) (const? 32 8)) (const? 32 1)) (LLVM.xor e (const? 32 1234)) ⊑
-    add (LLVM.xor (lshr e (const? 32 8)) (const? 32 5)) (LLVM.xor e (const? 32 1234)) := by 
+    add (LLVM.xor (lshr e (const? 32 8)) (const? 32 5)) (LLVM.xor e (const? 32 1234)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -64,7 +64,7 @@ theorem test5_thm (e : IntW 32) :
 
 theorem test6_thm (e : IntW 32) :
   add (lshr (LLVM.xor e (const? 32 1234)) (const? 32 16)) (LLVM.xor e (const? 32 1234)) ⊑
-    add (lshr e (const? 32 16)) (LLVM.xor e (const? 32 1234)) := by 
+    add (lshr e (const? 32 16)) (LLVM.xor e (const? 32 1234)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -74,7 +74,7 @@ theorem test6_thm (e : IntW 32) :
 
 
 theorem test7_thm (e e_1 : IntW 32) :
-  LLVM.xor (LLVM.or e_1 e) (LLVM.xor e_1 (const? 32 (-1))) ⊑ LLVM.or e_1 (LLVM.xor e (const? 32 (-1))) := by 
+  LLVM.xor (LLVM.or e_1 e) (LLVM.xor e_1 (const? 32 (-1))) ⊑ LLVM.or e_1 (LLVM.xor e (const? 32 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -84,7 +84,7 @@ theorem test7_thm (e e_1 : IntW 32) :
 
 
 theorem test8_thm (e e_1 : IntW 32) :
-  LLVM.xor (LLVM.xor e_1 (const? 32 (-1))) (LLVM.or e_1 e) ⊑ LLVM.or e_1 (LLVM.xor e (const? 32 (-1))) := by 
+  LLVM.xor (LLVM.xor e_1 (const? 32 (-1))) (LLVM.or e_1 e) ⊑ LLVM.or e_1 (LLVM.xor e (const? 32 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -93,7 +93,7 @@ theorem test8_thm (e e_1 : IntW 32) :
     all_goals sorry
 
 
-theorem test9_thm (e e_1 : IntW 32) : LLVM.xor (LLVM.and e_1 e) (LLVM.xor e_1 e) ⊑ LLVM.or e_1 e := by 
+theorem test9_thm (e e_1 : IntW 32) : LLVM.xor (LLVM.and e_1 e) (LLVM.xor e_1 e) ⊑ LLVM.or e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -102,7 +102,7 @@ theorem test9_thm (e e_1 : IntW 32) : LLVM.xor (LLVM.and e_1 e) (LLVM.xor e_1 e)
     all_goals sorry
 
 
-theorem test9b_thm (e e_1 : IntW 32) : LLVM.xor (LLVM.and e_1 e) (LLVM.xor e e_1) ⊑ LLVM.or e_1 e := by 
+theorem test9b_thm (e e_1 : IntW 32) : LLVM.xor (LLVM.and e_1 e) (LLVM.xor e e_1) ⊑ LLVM.or e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -111,7 +111,7 @@ theorem test9b_thm (e e_1 : IntW 32) : LLVM.xor (LLVM.and e_1 e) (LLVM.xor e e_1
     all_goals sorry
 
 
-theorem test10_thm (e e_1 : IntW 32) : LLVM.xor (LLVM.xor e_1 e) (LLVM.and e_1 e) ⊑ LLVM.or e_1 e := by 
+theorem test10_thm (e e_1 : IntW 32) : LLVM.xor (LLVM.xor e_1 e) (LLVM.and e_1 e) ⊑ LLVM.or e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -120,7 +120,7 @@ theorem test10_thm (e e_1 : IntW 32) : LLVM.xor (LLVM.xor e_1 e) (LLVM.and e_1 e
     all_goals sorry
 
 
-theorem test10b_thm (e e_1 : IntW 32) : LLVM.xor (LLVM.xor e_1 e) (LLVM.and e e_1) ⊑ LLVM.or e_1 e := by 
+theorem test10b_thm (e e_1 : IntW 32) : LLVM.xor (LLVM.xor e_1 e) (LLVM.and e e_1) ⊑ LLVM.or e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -131,7 +131,7 @@ theorem test10b_thm (e e_1 : IntW 32) : LLVM.xor (LLVM.xor e_1 e) (LLVM.and e e_
 
 theorem test11_thm (e e_1 : IntW 32) :
   LLVM.and (LLVM.xor e_1 e) (LLVM.xor (LLVM.xor e (const? 32 (-1))) e_1) ⊑
-    LLVM.and (LLVM.xor e_1 e) (LLVM.xor (LLVM.xor e e_1) (const? 32 (-1))) := by 
+    LLVM.and (LLVM.xor e_1 e) (LLVM.xor (LLVM.xor e e_1) (const? 32 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -142,7 +142,7 @@ theorem test11_thm (e e_1 : IntW 32) :
 
 theorem test11b_thm (e e_1 : IntW 32) :
   LLVM.and (LLVM.xor (LLVM.xor e_1 (const? 32 (-1))) e) (LLVM.xor e e_1) ⊑
-    LLVM.and (LLVM.xor e e_1) (LLVM.xor (LLVM.xor e_1 e) (const? 32 (-1))) := by 
+    LLVM.and (LLVM.xor e e_1) (LLVM.xor (LLVM.xor e_1 e) (const? 32 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -153,7 +153,7 @@ theorem test11b_thm (e e_1 : IntW 32) :
 
 theorem test11c_thm (e e_1 : IntW 32) :
   LLVM.and (LLVM.xor e_1 e) (LLVM.xor (LLVM.xor e_1 (const? 32 (-1))) e) ⊑
-    LLVM.and (LLVM.xor e_1 e) (LLVM.xor (LLVM.xor e_1 e) (const? 32 (-1))) := by 
+    LLVM.and (LLVM.xor e_1 e) (LLVM.xor (LLVM.xor e_1 e) (const? 32 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -164,7 +164,7 @@ theorem test11c_thm (e e_1 : IntW 32) :
 
 theorem test11d_thm (e e_1 : IntW 32) :
   LLVM.and (LLVM.xor (LLVM.xor e_1 (const? 32 (-1))) e) (LLVM.xor e_1 e) ⊑
-    LLVM.and (LLVM.xor e_1 e) (LLVM.xor (LLVM.xor e_1 e) (const? 32 (-1))) := by 
+    LLVM.and (LLVM.xor e_1 e) (LLVM.xor (LLVM.xor e_1 e) (const? 32 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -175,7 +175,7 @@ theorem test11d_thm (e e_1 : IntW 32) :
 
 theorem test11e_thm (e e_1 e_2 : IntW 32) :
   LLVM.and (LLVM.xor (mul e_2 e_1) e) (LLVM.xor (mul e_2 e_1) (LLVM.xor e (const? 32 (-1)))) ⊑
-    LLVM.and (LLVM.xor (mul e_2 e_1) e) (LLVM.xor (LLVM.xor e (mul e_2 e_1)) (const? 32 (-1))) := by 
+    LLVM.and (LLVM.xor (mul e_2 e_1) e) (LLVM.xor (LLVM.xor e (mul e_2 e_1)) (const? 32 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -186,7 +186,7 @@ theorem test11e_thm (e e_1 e_2 : IntW 32) :
 
 theorem test11f_thm (e e_1 e_2 : IntW 32) :
   LLVM.and (LLVM.xor (mul e_2 e_1) (LLVM.xor e (const? 32 (-1)))) (LLVM.xor (mul e_2 e_1) e) ⊑
-    LLVM.and (LLVM.xor (mul e_2 e_1) e) (LLVM.xor (LLVM.xor e (mul e_2 e_1)) (const? 32 (-1))) := by 
+    LLVM.and (LLVM.xor (mul e_2 e_1) e) (LLVM.xor (LLVM.xor e (mul e_2 e_1)) (const? 32 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -197,7 +197,7 @@ theorem test11f_thm (e e_1 e_2 : IntW 32) :
 
 theorem test12_thm (e e_1 : IntW 32) :
   LLVM.xor (LLVM.and e_1 (LLVM.xor e (const? 32 (-1)))) (LLVM.xor e_1 (const? 32 (-1))) ⊑
-    LLVM.xor (LLVM.and e_1 e) (const? 32 (-1)) := by 
+    LLVM.xor (LLVM.and e_1 e) (const? 32 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -208,7 +208,7 @@ theorem test12_thm (e e_1 : IntW 32) :
 
 theorem test12commuted_thm (e e_1 : IntW 32) :
   LLVM.xor (LLVM.and (LLVM.xor e_1 (const? 32 (-1))) e) (LLVM.xor e (const? 32 (-1))) ⊑
-    LLVM.xor (LLVM.and e e_1) (const? 32 (-1)) := by 
+    LLVM.xor (LLVM.and e e_1) (const? 32 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -219,7 +219,7 @@ theorem test12commuted_thm (e e_1 : IntW 32) :
 
 theorem test13_thm (e e_1 : IntW 32) :
   LLVM.xor (LLVM.xor e_1 (const? 32 (-1))) (LLVM.and e_1 (LLVM.xor e (const? 32 (-1)))) ⊑
-    LLVM.xor (LLVM.and e_1 e) (const? 32 (-1)) := by 
+    LLVM.xor (LLVM.and e_1 e) (const? 32 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -230,7 +230,7 @@ theorem test13_thm (e e_1 : IntW 32) :
 
 theorem test13commuted_thm (e e_1 : IntW 32) :
   LLVM.xor (LLVM.xor e_1 (const? 32 (-1))) (LLVM.and (LLVM.xor e (const? 32 (-1))) e_1) ⊑
-    LLVM.xor (LLVM.and e_1 e) (const? 32 (-1)) := by 
+    LLVM.xor (LLVM.and e_1 e) (const? 32 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -240,7 +240,7 @@ theorem test13commuted_thm (e e_1 : IntW 32) :
 
 
 theorem xor_or_xor_common_op_commute1_thm (e e_1 e_2 : IntW 32) :
-  LLVM.xor (LLVM.xor e_2 e_1) (LLVM.or e_2 e) ⊑ LLVM.xor (LLVM.and e (LLVM.xor e_2 (const? 32 (-1)))) e_1 := by 
+  LLVM.xor (LLVM.xor e_2 e_1) (LLVM.or e_2 e) ⊑ LLVM.xor (LLVM.and e (LLVM.xor e_2 (const? 32 (-1)))) e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -250,7 +250,7 @@ theorem xor_or_xor_common_op_commute1_thm (e e_1 e_2 : IntW 32) :
 
 
 theorem xor_or_xor_common_op_commute2_thm (e e_1 e_2 : IntW 32) :
-  LLVM.xor (LLVM.xor e_2 e_1) (LLVM.or e_1 e) ⊑ LLVM.xor (LLVM.and e (LLVM.xor e_1 (const? 32 (-1)))) e_2 := by 
+  LLVM.xor (LLVM.xor e_2 e_1) (LLVM.or e_1 e) ⊑ LLVM.xor (LLVM.and e (LLVM.xor e_1 (const? 32 (-1)))) e_2 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -260,7 +260,7 @@ theorem xor_or_xor_common_op_commute2_thm (e e_1 e_2 : IntW 32) :
 
 
 theorem xor_or_xor_common_op_commute3_thm (e e_1 e_2 : IntW 32) :
-  LLVM.xor (LLVM.xor e_2 e_1) (LLVM.or e e_2) ⊑ LLVM.xor (LLVM.and e (LLVM.xor e_2 (const? 32 (-1)))) e_1 := by 
+  LLVM.xor (LLVM.xor e_2 e_1) (LLVM.or e e_2) ⊑ LLVM.xor (LLVM.and e (LLVM.xor e_2 (const? 32 (-1)))) e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -270,7 +270,7 @@ theorem xor_or_xor_common_op_commute3_thm (e e_1 e_2 : IntW 32) :
 
 
 theorem xor_or_xor_common_op_commute4_thm (e e_1 e_2 : IntW 32) :
-  LLVM.xor (LLVM.xor e_2 e_1) (LLVM.or e e_1) ⊑ LLVM.xor (LLVM.and e (LLVM.xor e_1 (const? 32 (-1)))) e_2 := by 
+  LLVM.xor (LLVM.xor e_2 e_1) (LLVM.or e e_1) ⊑ LLVM.xor (LLVM.and e (LLVM.xor e_1 (const? 32 (-1)))) e_2 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -280,7 +280,7 @@ theorem xor_or_xor_common_op_commute4_thm (e e_1 e_2 : IntW 32) :
 
 
 theorem xor_or_xor_common_op_commute5_thm (e e_1 e_2 : IntW 32) :
-  LLVM.xor (LLVM.or e_2 e_1) (LLVM.xor e_2 e) ⊑ LLVM.xor (LLVM.and e_1 (LLVM.xor e_2 (const? 32 (-1)))) e := by 
+  LLVM.xor (LLVM.or e_2 e_1) (LLVM.xor e_2 e) ⊑ LLVM.xor (LLVM.and e_1 (LLVM.xor e_2 (const? 32 (-1)))) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -290,7 +290,7 @@ theorem xor_or_xor_common_op_commute5_thm (e e_1 e_2 : IntW 32) :
 
 
 theorem xor_or_xor_common_op_commute6_thm (e e_1 e_2 : IntW 32) :
-  LLVM.xor (LLVM.or e_2 e_1) (LLVM.xor e e_2) ⊑ LLVM.xor (LLVM.and e_1 (LLVM.xor e_2 (const? 32 (-1)))) e := by 
+  LLVM.xor (LLVM.or e_2 e_1) (LLVM.xor e e_2) ⊑ LLVM.xor (LLVM.and e_1 (LLVM.xor e_2 (const? 32 (-1)))) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -300,7 +300,7 @@ theorem xor_or_xor_common_op_commute6_thm (e e_1 e_2 : IntW 32) :
 
 
 theorem xor_or_xor_common_op_commute7_thm (e e_1 e_2 : IntW 32) :
-  LLVM.xor (LLVM.or e_2 e_1) (LLVM.xor e_1 e) ⊑ LLVM.xor (LLVM.and e_2 (LLVM.xor e_1 (const? 32 (-1)))) e := by 
+  LLVM.xor (LLVM.or e_2 e_1) (LLVM.xor e_1 e) ⊑ LLVM.xor (LLVM.and e_2 (LLVM.xor e_1 (const? 32 (-1)))) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -310,7 +310,7 @@ theorem xor_or_xor_common_op_commute7_thm (e e_1 e_2 : IntW 32) :
 
 
 theorem xor_or_xor_common_op_commute8_thm (e e_1 e_2 : IntW 32) :
-  LLVM.xor (LLVM.or e_2 e_1) (LLVM.xor e e_1) ⊑ LLVM.xor (LLVM.and e_2 (LLVM.xor e_1 (const? 32 (-1)))) e := by 
+  LLVM.xor (LLVM.or e_2 e_1) (LLVM.xor e e_1) ⊑ LLVM.xor (LLVM.and e_2 (LLVM.xor e_1 (const? 32 (-1)))) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -322,7 +322,7 @@ theorem xor_or_xor_common_op_commute8_thm (e e_1 e_2 : IntW 32) :
 theorem test15_thm (e e_1 : IntW 8) :
   mul (LLVM.and (LLVM.xor e_1 e) (LLVM.xor (LLVM.xor e (const? 8 33)) e_1)) (LLVM.xor (LLVM.xor e (const? 8 33)) e_1) ⊑
     mul (LLVM.and (LLVM.xor e_1 e) (LLVM.xor (LLVM.xor e e_1) (const? 8 33)))
-      (LLVM.xor (LLVM.xor e e_1) (const? 8 33)) := by 
+      (LLVM.xor (LLVM.xor e e_1) (const? 8 33)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -334,7 +334,7 @@ theorem test15_thm (e e_1 : IntW 8) :
 theorem test16_thm (e e_1 : IntW 8) :
   mul (LLVM.and (LLVM.xor (LLVM.xor e_1 (const? 8 33)) e) (LLVM.xor e e_1)) (LLVM.xor (LLVM.xor e_1 (const? 8 33)) e) ⊑
     mul (LLVM.and (LLVM.xor (LLVM.xor e_1 e) (const? 8 33)) (LLVM.xor e e_1))
-      (LLVM.xor (LLVM.xor e_1 e) (const? 8 33)) := by 
+      (LLVM.xor (LLVM.xor e_1 e) (const? 8 33)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -345,7 +345,7 @@ theorem test16_thm (e e_1 : IntW 8) :
 
 theorem not_xor_to_or_not1_thm (e e_1 e_2 : IntW 3) :
   LLVM.xor (LLVM.xor (LLVM.and e_2 e_1) (LLVM.or e e_1)) (const? 3 (-1)) ⊑
-    LLVM.or (LLVM.and e_2 e_1) (LLVM.xor (LLVM.or e e_1) (const? 3 (-1))) := by 
+    LLVM.or (LLVM.and e_2 e_1) (LLVM.xor (LLVM.or e e_1) (const? 3 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -356,7 +356,7 @@ theorem not_xor_to_or_not1_thm (e e_1 e_2 : IntW 3) :
 
 theorem not_xor_to_or_not2_thm (e e_1 e_2 : IntW 3) :
   LLVM.xor (LLVM.xor (LLVM.and e_2 e_1) (LLVM.or e_1 e)) (const? 3 (-1)) ⊑
-    LLVM.or (LLVM.and e_2 e_1) (LLVM.xor (LLVM.or e_1 e) (const? 3 (-1))) := by 
+    LLVM.or (LLVM.and e_2 e_1) (LLVM.xor (LLVM.or e_1 e) (const? 3 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -367,7 +367,7 @@ theorem not_xor_to_or_not2_thm (e e_1 e_2 : IntW 3) :
 
 theorem not_xor_to_or_not3_thm (e e_1 e_2 : IntW 3) :
   LLVM.xor (LLVM.xor (LLVM.and e_2 e_1) (LLVM.or e_2 e)) (const? 3 (-1)) ⊑
-    LLVM.or (LLVM.and e_2 e_1) (LLVM.xor (LLVM.or e_2 e) (const? 3 (-1))) := by 
+    LLVM.or (LLVM.and e_2 e_1) (LLVM.xor (LLVM.or e_2 e) (const? 3 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -378,7 +378,7 @@ theorem not_xor_to_or_not3_thm (e e_1 e_2 : IntW 3) :
 
 theorem not_xor_to_or_not4_thm (e e_1 e_2 : IntW 3) :
   LLVM.xor (LLVM.xor (LLVM.and e_2 e_1) (LLVM.or e e_2)) (const? 3 (-1)) ⊑
-    LLVM.or (LLVM.and e_2 e_1) (LLVM.xor (LLVM.or e e_2) (const? 3 (-1))) := by 
+    LLVM.or (LLVM.and e_2 e_1) (LLVM.xor (LLVM.or e e_2) (const? 3 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -389,7 +389,7 @@ theorem not_xor_to_or_not4_thm (e e_1 e_2 : IntW 3) :
 
 theorem xor_notand_to_or_not1_thm (e e_1 e_2 : IntW 3) :
   LLVM.xor (LLVM.xor (LLVM.and e_2 e_1) (const? 3 (-1))) (LLVM.or e e_1) ⊑
-    LLVM.or (LLVM.and e_2 e_1) (LLVM.xor (LLVM.or e e_1) (const? 3 (-1))) := by 
+    LLVM.or (LLVM.and e_2 e_1) (LLVM.xor (LLVM.or e e_1) (const? 3 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -400,7 +400,7 @@ theorem xor_notand_to_or_not1_thm (e e_1 e_2 : IntW 3) :
 
 theorem xor_notand_to_or_not2_thm (e e_1 e_2 : IntW 3) :
   LLVM.xor (LLVM.xor (LLVM.and e_2 e_1) (const? 3 (-1))) (LLVM.or e_1 e) ⊑
-    LLVM.or (LLVM.and e_2 e_1) (LLVM.xor (LLVM.or e_1 e) (const? 3 (-1))) := by 
+    LLVM.or (LLVM.and e_2 e_1) (LLVM.xor (LLVM.or e_1 e) (const? 3 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -411,7 +411,7 @@ theorem xor_notand_to_or_not2_thm (e e_1 e_2 : IntW 3) :
 
 theorem xor_notand_to_or_not3_thm (e e_1 e_2 : IntW 3) :
   LLVM.xor (LLVM.xor (LLVM.and e_2 e_1) (const? 3 (-1))) (LLVM.or e_2 e) ⊑
-    LLVM.or (LLVM.and e_2 e_1) (LLVM.xor (LLVM.or e_2 e) (const? 3 (-1))) := by 
+    LLVM.or (LLVM.and e_2 e_1) (LLVM.xor (LLVM.or e_2 e) (const? 3 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -422,7 +422,7 @@ theorem xor_notand_to_or_not3_thm (e e_1 e_2 : IntW 3) :
 
 theorem xor_notand_to_or_not4_thm (e e_1 e_2 : IntW 3) :
   LLVM.xor (LLVM.xor (LLVM.and e_2 e_1) (const? 3 (-1))) (LLVM.or e e_2) ⊑
-    LLVM.or (LLVM.and e_2 e_1) (LLVM.xor (LLVM.or e e_2) (const? 3 (-1))) := by 
+    LLVM.or (LLVM.and e_2 e_1) (LLVM.xor (LLVM.or e e_2) (const? 3 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gxor_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gxor_proof.lean
@@ -8,7 +8,7 @@ set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
 
 section gxor_proof
-theorem test0_thm (e : IntW 1) : LLVM.xor e (const? 1 0) ⊑ e := by 
+theorem test0_thm (e : IntW 1) : LLVM.xor e (const? 1 0) ⊑ e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -17,7 +17,7 @@ theorem test0_thm (e : IntW 1) : LLVM.xor e (const? 1 0) ⊑ e := by
     all_goals sorry
 
 
-theorem test1_thm (e : IntW 32) : LLVM.xor e (const? 32 0) ⊑ e := by 
+theorem test1_thm (e : IntW 32) : LLVM.xor e (const? 32 0) ⊑ e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -26,7 +26,7 @@ theorem test1_thm (e : IntW 32) : LLVM.xor e (const? 32 0) ⊑ e := by
     all_goals sorry
 
 
-theorem test2_thm (e : IntW 1) : LLVM.xor e e ⊑ const? 1 0 := by 
+theorem test2_thm (e : IntW 1) : LLVM.xor e e ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -35,7 +35,7 @@ theorem test2_thm (e : IntW 1) : LLVM.xor e e ⊑ const? 1 0 := by
     all_goals sorry
 
 
-theorem test3_thm (e : IntW 32) : LLVM.xor e e ⊑ const? 32 0 := by 
+theorem test3_thm (e : IntW 32) : LLVM.xor e e ⊑ const? 32 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -44,7 +44,7 @@ theorem test3_thm (e : IntW 32) : LLVM.xor e e ⊑ const? 32 0 := by
     all_goals sorry
 
 
-theorem test4_thm (e : IntW 32) : LLVM.xor e (LLVM.xor (const? 32 (-1)) e) ⊑ const? 32 (-1) := by 
+theorem test4_thm (e : IntW 32) : LLVM.xor e (LLVM.xor (const? 32 (-1)) e) ⊑ const? 32 (-1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -54,7 +54,7 @@ theorem test4_thm (e : IntW 32) : LLVM.xor e (LLVM.xor (const? 32 (-1)) e) ⊑ c
 
 
 theorem test5_thm (e : IntW 32) :
-  LLVM.xor (LLVM.or e (const? 32 123)) (const? 32 123) ⊑ LLVM.and e (const? 32 (-124)) := by 
+  LLVM.xor (LLVM.or e (const? 32 123)) (const? 32 123) ⊑ LLVM.and e (const? 32 (-124)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -63,7 +63,7 @@ theorem test5_thm (e : IntW 32) :
     all_goals sorry
 
 
-theorem test6_thm (e : IntW 8) : LLVM.xor (LLVM.xor e (const? 8 17)) (const? 8 17) ⊑ e := by 
+theorem test6_thm (e : IntW 8) : LLVM.xor (LLVM.xor e (const? 8 17)) (const? 8 17) ⊑ e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -74,7 +74,7 @@ theorem test6_thm (e : IntW 8) : LLVM.xor (LLVM.xor e (const? 8 17)) (const? 8 1
 
 theorem test7_thm (e e_1 : IntW 32) :
   LLVM.xor (LLVM.and e_1 (const? 32 7)) (LLVM.and e (const? 32 128)) ⊑
-    LLVM.or (LLVM.and e_1 (const? 32 7)) (LLVM.and e (const? 32 128)) { «disjoint» := true } := by 
+    LLVM.or (LLVM.and e_1 (const? 32 7)) (LLVM.and e (const? 32 128)) { «disjoint» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -84,7 +84,7 @@ theorem test7_thm (e e_1 : IntW 32) :
 
 
 theorem test9_thm (e : IntW 8) :
-  icmp IntPredicate.eq (LLVM.xor e (const? 8 123)) (const? 8 34) ⊑ icmp IntPredicate.eq e (const? 8 89) := by 
+  icmp IntPredicate.eq (LLVM.xor e (const? 8 123)) (const? 8 34) ⊑ icmp IntPredicate.eq e (const? 8 89) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -95,7 +95,7 @@ theorem test9_thm (e : IntW 8) :
 
 theorem test10_thm (e : IntW 8) :
   LLVM.xor (LLVM.and e (const? 8 3)) (const? 8 4) ⊑
-    LLVM.or (LLVM.and e (const? 8 3)) (const? 8 4) { «disjoint» := true } := by 
+    LLVM.or (LLVM.and e (const? 8 3)) (const? 8 4) { «disjoint» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -106,7 +106,7 @@ theorem test10_thm (e : IntW 8) :
 
 theorem test11_thm (e : IntW 8) :
   LLVM.xor (LLVM.or e (const? 8 12)) (const? 8 4) ⊑
-    LLVM.or (LLVM.and e (const? 8 (-13))) (const? 8 8) { «disjoint» := true } := by 
+    LLVM.or (LLVM.and e (const? 8 (-13))) (const? 8 8) { «disjoint» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -116,7 +116,7 @@ theorem test11_thm (e : IntW 8) :
 
 
 theorem test12_thm (e : IntW 8) :
-  icmp IntPredicate.ne (LLVM.xor e (const? 8 4)) (const? 8 0) ⊑ icmp IntPredicate.ne e (const? 8 4) := by 
+  icmp IntPredicate.ne (LLVM.xor e (const? 8 4)) (const? 8 0) ⊑ icmp IntPredicate.ne e (const? 8 4) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -125,7 +125,7 @@ theorem test12_thm (e : IntW 8) :
     all_goals sorry
 
 
-theorem test18_thm (e : IntW 32) : sub (const? 32 123) (LLVM.xor e (const? 32 (-1))) ⊑ add e (const? 32 124) := by 
+theorem test18_thm (e : IntW 32) : sub (const? 32 123) (LLVM.xor e (const? 32 (-1))) ⊑ add e (const? 32 124) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -134,7 +134,7 @@ theorem test18_thm (e : IntW 32) : sub (const? 32 123) (LLVM.xor e (const? 32 (-
     all_goals sorry
 
 
-theorem test19_thm (e e_1 : IntW 32) : LLVM.xor (LLVM.xor e_1 e) e_1 ⊑ e := by 
+theorem test19_thm (e e_1 : IntW 32) : LLVM.xor (LLVM.xor e_1 e) e_1 ⊑ e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -143,7 +143,7 @@ theorem test19_thm (e e_1 : IntW 32) : LLVM.xor (LLVM.xor e_1 e) e_1 ⊑ e := by
     all_goals sorry
 
 
-theorem test22_thm (e : IntW 1) : LLVM.xor (zext 32 (LLVM.xor e (const? 1 1))) (const? 32 1) ⊑ zext 32 e := by 
+theorem test22_thm (e : IntW 1) : LLVM.xor (zext 32 (LLVM.xor e (const? 1 1))) (const? 32 1) ⊑ zext 32 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -153,7 +153,7 @@ theorem test22_thm (e : IntW 1) : LLVM.xor (zext 32 (LLVM.xor e (const? 1 1))) (
 
 
 theorem fold_zext_xor_sandwich_thm (e : IntW 1) :
-  LLVM.xor (zext 32 (LLVM.xor e (const? 1 1))) (const? 32 2) ⊑ LLVM.xor (zext 32 e) (const? 32 3) := by 
+  LLVM.xor (zext 32 (LLVM.xor e (const? 1 1))) (const? 32 2) ⊑ LLVM.xor (zext 32 e) (const? 32 3) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -163,7 +163,7 @@ theorem fold_zext_xor_sandwich_thm (e : IntW 1) :
 
 
 theorem test23_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.eq (LLVM.xor e_1 e) e ⊑ icmp IntPredicate.eq e_1 (const? 32 0) := by 
+  icmp IntPredicate.eq (LLVM.xor e_1 e) e ⊑ icmp IntPredicate.eq e_1 (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -173,7 +173,7 @@ theorem test23_thm (e e_1 : IntW 32) :
 
 
 theorem test24_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.ne (LLVM.xor e_1 e) e ⊑ icmp IntPredicate.ne e_1 (const? 32 0) := by 
+  icmp IntPredicate.ne (LLVM.xor e_1 e) e ⊑ icmp IntPredicate.ne e_1 (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -183,7 +183,7 @@ theorem test24_thm (e e_1 : IntW 32) :
 
 
 theorem test25_thm (e e_1 : IntW 32) :
-  LLVM.xor (LLVM.and (LLVM.xor e_1 (const? 32 (-1))) e) e ⊑ LLVM.and e e_1 := by 
+  LLVM.xor (LLVM.and (LLVM.xor e_1 (const? 32 (-1))) e) e ⊑ LLVM.and e e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -193,7 +193,7 @@ theorem test25_thm (e e_1 : IntW 32) :
 
 
 theorem test27_thm (e e_1 e_2 : IntW 32) :
-  zext 32 (icmp IntPredicate.eq (LLVM.xor e_2 e_1) (LLVM.xor e_2 e)) ⊑ zext 32 (icmp IntPredicate.eq e_1 e) := by 
+  zext 32 (icmp IntPredicate.eq (LLVM.xor e_2 e_1) (LLVM.xor e_2 e)) ⊑ zext 32 (icmp IntPredicate.eq e_1 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -203,7 +203,7 @@ theorem test27_thm (e e_1 e_2 : IntW 32) :
 
 
 theorem test28_thm (e : IntW 32) :
-  LLVM.xor (add e (const? 32 (-2147483647))) (const? 32 (-2147483648)) ⊑ add e (const? 32 1) := by 
+  LLVM.xor (add e (const? 32 (-2147483647))) (const? 32 (-2147483648)) ⊑ add e (const? 32 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -213,7 +213,7 @@ theorem test28_thm (e : IntW 32) :
 
 
 theorem test28_sub_thm (e : IntW 32) :
-  LLVM.xor (sub (const? 32 (-2147483647)) e) (const? 32 (-2147483648)) ⊑ sub (const? 32 1) e := by 
+  LLVM.xor (sub (const? 32 (-2147483647)) e) (const? 32 (-2147483648)) ⊑ sub (const? 32 1) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -224,7 +224,7 @@ theorem test28_sub_thm (e : IntW 32) :
 
 theorem test29_thm (e : IntW 1) :
   LLVM.xor (select e (const? 32 1000) (const? 32 10)) (const? 32 123) ⊑
-    select e (const? 32 915) (const? 32 113) := by 
+    select e (const? 32 915) (const? 32 113) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -235,7 +235,7 @@ theorem test29_thm (e : IntW 1) :
 
 theorem or_xor_commute1_thm (e e_1 : IntW 32) :
   LLVM.xor (LLVM.udiv (const? 32 42) e_1) (LLVM.or (LLVM.udiv (const? 32 42) e_1) (LLVM.udiv (const? 32 42) e)) ⊑
-    LLVM.and (LLVM.udiv (const? 32 42) e) (LLVM.xor (LLVM.udiv (const? 32 42) e_1) (const? 32 (-1))) := by 
+    LLVM.and (LLVM.udiv (const? 32 42) e) (LLVM.xor (LLVM.udiv (const? 32 42) e_1) (const? 32 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -246,7 +246,7 @@ theorem or_xor_commute1_thm (e e_1 : IntW 32) :
 
 theorem or_xor_commute2_thm (e e_1 : IntW 32) :
   LLVM.xor (LLVM.or (LLVM.udiv (const? 32 42) e_1) (LLVM.udiv (const? 32 42) e)) (LLVM.udiv (const? 32 42) e) ⊑
-    LLVM.and (LLVM.udiv (const? 32 42) e_1) (LLVM.xor (LLVM.udiv (const? 32 42) e) (const? 32 (-1))) := by 
+    LLVM.and (LLVM.udiv (const? 32 42) e_1) (LLVM.xor (LLVM.udiv (const? 32 42) e) (const? 32 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -257,7 +257,7 @@ theorem or_xor_commute2_thm (e e_1 : IntW 32) :
 
 theorem or_xor_commute3_thm (e e_1 : IntW 32) :
   LLVM.xor (LLVM.or (LLVM.udiv (const? 32 42) e_1) (LLVM.udiv (const? 32 42) e)) (LLVM.udiv (const? 32 42) e_1) ⊑
-    LLVM.and (LLVM.udiv (const? 32 42) e) (LLVM.xor (LLVM.udiv (const? 32 42) e_1) (const? 32 (-1))) := by 
+    LLVM.and (LLVM.udiv (const? 32 42) e) (LLVM.xor (LLVM.udiv (const? 32 42) e_1) (const? 32 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -268,7 +268,7 @@ theorem or_xor_commute3_thm (e e_1 : IntW 32) :
 
 theorem or_xor_commute4_thm (e e_1 : IntW 32) :
   LLVM.xor (LLVM.udiv (const? 32 42) e_1) (LLVM.or (LLVM.udiv (const? 32 42) e) (LLVM.udiv (const? 32 42) e_1)) ⊑
-    LLVM.and (LLVM.udiv (const? 32 42) e) (LLVM.xor (LLVM.udiv (const? 32 42) e_1) (const? 32 (-1))) := by 
+    LLVM.and (LLVM.udiv (const? 32 42) e) (LLVM.xor (LLVM.udiv (const? 32 42) e_1) (const? 32 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -279,7 +279,7 @@ theorem or_xor_commute4_thm (e e_1 : IntW 32) :
 
 theorem and_xor_commute1_thm (e e_1 : IntW 32) :
   LLVM.xor (LLVM.udiv (const? 32 42) e_1) (LLVM.and (LLVM.udiv (const? 32 42) e_1) (LLVM.udiv (const? 32 42) e)) ⊑
-    LLVM.and (LLVM.udiv (const? 32 42) e_1) (LLVM.xor (LLVM.udiv (const? 32 42) e) (const? 32 (-1))) := by 
+    LLVM.and (LLVM.udiv (const? 32 42) e_1) (LLVM.xor (LLVM.udiv (const? 32 42) e) (const? 32 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -290,7 +290,7 @@ theorem and_xor_commute1_thm (e e_1 : IntW 32) :
 
 theorem and_xor_commute2_thm (e e_1 : IntW 32) :
   LLVM.xor (LLVM.and (LLVM.udiv (const? 32 42) e_1) (LLVM.udiv (const? 32 42) e)) (LLVM.udiv (const? 32 42) e) ⊑
-    LLVM.and (LLVM.udiv (const? 32 42) e) (LLVM.xor (LLVM.udiv (const? 32 42) e_1) (const? 32 (-1))) := by 
+    LLVM.and (LLVM.udiv (const? 32 42) e) (LLVM.xor (LLVM.udiv (const? 32 42) e_1) (const? 32 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -301,7 +301,7 @@ theorem and_xor_commute2_thm (e e_1 : IntW 32) :
 
 theorem and_xor_commute3_thm (e e_1 : IntW 32) :
   LLVM.xor (LLVM.and (LLVM.udiv (const? 32 42) e_1) (LLVM.udiv (const? 32 42) e)) (LLVM.udiv (const? 32 42) e_1) ⊑
-    LLVM.and (LLVM.udiv (const? 32 42) e_1) (LLVM.xor (LLVM.udiv (const? 32 42) e) (const? 32 (-1))) := by 
+    LLVM.and (LLVM.udiv (const? 32 42) e_1) (LLVM.xor (LLVM.udiv (const? 32 42) e) (const? 32 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -312,7 +312,7 @@ theorem and_xor_commute3_thm (e e_1 : IntW 32) :
 
 theorem and_xor_commute4_thm (e e_1 : IntW 32) :
   LLVM.xor (LLVM.udiv (const? 32 42) e_1) (LLVM.and (LLVM.udiv (const? 32 42) e) (LLVM.udiv (const? 32 42) e_1)) ⊑
-    LLVM.and (LLVM.udiv (const? 32 42) e_1) (LLVM.xor (LLVM.udiv (const? 32 42) e) (const? 32 (-1))) := by 
+    LLVM.and (LLVM.udiv (const? 32 42) e_1) (LLVM.xor (LLVM.udiv (const? 32 42) e) (const? 32 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -322,7 +322,7 @@ theorem and_xor_commute4_thm (e e_1 : IntW 32) :
 
 
 theorem or_or_xor_thm (e e_1 e_2 : IntW 4) :
-  LLVM.xor (LLVM.or e_2 e_1) (LLVM.or e_2 e) ⊑ LLVM.and (LLVM.xor e_1 e) (LLVM.xor e_2 (const? 4 (-1))) := by 
+  LLVM.xor (LLVM.or e_2 e_1) (LLVM.or e_2 e) ⊑ LLVM.and (LLVM.xor e_1 e) (LLVM.xor e_2 (const? 4 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -332,7 +332,7 @@ theorem or_or_xor_thm (e e_1 e_2 : IntW 4) :
 
 
 theorem or_or_xor_commute1_thm (e e_1 e_2 : IntW 4) :
-  LLVM.xor (LLVM.or e_2 e_1) (LLVM.or e_1 e) ⊑ LLVM.and (LLVM.xor e_2 e) (LLVM.xor e_1 (const? 4 (-1))) := by 
+  LLVM.xor (LLVM.or e_2 e_1) (LLVM.or e_1 e) ⊑ LLVM.and (LLVM.xor e_2 e) (LLVM.xor e_1 (const? 4 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -342,7 +342,7 @@ theorem or_or_xor_commute1_thm (e e_1 e_2 : IntW 4) :
 
 
 theorem or_or_xor_commute2_thm (e e_1 e_2 : IntW 4) :
-  LLVM.xor (LLVM.or e_2 e_1) (LLVM.or e e_2) ⊑ LLVM.and (LLVM.xor e_1 e) (LLVM.xor e_2 (const? 4 (-1))) := by 
+  LLVM.xor (LLVM.or e_2 e_1) (LLVM.or e e_2) ⊑ LLVM.and (LLVM.xor e_1 e) (LLVM.xor e_2 (const? 4 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -353,7 +353,7 @@ theorem or_or_xor_commute2_thm (e e_1 e_2 : IntW 4) :
 
 theorem not_is_canonical_thm (e e_1 : IntW 32) :
   shl (add (LLVM.xor e_1 (const? 32 1073741823)) e) (const? 32 2) ⊑
-    shl (add e (LLVM.xor e_1 (const? 32 (-1)))) (const? 32 2) := by 
+    shl (add e (LLVM.xor e_1 (const? 32 (-1)))) (const? 32 2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -363,7 +363,7 @@ theorem not_is_canonical_thm (e e_1 : IntW 32) :
 
 
 theorem not_shl_thm (e : IntW 8) :
-  LLVM.xor (shl e (const? 8 7)) (const? 8 (-128)) ⊑ shl (LLVM.xor e (const? 8 (-1))) (const? 8 7) := by 
+  LLVM.xor (shl e (const? 8 7)) (const? 8 (-128)) ⊑ shl (LLVM.xor e (const? 8 (-1))) (const? 8 7) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -373,7 +373,7 @@ theorem not_shl_thm (e : IntW 8) :
 
 
 theorem not_lshr_thm (e : IntW 8) :
-  LLVM.xor (lshr e (const? 8 5)) (const? 8 7) ⊑ lshr (LLVM.xor e (const? 8 (-1))) (const? 8 5) := by 
+  LLVM.xor (lshr e (const? 8 5)) (const? 8 7) ⊑ lshr (LLVM.xor e (const? 8 (-1))) (const? 8 5) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -383,7 +383,7 @@ theorem not_lshr_thm (e : IntW 8) :
 
 
 theorem ashr_not_thm (e : IntW 8) :
-  ashr (LLVM.xor e (const? 8 (-1))) (const? 8 5) ⊑ LLVM.xor (ashr e (const? 8 5)) (const? 8 (-1)) := by 
+  ashr (LLVM.xor e (const? 8 (-1))) (const? 8 5) ⊑ LLVM.xor (ashr e (const? 8 5)) (const? 8 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -394,7 +394,7 @@ theorem ashr_not_thm (e : IntW 8) :
 
 theorem xor_andn_commute2_thm (e e_1 : IntW 33) :
   LLVM.xor (LLVM.and (LLVM.udiv (const? 33 42) e_1) (LLVM.xor e (const? 33 (-1)))) e ⊑
-    LLVM.or e (LLVM.udiv (const? 33 42) e_1) := by 
+    LLVM.or e (LLVM.udiv (const? 33 42) e_1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -405,7 +405,7 @@ theorem xor_andn_commute2_thm (e e_1 : IntW 33) :
 
 theorem xor_andn_commute3_thm (e e_1 : IntW 32) :
   LLVM.xor (LLVM.udiv (const? 32 42) e_1) (LLVM.and (LLVM.xor (LLVM.udiv (const? 32 42) e_1) (const? 32 (-1))) e) ⊑
-    LLVM.or (LLVM.udiv (const? 32 42) e_1) e := by 
+    LLVM.or (LLVM.udiv (const? 32 42) e_1) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -417,7 +417,7 @@ theorem xor_andn_commute3_thm (e e_1 : IntW 32) :
 theorem xor_andn_commute4_thm (e e_1 : IntW 32) :
   LLVM.xor (LLVM.udiv (const? 32 42) e_1)
       (LLVM.and (LLVM.udiv (const? 32 42) e) (LLVM.xor (LLVM.udiv (const? 32 42) e_1) (const? 32 (-1)))) ⊑
-    LLVM.or (LLVM.udiv (const? 32 42) e_1) (LLVM.udiv (const? 32 42) e) := by 
+    LLVM.or (LLVM.udiv (const? 32 42) e_1) (LLVM.udiv (const? 32 42) e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -428,7 +428,7 @@ theorem xor_andn_commute4_thm (e e_1 : IntW 32) :
 
 theorem xor_orn_commute1_thm (e e_1 : IntW 8) :
   LLVM.xor (LLVM.udiv (const? 8 42) e_1) (LLVM.or (LLVM.xor (LLVM.udiv (const? 8 42) e_1) (const? 8 (-1))) e) ⊑
-    LLVM.xor (LLVM.and (LLVM.udiv (const? 8 42) e_1) e) (const? 8 (-1)) := by 
+    LLVM.xor (LLVM.and (LLVM.udiv (const? 8 42) e_1) e) (const? 8 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -438,7 +438,7 @@ theorem xor_orn_commute1_thm (e e_1 : IntW 8) :
 
 
 theorem tryFactorization_xor_ashr_lshr_thm (e : IntW 32) :
-  LLVM.xor (ashr (const? 32 (-3)) e) (lshr (const? 32 5) e) ⊑ ashr (const? 32 (-8)) e := by 
+  LLVM.xor (ashr (const? 32 (-3)) e) (lshr (const? 32 5) e) ⊑ ashr (const? 32 (-8)) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -448,7 +448,7 @@ theorem tryFactorization_xor_ashr_lshr_thm (e : IntW 32) :
 
 
 theorem tryFactorization_xor_lshr_ashr_thm (e : IntW 32) :
-  LLVM.xor (lshr (const? 32 5) e) (ashr (const? 32 (-3)) e) ⊑ ashr (const? 32 (-8)) e := by 
+  LLVM.xor (lshr (const? 32 5) e) (ashr (const? 32 (-3)) e) ⊑ ashr (const? 32 (-8)) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -458,7 +458,7 @@ theorem tryFactorization_xor_lshr_ashr_thm (e : IntW 32) :
 
 
 theorem tryFactorization_xor_lshr_lshr_thm (e : IntW 32) :
-  LLVM.xor (lshr (const? 32 (-3)) e) (lshr (const? 32 5) e) ⊑ lshr (const? 32 (-8)) e := by 
+  LLVM.xor (lshr (const? 32 (-3)) e) (lshr (const? 32 5) e) ⊑ lshr (const? 32 (-8)) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -468,7 +468,7 @@ theorem tryFactorization_xor_lshr_lshr_thm (e : IntW 32) :
 
 
 theorem tryFactorization_xor_ashr_ashr_thm (e : IntW 32) :
-  LLVM.xor (ashr (const? 32 (-3)) e) (ashr (const? 32 (-5)) e) ⊑ lshr (const? 32 6) e := by 
+  LLVM.xor (ashr (const? 32 (-3)) e) (ashr (const? 32 (-5)) e) ⊑ lshr (const? 32 6) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -479,7 +479,7 @@ theorem tryFactorization_xor_ashr_ashr_thm (e : IntW 32) :
 
 theorem PR96857_xor_with_noundef_thm (e e_1 e_2 : IntW 4) :
   LLVM.xor (LLVM.and e_2 e_1) (LLVM.and (LLVM.xor e_2 (const? 4 (-1))) e) ⊑
-    LLVM.or (LLVM.and e_2 e_1) (LLVM.and e (LLVM.xor e_2 (const? 4 (-1)))) { «disjoint» := true } := by 
+    LLVM.or (LLVM.and e_2 e_1) (LLVM.and e (LLVM.xor e_2 (const? 4 (-1)))) { «disjoint» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -490,7 +490,7 @@ theorem PR96857_xor_with_noundef_thm (e e_1 e_2 : IntW 4) :
 
 theorem PR96857_xor_without_noundef_thm (e e_1 e_2 : IntW 4) :
   LLVM.xor (LLVM.and e_2 e_1) (LLVM.and (LLVM.xor e_2 (const? 4 (-1))) e) ⊑
-    LLVM.or (LLVM.and e_2 e_1) (LLVM.and e (LLVM.xor e_2 (const? 4 (-1)))) := by 
+    LLVM.or (LLVM.and e_2 e_1) (LLVM.and e (LLVM.xor e_2 (const? 4 (-1)))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -499,7 +499,7 @@ theorem PR96857_xor_without_noundef_thm (e e_1 e_2 : IntW 4) :
     all_goals sorry
 
 
-theorem or_disjoint_with_xor_thm (e e_1 : IntW 32) : LLVM.xor (LLVM.or e_1 e { «disjoint» := true }) e_1 ⊑ e := by 
+theorem or_disjoint_with_xor_thm (e e_1 : IntW 32) : LLVM.xor (LLVM.or e_1 e { «disjoint» := true }) e_1 ⊑ e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -508,7 +508,7 @@ theorem or_disjoint_with_xor_thm (e e_1 : IntW 32) : LLVM.xor (LLVM.or e_1 e { �
     all_goals sorry
 
 
-theorem xor_with_or_disjoint_ab_thm (e e_1 : IntW 32) : LLVM.xor e_1 (LLVM.or e_1 e { «disjoint» := true }) ⊑ e := by 
+theorem xor_with_or_disjoint_ab_thm (e e_1 : IntW 32) : LLVM.xor e_1 (LLVM.or e_1 e { «disjoint» := true }) ⊑ e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -517,7 +517,7 @@ theorem xor_with_or_disjoint_ab_thm (e e_1 : IntW 32) : LLVM.xor e_1 (LLVM.or e_
     all_goals sorry
 
 
-theorem xor_with_or_disjoint_ba_thm (e e_1 : IntW 32) : LLVM.xor e_1 (LLVM.or e_1 e { «disjoint» := true }) ⊑ e := by 
+theorem xor_with_or_disjoint_ba_thm (e e_1 : IntW 32) : LLVM.xor e_1 (LLVM.or e_1 e { «disjoint» := true }) ⊑ e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -529,7 +529,7 @@ theorem xor_with_or_disjoint_ba_thm (e e_1 : IntW 32) : LLVM.xor e_1 (LLVM.or e_
 theorem select_or_disjoint_or_thm (e : IntW 32) (e_1 : IntW 1) :
   add (LLVM.or (select e_1 (const? 32 0) (const? 32 4)) (shl e (const? 32 4)) { «disjoint» := true }) (const? 32 4) ⊑
     add (LLVM.or (select e_1 (const? 32 0) (const? 32 4)) (shl e (const? 32 4)) { «disjoint» := true }) (const? 32 4)
-      { «nsw» := true, «nuw» := true } := by 
+      { «nsw» := true, «nuw» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gxorhandhor_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gxorhandhor_proof.lean
@@ -9,7 +9,7 @@ set_option linter.unreachableTactic false
 
 section gxorhandhor_proof
 theorem xor_logic_and_logic_or1_thm (e e_1 e_2 : IntW 1) :
-  LLVM.xor (select e_2 e_1 (const? 1 0)) (select e_2 (const? 1 1) e) ⊑ select e_2 (LLVM.xor e_1 (const? 1 1)) e := by 
+  LLVM.xor (select e_2 e_1 (const? 1 0)) (select e_2 (const? 1 1) e) ⊑ select e_2 (LLVM.xor e_1 (const? 1 1)) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -19,7 +19,7 @@ theorem xor_logic_and_logic_or1_thm (e e_1 e_2 : IntW 1) :
 
 
 theorem xor_logic_and_logic_or2_thm (e e_1 e_2 : IntW 1) :
-  LLVM.xor (select e_2 e_1 (const? 1 0)) (select e (const? 1 1) e_2) ⊑ select e_2 (LLVM.xor e_1 (const? 1 1)) e := by 
+  LLVM.xor (select e_2 e_1 (const? 1 0)) (select e (const? 1 1) e_2) ⊑ select e_2 (LLVM.xor e_1 (const? 1 1)) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -29,7 +29,7 @@ theorem xor_logic_and_logic_or2_thm (e e_1 e_2 : IntW 1) :
 
 
 theorem xor_logic_and_logic_or4_thm (e e_1 e_2 : IntW 1) :
-  LLVM.xor (select e_2 e_1 (const? 1 0)) (select e_1 (const? 1 1) e) ⊑ select e_1 (LLVM.xor e_2 (const? 1 1)) e := by 
+  LLVM.xor (select e_2 e_1 (const? 1 0)) (select e_1 (const? 1 1) e) ⊑ select e_1 (LLVM.xor e_2 (const? 1 1)) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -39,7 +39,7 @@ theorem xor_logic_and_logic_or4_thm (e e_1 e_2 : IntW 1) :
 
 
 theorem xor_and_logic_or1_thm (e e_1 e_2 : IntW 1) :
-  LLVM.xor (LLVM.and e_2 e_1) (select e_2 (const? 1 1) e) ⊑ select e_2 (LLVM.xor e_1 (const? 1 1)) e := by 
+  LLVM.xor (LLVM.and e_2 e_1) (select e_2 (const? 1 1) e) ⊑ select e_2 (LLVM.xor e_1 (const? 1 1)) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -49,7 +49,7 @@ theorem xor_and_logic_or1_thm (e e_1 e_2 : IntW 1) :
 
 
 theorem xor_and_logic_or2_thm (e e_1 e_2 : IntW 1) :
-  LLVM.xor (LLVM.and e_2 e_1) (select e (const? 1 1) e_1) ⊑ select e_1 (LLVM.xor e_2 (const? 1 1)) e := by 
+  LLVM.xor (LLVM.and e_2 e_1) (select e (const? 1 1) e_1) ⊑ select e_1 (LLVM.xor e_2 (const? 1 1)) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -59,7 +59,7 @@ theorem xor_and_logic_or2_thm (e e_1 e_2 : IntW 1) :
 
 
 theorem xor_logic_and_or1_thm (e e_1 e_2 : IntW 1) :
-  LLVM.xor (select e_2 e_1 (const? 1 0)) (LLVM.or e e_2) ⊑ select e_2 (LLVM.xor e_1 (const? 1 1)) e := by 
+  LLVM.xor (select e_2 e_1 (const? 1 0)) (LLVM.or e e_2) ⊑ select e_2 (LLVM.xor e_1 (const? 1 1)) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -69,7 +69,7 @@ theorem xor_logic_and_or1_thm (e e_1 e_2 : IntW 1) :
 
 
 theorem xor_logic_and_or2_thm (e e_1 e_2 : IntW 1) :
-  LLVM.xor (select e_2 e_1 (const? 1 0)) (LLVM.or e_1 e) ⊑ select e_1 (LLVM.xor e_2 (const? 1 1)) e := by 
+  LLVM.xor (select e_2 e_1 (const? 1 0)) (LLVM.or e_1 e) ⊑ select e_1 (LLVM.xor e_2 (const? 1 1)) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -79,7 +79,7 @@ theorem xor_logic_and_or2_thm (e e_1 e_2 : IntW 1) :
 
 
 theorem xor_and_or_thm (e e_1 e_2 : IntW 1) :
-  LLVM.xor (LLVM.and e_2 e_1) (LLVM.or e e_2) ⊑ select e_2 (LLVM.xor e_1 (const? 1 1)) e := by 
+  LLVM.xor (LLVM.and e_2 e_1) (LLVM.or e e_2) ⊑ select e_2 (LLVM.xor e_1 (const? 1 1)) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gxorhashr_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gxorhashr_proof.lean
@@ -10,7 +10,7 @@ set_option linter.unreachableTactic false
 section gxorhashr_proof
 theorem testi8i8_thm (e : IntW 8) :
   LLVM.xor (ashr e (const? 8 7)) (const? 8 127) ⊑
-    select (icmp IntPredicate.sgt e (const? 8 (-1))) (const? 8 127) (const? 8 (-128)) := by 
+    select (icmp IntPredicate.sgt e (const? 8 (-1))) (const? 8 127) (const? 8 (-128)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -21,7 +21,7 @@ theorem testi8i8_thm (e : IntW 8) :
 
 theorem testi16i8_thm (e : IntW 16) :
   LLVM.xor (trunc 8 (ashr e (const? 16 15))) (const? 8 27) ⊑
-    select (icmp IntPredicate.sgt e (const? 16 (-1))) (const? 8 27) (const? 8 (-28)) := by 
+    select (icmp IntPredicate.sgt e (const? 16 (-1))) (const? 8 27) (const? 8 (-28)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -32,7 +32,7 @@ theorem testi16i8_thm (e : IntW 16) :
 
 theorem testi64i32_thm (e : IntW 64) :
   LLVM.xor (trunc 32 (ashr e (const? 64 63))) (const? 32 127) ⊑
-    select (icmp IntPredicate.sgt e (const? 64 (-1))) (const? 32 127) (const? 32 (-128)) := by 
+    select (icmp IntPredicate.sgt e (const? 64 (-1))) (const? 32 127) (const? 32 (-128)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -43,7 +43,7 @@ theorem testi64i32_thm (e : IntW 64) :
 
 theorem testi128i128_thm (e : IntW 128) :
   LLVM.xor (ashr e (const? 128 127)) (const? 128 27) ⊑
-    select (icmp IntPredicate.sgt e (const? 128 (-1))) (const? 128 27) (const? 128 (-28)) := by 
+    select (icmp IntPredicate.sgt e (const? 128 (-1))) (const? 128 27) (const? 128 (-28)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -54,7 +54,7 @@ theorem testi128i128_thm (e : IntW 128) :
 
 theorem wrongimm_thm (e : IntW 16) :
   LLVM.xor (trunc 8 (ashr e (const? 16 14))) (const? 8 27) ⊑
-    LLVM.xor (trunc 8 (ashr e (const? 16 14)) { «nsw» := true, «nuw» := false }) (const? 8 27) := by 
+    LLVM.xor (trunc 8 (ashr e (const? 16 14)) { «nsw» := true, «nuw» := false }) (const? 8 27) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gxorhicmps_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gxorhicmps_proof.lean
@@ -10,7 +10,7 @@ set_option linter.unreachableTactic false
 section gxorhicmps_proof
 theorem slt_zero_thm (e e_1 : IntW 4) :
   LLVM.xor (icmp IntPredicate.slt e_1 (const? 4 0)) (icmp IntPredicate.slt e (const? 4 0)) ⊑
-    icmp IntPredicate.slt (LLVM.xor e_1 e) (const? 4 0) := by 
+    icmp IntPredicate.slt (LLVM.xor e_1 e) (const? 4 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -21,7 +21,7 @@ theorem slt_zero_thm (e e_1 : IntW 4) :
 
 theorem sgt_minus1_thm (e e_1 : IntW 4) :
   LLVM.xor (icmp IntPredicate.sgt e_1 (const? 4 (-1))) (icmp IntPredicate.sgt e (const? 4 (-1))) ⊑
-    icmp IntPredicate.slt (LLVM.xor e_1 e) (const? 4 0) := by 
+    icmp IntPredicate.slt (LLVM.xor e_1 e) (const? 4 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -32,7 +32,7 @@ theorem sgt_minus1_thm (e e_1 : IntW 4) :
 
 theorem slt_zero_sgt_minus1_thm (e e_1 : IntW 4) :
   LLVM.xor (icmp IntPredicate.slt e_1 (const? 4 0)) (icmp IntPredicate.sgt e (const? 4 (-1))) ⊑
-    icmp IntPredicate.sgt (LLVM.xor e_1 e) (const? 4 (-1)) := by 
+    icmp IntPredicate.sgt (LLVM.xor e_1 e) (const? 4 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -42,7 +42,7 @@ theorem slt_zero_sgt_minus1_thm (e e_1 : IntW 4) :
 
 
 theorem test13_thm (e e_1 : IntW 8) :
-  LLVM.xor (icmp IntPredicate.ult e_1 e) (icmp IntPredicate.ugt e_1 e) ⊑ icmp IntPredicate.ne e_1 e := by 
+  LLVM.xor (icmp IntPredicate.ult e_1 e) (icmp IntPredicate.ugt e_1 e) ⊑ icmp IntPredicate.ne e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -52,7 +52,7 @@ theorem test13_thm (e e_1 : IntW 8) :
 
 
 theorem test14_thm (e e_1 : IntW 8) :
-  LLVM.xor (icmp IntPredicate.eq e_1 e) (icmp IntPredicate.ne e e_1) ⊑ const? 1 1 := by 
+  LLVM.xor (icmp IntPredicate.eq e_1 e) (icmp IntPredicate.ne e e_1) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -62,7 +62,7 @@ theorem test14_thm (e e_1 : IntW 8) :
 
 
 theorem xor_icmp_true_signed_thm (e : IntW 32) :
-  LLVM.xor (icmp IntPredicate.sgt e (const? 32 5)) (icmp IntPredicate.slt e (const? 32 6)) ⊑ const? 1 1 := by 
+  LLVM.xor (icmp IntPredicate.sgt e (const? 32 5)) (icmp IntPredicate.slt e (const? 32 6)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -72,7 +72,7 @@ theorem xor_icmp_true_signed_thm (e : IntW 32) :
 
 
 theorem xor_icmp_true_signed_commuted_thm (e : IntW 32) :
-  LLVM.xor (icmp IntPredicate.slt e (const? 32 6)) (icmp IntPredicate.sgt e (const? 32 5)) ⊑ const? 1 1 := by 
+  LLVM.xor (icmp IntPredicate.slt e (const? 32 6)) (icmp IntPredicate.sgt e (const? 32 5)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -82,7 +82,7 @@ theorem xor_icmp_true_signed_commuted_thm (e : IntW 32) :
 
 
 theorem xor_icmp_true_unsigned_thm (e : IntW 32) :
-  LLVM.xor (icmp IntPredicate.ugt e (const? 32 5)) (icmp IntPredicate.ult e (const? 32 6)) ⊑ const? 1 1 := by 
+  LLVM.xor (icmp IntPredicate.ugt e (const? 32 5)) (icmp IntPredicate.ult e (const? 32 6)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -93,7 +93,7 @@ theorem xor_icmp_true_unsigned_thm (e : IntW 32) :
 
 theorem xor_icmp_to_ne_thm (e : IntW 32) :
   LLVM.xor (icmp IntPredicate.sgt e (const? 32 4)) (icmp IntPredicate.slt e (const? 32 6)) ⊑
-    icmp IntPredicate.ne e (const? 32 5) := by 
+    icmp IntPredicate.ne e (const? 32 5) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -104,7 +104,7 @@ theorem xor_icmp_to_ne_thm (e : IntW 32) :
 
 theorem xor_icmp_to_icmp_add_thm (e : IntW 32) :
   LLVM.xor (icmp IntPredicate.sgt e (const? 32 3)) (icmp IntPredicate.slt e (const? 32 6)) ⊑
-    icmp IntPredicate.ult (add e (const? 32 (-6))) (const? 32 (-2)) := by 
+    icmp IntPredicate.ult (add e (const? 32 (-6))) (const? 32 (-2)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -115,7 +115,7 @@ theorem xor_icmp_to_icmp_add_thm (e : IntW 32) :
 
 theorem xor_icmp_invalid_range_thm (e : IntW 8) :
   LLVM.xor (icmp IntPredicate.eq e (const? 8 0)) (icmp IntPredicate.ne e (const? 8 4)) ⊑
-    icmp IntPredicate.ne (LLVM.and e (const? 8 (-5))) (const? 8 0) := by 
+    icmp IntPredicate.ne (LLVM.and e (const? 8 (-5))) (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gxorhofhor_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gxorhofhor_proof.lean
@@ -9,7 +9,7 @@ set_option linter.unreachableTactic false
 
 section gxorhofhor_proof
 theorem t1_thm (e : IntW 4) :
-  LLVM.xor (LLVM.or e (const? 4 (-4))) (const? 4 (-6)) ⊑ LLVM.xor (LLVM.and e (const? 4 3)) (const? 4 6) := by 
+  LLVM.xor (LLVM.or e (const? 4 (-4))) (const? 4 (-6)) ⊑ LLVM.xor (LLVM.and e (const? 4 3)) (const? 4 6) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gzeroexthandhreduce_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gzeroexthandhreduce_proof.lean
@@ -9,7 +9,7 @@ set_option linter.unreachableTactic false
 
 section gzeroexthandhreduce_proof
 theorem test1_thm (e : IntW 8) :
-  LLVM.and (zext 32 e) (const? 32 65544) ⊑ zext 32 (LLVM.and e (const? 8 8)) { «nneg» := true } := by 
+  LLVM.and (zext 32 e) (const? 32 65544) ⊑ zext 32 (LLVM.and e (const? 8 8)) { «nneg» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gzext_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gzext_proof.lean
@@ -8,7 +8,7 @@ set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
 
 section gzext_proof
-theorem test_sext_zext_thm (e : IntW 16) : sext 64 (zext 32 e) ⊑ zext 64 e := by 
+theorem test_sext_zext_thm (e : IntW 16) : sext 64 (zext 32 e) ⊑ zext 64 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -18,7 +18,7 @@ theorem test_sext_zext_thm (e : IntW 16) : sext 64 (zext 32 e) ⊑ zext 64 e := 
 
 
 theorem fold_xor_zext_sandwich_thm (e : IntW 1) :
-  zext 64 (LLVM.xor (zext 32 e) (const? 32 1)) ⊑ zext 64 (LLVM.xor e (const? 1 1)) := by 
+  zext 64 (LLVM.xor (zext 32 e) (const? 32 1)) ⊑ zext 64 (LLVM.xor e (const? 1 1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -29,7 +29,7 @@ theorem fold_xor_zext_sandwich_thm (e : IntW 1) :
 
 theorem fold_and_zext_icmp_thm (e e_1 e_2 : IntW 64) :
   LLVM.and (zext 8 (icmp IntPredicate.sgt e_2 e_1)) (zext 8 (icmp IntPredicate.slt e_2 e)) ⊑
-    zext 8 (LLVM.and (icmp IntPredicate.sgt e_2 e_1) (icmp IntPredicate.slt e_2 e)) := by 
+    zext 8 (LLVM.and (icmp IntPredicate.sgt e_2 e_1) (icmp IntPredicate.slt e_2 e)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -40,7 +40,7 @@ theorem fold_and_zext_icmp_thm (e e_1 e_2 : IntW 64) :
 
 theorem fold_or_zext_icmp_thm (e e_1 e_2 : IntW 64) :
   LLVM.or (zext 8 (icmp IntPredicate.sgt e_2 e_1)) (zext 8 (icmp IntPredicate.slt e_2 e)) ⊑
-    zext 8 (LLVM.or (icmp IntPredicate.sgt e_2 e_1) (icmp IntPredicate.slt e_2 e)) := by 
+    zext 8 (LLVM.or (icmp IntPredicate.sgt e_2 e_1) (icmp IntPredicate.slt e_2 e)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -51,7 +51,7 @@ theorem fold_or_zext_icmp_thm (e e_1 e_2 : IntW 64) :
 
 theorem fold_xor_zext_icmp_thm (e e_1 e_2 : IntW 64) :
   LLVM.xor (zext 8 (icmp IntPredicate.sgt e_2 e_1)) (zext 8 (icmp IntPredicate.slt e_2 e)) ⊑
-    zext 8 (LLVM.xor (icmp IntPredicate.sgt e_2 e_1) (icmp IntPredicate.slt e_2 e)) := by 
+    zext 8 (LLVM.xor (icmp IntPredicate.sgt e_2 e_1) (icmp IntPredicate.slt e_2 e)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -65,7 +65,7 @@ theorem fold_nested_logic_zext_icmp_thm (e e_1 e_2 e_3 : IntW 64) :
       (zext 8 (icmp IntPredicate.eq e_3 e)) ⊑
     zext 8
       (LLVM.or (LLVM.and (icmp IntPredicate.sgt e_3 e_2) (icmp IntPredicate.slt e_3 e_1))
-        (icmp IntPredicate.eq e_3 e)) := by 
+        (icmp IntPredicate.eq e_3 e)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -74,7 +74,7 @@ theorem fold_nested_logic_zext_icmp_thm (e e_1 e_2 e_3 : IntW 64) :
     all_goals sorry
 
 
-theorem sext_zext_apint1_thm (e : IntW 77) : sext 1024 (zext 533 e) ⊑ zext 1024 e := by 
+theorem sext_zext_apint1_thm (e : IntW 77) : sext 1024 (zext 533 e) ⊑ zext 1024 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -83,7 +83,7 @@ theorem sext_zext_apint1_thm (e : IntW 77) : sext 1024 (zext 533 e) ⊑ zext 102
     all_goals sorry
 
 
-theorem sext_zext_apint2_thm (e : IntW 11) : sext 47 (zext 39 e) ⊑ zext 47 e := by 
+theorem sext_zext_apint2_thm (e : IntW 11) : sext 47 (zext 39 e) ⊑ zext 47 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -94,7 +94,7 @@ theorem sext_zext_apint2_thm (e : IntW 11) : sext 47 (zext 39 e) ⊑ zext 47 e :
 
 theorem masked_bit_set_thm (e e_1 : IntW 32) :
   zext 32 (icmp IntPredicate.ne (LLVM.and (shl (const? 32 1) e_1) e) (const? 32 0)) ⊑
-    LLVM.and (lshr e e_1) (const? 32 1) := by 
+    LLVM.and (lshr e e_1) (const? 32 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -105,7 +105,7 @@ theorem masked_bit_set_thm (e e_1 : IntW 32) :
 
 theorem masked_bit_clear_commute_thm (e e_1 : IntW 32) :
   zext 32 (icmp IntPredicate.eq (LLVM.and (LLVM.srem (const? 32 42) e_1) (shl (const? 32 1) e)) (const? 32 0)) ⊑
-    LLVM.and (lshr (LLVM.xor (LLVM.srem (const? 32 42) e_1) (const? 32 (-1))) e) (const? 32 1) := by 
+    LLVM.and (lshr (LLVM.xor (LLVM.srem (const? 32 42) e_1) (const? 32 (-1))) e) (const? 32 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -118,7 +118,7 @@ theorem div_bit_set_thm (e e_1 : IntW 32) :
   zext 32 (icmp IntPredicate.ne (LLVM.sdiv (shl (const? 32 1) e_1) e) (const? 32 0)) ⊑
     zext 32
       (icmp IntPredicate.ne (LLVM.sdiv (shl (const? 32 1) e_1 { «nsw» := false, «nuw» := true }) e)
-        (const? 32 0)) := by 
+        (const? 32 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -131,7 +131,7 @@ theorem masked_bit_set_nonzero_cmp_thm (e e_1 : IntW 32) :
   zext 32 (icmp IntPredicate.ne (LLVM.and (shl (const? 32 1) e_1) e) (const? 32 1)) ⊑
     zext 32
       (icmp IntPredicate.ne (LLVM.and (shl (const? 32 1) e_1 { «nsw» := false, «nuw» := true }) e)
-        (const? 32 1)) := by 
+        (const? 32 1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -144,7 +144,7 @@ theorem masked_bit_wrong_pred_thm (e e_1 : IntW 32) :
   zext 32 (icmp IntPredicate.sgt (LLVM.and (shl (const? 32 1) e_1) e) (const? 32 0)) ⊑
     zext 32
       (icmp IntPredicate.sgt (LLVM.and (shl (const? 32 1) e_1 { «nsw» := false, «nuw» := true }) e)
-        (const? 32 0)) := by 
+        (const? 32 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -160,7 +160,7 @@ theorem zext_or_masked_bit_test_thm (e e_1 e_2 : IntW 32) :
     zext 32
       (LLVM.or
         (icmp IntPredicate.ne (LLVM.and (shl (const? 32 1) e_2 { «nsw» := false, «nuw» := true }) e_1) (const? 32 0))
-        (icmp IntPredicate.eq e e_2)) := by 
+        (icmp IntPredicate.eq e e_2)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -171,7 +171,7 @@ theorem zext_or_masked_bit_test_thm (e e_1 e_2 : IntW 32) :
 
 theorem zext_masked_bit_zero_to_smaller_bitwidth_thm (e e_1 : IntW 32) :
   zext 16 (icmp IntPredicate.eq (LLVM.and (shl (const? 32 1) e_1) e) (const? 32 0)) ⊑
-    LLVM.and (trunc 16 (lshr (LLVM.xor e (const? 32 (-1))) e_1)) (const? 16 1) := by 
+    LLVM.and (trunc 16 (lshr (LLVM.xor e (const? 32 (-1))) e_1)) (const? 16 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -182,7 +182,7 @@ theorem zext_masked_bit_zero_to_smaller_bitwidth_thm (e e_1 : IntW 32) :
 
 theorem zext_masked_bit_nonzero_to_smaller_bitwidth_thm (e e_1 : IntW 32) :
   zext 16 (icmp IntPredicate.ne (LLVM.and (shl (const? 32 1) e_1) e) (const? 32 0)) ⊑
-    LLVM.and (trunc 16 (lshr e e_1)) (const? 16 1) := by 
+    LLVM.and (trunc 16 (lshr e e_1)) (const? 16 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -193,7 +193,7 @@ theorem zext_masked_bit_nonzero_to_smaller_bitwidth_thm (e e_1 : IntW 32) :
 
 theorem zext_masked_bit_zero_to_larger_bitwidth_thm (e e_1 : IntW 32) :
   zext 64 (icmp IntPredicate.eq (LLVM.and (shl (const? 32 1) e_1) e) (const? 32 0)) ⊑
-    zext 64 (LLVM.and (lshr (LLVM.xor e (const? 32 (-1))) e_1) (const? 32 1)) { «nneg» := true } := by 
+    zext 64 (LLVM.and (lshr (LLVM.xor e (const? 32 (-1))) e_1) (const? 32 1)) { «nneg» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -204,7 +204,7 @@ theorem zext_masked_bit_zero_to_larger_bitwidth_thm (e e_1 : IntW 32) :
 
 theorem zext_nneg_flag_drop_thm (e : IntW 16) (e_1 : IntW 8) :
   LLVM.or (LLVM.or (zext 16 (LLVM.and e_1 (const? 8 127)) { «nneg» := true }) e) (const? 16 128) ⊑
-    LLVM.or (LLVM.or e (zext 16 e_1)) (const? 16 128) := by 
+    LLVM.or (LLVM.or e (zext 16 e_1)) (const? 16 128) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -214,7 +214,7 @@ theorem zext_nneg_flag_drop_thm (e : IntW 16) (e_1 : IntW 8) :
 
 
 theorem zext_nneg_redundant_and_thm (e : IntW 8) :
-  LLVM.and (zext 32 e { «nneg» := true }) (const? 32 127) ⊑ zext 32 e { «nneg» := true } := by 
+  LLVM.and (zext 32 e { «nneg» := true }) (const? 32 127) ⊑ zext 32 e { «nneg» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -223,7 +223,7 @@ theorem zext_nneg_redundant_and_thm (e : IntW 8) :
     all_goals sorry
 
 
-theorem zext_nneg_signbit_extract_thm (e : IntW 32) : lshr (zext 64 e { «nneg» := true }) (const? 64 31) ⊑ const? 64 0 := by 
+theorem zext_nneg_signbit_extract_thm (e : IntW 32) : lshr (zext 64 e { «nneg» := true }) (const? 64 31) ⊑ const? 64 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -232,7 +232,7 @@ theorem zext_nneg_signbit_extract_thm (e : IntW 32) : lshr (zext 64 e { «nneg»
     all_goals sorry
 
 
-theorem zext_nneg_i1_thm (e : IntW 1) : zext 32 e { «nneg» := true } ⊑ const? 32 0 := by 
+theorem zext_nneg_i1_thm (e : IntW 1) : zext 32 e { «nneg» := true } ⊑ const? 32 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gzexthboolhaddhsub_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gzexthboolhaddhsub_proof.lean
@@ -10,7 +10,7 @@ set_option linter.unreachableTactic false
 section gzexthboolhaddhsub_proof
 theorem a_thm (e e_1 : IntW 1) :
   add (add (zext 32 e_1) (const? 32 1)) (sub (const? 32 0) (zext 32 e)) ⊑
-    add (select e_1 (const? 32 2) (const? 32 1)) (sext 32 e) { «nsw» := true, «nuw» := false } := by 
+    add (select e_1 (const? 32 2) (const? 32 1)) (sext 32 e) { «nsw» := true, «nuw» := false } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -25,7 +25,7 @@ theorem PR30273_three_bools_thm (e e_1 e_2 : IntW 1) :
         { «nsw» := true, «nuw» := false })
       (select e_1 (add (zext 32 e) (const? 32 1) { «nsw» := true, «nuw» := false }) (zext 32 e)) ⊑
     add (select e_1 (select e (const? 32 2) (const? 32 1)) (zext 32 e)) (zext 32 e_2)
-      { «nsw» := true, «nuw» := true } := by 
+      { «nsw» := true, «nuw» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -34,7 +34,7 @@ theorem PR30273_three_bools_thm (e e_1 e_2 : IntW 1) :
     all_goals sorry
 
 
-theorem zext_add_scalar_thm (e : IntW 1) : add (zext 32 e) (const? 32 42) ⊑ select e (const? 32 43) (const? 32 42) := by 
+theorem zext_add_scalar_thm (e : IntW 1) : add (zext 32 e) (const? 32 42) ⊑ select e (const? 32 43) (const? 32 42) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -43,7 +43,7 @@ theorem zext_add_scalar_thm (e : IntW 1) : add (zext 32 e) (const? 32 42) ⊑ se
     all_goals sorry
 
 
-theorem zext_negate_thm (e : IntW 1) : sub (const? 64 0) (zext 64 e) ⊑ sext 64 e := by 
+theorem zext_negate_thm (e : IntW 1) : sub (const? 64 0) (zext 64 e) ⊑ sext 64 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -52,7 +52,7 @@ theorem zext_negate_thm (e : IntW 1) : sub (const? 64 0) (zext 64 e) ⊑ sext 64
     all_goals sorry
 
 
-theorem zext_sub_const_thm (e : IntW 1) : sub (const? 64 42) (zext 64 e) ⊑ select e (const? 64 41) (const? 64 42) := by 
+theorem zext_sub_const_thm (e : IntW 1) : sub (const? 64 42) (zext 64 e) ⊑ select e (const? 64 41) (const? 64 42) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -61,7 +61,7 @@ theorem zext_sub_const_thm (e : IntW 1) : sub (const? 64 42) (zext 64 e) ⊑ sel
     all_goals sorry
 
 
-theorem sext_negate_thm (e : IntW 1) : sub (const? 64 0) (sext 64 e) ⊑ zext 64 e := by 
+theorem sext_negate_thm (e : IntW 1) : sub (const? 64 0) (sext 64 e) ⊑ zext 64 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -70,7 +70,7 @@ theorem sext_negate_thm (e : IntW 1) : sub (const? 64 0) (sext 64 e) ⊑ zext 64
     all_goals sorry
 
 
-theorem sext_sub_const_thm (e : IntW 1) : sub (const? 64 42) (sext 64 e) ⊑ select e (const? 64 43) (const? 64 42) := by 
+theorem sext_sub_const_thm (e : IntW 1) : sub (const? 64 42) (sext 64 e) ⊑ select e (const? 64 43) (const? 64 42) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -79,7 +79,7 @@ theorem sext_sub_const_thm (e : IntW 1) : sub (const? 64 42) (sext 64 e) ⊑ sel
     all_goals sorry
 
 
-theorem sext_sub_thm (e : IntW 1) (e_1 : IntW 8) : sub e_1 (sext 8 e) ⊑ add e_1 (zext 8 e) := by 
+theorem sext_sub_thm (e : IntW 1) (e_1 : IntW 8) : sub e_1 (sext 8 e) ⊑ add e_1 (zext 8 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -89,7 +89,7 @@ theorem sext_sub_thm (e : IntW 1) (e_1 : IntW 8) : sub e_1 (sext 8 e) ⊑ add e_
 
 
 theorem sext_sub_nuw_thm (e : IntW 1) (e_1 : IntW 8) :
-  sub e_1 (sext 8 e) { «nsw» := false, «nuw» := true } ⊑ add e_1 (zext 8 e) := by 
+  sub e_1 (sext 8 e) { «nsw» := false, «nuw» := true } ⊑ add e_1 (zext 8 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -98,7 +98,7 @@ theorem sext_sub_nuw_thm (e : IntW 1) (e_1 : IntW 8) :
     all_goals sorry
 
 
-theorem sextbool_add_thm (e : IntW 32) (e_1 : IntW 1) : add (sext 32 e_1) e ⊑ add e (sext 32 e_1) := by 
+theorem sextbool_add_thm (e : IntW 32) (e_1 : IntW 1) : add (sext 32 e_1) e ⊑ add e (sext 32 e_1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -109,7 +109,7 @@ theorem sextbool_add_thm (e : IntW 32) (e_1 : IntW 1) : add (sext 32 e_1) e ⊑ 
 
 theorem sextbool_add_commute_thm (e : IntW 1) (e_1 : IntW 32) :
   add (urem e_1 (const? 32 42)) (sext 32 e) ⊑
-    add (urem e_1 (const? 32 42)) (sext 32 e) { «nsw» := true, «nuw» := false } := by 
+    add (urem e_1 (const? 32 42)) (sext 32 e) { «nsw» := true, «nuw» := false } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gzexthorhicmp_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gzexthorhicmp_proof.lean
@@ -11,7 +11,7 @@ section gzexthorhicmp_proof
 theorem zext_or_eq_ult_add_thm (e : IntW 32) :
   zext 32
       (LLVM.or (icmp IntPredicate.ult (add e (const? 32 (-3))) (const? 32 3)) (icmp IntPredicate.eq e (const? 32 5))) ⊑
-    zext 32 (icmp IntPredicate.ult (add e (const? 32 (-3))) (const? 32 3)) := by 
+    zext 32 (icmp IntPredicate.ult (add e (const? 32 (-3))) (const? 32 3)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -23,7 +23,7 @@ theorem zext_or_eq_ult_add_thm (e : IntW 32) :
 theorem select_zext_or_eq_ult_add_thm (e : IntW 32) :
   select (icmp IntPredicate.ult (add e (const? 32 (-3))) (const? 32 2)) (const? 32 1)
       (zext 32 (icmp IntPredicate.eq e (const? 32 5))) ⊑
-    zext 32 (icmp IntPredicate.ult (add e (const? 32 (-3))) (const? 32 3)) := by 
+    zext 32 (icmp IntPredicate.ult (add e (const? 32 (-3))) (const? 32 3)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash


### PR DESCRIPTION
The files where regenerated by calling
`SSA/Projects/InstCombine/scripts/proof-gen.py` from the project root.