### PR TITLE
chore: fix import in variadic dialect example

### DIFF
--- a/SSA/Projects/PaperExamples/VariadicExample.lean
+++ b/SSA/Projects/PaperExamples/VariadicExample.lean
@@ -1,5 +1,6 @@
 import SSA.Core.Framework
 import SSA.Core.Framework.Macro
+import SSA.Core.Tactic.SimpSet
 
 /-!
 ## Variadic Example Dialect


### PR DESCRIPTION
this PR adds `import SSA.Core.Tactic.SimpSet` to fix the variadic dialect example.