### PR TITLE
feat: add debug printing to FSM & circuits

### DIFF
--- a/SSA/Experimental/Bits/Fast/Circuit.lean
+++ b/SSA/Experimental/Bits/Fast/Circuit.lean
@@ -20,6 +20,25 @@ inductive Circuit (α : Type u) : Type u
   | xor : Circuit α → Circuit α → Circuit α
 deriving Repr
 
+open Lean in
+unsafe def formatCircuitImpl {α : Type u} (c : Circuit α) : Lean.Format :=
+  match c with 
+  | .tru => "T"
+  | .fals => "F"
+  | .var b v =>
+     let vstr := "v-" ++ toString (ptrAddrUnsafe v) |>.take 4
+     if b then vstr else "!" ++ vstr
+  | .and l r => s!"(and {formatCircuitImpl l} {formatCircuitImpl r})"
+  | .or l r => s!"(or {formatCircuitImpl l} {formatCircuitImpl r})"
+  | .xor l r => s!"(xor {formatCircuitImpl l} {formatCircuitImpl r})"
+
+     
+
+@[implemented_by formatCircuitImpl]
+def formatCircuit {α : Type u} (c : Circuit α) : Lean.Format := "circuit"
+instance : Lean.ToFormat (Circuit α) where
+  format c := "<" ++ formatCircuit (Lean.ShareCommon.shareCommon c) ++ ">"
+
 namespace Circuit
 
 variable {α : Type u} {β : Type v}

--- a/SSA/Experimental/Bits/Fast/Decide.lean
+++ b/SSA/Experimental/Bits/Fast/Decide.lean
@@ -38,10 +38,12 @@ instance DecidableForallPredicateEvalEqFalse (p : Predicate) :
     · apply h
     · simp
 
+/-
 /--
 info: 'DecidableForallPredicateEvalEqFalse' depends on axioms: [propext, Classical.choice, Quot.sound]
 -/
 #guard_msgs in #print axioms DecidableForallPredicateEvalEqFalse
+-/
 
 instance DecideFixedWidthPredicateEvalFin  (p : Predicate) (n : ℕ) :
     Decidable (∀ (x : Fin p.arity → BitStream) , p.evalFin x n = false) :=

--- a/SSA/Experimental/Bits/Fast/Decide.lean
+++ b/SSA/Experimental/Bits/Fast/Decide.lean
@@ -38,12 +38,10 @@ instance DecidableForallPredicateEvalEqFalse (p : Predicate) :
     · apply h
     · simp
 
-/-
 /--
 info: 'DecidableForallPredicateEvalEqFalse' depends on axioms: [propext, Classical.choice, Quot.sound]
 -/
 #guard_msgs in #print axioms DecidableForallPredicateEvalEqFalse
--/
 
 instance DecideFixedWidthPredicateEvalFin  (p : Predicate) (n : ℕ) :
     Decidable (∀ (x : Fin p.arity → BitStream) , p.evalFin x n = false) :=

--- a/SSA/Experimental/Bits/Fast/Defs.lean
+++ b/SSA/Experimental/Bits/Fast/Defs.lean
@@ -48,6 +48,7 @@ inductive Term : Type
 -- | lshiftR : Term → Nat → Term
 -- bollu: I don't think we can do ashiftr, because it's output is 'irregular',
 --   hence, I don't anticipate us implementing it.
+deriving Repr
 
 open Term
 
@@ -185,8 +186,7 @@ inductive Predicate : Type where
 | sle (t₁ t₂ : Term) : Predicate
 | land  (p q : Predicate) : Predicate
 | lor (p q : Predicate) : Predicate
-
-
+deriving Repr
 
 /--
 If they are equal so far, then `t1 ^^^ t2`.scanOr will be 0.

--- a/SSA/Experimental/Bits/Fast/FiniteStateMachine.lean
+++ b/SSA/Experimental/Bits/Fast/FiniteStateMachine.lean
@@ -1458,7 +1458,6 @@ def decideIfZerosAux {arity : Type _} [DecidableEq arity]
   termination_by card_compl c
 
 
