### PR TITLE
feat: Add `ModArith` dialect

### DIFF
--- a/SSA/Projects/ModArith/Basic.lean
+++ b/SSA/Projects/ModArith/Basic.lean
@@ -1,0 +1,152 @@
+/-
+Released under Apache 2.0 license as described in the file LICENSE.
+
+This file contains the definition of the MLIR `ModArith` dialect as
+implemented in HEIR, see:
+  https://heir.dev/docs/dialects/modarith/
+
+It is structurally similar to `Poly.Basic.lean` but focuses on arithmetic
+directly in ℤ/qℤ (ZMod q), rather than polynomials over ℤ/qℤ.
+
+Authors: Jaeho Choi<zerozerozero0216@gmail.com>
+-/
+import Mathlib.Data.ZMod.Basic
+import SSA.Core.Framework
+
+open ZMod
+
+/-!
+  # ModArith Dialect
+
+  The `ModArith` dialect is a simpler variant that models integer arithmetic
+  **modulo `q`**, i.e., arithmetic in the ring `ZMod q`.
+
+  We assume `q > 1` as a fact. We denote our base ring as: `R = ZMod q`.
+
+  The dialect's type system includes (for example) `index`, `integer`, and
+  a specialized type `modLike` for elements in `ZMod q`.
+
+  Operations: Add, Sub, Mul, and constants for this ring, plus integers and
+  indices.
+-/
+
+section CommRing
+/- We assume `q > 1`. -/
+variable (q : ℕ) [Fact (q > 1)]
+
+/--
+By analogy to `R q n` from the `Poly` dialect, we simply define
+`R q := ZMod q`. The ring structure on `ZMod q` is already known
+to mathlib.
+-/
+abbrev R := ZMod q
+
+end CommRing
+
+/-!
+## Dialect type definitions
+
+Here, we define a small type system for the `ModArith` dialect:
+  1. `index` – if you also want natural-number indices (mirroring MLIR’s index).
+  2. `integer` – for full-range integers in Lean (ℤ).
+  3. `modLike` – for our ring `ZMod q`.
+
+You can freely add more types or rename them according to your needs.
+-/
+inductive Ty (q : ℕ) where
+| index
+| integer
+| modLike
+deriving DecidableEq, Repr
+
+instance : Inhabited (Ty q) := ⟨Ty.index⟩
+
+/--
+We provide a `TyDenote` instance: this is how we translate each
+dialect type into an actual Lean type.
+-/
+instance : TyDenote (Ty q) where
+toType
+| Ty.index   => Nat
+| Ty.integer => Int
+| Ty.modLike => R q  -- i.e. `ZMod q`
+
+/-!
+## Dialect operation definitions
+
+Here are some sample operations. Adjust as appropriate for the
+`modarith` dialect: e.g. you might have add/sub/mul, an operation for
+returning constants mod q, an integer constant, index constant, etc.
+-/
+inductive Op (q : ℕ) where
+| add : Op q        -- (modLike, modLike) → modLike
+| sub : Op q        -- (modLike, modLike) → modLike
+| mul : Op q        -- (modLike, modLike) → modLike
+| const (c : R q) : Op q  -- produce a constant in ZMod q
+| const_int (c : Int) : Op q  -- produce a constant integer
+| const_idx (c : Nat) : Op q  -- produce a constant index
+
+/--
+For each operation, we specify its input `sig` (a list of
+types) and its `outTy` (the output type).
+-/
+@[simp, reducible]
+def Op.sig : Op q → List (Ty q)
+| .add            => [Ty.modLike, Ty.modLike]
+| .sub            => [Ty.modLike, Ty.modLike]
+| .mul            => [Ty.modLike, Ty.modLike]
+| .const _        => []
+| .const_int _    => []
+| .const_idx _    => []
+
+@[simp, reducible]
+def Op.outTy : Op q → Ty q
+| .add         => Ty.modLike
+| .sub         => Ty.modLike
+| .mul         => Ty.modLike
+| .const _     => Ty.modLike
+| .const_int _ => Ty.integer
+| .const_idx _ => Ty.index
+
+/-- Put them together into a `Signature`. -/
+@[simp, reducible]
+def Op.signature : Op q → Signature (Ty q)
+| o => { sig := o.sig, outTy := o.outTy, regSig := [] }
+
+/-!
+## The `ModArith` dialect
+
+We bundle up our `Op` and `Ty` into a dialect called `ModArith q`.
+-/
+abbrev ModArith (q : ℕ) [Fact (q > 1)] : Dialect where
+Op := Op q
+Ty := Ty q
+
+instance (q : ℕ) [Fact (q > 1)] : DialectSignature (ModArith q) := ⟨Op.signature⟩
+
+/-!
+## Dialect semantics
+
+Finally, we provide the Lean semantics for each operation in the dialect:
+i.e., how to interpret `add`, `sub`, `mul`, etc. as Lean functions.
+-/
+noncomputable instance (q : ℕ) [Fact (q > 1)] : DialectDenote (ModArith q) where
+denote
+  | .add, arg, _ =>
+      -- Add mod q
+      (fun args : R q × R q => args.1 + args.2) arg.toPair
+  | .sub, arg, _ =>
+      -- Sub mod q
+      (fun args : R q × R q => args.1 - args.2) arg.toPair
+  | .mul, arg, _ =>
+      -- Mul mod q
+      (fun args : R q × R q => args.1 * args.2) arg.toPair
+  | .const c, _, _ =>
+      -- A constant in ZMod q
+      c
+  | .const_int c, _, _ =>
+      -- A plain integer (ℤ)
+      c
+  | .const_idx c, _, _ =>
+      -- A plain index (ℕ)
+      c

--- a/SSA/Projects/ModArith/Basic.lean
+++ b/SSA/Projects/ModArith/Basic.lean
@@ -1,11 +1,9 @@
 /-
-Released under Apache 2.0 license as described in the file LICENSE.
-
 This file contains the definition of the MLIR `ModArith` dialect as
 implemented in HEIR, see:
   https://heir.dev/docs/dialects/modarith/
 
-It is structurally similar to `Poly.Basic.lean` but focuses on arithmetic
+It is structurally similar to `FullyHomomorphicEncryption.Basic.lean` but focuses on arithmetic
 directly in ℤ/qℤ (ZMod q), rather than polynomials over ℤ/qℤ.
 
 Authors: Jaeho Choi<zerozerozero0216@gmail.com>

--- a/SSA/Projects/ModArith/Examples.lean
+++ b/SSA/Projects/ModArith/Examples.lean
@@ -1,6 +1,4 @@
 /-
-Released under Apache 2.0 license as described in the file LICENSE.
-
 End-to-end showcase of the framework for verifying rewrites about ModArith semantics,
 by analogy to the FHE/Poly `PaperExamples.lean`.
 

