### PR TITLE
fix: reduce concurrency of llvm evaluation CI

### DIFF
--- a/.github/workflows/evaluation.yml
+++ b/.github/workflows/evaluation.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Run LLVM
         continue-on-error: true
         run: |
-          (cd bv-evaluation; python3 ./compare-leansat-vs-bitwuzla-llvm.py -j128)
+          (cd bv-evaluation; python3 ./compare-leansat-vs-bitwuzla-llvm.py -j64)
 
       - name: Run Alive Symbolic
         run: |

--- a/bv-evaluation/compare-leansat-vs-bitwuzla-llvm.py
+++ b/bv-evaluation/compare-leansat-vs-bitwuzla-llvm.py
@@ -12,7 +12,7 @@ BENCHMARK_DIR = ROOT_DIR + '/SSA/Projects/InstCombine/tests/proofs/'
 
 REPS = 1 
 
-TIMEOUT = 1800
+TIMEOUT = 3600
 
 def clear_folder():
     for file in os.listdir(RESULTS_DIR):


### PR DESCRIPTION
For some reason, running with a large number of workers results in a reduction of instances that get reported as solved. The build logs don't show any particular errors, rather, they seem like they cut short.

I hypothesize that somehow the high concurrency is running against some resource limit (memory, perhaps?) and the compile processes are getting killed. Reducing the number of workers used by the evaluation CI seems to bring us back to regular numbers. We also increase the timeout, to account for the fact that CI will now likely take longer.