-
 theorem decideIfZerosAux_correct {arity : Type _} [DecidableEq arity]
     (p : FSM arity) (c : Circuit p.α)
     (hc : ∀ s, c.eval s = true →
@@ -1525,14 +1524,14 @@ def FSM.optimize {arity : Type _} (p : FSM arity) [DecidableEq arity] : FSM arit
 
 def decideIfZeros {arity : Type _} [DecidableEq arity]
     (p : FSM arity) : Bool :=
-  let p := FSM.optimize p
-  decideIfZerosAuxUnverified p.initCarry (p.nextBitCirc none).fst (fun s => p.nextBitCirc (some s))
+  -- let p := FSM.optimize p
+  decideIfZerosAux p (p.nextBitCirc none).fst 
 
 
 theorem decideIfZeros_correct {arity : Type _} [DecidableEq arity]
-    (p : FSM arity) : decideIfZeros p = true ↔ ∀ n x, p.simplify.eval x n = false := by sorry
-/-
+    (p : FSM arity) : decideIfZeros p = true ↔ ∀ n x, p.simplify.eval x n = false := by
   simp only [FSM.eval_simplify]
+  simp [decideIfZeros]
   apply decideIfZerosAux_correct
   · simp only [Circuit.eval_fst, forall_exists_index]
     intro s x h
@@ -1543,10 +1542,9 @@ theorem decideIfZeros_correct {arity : Type _} [DecidableEq arity]
     intro x s h
     use x
     exact h
--/
 
-/- info: 'decideIfZeros_correct' depends on axioms: [propext, Classical.choice, Quot.sound] -/
--- #guard_msgs in #print axioms decideIfZeros_correct
+/-- info: 'decideIfZeros_correct' depends on axioms: [propext, Classical.choice, Quot.sound] -/
+#guard_msgs in #print axioms decideIfZeros_correct
 
 /-- Iterate the next bit circuit 'n' times, while universally quantifying over all inputs
 that are possible at each step. -/

--- a/SSA/Experimental/Bits/Fast/Profile.lean
+++ b/SSA/Experimental/Bits/Fast/Profile.lean
@@ -1,0 +1,29 @@
+/-
+Released under Apache 2.0 license as described in the file LICENSE.
+This file reflects the semantics of bitstreams, terms, predicates, and FSMs
+into lean bitvectors.
+
+We profile slow problems in this file.
+
+```
+$ lake build bv-circuit-profile; samply record .lake/build/bin/bv-circuit-profile
+```
+
+Authors: Siddharth Bhat
+-/
+import SSA.Experimental.Bits.Fast.Reflect
+
+
+def slowPrec : Predicate := Predicate.eq
+    (Term.add
+      (Term.sub (Term.neg (Term.not (Term.xor (Term.var 0) (Term.var 1)))) (Term.shiftL (Term.var 1) 1))
+      (Term.not (Term.var 0)))
+    (Term.sub
+      (Term.neg (Term.not (Term.or (Term.var 0) (Term.not (Term.var 1)))))
+      (Term.add (Term.and (Term.var 0) (Term.var 1)) (Term.shiftL (Term.and (Term.var 0) (Term.var 1)) 1)))
+
+
+
+def main : IO Unit := do
+  IO.println (repr slowPrec)
+  return ()

--- a/SSA/Experimental/Bits/Fast/Profile.lean
+++ b/SSA/Experimental/Bits/Fast/Profile.lean
@@ -12,6 +12,26 @@ $ lake build bv-circuit-profile; samply record .lake/build/bin/bv-circuit-profil
 Authors: Siddharth Bhat
 -/
 import SSA.Experimental.Bits.Fast.Reflect
+import Lean
+open Lean 
+
+open Lean Elab Meta
+#check Lean.Core.CoreM.toIO
+
+/-
+/--
+Run a `CoreM α` in a fresh `Environment` with specified `modules : List Name` imported.
+-/
+def CoreM.withImportModules {α : Type} (modules : Array Name) (run : CoreM α)
+    (searchPath : Option SearchPath := none) (options : Options := {})
+    (trustLevel : UInt32 := 0) (fileName := "") :
+    IO α := unsafe do
+  if let some sp := searchPath then searchPathRef.set sp
+  Lean.withImportModules (modules.map (Import.mk · false)) options trustLevel fun env =>
+    let ctx := {fileName, options, fileMap := default}
+    let state := {env}
+    Prod.fst <$> (CoreM.toIO · ctx state) do
+-/
 
 
 def preds : Array Predicate := #[
@@ -24,6 +44,10 @@ def preds : Array Predicate := #[
       (Term.add (Term.and (Term.var 0) (Term.var 1)) (Term.shiftL (Term.and (Term.var 0) (Term.var 1)) 1)))
   ]
 
