### PR TITLE
feat: make AutoStructs faster

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ test-semantics/*.llvm
 *.olean
 lakefile.olean
 .lake/
+profile.json

--- a/SSA/Experimental/Bits/AutoStructs/Basic.lean
+++ b/SSA/Experimental/Bits/AutoStructs/Basic.lean
@@ -215,8 +215,7 @@ def RawCNFA.createSink (m : RawCNFA A) : State × RawCNFA A :=
   (s, m)
 
 def RawCNFA.transSet (m : RawCNFA A) (ss : Std.HashSet State) (a : A) : Std.HashSet State :=
-  ss.fold (init := ∅) fun ss' s =>
-    ss'.insertMany $ m.trans.getD (s, a) ∅
+  ss.fold (init := ∅) fun ss' s => ss'.insertMany $ m.tr s a
 
 def RawCNFA.transBV (m : RawCNFA A) (s : m.states) (a : A) : BitVec m.stateMax :=
   let ts := m.trans.getD (s, a) ∅
@@ -487,6 +486,12 @@ lemma createSink_trans [LawfulBEq A] {m : RawCNFA A} (hwf : m.WF) :
     · simp only [addTrans_tr]; tauto
     · simp [hwf', hstates]
     · simp [hstates]
+
+def CNFA.transSet (m : CNFA n) (ss : Std.HashSet m.m.states) (a : BitVec n) : Std.HashSet m.m.states :=
+  ss.fold (init := ∅) fun ss' (s : m.m.states) =>
+    let ss' := m.m.tr s a
+    let ss' := ss'.attachWith (λ s ↦ s ∈ m.m.states) (by simp_all; sorry)
+    ss'.insertMany ss'
 
 instance RawCNFA_Inhabited : Inhabited (RawCNFA A) where
   default := RawCNFA.empty

--- a/SSA/Experimental/Bits/AutoStructs/Basic.lean
+++ b/SSA/Experimental/Bits/AutoStructs/Basic.lean
@@ -489,9 +489,8 @@ lemma createSink_trans [LawfulBEq A] {m : RawCNFA A} (hwf : m.WF) :
 
 def CNFA.transSet (m : CNFA n) (ss : Std.HashSet m.m.states) (a : BitVec n) : Std.HashSet m.m.states :=
   ss.fold (init := ∅) fun ss' (s : m.m.states) =>
-    let ss' := m.m.tr s a
-    let ss' := ss'.attachWith (λ s ↦ s ∈ m.m.states) (by simp_all; sorry)
-    ss'.insertMany ss'
+    let ssn := (m.m.tr s a).attachWith (λ s ↦ s ∈ m.m.states) (by simp_all; sorry)
+    ss'.insertMany ssn
 
 instance RawCNFA_Inhabited : Inhabited (RawCNFA A) where
   default := RawCNFA.empty

--- a/SSA/Experimental/Bits/AutoStructs/Constructions.lean
+++ b/SSA/Experimental/Bits/AutoStructs/Constructions.lean
@@ -422,7 +422,6 @@ instance [BEq α] [LawfulBEq α] [Hashable α] : LawfulBEq (Std.HashSet α) :=
 instance [BEq α] [Hashable α] : Hashable (Std.HashSet α) where
   hash m := m.fold (init := 0) fun h x => h ^^^ hash x
 
-
 -- Is it necessary? maybe rework the worklist function to only use `==`
 instance [BEq α] [Hashable α] : DecidableEq (Std.HashSet α) :=
   sorry
@@ -662,6 +661,19 @@ def CNFA.neg_spec (m : CNFA n)  {M : NFA' n} (hsim : m.Sim M) :
   rw [NFA'.neg_eq, CNFA.neg]
   apply CNFA.flipFinals_spec
   apply determinize_spec m hsim
+
+def RawCNFA.reverse (m : RawCNFA A) : RawCNFA A :=
+   let m' := { stateMax := m.stateMax, trans := Std.HashMap.empty, initials := m.finals, finals := m.initials}
+   m.trans.fold (init := m') fun m' (s, a) ss' =>
+     ss'.fold (init := m') fun m' s' =>
+       m'.addTrans a s' s
+
+ def CNFA.reverse (m : CNFA n) : CNFA n :=
+   ⟨m.m.reverse, sorry⟩
+
+ def CNFA.minimize (m : CNFA n) : CNFA n :=
+   let mᵣ := m.reverse.determinize
+   mᵣ.reverse.determinize
 
 end determinization
 

--- a/SSA/Experimental/Bits/AutoStructs/Defs.lean
+++ b/SSA/Experimental/Bits/AutoStructs/Defs.lean
@@ -29,6 +29,17 @@ def liftMax1 (n m : Nat) : Fin n → Fin (max n m) :=
 def liftMax2 (n m : Nat) : Fin m → Fin (max n m) :=
   fun k => k.castLE (by omega)
 
+def liftLast3 n : Fin 3 → Fin (n + 3)
+| 0 => n
+| 1 => n + 1
+| 2 => Fin.last (n + 2)
+def liftMaxSuccSucc1 (n m : Nat) : Fin (n + 1) → Fin (max n m + 3) :=
+  fun k => if _ : k = n then max n m else k.castLE (by omega)
+def liftMaxSuccSucc2 (n m : Nat) : Fin (m + 1) → Fin (max n m + 3) :=
+  fun k => if _ : k = m then max n m + 1 else k.castLE (by omega)
+def liftExcept3 n : Fin n → Fin (n + 3) :=
+  fun k => Fin.castLE (by omega) k
+
 /-!
 # Term Language
 This file defines the term language the decision procedure operates on,

--- a/SSA/Experimental/Bits/AutoStructs/FormulaToAuto.lean
+++ b/SSA/Experimental/Bits/AutoStructs/FormulaToAuto.lean
@@ -1081,6 +1081,133 @@ def binopAbsNfa (op : Binop) (M1 M2: NFA' n) : NFA' n :=
   | .impl => M1.neg.union M2
   | .equiv => (M1.neg.union M2).inter (M2.neg.union M1)
 
+
+def liftOp n : Fin (n + 1) → Fin (n + 3) :=
+  fun k =>
+    if k = n then Fin.last (n+2) else k.castLE (by omega)
+
+def liftUnop n : Fin (n + 1) → Fin (n + 2) :=
+  fun k =>
+    if k = n then Fin.last (n+1) else k.castLE (by omega)
+
+def nfaOfTerm (t : Term) : CNFA (t.arity + 1) :=
+  match t with
+  | .var n => FSM.ofTerm (.var n) |> CNFA.ofFSM
+  | .zero => FSM.ofTerm .zero |> CNFA.ofFSM
+  | .negOne => FSM.ofTerm .negOne |> CNFA.ofFSM
+  | .one => FSM.ofTerm .one |> CNFA.ofFSM
+  | .ofNat n => FSM.ofTerm (.ofNat n) |> CNFA.ofFSM
+  | .and t₁ t₂ =>
+    let m₁ := nfaOfTerm t₁
+    let m₂ := nfaOfTerm t₂
+    let m : CNFA 3 := FSM.ofTerm (.and (.var 0) (.var 1)) |> CNFA.ofFSM
+    let f₁ := liftMaxSuccSucc1 (FinEnum.card $ Fin t₁.arity) (FinEnum.card $ Fin t₂.arity)
+    let m1' := m₁.lift f₁
+    let f₂ := liftMaxSuccSucc2 (FinEnum.card $ Fin t₁.arity) (FinEnum.card $ Fin t₂.arity)
+    let m2' := m₂.lift f₂
+    let mop := m.lift $ liftLast3 (max (FinEnum.card (Fin t₁.arity)) (FinEnum.card (Fin t₂.arity)))
+    let m := CNFA.inter m1' m2' |> CNFA.inter mop
+    let mfinal := m.proj (liftOp _)
+    mfinal.minimize
+  | .or t₁ t₂ =>
+    let m₁ := nfaOfTerm t₁
+    let m₂ := nfaOfTerm t₂
+    let m : CNFA 3 := FSM.ofTerm (.or (.var 0) (.var 1)) |> CNFA.ofFSM
+    let f₁ := liftMaxSuccSucc1 (FinEnum.card $ Fin t₁.arity) (FinEnum.card $ Fin t₂.arity)
+    let m1' := m₁.lift f₁
+    let f₂ := liftMaxSuccSucc2 (FinEnum.card $ Fin t₁.arity) (FinEnum.card $ Fin t₂.arity)
+    let m2' := m₂.lift f₂
+    let mop := m.lift $ liftLast3 (max (FinEnum.card (Fin t₁.arity)) (FinEnum.card (Fin t₂.arity)))
+    let m := CNFA.inter m1' m2' |> CNFA.inter mop
+    let mfinal := m.proj (liftOp _)
+    mfinal.minimize
+  | .xor t₁ t₂ =>
+    let m₁ := nfaOfTerm t₁
+    let m₂ := nfaOfTerm t₂
+    let m : CNFA 3 := FSM.ofTerm (.xor (.var 0) (.var 1)) |> CNFA.ofFSM
+    let f₁ := liftMaxSuccSucc1 (FinEnum.card $ Fin t₁.arity) (FinEnum.card $ Fin t₂.arity)
+    let m1' := m₁.lift f₁
+    let f₂ := liftMaxSuccSucc2 (FinEnum.card $ Fin t₁.arity) (FinEnum.card $ Fin t₂.arity)
+    let m2' := m₂.lift f₂
+    let mop := m.lift $ liftLast3 (max (FinEnum.card (Fin t₁.arity)) (FinEnum.card (Fin t₂.arity)))
+    let m := CNFA.inter m1' m2' |> CNFA.inter mop
+    let mfinal := m.proj (liftOp _)
+    mfinal.minimize
+  | .add t₁ t₂ =>
+    let m₁ := nfaOfTerm t₁
+    let m₂ := nfaOfTerm t₂
+    let m : CNFA 3 := FSM.ofTerm (.add (.var 0) (.var 1)) |> CNFA.ofFSM
+    let f₁ := liftMaxSuccSucc1 (FinEnum.card $ Fin t₁.arity) (FinEnum.card $ Fin t₂.arity)
+    let m1' := m₁.lift f₁
+    let f₂ := liftMaxSuccSucc2 (FinEnum.card $ Fin t₁.arity) (FinEnum.card $ Fin t₂.arity)
+    let m2' := m₂.lift f₂
+    let mop := m.lift $ liftLast3 (max (FinEnum.card (Fin t₁.arity)) (FinEnum.card (Fin t₂.arity)))
+    let m := CNFA.inter m1' m2' |> CNFA.inter mop
+    let mfinal := m.proj (liftOp _)
+    mfinal.minimize
+  | .sub t₁ t₂ =>
+    let m₁ := nfaOfTerm t₁
+    let m₂ := nfaOfTerm t₂
+    let m : CNFA 3 := FSM.ofTerm (.sub (.var 0) (.var 1)) |> CNFA.ofFSM
+    let f₁ := liftMaxSuccSucc1 (FinEnum.card $ Fin t₁.arity) (FinEnum.card $ Fin t₂.arity)
+    let m1' := m₁.lift f₁
+    let f₂ := liftMaxSuccSucc2 (FinEnum.card $ Fin t₁.arity) (FinEnum.card $ Fin t₂.arity)
+    let m2' := m₂.lift f₂
+    let mop := m.lift $ liftLast3 (max (FinEnum.card (Fin t₁.arity)) (FinEnum.card (Fin t₂.arity)))
+    let m := CNFA.inter m1' m2' |> CNFA.inter mop
+    let mfinal := m.proj (liftOp _)
+    mfinal.minimize
+  | .neg t =>
+    let m := nfaOfTerm t
+    let mop : CNFA 2 := FSM.ofTerm (.neg (.var 0)) |> CNFA.ofFSM
+    let m : CNFA (t.arity + 2) := m.lift (λ i ↦ i.castLE (by omega))
+    let mop : CNFA (t.arity + 2) := mop.lift (λ i ↦ i + t.arity)
+    let m := CNFA.inter m mop
+    let mfinal := m.proj (liftUnop t.arity)
+    mfinal.minimize
+  | .not t =>
+    let m := nfaOfTerm t
+    let mop : CNFA 2 := FSM.ofTerm (.not (.var 0)) |> CNFA.ofFSM
+    let m : CNFA (t.arity + 2) := m.lift (λ i ↦ i.castLE (by omega))
+    let mop : CNFA (t.arity + 2) := mop.lift (λ i ↦ i + t.arity)
+    let m := CNFA.inter m mop
+    let mfinal := m.proj (liftUnop t.arity)
+    mfinal.minimize
+  | .shiftL t k =>
+    let m := nfaOfTerm t
+    let mop : CNFA 2 := FSM.ofTerm (.shiftL (.var 0) k) |> CNFA.ofFSM
+    let m : CNFA (t.arity + 2) := m.lift (λ i ↦ i.castLE (by omega))
+    let mop : CNFA (t.arity + 2) := mop.lift (λ i ↦ i + t.arity)
+    let m := CNFA.inter m mop
+    let mfinal := m.proj (liftUnop t.arity)
+    mfinal.minimize
+
+def nfaOfFormula' (φ : Formula) : CNFA φ.arity :=
+  match φ with
+  | .width wp n => CNFA.autWidth wp n
+  | .atom rel t1 t2 =>
+    let m1 := nfaOfTerm t1
+    let m2 := nfaOfTerm t2
+    let f1 := liftMaxSucc1 (FinEnum.card $ Fin t1.arity) (FinEnum.card $ Fin t2.arity)
+    let m1' := m1.lift f1
+    let f2 := liftMaxSucc2 (FinEnum.card $ Fin t1.arity) (FinEnum.card $ Fin t2.arity)
+    let m2' := m2.lift f2
+    let meq := rel.autOfRelation.lift $ liftLast2 (max (FinEnum.card (Fin t1.arity)) (FinEnum.card (Fin t2.arity)))
+    let m := CNFA.inter m1' m2' |> CNFA.inter meq
+    let mfinal := m.proj (liftExcept2 _)
+    mfinal
+  | .msbSet t =>
+    let m := (termEvalEqFSM t).toFSM |> CNFA.ofFSM
+    let mMsb := CNFA.autMsbSet.lift $ fun _ => Fin.last t.arity
+    let res := m.inter mMsb
+    res.proj $ fun n => n.castLE (by simp [Formula.arity, FinEnum.card])
+  | .unop op φ => unopNfa op (nfaOfFormula' φ)
+  | .binop op φ1 φ2 =>
+    let m1 := (nfaOfFormula' φ1).lift $ liftMax1 φ1.arity φ2.arity
+    let m2 := (nfaOfFormula' φ2).lift $ liftMax2 φ1.arity φ2.arity
+    binopNfa op m1 m2
+
+@[implemented_by nfaOfFormula']
 def nfaOfFormula (φ : Formula) : CNFA φ.arity :=
   match φ with
   | .width wp n => CNFA.autWidth wp n

--- a/SSA/Experimental/Bits/FastCopy/Profile.lean
+++ b/SSA/Experimental/Bits/FastCopy/Profile.lean
@@ -17,76 +17,34 @@ open Lean Elab Meta
 
 namespace Copy
 def preds : Array Predicate := #[
-  -- Predicate.eq
-  --   (Term.add
-  --     (Term.sub (Term.neg (Term.not (Term.xor (Term.var 0) (Term.var 1)))) (Term.shiftL (Term.var 1) 1))
-  --     (Term.not (Term.var 0)))
-  --   (Term.sub
-  --     (Term.neg (Term.not (Term.or (Term.var 0) (Term.not (Term.var 1)))))
-  --     (Term.add (Term.and (Term.var 0) (Term.var 1)) (Term.shiftL (Term.and (Term.var 0) (Term.var 1)) 1))),
-  -- 1 *  ~~~x - 2 * (x ^^^ y) + 1 *  ~~~(x &&& y) = 2 *  ~~~(x ||| y) - 1 * (x &&&  ~~~y) := by
-  -- Predicate.eq
-  --   (Term.add
-  --     (Term.sub
-  --       (Term.not (Term.var 0))
-  --       (Term.add (Term.xor (Term.var 0) (Term.var 1)) (Term.xor (Term.var 0) (Term.var 1))))
-  --     (Term.not (Term.and (Term.var 0) (Term.var 1))))
-  --   (Term.sub
-  --     (Term.add (Term.not (Term.or (Term.var 0) (Term.var 1))) (Term.not (Term.or (Term.var 0) (Term.var 1))))
-  --     (Term.and (Term.var 0) (Term.not (Term.var 1)))),
-
-  -- 11 *  ~~~(x &&&  ~~~y) - 9 *  ~~~(x ||| y) + 2 * (x &&&  ~~~y) = 2 *  ~~~y + 11 * y := by
-  -- Predicate.eq
-  --   (Term.add
-  --     (Term.sub
-  --       (Term.add
-  --         (Term.not (Term.and (Term.var 0) (Term.not (Term.var 1))))
-  --         (Term.add
-  --           (Term.shiftL (Term.not (Term.and (Term.var 0) (Term.not (Term.var 1)))) 1)
-  --           (Term.shiftL (Term.shiftL (Term.shiftL (Term.not (Term.and (Term.var 0) (Term.not (Term.var 1)))) 1) 1) 1)))
-  --       (Term.add
-  --         (Term.not (Term.or (Term.var 0) (Term.var 1)))
-  --         (Term.shiftL (Term.shiftL (Term.shiftL (Term.not (Term.or (Term.var 0) (Term.var 1))) 1) 1) 1)))
-  --     (Term.add (Term.and (Term.var 0) (Term.not (Term.var 1))) (Term.and (Term.var 0) (Term.not (Term.var 1)))))
-  --   (Term.add
-  --     (Term.add (Term.not (Term.var 1)) (Term.not (Term.var 1)))
-  --     (Term.add
-  --       (Term.var 1)
-  --       (Term.add (Term.shiftL (Term.var 1) 1) (Term.shiftL (Term.shiftL (Term.shiftL (Term.var 1) 1) 1) 1))))
-    -- 11 *  ~~~(x &&&  ~~~y) - 11 * x + 11 * (x &&&  ~~~y) + 11 * (x &&& y) = 11 *  ~~~(x ||| y) + 11 * y
-    Predicate.binary .eq
-    (Term.add
-      (Term.add
-        (Term.sub
-          (Term.add
-            (Term.not (Term.and (Term.var 0) (Term.not (Term.var 1))))
-            (Term.add
-              (Term.shiftL (Term.not (Term.and (Term.var 0) (Term.not (Term.var 1)))) 1)
-              (Term.shiftL
-                (Term.shiftL (Term.shiftL (Term.not (Term.and (Term.var 0) (Term.not (Term.var 1)))) 1) 1)
-                1)))
-          (Term.add
-            (Term.var 0)
-            (Term.add (Term.shiftL (Term.var 0) 1) (Term.shiftL (Term.shiftL (Term.shiftL (Term.var 0) 1) 1) 1))))
-        (Term.add
-          (Term.and (Term.var 0) (Term.not (Term.var 1)))
-          (Term.add
-            (Term.shiftL (Term.and (Term.var 0) (Term.not (Term.var 1))) 1)
-            (Term.shiftL (Term.shiftL (Term.shiftL (Term.and (Term.var 0) (Term.not (Term.var 1))) 1) 1) 1))))
-      (Term.add
-        (Term.and (Term.var 0) (Term.var 1))
-        (Term.add
-          (Term.shiftL (Term.and (Term.var 0) (Term.var 1)) 1)
-          (Term.shiftL (Term.shiftL (Term.shiftL (Term.and (Term.var 0) (Term.var 1)) 1) 1) 1))))
-    (Term.add
-      (Term.add
-        (Term.not (Term.or (Term.var 0) (Term.var 1)))
-        (Term.add
-          (Term.shiftL (Term.not (Term.or (Term.var 0) (Term.var 1))) 1)
-          (Term.shiftL (Term.shiftL (Term.shiftL (Term.not (Term.or (Term.var 0) (Term.var 1))) 1) 1) 1)))
-      (Term.add
-        (Term.var 1)
-        (Term.add (Term.shiftL (Term.var 1) 1) (Term.shiftL (Term.shiftL (Term.shiftL (Term.var 1) 1) 1) 1))))
+(Copy.Predicate.binary Copy.BinaryPredicate.eq
+                  (((((((((((Copy.Term.var 0).or (Copy.Term.var 1)).add
+                                                    ((((Copy.Term.var 0).or (Copy.Term.var 1)).shiftL 1).add
+                                                      (((((Copy.Term.var 0).or (Copy.Term.var 1)).shiftL 1).shiftL
+                                                            1).shiftL
+                                                        1))).add
+                                                (((Copy.Term.var 0).xor (Copy.Term.var 1)).not.add
+                                                  (((Copy.Term.var 0).xor (Copy.Term.var 1)).not.shiftL 1))).add
+                                            ((Copy.Term.var 0).xor (Copy.Term.var 1))).sub
+                                        ((Copy.Term.var 1).add ((Copy.Term.var 1).shiftL 1))).add
+                                    (((Copy.Term.var 0).and (Copy.Term.var 1).not).not.add
+                                      (((Copy.Term.var 0).and (Copy.Term.var 1).not).not.shiftL 1))).add
+                                ((Copy.Term.var 0).add
+                                  (((Copy.Term.var 0).shiftL 1).add
+                                    ((((Copy.Term.var 0).shiftL 1).shiftL 1).shiftL 1)))).sub
+                            ((((Copy.Term.var 0).or (Copy.Term.var 1)).not.shiftL 1).add
+                              (((((Copy.Term.var 0).or (Copy.Term.var 1)).not.shiftL 1).shiftL 1).shiftL 1))).sub
+                        ((((((Copy.Term.var 0).or (Copy.Term.var 1).not).not.shiftL 1).shiftL 1).shiftL 1).shiftL
+                          1)).sub
+                    (((Copy.Term.var 0).and (Copy.Term.var 1)).add
+                      ((((((Copy.Term.var 0).and (Copy.Term.var 1)).shiftL 1).shiftL 1).shiftL 1).add
+                        ((((((Copy.Term.var 0).and (Copy.Term.var 1)).shiftL 1).shiftL 1).shiftL 1).shiftL 1))))
+                  ((((Copy.Term.var 0).and (Copy.Term.var 1).not).add
+                        ((((Copy.Term.var 0).and (Copy.Term.var 1).not).shiftL 1).add
+                          (((((Copy.Term.var 0).and (Copy.Term.var 1).not).shiftL 1).shiftL 1).add
+                            ((((((Copy.Term.var 0).and (Copy.Term.var 1).not).shiftL 1).shiftL 1).shiftL 1).shiftL
+                              1)))).sub
+                    (((Copy.Term.var 0).not.shiftL 1).shiftL 1)))
   ]
 
 def timeElapsedMs (x : IO α) : IO (α × Int) := do
@@ -95,6 +53,8 @@ def timeElapsedMs (x : IO α) : IO (α × Int) := do
     let tEnd ← IO.monoMsNow
     return (b, tEnd - tStart)
 
+end Copy
+open Copy
 /-!
 We disable closed term extraction to make sure that the evaluation of
 FSM.decideAllZeroes is not lifted into a top-level closed term whose value is computed at initialization.
@@ -103,24 +63,18 @@ set_option compiler.extract_closed false in
 unsafe def main : IO Unit := do
   initSearchPath (← findSysroot)
   Lean.withImportModules #[{ module := `Lean.Elab.Tactic.BVDecide}, {module := `Std.Tactic.BVDecide}]
-      (opts := {}) (trustLevel := 0) fun env => do
-    let ctxCore : Core.Context := { fileName := "SynthCadicalFile", fileMap := FileMap.ofString "" }
-    let sCore : Core.State :=  { env }
-    let ctxMeta : Meta.Context := {}
-    let sMeta : Meta.State := {}
-    let ctxTerm : Term.Context :=  { declName? := .some (Name.mkSimple s!"problem")}
-    let sTerm : Term.State := {}
+      (opts := {}) (trustLevel := 0) fun _env => do
     for p in preds do
       IO.println (repr p)
-      for i in [0:1] do
-        IO.println s!"Iteration #{i + 1} of Running Algorithm"
-        let fsm := predicateEvalEqFSM p
-        -- let (bPure, tElapsedPure) ← timeElapsedMs (IO.lazyPure fun () => decideIfZeros fsm.toFSM)
-        let (bCadical, tElapsedCadical) ← timeElapsedMs do
-          let (b, _coreState, _metaState, _termState) ←
-            fsm.toFSM.decideIfZerosMCadical |>.toIO ctxCore sCore ctxMeta sMeta ctxTerm sTerm
-          return b
-        -- IO.println s!" (pure)     is all zeroes: '{bPure}' | time: '{tElapsedPure}' ms"
-        IO.println s!" (cadical)  is all zeroes: '{bCadical}' | time: '{tElapsedCadical}' ms"
-        IO.println "--"
+      let tStart ← IO.monoMsNow
+      let nfa := nfaOfFormula (AutoStructs.formula_of_predicate p)
+      let tMid ← IO.monoMsNow
+      IO.println s!"It took {tMid - tStart}ms to compute the {nfa.m.stateMax} states of the NFA"
+      let nfa := nfa.minimize
+      let tMid' ← IO.monoMsNow
+      IO.println s!"It took {tMid' - tMid}ms to determinize the NFA, into {nfa.m.stateMax} states"
+      let res := nfa.isUniversal
+      let tEnd ← IO.monoMsNow
+      IO.println s!"It took {tEnd - tMid'}ms to compute whether the NFA is universal: {res}"
+      IO.println "--"
   return ()

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -41,6 +41,10 @@ name = "bv-circuit-profile"
 root = "SSA.Experimental.Bits.Fast.Profile"
 
 [[lean_exe]]
+name = "bv-classic-profile"
+root = "SSA.Experimental.Bits.FastCopy.Profile"
+
+[[lean_exe]]
 name = "opt"
 root = "SSA.Projects.InstCombine.LLVM.Opt"
 supportInterpreter = true


### PR DESCRIPTION
This PR improves the performance of the automata based decision procedure for bitvectors: it solves all the 2500 tests of dataset2.

It is achieved by:
- using HashSets in the determinization procedure
- constructing the NFA for the terms using NFA constructions instead of FSM
- (related) minimize the NFA at each step of the interpretation of terms

Note: I still need to prove the correctness of these changes.