### PR TITLE
feat: HVector.foldld dependent fold over hvector

### DIFF
--- a/SSA/Core/HVector.lean
+++ b/SSA/Core/HVector.lean
@@ -43,6 +43,7 @@ def map' {A : α → Type*} {B : β → Type*} (f' : α → β) (f : ∀ (a : α
   | [],   .nil        => .nil
   | t::_, .cons a as  => .cons (f t a) (map' f' f as)
 
+/-- Folds a function over an hvector from the left, where the accumulator has a fixed type. -/
 def foldl {B : Type*} (f : ∀ (a : α), B → A a → B) :
     ∀ {l : List α}, B → HVector A l → B
   | [],   b, .nil       => b
@@ -54,6 +55,20 @@ def foldr {β : Type*} (f : ∀ (a : α), A a → β → β) :
   | t::_, b, .cons a as =>
     let b' := foldr f b as
     f t a b'
+
+/--
+Folds a function over an hvector from the left, where the type of the
+accumulator depends on the elements processed.
+
+In particular, the type of the accumulator after processing i elements is obtained
+by folding `fType` over the first i elements of `as`, and applying `B` to the
+result of that fold.
+-/
+def foldld {β : Type*} (B : β → Type*) (fType : β → α → β)
+    (fElem : {b : β} → {a : α} → B b → A a → B (fType b a)) :
+    {as : List α} → HVector A as → {b : β} → (init : B b) → B (as.foldl fType b)
+  | [], .nil, _, init         => init
+  | _::_, .cons a as, _, init => foldld B fType fElem as (fElem init a)
 
 def get {as} : HVector A as → (i : Fin as.length) → A (as.get i)
   | .nil, i => i.elim0


### PR DESCRIPTION
This PR adds `HVector.foldld`, which is a fold from the left, where the type of the accumulator may depend on the type of the elements already processed. 

That is, it simultaneously folds over the list of types `as` and the elements in an `HVector _ as`.