### PR TITLE
chore: downgrade toolchain to nightly-2025-03-15, to match Mathlib

### DIFF
--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:nightly-2025-03-16
+leanprover/lean4:nightly-2025-03-15


### PR DESCRIPTION
Currently, `lake exe cache get` complains about the mismatched toolchains and refuses to work, hence let's downgrade to match Mathlib.