### PR TITLE
feat: tweak runner.py for MBA eval

### DIFF
--- a/SSA/Experimental/Bits/Fast/Dataset2/runner.py
+++ b/SSA/Experimental/Bits/Fast/Dataset2/runner.py
@@ -53,15 +53,16 @@ async def run_lake_build(db, git_root_dir, semaphore, timeout, i_test, n_tests, 
         """, (filename, timeout))
         # Fetch the result, if no rows exist, the result will be an empty list
         result = cur.fetchone()
-        logging.info(f"[Looking up cached {filename}]  DONE")
         con.close()
 
         # Return True if no row is found (i.e., result is None)
+        logging.info(f"[Looking up cached {filename}]  DONE (cached: {result is not None})")
         if result is not None:
             logging.warning(f"Skipping ({filename}, {timeout}) as run already exists.")
             completed_counter.increment()
             return
 
+        logging.info(f"Running {filename}, no cache found.")
         process = await asyncio.create_subprocess_exec(
             "lake",
             "build",
@@ -122,6 +123,7 @@ import Std.Tactic.BVDecide
 import SSA.Experimental.Bits.Fast.MBA
 
 set_option maxHeartbeats 0
+set_option maxRecDepth 9000
 
 /-
 This dataset was derived from
@@ -224,3 +226,4 @@ if __name__ == "__main__":
     # https://stackoverflow.com/questions/65682221/runtimeerror-exception-ignored-in-function-proactorbasepipetransport
     # asyncio.run(main(args), debug=True)
     logging.debug("done asyncio")
+    logging.info(f"completed run {args}")


### PR DESCRIPTION
This runs the MBA evaluation, increasing `maxRecDepth` to allow our meta-time-reflection to correctly absorb the largest programs in the test suite.

```
2025-01-27 23:25:30,924 - INFO - completed run Namespace(db='run-2025-01-27-23:23:54.sqlite3', prod_run=True, j=90, timeout=60)
bollu@instance-20241102-191016:~/lean-mlir/SSA/Experimental/Bits/Fast/Dataset2$ sqlite3 run-2025-01-27-23:23:54.sqlite3
SQLite version 3.45.1 2024-01-30 16:01:20
Enter ".help" for usage hints.
sqlite> .schema
CREATE TABLE tests (
            filename TEXT,
            timeout INTEGER,
            status TEXT,
            exit_code INTEGER,
            PRIMARY KEY (filename, timeout)  -- Composite primary key
            );
sqlite> select status, count(status) from tests group by status;
success|2500
```