### PR TITLE
feat: Try to build smaller circuit for bv_automata_circuit

### DIFF
--- a/SSA/Experimental/Bits/Fast/Reflect.lean
+++ b/SSA/Experimental/Bits/Fast/Reflect.lean
@@ -1081,9 +1081,9 @@ open Lean Meta Elab Tactic
 
 inductive CircuitBackend
 /-- Pure lean implementation, verified. -/
-| lean 
+| lean
 /-- bv_decide based backend. Currently unverified. -/
-| cadical 
+| cadical
 /-- Dry run, do not execute and close proof with `sorry` -/
 | dryrun
 deriving Repr, DecidableEq
@@ -1543,8 +1543,8 @@ def checkCircuitSatAux [DecidableEq α] [Hashable α] [Fintype α] (c : Circuit 
     let ⟨entrypoint, _hEntrypoint⟩ := c.toAIG AIG.empty
     let ⟨entrypoint, _labelling⟩ := entrypoint.relabelNat'
     let cnf := toCNF entrypoint
-    let out ← runExternal cnf cfg.solver cfg.lratPath 
-      (trimProofs := true) 
+    let out ← runExternal cnf cfg.solver cfg.lratPath
+      (trimProofs := true)
       (timeout := cadicalTimeoutSec)
       (binaryProofs := true)
     match out with
@@ -1587,28 +1587,28 @@ partial def decideIfZerosAuxTermElabM {arity : Type _} [DecidableEq arity] [Fint
     (p : FSM arity) (c : Circuit (p.α ⊕ β))  (iter : Nat) : TermElabM Bool := do
   IO.eprintln s!"## K-induction (iter {iter})"
   IO.eprintln s!"Evaluating circuit of size '{c.size}' on initial state"
-  let cInit := c.assignVars fun v hv => 
-    match v with 
+  let cInit := c.assignVars fun v hv =>
+    match v with
     | .inl a => .inr (p.initCarry a)
     | .inr b => .inl b
   if ← checkCircuitSatAux cInit
-  then 
+  then
     IO.println s!"Safety property failed on initial state."
     return false
   else
     IO.println s!"Safety property succeeded on initial state. Building next state circuit..."
     let tStart ← IO.monoMsNow
-    let cNext : Circuit (p.α ⊕ (β ⊕ arity)) := 
+    let cNext : Circuit (p.α ⊕ (β ⊕ arity)) :=
       c.bind fun v =>
         match v with
-        | .inl a => p.nextBitCirc (some a) |>.map fun v => 
-          match v with 
-          | .inl a => .inl a 
+        | .inl a => p.nextBitCirc (some a) |>.map fun v =>
+          match v with
+          | .inl a => .inl a
           | .inr x => .inr (.inr x)
         | .inr b => .var true (.inr (.inl b))
     let c : Circuit (p.α ⊕ (β ⊕ arity)) := c.map fun v =>
-      match v with 
-      | .inl a => .inl a 
+      match v with
+      | .inl a => .inl a
       | .inr b => .inr (.inl b)
     let tEnd ← IO.monoMsNow
     let tElapsedSec := (tEnd - tStart) / 1000
@@ -1618,7 +1618,7 @@ partial def decideIfZerosAuxTermElabM {arity : Type _} [DecidableEq arity] [Fint
     let le ← Circuit.decLeCadical cNext c
     let tEnd ← IO.monoMsNow
     let tElapsedSec := (tEnd - tStart) / 1000
-    if h : le then 
+    if h : le then
       IO.eprintln s!"Inductive invariant established! (time={tElapsedSec}s)"
       return true
     else
@@ -1706,7 +1706,7 @@ def reflectUniversalWidthBVs (g : MVarId) (cfg : Config) : TermElabM (List MVarI
     let fsm := predicateEvalEqFSM result.e |>.toFSM
     logInfo f!"{fsm.format}'"
 
-    match cfg.backend with 
+    match cfg.backend with
     | .dryrun =>
         g.assign (← mkSorry (← g.getType) (synthetic := false))
         logInfo "Closing goal with 'sorry' for dry-run"

--- a/SSA/Experimental/Bits/Fast/Reflect.lean
+++ b/SSA/Experimental/Bits/Fast/Reflect.lean
@@ -1109,7 +1109,7 @@ structure Config where
   /--
   Whether the tactic should use the (currently unverified) bv_decide based backend for solving constraints.
   -/
-  backend : CircuitBackend := .lean
+  backend : CircuitBackend := .cadical
 
 /-- Default user configuration -/
 def Config.default : Config := {}
@@ -1575,63 +1575,66 @@ An axiom that tracks that a theorem is true because of our currently unverified
 -/
 axiom decideIfZerosMAx {p : Prop} : p
 
-def Circuit.decLeCadical {α : Type} [DecidableEq α] [Fintype α] [Hashable α]
+def Circuit.impliesCadical {α : Type} [DecidableEq α] [Fintype α] [Hashable α]
   (c : Circuit α) (c' : Circuit α) : TermElabM { b : Bool // b ↔ c ≤ c' } := do
  -- Justified by Circuit.le_iff_implies
+ -- c = 0 => c' = 0
+ -- !c => !c'
+ -- !!c || !c'
+ -- c || !c'
+ -- c' => c
  let impliesCircuit := c.implies c'
  let ret ← checkCircuitTautoAux impliesCircuit
  return ⟨ret, decideIfZerosMAx⟩
 
 partial def decideIfZerosAuxTermElabM {arity : Type _} [DecidableEq arity] [Fintype arity] [Hashable arity]
   [DecidableEq β] [Fintype β] [Hashable β]
-    (p : FSM arity) (c : Circuit (p.α ⊕ β))  (iter : Nat) : TermElabM Bool := do
+    (p : FSM arity) (c0K : Circuit (p.α ⊕ β)) (cK : Circuit (p.α ⊕ β))  (iter : Nat) : TermElabM Bool := do
   IO.eprintln s!"## K-induction (iter {iter})"
-  IO.eprintln s!"Evaluating circuit of size '{c.size}' on initial state"
-  let cInit := c.assignVars fun v hv =>
+  IO.eprintln s!"Evaluating circuit of size '{cK.size}' on initial state"
+  let cKWithInit := cK.assignVars fun v hv =>
     match v with
     | .inl a => .inr (p.initCarry a)
     | .inr b => .inl b
-  if ← checkCircuitSatAux cInit
+  if ← checkCircuitSatAux cKWithInit
   then
     IO.println s!"Safety property failed on initial state."
     return false
   else
     IO.println s!"Safety property succeeded on initial state. Building next state circuit..."
-    let tStart ← IO.monoMsNow
-    let cNext : Circuit (p.α ⊕ (β ⊕ arity)) :=
-      c.bind fun v =>
+    let cKSucc : Circuit (p.α ⊕ (β ⊕ arity)) :=
+      cK.bind fun v =>
         match v with
         | .inl a => p.nextBitCirc (some a) |>.map fun v =>
           match v with
           | .inl a => .inl a
           | .inr x => .inr (.inr x)
         | .inr b => .var true (.inr (.inl b))
-    let c : Circuit (p.α ⊕ (β ⊕ arity)) := c.map fun v =>
-      match v with
-      | .inl a => .inl a
-      | .inr b => .inr (.inl b)
+    let c0KAdapted : Circuit (p.α ⊕ (β ⊕ arity)) := c0K.map fun v =>
+       match v with
+       | .inl a => .inl a
+       | .inr b => .inr (.inl b)
+    let tStart ← IO.monoMsNow
     let tEnd ← IO.monoMsNow
     let tElapsedSec := (tEnd - tStart) / 1000
-    IO.eprintln s!"Built state circuit of size: '{cNext.size}' (time={tElapsedSec}s)"
+    IO.eprintln s!"Built state circuit of size: '{c0KAdapted.size + cKSucc.size}' (time={tElapsedSec}s)"
     IO.eprintln s!"Establishing inductive invariant with cadical..."
     let tStart ← IO.monoMsNow
-    let le ← Circuit.decLeCadical cNext c
+    -- c = 0 => c' = 0
+    -- !c => !c'
+    -- !!c || !c'
+    -- c || !c'
+    -- c' => c
+    let impliesCircuit := cKSucc.implies c0KAdapted
+    let le ← checkCircuitTautoAux impliesCircuit
     let tEnd ← IO.monoMsNow
     let tElapsedSec := (tEnd - tStart) / 1000
-    if h : le then
+    if le then
       IO.eprintln s!"Inductive invariant established! (time={tElapsedSec}s)"
       return true
     else
-      -- have _wf : card_compl (cNext ||| c) < card_compl c :=
-      --   have := le.prop
-      --   have hNotLt : ¬ cNext ≤ c := by
-      --     simp at h
-      --     have := this.not
-      --     simp at this
-      --     exact this.mp h
-      --   decideIfZeroAux_wf hNotLt
       IO.eprintln s!"Unable to establish inductive invariant (time={tElapsedSec}s). Recursing..."
-      decideIfZerosAuxTermElabM p (cNext ||| c) (iter + 1)
+      decideIfZerosAuxTermElabM p (c0KAdapted ||| cKSucc) cKSucc (iter + 1)
   -- termination_by sorry -- card_compl c
 
 def decideIfZerosM {arity : Type _} [DecidableEq arity] [Monad m]
@@ -1641,10 +1644,10 @@ def decideIfZerosM {arity : Type _} [DecidableEq arity] [Monad m]
   decideIfZerosAuxM decLe p (p.nextBitCirc none).fst
 
 def _root_.FSM.decideIfZerosMCadical  {arity : Type _} [DecidableEq arity]  [Fintype arity] [Hashable arity] (fsm : FSM arity) : TermElabM Bool :=
-  -- decideIfZerosM Circuit.decLeCadical fsm
+  -- decideIfZerosM Circuit.impliesCadical fsm
   withTraceNode `bv_automata_circuit (fun _ => return "k-induction") (collapsed := true) do
     let c : Circuit (fsm.α ⊕ Empty) := (fsm.nextBitCirc none).fst.map Sum.inl
-    decideIfZerosAuxTermElabM fsm c 1
+    decideIfZerosAuxTermElabM fsm c c 1
 
 end BvDecide
 

--- a/SSA/Experimental/Bits/Fast/Reflect.lean
+++ b/SSA/Experimental/Bits/Fast/Reflect.lean
@@ -1109,7 +1109,7 @@ structure Config where
   /--
   Whether the tactic should use the (currently unverified) bv_decide based backend for solving constraints.
   -/
-  backend : CircuitBackend := .cadical
+  backend : CircuitBackend := .lean
 
 /-- Default user configuration -/
 def Config.default : Config := {}
@@ -1592,7 +1592,7 @@ partial def decideIfZerosAuxTermElabM {arity : Type _} [DecidableEq arity] [Fint
     (p : FSM arity) (c0K : Circuit (p.α ⊕ β)) (cK : Circuit (p.α ⊕ β))  (iter : Nat) : TermElabM Bool := do
   IO.eprintln s!"## K-induction (iter {iter})"
   IO.eprintln s!"Evaluating circuit of size '{cK.size}' on initial state"
-  let cKWithInit := cK.assignVars fun v hv =>
+  let cKWithInit := cK.assignVars fun v _hv =>
     match v with
     | .inl a => .inr (p.initCarry a)
     | .inr b => .inl b


### PR DESCRIPTION
I believe the old circuit was establishing a much stronger inductive invariant than necessary, of the form $$S(0) \land S(1) \dots \land S(k) \implies S(0) \land S(1) \dots \land S(k) \land S(k + 1)$$.

We now establish the invariant $$S(0) \land S(1) \dots \land S(k) \implies S(k + 1)$$ which is of course sufficient. This should build a much smaller SAT formula than previously. 