### PR TITLE
feat: alternative, more robust EDSL elaborator 

### DIFF
--- a/SSA/Core/EffectKind.lean
+++ b/SSA/Core/EffectKind.lean
@@ -4,7 +4,7 @@ import Mathlib.Order.Lattice
 inductive EffectKind
 | pure -- pure effects.
 | impure -- impure, lives in IO.
-deriving Repr, DecidableEq
+deriving Repr, DecidableEq, Lean.ToExpr
 
 namespace EffectKind
 

--- a/SSA/Core/ErasedContext.lean
+++ b/SSA/Core/ErasedContext.lean
@@ -86,7 +86,7 @@ def Var (Γ : Ctxt Ty) (t : Ty) : Type :=
   { i : Nat // Γ.get? i = some t }
 
 /-- constructor for Var. -/
-def Var.mk (Γ : Ctxt Ty) (t : Ty) (i : Nat) (hi : Γ.get? i = some t) : Γ.Var t :=
+def Var.mk {Γ : Ctxt Ty} {t : Ty} (i : Nat) (hi : Γ.get? i = some t) : Γ.Var t :=
   ⟨i, hi⟩
 
 namespace Var

--- a/SSA/Core/ErasedContext.lean
+++ b/SSA/Core/ErasedContext.lean
@@ -655,26 +655,35 @@ variable [ToExpr Ty] {Γ : Ctxt Ty} {ty : Ty}
 instance : ToExpr (Ctxt Ty) :=
   inferInstanceAs <| ToExpr (List Ty)
 
+/-- Construct an expression of type `Var Γ ty`.
+
+If no proof `hi : Γ.get? i = some ty` is provided,
+it's assumed to be true by rfl. -/
+def mkVar (Ty : Q(Type)) (Γ : Q(Ctxt $Ty)) (ty : Q($Ty)) (i : Q(Nat))
+    (hi? : Option Q(($Γ).get? $i = some $ty) := none) :
+    Q(($Γ).Var $ty) :=
+  let optTy := mkApp (.const ``Option [0]) Ty
+  let someTy := mkApp2 (.const ``Option.some [0]) Ty ty
+  let P :=
+    let getE := mkApp3 (mkConst ``Ctxt.get?) Ty Γ (.bvar 0)
+    let eq := mkApp3 (.const ``Eq [1]) optTy getE someTy
+    Expr.lam `i (mkConst ``Nat) eq .default
+  let hi := hi?.getD <| /- : Γ.get? i = some ty := rfl -/
+    mkApp2 (.const ``rfl [1]) optTy someTy
+  mkApp4 (.const ``Subtype.mk [1]) (mkConst ``Nat) P i hi
+
 instance : ToExpr (Var Γ ty) where
   toTypeExpr := mkApp3 (mkConst ``Var) (toTypeExpr Ty) (toExpr Γ) (toExpr ty)
   toExpr := fun ⟨i, _hi⟩ =>
     let Ty := toTypeExpr Ty
-    let optTy := mkApp (.const ``Option [0]) Ty
     let Γ := toExpr Γ
     let ty := toExpr ty
     let i := toExpr i
-    let someTy := mkApp2 (.const ``Option.some [0]) Ty ty
-    let hi := /- : Γ.get? i = some ty := rfl -/
-      /- Folklore suggests an explicit proof (instead of `rfl`) would be more
+    /- Folklore suggests an explicit proof (instead of `rfl`) would be more
         efficient, as the kernel might not know what to reduce.
         In this case, though, `ty` should be in normal form by construction,
         thus reduction should be safe. -/
-      mkApp2 (.const ``rfl [1]) optTy someTy
-    let P :=
-      let getE := mkApp3 (mkConst ``Ctxt.get?) Ty Γ (.bvar 0)
-      let eq := mkApp3 (.const ``Eq [1]) optTy getE someTy
-      Expr.lam `i (mkConst ``Nat) eq .default
-    mkApp4 (.const ``Subtype.mk [1]) (mkConst ``Nat) P i hi
+    mkVar Ty Γ ty i
 
 instance : HVector.ToExpr (Var Γ) where
   toTypeExpr := mkApp2 (mkConst ``Var) (toTypeExpr Ty) (toExpr Γ)

--- a/SSA/Core/ErasedContext.lean
+++ b/SSA/Core/ErasedContext.lean
@@ -637,4 +637,36 @@ instance : CoeOut (Var (Γ.dropUntil v) ty) (Var Γ ty) where
   coe v := dropUntilDiff.toHom v
 
 
+/-!
+# ToExpr
+-/
+section ToExpr
+open Lean Qq
+variable [ToExpr Ty] {Γ : Ctxt Ty} {ty : Ty}
+
+instance : ToExpr (Ctxt Ty) :=
+  inferInstanceAs <| ToExpr (List Ty)
+
+instance : ToExpr (Var Γ ty) where
+  toTypeExpr := mkApp3 (mkConst ``Var) (toTypeExpr Ty) (toExpr Γ) (toExpr ty)
+  toExpr := fun ⟨i, _hi⟩ =>
+    let Ty := toTypeExpr Ty
+    let Γ := toExpr Γ
+    let ty := toExpr ty
+    let i := toExpr i
+    let hi := /- : Γ.get? i = some ty := rfl -/
+      /- Folklore suggests an explicit proof (instead of `rfl`) would be more
+        efficient, as the kernel might not know what to reduce.
+        In this case, though, `ty` should be in normal form by construction,
+        thus reduction should be safe. -/
+      let optTy := mkApp (.const ``Option [0]) Ty
+      let getE := mkApp2 (mkConst ``Ctxt.get?) Γ i
+      mkApp2 (.const ``rfl [1]) optTy getE
+    mkApp5 (mkConst ``Var.mk) Ty Γ ty i hi
+
+instance : HVector.ToExpr (Var Γ) where
+  toTypeExpr := mkApp2 (mkConst ``Var) (toTypeExpr Ty) (toExpr Γ)
+
+end ToExpr
+
 end Ctxt

--- a/SSA/Core/ErasedContext.lean
+++ b/SSA/Core/ErasedContext.lean
@@ -27,6 +27,14 @@ namespace Ctxt
 
 variable {Ty : Type}
 
+/-! ### Inherited Instances-/
+/-- `inherit_instance Foo` wil define an instance of `[Foo Ty] → Foo (Ctxt Ty)`,
+  assuming an instance of `Foo` exists for `List` -/
+local macro "inherit_instance" cls:term : command =>
+  `(instance {Ty : Type} [$cls Ty] : $cls (Ctxt Ty) := inferInstanceAs <| $cls (List Ty))
+inherit_instance Repr
+inherit_instance Lean.ToMessageData
+
 -- def empty : Ctxt := Erased.mk []
 def empty : Ctxt Ty := []
 

--- a/SSA/Core/ErasedContext.lean
+++ b/SSA/Core/ErasedContext.lean
@@ -685,7 +685,7 @@ instance : ToExpr (Var Γ ty) where
         thus reduction should be safe. -/
     mkVar Ty Γ ty i
 
-instance : HVector.ToExpr (Var Γ) where
+instance : HVector.ToExprPi (Var Γ) where
   toTypeExpr := mkApp2 (mkConst ``Var) (toTypeExpr Ty) (toExpr Γ)
 
 end ToExpr

--- a/SSA/Core/ErasedContext.lean
+++ b/SSA/Core/ErasedContext.lean
@@ -660,7 +660,7 @@ instance : ToExpr (Var Γ ty) where
         In this case, though, `ty` should be in normal form by construction,
         thus reduction should be safe. -/
       let optTy := mkApp (.const ``Option [0]) Ty
-      let getE := mkApp2 (mkConst ``Ctxt.get?) Γ i
+      let getE := mkApp3 (mkConst ``Ctxt.get?) Ty Γ i
       mkApp2 (.const ``rfl [1]) optTy getE
     mkApp5 (mkConst ``Var.mk) Ty Γ ty i hi
 

--- a/SSA/Core/Framework/Dialect.lean
+++ b/SSA/Core/Framework/Dialect.lean
@@ -31,15 +31,8 @@ hence needing this extra class.
 -/
 class DialectToExpr (δ : Dialect) [ToExpr δ.Op] [ToExpr δ.Ty] where
   toExprM : Q(Type → Type)
+  toExprDialect : Q(Dialect)
 
 /-- Construct the `Expr` that represents dialect `δ` -/
 def Dialect.toExpr (δ : Dialect) [ToExpr δ.Op] [ToExpr δ.Ty] [DialectToExpr δ] : Q(Dialect) :=
-  let Op : Q(Type) := ToExpr.toTypeExpr δ.Op
-  let Ty : Q(Type) := ToExpr.toTypeExpr δ.Ty
-  let m : Q(Type → Type) := DialectToExpr.toExprM δ
-  q(⟨$Op, $Ty, $m⟩)
-
-/-- Define a default `DialectToExpr` instance for pure dialects -/
-def DialectToExpr.ofPure {d : Dialect} (_isPure : d.m = Id := by rfl)
-    [ToExpr d.Op] [ToExpr d.Ty] : DialectToExpr d where
-  toExprM := q(Id)
+  DialectToExpr.toExprDialect δ

--- a/SSA/Core/Framework/Dialect.lean
+++ b/SSA/Core/Framework/Dialect.lean
@@ -38,3 +38,8 @@ def Dialect.toExpr (δ : Dialect) [ToExpr δ.Op] [ToExpr δ.Ty] [DialectToExpr �
   let Ty : Q(Type) := ToExpr.toTypeExpr δ.Ty
   let m : Q(Type → Type) := DialectToExpr.toExprM δ
   q(⟨$Op, $Ty, $m⟩)
+
+/-- Define a default `DialectToExpr` instance for pure dialects -/
+def DialectToExpr.ofPure {d : Dialect} (_isPure : d.m = Id := by rfl)
+    [ToExpr d.Op] [ToExpr d.Ty] : DialectToExpr d where
+  toExprM := q(Id)

--- a/SSA/Core/Framework/ToExpr.lean
+++ b/SSA/Core/Framework/ToExpr.lean
@@ -1,0 +1,94 @@
+/-
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import SSA.Core.Framework
+import Qq
+
+/-!
+## ToExpr instances
+Define a `ToExpr` instance for core datastructures
+
+-/
+open Lean (ToExpr toExpr MetaM mkAppN mkConst mkApp mkApp2 mkApp6)
+open Qq
+
+variable {d : Dialect} [DialectSignature d]
+  [Lean.ToExpr d.Ty] [Lean.ToExpr d.Op] [DialectToExpr d]
+
+set_option pp.rawOnError true
+
+private def effLeToExpr {eff eff' : EffectKind} (h : eff ≤ eff') : Q($eff ≤ $eff') :=
+  sorry
+
+mutual
+
+def Com.toExprAux {Γ : Ctxt d.Ty} {eff : EffectKind} {ty : d.Ty}
+    (dE : Q(Dialect) := d.toExpr)
+    (sig : Q(DialectSignature $dE))
+    (com : Com d Γ eff ty) : Lean.Expr :=
+  let ΓE : Q(Ctxt ($dE).Ty) := Lean.toExpr Γ
+  let tyE : Q(($dE).Ty) := Lean.toExpr ty
+  let effE : Q(EffectKind) := Lean.toExpr eff
+  match com with
+  | .ret v =>
+    let v := toExpr v
+    mkAppN (mkConst ``Com.ret) #[dE, sig, ΓE, tyE, effE, v]
+  | .var e body =>
+    let e := e.toExprAux dE sig
+    let body := body.toExprAux dE sig
+    mkAppN (mkConst ``Com.ret) #[dE, sig, ΓE, tyE, effE, e, body]
+decreasing_by all_goals sorry
+
+def Expr.toExprAux {Γ : Ctxt d.Ty} {eff : EffectKind} {ty : d.Ty}
+    (dE : Q(Dialect) := d.toExpr)
+    (sig : Q(DialectSignature $dE))
+    : Expr d Γ eff ty → Lean.Expr :=
+  let ΓE : Q(Ctxt ($dE).Ty) := Lean.toExpr Γ
+  let tyE : Q(($dE).Ty) := Lean.toExpr ty
+  let effE : Q(EffectKind) := Lean.toExpr eff
+  fun
+  | ⟨op, _ty_eq, eff_le, args, regArgs⟩ =>
+    let Ty := mkApp (mkConst ``Dialect.Ty) dE
+    let ty_eq : Lean.Expr := mkApp2 (.const ``rfl [1]) Ty tyE
+    let eff_le := effLeToExpr eff_le
+
+    let regArgs := Regions.toExprAux dE sig regArgs
+
+    mkAppN (mkConst ``Expr.mk) #[
+      dE, sig, effE, ΓE, tyE, toExpr op, ty_eq, eff_le, toExpr args, regArgs
+    ]
+decreasing_by sorry
+
+def Regions.toExprAux {regSig : List (Ctxt d.Ty × d.Ty)}
+    (dE : Q(Dialect) := d.toExpr)
+    (sig : Q(DialectSignature $dE))
+    (regs : HVector (fun (t : _ × _) => Com d t.1 EffectKind.impure t.2) regSig) :
+    Lean.Expr :=
+  let Ty := Lean.toTypeExpr d.Ty
+  let A : Lean.Expr := q(fun (t : _ × _) => Com $dE t.1 EffectKind.impure t.2)
+  match regSig, regs with
+  | [], .nil =>
+    mkApp2 (.const ``HVector.nil [0,0]) Ty A
+  | a::as, .cons x xs =>
+    let a := Lean.toExpr a
+    let as := Lean.toExpr as
+    let x := x.toExprAux dE sig
+    let xs := Regions.toExprAux dE sig xs
+    mkApp6 (.const ``HVector.cons [0,0]) Ty A as a x xs
+decreasing_by all_goals sorry
+
+end
+
+variable {Γ : Ctxt d.Ty} {eff : EffectKind} {ty : d.Ty}
+
+/-- Build a (Lean) `Expr` to represent a LeanMLIR program -/
+def Com.toExpr (com : Com d Γ eff ty) : MetaM Lean.Expr := do
+  let dE := d.toExpr
+  let sig ← synthInstanceQ q(DialectSignature $dE)
+  return com.toExprAux dE sig
+
+/-- Build a (Lean) `Expr` to represent a LeanMLIR expression -/
+def Expr.toExpr (expr : Expr d Γ eff ty) : MetaM Lean.Expr := do
+  let dE := d.toExpr
+  let sig ← synthInstanceQ q(DialectSignature $dE)
+  return expr.toExprAux dE sig

--- a/SSA/Core/Framework/ToExpr.lean
+++ b/SSA/Core/Framework/ToExpr.lean
@@ -33,10 +33,11 @@ partial def Com.toExprAux {Γ : Ctxt d.Ty} {eff : EffectKind} {ty : d.Ty}
   | .ret v =>
     let v := toExpr v
     mkAppN (mkConst ``Com.ret) #[dE, sig, ΓE, tyE, effE, v]
-  | .var e body =>
+  | .var (α := eTy) e body =>
+    let eTyE := toExpr eTy
     let e := e.toExprAux dE sig
     let body := body.toExprAux dE sig
-    mkAppN (mkConst ``Com.ret) #[dE, sig, ΓE, tyE, effE, e, body]
+    mkAppN (mkConst ``Com.var) #[dE, sig, ΓE, effE, eTyE, tyE, e, body]
 
 partial def Expr.toExprAux {Γ : Ctxt d.Ty} {eff : EffectKind} {ty : d.Ty}
     (dE : Q(Dialect) := d.toExpr)

--- a/SSA/Core/Framework/ToExpr.lean
+++ b/SSA/Core/Framework/ToExpr.lean
@@ -15,10 +15,10 @@ open Qq
 variable {d : Dialect} [DialectSignature d]
   [Lean.ToExpr d.Ty] [Lean.ToExpr d.Op] [DialectToExpr d]
 
-set_option pp.rawOnError true
-
-private def effLeToExpr {eff eff' : EffectKind} (h : eff ≤ eff') : Q($eff ≤ $eff') :=
-  sorry
+private def effLeToExpr : {eff eff' : EffectKind} → (h : eff ≤ eff') → Q($eff ≤ $eff')
+  | .impure, .impure, _ => q(EffectKind.le_refl .impure)
+  | .pure, .pure, _     => q(EffectKind.le_refl .pure)
+  | .pure, .impure, _   => q(EffectKind.pure_le .impure)
 
 mutual
 

--- a/SSA/Core/Framework/ToExpr.lean
+++ b/SSA/Core/Framework/ToExpr.lean
@@ -9,7 +9,7 @@ import Qq
 Define a `ToExpr` instance for core datastructures
 
 -/
-open Lean (ToExpr toExpr MetaM mkAppN mkConst mkApp mkApp2 mkApp6)
+open Lean (ToExpr toExpr MetaM mkAppN mkConst mkApp mkApp2 mkApp3 mkApp4 mkApp6)
 open Qq
 
 variable {d : Dialect} [DialectSignature d]
@@ -58,32 +58,63 @@ def DialectMetaMorphism.id (d : Dialect) [DialectSignature d]
   mapOp := toExpr
   mapTy := toExpr
 
+/-- Obtain an Lean expression of a list, from a list of Lean expressions. -/
+protected def List.foldToExpr {α : Q(Type)} : List Q($α) → Q(List $α) :=
+  List.foldr (fun a as => q($a :: $as)) q([])
+/-- Obtain an Lean expression of a product, from a product of Lean expressions. -/
+protected def Prod.foldToExpr {α β : Q(Type)} : Q($α) × Q($β) → Q($α × $β) :=
+  Function.uncurry <| mkApp4 (.const ``Prod [1,1]) α β
 
-variable {d'} (f : DialectMetaMorphism d d') in
+namespace DialectMetaMorphism
+
+variable {d'} (f : DialectMetaMorphism d d')
+
+def mapList (Γ : List d.Ty) : Q(List $(d').Ty) := (f.mapTy <$> Γ).foldToExpr
+def mapCtxt : (Γ : Ctxt d.Ty) → Q(Ctxt $(d').Ty) := f.mapList
+
+def mapVar {Γ : Ctxt d.Ty} (v : Γ.Var ty) : Q(Ctxt.Var $(f.mapCtxt Γ) $(f.mapTy ty)) :=
+  let Ty := q(($d').Ty)
+  let Γ := f.mapCtxt Γ
+  let ty := f.mapTy ty
+  let i := toExpr v.1
+  Ctxt.mkVar Ty Γ ty i none
+
+def mapArgs {Γ : Ctxt d.Ty} {argSig} (args : HVector (Γ.Var) argSig) :
+    Lean.Expr :=
+  let Ty : Q(Type) := q(($d').Ty)
+  let Γ := f.mapCtxt Γ
+  let A : Q($Ty → Type) := q(($Γ).Var)
+  let nil : (ts : Q(List $Ty)) × Q(HVector $A $ts) := ⟨q([]), q(.nil)⟩
+  let res := (args.foldr · nil) <| fun t v ⟨ts, xs⟩ =>
+    let t := f.mapTy t
+    let v := Ctxt.mkVar Ty Γ t (toExpr v.1) none
+    ⟨q($t :: $ts), q($v ::ₕ $xs)⟩
+  res.snd
+
+end DialectMetaMorphism
+
+variable {d'} (f : DialectMetaMorphism d d')
+  (dE : Q(Dialect)) (sig : Q(DialectSignature $dE)) in
 mutual
 
 partial def Com.toExprAux {Γ : Ctxt d.Ty} {eff : EffectKind} {ty : d.Ty}
-    (dE : Q(Dialect) := d.toExpr)
-    (sig : Q(DialectSignature $dE))
     (com : Com d Γ eff ty) : Lean.Expr :=
-  let ΓE : Q(Ctxt ($dE).Ty) := Lean.toExpr Γ
-  let tyE : Q(($dE).Ty) := Lean.toExpr ty
+  let ΓE : Q(Ctxt ($dE).Ty) := f.mapCtxt Γ
+  let tyE : Q(($dE).Ty) := f.mapTy ty
   let effE : Q(EffectKind) := Lean.toExpr eff
   match com with
   | .ret v =>
-    let v := toExpr v
+    let v := f.mapVar v
     mkAppN (mkConst ``Com.ret) #[dE, sig, ΓE, tyE, effE, v]
   | .var (α := eTy) e body =>
-    let eTyE := toExpr eTy
-    let e := e.toExprAux dE sig
-    let body := body.toExprAux dE sig
+    let eTyE := f.mapTy eTy
+    let e := e.toExprAux
+    let body := body.toExprAux
     mkAppN (mkConst ``Com.var) #[dE, sig, ΓE, effE, eTyE, tyE, e, body]
 
-partial def Expr.toExprAux {Γ : Ctxt d.Ty} {eff : EffectKind} {ty : d.Ty}
-    (dE : Q(Dialect) := d.toExpr)
-    (sig : Q(DialectSignature $dE))
-    : Expr d Γ eff ty → Lean.Expr :=
-  let ΓE : Q(Ctxt ($dE).Ty) := Lean.toExpr Γ
+partial def Expr.toExprAux {Γ : Ctxt d.Ty} {eff : EffectKind} {ty : d.Ty} :
+    Expr d Γ eff ty → Lean.Expr :=
+  let ΓE : Q(Ctxt ($dE).Ty) := f.mapCtxt Γ
   let tyE : Q(($dE).Ty) := f.mapTy ty
   let effE : Q(EffectKind) := Lean.toExpr eff
   fun
@@ -93,15 +124,14 @@ partial def Expr.toExprAux {Γ : Ctxt d.Ty} {eff : EffectKind} {ty : d.Ty}
     let ty_eq : Lean.Expr := mkApp2 (.const ``rfl [1]) Ty tyE
     let eff_le := f.mapEffLe eff_le
 
-    let regArgs := Regions.toExprAux dE sig regArgs
+    let args := f.mapArgs args
+    let regArgs := Regions.toExprAux regArgs
 
     mkAppN (mkConst ``Expr.mk) #[
-      dE, sig, effE, ΓE, tyE, op, ty_eq, eff_le, toExpr args, regArgs
+      dE, sig, effE, ΓE, tyE, op, ty_eq, eff_le, args, regArgs
     ]
 
 partial def Regions.toExprAux {regSig : List (Ctxt d.Ty × d.Ty)}
-    (dE : Q(Dialect) := d.toExpr)
-    (sig : Q(DialectSignature $dE))
     (regs : HVector (fun (t : _ × _) => Com d t.1 EffectKind.impure t.2) regSig) :
     Lean.Expr :=
   let α := q(Ctxt ($dE).Ty × ($dE).Ty)
@@ -111,10 +141,12 @@ partial def Regions.toExprAux {regSig : List (Ctxt d.Ty × d.Ty)}
   | [], .nil =>
     mkApp2 (.const ``HVector.nil [0,0]) α A
   | a::as, .cons x xs =>
-    let a := Lean.toExpr a
-    let as := Lean.toExpr as
-    let x := x.toExprAux dE sig
-    let xs := Regions.toExprAux dE sig xs
+    let pToExpr (a) := Prod.foldToExpr <| a.map f.mapCtxt f.mapTy
+    let a := pToExpr a
+    let as := (as.map pToExpr).foldToExpr
+
+    let x := x.toExprAux
+    let xs := Regions.toExprAux xs
     mkApp6 (.const ``HVector.cons [0,0]) α A as a x xs
 
 end
@@ -129,16 +161,14 @@ section Map
 /-- Map a meta morphism over a LeanMLIR program, to obtain a (Lean) `Expr` representing
 the mapped program. -/
 def Com.metaMap (com : Com d Γ eff ty) (f : DialectMetaMorphism d d') : MetaM Lean.Expr := do
-  let dE := d.toExpr
-  let sig ← synthInstanceQ q(DialectSignature $dE)
-  return com.toExprAux f dE sig
+  let sig ← synthInstanceQ q(DialectSignature $d')
+  return com.toExprAux f d' sig
 
 /-- Map a meta morphism over a LeanMLIR expression, to obtain a (Lean) `Expr`
 representing the mapped expression. -/
 def Expr.metaMap (expr : Expr d Γ eff ty) (f : DialectMetaMorphism d d') : MetaM Lean.Expr := do
-  let dE := d.toExpr
-  let sig ← synthInstanceQ q(DialectSignature $dE)
-  return expr.toExprAux f dE sig
+  let sig ← synthInstanceQ q(DialectSignature $d')
+  return expr.toExprAux f d' sig
 
 /-!
 ## ToExpr

--- a/SSA/Core/Framework/ToExpr.lean
+++ b/SSA/Core/Framework/ToExpr.lean
@@ -82,13 +82,13 @@ end
 variable {Γ : Ctxt d.Ty} {eff : EffectKind} {ty : d.Ty}
 
 /-- Build a (Lean) `Expr` to represent a LeanMLIR program -/
-def Com.toExpr (com : Com d Γ eff ty) : MetaM Lean.Expr := do
+def Com.toExprM (com : Com d Γ eff ty) : MetaM Lean.Expr := do
   let dE := d.toExpr
   let sig ← synthInstanceQ q(DialectSignature $dE)
   return com.toExprAux dE sig
 
 /-- Build a (Lean) `Expr` to represent a LeanMLIR expression -/
-def Expr.toExpr (expr : Expr d Γ eff ty) : MetaM Lean.Expr := do
+def Expr.toExprM (expr : Expr d Γ eff ty) : MetaM Lean.Expr := do
   let dE := d.toExpr
   let sig ← synthInstanceQ q(DialectSignature $dE)
   return expr.toExprAux dE sig

--- a/SSA/Core/Framework/ToExpr.lean
+++ b/SSA/Core/Framework/ToExpr.lean
@@ -15,11 +15,51 @@ open Qq
 variable {d : Dialect} [DialectSignature d]
   [Lean.ToExpr d.Ty] [Lean.ToExpr d.Op] [DialectToExpr d]
 
-private def effLeToExpr : {eff eff' : EffectKind} → (h : eff ≤ eff') → Q($eff ≤ $eff')
+def effLeToExpr : {eff eff' : EffectKind} → (h : eff ≤ eff') → Q($eff ≤ $eff')
   | .impure, .impure, _ => q(EffectKind.le_refl .impure)
   | .pure, .pure, _     => q(EffectKind.le_refl .pure)
   | .pure, .impure, _   => q(EffectKind.pure_le .impure)
 
+open DialectSignature in
+/--
+A dialect morphism represents a mapping from programs in the source dialect `d`
+into Lean *expressions* representing programs in the target dialect `d'`.
+
+`d` and `d'` could be the same dialect, in which case the morphism represents a
+straightforward `toExpr` transform (see also `DialectMorphism.id`).
+
+Alternatively, `d` could be a meta dialect with, e.g., embedded Lean expressions
+(i.e., anti-quotations). The morphism abstractions allows us to transparently
+emit such embedded anti-quotations when transforming a meta-time object into
+a Lean expression.
+-/
+structure DialectMetaMorphism (d : Dialect) [DialectSignature d] (d' : Q(Dialect)) where
+  /-- Map a source Operation into an expression of a target Operation -/
+  mapOp : d.Op → Q(($d').Op)
+  /-- Map a source Type into an expression of a target Type -/
+  mapTy : d.Ty → Q(($d').Ty)
+  /-- Transport a proof that `effectKind op ≤ eff` to
+      an expression of a proof that `effectKind (mapOp op) ≤ eff`.
+
+      NOTE: the default implementation assumes that `mapOp` preserves the
+            effectKind of mapped operations.
+  -/
+  mapEffLe {op : d.Op} {eff : EffectKind} (h : effectKind op ≤ eff) : Lean.Expr :=
+    effLeToExpr h
+
+open DialectToExpr (toExprDialect)
+/-- The trivial identity morphism, which maps programs in dialect `d` to
+*expressions* of programs in dialect `d`.
+
+That is, this morphism represents a straightforward `toExpr` transformation. -/
+def DialectMetaMorphism.id (d : Dialect) [DialectSignature d]
+    [ToExpr d.Op] [ToExpr d.Ty] [DialectToExpr d] :
+    DialectMetaMorphism d (toExprDialect d) where
+  mapOp := toExpr
+  mapTy := toExpr
+
+
+variable {d'} (f : DialectMetaMorphism d d') in
 mutual
 
 partial def Com.toExprAux {Γ : Ctxt d.Ty} {eff : EffectKind} {ty : d.Ty}
@@ -44,18 +84,19 @@ partial def Expr.toExprAux {Γ : Ctxt d.Ty} {eff : EffectKind} {ty : d.Ty}
     (sig : Q(DialectSignature $dE))
     : Expr d Γ eff ty → Lean.Expr :=
   let ΓE : Q(Ctxt ($dE).Ty) := Lean.toExpr Γ
-  let tyE : Q(($dE).Ty) := Lean.toExpr ty
+  let tyE : Q(($dE).Ty) := f.mapTy ty
   let effE : Q(EffectKind) := Lean.toExpr eff
   fun
   | ⟨op, _ty_eq, eff_le, args, regArgs⟩ =>
     let Ty := mkApp (mkConst ``Dialect.Ty) dE
+    let op := f.mapOp op
     let ty_eq : Lean.Expr := mkApp2 (.const ``rfl [1]) Ty tyE
-    let eff_le := effLeToExpr eff_le
+    let eff_le := f.mapEffLe eff_le
 
     let regArgs := Regions.toExprAux dE sig regArgs
 
     mkAppN (mkConst ``Expr.mk) #[
-      dE, sig, effE, ΓE, tyE, toExpr op, ty_eq, eff_le, toExpr args, regArgs
+      dE, sig, effE, ΓE, tyE, op, ty_eq, eff_le, toExpr args, regArgs
     ]
 
 partial def Regions.toExprAux {regSig : List (Ctxt d.Ty × d.Ty)}
@@ -80,14 +121,31 @@ end
 
 variable {Γ : Ctxt d.Ty} {eff : EffectKind} {ty : d.Ty}
 
-/-- Build a (Lean) `Expr` to represent a LeanMLIR program -/
-def Com.toExprM (com : Com d Γ eff ty) : MetaM Lean.Expr := do
-  let dE := d.toExpr
-  let sig ← synthInstanceQ q(DialectSignature $dE)
-  return com.toExprAux dE sig
+/-!
+## MetaMap helper
+-/
+section Map
 
-/-- Build a (Lean) `Expr` to represent a LeanMLIR expression -/
-def Expr.toExprM (expr : Expr d Γ eff ty) : MetaM Lean.Expr := do
+/-- Map a meta morphism over a LeanMLIR program, to obtain a (Lean) `Expr` representing
+the mapped program. -/
+def Com.metaMap (com : Com d Γ eff ty) (f : DialectMetaMorphism d d') : MetaM Lean.Expr := do
   let dE := d.toExpr
   let sig ← synthInstanceQ q(DialectSignature $dE)
-  return expr.toExprAux dE sig
+  return com.toExprAux f dE sig
+
+/-- Map a meta morphism over a LeanMLIR expression, to obtain a (Lean) `Expr`
+representing the mapped expression. -/
+def Expr.metaMap (expr : Expr d Γ eff ty) (f : DialectMetaMorphism d d') : MetaM Lean.Expr := do
+  let dE := d.toExpr
+  let sig ← synthInstanceQ q(DialectSignature $dE)
+  return expr.toExprAux f dE sig
+
+/-!
+## ToExpr
+-/
+
+/-- Build a (Lean) `Expr` to represent a LeanMLIR program. -/
+def Com.toExprM (com : Com d Γ eff ty) : MetaM Lean.Expr := com.metaMap (.id _)
+
+/-- Build a (Lean) `Expr` to represent a LeanMLIR expression. -/
+def Expr.toExprM (expr : Expr d Γ eff ty) : MetaM Lean.Expr := expr.metaMap (.id _)

--- a/SSA/Core/Framework/ToExpr.lean
+++ b/SSA/Core/Framework/ToExpr.lean
@@ -63,17 +63,18 @@ partial def Regions.toExprAux {regSig : List (Ctxt d.Ty × d.Ty)}
     (sig : Q(DialectSignature $dE))
     (regs : HVector (fun (t : _ × _) => Com d t.1 EffectKind.impure t.2) regSig) :
     Lean.Expr :=
-  let Ty := Lean.toTypeExpr d.Ty
-  let A : Lean.Expr := q(fun (t : _ × _) => Com $dE t.1 EffectKind.impure t.2)
+  let α := q(Ctxt ($dE).Ty × ($dE).Ty)
+  let A :=
+    q(fun (t : Ctxt ($dE).Ty × ($dE).Ty) => Com $dE t.1 EffectKind.impure t.2)
   match regSig, regs with
   | [], .nil =>
-    mkApp2 (.const ``HVector.nil [0,0]) Ty A
+    mkApp2 (.const ``HVector.nil [0,0]) α A
   | a::as, .cons x xs =>
     let a := Lean.toExpr a
     let as := Lean.toExpr as
     let x := x.toExprAux dE sig
     let xs := Regions.toExprAux dE sig xs
-    mkApp6 (.const ``HVector.cons [0,0]) Ty A as a x xs
+    mkApp6 (.const ``HVector.cons [0,0]) α A as a x xs
 
 end
 

--- a/SSA/Core/Framework/ToExpr.lean
+++ b/SSA/Core/Framework/ToExpr.lean
@@ -22,7 +22,7 @@ private def effLeToExpr {eff eff' : EffectKind} (h : eff ≤ eff') : Q($eff ≤ 
 
 mutual
 
-def Com.toExprAux {Γ : Ctxt d.Ty} {eff : EffectKind} {ty : d.Ty}
+partial def Com.toExprAux {Γ : Ctxt d.Ty} {eff : EffectKind} {ty : d.Ty}
     (dE : Q(Dialect) := d.toExpr)
     (sig : Q(DialectSignature $dE))
     (com : Com d Γ eff ty) : Lean.Expr :=
@@ -37,9 +37,8 @@ def Com.toExprAux {Γ : Ctxt d.Ty} {eff : EffectKind} {ty : d.Ty}
     let e := e.toExprAux dE sig
     let body := body.toExprAux dE sig
     mkAppN (mkConst ``Com.ret) #[dE, sig, ΓE, tyE, effE, e, body]
-decreasing_by all_goals sorry
 
-def Expr.toExprAux {Γ : Ctxt d.Ty} {eff : EffectKind} {ty : d.Ty}
+partial def Expr.toExprAux {Γ : Ctxt d.Ty} {eff : EffectKind} {ty : d.Ty}
     (dE : Q(Dialect) := d.toExpr)
     (sig : Q(DialectSignature $dE))
     : Expr d Γ eff ty → Lean.Expr :=
@@ -57,9 +56,8 @@ def Expr.toExprAux {Γ : Ctxt d.Ty} {eff : EffectKind} {ty : d.Ty}
     mkAppN (mkConst ``Expr.mk) #[
       dE, sig, effE, ΓE, tyE, toExpr op, ty_eq, eff_le, toExpr args, regArgs
     ]
-decreasing_by sorry
 
-def Regions.toExprAux {regSig : List (Ctxt d.Ty × d.Ty)}
+partial def Regions.toExprAux {regSig : List (Ctxt d.Ty × d.Ty)}
     (dE : Q(Dialect) := d.toExpr)
     (sig : Q(DialectSignature $dE))
     (regs : HVector (fun (t : _ × _) => Com d t.1 EffectKind.impure t.2) regSig) :
@@ -75,7 +73,6 @@ def Regions.toExprAux {regSig : List (Ctxt d.Ty × d.Ty)}
     let x := x.toExprAux dE sig
     let xs := Regions.toExprAux dE sig xs
     mkApp6 (.const ``HVector.cons [0,0]) Ty A as a x xs
-decreasing_by all_goals sorry
 
 end
 

--- a/SSA/Core/Framework/Trace.lean
+++ b/SSA/Core/Framework/Trace.lean
@@ -1,0 +1,11 @@
+/-
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import Lean
+
+/-!
+## LeanMLIR trace classes
+-/
+
+-- Trace class for LeanMLIR elaboration code
+initialize Lean.registerTraceClass `LeanMLIR.Elab

--- a/SSA/Core/HVector.lean
+++ b/SSA/Core/HVector.lean
@@ -145,20 +145,20 @@ infixl:50 "::ₕ" => HVector.cons
 /-
   # ToExpr
 -/
-section ToExpr
+section ToExprPi
 open Lean Qq
 
-class ToExpr {α : Type u} (A : α → Type v) [∀ a, ToExpr (A a)] where
+class ToExprPi {α : Type u} (A : α → Type v) [∀ a, ToExpr (A a)] where
   /-- The expression representing `A` -/
   toTypeExpr : Expr
 
 variable {A : α → Type v}
 
-instance [Lean.ToExpr α] [∀ a, Lean.ToExpr (A a)] [HVector.ToExpr A]
+instance [Lean.ToExpr α] [∀ a, Lean.ToExpr (A a)] [HVector.ToExprPi A]
     [Lean.ToLevel.{u}] [Lean.ToLevel.{v}] :
     Lean.ToExpr (HVector A as) :=
   let α := toTypeExpr α
-  let AE := ToExpr.toTypeExpr A
+  let AE := ToExprPi.toTypeExpr A
   let us := [toLevel.{u}, toLevel.{v}]
   let rec toExpr : {as : List _} → HVector A as → Lean.Expr
   | [], .nil =>
@@ -174,7 +174,7 @@ instance [Lean.ToExpr α] [∀ a, Lean.ToExpr (A a)] [HVector.ToExpr A]
       mkApp2 (.const ``HVector us) AE as
     toExpr }
 
-end ToExpr
+end ToExprPi
 
 
 end HVector

--- a/SSA/Core/HVector.lean
+++ b/SSA/Core/HVector.lean
@@ -48,6 +48,13 @@ def foldl {B : Type*} (f : ∀ (a : α), B → A a → B) :
   | [],   b, .nil       => b
   | t::_, b, .cons a as => foldl f (f t b a) as
 
+def foldr {β : Type*} (f : ∀ (a : α), A a → β → β) :
+    ∀ {l : List α}, (init : β) → HVector A l → β
+  | [],   b, .nil       => b
+  | t::_, b, .cons a as =>
+    let b' := foldr f b as
+    f t a b'
+
 def get {as} : HVector A as → (i : Fin as.length) → A (as.get i)
   | .nil, i => i.elim0
   | .cons x  _, ⟨0,   _⟩  => x

--- a/SSA/Core/MLIRSyntax/EDSL.lean
+++ b/SSA/Core/MLIRSyntax/EDSL.lean
@@ -3,6 +3,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import SSA.Core.MLIRSyntax.GenericParser
 import SSA.Core.MLIRSyntax.Transform
+import SSA.Core.Framework.Trace
 
 /-!
 # MLIR Dialect Domain Specific Language
@@ -64,14 +65,14 @@ def elabIntoCom (region : TSyntax `mlir_region) (d : Q(Dialect)) {φ : Q(Nat)}
     (_transformReturn  : Q(TransformReturn $d $φ) := by exact q(by infer_instance)) :
     TermElabM Expr := do
   let com : Q(ExceptM $d (Σ Γ' eff ty, Com $d Γ' eff ty)) ←
-    withTraceNode `elabIntoCom (return m!"{exceptEmoji ·} building `Com` expression") <| do
+    withTraceNode `LeanMLIR.Elab (return m!"{exceptEmoji ·} building `Com` expression") <| do
     let ast_stx ← `([mlir_region| $region])
     let ast ← elabTermEnsuringTypeQ ast_stx q(Region $φ)
     return q(MLIR.AST.mkCom $ast)
-  withTraceNode `elabIntoCom (return m!"{exceptEmoji ·} synthesizingMVars") <|
+  withTraceNode `LeanMLIR.Elab (return m!"{exceptEmoji ·} synthesizingMVars") <|
     synthesizeSyntheticMVarsNoPostponing
 
-  withTraceNode `elabIntoCom (return m!"{exceptEmoji ·} unwrapping `Com` expression") <| do
+  withTraceNode `LeanMLIR.Elab (return m!"{exceptEmoji ·} unwrapping `Com` expression") <| do
     /- Now we repeatedly call `whnf` and then match on the resulting expression, to extract an
       expression of type `Com ..` -/
     let com : Q(ExceptM $d (Σ Γ' eff ty, Com $d Γ' eff ty)) ← whnf com
@@ -88,7 +89,7 @@ def elabIntoCom (region : TSyntax `mlir_region) (d : Q(Dialect)) {φ : Q(Nat)}
                 /- Finally, use `comNf` to ensure the resulting expression is of the form
                     `Com.var (Expr.mk ...) <| Com.var (Expr.mk ...) ... <| Com.rete _`,
                   where the arguments to `Expr.mk` are not reduced -/
-                withTraceNode `elabIntoCom (return m!"{exceptEmoji ·} reducing `Com` expression") <|
+                withTraceNode `LeanMLIR.Elab (return m!"{exceptEmoji ·} reducing `Com` expression") <|
                   comNf com
             | .none => throwError "Expected (Sigma.mk _ _), found {expr}"
           | .none => throwError "Expected (Sigma.mk _ _), found {expr}"

--- a/SSA/Core/MLIRSyntax/EDSL2.lean
+++ b/SSA/Core/MLIRSyntax/EDSL2.lean
@@ -23,6 +23,10 @@ open MLIR.AST
 
 private unsafe def evalExprOfTypeRegionAux (φ : Nat) : Q(Region $φ) → MetaM (Region φ) :=
   evalExpr (Region φ) q(Region $φ)
+/-
+SAFETY: the `implemented_by` is safe, *assuming* that `Region φ` and `q(Region φ)`
+  are the same; this means we trust Qq to construct the right `Expr`.
+-/
 @[implemented_by evalExprOfTypeRegionAux]
 partial def evalExprOfTypeRegion (φ : Nat) : Q(Region $φ) → MetaM (Region φ) :=
   default
@@ -38,8 +42,7 @@ def elabIntoCom' (region : TSyntax `mlir_region) (d : Dialect) {φ : Nat}
     let expr ← elabTermEnsuringTypeQ stx q(Region $φ)
     withTraceNode `elabIntoCom (fun _ => return m!"parsed Expr … ") <| do
       trace[elabIntoCom] "{expr}"
-    -- SAFETY: the next line is safe, *assuming* that `Region φ` and `q(Region φ)`
-    --         are the same; this means we trust Qq to construct the right `Expr`.
+
     evalExprOfTypeRegion φ expr
 
   let ⟨_Γ, _eff, _ty, com⟩ ←

--- a/SSA/Core/MLIRSyntax/EDSL2.lean
+++ b/SSA/Core/MLIRSyntax/EDSL2.lean
@@ -40,6 +40,8 @@ def elabIntoCom' (region : TSyntax `mlir_region) (d : Dialect) {φ : Nat}
     withTraceNode `elabIntoCom (return m!"{exceptEmoji ·} evaluating AST expression") <| do
     let stx  ← `([mlir_region| $region])
     let expr ← elabTermEnsuringTypeQ stx q(Region $φ)
+    synthesizeSyntheticMVarsNoPostponing
+    let expr ← instantiateMVars expr
     withTraceNode `elabIntoCom (fun _ => return m!"parsed Expr … ") <| do
       trace[elabIntoCom] "{expr}"
 

--- a/SSA/Core/MLIRSyntax/EDSL2.lean
+++ b/SSA/Core/MLIRSyntax/EDSL2.lean
@@ -1,0 +1,53 @@
+/-
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import SSA.Core.MLIRSyntax.GenericParser
+import SSA.Core.MLIRSyntax.Transform
+import SSA.Core.Framework.ToExpr
+
+/-!
+# MLIR Dialect Domain Specific Language (v2)
+This file sets up generic glue meta-code to tie together the generic MLIR parser with the
+`Transform` mechanism, to obtain an easy way to specify a DSL that elaborates into `Com`/`Expr`
+instances for a specific dialect.
+
+This is an alternative implementation to `EDSL.lean`, which aims to compute more with meta-time
+objects, instead of kernel reducing `Expr`s, in an attempt to avoid some of the pittfals
+that kernel reduction causes.
+-/
+
+namespace SSA
+
+open Qq Lean Meta Elab Term
+open MLIR.AST
+
+private unsafe def evalExprOfTypeRegionAux (φ : Nat) : Q(Region $φ) → MetaM (Region φ) :=
+  evalExpr (Region φ) q(Region $φ)
+@[implemented_by evalExprOfTypeRegionAux]
+partial def evalExprOfTypeRegion (φ : Nat) : Q(Region $φ) → MetaM (Region φ) :=
+  default
+
+def elabIntoCom' (region : TSyntax `mlir_region) (d : Dialect) {φ : Nat}
+    [ToExpr d.Op] [ToExpr d.Ty] [DialectToExpr d]
+    [DialectSignature d] [Repr d.Ty]
+    [TransformTy d φ] [TransformExpr d φ] [TransformReturn d φ] :
+    TermElabM Expr := withRef region <| do
+  let ast : Region φ ←
+    withTraceNode `elabIntoCom (return m!"{exceptEmoji ·} evaluating AST expression") <| do
+    let stx  ← `([mlir_region| $region])
+    let expr ← elabTermEnsuringTypeQ stx q(Region $φ)
+    withTraceNode `elabIntoCom (fun _ => return m!"parsed Expr … ") <| do
+      trace[elabIntoCom] "{expr}"
+    -- SAFETY: the next line is safe, *assuming* that `Region φ` and `q(Region φ)`
+    --         are the same; this means we trust Qq to construct the right `Expr`.
+    evalExprOfTypeRegion φ expr
+
+  let ⟨_Γ, _eff, _ty, com⟩ ←
+    withTraceNode `elabIntoCom (return m!"{exceptEmoji ·} parsing AST") <| do
+    match mkCom ast with
+    | .error (e : TransformError d.Ty) => throwError (repr e)
+    | .ok res => pure res
+
+  com.toExprM
+
+end SSA

--- a/SSA/Core/MLIRSyntax/Transform.lean
+++ b/SSA/Core/MLIRSyntax/Transform.lean
@@ -58,6 +58,12 @@ end Monads
   returns with `TransformReturn`.
   - These three automatically give an instance of `TransformDialect`.
 -/
+
+/- TODO: the above mentions a `TransformDialect`, but such a class does not
+          exist. Was it removed for some reason, or did we just not implement it?
+          It would be nice to not have to spell out the three different classes
+          in, e.g., `mkCom` -/
+
 class TransformTy (d : Dialect) (φ : outParam Nat) [DialectSignature d]  where
   mkTy   : MLIRType φ → ExceptM d d.Ty
 

--- a/SSA/Core/Util/ConcreteOrMVar.lean
+++ b/SSA/Core/Util/ConcreteOrMVar.lean
@@ -43,10 +43,17 @@ def instantiateOne (a : α) : ConcreteOrMVar α (φ+1) → ConcreteOrMVar α φ
       (.concrete a)       -- `i = Fin.last`
       (fun j => .mvar j)  -- `i = Fin.castSucc j`
 
-/-- Instantiate all meta-variables -/
+/-- Instantiate all meta-variables using values -/
 def instantiate (as : List.Vector α φ) : ConcreteOrMVar α φ → α
   | .concrete w => w
   | .mvar i => as.get i
+
+open Lean in
+/-- Instantiate all meta-variables using Lean expressions,
+resulting in a Lean expression of type `α`. -/
+def metaInstantiate [ToExpr α] (as : Vector Lean.Expr φ) : ConcreteOrMVar α φ → Lean.Expr
+  | .concrete w => toExpr w
+  | .mvar i => as[i]
 
 /-- We choose ConcreteOrMVar.concrete to be our simp normal form. -/
 @[simp]


### PR DESCRIPTION
This PR implements `elabIntoCom'` as an alternative to `elabIntoCom` which follows the following strategy:
1) Evaluate the AST object into a meta-time object, 
2) Then, *run* the AST -> Com parsing code at meta-time
3) Turn the meta-time Com object into an expression via `ToExpr`

Most of the changed lines of this PR are to actually implement the `Com` to `Expr` transformation.
Replacing kernel reduction with metatime computation should be much more reliable, as it removes the need for `unseal`ing specific irreducible definitions. The transformation is made generic over a `DialectMetaMorhpism`, which just bundles `Op -> Expr` and `Ty -> Expr` transformations. This will be used in, for instance, the LLVM elaborator to also instantiate metavariables at meta-time.

See also the `comb-dialect-edsl2` branch, which demonstrated the new elaborator against #949, or #1024 which uses the new elaborator for the LLVM dialect.