### PR TITLE
chore: increase maxHeartbeats in LLVM tests

### DIFF
--- a/SSA/Projects/InstCombine/scripts/proof-gen.py
+++ b/SSA/Projects/InstCombine/scripts/proof-gen.py
@@ -39,6 +39,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section {stem}_proof
 """

--- a/SSA/Projects/InstCombine/tests/proofs/g2003h05h26hCastMiscompile_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/g2003h05h26hCastMiscompile_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section g2003h05h26hCastMiscompile_proof
 theorem test_thm (e : IntW 64) : zext 64 (trunc 32 e) ⊑ LLVM.and e (const? 64 4294967295) := by

--- a/SSA/Projects/InstCombine/tests/proofs/g2004h02h23hShiftShiftOverflow_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/g2004h02h23hShiftShiftOverflow_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section g2004h02h23hShiftShiftOverflow_proof
 theorem test_thm (e : IntW 32) : ashr (ashr e (const? 32 17)) (const? 32 17) ⊑ ashr e (const? 32 31) := by

--- a/SSA/Projects/InstCombine/tests/proofs/g2004h08h10hBoolSetCC_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/g2004h08h10hBoolSetCC_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section g2004h08h10hBoolSetCC_proof
 theorem test_thm (e : IntW 1) : icmp IntPredicate.ult e (const? 1 0) ⊑ const? 1 0 := by

--- a/SSA/Projects/InstCombine/tests/proofs/g2004h09h28hBadShiftAndSetCC_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/g2004h09h28hBadShiftAndSetCC_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section g2004h09h28hBadShiftAndSetCC_proof
 theorem test_thm (e : IntW 32) :

--- a/SSA/Projects/InstCombine/tests/proofs/g2004h11h22hMissedhandhfold_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/g2004h11h22hMissedhandhfold_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section g2004h11h22hMissedhandhfold_proof
 theorem test21_thm (e : IntW 8) : LLVM.and (ashr e (const? 8 7)) (const? 8 1) ⊑ lshr e (const? 8 7) := by

--- a/SSA/Projects/InstCombine/tests/proofs/g2004h11h27hSetCCForCastLargerAndConstant_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/g2004h11h27hSetCCForCastLargerAndConstant_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section g2004h11h27hSetCCForCastLargerAndConstant_proof
 theorem lt_signed_to_large_unsigned_thm (e : IntW 8) :

--- a/SSA/Projects/InstCombine/tests/proofs/g2005h03h04hShiftOverflow_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/g2005h03h04hShiftOverflow_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section g2005h03h04hShiftOverflow_proof
 theorem test_thm (e : IntW 64) :

--- a/SSA/Projects/InstCombine/tests/proofs/g2005h04h07hUDivSelectCrash_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/g2005h04h07hUDivSelectCrash_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section g2005h04h07hUDivSelectCrash_proof
 theorem test_thm (e : IntW 1) (e_1 : IntW 32) :

--- a/SSA/Projects/InstCombine/tests/proofs/g2005h06h16hRangeCrash_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/g2005h06h16hRangeCrash_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section g2005h06h16hRangeCrash_proof
 theorem test_thm :

--- a/SSA/Projects/InstCombine/tests/proofs/g2006h02h13hDemandedMiscompile_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/g2006h02h13hDemandedMiscompile_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section g2006h02h13hDemandedMiscompile_proof
 theorem test_thm (e : IntW 8) : ashr (sext 32 e) (const? 32 8) ⊑ sext 32 (ashr e (const? 8 7)) := by

--- a/SSA/Projects/InstCombine/tests/proofs/g2006h02h28hCrash_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/g2006h02h28hCrash_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section g2006h02h28hCrash_proof
 theorem test_thm : zext 32 (icmp IntPredicate.eq (const? 32 1) (const? 32 2)) ⊑ const? 32 0 := by

--- a/SSA/Projects/InstCombine/tests/proofs/g2006h04h28hShiftShiftLongLong_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/g2006h04h28hShiftShiftLongLong_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section g2006h04h28hShiftShiftLongLong_proof
 theorem test_thm (e : IntW 64) :

--- a/SSA/Projects/InstCombine/tests/proofs/g2006h10h19hSignedToUnsignedCastAndConsth2_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/g2006h10h19hSignedToUnsignedCastAndConsth2_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section g2006h10h19hSignedToUnsignedCastAndConsth2_proof
 theorem eq_signed_to_small_unsigned_thm (e : IntW 8) :

--- a/SSA/Projects/InstCombine/tests/proofs/g2006h10h20hmask_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/g2006h10h20hmask_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section g2006h10h20hmask_proof
 theorem foo_thm (e e_1 : IntW 64) :

--- a/SSA/Projects/InstCombine/tests/proofs/g2006h11h10hashrhmiscompile_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/g2006h11h10hashrhmiscompile_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section g2006h11h10hashrhmiscompile_proof
 theorem test_thm (e : IntW 8) :

--- a/SSA/Projects/InstCombine/tests/proofs/g2007h01h13hExtCompareMiscompile_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/g2007h01h13hExtCompareMiscompile_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section g2007h01h13hExtCompareMiscompile_proof
 theorem test_thm (e e_1 : IntW 8) :

--- a/SSA/Projects/InstCombine/tests/proofs/g2007h03h13hCompareMerge_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/g2007h03h13hCompareMerge_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section g2007h03h13hCompareMerge_proof
 theorem test_thm (e e_1 : IntW 32) :

--- a/SSA/Projects/InstCombine/tests/proofs/g2007h03h19hBadTruncChangePR1261_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/g2007h03h19hBadTruncChangePR1261_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section g2007h03h19hBadTruncChangePR1261_proof
 theorem test_thm (e : IntW 31) :

--- a/SSA/Projects/InstCombine/tests/proofs/g2007h03h21hSignedRangeTest_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/g2007h03h21hSignedRangeTest_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section g2007h03h21hSignedRangeTest_proof
 theorem test_thm (e : IntW 32) :

--- a/SSA/Projects/InstCombine/tests/proofs/g2007h03h25hDoubleShift_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/g2007h03h25hDoubleShift_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section g2007h03h25hDoubleShift_proof
 theorem test_thm (e : IntW 32) :

--- a/SSA/Projects/InstCombine/tests/proofs/g2007h05h10hicmphor_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/g2007h05h10hicmphor_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section g2007h05h10hicmphor_proof
 theorem test_thm (e : IntW 32) :

--- a/SSA/Projects/InstCombine/tests/proofs/g2007h06h21hDivCompareMiscomp_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/g2007h06h21hDivCompareMiscomp_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section g2007h06h21hDivCompareMiscomp_proof
 theorem test_thm (e : IntW 32) :

--- a/SSA/Projects/InstCombine/tests/proofs/g2007h08h02hInfiniteLoop_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/g2007h08h02hInfiniteLoop_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section g2007h08h02hInfiniteLoop_proof
 theorem test_thm (e e_1 : IntW 16) :

--- a/SSA/Projects/InstCombine/tests/proofs/g2007h11h15hCompareMiscomp_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/g2007h11h15hCompareMiscomp_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section g2007h11h15hCompareMiscomp_proof
 theorem test_thm (e : IntW 32) :

--- a/SSA/Projects/InstCombine/tests/proofs/g2008h01h13hAndCmpCmp_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/g2008h01h13hAndCmpCmp_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section g2008h01h13hAndCmpCmp_proof
 theorem test_logical_thm (e : IntW 32) :

--- a/SSA/Projects/InstCombine/tests/proofs/g2008h01h21hMulTrunc_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/g2008h01h21hMulTrunc_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section g2008h01h21hMulTrunc_proof
 theorem test1_thm (e : IntW 16) :

--- a/SSA/Projects/InstCombine/tests/proofs/g2008h02h16hSDivOverflow2_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/g2008h02h16hSDivOverflow2_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section g2008h02h16hSDivOverflow2_proof
 theorem i_thm (e : IntW 8) :

--- a/SSA/Projects/InstCombine/tests/proofs/g2008h02h23hMulSub_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/g2008h02h23hMulSub_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section g2008h02h23hMulSub_proof
 theorem test_thm (e : IntW 26) : sub (mul e (const? 26 2885)) (mul e (const? 26 2884)) ⊑ e := by

--- a/SSA/Projects/InstCombine/tests/proofs/g2008h05h31hAddBool_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/g2008h05h31hAddBool_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section g2008h05h31hAddBool_proof
 theorem test_thm (e e_1 : IntW 1) : add e_1 e ⊑ LLVM.xor e_1 e := by

--- a/SSA/Projects/InstCombine/tests/proofs/g2008h05h31hBools_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/g2008h05h31hBools_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section g2008h05h31hBools_proof
 theorem foo1_thm (e e_1 : IntW 1) : sub e_1 e ⊑ LLVM.xor e e_1 := by

--- a/SSA/Projects/InstCombine/tests/proofs/g2008h06h21hCompareMiscomp_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/g2008h06h21hCompareMiscomp_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section g2008h06h21hCompareMiscomp_proof
 theorem test_thm (e : IntW 32) :

--- a/SSA/Projects/InstCombine/tests/proofs/g2008h07h08hShiftOneAndOne_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/g2008h07h08hShiftOneAndOne_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section g2008h07h08hShiftOneAndOne_proof
 theorem PR2330_thm (e : IntW 32) :

--- a/SSA/Projects/InstCombine/tests/proofs/g2008h07h08hSubAnd_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/g2008h07h08hSubAnd_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section g2008h07h08hSubAnd_proof
 theorem a_thm (e : IntW 32) :

--- a/SSA/Projects/InstCombine/tests/proofs/g2008h07h09hSubAndError_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/g2008h07h09hSubAndError_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section g2008h07h09hSubAndError_proof
 theorem foo_thm (e : IntW 32) :

--- a/SSA/Projects/InstCombine/tests/proofs/g2008h07h10hCastSextBool_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/g2008h07h10hCastSextBool_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section g2008h07h10hCastSextBool_proof
 theorem PR2539_A_thm (e : IntW 1) : icmp IntPredicate.slt (zext 32 e) (const? 32 1) ⊑ LLVM.xor e (const? 1 1) := by

--- a/SSA/Projects/InstCombine/tests/proofs/g2008h07h11hRemAnd_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/g2008h07h11hRemAnd_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section g2008h07h11hRemAnd_proof
 theorem a_thm (e : IntW 32) :

--- a/SSA/Projects/InstCombine/tests/proofs/g2008h10h11hDivCompareFold_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/g2008h10h11hDivCompareFold_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section g2008h10h11hDivCompareFold_proof
 theorem x_thm (e : IntW 32) :

--- a/SSA/Projects/InstCombine/tests/proofs/g2008h11h01hSRemDemandedBits_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/g2008h11h01hSRemDemandedBits_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section g2008h11h01hSRemDemandedBits_proof
 theorem foo_thm (e : IntW 32) :

--- a/SSA/Projects/InstCombine/tests/proofs/g2009h03h24hInfLoop_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/g2009h03h24hInfLoop_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section g2009h03h24hInfLoop_proof
 theorem test_thm (e : IntW 32) :

--- a/SSA/Projects/InstCombine/tests/proofs/g2010h11h01hlshrhmask_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/g2010h11h01hlshrhmask_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section g2010h11h01hlshrhmask_proof
 theorem main_thm (e : IntW 32) :

--- a/SSA/Projects/InstCombine/tests/proofs/g2010h11h23hDistributed_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/g2010h11h23hDistributed_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section g2010h11h23hDistributed_proof
 theorem foo_thm (e e_1 : IntW 32) :

--- a/SSA/Projects/InstCombine/tests/proofs/g2011h03h08hSRemMinusOneBadOpt_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/g2011h03h08hSRemMinusOneBadOpt_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section g2011h03h08hSRemMinusOneBadOpt_proof
 theorem test_thm (e : IntW 64) :

--- a/SSA/Projects/InstCombine/tests/proofs/g2012h02h28hICmp_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/g2012h02h28hICmp_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section g2012h02h28hICmp_proof
 theorem f1_logical_thm (e : IntW 32) :

--- a/SSA/Projects/InstCombine/tests/proofs/g2012h08h28hudiv_ashl_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/g2012h08h28hudiv_ashl_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section g2012h08h28hudiv_ashl_proof
 theorem udiv400_thm (e : IntW 32) :

--- a/SSA/Projects/InstCombine/tests/proofs/gAddOverFlow_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gAddOverFlow_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gAddOverFlow_proof
 theorem oppositesign_thm (e e_1 : IntW 16) :

--- a/SSA/Projects/InstCombine/tests/proofs/gJavaCompare_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gJavaCompare_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gJavaCompare_proof
 theorem le_thm (e e_1 : IntW 32) :

--- a/SSA/Projects/InstCombine/tests/proofs/gabsh1_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gabsh1_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gabsh1_proof
 theorem abs_must_be_positive_thm (e : IntW 32) :

--- a/SSA/Projects/InstCombine/tests/proofs/gadd2_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gadd2_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gadd2_proof
 theorem test1_thm (e : IntW 64) (e_1 : IntW 32) :

--- a/SSA/Projects/InstCombine/tests/proofs/gadd4_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gadd4_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gadd4_proof
 theorem match_unsigned_thm (e : IntW 64) :

--- a/SSA/Projects/InstCombine/tests/proofs/gadd_or_sub_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gadd_or_sub_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gadd_or_sub_proof
 theorem add_or_sub_comb_i32_commuted1_nuw_thm (e : IntW 32) :

--- a/SSA/Projects/InstCombine/tests/proofs/gaddhmask_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gaddhmask_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gaddhmask_proof
 theorem add_mask_sign_i32_thm (e : IntW 32) :

--- a/SSA/Projects/InstCombine/tests/proofs/gaddhmaskhneg_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gaddhmaskhneg_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gaddhmaskhneg_proof
 theorem dec_mask_neg_i32_thm (e : IntW 32) :

--- a/SSA/Projects/InstCombine/tests/proofs/gaddhshift_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gaddhshift_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gaddhshift_proof
 theorem flip_add_of_shift_neg_thm (e e_1 e_2 : IntW 8) :

--- a/SSA/Projects/InstCombine/tests/proofs/gaddhshlhsdivhtohsrem_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gaddhshlhsdivhtohsrem_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gaddhshlhsdivhtohsrem_proof
 theorem addhshlhsdivhscalar0_thm (e : IntW 8) :

--- a/SSA/Projects/InstCombine/tests/proofs/gaddnegneg_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gaddnegneg_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gaddnegneg_proof
 theorem l_thm (e e_1 e_2 : IntW 32) :

--- a/SSA/Projects/InstCombine/tests/proofs/gaddsubhconstanthfolding_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gaddsubhconstanthfolding_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gaddsubhconstanthfolding_proof
 theorem add_const_add_const_thm (e : IntW 32) : add (add e (const? 32 8)) (const? 32 2) ⊑ add e (const? 32 10) := by

--- a/SSA/Projects/InstCombine/tests/proofs/gand2_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gand2_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gand2_proof
 theorem test2_thm (e e_1 : IntW 1) : LLVM.and (LLVM.and e_1 e) e_1 ⊑ LLVM.and e_1 e := by

--- a/SSA/Projects/InstCombine/tests/proofs/gand_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gand_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gand_proof
 theorem test_with_1_thm (e : IntW 32) :

--- a/SSA/Projects/InstCombine/tests/proofs/gandhcompare_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gandhcompare_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gandhcompare_proof
 theorem test1_thm (e e_1 : IntW 32) :

--- a/SSA/Projects/InstCombine/tests/proofs/gandhnarrow_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gandhnarrow_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gandhnarrow_proof
 theorem zext_add_thm (e : IntW 8) :

--- a/SSA/Projects/InstCombine/tests/proofs/gandhorhand_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gandhorhand_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gandhorhand_proof
 theorem test1_thm (e e_1 : IntW 32) :

--- a/SSA/Projects/InstCombine/tests/proofs/gandhorhicmphconsthicmp_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gandhorhicmphconsthicmp_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gandhorhicmphconsthicmp_proof
 theorem eq_basic_thm (e e_1 : IntW 8) :

--- a/SSA/Projects/InstCombine/tests/proofs/gandhorhicmphminhmax_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gandhorhicmphminhmax_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gandhorhicmphminhmax_proof
 theorem slt_and_max_thm (e e_1 : IntW 8) :

--- a/SSA/Projects/InstCombine/tests/proofs/gandhorhicmps_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gandhorhicmps_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gandhorhicmps_proof
 theorem PR1817_1_thm (e : IntW 32) :

--- a/SSA/Projects/InstCombine/tests/proofs/gandhorhimpliedhcondhnot_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gandhorhimpliedhcondhnot_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gandhorhimpliedhcondhnot_proof
 theorem test_imply_not2_thm (e : IntW 1) (e_1 : IntW 32) :

--- a/SSA/Projects/InstCombine/tests/proofs/gandhorhnot_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gandhorhnot_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gandhorhnot_proof
 theorem and_to_xor1_thm (e e_1 : IntW 32) :

--- a/SSA/Projects/InstCombine/tests/proofs/gandhxorhmerge_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gandhxorhmerge_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gandhxorhmerge_proof
 theorem test1_thm (e e_1 e_2 : IntW 32) :

--- a/SSA/Projects/InstCombine/tests/proofs/gandhxorhor_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gandhxorhor_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gandhxorhor_proof
 theorem and_xor_common_op_thm (e e_1 : IntW 32) :

--- a/SSA/Projects/InstCombine/tests/proofs/gannotations_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gannotations_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gannotations_proof
 theorem do_not_add_annotation_to_existing_instr_thm (e e_1 : IntW 32) : add (const? 32 0) (add e_1 e) ⊑ add e_1 e := by

--- a/SSA/Projects/InstCombine/tests/proofs/gapinthadd_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gapinthadd_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gapinthadd_proof
 theorem test1_thm (e : IntW 1) : add (LLVM.xor e (const? 1 1)) (const? 1 1) ⊑ e := by

--- a/SSA/Projects/InstCombine/tests/proofs/gapinthand_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gapinthand_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gapinthand_proof
 theorem test0_thm (e : IntW 39) : LLVM.and e (const? 39 0) ⊑ const? 39 0 := by

--- a/SSA/Projects/InstCombine/tests/proofs/gapinthandhcompare_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gapinthandhcompare_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gapinthandhcompare_proof
 theorem test1_thm (e e_1 : IntW 33) :

--- a/SSA/Projects/InstCombine/tests/proofs/gapinthandhorhand_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gapinthandhorhand_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gapinthandhorhand_proof
 theorem test1_thm (e e_1 : IntW 17) :

--- a/SSA/Projects/InstCombine/tests/proofs/gapinthandhxorhmerge_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gapinthandhxorhmerge_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gapinthandhxorhmerge_proof
 theorem test1_thm (e e_1 e_2 : IntW 57) :

--- a/SSA/Projects/InstCombine/tests/proofs/gapinthcast_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gapinthcast_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gapinthcast_proof
 theorem test1_thm (e : IntW 17) :

--- a/SSA/Projects/InstCombine/tests/proofs/gapinthcasthcasthtohand_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gapinthcasthcasthtohand_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gapinthcasthcasthtohand_proof
 theorem test1_thm (e : IntW 61) : zext 61 (trunc 41 e) ⊑ LLVM.and e (const? 61 2199023255551) := by

--- a/SSA/Projects/InstCombine/tests/proofs/gapinthdiv1_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gapinthdiv1_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gapinthdiv1_proof
 theorem test1_thm (e : IntW 33) : LLVM.udiv e (const? 33 4096) ⊑ lshr e (const? 33 12) := by

--- a/SSA/Projects/InstCombine/tests/proofs/gapinthdiv2_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gapinthdiv2_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gapinthdiv2_proof
 theorem test1_thm (e : IntW 333) : LLVM.udiv e (const? 333 70368744177664) ⊑ lshr e (const? 333 46) := by

--- a/SSA/Projects/InstCombine/tests/proofs/gapinthmul1_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gapinthmul1_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gapinthmul1_proof
 theorem test1_thm (e : IntW 17) : mul e (const? 17 1024) ⊑ shl e (const? 17 10) := by

--- a/SSA/Projects/InstCombine/tests/proofs/gapinthmul2_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gapinthmul2_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gapinthmul2_proof
 theorem test1_thm (e : IntW 177) : mul e (shl (const? 177 1) (const? 177 155)) ⊑ shl e (const? 177 155) := by

--- a/SSA/Projects/InstCombine/tests/proofs/gapinthnot_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gapinthnot_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gapinthnot_proof
 theorem test1_thm (e : IntW 33) : LLVM.xor (LLVM.xor e (const? 33 (-1))) (const? 33 (-1)) ⊑ e := by

--- a/SSA/Projects/InstCombine/tests/proofs/gapinthor_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gapinthor_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gapinthor_proof
 theorem test1_thm (e : IntW 23) : LLVM.or e (LLVM.xor (const? 23 (-1)) e) ⊑ const? 23 (-1) := by

--- a/SSA/Projects/InstCombine/tests/proofs/gapinthrem1_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gapinthrem1_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gapinthrem1_proof
 theorem test1_thm (e : IntW 33) : urem e (const? 33 4096) ⊑ LLVM.and e (const? 33 4095) := by

--- a/SSA/Projects/InstCombine/tests/proofs/gapinthrem2_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gapinthrem2_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gapinthrem2_proof
 theorem test1_thm (e : IntW 333) :

--- a/SSA/Projects/InstCombine/tests/proofs/gapinthselect_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gapinthselect_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gapinthselect_proof
 theorem zext_thm (e : IntW 1) : select e (const? 41 1) (const? 41 0) ⊑ zext 41 e := by

--- a/SSA/Projects/InstCombine/tests/proofs/gapinthshift_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gapinthshift_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gapinthshift_proof
 theorem test6_thm (e : IntW 55) : mul (shl e (const? 55 1)) (const? 55 3) ⊑ mul e (const? 55 6) := by

--- a/SSA/Projects/InstCombine/tests/proofs/gapinthshifthsimplify_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gapinthshifthsimplify_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gapinthshifthsimplify_proof
 theorem test0_thm (e e_1 e_2 : IntW 41) : LLVM.and (shl e_2 e_1) (shl e e_1) ⊑ shl (LLVM.and e_2 e) e_1 := by

--- a/SSA/Projects/InstCombine/tests/proofs/gapinthsub_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gapinthsub_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gapinthsub_proof
 theorem test1_thm (e : IntW 23) : sub e e ⊑ const? 23 0 := by

--- a/SSA/Projects/InstCombine/tests/proofs/gapinthxor1_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gapinthxor1_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gapinthxor1_proof
 theorem test1_thm (e e_1 : IntW 47) :

--- a/SSA/Projects/InstCombine/tests/proofs/gapinthxor2_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gapinthxor2_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gapinthxor2_proof
 theorem test1_thm (e e_1 : IntW 447) :

--- a/SSA/Projects/InstCombine/tests/proofs/gashrhdemand_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gashrhdemand_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gashrhdemand_proof
 theorem srem2_ashr_mask_thm (e : IntW 32) :

--- a/SSA/Projects/InstCombine/tests/proofs/gashrhlshr_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gashrhlshr_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gashrhlshr_proof
 theorem ashr_lshr_exact_ashr_only_thm (e e_1 : IntW 32) :

--- a/SSA/Projects/InstCombine/tests/proofs/gassochcasthassoc_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gassochcasthassoc_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gassochcasthassoc_proof
 theorem XorZextXor_thm (e : IntW 3) :

--- a/SSA/Projects/InstCombine/tests/proofs/gavghlsb_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gavghlsb_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gavghlsb_proof
 theorem avg_lsb_thm (e e_1 : IntW 8) :

--- a/SSA/Projects/InstCombine/tests/proofs/gbinophandhshifts_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gbinophandhshifts_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gbinophandhshifts_proof
 theorem shl_and_and_thm (e e_1 : IntW 8) :

--- a/SSA/Projects/InstCombine/tests/proofs/gbinophcast_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gbinophcast_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gbinophcast_proof
 theorem and_sext_to_sel_thm (e : IntW 32) (e_1 : IntW 1) : LLVM.and (sext 32 e_1) e ⊑ select e_1 e (const? 32 0) := by

--- a/SSA/Projects/InstCombine/tests/proofs/gbinophofhdisplacedhshifts_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gbinophofhdisplacedhshifts_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gbinophofhdisplacedhshifts_proof
 theorem shl_or_thm (e : IntW 8) :

--- a/SSA/Projects/InstCombine/tests/proofs/gbinophselect_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gbinophselect_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gbinophselect_proof
 theorem and_sel_op0_thm (e : IntW 1) : LLVM.and (select e (const? 32 25) (const? 32 0)) (const? 32 1) ⊑ zext 32 e := by

--- a/SSA/Projects/InstCombine/tests/proofs/gbinophselecthcasthofhselecthcond_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gbinophselecthcasthofhselecthcond_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gbinophselecthcasthofhselecthcond_proof
 theorem add_select_zext_thm (e : IntW 1) :

--- a/SSA/Projects/InstCombine/tests/proofs/gbithchecks_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gbithchecks_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gbithchecks_proof
 theorem main1_thm (e : IntW 32) :

--- a/SSA/Projects/InstCombine/tests/proofs/gbitreverse_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gbitreverse_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gbitreverse_proof
 theorem rev8_mul_and_lshr_thm (e : IntW 8) :

--- a/SSA/Projects/InstCombine/tests/proofs/gbswap_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gbswap_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gbswap_proof
 theorem test1_trunc_thm (e : IntW 32) :

--- a/SSA/Projects/InstCombine/tests/proofs/gcanonicalizehashrhshlhtohmasking_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gcanonicalizehashrhshlhtohmasking_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gcanonicalizehashrhshlhtohmasking_proof
 theorem positive_samevar_thm (e e_1 : IntW 8) :

--- a/SSA/Projects/InstCombine/tests/proofs/gcanonicalizehclamphlikehpatternhbetweenhnegativehandhpositivehthresholds_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gcanonicalizehclamphlikehpatternhbetweenhnegativehandhpositivehthresholds_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gcanonicalizehclamphlikehpatternhbetweenhnegativehandhpositivehthresholds_proof
 theorem t0_ult_slt_128_thm (e e_1 e_2 : IntW 32) :

--- a/SSA/Projects/InstCombine/tests/proofs/gcanonicalizehclamphlikehpatternhbetweenhzerohandhpositivehthreshold_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gcanonicalizehclamphlikehpatternhbetweenhzerohandhpositivehthreshold_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gcanonicalizehclamphlikehpatternhbetweenhzerohandhpositivehthreshold_proof
 theorem t0_ult_slt_65536_thm (e e_1 e_2 : IntW 32) :

--- a/SSA/Projects/InstCombine/tests/proofs/gcanonicalizehconstanthlowhbithmaskhandhicmpheqhtohicmphule_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gcanonicalizehconstanthlowhbithmaskhandhicmpheqhtohicmphule_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gcanonicalizehconstanthlowhbithmaskhandhicmpheqhtohicmphule_proof
 theorem p0_thm (e : IntW 8) :

--- a/SSA/Projects/InstCombine/tests/proofs/gcanonicalizehconstanthlowhbithmaskhandhicmphnehtohicmphugt_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gcanonicalizehconstanthlowhbithmaskhandhicmphnehtohicmphugt_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gcanonicalizehconstanthlowhbithmaskhandhicmphnehtohicmphugt_proof
 theorem p0_thm (e : IntW 8) :

--- a/SSA/Projects/InstCombine/tests/proofs/gcanonicalizehconstanthlowhbithmaskhandhicmphsgehtohicmphsle_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gcanonicalizehconstanthlowhbithmaskhandhicmphsgehtohicmphsle_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gcanonicalizehconstanthlowhbithmaskhandhicmphsgehtohicmphsle_proof
 theorem p0_thm (e : IntW 8) :

--- a/SSA/Projects/InstCombine/tests/proofs/gcanonicalizehconstanthlowhbithmaskhandhicmphsgthtohicmphsgt_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gcanonicalizehconstanthlowhbithmaskhandhicmphsgthtohicmphsgt_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gcanonicalizehconstanthlowhbithmaskhandhicmphsgthtohicmphsgt_proof
 theorem c0_thm (e : IntW 8) :

--- a/SSA/Projects/InstCombine/tests/proofs/gcanonicalizehconstanthlowhbithmaskhandhicmphslehtohicmphsle_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gcanonicalizehconstanthlowhbithmaskhandhicmphslehtohicmphsle_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gcanonicalizehconstanthlowhbithmaskhandhicmphslehtohicmphsle_proof
 theorem c0_thm (e : IntW 8) :

--- a/SSA/Projects/InstCombine/tests/proofs/gcanonicalizehconstanthlowhbithmaskhandhicmphslthtohicmphsgt_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gcanonicalizehconstanthlowhbithmaskhandhicmphslthtohicmphsgt_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gcanonicalizehconstanthlowhbithmaskhandhicmphslthtohicmphsgt_proof
 theorem p0_thm (e : IntW 8) :

--- a/SSA/Projects/InstCombine/tests/proofs/gcanonicalizehconstanthlowhbithmaskhandhicmphugehtohicmphule_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gcanonicalizehconstanthlowhbithmaskhandhicmphugehtohicmphule_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gcanonicalizehconstanthlowhbithmaskhandhicmphugehtohicmphule_proof
 theorem p0_thm (e : IntW 8) :

--- a/SSA/Projects/InstCombine/tests/proofs/gcanonicalizehconstanthlowhbithmaskhandhicmphugthtohicmphugt_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gcanonicalizehconstanthlowhbithmaskhandhicmphugthtohicmphugt_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gcanonicalizehconstanthlowhbithmaskhandhicmphugthtohicmphugt_proof
 theorem c0_thm (e : IntW 8) : icmp IntPredicate.ugt (LLVM.and e (const? 8 3)) e ⊑ const? 1 0 := by

--- a/SSA/Projects/InstCombine/tests/proofs/gcanonicalizehconstanthlowhbithmaskhandhicmphulehtohicmphule_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gcanonicalizehconstanthlowhbithmaskhandhicmphulehtohicmphule_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gcanonicalizehconstanthlowhbithmaskhandhicmphulehtohicmphule_proof
 theorem c0_thm (e : IntW 8) : icmp IntPredicate.ule (LLVM.and e (const? 8 3)) e ⊑ const? 1 1 := by

--- a/SSA/Projects/InstCombine/tests/proofs/gcanonicalizehconstanthlowhbithmaskhandhicmphulthtohicmphugt_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gcanonicalizehconstanthlowhbithmaskhandhicmphulthtohicmphugt_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gcanonicalizehconstanthlowhbithmaskhandhicmphulthtohicmphugt_proof
 theorem p0_thm (e : IntW 8) :

--- a/SSA/Projects/InstCombine/tests/proofs/gcanonicalizehlackhofhsignedhtruncationhcheck_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gcanonicalizehlackhofhsignedhtruncationhcheck_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gcanonicalizehlackhofhsignedhtruncationhcheck_proof
 theorem p0_thm (e : IntW 8) :

--- a/SSA/Projects/InstCombine/tests/proofs/gcanonicalizehlowhbithmaskhandhicmpheqhtohicmphule_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gcanonicalizehlowhbithmaskhandhicmpheqhtohicmphule_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gcanonicalizehlowhbithmaskhandhicmpheqhtohicmphule_proof
 theorem p0_thm (e e_1 : IntW 8) :

--- a/SSA/Projects/InstCombine/tests/proofs/gcanonicalizehlowhbithmaskhandhicmphnehtohicmphugt_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gcanonicalizehlowhbithmaskhandhicmphnehtohicmphugt_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gcanonicalizehlowhbithmaskhandhicmphnehtohicmphugt_proof
 theorem p0_thm (e e_1 : IntW 8) :

--- a/SSA/Projects/InstCombine/tests/proofs/gcanonicalizehlowhbithmaskhv2handhicmpheqhtohicmphule_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gcanonicalizehlowhbithmaskhv2handhicmpheqhtohicmphule_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gcanonicalizehlowhbithmaskhv2handhicmpheqhtohicmphule_proof
 theorem p0_thm (e e_1 : IntW 8) :

--- a/SSA/Projects/InstCombine/tests/proofs/gcanonicalizehlowhbithmaskhv2handhicmphnehtohicmphugt_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gcanonicalizehlowhbithmaskhv2handhicmphnehtohicmphugt_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gcanonicalizehlowhbithmaskhv2handhicmphnehtohicmphugt_proof
 theorem p0_thm (e e_1 : IntW 8) :

--- a/SSA/Projects/InstCombine/tests/proofs/gcanonicalizehlshrhshlhtohmasking_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gcanonicalizehlshrhshlhtohmasking_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gcanonicalizehlshrhshlhtohmasking_proof
 theorem positive_samevar_thm (e e_1 : IntW 8) :

--- a/SSA/Projects/InstCombine/tests/proofs/gcanonicalizehselectshicmphconditionhbittest_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gcanonicalizehselectshicmphconditionhbittest_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gcanonicalizehselectshicmphconditionhbittest_proof
 theorem p0_thm (e e_1 e_2 : IntW 8) :

--- a/SSA/Projects/InstCombine/tests/proofs/gcanonicalizehshlhlshrhtohmasking_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gcanonicalizehshlhlshrhtohmasking_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gcanonicalizehshlhlshrhtohmasking_proof
 theorem positive_samevar_thm (e e_1 : IntW 32) : lshr (shl e_1 e) e ⊑ LLVM.and (lshr (const? 32 (-1)) e) e_1 := by

--- a/SSA/Projects/InstCombine/tests/proofs/gcanonicalizehsignedhtruncationhcheck_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gcanonicalizehsignedhtruncationhcheck_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gcanonicalizehsignedhtruncationhcheck_proof
 theorem p0_thm (e : IntW 8) :

--- a/SSA/Projects/InstCombine/tests/proofs/gcast_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gcast_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gcast_proof
 theorem test2_thm (e : IntW 8) : zext 64 (zext 32 (zext 16 e)) ⊑ zext 64 e := by

--- a/SSA/Projects/InstCombine/tests/proofs/gcasthmulhselect_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gcasthmulhselect_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gcasthmulhselect_proof
 theorem mul_thm (e e_1 : IntW 32) :

--- a/SSA/Projects/InstCombine/tests/proofs/gcasthselect_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gcasthselect_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gcasthselect_proof
 theorem trunc_thm (e e_1 e_2 : IntW 32) :

--- a/SSA/Projects/InstCombine/tests/proofs/gcasthset_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gcasthset_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gcasthset_proof
 theorem test5_thm (e : IntW 16) : trunc 16 (LLVM.and (sext 32 e) (const? 32 15)) ⊑ LLVM.and e (const? 16 15) := by

--- a/SSA/Projects/InstCombine/tests/proofs/gcmphxhvshneghx_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gcmphxhvshneghx_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gcmphxhvshneghx_proof
 theorem t0_thm (e : IntW 8) :

--- a/SSA/Projects/InstCombine/tests/proofs/gcomparehsigns_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gcomparehsigns_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gcomparehsigns_proof
 theorem test1_thm (e e_1 : IntW 32) :

--- a/SSA/Projects/InstCombine/tests/proofs/gcomparehudiv_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gcomparehudiv_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gcomparehudiv_proof
 theorem test1_thm (e e_1 : IntW 32) :

--- a/SSA/Projects/InstCombine/tests/proofs/gconditionalhnegation_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gconditionalhnegation_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gconditionalhnegation_proof
 theorem t0_thm (e : IntW 8) (e_1 : IntW 1) :

--- a/SSA/Projects/InstCombine/tests/proofs/gdebuginfohvariables_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gdebuginfohvariables_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gdebuginfohvariables_proof
 theorem test_sext_zext_thm (e : IntW 16) : sext 64 (zext 32 e) ⊑ zext 64 e := by

--- a/SSA/Projects/InstCombine/tests/proofs/gdemand_shrink_nsw_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gdemand_shrink_nsw_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gdemand_shrink_nsw_proof
 theorem foo_thm (e : IntW 32) :

--- a/SSA/Projects/InstCombine/tests/proofs/gdemorgan_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gdemorgan_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gdemorgan_proof
 theorem demorgan_or_apint1_thm (e e_1 : IntW 43) :

--- a/SSA/Projects/InstCombine/tests/proofs/gdemorganhsinkhnothintohxor_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gdemorganhsinkhnothintohxor_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gdemorganhsinkhnothintohxor_proof
 theorem positive_easyinvert_thm (e : IntW 16) (e_1 : IntW 8) :

--- a/SSA/Projects/InstCombine/tests/proofs/gdistribute_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gdistribute_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gdistribute_proof
 theorem factorize_thm (e : IntW 32) : LLVM.and (LLVM.or e (const? 32 1)) (LLVM.or e (const? 32 2)) ⊑ e := by

--- a/SSA/Projects/InstCombine/tests/proofs/gdivhi1_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gdivhi1_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gdivhi1_proof
 theorem sdiv_i1_is_op0_thm (e e_1 : IntW 1) : LLVM.sdiv e_1 e ⊑ e_1 := by

--- a/SSA/Projects/InstCombine/tests/proofs/gdivhshift_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gdivhshift_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gdivhshift_proof
 theorem t1_thm (e : IntW 32) (e_1 : IntW 16) :

--- a/SSA/Projects/InstCombine/tests/proofs/gearly_constfold_changes_IR_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gearly_constfold_changes_IR_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gearly_constfold_changes_IR_proof
 theorem foo_thm (e : IntW 32) : LLVM.and e (LLVM.or (const? 32 0) (const? 32 7)) ⊑ LLVM.and e (const? 32 7) := by

--- a/SSA/Projects/InstCombine/tests/proofs/geqhofhparts_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/geqhofhparts_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section geqhofhparts_proof
 theorem eq_10_thm (e e_1 : IntW 32) :

--- a/SSA/Projects/InstCombine/tests/proofs/gexact_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gexact_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gexact_proof
 theorem sdiv2_thm (e : IntW 32) :

--- a/SSA/Projects/InstCombine/tests/proofs/gfoldhahorhbhzero_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gfoldhahorhbhzero_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gfoldhahorhbhzero_proof
 theorem a_or_b_thm (e e_1 : IntW 32) :

--- a/SSA/Projects/InstCombine/tests/proofs/gfoldhinchofhaddhofhnothxhandhyhtohsubhxhfromhy_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gfoldhinchofhaddhofhnothxhandhyhtohsubhxhfromhy_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gfoldhinchofhaddhofhnothxhandhyhtohsubhxhfromhy_proof
 theorem t0_thm (e e_1 : IntW 32) : add (add (LLVM.xor e_1 (const? 32 (-1))) e) (const? 32 1) ⊑ sub e e_1 := by

--- a/SSA/Projects/InstCombine/tests/proofs/gfoldhselecthtrunc_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gfoldhselecthtrunc_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gfoldhselecthtrunc_proof
 theorem fold_select_trunc_nuw_true_thm (e e_1 : IntW 8) :

--- a/SSA/Projects/InstCombine/tests/proofs/gfoldhsignbithtesthpower2_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gfoldhsignbithtesthpower2_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gfoldhsignbithtesthpower2_proof
 theorem pow2_or_zero_is_negative_commute_thm (e : IntW 8) :

--- a/SSA/Projects/InstCombine/tests/proofs/gfoldhsubhofhnothtohinchofhadd_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gfoldhsubhofhnothtohinchofhadd_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gfoldhsubhofhnothtohinchofhadd_proof
 theorem p0_scalar_thm (e e_1 : IntW 32) : sub e_1 (LLVM.xor e (const? 32 (-1))) ⊑ add (add e (const? 32 1)) e_1 := by

--- a/SSA/Projects/InstCombine/tests/proofs/gfreehinversion_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gfreehinversion_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gfreehinversion_proof
 theorem xor_1_thm (e e_1 e_2 : IntW 8) (e_3 : IntW 1) :

--- a/SSA/Projects/InstCombine/tests/proofs/gfunnel_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gfunnel_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gfunnel_proof
 theorem unmasked_shlop_insufficient_mask_shift_amount_thm (e e_1 e_2 : IntW 16) :

--- a/SSA/Projects/InstCombine/tests/proofs/ggethlowbitmaskhuptohandhincludinghbit_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/ggethlowbitmaskhuptohandhincludinghbit_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section ggethlowbitmaskhuptohandhincludinghbit_proof
 theorem t0_thm (e : IntW 8) :

--- a/SSA/Projects/InstCombine/tests/proofs/ghighhbithsignmask_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/ghighhbithsignmask_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section ghighhbithsignmask_proof
 theorem t0_thm (e : IntW 64) : sub (const? 64 0) (lshr e (const? 64 63)) ⊑ ashr e (const? 64 63) := by

--- a/SSA/Projects/InstCombine/tests/proofs/ghighhbithsignmaskhwithhtrunc_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/ghighhbithsignmaskhwithhtrunc_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section ghighhbithsignmaskhwithhtrunc_proof
 theorem t0_thm (e : IntW 64) :

--- a/SSA/Projects/InstCombine/tests/proofs/ghoisthnegationhouthofhbiashcalculation_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/ghoisthnegationhouthofhbiashcalculation_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section ghoisthnegationhouthofhbiashcalculation_proof
 theorem t0_thm (e e_1 : IntW 8) :

--- a/SSA/Projects/InstCombine/tests/proofs/ghoisthnegationhouthofhbiashcalculationhwithhconstant_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/ghoisthnegationhouthofhbiashcalculationhwithhconstant_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section ghoisthnegationhouthofhbiashcalculationhwithhconstant_proof
 theorem t0_thm (e : IntW 8) :

--- a/SSA/Projects/InstCombine/tests/proofs/ghoisthnothfromhashrhoperand_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/ghoisthnothfromhashrhoperand_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section ghoisthnothfromhashrhoperand_proof
 theorem t0_thm (e e_1 : IntW 8) :

--- a/SSA/Projects/InstCombine/tests/proofs/ghoisthxorhbyhconstanthfromhxorhbyhvalue_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/ghoisthxorhbyhconstanthfromhxorhbyhvalue_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section ghoisthxorhbyhconstanthfromhxorhbyhvalue_proof
 theorem t0_scalar_thm (e e_1 : IntW 8) :

--- a/SSA/Projects/InstCombine/tests/proofs/gicmphandhlowbithmask_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gicmphandhlowbithmask_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gicmphandhlowbithmask_proof
 theorem src_is_mask_zext_thm (e : IntW 8) (e_1 : IntW 16) :

--- a/SSA/Projects/InstCombine/tests/proofs/gicmphandhshift_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gicmphandhshift_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gicmphandhshift_proof
 theorem icmp_eq_and_pow2_shl1_thm (e : IntW 32) :

--- a/SSA/Projects/InstCombine/tests/proofs/gicmphbinop_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gicmphbinop_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gicmphbinop_proof
 theorem mul_unkV_oddC_eq_thm (e : IntW 32) :

--- a/SSA/Projects/InstCombine/tests/proofs/gicmphcustomhdl_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gicmphcustomhdl_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gicmphcustomhdl_proof
 theorem icmp_and_ashr_multiuse_thm (e : IntW 32) :

--- a/SSA/Projects/InstCombine/tests/proofs/gicmphdivhconstant_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gicmphdivhconstant_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gicmphdivhconstant_proof
 theorem is_rem2_neg_i8_thm (e : IntW 8) :

--- a/SSA/Projects/InstCombine/tests/proofs/gicmphequalityhtest_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gicmphequalityhtest_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gicmphequalityhtest_proof
 theorem icmp_equality_test_thm (e e_1 e_2 : IntW 64) :

--- a/SSA/Projects/InstCombine/tests/proofs/gicmphequalityhxor_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gicmphequalityhxor_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gicmphequalityhxor_proof
 theorem cmpeq_xor_cst1_thm (e e_1 : IntW 32) :

--- a/SSA/Projects/InstCombine/tests/proofs/gicmphexthext_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gicmphexthext_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gicmphexthext_proof
 theorem zext_zext_sgt_thm (e e_1 : IntW 8) :

--- a/SSA/Projects/InstCombine/tests/proofs/gicmphlogical_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gicmphlogical_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gicmphlogical_proof
 theorem masked_and_notallzeroes_thm (e : IntW 32) :

--- a/SSA/Projects/InstCombine/tests/proofs/gicmphmul_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gicmphmul_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gicmphmul_proof
 theorem squared_nsw_eq0_thm (e : IntW 5) :

--- a/SSA/Projects/InstCombine/tests/proofs/gicmphmulhand_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gicmphmulhand_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gicmphmulhand_proof
 theorem mul_mask_pow2_eq0_thm (e : IntW 8) :

--- a/SSA/Projects/InstCombine/tests/proofs/gicmphofhandhx_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gicmphofhandhx_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gicmphofhandhx_proof
 theorem icmp_ult_x_y_thm (e e_1 : IntW 8) :

--- a/SSA/Projects/InstCombine/tests/proofs/gicmphofhorhx_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gicmphofhorhx_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gicmphofhorhx_proof
 theorem or_ugt_thm (e e_1 : IntW 8) :

--- a/SSA/Projects/InstCombine/tests/proofs/gicmphofhtrunchext_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gicmphofhtrunchext_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gicmphofhtrunchext_proof
 theorem trunc_unsigned_nuw_thm (e e_1 : IntW 16) :

--- a/SSA/Projects/InstCombine/tests/proofs/gicmphofhxorhx_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gicmphofhxorhx_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gicmphofhxorhx_proof
 theorem test_xor_ne_thm (e e_1 e_2 : IntW 8) :

--- a/SSA/Projects/InstCombine/tests/proofs/gicmphorhofhselecthwithhzero_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gicmphorhofhselecthwithhzero_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gicmphorhofhselecthwithhzero_proof
 theorem src_tv_eq_thm (e e_1 : IntW 8) (e_2 : IntW 1) :

--- a/SSA/Projects/InstCombine/tests/proofs/gicmphpower2handhicmphshiftedhmask_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gicmphpower2handhicmphshiftedhmask_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gicmphpower2handhicmphshiftedhmask_proof
 theorem icmp_power2_and_icmp_shifted_mask_2147483648_1610612736_thm (e : IntW 32) :

--- a/SSA/Projects/InstCombine/tests/proofs/gicmphrange_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gicmphrange_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gicmphrange_proof
 theorem ugt_zext_thm (e : IntW 8) (e_1 : IntW 1) :

--- a/SSA/Projects/InstCombine/tests/proofs/gicmphselect_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gicmphselect_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gicmphselect_proof
 theorem icmp_select_const_thm (e e_1 : IntW 8) :

--- a/SSA/Projects/InstCombine/tests/proofs/gicmphselecthimplieshcommonhop_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gicmphselecthimplieshcommonhop_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gicmphselecthimplieshcommonhop_proof
 theorem sgt_3_impliesF_eq_2_thm (e e_1 : IntW 8) :

--- a/SSA/Projects/InstCombine/tests/proofs/gicmphshl_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gicmphshl_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gicmphshl_proof
 theorem shl_nuw_eq_0_thm (e e_1 : IntW 8) :

--- a/SSA/Projects/InstCombine/tests/proofs/gicmphshlh1hoverflow_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gicmphshlh1hoverflow_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gicmphshlh1hoverflow_proof
 theorem icmp_shl_ugt_1_thm (e : IntW 8) :

--- a/SSA/Projects/InstCombine/tests/proofs/gicmphshlhnsw_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gicmphshlhnsw_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gicmphshlhnsw_proof
 theorem icmp_shl_nsw_sgt_thm (e : IntW 32) :

--- a/SSA/Projects/InstCombine/tests/proofs/gicmphshlhnuw_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gicmphshlhnuw_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gicmphshlhnuw_proof
 theorem icmp_ugt_32_thm (e : IntW 64) :

--- a/SSA/Projects/InstCombine/tests/proofs/gicmphshr_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gicmphshr_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gicmphshr_proof
 theorem lshr_eq_msb_low_last_zero_thm (e : IntW 8) :

--- a/SSA/Projects/InstCombine/tests/proofs/gicmphshrhlthgt_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gicmphshrhlthgt_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gicmphshrhlthgt_proof
 theorem lshrugt_01_00_thm (e : IntW 4) :

--- a/SSA/Projects/InstCombine/tests/proofs/gicmphsignmask_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gicmphsignmask_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gicmphsignmask_proof
 theorem cmp_x_and_negp2_with_eq_thm (e : IntW 8) :

--- a/SSA/Projects/InstCombine/tests/proofs/gicmphsub_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gicmphsub_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gicmphsub_proof
 theorem test_nuw_and_unsigned_pred_thm (e : IntW 64) :

--- a/SSA/Projects/InstCombine/tests/proofs/gicmphtopbitssame_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gicmphtopbitssame_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gicmphtopbitssame_proof
 theorem testi16i8_thm (e : IntW 16) :

--- a/SSA/Projects/InstCombine/tests/proofs/gicmphtrunc_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gicmphtrunc_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gicmphtrunc_proof
 theorem ult_2_thm (e : IntW 32) :

--- a/SSA/Projects/InstCombine/tests/proofs/gicmphugehofhnothofhshlhalloneshbyhbitshandhvalhtohicmpheqhofhlshrhvalhbyhbitshandh0_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gicmphugehofhnothofhshlhalloneshbyhbitshandhvalhtohicmpheqhofhlshrhvalhbyhbitshandh0_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gicmphugehofhnothofhshlhalloneshbyhbitshandhvalhtohicmpheqhofhlshrhvalhbyhbitshandh0_proof
 theorem p0_thm (e e_1 : IntW 8) :

--- a/SSA/Projects/InstCombine/tests/proofs/gicmphugthofhshlh1hbyhbitshandhvalhtohicmpheqhofhlshrhvalhbyhbitshandh0_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gicmphugthofhshlh1hbyhbitshandhvalhtohicmpheqhofhlshrhvalhbyhbitshandh0_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gicmphugthofhshlh1hbyhbitshandhvalhtohicmpheqhofhlshrhvalhbyhbitshandh0_proof
 theorem p0_thm (e e_1 : IntW 8) :

--- a/SSA/Projects/InstCombine/tests/proofs/gicmphulehofhshlh1hbyhbitshandhvalhtohicmphnehofhlshrhvalhbyhbitshandh0_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gicmphulehofhshlh1hbyhbitshandhvalhtohicmphnehofhlshrhvalhbyhbitshandh0_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gicmphulehofhshlh1hbyhbitshandhvalhtohicmphnehofhlshrhvalhbyhbitshandh0_proof
 theorem p0_thm (e e_1 : IntW 8) :

--- a/SSA/Projects/InstCombine/tests/proofs/gicmphulthofhnothofhshlhalloneshbyhbitshandhvalhtohicmphnehofhlshrhvalhbyhbitshandh0_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gicmphulthofhnothofhshlhalloneshbyhbitshandhvalhtohicmphnehofhlshrhvalhbyhbitshandh0_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gicmphulthofhnothofhshlhalloneshbyhbitshandhvalhtohicmphnehofhlshrhvalhbyhbitshandh0_proof
 theorem p0_thm (e e_1 : IntW 8) :

--- a/SSA/Projects/InstCombine/tests/proofs/gicmphwithhselects_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gicmphwithhselects_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gicmphwithhselects_proof
 theorem both_sides_fold_slt_thm (e : IntW 32) (e_1 : IntW 1) :

--- a/SSA/Projects/InstCombine/tests/proofs/gicmphxorhsignbit_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gicmphxorhsignbit_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gicmphxorhsignbit_proof
 theorem slt_to_ult_thm (e e_1 : IntW 8) :

--- a/SSA/Projects/InstCombine/tests/proofs/gintegerhroundhuphpow2halignment_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gintegerhroundhuphpow2halignment_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gintegerhroundhuphpow2halignment_proof
 theorem t0_thm (e : IntW 8) :

--- a/SSA/Projects/InstCombine/tests/proofs/ginverthvariablehmaskhinhmaskedhmergehscalar_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/ginverthvariablehmaskhinhmaskedhmergehscalar_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section ginverthvariablehmaskhinhmaskedhmergehscalar_proof
 theorem scalar_thm (e e_1 e_2 : IntW 4) :

--- a/SSA/Projects/InstCombine/tests/proofs/gknownhsignbithshift_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gknownhsignbithshift_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gknownhsignbithshift_proof
 theorem test_shift_nonnegative_thm (e : IntW 32) :

--- a/SSA/Projects/InstCombine/tests/proofs/glogicalhselecthinseltpoison_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/glogicalhselecthinseltpoison_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section glogicalhselecthinseltpoison_proof
 theorem foo_thm (e e_1 e_2 e_3 : IntW 32) :

--- a/SSA/Projects/InstCombine/tests/proofs/glowhbithsplat_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/glowhbithsplat_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section glowhbithsplat_proof
 theorem t0_thm (e : IntW 8) :

--- a/SSA/Projects/InstCombine/tests/proofs/glshr_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/glshr_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section glshr_proof
 theorem lshr_exact_thm (e : IntW 8) :

--- a/SSA/Projects/InstCombine/tests/proofs/glshrhandhnegChicmpeqhzero_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/glshrhandhnegChicmpeqhzero_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section glshrhandhnegChicmpeqhzero_proof
 theorem scalar_i8_lshr_and_negC_eq_thm (e e_1 : IntW 8) :

--- a/SSA/Projects/InstCombine/tests/proofs/glshrhandhsignbithicmpeqhzero_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/glshrhandhsignbithicmpeqhzero_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section glshrhandhsignbithicmpeqhzero_proof
 theorem scalar_i8_lshr_and_signbit_eq_thm (e e_1 : IntW 8) :

--- a/SSA/Projects/InstCombine/tests/proofs/glshrhtrunchsexthtohashrhsext_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/glshrhtrunchsexthtohashrhsext_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section glshrhtrunchsexthtohashrhsext_proof
 theorem t0_thm (e : IntW 8) : sext 16 (trunc 4 (lshr e (const? 8 4))) ⊑ sext 16 (ashr e (const? 8 4)) := by

--- a/SSA/Projects/InstCombine/tests/proofs/gmaskedhmergehadd_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gmaskedhmergehadd_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gmaskedhmergehadd_proof
 theorem p_thm (e e_1 e_2 : IntW 32) :

--- a/SSA/Projects/InstCombine/tests/proofs/gmaskedhmergehandhofhors_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gmaskedhmergehandhofhors_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gmaskedhmergehandhofhors_proof
 theorem p_thm (e e_1 e_2 : IntW 32) :

--- a/SSA/Projects/InstCombine/tests/proofs/gmaskedhmergehor_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gmaskedhmergehor_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gmaskedhmergehor_proof
 theorem p_thm (e e_1 e_2 : IntW 32) :

--- a/SSA/Projects/InstCombine/tests/proofs/gmaskedhmergehxor_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gmaskedhmergehxor_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gmaskedhmergehxor_proof
 theorem p_thm (e e_1 e_2 : IntW 32) :

--- a/SSA/Projects/InstCombine/tests/proofs/gmax_known_bits_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gmax_known_bits_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gmax_known_bits_proof
 theorem foo_thm (e : IntW 16) :

--- a/SSA/Projects/InstCombine/tests/proofs/gmaxhofhnots_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gmaxhofhnots_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gmaxhofhnots_proof
 theorem max_of_min_thm (e : IntW 32) :

--- a/SSA/Projects/InstCombine/tests/proofs/gmergehicmp_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gmergehicmp_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gmergehicmp_proof
 theorem or_basic_thm (e : IntW 16) :

--- a/SSA/Projects/InstCombine/tests/proofs/gminmaxhdemandbits_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gminmaxhdemandbits_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gminmaxhdemandbits_proof
 theorem and_umax_less_thm (e : IntW 32) :

--- a/SSA/Projects/InstCombine/tests/proofs/gminmaxhfold_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gminmaxhfold_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gminmaxhfold_proof
 theorem add_umin_constant_limit_thm (e : IntW 32) :

--- a/SSA/Projects/InstCombine/tests/proofs/gmisch2002_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gmisch2002_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gmisch2002_proof
 theorem cast_test_2002h08h02_thm (e : IntW 64) : zext 64 (trunc 8 e) ⊑ LLVM.and e (const? 64 255) := by

--- a/SSA/Projects/InstCombine/tests/proofs/gmodulo_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gmodulo_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gmodulo_proof
 theorem modulo2_thm (e : IntW 32) :

--- a/SSA/Projects/InstCombine/tests/proofs/gmul_fold_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gmul_fold_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gmul_fold_proof
 theorem mul8_low_A0_B0_thm (e e_1 : IntW 8) :

--- a/SSA/Projects/InstCombine/tests/proofs/gmul_full_64_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gmul_full_64_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gmul_full_64_proof
 theorem mullo_thm (e e_1 : IntW 64) :

--- a/SSA/Projects/InstCombine/tests/proofs/gmulhpow2_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gmulhpow2_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gmulhpow2_proof
 theorem mul_selectp2_x_thm (e : IntW 8) (e_1 : IntW 1) :

--- a/SSA/Projects/InstCombine/tests/proofs/gnarrow_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gnarrow_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gnarrow_proof
 theorem test1_thm (e e_1 : IntW 32) :

--- a/SSA/Projects/InstCombine/tests/proofs/gnarrowhmath_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gnarrowhmath_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gnarrowhmath_proof
 theorem sext_sext_add_thm (e : IntW 32) :

--- a/SSA/Projects/InstCombine/tests/proofs/gnegatedhbitmask_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gnegatedhbitmask_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gnegatedhbitmask_proof
 theorem neg_mask1_lshr_thm (e : IntW 8) :

--- a/SSA/Projects/InstCombine/tests/proofs/gnot_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gnot_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gnot_proof
 theorem test1_thm (e : IntW 32) : LLVM.xor (LLVM.xor e (const? 32 (-1))) (const? 32 (-1)) ⊑ e := by

--- a/SSA/Projects/InstCombine/tests/proofs/gnothadd_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gnothadd_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gnothadd_proof
 theorem basic_thm (e e_1 : IntW 8) :

--- a/SSA/Projects/InstCombine/tests/proofs/gomithuremhofhpowerhofhtwohorhzerohwhenhcomparinghwithhzero_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gomithuremhofhpowerhofhtwohorhzerohwhenhcomparinghwithhzero_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gomithuremhofhpowerhofhtwohorhzerohwhenhcomparinghwithhzero_proof
 theorem p0_scalar_urem_by_const_thm (e : IntW 32) :

--- a/SSA/Projects/InstCombine/tests/proofs/gonehot_merge_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gonehot_merge_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gonehot_merge_proof
 theorem and_consts_thm (e : IntW 32) :

--- a/SSA/Projects/InstCombine/tests/proofs/goperandhcomplexity_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/goperandhcomplexity_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section goperandhcomplexity_proof
 theorem neg_thm (e : IntW 8) :

--- a/SSA/Projects/InstCombine/tests/proofs/gorhshiftedhmasks_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gorhshiftedhmasks_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gorhshiftedhmasks_proof
 theorem or_and_shifts1_thm (e : IntW 32) :

--- a/SSA/Projects/InstCombine/tests/proofs/gorhxor_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gorhxor_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gorhxor_proof
 theorem test1_thm (e e_1 : IntW 32) :

--- a/SSA/Projects/InstCombine/tests/proofs/gorhxorhxor_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gorhxorhxor_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gorhxorhxor_proof
 theorem or_xor_xor_normal_variant1_thm (e e_1 : IntW 1) :

--- a/SSA/Projects/InstCombine/tests/proofs/goverflowhmul_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/goverflowhmul_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section goverflowhmul_proof
 theorem pr4917_3_thm (e e_1 : IntW 32) :

--- a/SSA/Projects/InstCombine/tests/proofs/gpartallyhredundanthlefthshifthinputhmaskinghafterhtruncationhvarianthd_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gpartallyhredundanthlefthshifthinputhmaskinghafterhtruncationhvarianthd_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gpartallyhredundanthlefthshifthinputhmaskinghafterhtruncationhvarianthd_proof
 theorem PR51351_thm (e : IntW 64) (e_1 : IntW 32) :

--- a/SSA/Projects/InstCombine/tests/proofs/gpr14365_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gpr14365_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gpr14365_proof
 theorem test0_thm (e : IntW 32) :

--- a/SSA/Projects/InstCombine/tests/proofs/gpr17827_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gpr17827_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gpr17827_proof
 theorem test_shift_and_cmp_changed1_thm (e e_1 : IntW 8) :

--- a/SSA/Projects/InstCombine/tests/proofs/gpr34349_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gpr34349_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gpr34349_proof
 theorem fast_div_201_thm (e : IntW 8) :

--- a/SSA/Projects/InstCombine/tests/proofs/gpr49688_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gpr49688_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gpr49688_proof
 theorem f_thm (e : IntW 32) :

--- a/SSA/Projects/InstCombine/tests/proofs/gpr53357_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gpr53357_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gpr53357_proof
 theorem src_thm (e e_1 : IntW 32) :

--- a/SSA/Projects/InstCombine/tests/proofs/gpr72433_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gpr72433_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gpr72433_proof
 theorem widget_thm (e : IntW 32) :

--- a/SSA/Projects/InstCombine/tests/proofs/gpreservedhanalyses_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gpreservedhanalyses_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gpreservedhanalyses_proof
 theorem test_thm (e : IntW 32) : add (add e (const? 32 5)) (const? 32 (-5)) ⊑ e := by

--- a/SSA/Projects/InstCombine/tests/proofs/gpreventhcmphmerge_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gpreventhcmphmerge_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gpreventhcmphmerge_proof
 theorem test1_thm (e e_1 : IntW 32) :

--- a/SSA/Projects/InstCombine/tests/proofs/gpullhbinophthroughhshift_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gpullhbinophthroughhshift_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gpullhbinophthroughhshift_proof
 theorem and_signbit_shl_thm (e : IntW 32) :

--- a/SSA/Projects/InstCombine/tests/proofs/gpullhconditionalhbinophthroughhshift_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gpullhconditionalhbinophthroughhshift_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gpullhconditionalhbinophthroughhshift_proof
 theorem and_signbit_select_shl_thm (e : IntW 32) (e_1 : IntW 1) :

--- a/SSA/Projects/InstCombine/tests/proofs/grangehcheck_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/grangehcheck_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section grangehcheck_proof
 theorem test_and1_thm (e e_1 : IntW 32) :

--- a/SSA/Projects/InstCombine/tests/proofs/greassociatehnuw_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/greassociatehnuw_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section greassociatehnuw_proof
 theorem reassoc_add_nuw_thm (e : IntW 32) :

--- a/SSA/Projects/InstCombine/tests/proofs/gredundanthlefthshifthinputhmaskinghpr49778_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gredundanthlefthshifthinputhmaskinghpr49778_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gredundanthlefthshifthinputhmaskinghpr49778_proof
 theorem src_thm (e : IntW 1) :

--- a/SSA/Projects/InstCombine/tests/proofs/gredundanthrighthshifthinputhmasking_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gredundanthrighthshifthinputhmasking_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gredundanthrighthshifthinputhmasking_proof
 theorem t0_lshr_thm (e e_1 : IntW 32) :

--- a/SSA/Projects/InstCombine/tests/proofs/grem_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/grem_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section grem_proof
 theorem test1_thm (e : IntW 32) : LLVM.srem e (const? 32 1) ⊑ const? 32 0 := by

--- a/SSA/Projects/InstCombine/tests/proofs/greusehconstanthfromhselecthinhicmp_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/greusehconstanthfromhselecthinhicmp_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section greusehconstanthfromhselecthinhicmp_proof
 theorem p0_ult_65536_thm (e e_1 : IntW 32) :

--- a/SSA/Projects/InstCombine/tests/proofs/grotate_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/grotate_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section grotate_proof
 theorem rotateleft_9_neg_mask_wide_amount_commute_thm (e : IntW 33) (e_1 : IntW 9) :

--- a/SSA/Projects/InstCombine/tests/proofs/gsaturatinghaddhsub_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gsaturatinghaddhsub_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gsaturatinghaddhsub_proof
 theorem test_simplify_decrement_invalid_ne_thm (e : IntW 8) :

--- a/SSA/Projects/InstCombine/tests/proofs/gsdivh1_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gsdivh1_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gsdivh1_proof
 theorem c_thm :

--- a/SSA/Projects/InstCombine/tests/proofs/gsdivhcanonicalize_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gsdivhcanonicalize_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gsdivhcanonicalize_proof
 theorem test_sdiv_canonicalize_op0_thm (e e_1 : IntW 32) :

--- a/SSA/Projects/InstCombine/tests/proofs/gsdivhexacthbyhnegativehpowerhofhtwo_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gsdivhexacthbyhnegativehpowerhofhtwo_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gsdivhexacthbyhnegativehpowerhofhtwo_proof
 theorem t0_thm (e : IntW 8) :

--- a/SSA/Projects/InstCombine/tests/proofs/gsdivhexacthbyhpowerhofhtwo_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gsdivhexacthbyhpowerhofhtwo_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gsdivhexacthbyhpowerhofhtwo_proof
 theorem t0_thm (e : IntW 8) :

--- a/SSA/Projects/InstCombine/tests/proofs/gsdivhicmp_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gsdivhicmp_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gsdivhicmp_proof
 theorem sdiv_exact_eq_0_thm (e e_1 : IntW 8) :

--- a/SSA/Projects/InstCombine/tests/proofs/gselect_meta_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gselect_meta_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gselect_meta_proof
 theorem foo_thm (e : IntW 32) :

--- a/SSA/Projects/InstCombine/tests/proofs/gselecth2_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gselecth2_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gselecth2_proof
 theorem ashr_exact_poison_constant_fold_thm (e : IntW 8) (e_1 : IntW 1) :

--- a/SSA/Projects/InstCombine/tests/proofs/gselecthandhor_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gselecthandhor_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gselecthandhor_proof
 theorem logical_and_not_thm (e e_1 : IntW 1) :

--- a/SSA/Projects/InstCombine/tests/proofs/gselecthbinophcmp_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gselecthbinophcmp_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gselecthbinophcmp_proof
 theorem select_xor_icmp_thm (e e_1 e_2 : IntW 32) :

--- a/SSA/Projects/InstCombine/tests/proofs/gselecthbitext_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gselecthbitext_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gselecthbitext_proof
 theorem sel_sext_constants_thm (e : IntW 1) :

--- a/SSA/Projects/InstCombine/tests/proofs/gselecthbitexthbitwisehops_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gselecthbitexthbitwisehops_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gselecthbitexthbitwisehops_proof
 theorem sel_false_val_is_a_masked_shl_of_true_val1_thm (e : IntW 64) (e_1 : IntW 32) :

--- a/SSA/Projects/InstCombine/tests/proofs/gselecthdivrem_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gselecthdivrem_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gselecthdivrem_proof
 theorem udiv_common_divisor_thm (e e_1 e_2 : IntW 5) (e_3 : IntW 1) :

--- a/SSA/Projects/InstCombine/tests/proofs/gselecthfactorize_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gselecthfactorize_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gselecthfactorize_proof
 theorem logic_and_logic_or_1_thm (e e_1 e_2 : IntW 1) :

--- a/SSA/Projects/InstCombine/tests/proofs/gselecthicmphand_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gselecthicmphand_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gselecthicmphand_proof
 theorem test5_thm (e : IntW 41) :

--- a/SSA/Projects/InstCombine/tests/proofs/gselecthicmphandhzerohshl_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gselecthicmphandhzerohshl_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gselecthicmphandhzerohshl_proof
 theorem test_eq_thm (e : IntW 32) :

--- a/SSA/Projects/InstCombine/tests/proofs/gselecthicmphxor_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gselecthicmphxor_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gselecthicmphxor_proof
 theorem select_icmp_eq_pow2_thm (e : IntW 8) :

--- a/SSA/Projects/InstCombine/tests/proofs/gselecthimmhcanon_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gselecthimmhcanon_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gselecthimmhcanon_proof
 theorem thisdoesnotloop_thm (e e_1 : IntW 32) :

--- a/SSA/Projects/InstCombine/tests/proofs/gselecthobohpeohops_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gselecthobohpeohops_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gselecthobohpeohops_proof
 theorem test_shl_nuw_nsw__all_are_safe_thm (e : IntW 64) (e_1 : IntW 32) :

--- a/SSA/Projects/InstCombine/tests/proofs/gselecthofhbittest_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gselecthofhbittest_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gselecthofhbittest_proof
 theorem and_lshr_and_thm (e : IntW 32) :

--- a/SSA/Projects/InstCombine/tests/proofs/gselecthofhsymmetrichselects_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gselecthofhsymmetrichselects_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gselecthofhsymmetrichselects_proof
 theorem select_of_symmetric_selects_thm (e e_1 : IntW 32) (e_2 e_3 : IntW 1) :

--- a/SSA/Projects/InstCombine/tests/proofs/gselecthsafehboolhtransforms_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gselecthsafehboolhtransforms_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gselecthsafehboolhtransforms_proof
 theorem land_land_left1_thm (e e_1 : IntW 1) :

--- a/SSA/Projects/InstCombine/tests/proofs/gselecthsafehimpliedcondhtransforms_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gselecthsafehimpliedcondhtransforms_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gselecthsafehimpliedcondhtransforms_proof
 theorem a_true_implies_b_true_thm (e e_1 : IntW 1) (e_2 : IntW 8) :

--- a/SSA/Projects/InstCombine/tests/proofs/gselecthsafehtransforms_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gselecthsafehtransforms_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gselecthsafehtransforms_proof
 theorem cond_eq_and_const_thm (e e_1 : IntW 8) :

--- a/SSA/Projects/InstCombine/tests/proofs/gselecthwithhbitwisehops_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gselecthwithhbitwisehops_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gselecthwithhbitwisehops_proof
 theorem select_icmp_eq_and_1_0_or_2_thm (e e_1 : IntW 32) :

--- a/SSA/Projects/InstCombine/tests/proofs/gset_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gset_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gset_proof
 theorem test3_thm (e : IntW 32) : icmp IntPredicate.slt e e ⊑ const? 1 0 := by

--- a/SSA/Projects/InstCombine/tests/proofs/gsetcchstrengthhreduce_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gsetcchstrengthhreduce_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gsetcchstrengthhreduce_proof
 theorem test1_thm (e : IntW 32) :

--- a/SSA/Projects/InstCombine/tests/proofs/gsethlowbitshmaskhcanonicalize_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gsethlowbitshmaskhcanonicalize_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gsethlowbitshmaskhcanonicalize_proof
 theorem shl_add_thm (e : IntW 32) :

--- a/SSA/Projects/InstCombine/tests/proofs/gsext_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gsext_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gsext_proof
 theorem test4_thm (e : IntW 32) :

--- a/SSA/Projects/InstCombine/tests/proofs/gsexthand_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gsexthand_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gsexthand_proof
 theorem fold_sext_to_and_thm (e : IntW 8) :

--- a/SSA/Projects/InstCombine/tests/proofs/gsexthofhtrunchnsw_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gsexthofhtrunchnsw_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gsexthofhtrunchnsw_proof
 theorem narrow_source_matching_signbits_thm (e : IntW 32) :

--- a/SSA/Projects/InstCombine/tests/proofs/gshifthadd_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gshifthadd_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gshifthadd_proof
 theorem shl_C1_add_A_C2_i32_thm (e : IntW 16) :

--- a/SSA/Projects/InstCombine/tests/proofs/gshifthaddhinseltpoison_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gshifthaddhinseltpoison_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gshifthaddhinseltpoison_proof
 theorem shl_C1_add_A_C2_i32_thm (e : IntW 16) :

--- a/SSA/Projects/InstCombine/tests/proofs/gshifthamounthreassociation_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gshifthamounthreassociation_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gshifthamounthreassociation_proof
 theorem t0_thm (e e_1 : IntW 32) :

--- a/SSA/Projects/InstCombine/tests/proofs/gshifthamounthreassociationhinhbittest_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gshifthamounthreassociationhinhbittest_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gshifthamounthreassociationhinhbittest_proof
 theorem t0_const_lshr_shl_ne_thm (e e_1 : IntW 32) :

--- a/SSA/Projects/InstCombine/tests/proofs/gshifthamounthreassociationhinhbittesthwithhtruncationhlshr_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gshifthamounthreassociationhinhbittesthwithhtruncationhlshr_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gshifthamounthreassociationhinhbittesthwithhtruncationhlshr_proof
 theorem n0_thm (e : IntW 64) (e_1 e_2 : IntW 32) :

--- a/SSA/Projects/InstCombine/tests/proofs/gshifthamounthreassociationhinhbittesthwithhtruncationhshl_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gshifthamounthreassociationhinhbittesthwithhtruncationhshl_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gshifthamounthreassociationhinhbittesthwithhtruncationhshl_proof
 theorem t0_const_after_fold_lshr_shl_ne_thm (e : IntW 64) (e_1 e_2 : IntW 32) :

--- a/SSA/Projects/InstCombine/tests/proofs/gshifthamounthreassociationhwithhtruncationhashr_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gshifthamounthreassociationhwithhtruncationhashr_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gshifthamounthreassociationhwithhtruncationhashr_proof
 theorem t0_thm (e : IntW 16) (e_1 : IntW 32) :

--- a/SSA/Projects/InstCombine/tests/proofs/gshifthamounthreassociationhwithhtruncationhlshr_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gshifthamounthreassociationhwithhtruncationhlshr_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gshifthamounthreassociationhwithhtruncationhlshr_proof
 theorem t0_thm (e : IntW 16) (e_1 : IntW 32) :

--- a/SSA/Projects/InstCombine/tests/proofs/gshifthamounthreassociationhwithhtruncationhshl_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gshifthamounthreassociationhwithhtruncationhshl_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gshifthamounthreassociationhwithhtruncationhshl_proof
 theorem t0_thm (e : IntW 16) (e_1 : IntW 32) :

--- a/SSA/Projects/InstCombine/tests/proofs/gshifthbyhsignext_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gshifthbyhsignext_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gshifthbyhsignext_proof
 theorem t0_shl_thm (e : IntW 8) (e_1 : IntW 32) : shl e_1 (sext 32 e) ⊑ shl e_1 (zext 32 e { «nneg» := true }) := by

--- a/SSA/Projects/InstCombine/tests/proofs/gshifthdirectionhinhbithtest_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gshifthdirectionhinhbithtest_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gshifthdirectionhinhbithtest_proof
 theorem t7_twoshifts2_thm (e e_1 e_2 : IntW 32) :

--- a/SSA/Projects/InstCombine/tests/proofs/gshifthflags_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gshifthflags_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gshifthflags_proof
 theorem shl_add_nuw_thm (e e_1 : IntW 8) :

--- a/SSA/Projects/InstCombine/tests/proofs/gshifthlogic_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gshifthlogic_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gshifthlogic_proof
 theorem shl_and_thm (e e_1 : IntW 8) :

--- a/SSA/Projects/InstCombine/tests/proofs/gshifthshift_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gshifthshift_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gshifthshift_proof
 theorem shl_shl_thm (e : IntW 32) : shl (shl e (const? 32 6)) (const? 32 28) ⊑ const? 32 0 := by

--- a/SSA/Projects/InstCombine/tests/proofs/gshifthsra_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gshifthsra_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gshifthsra_proof
 theorem test1_thm (e : IntW 8) (e_1 : IntW 32) :

--- a/SSA/Projects/InstCombine/tests/proofs/gshlhandhnegChicmpeqhzero_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gshlhandhnegChicmpeqhzero_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gshlhandhnegChicmpeqhzero_proof
 theorem scalar_i8_shl_and_negC_eq_thm (e e_1 : IntW 8) :

--- a/SSA/Projects/InstCombine/tests/proofs/gshlhandhsignbithicmpeqhzero_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gshlhandhsignbithicmpeqhzero_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gshlhandhsignbithicmpeqhzero_proof
 theorem scalar_i8_shl_and_signbit_eq_thm (e e_1 : IntW 8) :

--- a/SSA/Projects/InstCombine/tests/proofs/gshlhbo_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gshlhbo_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gshlhbo_proof
 theorem lshr_add_thm (e e_1 : IntW 8) :

--- a/SSA/Projects/InstCombine/tests/proofs/gshlhdemand_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gshlhdemand_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gshlhdemand_proof
 theorem src_srem_shl_demand_max_signbit_thm (e : IntW 32) :

--- a/SSA/Projects/InstCombine/tests/proofs/gshlhfactor_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gshlhfactor_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gshlhfactor_proof
 theorem add_shl_same_amount_thm (e e_1 e_2 : IntW 6) : add (shl e_2 e_1) (shl e e_1) ⊑ shl (add e_2 e) e_1 := by

--- a/SSA/Projects/InstCombine/tests/proofs/gshlhsub_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gshlhsub_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gshlhsub_proof
 theorem shl_sub_i32_thm (e : IntW 32) :

--- a/SSA/Projects/InstCombine/tests/proofs/gshlhunsignedhcmphconst_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gshlhunsignedhcmphconst_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gshlhunsignedhcmphconst_proof
 theorem scalar_i8_shl_ult_const_1_thm (e : IntW 8) :

--- a/SSA/Projects/InstCombine/tests/proofs/gshouldhchangehtype_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gshouldhchangehtype_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gshouldhchangehtype_proof
 theorem test1_thm (e e_1 : IntW 8) : trunc 8 (add (zext 64 e_1) (zext 64 e)) ⊑ add e_1 e := by

--- a/SSA/Projects/InstCombine/tests/proofs/gsignbithlshrhandhicmpeqhzero_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gsignbithlshrhandhicmpeqhzero_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gsignbithlshrhandhicmpeqhzero_proof
 theorem scalar_i8_signbit_lshr_and_eq_thm (e e_1 : IntW 8) :

--- a/SSA/Projects/InstCombine/tests/proofs/gsignbithshlhandhicmpeqhzero_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gsignbithshlhandhicmpeqhzero_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gsignbithshlhandhicmpeqhzero_proof
 theorem scalar_i32_signbit_shl_and_eq_X_is_constant1_thm (e : IntW 32) :

--- a/SSA/Projects/InstCombine/tests/proofs/gsignedhcomparison_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gsignedhcomparison_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gsignedhcomparison_proof
 theorem scalar_zext_slt_thm (e : IntW 16) :

--- a/SSA/Projects/InstCombine/tests/proofs/gsignedhtruncationhcheck_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gsignedhtruncationhcheck_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gsignedhtruncationhcheck_proof
 theorem positive_with_signbit_thm (e : IntW 32) :

--- a/SSA/Projects/InstCombine/tests/proofs/gsignext_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gsignext_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gsignext_proof
 theorem sextinreg_thm (e : IntW 32) :

--- a/SSA/Projects/InstCombine/tests/proofs/gsignhbithtesthviahrighthshiftinghallhotherhbits_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gsignhbithtesthviahrighthshiftinghallhotherhbits_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gsignhbithtesthviahrighthshiftinghallhotherhbits_proof
 theorem unsigned_sign_bit_extract_thm (e : IntW 32) :

--- a/SSA/Projects/InstCombine/tests/proofs/gsignhtesthandhor_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gsignhtesthandhor_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gsignhtesthandhor_proof
 theorem test1_thm (e e_1 : IntW 32) :

--- a/SSA/Projects/InstCombine/tests/proofs/gsignmaskhofhsexthvshofhshlhofhzext_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gsignmaskhofhsexthvshofhshlhofhzext_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gsignmaskhofhsexthvshofhshlhofhzext_proof
 theorem t0_thm (e : IntW 16) :

--- a/SSA/Projects/InstCombine/tests/proofs/gsinkhnothintohand_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gsinkhnothintohand_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gsinkhnothintohand_proof
 theorem t0_thm (e e_1 e_2 e_3 : IntW 32) :

--- a/SSA/Projects/InstCombine/tests/proofs/gsinkhnothintohanotherhhandhofhand_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gsinkhnothintohanotherhhandhofhand_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gsinkhnothintohanotherhhandhofhand_proof
 theorem t0_thm (e e_1 e_2 e_3 : IntW 8) (e_4 : IntW 1) :

--- a/SSA/Projects/InstCombine/tests/proofs/gsinkhnothintohanotherhhandhofhlogicalhand_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gsinkhnothintohanotherhhandhofhlogicalhand_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gsinkhnothintohanotherhhandhofhlogicalhand_proof
 theorem t0_thm (e e_1 e_2 e_3 : IntW 8) (e_4 : IntW 1) :

--- a/SSA/Projects/InstCombine/tests/proofs/gsinkhnothintohanotherhhandhofhlogicalhor_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gsinkhnothintohanotherhhandhofhlogicalhor_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gsinkhnothintohanotherhhandhofhlogicalhor_proof
 theorem t0_thm (e e_1 e_2 e_3 : IntW 8) (e_4 : IntW 1) :

--- a/SSA/Projects/InstCombine/tests/proofs/gsinkhnothintohanotherhhandhofhor_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gsinkhnothintohanotherhhandhofhor_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gsinkhnothintohanotherhhandhofhor_proof
 theorem t0_thm (e e_1 e_2 e_3 : IntW 8) (e_4 : IntW 1) :

--- a/SSA/Projects/InstCombine/tests/proofs/gsinkhnothintohlogicalhand_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gsinkhnothintohlogicalhand_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gsinkhnothintohlogicalhand_proof
 theorem t0_thm (e e_1 e_2 e_3 : IntW 32) :

--- a/SSA/Projects/InstCombine/tests/proofs/gsinkhnothintohlogicalhor_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gsinkhnothintohlogicalhor_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gsinkhnothintohlogicalhor_proof
 theorem t0_thm (e e_1 e_2 e_3 : IntW 32) :

--- a/SSA/Projects/InstCombine/tests/proofs/gsinkhnothintohor_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gsinkhnothintohor_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gsinkhnothintohor_proof
 theorem t0_thm (e e_1 e_2 e_3 : IntW 32) :

--- a/SSA/Projects/InstCombine/tests/proofs/gsmaxhicmp_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gsmaxhicmp_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gsmaxhicmp_proof
 theorem eq_smax1_thm (e e_1 : IntW 32) :

--- a/SSA/Projects/InstCombine/tests/proofs/gsminhicmp_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gsminhicmp_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gsminhicmp_proof
 theorem eq_smin1_thm (e e_1 : IntW 32) :

--- a/SSA/Projects/InstCombine/tests/proofs/gsremhcanonicalize_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gsremhcanonicalize_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gsremhcanonicalize_proof
 theorem test_srem_canonicalize_op0_thm (e e_1 : IntW 32) :

--- a/SSA/Projects/InstCombine/tests/proofs/gsremhsimplifyhbug_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gsremhsimplifyhbug_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gsremhsimplifyhbug_proof
 theorem f_thm (e : IntW 32) :

--- a/SSA/Projects/InstCombine/tests/proofs/gsubhandhorhneghxor_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gsubhandhorhneghxor_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gsubhandhorhneghxor_proof
 theorem sub_to_xor_thm (e e_1 : IntW 32) :

--- a/SSA/Projects/InstCombine/tests/proofs/gsubhashrhandhtohicmphselect_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gsubhashrhandhtohicmphselect_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gsubhashrhandhtohicmphselect_proof
 theorem sub_ashr_and_i8_thm (e e_1 : IntW 8) :

--- a/SSA/Projects/InstCombine/tests/proofs/gsubhashrhorhtohicmphselect_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gsubhashrhorhtohicmphselect_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gsubhashrhorhtohicmphselect_proof
 theorem sub_ashr_or_i8_thm (e e_1 : IntW 8) :

--- a/SSA/Projects/InstCombine/tests/proofs/gsubhfromhsub_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gsubhfromhsub_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gsubhfromhsub_proof
 theorem t0_thm (e e_1 e_2 : IntW 8) : sub (sub e_2 e_1) e ⊑ sub e_2 (add e_1 e) := by

--- a/SSA/Projects/InstCombine/tests/proofs/gsubhlshrhorhtohicmphselect_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gsubhlshrhorhtohicmphselect_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gsubhlshrhorhtohicmphselect_proof
 theorem neg_or_lshr_i32_thm (e : IntW 32) :

--- a/SSA/Projects/InstCombine/tests/proofs/gsubhnot_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gsubhnot_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gsubhnot_proof
 theorem sub_not_thm (e e_1 : IntW 8) :

--- a/SSA/Projects/InstCombine/tests/proofs/gsubhofhnegatible_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gsubhofhnegatible_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gsubhofhnegatible_proof
 theorem t0_thm (e : IntW 8) : sub e (const? 8 (-42)) ⊑ add e (const? 8 42) := by

--- a/SSA/Projects/InstCombine/tests/proofs/gsubhofhnegatiblehinseltpoison_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gsubhofhnegatiblehinseltpoison_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gsubhofhnegatiblehinseltpoison_proof
 theorem t0_thm (e : IntW 8) : sub e (const? 8 (-42)) ⊑ add e (const? 8 42) := by

--- a/SSA/Projects/InstCombine/tests/proofs/gsubhorhandhxor_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gsubhorhandhxor_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gsubhorhandhxor_proof
 theorem sub_to_xor_thm (e e_1 : IntW 32) : sub (LLVM.or e_1 e) (LLVM.and e_1 e) ⊑ LLVM.xor e_1 e := by

--- a/SSA/Projects/InstCombine/tests/proofs/gsubhxor_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gsubhxor_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gsubhxor_proof
 theorem low_mask_nsw_nuw_thm (e : IntW 32) :

--- a/SSA/Projects/InstCombine/tests/proofs/gsubhxorhcmp_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gsubhxorhcmp_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gsubhxorhcmp_proof
 theorem sext_xor_sub_thm (e : IntW 1) (e_1 : IntW 64) :

--- a/SSA/Projects/InstCombine/tests/proofs/gsubhxorhorhneghand_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gsubhxorhorhneghand_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gsubhxorhorhneghand_proof
 theorem sub_to_and_thm (e e_1 : IntW 32) :

--- a/SSA/Projects/InstCombine/tests/proofs/gsubtracthfromhonehhandhofhselect_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gsubtracthfromhonehhandhofhselect_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gsubtracthfromhonehhandhofhselect_proof
 theorem t0_sub_from_trueval_thm (e : IntW 8) (e_1 : IntW 1) (e_2 : IntW 8) :

--- a/SSA/Projects/InstCombine/tests/proofs/gsubtracthofhonehhandhofhselect_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gsubtracthofhonehhandhofhselect_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gsubtracthofhonehhandhofhselect_proof
 theorem t0_sub_of_trueval_thm (e e_1 : IntW 8) (e_2 : IntW 1) :

--- a/SSA/Projects/InstCombine/tests/proofs/gtrunc_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gtrunc_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gtrunc_proof
 theorem test5_thm (e : IntW 32) : trunc 32 (lshr (zext 128 e) (const? 128 16)) ⊑ lshr e (const? 32 16) := by

--- a/SSA/Projects/InstCombine/tests/proofs/gtruncatinghsaturate_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gtruncatinghsaturate_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gtruncatinghsaturate_proof
 theorem testtrunclowhigh_thm (e e_1 : IntW 16) (e_2 : IntW 32) :

--- a/SSA/Projects/InstCombine/tests/proofs/gtrunchbinophext_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gtrunchbinophext_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gtrunchbinophext_proof
 theorem narrow_sext_and_thm (e : IntW 32) (e_1 : IntW 16) :

--- a/SSA/Projects/InstCombine/tests/proofs/gtrunchdemand_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gtrunchdemand_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gtrunchdemand_proof
 theorem trunc_lshr_thm (e : IntW 8) :

--- a/SSA/Projects/InstCombine/tests/proofs/gtrunchinseltpoison_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gtrunchinseltpoison_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gtrunchinseltpoison_proof
 theorem test5_thm (e : IntW 32) : trunc 32 (lshr (zext 128 e) (const? 128 16)) ⊑ lshr e (const? 32 16) := by

--- a/SSA/Projects/InstCombine/tests/proofs/gtrunchshifthtrunc_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gtrunchshifthtrunc_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gtrunchshifthtrunc_proof
 theorem trunc_lshr_trunc_thm (e : IntW 64) : trunc 8 (lshr (trunc 32 e) (const? 32 8)) ⊑ trunc 8 (lshr e (const? 64 8)) := by

--- a/SSA/Projects/InstCombine/tests/proofs/gtrunchshlhzext_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gtrunchshlhzext_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gtrunchshlhzext_proof
 theorem trunc_shl_zext_32_thm (e : IntW 32) :

--- a/SSA/Projects/InstCombine/tests/proofs/guaddo_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/guaddo_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section guaddo_proof
 theorem uaddo_commute3_thm (e e_1 e_2 : IntW 32) :

--- a/SSA/Projects/InstCombine/tests/proofs/gudiv_select_to_select_shift_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gudiv_select_to_select_shift_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gudiv_select_to_select_shift_proof
 theorem test_thm (e : IntW 1) (e_1 : IntW 64) :

--- a/SSA/Projects/InstCombine/tests/proofs/gudivremhchangehwidth_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gudivremhchangehwidth_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gudivremhchangehwidth_proof
 theorem udiv_i8_thm (e e_1 : IntW 8) : trunc 8 (LLVM.udiv (zext 32 e_1) (zext 32 e)) ⊑ LLVM.udiv e_1 e := by

--- a/SSA/Projects/InstCombine/tests/proofs/gumaxhicmp_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gumaxhicmp_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gumaxhicmp_proof
 theorem eq_umax1_thm (e e_1 : IntW 32) :

--- a/SSA/Projects/InstCombine/tests/proofs/guminhicmp_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/guminhicmp_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section guminhicmp_proof
 theorem eq_umin1_thm (e e_1 : IntW 32) :

--- a/SSA/Projects/InstCombine/tests/proofs/gunfoldhmaskedhmergehwithhconsthmaskhscalar_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gunfoldhmaskedhmergehwithhconsthmaskhscalar_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gunfoldhmaskedhmergehwithhconsthmaskhscalar_proof
 theorem scalar0_thm (e e_1 : IntW 4) :

--- a/SSA/Projects/InstCombine/tests/proofs/gunsigned_saturated_sub_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gunsigned_saturated_sub_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gunsigned_saturated_sub_proof
 theorem max_sub_ugt_c0_thm (e : IntW 32) :

--- a/SSA/Projects/InstCombine/tests/proofs/gunsignedhaddhlackhofhoverflowhcheck_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gunsignedhaddhlackhofhoverflowhcheck_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gunsignedhaddhlackhofhoverflowhcheck_proof
 theorem t0_basic_thm (e e_1 : IntW 8) :

--- a/SSA/Projects/InstCombine/tests/proofs/gunsignedhaddhlackhofhoverflowhcheckhviahadd_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gunsignedhaddhlackhofhoverflowhcheckhviahadd_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gunsignedhaddhlackhofhoverflowhcheckhviahadd_proof
 theorem t6_no_extrause_thm (e e_1 : IntW 8) :

--- a/SSA/Projects/InstCombine/tests/proofs/gunsignedhaddhlackhofhoverflowhcheckhviahxor_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gunsignedhaddhlackhofhoverflowhcheckhviahxor_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gunsignedhaddhlackhofhoverflowhcheckhviahxor_proof
 theorem t3_no_extrause_thm (e e_1 : IntW 8) :

--- a/SSA/Projects/InstCombine/tests/proofs/gunsignedhaddhoverflowhcheck_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gunsignedhaddhoverflowhcheck_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gunsignedhaddhoverflowhcheck_proof
 theorem t0_basic_thm (e e_1 : IntW 8) :

--- a/SSA/Projects/InstCombine/tests/proofs/gunsignedhaddhoverflowhcheckhviahadd_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gunsignedhaddhoverflowhcheckhviahadd_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gunsignedhaddhoverflowhcheckhviahadd_proof
 theorem t6_no_extrause_thm (e e_1 : IntW 8) :

--- a/SSA/Projects/InstCombine/tests/proofs/gunsignedhaddhoverflowhcheckhviahxor_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gunsignedhaddhoverflowhcheckhviahxor_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gunsignedhaddhoverflowhcheckhviahxor_proof
 theorem t3_no_extrause_thm (e e_1 : IntW 8) :

--- a/SSA/Projects/InstCombine/tests/proofs/gunsignedhsubhlackhofhoverflowhcheck_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gunsignedhsubhlackhofhoverflowhcheck_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gunsignedhsubhlackhofhoverflowhcheck_proof
 theorem t0_basic_thm (e e_1 : IntW 8) : icmp IntPredicate.ule (sub e_1 e) e_1 ⊑ icmp IntPredicate.ule e e_1 := by

--- a/SSA/Projects/InstCombine/tests/proofs/gunsignedhsubhoverflowhcheck_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gunsignedhsubhoverflowhcheck_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gunsignedhsubhoverflowhcheck_proof
 theorem t0_basic_thm (e e_1 : IntW 8) : icmp IntPredicate.ugt (sub e_1 e) e_1 ⊑ icmp IntPredicate.ugt e e_1 := by

--- a/SSA/Projects/InstCombine/tests/proofs/gxor2_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gxor2_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gxor2_proof
 theorem test0_thm (e : IntW 32) :

--- a/SSA/Projects/InstCombine/tests/proofs/gxor_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gxor_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gxor_proof
 theorem test0_thm (e : IntW 1) : LLVM.xor e (const? 1 0) ⊑ e := by

--- a/SSA/Projects/InstCombine/tests/proofs/gxorhandhor_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gxorhandhor_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gxorhandhor_proof
 theorem xor_logic_and_logic_or1_thm (e e_1 e_2 : IntW 1) :

--- a/SSA/Projects/InstCombine/tests/proofs/gxorhashr_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gxorhashr_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gxorhashr_proof
 theorem testi8i8_thm (e : IntW 8) :

--- a/SSA/Projects/InstCombine/tests/proofs/gxorhicmps_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gxorhicmps_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gxorhicmps_proof
 theorem slt_zero_thm (e e_1 : IntW 4) :

--- a/SSA/Projects/InstCombine/tests/proofs/gxorhofhor_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gxorhofhor_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gxorhofhor_proof
 theorem t1_thm (e : IntW 4) :

--- a/SSA/Projects/InstCombine/tests/proofs/gzeroexthandhreduce_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gzeroexthandhreduce_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gzeroexthandhreduce_proof
 theorem test1_thm (e : IntW 8) :

--- a/SSA/Projects/InstCombine/tests/proofs/gzext_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gzext_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gzext_proof
 theorem test_sext_zext_thm (e : IntW 16) : sext 64 (zext 32 e) ⊑ zext 64 e := by

--- a/SSA/Projects/InstCombine/tests/proofs/gzexthboolhaddhsub_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gzexthboolhaddhsub_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gzexthboolhaddhsub_proof
 theorem a_thm (e e_1 : IntW 1) :

--- a/SSA/Projects/InstCombine/tests/proofs/gzexthorhicmp_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gzexthorhicmp_proof.lean
@@ -6,6 +6,7 @@ open LLVM
 
 set_option linter.unusedTactic false
 set_option linter.unreachableTactic false
+set_option maxHeartbeats 5000000
 
 section gzexthorhicmp_proof
 theorem zext_or_eq_ult_add_thm (e : IntW 32) :


### PR DESCRIPTION
Some bitblasting test cases may run a bit longer. Let's give them some more time to actually identify them.