--- a/SSA/Projects/ModArith/Examples.lean
+++ b/SSA/Projects/ModArith/Examples.lean
@@ -1,0 +1,834 @@
+/-
+Released under Apache 2.0 license as described in the file LICENSE.
+
+End-to-end showcase of the framework for verifying rewrites about ModArith semantics,
+by analogy to the FHE/Poly `PaperExamples.lean`.
+
+Authors: Jaeho Choi<zerozerozero0216@gmail.com>
+-/
+import SSA.Core.MLIRSyntax.GenericParser
+import SSA.Core.Tactic
+import SSA.Projects.ModArith.Basic
+import SSA.Projects.ModArith.Statements
+import SSA.Projects.ModArith.Syntax
+import SSA.Projects.ModArith.PrettySyntax
+
+open Ctxt (Var Valuation DerivedCtxt)
+open MLIR AST
+
+/-
+We assume `q : Nat` with `[Fact (q > 1)]`, so that `(ZMod q)` is nontrivial.
+You can fix `q = 42` or keep it a variable. This example sets `q=42` per your tests.
+-/
+namespace ModArithCanonicalization
+
+-- variable {q : Nat} [hq : Fact (q > 1)]
+def q : Nat := 42
+instance hq : Fact (q > 1) := ⟨by decide⟩
+instance h41 : (41 : ZMod q) = -1 := rfl
+
+--------------------------------------------------------------------------------
+-- test_add_fold
+-- // CHECK-LABEL: @test_add_fold
+-- // CHECK: () -> [[T:.*]] {
+-- func.func @test_add_fold() -> !Zp {
+--   // CHECK: %[[RESULT:.+]] = mod_arith.constant 18 : [[T]]
+--   %e1 = mod_arith.constant 12 : !Zp
+--   %e2 = mod_arith.constant 34 : !Zp
+--   %add = mod_arith.add %e1, %e2 : !Zp
+--   %e3 = mod_arith.constant 56 : !Zp
+--   %add2 = mod_arith.add %add, %e3 : !Zp
+--   // CHECK: return %[[RESULT]] : [[T]]
+--   return %add2 : !Zp
+-- }
+--------------------------------------------------------------------------------
+
+def test_add_fold_LHS :=
+[mod_arith q, hq| {
+  ^bb0():
+    %e1 = mod_arith.constant 12 : !R
+    %e2 = mod_arith.constant 34 : !R
+    %add = mod_arith.add %e1, %e2 : !R
+    %e3 = mod_arith.constant 56 : !R
+    %add2 = mod_arith.add %add, %e3 : !R
+    return %add2 : !R
+}]
+
+def test_add_fold_RHS := [mod_arith q, hq| {
+  ^bb0():
+    %res = mod_arith.constant 18 : !R
+    return %res : !R
+}]
+
+noncomputable def TV_add_fold : PeepholeRewrite (ModArith q) [] .modLike :=
+{
+  lhs := test_add_fold_LHS,
+  rhs := test_add_fold_RHS,
+  correct := by
+    funext valuation
+    -- Expand the definitions:
+    unfold test_add_fold_LHS test_add_fold_RHS
+    simp_peephole [] at valuation
+    norm_cast
+}
+
+--------------------------------------------------------------------------------
+-- test_sub_fold
+-- // CHECK-LABEL: @test_sub_fold
+-- // CHECK: () -> [[T:.*]] {
+-- func.func @test_sub_fold() -> !Zp {
+--   // CHECK: %[[RESULT:.+]] = mod_arith.constant 6 : [[T]]
+--   %e1 = mod_arith.constant 12 : !Zp
+--   %e2 = mod_arith.constant 34 : !Zp
+--   %sub = mod_arith.sub %e1, %e2 : !Zp
+--   %e3 = mod_arith.constant 56 : !Zp
+--   %sub2 = mod_arith.sub %sub, %e3 : !Zp
+--   // CHECK: return %[[RESULT]] : [[T]]
+--   return %sub2 : !Zp
+-- }
+--------------------------------------------------------------------------------
+
+def test_sub_fold_LHS :=
+[mod_arith q, hq| {
+  ^bb0():
+    %e1 = mod_arith.constant 12 : !R
+    %e2 = mod_arith.constant 34 : !R
+    %sub = mod_arith.sub %e1, %e2 : !R
+    %e3 = mod_arith.constant 56 : !R
+    %sub2 = mod_arith.sub %sub, %e3 : !R
+    return %sub2 : !R
+}]
+def test_sub_fold_RHS := [mod_arith q, hq| {
+  ^bb0():
+    %res = mod_arith.constant 6 : !R
+    return %res : !R
+}]
+noncomputable def TV_sub_fold : PeepholeRewrite (ModArith q) [] .modLike :=
+{
+  lhs := test_sub_fold_LHS,
+  rhs := test_sub_fold_RHS,
+  correct := by
+    funext valuation
+    unfold test_sub_fold_LHS test_sub_fold_RHS
+    simp_peephole [] at valuation
+    norm_cast
+}
+
+--------------------------------------------------------------------------------
+-- test_mul_fold
+-- // CHECK-LABEL: @test_mul_fold
+-- // CHECK: () -> [[T:.*]] {
+-- func.func @test_mul_fold() -> !Zp {
+--   // CHECK: %[[RESULT:.+]] = mod_arith.constant 0 : [[T]]
+--   %e1 = mod_arith.constant 12 : !Zp
+--   %e2 = mod_arith.constant 34 : !Zp
+--   %mul = mod_arith.mul %e1, %e2 : !Zp
+--   %e3 = mod_arith.constant 56 : !Zp
+--   %mul2 = mod_arith.mul %mul, %e3 : !Zp
+--   return %mul2 : !Zp
+-- }
+--------------------------------------------------------------------------------
+def test_mul_fold_LHS := [mod_arith q, hq| {
+  ^bb0():
+    %e1 = mod_arith.constant 12 : !R
+    %e2 = mod_arith.constant 34 : !R
+    %mul = mod_arith.mul %e1, %e2 : !R
+    %e3 = mod_arith.constant 56 : !R
+    %mul2 = mod_arith.mul %mul, %e3 : !R
+    return %mul2 : !R
+}]
+def test_mul_fold_RHS := [mod_arith q, hq| {
+  ^bb0():
+    %res = mod_arith.constant 0 : !R
+    return %res : !R
+}]
+noncomputable def TV_mul_fold : PeepholeRewrite (ModArith q) [] .modLike :=
+{
+  lhs := test_mul_fold_LHS,
+  rhs := test_mul_fold_RHS,
+  correct := by
+    funext valuation
+    unfold test_mul_fold_LHS test_mul_fold_RHS
+    simp_peephole [] at valuation
+    norm_cast
+}
+
+--------------------------------------------------------------------------------
+-- test_add_zero_rhs
+-- // CHECK-LABEL: @test_add_zero_rhs
+-- // CHECK: (%[[arg0:.*]]: [[T:.*]]) -> [[T]]
+-- func.func @test_add_zero_rhs(%x: !Zp) -> !Zp {
+--   %zero = mod_arith.constant 0 : !Zp
+--   %add = mod_arith.add %x, %zero : !Zp
+--   // CHECK: return %[[arg0]] : [[T]]
+--   return %add : !Zp
+-- }
+--------------------------------------------------------------------------------
+def test_add_zero_rhs_LHS := [mod_arith q, hq| {
+  ^bb0(%x : !R):
+    %zero = mod_arith.constant 0 : !R
+    %add = mod_arith.add %x, %zero : !R
+    return %add : !R
+}]
+def test_add_zero_rhs_RHS := [mod_arith q, hq| {
+  ^bb0(%x : !R):
+    return %x : !R
+}]
+noncomputable def TV_add_zero_rhs : PeepholeRewrite (ModArith q) [.modLike] .modLike :=
+{
+  lhs := test_add_zero_rhs_LHS,
+  rhs := test_add_zero_rhs_RHS,
+  correct := by
+    funext valuation
+    unfold test_add_zero_rhs_LHS test_add_zero_rhs_RHS
+    simp_peephole [] at valuation
+    intro x
+    ring_nf
+}
+--------------------------------------------------------------------------------
+-- test_add_zero_lhs
+-- // CHECK-LABEL: @test_add_zero_lhs
+-- // CHECK: (%[[arg0:.*]]: [[T:.*]]) -> [[T]]
+-- func.func @test_add_zero_lhs(%x: !Zp) -> !Zp {
+--   %zero = mod_arith.constant 0 : !Zp
+--   %add = mod_arith.add %zero, %x : !Zp
+--   // CHECK: return %[[arg0]] : [[T]]
+--   return %add : !Zp
+-- }
+--------------------------------------------------------------------------------
+def test_add_zero_lhs_LHS := [mod_arith q, hq| {
+  ^bb0(%x : !R):
+    %zero = mod_arith.constant 0 : !R
+    %add = mod_arith.add %zero, %x : !R
+    return %add : !R
+}]
+def test_add_zero_lhs_RHS := [mod_arith q, hq| {
+  ^bb0(%x : !R):
+    return %x : !R
+}]
+noncomputable def TV_add_zero_lhs : PeepholeRewrite (ModArith q) [.modLike] .modLike :=
+{
+  lhs := test_add_zero_lhs_LHS,
+  rhs := test_add_zero_lhs_RHS,
+  correct := by
+    funext valuation
+    unfold test_add_zero_lhs_LHS test_add_zero_lhs_RHS
+    simp_peephole [] at valuation
+    intro x
+    ring_nf
+}
+
+--------------------------------------------------------------------------------
+-- test_sub_zero
+-- // CHECK-LABEL: @test_sub_zero
+-- // CHECK: (%[[arg0:.*]]: [[T:.*]]) -> [[T]]
+-- func.func @test_sub_zero(%x: !Zp) -> !Zp {
+--   %zero = mod_arith.constant 0 : !Zp
+--   %sub = mod_arith.sub %x, %zero : !Zp
+--   // CHECK: return %[[arg0]] : [[T]]
+--   return %sub : !Zp
+-- }
+--------------------------------------------------------------------------------
+def test_sub_zero_LHS := [mod_arith q, hq| {
+  ^bb0(%x : !R):
+    %zero = mod_arith.constant 0 : !R
+    %sub = mod_arith.sub %x, %zero : !R
+    return %sub : !R
+}]
+def test_sub_zero_RHS := [mod_arith q, hq| {
+  ^bb0(%x : !R):
+    return %x : !R
+}]
+noncomputable def TV_sub_zero : PeepholeRewrite (ModArith q) [.modLike] .modLike :=
+{
+  lhs := test_sub_zero_LHS,
+  rhs := test_sub_zero_RHS,
+  correct := by
+    funext valuation
+    unfold test_sub_zero_LHS test_sub_zero_RHS
+    simp_peephole [] at valuation
+    intro x
+    ring_nf
+}
+
+--------------------------------------------------------------------------------
+-- test_mul_zero_rhs
+-- // CHECK-LABEL: @test_mul_zero_rhs
+-- // CHECK: (%[[arg0:.*]]: [[T:.*]]) -> [[T]]
+-- func.func @test_mul_zero_rhs(%x: !Zp) -> !Zp {
+--   // CHECK: %[[res0:.+]] = mod_arith.constant 0 : [[T]]
+--   %zero = mod_arith.constant 0 : !Zp
+--   %mul = mod_arith.mul %x, %zero : !Zp
+--   // CHECK: return %[[res0]] : [[T]]
+--   return %mul : !Zp
+-- }
+--------------------------------------------------------------------------------
+def test_mul_zero_rhs_LHS := [mod_arith q, hq| {
+  ^bb0(%x : !R):
+    %zero = mod_arith.constant 0 : !R
+    %mul = mod_arith.mul %x, %zero : !R
+    return %mul : !R
+}]
+def test_mul_zero_rhs_RHS := [mod_arith q, hq| {
+  ^bb0(%x : !R):
+    %zero = mod_arith.constant 0 : !R
+    return %zero : !R
+}]
+noncomputable def TV_mul_zero_rhs : PeepholeRewrite (ModArith q) [.modLike] .modLike :=
+{
+  lhs := test_mul_zero_rhs_LHS,
+  rhs := test_mul_zero_rhs_RHS,
+  correct := by
+    funext valuation
+    unfold test_mul_zero_rhs_LHS test_mul_zero_rhs_RHS
+    simp_peephole [] at valuation
+    intro x
+    ring_nf
+}
+
+--------------------------------------------------------------------------------
+-- test_mul_zero_lhs
+-- // CHECK-LABEL: @test_mul_zero_lhs
+-- // CHECK: (%[[arg0:.*]]: [[T:.*]]) -> [[T]]
+-- func.func @test_mul_zero_lhs(%x: !Zp) -> !Zp {
+--   // CHECK: %[[res0:.+]] = mod_arith.constant 0 : [[T]]
+--   %zero = mod_arith.constant 0 : !Zp
+--   %mul = mod_arith.mul %zero, %x : !Zp
+--   // CHECK: return %[[res0]] : [[T]]
+--   return %mul : !Zp
+-- }
+--------------------------------------------------------------------------------
+def test_mul_zero_lhs_LHS := [mod_arith q, hq| {
+  ^bb0(%x : !R):
+    %zero = mod_arith.constant 0 : !R
+    %mul = mod_arith.mul %zero, %x : !R
+    return %mul : !R
+}]
+def test_mul_zero_lhs_RHS := [mod_arith q, hq| {
+  ^bb0(%x : !R):
+    %zero = mod_arith.constant 0 : !R
+    return %zero : !R
+}]
+noncomputable def TV_mul_zero_lhs : PeepholeRewrite (ModArith q) [.modLike] .modLike :=
+{
+  lhs := test_mul_zero_lhs_LHS,
+  rhs := test_mul_zero_lhs_RHS,
+  correct := by
+    funext valuation
+    unfold test_mul_zero_lhs_LHS test_mul_zero_lhs_RHS
+    simp_peephole [] at valuation
+    intro x
+    ring_nf
+}
+
+--------------------------------------------------------------------------------
+-- test_mul_one_rhs
+-- // CHECK-LABEL: @test_mul_one_rhs
+-- // CHECK: (%[[arg0:.*]]: [[T:.*]]) -> [[T]]
+-- func.func @test_mul_one_rhs(%x: !Zp) -> !Zp {
+--   %one = mod_arith.constant 1 : !Zp
+--   %mul = mod_arith.mul %x, %one : !Zp
+--   // CHECK: return %[[arg0]] : [[T]]
+--   return %mul : !Zp
+-- }
+--------------------------------------------------------------------------------
+def test_mul_one_rhs_LHS := [mod_arith q, hq| {
+  ^bb0(%x : !R):
+    %one = mod_arith.constant 1 : !R
+    %mul = mod_arith.mul %x, %one : !R
+    return %mul : !R
+}]
+def test_mul_one_rhs_RHS := [mod_arith q, hq| {
+  ^bb0(%x : !R):
+    return %x : !R
+}]
+noncomputable def TV_mul_one_rhs : PeepholeRewrite (ModArith q) [.modLike] .modLike :=
+{
+  lhs := test_mul_one_rhs_LHS,
+  rhs := test_mul_one_rhs_RHS,
+  correct := by
+    funext valuation
+    unfold test_mul_one_rhs_LHS test_mul_one_rhs_RHS
+    simp_peephole [] at valuation
+    intro x
+    ring_nf
+}
+
+--------------------------------------------------------------------------------
+-- test_mul_one_lhs
+-- // CHECK-LABEL: @test_mul_one_lhs
+-- // CHECK: (%[[arg0:.*]]: [[T:.*]]) -> [[T]]
+-- func.func @test_mul_one_lhs(%x: !Zp) -> !Zp {
+--   %one = mod_arith.constant 1 : !Zp
+--   %mul = mod_arith.mul %one, %x : !Zp
+--   // CHECK: return %[[arg0]] : [[T]]
+--   return %mul : !Zp
+-- }
+--------------------------------------------------------------------------------
+def test_mul_one_lhs_LHS := [mod_arith q, hq| {
+  ^bb0(%x : !R):
+    %one = mod_arith.constant 1 : !R
+    %mul = mod_arith.mul %one, %x : !R
+    return %mul : !R
+}]
+def test_mul_one_lhs_RHS := [mod_arith q, hq| {
+  ^bb0(%x : !R):
+    return %x : !R
+}]
+noncomputable def TV_mul_one_lhs : PeepholeRewrite (ModArith q) [.modLike] .modLike :=
+{
+  lhs := test_mul_one_lhs_LHS,
+  rhs := test_mul_one_lhs_RHS,
+  correct := by
+    funext valuation
+    unfold test_mul_one_lhs_LHS test_mul_one_lhs_RHS
+    simp_peephole [] at valuation
+    intro x
+    ring_nf
+}
+
+--------------------------------------------------------------------------------
+-- test_add_add_const
+-- // CHECK-LABEL: @test_add_add_const
+-- // CHECK: (%[[arg0:.*]]: [[T:.*]]) -> [[T]]
+-- func.func @test_add_add_const(%x: !Zp) -> !Zp {
+--   // CHECK: %[[res0:.+]] = mod_arith.constant 4 : [[T]]
+--   // CHECK: %[[res1:.+]] = mod_arith.add %[[arg0]], %[[res0]] : [[T]]
+--   %c0 = mod_arith.constant 12 : !Zp
+--   %c1 = mod_arith.constant 34 : !Zp
+--   %add = mod_arith.add %x, %c0 : !Zp
+--   %add2 = mod_arith.add %add, %c1 : !Zp
+--   // CHECK: return %[[res1]] : [[T]]
+--   return %add2 : !Zp
+-- }
+--------------------------------------------------------------------------------
+def test_add_add_const_LHS := [mod_arith q, hq| {
+  ^bb0(%x : !R):
+    %c0 = mod_arith.constant 12 : !R
+    %c1 = mod_arith.constant 34 : !R
+    %add = mod_arith.add %x, %c0 : !R
+    %add2 = mod_arith.add %add, %c1 : !R
+    return %add2 : !R
+}]
+def test_add_add_const_RHS := [mod_arith q, hq| {
+  ^bb0(%x : !R):
+    %res0 = mod_arith.constant 4 : !R
+    %res1 = mod_arith.add %x, %res0 : !R
+    return %res1 : !R
+}]
+noncomputable def TV_add_add_const : PeepholeRewrite (ModArith q) [.modLike] .modLike :=
+{
+  lhs := test_add_add_const_LHS,
+  rhs := test_add_add_const_RHS,
+  correct := by
+    funext valuation
+    unfold test_add_add_const_LHS test_add_add_const_RHS
+    simp_peephole [] at valuation
+    intro x
+    ring_nf
+    rfl
+}
+
+--------------------------------------------------------------------------------
+-- test_add_sub_const_rhs
+-- // CHECK-LABEL: @test_add_sub_const_rhs
+-- // CHECK: (%[[arg0:.*]]: [[T:.*]]) -> [[T]]
+-- func.func @test_add_sub_const_rhs(%x: !Zp) -> !Zp {
+--   // CHECK: %[[res0:.+]] = mod_arith.constant 22 : [[T]]
+--   // CHECK: %[[res1:.+]] = mod_arith.add %[[arg0]], %[[res0]] : [[T]]
+--   %c0 = mod_arith.constant 12 : !Zp
+--   %c1 = mod_arith.constant 34 : !Zp
+--   %sub = mod_arith.sub %x, %c0 : !Zp
+--   %add = mod_arith.add %sub, %c1 : !Zp
+--   // CHECK: return %[[res1]] : [[T]]
+--   return %add : !Zp
+-- }
+--------------------------------------------------------------------------------
+def test_add_sub_const_rhs_LHS := [mod_arith q, hq| {
+  ^bb0(%x : !R):
+    %c0 = mod_arith.constant 12 : !R
+    %c1 = mod_arith.constant 34 : !R
+    %sub = mod_arith.sub %x, %c0 : !R
+    %add = mod_arith.add %sub, %c1 : !R
+    return %add : !R
+}]
+def test_add_sub_const_rhs_RHS := [mod_arith q, hq| {
+  ^bb0(%x : !R):
+    %res0 = mod_arith.constant 22 : !R
+    %res1 = mod_arith.add %x, %res0 : !R
+    return %res1 : !R
+}]
+noncomputable def TV_add_sub_const_rhs : PeepholeRewrite (ModArith q) [.modLike] .modLike :=
+{
+  lhs := test_add_sub_const_rhs_LHS,
+  rhs := test_add_sub_const_rhs_RHS,
+  correct := by
+    funext valuation
+    unfold test_add_sub_const_rhs_LHS test_add_sub_const_rhs_RHS
+    simp_peephole [] at valuation
+    intro x
+    ring_nf
+}
+
+--------------------------------------------------------------------------------
+-- test_add_sub_const_lhs
+-- // CHECK-LABEL: @test_add_sub_const_lhs
+-- // CHECK: (%[[arg0:.*]]: [[T:.*]]) -> [[T]]
+-- func.func @test_add_sub_const_lhs(%x: !Zp) -> !Zp {
+--   // CHECK: %[[res0:.+]] = mod_arith.constant 4 : [[T
+--   // CHECK: %[[res1:.+]] = mod_arith.sub %[[res0]], %[[arg0]] : [[T]]
+--   %c0 = mod_arith.constant 12 : !Zp
+--   %c1 = mod_arith.constant 34 : !Zp
+--   %sub = mod_arith.sub %c0, %x : !Zp
+--   %add = mod_arith.add %sub, %c1 : !Zp
+--   // CHECK: return %[[res1]] : [[T]]
+--   return %add : !Zp
+-- }
+--------------------------------------------------------------------------------
+def test_add_sub_const_lhs_LHS := [mod_arith q, hq| {
+  ^bb0(%x : !R):
+    %c0 = mod_arith.constant 12 : !R
+    %c1 = mod_arith.constant 34 : !R
+    %sub = mod_arith.sub %c0, %x : !R
+    %add = mod_arith.add %sub, %c1 : !R
+    return %add : !R
+}]
+def test_add_sub_const_lhs_RHS := [mod_arith q, hq| {
+  ^bb0(%x : !R):
+    %res0 = mod_arith.constant 4 : !R
+    %res1 = mod_arith.sub %res0, %x : !R
+    return %res1 : !R
+}]
+noncomputable def TV_add_sub_const_lhs : PeepholeRewrite (ModArith q) [.modLike] .modLike :=
+{
+  lhs := test_add_sub_const_lhs_LHS,
+  rhs := test_add_sub_const_lhs_RHS,
+  correct := by
+    funext valuation
+    unfold test_add_sub_const_lhs_LHS test_add_sub_const_lhs_RHS
+    simp_peephole [] at valuation
+    intro x
+    norm_cast
+    ring_nf
+    rfl
+}
+
+--------------------------------------------------------------------------------
+-- test_add_mul_neg_one_rhs
+-- // CHECK-LABEL: @test_add_mul_neg_one_rhs
+-- // CHECK: (%[[arg0:.*]]: [[T:.*]]) -> [[T]]
+-- func.func @test_add_mul_neg_one_rhs(%x: !Zp, %y: !Zp) -> !Zp {
+--   // CHECK: %[[res0:.+]] = mod_arith.sub %[[arg0]], %[[arg1]] : [[T]]
+--   %neg_one = mod_arith.constant 41 : !Zp
+--   %mul = mod_arith.mul %y, %neg_one : !Zp
+--   %add = mod_arith.add %x, %mul : !Zp
+--   // CHECK: return %[[res0]] : [[T]]
+--   return %add : !Zp
+-- }
+--------------------------------------------------------------------------------
+def test_add_mul_neg_one_rhs_LHS := [mod_arith q, hq| {
+  ^bb0(%x : !R, %y : !R):
+    %neg_one = mod_arith.constant 41 : !R
+    %mul = mod_arith.mul %y, %neg_one : !R
+    %add = mod_arith.add %x, %mul : !R
+    return %add : !R
+}]
+def test_add_mul_neg_one_rhs_RHS := [mod_arith q, hq| {
+  ^bb0(%x : !R, %y : !R):
+    %res0 = mod_arith.sub %x, %y : !R
+    return %res0 : !R
+}]
+noncomputable def TV_add_mul_neg_one_rhs : PeepholeRewrite (ModArith q) [.modLike, .modLike] .modLike :=
+{
+  lhs := test_add_mul_neg_one_rhs_LHS,
+  rhs := test_add_mul_neg_one_rhs_RHS,
+  correct := by
+    funext valuation
+    unfold test_add_mul_neg_one_rhs_LHS test_add_mul_neg_one_rhs_RHS
+    simp_peephole [] at valuation
+    intro x y
+    simp [h41]
+    ring_nf
+}
+
+--------------------------------------------------------------------------------
+-- test_add_mul_neg_one_lhs
+-- // CHECK-LABEL: @test_add_mul_neg_one_lhs
+-- // CHECK: (%[[arg0:.*]]: [[T:.*]]) -> [[T]]
+-- func.func @test_add_mul_neg_one_lhs(%x: !Zp, %y: !Zp) -> !Zp {
+--   // CHECK: %[[res0:.+]] = mod_arith.sub %[[arg1]], %[[arg0]] : [[T]]
+--   %neg_one = mod_arith.constant 41 : !Zp
+--   %mul = mod_arith.mul %neg_one, %x : !Zp
+--   %add = mod_arith.add %mul, %y : !Zp
+--   // CHECK: return %[[res0]] : [[T]]
+--   return %add : !Zp
+-- }
+--------------------------------------------------------------------------------
+def test_add_mul_neg_one_lhs_LHS := [mod_arith q, hq| {
+  ^bb0(%x : !R, %y : !R):
+    %neg_one = mod_arith.constant 41 : !R
+    %mul = mod_arith.mul %neg_one, %x : !R
+    %add = mod_arith.add %mul, %y : !R
+    return %add : !R
+}]
+def test_add_mul_neg_one_lhs_RHS := [mod_arith q, hq| {
+  ^bb0(%x : !R, %y : !R):
+    %res0 = mod_arith.sub %y, %x : !R
+    return %res0 : !R
+}]
+noncomputable def TV_add_mul_neg_one_lhs : PeepholeRewrite (ModArith q) [.modLike, .modLike] .modLike :=
+{
+  lhs := test_add_mul_neg_one_lhs_LHS,
+  rhs := test_add_mul_neg_one_lhs_RHS,
+  correct := by
+    funext valuation
+    unfold test_add_mul_neg_one_lhs_LHS test_add_mul_neg_one_lhs_RHS
+    simp_peephole [] at valuation
+    intro x y
+    simp [h41]
+    ring_nf
+}
+
+--------------------------------------------------------------------------------
+-- test_sub_mul_neg_one_rhs
+-- // CHECK: (%[[arg0:.*]]: [[T:.*]], %[[arg1:.*]]: [[T]]) -> [[T]]
+-- func.func @test_sub_mul_neg_one_lhs(%x: !Zp, %y: !Zp) -> !Zp {
+--   // CHECK: %[[res0:.+]] = mod_arith.constant 0 : [[T]]
+--   // CHECK: %[[res1:.+]] = mod_arith.add %[[arg0]], %[[arg1]] : [[T]]
+--   // CHECK: %[[res2:.+]] = mod_arith.sub %[[res0]], %[[res1]] : [[T]]
+--   %neg_one = mod_arith.constant 41 : !Zp
+--   %mul = mod_arith.mul %x, %neg_one : !Zp
+--   %sub = mod_arith.sub %mul, %y : !Zp
+--   // CHECK: return %[[res2]] : [[T]]
+--   return %sub : !Zp
+-- }
+--------------------------------------------------------------------------------
+def test_sub_mul_neg_one_rhs_LHS := [mod_arith q, hq| {
+  ^bb0(%x : !R, %y : !R):
+    %neg_one = mod_arith.constant 41 : !R
+    %mul = mod_arith.mul %x, %neg_one : !R
+    %sub = mod_arith.sub %mul, %y : !R
+    return %sub : !R
+}]
+def test_sub_mul_neg_one_rhs_RHS := [mod_arith q, hq| {
+  ^bb0(%x : !R, %y : !R):
+    %res0 = mod_arith.constant 0 : !R
+    %res1 = mod_arith.add %x, %y : !R
+    %res2 = mod_arith.sub %res0, %res1 : !R
+    return %res2 : !R
+}]
+noncomputable def TV_sub_mul_neg_one_rhs : PeepholeRewrite (ModArith q) [.modLike, .modLike] .modLike :=
+{
+  lhs := test_sub_mul_neg_one_rhs_LHS,
+  rhs := test_sub_mul_neg_one_rhs_RHS,
+  correct := by
+    funext valuation
+    unfold test_sub_mul_neg_one_rhs_LHS test_sub_mul_neg_one_rhs_RHS
+    simp_peephole [] at valuation
+    intro x y
+    simp [h41]
+    ring_nf
+}
+
+--------------------------------------------------------------------------------
+-- test_sub_mul_neg_one_lhs
+-- // CHECK: (%[[arg0:.*]]: [[T:.*]], %[[arg1:.*]]: [[T]]) -> [[T]]
+-- func.func @test_sub_mul_neg_one_lhs(%x: !Zp, %y: !Zp) -> !Zp {
+--   // CHECK: %[[res0:.+]] = mod_arith.constant 0 : [[T]]
+--   // CHECK: %[[res1:.+]] = mod_arith.add %[[arg0]], %[[arg1]] : [[T]]
+--   // CHECK: %[[res2:.+]] = mod_arith.sub %[[res0]], %[[res1]] : [[T]]
+--   %neg_one = mod_arith.constant 41 : !Zp
+--   %mul = mod_arith.mul %x, %neg_one : !Zp
+--   %sub = mod_arith.sub %mul, %y : !Zp
+--   // CHECK: return %[[res2]] : [[T]]
+--   return %sub : !Zp
+-- }
+def test_sub_mul_neg_one_lhs_LHS := [mod_arith q, hq| {
+  ^bb0(%x : !R, %y : !R):
+    %neg_one = mod_arith.constant 41 : !R
+    %mul = mod_arith.mul %neg_one, %x : !R
+    %sub = mod_arith.sub %mul, %y : !R
+    return %sub : !R
+}]
+def test_sub_mul_neg_one_lhs_RHS := [mod_arith q, hq| {
+  ^bb0(%x : !R, %y : !R):
+    %res0 = mod_arith.constant 0 : !R
+    %res1 = mod_arith.add %x, %y : !R
+    %res2 = mod_arith.sub %res0, %res1 : !R
+    return %res2 : !R
+}]
+noncomputable def TV_sub_mul_neg_one_lhs : PeepholeRewrite (ModArith q) [.modLike, .modLike] .modLike :=
+{
+  lhs := test_sub_mul_neg_one_lhs_LHS,
+  rhs := test_sub_mul_neg_one_lhs_RHS,
+  correct := by
+    funext valuation
+    unfold test_sub_mul_neg_one_lhs_LHS test_sub_mul_neg_one_lhs_RHS
+    simp_peephole [] at valuation
+    intro x y
+    simp [h41]
+    ring_nf
+}
+--------------------------------------------------------------------------------
+-- test_mul_mul_const
+-- // CHECK-LABEL: @test_mul_mul_const
+-- // CHECK: (%[[arg0:.*]]: [[T:.*]]) -> [[T]]
+-- func.func @test_mul_mul_const(%x: !Zp) -> !Zp {
+--   // CHECK: %[[res0:.+]] = mod_arith.constant 30 : [[T]]
+--   // CHECK: %[[res1:.+]] = mod_arith.mul %[[arg0]], %[[res0]] : [[T]]
+--   %c0 = mod_arith.constant 12 : !Zp
+--   %c1 = mod_arith.constant 34 : !Zp
+--   %mul = mod_arith.mul %x, %c0 : !Zp
+--   %mul2 = mod_arith.mul %mul, %c1 : !Zp
+--   // CHECK: return %[[res1]] : [[T]]
+--   return %mul2 : !Zp
+-- }
+--------------------------------------------------------------------------------
+def test_mul_mul_const_LHS := [mod_arith q, hq| {
+  ^bb0(%x : !R):
+    %c0 = mod_arith.constant 12 : !R
+    %c1 = mod_arith.constant 34 : !R
+    %mul = mod_arith.mul %x, %c0 : !R
+    %mul2 = mod_arith.mul %mul, %c1 : !R
+    return %mul2 : !R
+}]
+def test_mul_mul_const_RHS := [mod_arith q, hq| {
+  ^bb0(%x : !R):
+    %res0 = mod_arith.constant 30 : !R
+    %res1 = mod_arith.mul %x, %res0 : !R
+    return %res1 : !R
+}]
+noncomputable def TV_mul_mul_const : PeepholeRewrite (ModArith q) [.modLike] .modLike :=
+{
+  lhs := test_mul_mul_const_LHS,
+  rhs := test_mul_mul_const_RHS,
+  correct := by
+    funext valuation
+    unfold test_mul_mul_const_LHS test_mul_mul_const_RHS
+    simp_peephole [] at valuation
+    intro x
+    ring_nf
+    rfl
+}
+
+--------------------------------------------------------------------------------
+-- test_sub_rhs_add_const
+-- // CHECK-LABEL: @test_sub_rhs_add_const
+-- // CHECK: (%[[arg0:.*]]: [[T:.*]]) -> [[T]]
+-- func.func @test_sub_rhs_add_const(%x: !Zp) -> !Zp {
+--   // CHECK: %[[res0:.+]] = mod_arith.constant 20 : [[T]]
+--   // CHECK: %[[res1:.+]] = mod_arith.add %[[arg0]], %[[res0]] : [[T]]
+--   %c0 = mod_arith.constant 12 : !Zp
+--   %c1 = mod_arith.constant 34 : !Zp
+--   %add = mod_arith.add %x, %c0 : !Zp
+--   %sub = mod_arith.sub %add, %c1 : !Zp
+--   // CHECK: return %[[res1]] : [[T]]
+--   return %sub : !Zp
+-- }
+--------------------------------------------------------------------------------
+def test_sub_rhs_add_const_LHS := [mod_arith q, hq| {
+  ^bb0(%x : !R):
+    %c0 = mod_arith.constant 12 : !R
+    %c1 = mod_arith.constant 34 : !R
+    %add = mod_arith.add %x, %c0 : !R
+    %sub = mod_arith.sub %add, %c1 : !R
+    return %sub : !R
+}]
+def test_sub_rhs_add_const_RHS := [mod_arith q, hq| {
+  ^bb0(%x : !R):
+    %res0 = mod_arith.constant 20 : !R
+    %res1 = mod_arith.add %x, %res0 : !R
+    return %res1 : !R
+}]
+noncomputable def TV_sub_rhs_add_const : PeepholeRewrite (ModArith q) [.modLike] .modLike :=
+{
+  lhs := test_sub_rhs_add_const_LHS,
+  rhs := test_sub_rhs_add_const_RHS,
+  correct := by
+    funext valuation
+    unfold test_sub_rhs_add_const_LHS test_sub_rhs_add_const_RHS
+    simp_peephole [] at valuation
+    intro x
+    ring_nf
+    rfl
+}
+
+--------------------------------------------------------------------------------
+-- test_sub_lhs_add_const
+-- // CHECK-LABEL: @test_sub_lhs_add_const
+-- // CHECK: (%[[arg0:.*]]: [[T:.*]]) -> [[T]]
+-- func.func @test_sub_lhs_add_const(%x: !Zp) -> !Zp {
+--   // CHECK: %[[res0:.+]] = mod_arith.constant 22 : [[T]]
+--   // CHECK: %[[res1:.+]] = mod_arith.sub %[[res0]], %[[arg0]] : [[T]]
+--   %c0 = mod_arith.constant 12 : !Zp
+--   %c1 = mod_arith.constant 34 : !Zp
+--   %add = mod_arith.add %x, %c0 : !Zp
+--   %sub = mod_arith.sub %c1, %add : !Zp
+--   // CHECK: return %[[res1]] : [[T]]
+--   return %sub : !Zp
+-- }
+--------------------------------------------------------------------------------
+def test_sub_lhs_add_const_LHS := [mod_arith q, hq| {
+  ^bb0(%x : !R):
+    %c0 = mod_arith.constant 12 : !R
+    %c1 = mod_arith.constant 34 : !R
+    %add = mod_arith.add %x, %c0 : !R
+    %sub = mod_arith.sub %c1, %add : !R
+    return %sub : !R
+}]
+def test_sub_lhs_add_const_RHS := [mod_arith q, hq| {
+  ^bb0(%x : !R):
+    %res0 = mod_arith.constant 22 : !R
+    %res1 = mod_arith.sub %res0, %x : !R
+    return %res1 : !R
+}]
+noncomputable def TV_sub_lhs_add_const : PeepholeRewrite (ModArith q) [.modLike] .modLike :=
+{
+  lhs := test_sub_lhs_add_const_LHS,
+  rhs := test_sub_lhs_add_const_RHS,
+  correct := by
+    funext valuation
+    unfold test_sub_lhs_add_const_LHS test_sub_lhs_add_const_RHS
+    simp_peephole [] at valuation
+    intro x
+    ring_nf
+}
+
+--------------------------------------------------------------------------------
+-- test_sub_sub_lhs_rhs_lhs
+-- // CHECK-LABEL: @test_sub_sub_lhs_rhs_lhs
+-- // CHECK: (%[[arg0:.*]]: [[T:.*]], %[[arg1:.*]]: [[T]]) -> [[T]]
+-- func.func @test_sub_sub_lhs_rhs_lhs(%a: !Zp, %b: !Zp) -> !Zp {
+--   // CHECK: %[[res0:.+]] = mod_arith.constant 0 : [[T]]
+--   // CHECK: %[[res1:.+]] = mod_arith.sub %[[res0]], %[[arg1]] : [[T]]
+--   %sub = mod_arith.sub %a, %b : !Zp
+--   %sub2 = mod_arith.sub %sub, %a : !Zp
+--   // CHECK: return %[[res1]] : [[T]]
+--   return %sub2 : !Zp
+-- }
+--------------------------------------------------------------------------------
+def test_sub_sub_lhs_rhs_lhs_LHS := [mod_arith q, hq| {
+  ^bb0(%a : !R, %b : !R):
+    %sub = mod_arith.sub %a, %b : !R
+    %sub2 = mod_arith.sub %sub, %a : !R
+    return %sub2 : !R
+}]
+def test_sub_sub_lhs_rhs_lhs_RHS := [mod_arith q, hq| {
+  ^bb0(%a : !R, %b : !R):
+    %res0 = mod_arith.constant 0 : !R
+    %res1 = mod_arith.sub %res0, %b : !R
+    return %res1 : !R
+}]
+noncomputable def TV_sub_sub_lhs_rhs_lhs : PeepholeRewrite (ModArith q) [.modLike, .modLike] .modLike :=
+{
+  lhs := test_sub_sub_lhs_rhs_lhs_LHS,
+  rhs := test_sub_sub_lhs_rhs_lhs_RHS,
+  correct := by
+    funext valuation
+    unfold test_sub_sub_lhs_rhs_lhs_LHS test_sub_sub_lhs_rhs_lhs_RHS
+    simp_peephole [] at valuation
+    intro a b
+    ring_nf
+}
+
+end ModArithCanonicalization