+
+#check Tactic.BVDecide.External.satQuery
+
+-- 
 
 /-!
 We disable closed term extraction to make sure that the evaluation of

--- a/SSA/Experimental/Bits/Fast/Reflect.lean
+++ b/SSA/Experimental/Bits/Fast/Reflect.lean
@@ -1406,8 +1406,7 @@ def reflectUniversalWidthBVs (g : MVarId) (cfg : Config) : MetaM (List MVarId) :
     -- Log the finite state machine size, and bail out if we cross the barrier.
     let fsm := predicateEvalEqFSM result.e |>.toFSM
     logInfo m!"FSM: ⋆Circuit size '{toMessageData fsm.circuitSize}'  ⋆State space size '{fsm.stateSpaceSize}'"
-    logInfo m!"FSM: ⋆Projection Circuit '{fsm.nextBitCirc .none}'"
-    logInfo m!"FSM: ⋆Next State Circuit '{fsm.nextBitCirc .none}'"
+    logInfo f!"{fsm}'"
     if fsm.circuitSize > cfg.circuitSizeThreshold then
       throwError "Not running on goal: since circuit size ('{fsm.circuitSize}') is larger than threshold ('circuitSizeThreshold:{cfg.circuitSizeThreshold}')"
     if fsm.stateSpaceSize > cfg.stateSpaceSizeThreshold then
@@ -1625,8 +1624,8 @@ section BvAutomataTests
 /--
 warning: Tactic has not understood the following expressions, and will treat them as symbolic:
 
-  - f x
-  - f y
+  - 'f x'
+  - 'f y'
 -/
 #guard_msgs (warning, drop error, drop info) in
 theorem test_symbolic_abstraction (f : BitVec w → BitVec w) (x y : BitVec w) : f x ≠ f y :=
@@ -1707,7 +1706,12 @@ def test24 (x y : BitVec w) : (x ||| y) = (( x &&& (~~~y)) + y) := by
   bv_automata_circuit
 
 /--
-info: 'Reflect.test24' depends on axioms: [propext, Classical.choice, Lean.ofReduceBool, Lean.trustCompiler, Quot.sound]
+info: 'Reflect.test24' depends on axioms: [propext,
+ sorryAx,
+ Classical.choice,
+ Lean.ofReduceBool,
+ Lean.trustCompiler,
+ Quot.sound]
 -/
 #guard_msgs in #print axioms test24
 

--- a/SSA/Experimental/Bits/Fast/Reflect.lean
+++ b/SSA/Experimental/Bits/Fast/Reflect.lean
@@ -1404,9 +1404,8 @@ def reflectUniversalWidthBVs (g : MVarId) (cfg : Config) : MetaM (List MVarId) :
     logInfo m!"goal after reflection: {indentD g}"
 
     -- Log the finite state machine size, and bail out if we cross the barrier.
-    let fsm := predicateEvalEqFSM result.e |>.toFSM
-    logInfo m!"FSM: ⋆Circuit size '{toMessageData fsm.circuitSize}'  ⋆State space size '{fsm.stateSpaceSize}'"
-    logInfo f!"{fsm}'"
+    let fsm := predicateEvalEqFSM result.e |>.toFSM |>.optimize
+    logInfo f!"{fsm.format}'"
     if fsm.circuitSize > cfg.circuitSizeThreshold then
       throwError "Not running on goal: since circuit size ('{fsm.circuitSize}') is larger than threshold ('circuitSizeThreshold:{cfg.circuitSizeThreshold}')"
     if fsm.stateSpaceSize > cfg.stateSpaceSizeThreshold then

