### PR TITLE
feat: Build circuits with larger variables but no quantifier elimination

### DIFF
--- a/SSA/Experimental/Bits/Fast/Reflect.lean
+++ b/SSA/Experimental/Bits/Fast/Reflect.lean
@@ -1526,10 +1526,11 @@ def decideIfZerosM {arity : Type _} [DecidableEq arity] [Monad m]
     (p : FSM arity) : m Bool :=
   decideIfZerosAuxM decLe p (p.nextBitCirc none).fst
 
-def _root_.FSM.decideIfZerosMCadical  {arity : Type _} [DecidableEq arity]  (fsm : FSM arity) : TermElabM Bool :=
+def _root_.FSM.decideIfZerosMCadical  {arity : Type _} [DecidableEq arity]  [Fintype arity] [Hashable arity] (fsm : FSM arity) : TermElabM Bool :=
   -- decideIfZerosM Circuit.decLeCadical fsm
   withTraceNode `bv_automata_circuit (fun _ => return "k-induction") (collapsed := true) do
-    decideIfZerosAuxTermElabM fsm (fsm.nextBitCirc none).fst 1
+    let c : Circuit (fsm.α ⊕ Empty) := (fsm.nextBitCirc none).fst.map Sum.inl
+    decideIfZerosAuxTermElabM fsm c 1
 
 end BvDecide
 

--- a/SSA/Experimental/Bits/Fast/Reflect.lean
+++ b/SSA/Experimental/Bits/Fast/Reflect.lean
@@ -1508,14 +1508,14 @@ partial def decideIfZerosAuxTermElabM {arity : Type _} [DecidableEq arity] [Fint
       IO.println s!"Inductive invariant established! (time={tElapsedSec}s)"
       return true
     else
-      have _wf : card_compl (cNext ||| c) < card_compl c :=
-        have := le.prop
-        have hNotLt : ¬ cNext ≤ c := by
-          simp at h
-          have := this.not
-          simp at this
-          exact this.mp h
-        decideIfZeroAux_wf hNotLt
+      -- have _wf : card_compl (cNext ||| c) < card_compl c :=
+      --   have := le.prop
+      --   have hNotLt : ¬ cNext ≤ c := by
+      --     simp at h
+      --     have := this.not
+      --     simp at this
+      --     exact this.mp h
+      --   decideIfZeroAux_wf hNotLt
       IO.println s!"Unable to establish inductive invariant (time={tElapsedSec}s). Recursing..."
       decideIfZerosAuxTermElabM p (cNext ||| c) (iter + 1)
   -- termination_by sorry -- card_compl c


### PR DESCRIPTION
This allows us to push the universal quantifier (which after negation are existential, thereby fitting SAT) into the solver itself. This increases the number of variables, but should drastically cut down formula size, and present 'comprehensible' formuale to cadical. 