--- a/SSA/Projects/ModArith/PrettySyntax.lean
+++ b/SSA/Projects/ModArith/PrettySyntax.lean
@@ -1,6 +1,4 @@
 /-
-Released under Apache 2.0 license as described in the file LICENSE.
-
 This file defines a "pretty syntax" for the `ModArith` dialect, analogous to
 `FullyHomomorphicEncryption/PrettySyntax.lean`.
 

--- a/SSA/Projects/ModArith/PrettySyntax.lean
+++ b/SSA/Projects/ModArith/PrettySyntax.lean
@@ -1,0 +1,94 @@
+/-
+Released under Apache 2.0 license as described in the file LICENSE.
+
+This file defines a "pretty syntax" for the `ModArith` dialect, analogous to
+`FullyHomomorphicEncryption/PrettySyntax.lean`.
+
+It provides macros to parse lines of the form:
+  %v = mod_arith.constant 12 : !Zp
+  %w = mod_arith.add %x, %y : !Zp
+etc., into the uniform EDSL used by the MLIR translation in Lean.
+
+Authors: Jaeho Choi <zerozerozero0216@gmail.com>
+-/
+import SSA.Core.MLIRSyntax.PrettyEDSL
+import SSA.Projects.ModArith.Syntax
+
+namespace MLIR.EDSL.Pretty
+open Lean
+
+/--
+We declare `mod_arith.constant`, `mod_arith.add`, `mod_arith.sub`, etc.
+as uniform ops. This means we can write lines like:
+
+  %x = mod_arith.add %a, %b : (!Zp, !Zp) -> !Zp
+
+and the `PrettyEDSL` machinery will parse them automatically.
+-/
+syntax "mod_arith.constant" : MLIR.Pretty.uniform_op
+syntax "mod_arith.add" : MLIR.Pretty.uniform_op
+syntax "mod_arith.sub" : MLIR.Pretty.uniform_op
+syntax "mod_arith.mul" : MLIR.Pretty.uniform_op
+syntax "return" : MLIR.Pretty.uniform_op
+
+/--
+We handle two forms:
+
+  1) `%v = mod_arith.constant 42 : !Zp`
+     which gets parsed as an integer attribute with value 42
+
+  2) `%v = mod_arith.constant -10 : !Zp`
+     for negative numbers
+
+For each, we produce a uniform op in the underlying IR:
+
+  `%v = "mod_arith.constant" () {value = 42} : () -> (!Zp)`
+-/
+syntax mlir_op_operand " = " "mod_arith.constant" "$" noWs "{" term "}" " : " mlir_type : mlir_op
+syntax mlir_op_operand " = " "mod_arith.constant" neg_num " : " mlir_type : mlir_op
+
+macro_rules
+  -- Case (2): negative integer literal
+  | `(mlir_op| $v:mlir_op_operand = mod_arith.constant $x:neg_num : $t) =>
+    `(mlir_op| $v:mlir_op_operand = "mod_arith.constant" () {value = $x:neg_num} : () -> ($t))
+
+  -- Case (1): arbitrary integer expression in braces
+  | `(mlir_op| $v:mlir_op_operand = mod_arith.constant ${ $x:term } : $t) => do
+      let ctor := mkIdent ``MLIR.AST.AttrValue.int
+      let x ← `($ctor $x [mlir_type| i64])
+      `(mlir_op| $v:mlir_op_operand = "mod_arith.constant" () {value = $$($x)} : () -> ($t))
+
+section Test
+variable {q : Nat} [h : Fact (q > 1)]
+/--
+A small test snippet. If you do:
+
+  #check test_one_lhs
+
+It shows how Lean parses:
+
+  %e1 = mod_arith.constant 12 : !R
+  %e2 = mod_arith.constant -5 : !R
+  %add = mod_arith.add %e1, %e2 : !R
+  return %add : !R
+-/
+private def test_lhs := [mod_arith q, h | {
+  ^bb0(%a : !R):
+    %e1 = mod_arith.constant 12 : !R
+    %e2 = mod_arith.constant -5 : !R
+    %add = mod_arith.add %e1, %e2 : !R
+    return %a : !R
+}]
+
+/--
+info: '_private.SSA.Projects.ModArith.PrettySyntax.0.MLIR.EDSL.Pretty.test_lhs' depends on axioms: [propext, Quot.sound]
+-/
+#guard_msgs in #print axioms test_lhs
+
+end Test
+
+end Pretty
+
+end EDSL
+
+end MLIR

--- a/SSA/Projects/ModArith/Statements.lean
+++ b/SSA/Projects/ModArith/Statements.lean
@@ -1,0 +1,43 @@
+/-
+Released under Apache 2.0 license as described in the file LICENSE.
+
+This file contains some basic lemmas for the `ModArith` dialect in HEIR,
+analogous to the `Statements.lean` file from the `Poly` dialect.
+
+Authors: Jaeho Choi<zerozerozero0216@gmail.com>
+-/
+import SSA.Projects.ModArith.Basic
+import Batteries.Data.List.Lemmas
+import Mathlib.Algebra.Ring.Basic
+import Mathlib.Data.ZMod.Basic
+import Mathlib.Data.ZMod.QuotientRing
+
+namespace ModArith
+
+theorem add_comm (a b : R q) : a + b = b + a := by
+  ring
+theorem mul_comm (a b : R q) : a * b = b * a := by
+  ring
+
+theorem add_zero (a : ZMod q) : a + 0 = a := by
+  ring
+theorem zero_add (a : ZMod q) : 0 + a = a := by
+  ring
+
+theorem mul_zero (a : ZMod q) : a * 0 = 0 := by
+  ring
+theorem zero_mul (a : ZMod q) : 0 * a = 0 := by
+  ring
+
+theorem mul_one (a : ZMod q) : a * 1 = a := by
+  ring
+theorem one_mul (a : ZMod q) : 1 * a = a := by
+  ring
+
+theorem sub_zero (a : ZMod q) : a - 0 = a := by
+  ring
+
+theorem sub_self (a : ZMod q) : a - a = 0 := by
+  ring
+
+end ModArith

--- a/SSA/Projects/ModArith/Statements.lean
+++ b/SSA/Projects/ModArith/Statements.lean
@@ -1,6 +1,4 @@
 /-
-Released under Apache 2.0 license as described in the file LICENSE.
-
 This file contains some basic lemmas for the `ModArith` dialect in HEIR,
 analogous to the `Statements.lean` file from the `Poly` dialect.
 

--- a/SSA/Projects/ModArith/Syntax.lean
+++ b/SSA/Projects/ModArith/Syntax.lean
@@ -1,6 +1,4 @@
 /-
-Released under Apache 2.0 license as described in the file LICENSE.
-
 Syntax definitions for `ModArith`, providing a custom `[mod_arith q, hq | ...]` with syntax sugar
 analogous to FHE's `[poly| ...]`.
 

--- a/SSA/Projects/ModArith/Syntax.lean
+++ b/SSA/Projects/ModArith/Syntax.lean
@@ -1,0 +1,241 @@
+/-
+Released under Apache 2.0 license as described in the file LICENSE.
+
+Syntax definitions for `ModArith`, providing a custom `[mod_arith q, hq | ...]` with syntax sugar
+analogous to FHE's `[poly| ...]`.
+
+Authors: Jaeho Choi<zerozerozero0216@gmail.com>
+-/
+import SSA.Core.MLIRSyntax.EDSL
+import SSA.Projects.ModArith.Basic
+
+open MLIR AST Ctxt
+open ZMod
+
+section MkFuns
+
+/-
+We assume `q : Nat` and `[Fact (q > 1)]` so that `ZMod q` is nontrivial.
+-/
+variable {q : Nat} [Fact (q > 1)]
+
+/--
+This function maps from an MLIR type to our `ModArith` dialect’s type.
+We support:
+  - `R` (a textual marker) → `.modLike`
+  - `int` → `.integer`
+  - `index` → `.index`
+You can rename or expand these patterns as needed.
+-/
+def mkTy : MLIR.AST.MLIRType φ → MLIR.AST.ExceptM (ModArith q) (ModArith q).Ty
+  | MLIR.AST.MLIRType.undefined "R" =>
+    return .modLike
+  | MLIR.AST.MLIRType.int MLIR.AST.Signedness.Signless _ =>
+    return .integer
+  | MLIR.AST.MLIRType.index =>
+    return .index
+  | _ => throw .unsupportedType
+
+instance instTransformTy : MLIR.AST.TransformTy (ModArith q) 0 where
+  mkTy := mkTy
+
+/--
+A helper to construct a constant integer expression (in Lean’s sense of “plain Int”).
+-/
+def cstInt {Γ : Ctxt _} (z : Int) : Expr (ModArith q) Γ .pure .integer :=
+  Expr.mk
+    (op      := .const_int z)
+    (ty_eq   := rfl)
+    (eff_le  := by constructor)
+    (args    := .nil)
+    (regArgs := .nil)
+
+/--
+A helper to construct a constant index expression (Lean’s `Nat`).
+-/
+def cstIdx {Γ : Ctxt _} (i : Nat) : Expr (ModArith q) Γ .pure .index :=
+  Expr.mk
+    (op      := .const_idx i)
+    (ty_eq   := rfl)
+    (eff_le  := by constructor)
+    (args    := .nil)
+    (regArgs := .nil)
+
+/--
+A helper to construct a ring element in `ZMod q` from an `Int`.
+-/
+def cstMod {Γ : Ctxt _} (z : Int) : Expr (ModArith q) Γ .pure .modLike :=
+  -- If you want a “computable cast” approach, do similarly to FHE's `cstComputable`.
+  -- For now, we can just do a raw `.const` to embed `↑z : ZMod q`.
+  let zmod : ZMod q := z
+  Expr.mk
+    (op      := .const zmod)
+    (ty_eq   := rfl)
+    (eff_le  := by constructor)
+    (args    := .nil)
+    (regArgs := .nil)
+
+/--
+Build an “add” operation in `ZMod q`.
+-/
+def add {Γ : Ctxt (Ty q)} (x y : Var Γ .modLike)
+    : Expr (ModArith q) Γ .pure .modLike :=
+  Expr.mk
+    (op      := .add)
+    (ty_eq   := rfl)
+    (eff_le  := by constructor)
+    (args    := .cons x (.cons y .nil))
+    (regArgs := .nil)
+
+/--
+Build a “sub” operation in `ZMod q`.
+-/
+def sub {Γ : Ctxt (Ty q)} (x y : Var Γ .modLike)
+    : Expr (ModArith q) Γ .pure .modLike :=
+  Expr.mk
+    (op      := .sub)
+    (ty_eq   := rfl)
+    (eff_le  := by constructor)
+    (args    := .cons x (.cons y .nil))
+    (regArgs := .nil)
+
+/--
+Build a “mul” operation in `ZMod q`.
+-/
+def mul {Γ : Ctxt (Ty q)} (x y : Var Γ .modLike)
+    : Expr (ModArith q) Γ .pure .modLike :=
+  Expr.mk
+    (op      := .mul)
+    (ty_eq   := rfl)
+    (eff_le  := by constructor)
+    (args    := .cons x (.cons y .nil))
+    (regArgs := .nil)
+
+/--
+Given a single MLIR operation, produce a Lean expression in the `ModArith` dialect.
+
+We match on `opStx.name` to see if it is `"mod_arith.add"`, `"mod_arith.sub"`,
+`"arith.const"`, etc. Then we decode the arguments, attribute `value`,
+and produce the corresponding expression builder (add, sub, cstInt, etc.).
+-/
+def mkExpr (Γ : Ctxt (ModArith q).Ty) (opStx : MLIR.AST.Op 0)
+  : MLIR.AST.ReaderM (ModArith q) (Σ eff ty, Expr (ModArith q) Γ eff ty) := do
+  match opStx.name with
+
+  | "mod_arith.add" =>
+    match opStx.args with
+    | [xStx, yStx] => do
+      let ⟨tyX, x⟩ ← MLIR.AST.TypedSSAVal.mkVal Γ xStx
+      let ⟨tyY, y⟩ ← MLIR.AST.TypedSSAVal.mkVal Γ yStx
+      match tyX, tyY with
+      | .modLike, .modLike =>
+         return ⟨.pure, .modLike, add x y⟩
+      | _, _ =>
+         throw <| .generic s!"expected both operands to be of type 'modLike'"
+    | _ =>
+      throw <| .generic s!"mod_arith.add expects exactly 2 args, got {opStx.args.length}"
+
+  | "mod_arith.sub" =>
+    match opStx.args with
+    | [xStx, yStx] => do
+      let ⟨tyX, x⟩ ← MLIR.AST.TypedSSAVal.mkVal Γ xStx
+      let ⟨tyY, y⟩ ← MLIR.AST.TypedSSAVal.mkVal Γ yStx
+      match tyX, tyY with
+      | .modLike, .modLike =>
+         return ⟨.pure, .modLike, sub x y⟩
+      | _, _ =>
+         throw <| .generic s!"expected both operands to be of type 'modLike'"
+    | _ =>
+      throw <| .generic s!"mod_arith.sub expects exactly 2 args, got {opStx.args.length}"
+
+  | "mod_arith.mul" =>
+    match opStx.args with
+    | [xStx, yStx] => do
+      let ⟨tyX, x⟩ ← MLIR.AST.TypedSSAVal.mkVal Γ xStx
+      let ⟨tyY, y⟩ ← MLIR.AST.TypedSSAVal.mkVal Γ yStx
+      match tyX, tyY with
+      | .modLike, .modLike =>
+         return ⟨.pure, .modLike, mul x y⟩
+      | _, _ =>
+         throw <| .generic s!"expected both operands to be of type 'modLike'"
+    | _ =>
+      throw <| .generic s!"mod_arith.mul expects exactly 2 args, got {opStx.args.length}"
+
+  | "arith.constant" =>
+    -- We let the `arith.constant` produce either a plain integer or an index, etc.
+    match opStx.attrs.find_int "value" with
+    | .some (val, valTy) =>
+      match valTy with
+      | .int _sz _sign =>
+        -- check result type from `opStx.res`
+        match opStx.res with
+        | [(_, MLIR.AST.MLIRType.int .Signless _sz2)] =>
+          -- ok, produce cstInt
+          return ⟨.pure, .integer, cstInt val⟩
+        | [(_, MLIR.AST.MLIRType.index)] =>
+          return ⟨.pure, .index, cstIdx val.toNat⟩
+        | other =>
+          throw <| .generic s!"arith.constant: unsupported result type {repr other}"
+      | tyOther =>
+        throw <| .generic s!"arith.constant with unsupported type {repr tyOther}"
+    | .none =>
+      throw <| .generic s!"arith.constant expects int-attr 'value', got {repr opStx.attrs}"
+
+  | "mod_arith.constant" =>
+    -- A direct constant in `ZMod q`.
+    match opStx.attrs.find_int "value" with
+    | .some (val, _valTy) =>
+      return ⟨.pure, .modLike, cstMod val⟩
+    | .none =>
+      throw <| .generic s!"mod_arith.constant expects int-attr 'value', got {repr opStx.attrs}"
+
+  | other =>
+    throw <| .unsupportedOp s!"[mod_arith] mkExpr: operation name {other} not recognized"
+
+/--
+Given a return statement, produce a `Com (ModArith q)` that returns the given value.
+We check that the op is named "return" and has exactly one argument.
+-/
+def mkReturn (Γ : Ctxt (ModArith q).Ty) (opStx : MLIR.AST.Op 0)
+  : MLIR.AST.ReaderM (ModArith q) (Σ eff ty, Com (ModArith q) Γ eff ty) :=
+  if opStx.name == "return" then
+    match opStx.args with
+    | [argStx] => do
+      let ⟨tyArg, x⟩ ← MLIR.AST.TypedSSAVal.mkVal Γ argStx
+      return ⟨.pure, tyArg, Com.ret x⟩
+    | _ =>
+      throw <| .generic s!"[mod_arith] return expects exactly 1 argument"
+  else
+      throw <| .generic s!"[mod_arith] mkReturn called on non-return op {opStx.name}"
+
+
+instance : MLIR.AST.TransformExpr (ModArith q) 0 where
+  mkExpr := mkExpr
+
+instance : MLIR.AST.TransformReturn (ModArith q) 0 where
+  mkReturn := mkReturn
+
+end MkFuns
+
+open Qq MLIR AST Lean Elab Term Meta in
+elab "[mod_arith " qi:term "," hq:term " | " reg:mlir_region "]" : term => do
+  -- 1) elaborate `q : Nat`
+  let q_   : Q(Nat)             ← elabTermEnsuringTypeQ qi   q(Nat)
+  -- 2) elaborate `hq : Fact (q > 1)`
+  let hq_  : Q(Fact ($q_ > 1))  ← elabTermEnsuringTypeQ hq   q(Fact ($q_ > 1))
+  -- 3) call the EDSL machinery
+  SSA.elabIntoCom reg q(ModArith $q_)
+
+/-!
+Usage example might look like:
+
+```lean
+def myTest : Com (ModArith 17) [] .pure .modLike :=
+  [mod_arith 17, fact17 |
+    %x = arith.constant 42 : !i32 { value = 42 : i32 }
+    %y = mod_arith.const { value = 9 : i64 } : !R
+    %z = mod_arith.add %x, %y : !R
+    return %z
+  ]
+```
+-/


### PR DESCRIPTION
Hello lean-mlir team,

I'm very interested in translation validation/compiler verification techniques for MLIR-based compilers, and I found your work truly impressive and valuable—thank you for sharing it!

Recently, I used this project to validate a canonicalization pass I contributed to the `ModArith` dialect (which corresponds to arithmetic over Zp) in the [heir project](https://github.com/google/heir/pull/1506).

This PR contains the result of that effort. I’d appreciate it if you could take a look and review it. Most of the implementation was straightforward by referring to `SSA/Projects/FullyHomomorphicEncryption`.

For more context, I’ve shared a detailed discussion here: https://github.com/google/heir/issues/817#issuecomment-2737578749

Thank you!