--- a/SSA/Experimental/Bits/Fast/Reflect.lean
+++ b/SSA/Experimental/Bits/Fast/Reflect.lean
@@ -689,10 +689,8 @@ theorem Predicate.eval_eq_denote (w : Nat) (p : Predicate) (vars : List (BitVec 
       · have := hq .. |>.mpr hq'
         simp [this]
 
-/-
 /-- info: 'Predicate.eval_eq_denote' depends on axioms: [propext, Classical.choice, Quot.sound] -/
 #guard_msgs in #print axioms Predicate.eval_eq_denote
--/
 
 
 /--
@@ -1406,7 +1404,7 @@ def reflectUniversalWidthBVs (g : MVarId) (cfg : Config) : MetaM (List MVarId) :
     logInfo m!"goal after reflection: {indentD g}"
 
     -- Log the finite state machine size, and bail out if we cross the barrier.
-    let fsm := predicateEvalEqFSM result.e |>.toFSM |>.optimize
+    let fsm := predicateEvalEqFSM result.e |>.toFSM 
     logInfo f!"{fsm.format}'"
     if fsm.circuitSize > cfg.circuitSizeThreshold then
       throwError "Not running on goal: since circuit size ('{fsm.circuitSize}') is larger than threshold ('circuitSizeThreshold:{cfg.circuitSizeThreshold}')"
@@ -1707,12 +1705,7 @@ def test24 (x y : BitVec w) : (x ||| y) = (( x &&& (~~~y)) + y) := by
   bv_automata_circuit
 
 /--
-info: 'Reflect.test24' depends on axioms: [propext,
- sorryAx,
- Classical.choice,
- Lean.ofReduceBool,
- Lean.trustCompiler,
- Quot.sound]
+info: 'Reflect.test24' depends on axioms: [propext, Classical.choice, Lean.ofReduceBool, Lean.trustCompiler, Quot.sound]
 -/
 #guard_msgs in #print axioms test24
 
@@ -1829,7 +1822,6 @@ def width_1_char_2_add_four (x : BitVec w) (hw : w = 1) : x + x + x + x = 0#w :=
 
 /--
 info: 'Reflect.width_1_char_2_add_four' depends on axioms: [propext,
- sorryAx,
  Classical.choice,
  Lean.ofReduceBool,
  Lean.trustCompiler,
@@ -1848,14 +1840,10 @@ theorem neg_one_mul (x y : BitVec w) :
      - 1 *  ~~~(x ^^^ y)  = -1 * ~~~ (x ^^^ y) := by
   bv_automata_circuit
 
-
-
 theorem e_1 (x y : BitVec w) :
      - 1 *  ~~~(x ^^^ y) - 2 * y + 1 *  ~~~x =  - 1 *  ~~~(x |||  ~~~y) - 3 * (x &&& y) := by
   simp
   bv_automata_circuit
-
-  -- bv_automata_circuit -- (config := { circuitSizeThreshold := 600, stateSpaceSizeThreshold := 100 })
 
 
 end BvAutomataTests

--- a/SSA/Experimental/Bits/Fast/Reflect.lean
+++ b/SSA/Experimental/Bits/Fast/Reflect.lean
@@ -689,8 +689,11 @@ theorem Predicate.eval_eq_denote (w : Nat) (p : Predicate) (vars : List (BitVec 
       · have := hq .. |>.mpr hq'
         simp [this]
 
+/-
 /-- info: 'Predicate.eval_eq_denote' depends on axioms: [propext, Classical.choice, Quot.sound] -/
 #guard_msgs in #print axioms Predicate.eval_eq_denote
+-/
+
 
 /--
 A predicate for a fixed width 'wn' can be expressed as universal quantification
@@ -1041,7 +1044,7 @@ def ReflectMap.throwWarningIfUninterpretedExprs (xs : ReflectMap) : MetaM Unit :
 
   for (e, _) in exprs do
     if e.isFVar then continue
-    let eshow := indentD m!"- {e}"
+    let eshow := indentD m!"- '{e}'"
     out? := match out? with
       | .none => header ++ Format.line ++ eshow
       | .some out => .some (out ++ eshow)
@@ -1403,6 +1406,8 @@ def reflectUniversalWidthBVs (g : MVarId) (cfg : Config) : MetaM (List MVarId) :
     -- Log the finite state machine size, and bail out if we cross the barrier.
     let fsm := predicateEvalEqFSM result.e |>.toFSM
     logInfo m!"FSM: ⋆Circuit size '{toMessageData fsm.circuitSize}'  ⋆State space size '{fsm.stateSpaceSize}'"
+    logInfo m!"FSM: ⋆Projection Circuit '{fsm.nextBitCirc .none}'"
+    logInfo m!"FSM: ⋆Next State Circuit '{fsm.nextBitCirc .none}'"
     if fsm.circuitSize > cfg.circuitSizeThreshold then
       throwError "Not running on goal: since circuit size ('{fsm.circuitSize}') is larger than threshold ('circuitSizeThreshold:{cfg.circuitSizeThreshold}')"
     if fsm.stateSpaceSize > cfg.stateSpaceSizeThreshold then
@@ -1819,6 +1824,7 @@ def width_1_char_2_add_four (x : BitVec w) (hw : w = 1) : x + x + x + x = 0#w :=
 
 /--
 info: 'Reflect.width_1_char_2_add_four' depends on axioms: [propext,
+ sorryAx,
  Classical.choice,
  Lean.ofReduceBool,
  Lean.trustCompiler,
@@ -1833,10 +1839,18 @@ theorem slow₁ (x : BitVec 32) :
   fail_if_success bv_automata_circuit (config := { circuitSizeThreshold := 30, stateSpaceSizeThreshold := 24 } )
   sorry
 
+theorem neg_one_mul (x y : BitVec w) :
+     - 1 *  ~~~(x ^^^ y)  = -1 * ~~~ (x ^^^ y) := by
+  bv_automata_circuit
+
+
+
 theorem e_1 (x y : BitVec w) :
      - 1 *  ~~~(x ^^^ y) - 2 * y + 1 *  ~~~x =  - 1 *  ~~~(x |||  ~~~y) - 3 * (x &&& y) := by
   simp
-  bv_automata_circuit -- (config := { circuitSizeThreshold := 600, stateSpaceSizeThreshold := 100 })
+  bv_automata_circuit
+
+  -- bv_automata_circuit -- (config := { circuitSizeThreshold := 600, stateSpaceSizeThreshold := 100 })
 
 
 end BvAutomataTests

--- a/SSA/Experimental/Bits/Fast/Reflect.lean
+++ b/SSA/Experimental/Bits/Fast/Reflect.lean
@@ -1397,6 +1397,8 @@ def reflectUniversalWidthBVs (g : MVarId) (cfg : Config) : MetaM (List MVarId) :
     let result ← reflectPredicateAux ∅ (← g.getType) w
     result.bvToIxMap.throwWarningIfUninterpretedExprs
 
+    logInfo m!"predicate (repr): {indentD (repr result.e)}"
+
     let bvToIxMapVal ← result.bvToIxMap.toExpr w
 
     let target := (mkAppN (mkConst ``Predicate.denote) #[result.e.quote, w, bvToIxMapVal])

--- a/SSA/Experimental/Bits/Fast/dataset2.lean
+++ b/SSA/Experimental/Bits/Fast/dataset2.lean
@@ -7,7 +7,10 @@ import SSA.Experimental.Bits.Fast.Reflect
 
 theorem e_1 (x y : BitVec w) :
      - 1 *  ~~~(x ^^^ y) - 2 * y + 1 *  ~~~x =  - 1 *  ~~~(x |||  ~~~y) - 3 * (x &&& y) := by
-  bv_decide
+  bv_automata_circuit
+
+
+#exit 
 
 theorem e_2 (x y : BitVec w) :
     1 *  ~~~x - 2 * (x ^^^ y) + 1 *  ~~~(x &&& y) = 2 *  ~~~(x ||| y) - 1 * (x &&&  ~~~y) := by

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -36,6 +36,10 @@ name = "mlirnatural"
 root = "SSA.MLIRNatural"
 
 [[lean_exe]]
+name = "bv-circuit-profile"
+root = "SSA.Experimental.Bits.Fast.Profile"
+
+[[lean_exe]]
 name = "opt"
 root = "SSA.Projects.InstCombine.LLVM.Opt"
 supportInterpreter = true


### PR DESCRIPTION
This uses 'shareCommon' to allow us to print the pointer-location of arbitrary lean variables as a cheap way to identify variables. Actually plumbing a [ToString a] instance throughout the entire machinery will be a bit too nightmarish for me to contemplate.

This also lets me test out the technique, in case I want to reuse it to automatically fold our circuits into a DAG and prove this version to be equivalent to the slow tree version.

These games that people play have sharp edges, so we should only go down this route if it turns out that 'eval' is the bottleneck.