### PR TITLE
refactor: make LLVM dialect into a (semireducible) def instead of a (reducible) abbrev

### DIFF
--- a/SSA/MLIRNatural.lean
+++ b/SSA/MLIRNatural.lean
@@ -6,6 +6,7 @@ import SSA.Projects.InstCombine.LLVM.CLITests
 import Cli
 
 open Lean
+open InstCombine.LLVM.Ty (bitvec)
 
 -- Note that this application of 4 here doesn't really do anything, parameters not supported for now
 @[reducible]
@@ -19,8 +20,8 @@ def runTest (test : ConcreteCliTest) (arg : String) : IO Bool := do
     let res ← test.eval (p.map Option.some)
     -- Add the first match to help lean reduce the TyDenote instance
     match test.ty, res with
-      | .bitvec _, .some val => IO.println s!"result: {val}"
-      | .bitvec _, .none => IO.println s!"no result (undefined behavior)"
+      | bitvec _, .some val => IO.println s!"result: {val}"
+      | bitvec _, .none => IO.println s!"no result (undefined behavior)"
     return true
 
 def listAllTests : IO Unit := do

--- a/SSA/Projects/InstCombine/AliveHandwrittenLargeExamples.lean
+++ b/SSA/Projects/InstCombine/AliveHandwrittenLargeExamples.lean
@@ -8,6 +8,7 @@ import SSA.Experimental.Bits.ForLean
 
 open BitVec
 open MLIR AST
+open InstCombine (LLVM)
 
 namespace AliveHandwritten
 
@@ -95,13 +96,13 @@ Proof:
 -/
 open ComWrappers
 def MulDivRem805_lhs (w : ℕ) : Com InstCombine.LLVM
-    [/- %X -/ InstCombine.Ty.bitvec w] .pure (InstCombine.Ty.bitvec w) :=
+    [/- %X -/ LLVM.Ty.bitvec w] .pure (LLVM.Ty.bitvec w) :=
   /- c1 = -/ Com.var (const w 1) <|
   /- r = -/ Com.var (sdiv w /- c1-/ 0 /-%X -/ 1) <|
   Com.ret ⟨/-r-/0, by simp [Ctxt.snoc]⟩
 
 def MulDivRem805_rhs (w : ℕ) : Com InstCombine.LLVM
-    [/- %X -/ InstCombine.Ty.bitvec w] .pure (InstCombine.Ty.bitvec w) :=
+    [/- %X -/ LLVM.Ty.bitvec w] .pure (LLVM.Ty.bitvec w) :=
   /- c1 = -/ Com.var (const w 1) <|
   /- inc = -/ Com.var (add w /-c1 -/ 0 /-X-/ 1) <|
   /- c3 = -/ Com.var (const w 3) <|
@@ -338,8 +339,8 @@ Proof
 open ComWrappers
 def MulDivRem290_lhs (w : ℕ) :
   Com InstCombine.LLVM
-    [/- %X -/ InstCombine.Ty.bitvec w,
-    /- %Y -/ InstCombine.Ty.bitvec w] .pure (InstCombine.Ty.bitvec w) :=
+    [/- %X -/ LLVM.Ty.bitvec w,
+    /- %Y -/ LLVM.Ty.bitvec w] .pure (LLVM.Ty.bitvec w) :=
   /- c1 = -/ Com.var (const w 1) <|
   /- poty = -/ Com.var (shl w /- c1 -/ 0 /-%Y -/ 1) <|
   /- r = -/ Com.var (mul w /- poty -/ 0 /-%X -/ 3) <|
@@ -347,8 +348,8 @@ def MulDivRem290_lhs (w : ℕ) :
 
 def MulDivRem290_rhs (w : ℕ) :
     Com InstCombine.LLVM
-    [/- %X -/ InstCombine.Ty.bitvec w, /- %Y -/ InstCombine.Ty.bitvec w]
-    .pure (InstCombine.Ty.bitvec w) :=
+    [/- %X -/ LLVM.Ty.bitvec w, /- %Y -/ LLVM.Ty.bitvec w]
+    .pure (LLVM.Ty.bitvec w) :=
   /- r = -/ Com.var (shl w /-X-/ 1 /-Y-/ 0) <|
   Com.ret ⟨/-r-/0, by simp [Ctxt.snoc]⟩
 
@@ -384,10 +385,10 @@ open ComWrappers
 
 def AndOrXor2515_lhs (w : ℕ):
   Com InstCombine.LLVM
-    [/- C1 -/ InstCombine.Ty.bitvec w,
-     /- C2 -/ InstCombine.Ty.bitvec w,
-     /- C3 -/ InstCombine.Ty.bitvec w,
-     /- %X -/ InstCombine.Ty.bitvec w] .pure (InstCombine.Ty.bitvec w) :=
+    [/- C1 -/ LLVM.Ty.bitvec w,
+     /- C2 -/ LLVM.Ty.bitvec w,
+     /- C3 -/ LLVM.Ty.bitvec w,
+     /- %X -/ LLVM.Ty.bitvec w] .pure (LLVM.Ty.bitvec w) :=
   /- e1  = -/ Com.var (xor w /-x-/ 0 /-C1-/ 3) <|
   /- op0 = -/ Com.var (lshr w /-e1-/ 0 /-C2-/ 3) <|
   /- r   = -/ Com.var (xor w /-op0-/ 0 /-C3-/ 3) <|
@@ -395,10 +396,10 @@ def AndOrXor2515_lhs (w : ℕ):
 
 def AndOrXor2515_rhs (w : ℕ) :
   Com InstCombine.LLVM
-    [/- C1 -/ InstCombine.Ty.bitvec w,
-     /- C2 -/ InstCombine.Ty.bitvec w,
-     /- C3 -/ InstCombine.Ty.bitvec w,
-     /- %X -/ InstCombine.Ty.bitvec w] .pure (InstCombine.Ty.bitvec w) :=
+    [/- C1 -/ LLVM.Ty.bitvec w,
+     /- C2 -/ LLVM.Ty.bitvec w,
+     /- C3 -/ LLVM.Ty.bitvec w,
+     /- %X -/ LLVM.Ty.bitvec w] .pure (LLVM.Ty.bitvec w) :=
   /- o = -/ Com.var (lshr w /-X-/ 0 /-C2-/ 2) <|
   /- p = -/ Com.var (lshr w /-C1-/ 4 /-C2-/ 3) <|
   /- q = -/ Com.var (xor w /-p-/ 0 /-C3-/ 3) <|
@@ -467,7 +468,7 @@ Name: Select:746
 open ComWrappers
 def Select746_lhs (w : ℕ):
   Com InstCombine.LLVM
-    [/- A -/ InstCombine.Ty.bitvec w] .pure (InstCombine.Ty.bitvec w) :=
+    [/- A -/ LLVM.Ty.bitvec w] .pure (LLVM.Ty.bitvec w) :=
   /- c0     = -/ Com.var (const w 0) <|
   /- c      = -/ Com.var (icmp w .slt /-A-/ 1 /-c0-/ 0) <|
   /- minus  = -/ Com.var (sub w /-c0-/ 1 /-A-/ 2) <|
@@ -479,7 +480,7 @@ def Select746_lhs (w : ℕ):
 
 def Select746_rhs (w : ℕ):
   Com InstCombine.LLVM
-    [/- A -/ InstCombine.Ty.bitvec w] .pure (InstCombine.Ty.bitvec w) :=
+    [/- A -/ LLVM.Ty.bitvec w] .pure (LLVM.Ty.bitvec w) :=
   /- c0     = -/ Com.var (const w 0) <|
   /- c      = -/ Com.var (icmp w .slt /-A-/ 1 /-c0-/ 0) <|
   /- minus  = -/ Com.var (sub w /-c0-/ 1 /-A-/ 2) <|

--- a/SSA/Projects/InstCombine/Base.lean
+++ b/SSA/Projects/InstCombine/Base.lean
@@ -233,50 +233,51 @@ def deepCasesOn {motive : ∀ {φ}, MOp φ → Sort*}
 
 end MOp
 
-namespace Op
+namespace LLVM.Op
 
-@[match_pattern] abbrev unary   (w : Nat) (op : MOp.UnaryOp 0)  : Op := MOp.unary (.concrete w) op
-@[match_pattern] abbrev binary  (w : Nat) (op : MOp.BinaryOp) : Op := MOp.binary (.concrete w) op
+@[match_pattern] abbrev unary  (w : Nat) (op : MOp.UnaryOp 0) : LLVM.Op :=
+  MOp.unary (.concrete w) op
 
-@[match_pattern] abbrev and    : Nat → Op := MOp.and    ∘ .concrete
-@[match_pattern] abbrev not    : Nat → Op := MOp.not    ∘ .concrete
-@[match_pattern] abbrev sext   : Nat → Nat → Op := fun w w' => MOp.sext (.concrete w) (.concrete w')
-@[match_pattern] abbrev xor    : Nat → Op := MOp.xor    ∘ .concrete
-@[match_pattern] abbrev urem   : Nat → Op := MOp.urem   ∘ .concrete
-@[match_pattern] abbrev srem   : Nat → Op := MOp.srem   ∘ .concrete
-@[match_pattern] abbrev select : Nat → Op := MOp.select ∘ .concrete
-@[match_pattern] abbrev neg    : Nat → Op := MOp.neg    ∘ .concrete
-@[match_pattern] abbrev copy   : Nat → Op := MOp.copy   ∘ .concrete
+@[match_pattern] abbrev binary (w : Nat) (op : MOp.BinaryOp) : LLVM.Op :=
+  MOp.binary (.concrete w) op
 
-@[match_pattern] abbrev icmp (c : IntPred)   : Nat → Op  := MOp.icmp c ∘ .concrete
-@[match_pattern] abbrev const (w : Nat) (val : ℤ) : Op        := MOp.const (.concrete w) val
+@[match_pattern] abbrev and    : Nat → LLVM.Op := MOp.and    ∘ .concrete
+@[match_pattern] abbrev not    : Nat → LLVM.Op := MOp.not    ∘ .concrete
+@[match_pattern] abbrev sext   : Nat → Nat → LLVM.Op := fun w w' => MOp.sext (.concrete w) (.concrete w')
+@[match_pattern] abbrev xor    : Nat → LLVM.Op := MOp.xor    ∘ .concrete
+@[match_pattern] abbrev urem   : Nat → LLVM.Op := MOp.urem   ∘ .concrete
+@[match_pattern] abbrev srem   : Nat → LLVM.Op := MOp.srem   ∘ .concrete
+@[match_pattern] abbrev select : Nat → LLVM.Op := MOp.select ∘ .concrete
+@[match_pattern] abbrev neg    : Nat → LLVM.Op := MOp.neg    ∘ .concrete
+@[match_pattern] abbrev copy   : Nat → LLVM.Op := MOp.copy   ∘ .concrete
+
+@[match_pattern] abbrev icmp (c : IntPred)   : Nat → LLVM.Op  := MOp.icmp c ∘ .concrete
+@[match_pattern] abbrev const (w : Nat) (val : ℤ) : LLVM.Op        := MOp.const (.concrete w) val
 
 /- This operation is separate from the others because it takes in a flag: nneg. -/
-@[match_pattern] abbrev zext (w w': Nat) (flag : NonNegFlag := {nneg := false}) : Op := MOp.zext (.concrete w) (.concrete w') flag
+@[match_pattern] abbrev zext (w w': Nat) (flag : NonNegFlag := {nneg := false}) : LLVM.Op :=
+  MOp.zext (.concrete w) (.concrete w') flag
 
 /- This operation is separate from the others because it takes in a flag: disjoint. -/
-@[match_pattern] abbrev or (w : Nat) (flag : DisjointFlag := {disjoint := false} ) : Op := MOp.or (.concrete w) flag
+@[match_pattern] abbrev or (w : Nat) (flag : DisjointFlag := {disjoint := false} ) : LLVM.Op :=
+  MOp.or (.concrete w) flag
 
 /- These operations are separate from the others because they take in 2 flags: nuw and nsw.-/
-@[match_pattern] abbrev trunc (w w': Nat) (noWrapFlags: NoWrapFlags :=
-   {nsw := false , nuw := false}) : Op := MOp.trunc (.concrete w) (.concrete w') noWrapFlags
+@[match_pattern] abbrev trunc (w w': Nat) (flags: NoWrapFlags := {}) : LLVM.Op :=
+  MOp.trunc (.concrete w) (.concrete w') flags
 
-@[match_pattern] abbrev shl (w : Nat) (flags: NoWrapFlags :=
-   {nsw := false , nuw := false}) : Op:=  MOp.shl (.concrete w) flags
-@[match_pattern] abbrev add (w : Nat) (flags: NoWrapFlags :=
-   {nsw := false , nuw := false}) : Op:=  MOp.add (.concrete w) flags
-@[match_pattern] abbrev mul (w : Nat) (flags: NoWrapFlags :=
-   {nsw := false , nuw := false}) : Op:=  MOp.mul (.concrete w) flags
-@[match_pattern] abbrev sub (w : Nat) (flags: NoWrapFlags :=
-   {nsw := false , nuw := false}) : Op:=  MOp.sub (.concrete w) flags
+@[match_pattern] abbrev shl (w : Nat) (flags: NoWrapFlags := {}) : LLVM.Op := MOp.shl (.concrete w) flags
+@[match_pattern] abbrev add (w : Nat) (flags: NoWrapFlags := {}) : LLVM.Op := MOp.add (.concrete w) flags
+@[match_pattern] abbrev mul (w : Nat) (flags: NoWrapFlags := {}) : LLVM.Op := MOp.mul (.concrete w) flags
+@[match_pattern] abbrev sub (w : Nat) (flags: NoWrapFlags := {}) : LLVM.Op := MOp.sub (.concrete w) flags
 
 /- These operations are separate from the others because they take in 1 flag: exact.-/
-@[match_pattern] abbrev lshr (w : Nat) (flag : ExactFlag := {exact := false} ) : Op := MOp.lshr (.concrete w) flag
-@[match_pattern] abbrev ashr (w : Nat) (flag : ExactFlag := {exact := false} ) : Op := MOp.ashr (.concrete w) flag
-@[match_pattern] abbrev sdiv (w : Nat) (flag : ExactFlag := {exact := false} ) : Op := MOp.sdiv (.concrete w) flag
-@[match_pattern] abbrev udiv (w : Nat) (flag : ExactFlag := {exact := false} ) : Op := MOp.udiv (.concrete w) flag
+@[match_pattern] abbrev lshr (w : Nat) (flag : ExactFlag := {} ) : LLVM.Op := MOp.lshr (.concrete w) flag
+@[match_pattern] abbrev ashr (w : Nat) (flag : ExactFlag := {} ) : LLVM.Op := MOp.ashr (.concrete w) flag
+@[match_pattern] abbrev sdiv (w : Nat) (flag : ExactFlag := {} ) : LLVM.Op := MOp.sdiv (.concrete w) flag
+@[match_pattern] abbrev udiv (w : Nat) (flag : ExactFlag := {} ) : LLVM.Op := MOp.udiv (.concrete w) flag
 
-end Op
+end LLVM.Op
 
 /-! ### Basic Instances -/
 
@@ -366,7 +367,7 @@ def MOp.UnaryOp.outTy (w : Width φ) : MOp.UnaryOp φ → MTy φ
 def MOp.outTy : MOp φ → MTy φ
 | .binary w _ | .select w | .const w _ =>
   .bitvec w
-| .unary w op => op.outTy w
+| .unary w op => UnaryOp.outTy w op
 | .icmp _ _ => .bitvec 1
 
 instance {φ} : DialectSignature (MetaLLVM φ) where
@@ -420,28 +421,28 @@ end LLVM.Ty
 def Op.denote (o : LLVM.Op) (op : HVector TyDenote.toType (DialectSignature.sig o)) :
     (TyDenote.toType <| DialectSignature.outTy o) :=
   match o with
-  | Op.const _ val    => const? _ val
-  | Op.copy _         =>               (op.getN 0 (by simp [DialectSignature.sig, signature]))
-  | Op.not _          => LLVM.not      (op.getN 0 (by simp [DialectSignature.sig, signature]))
-  | Op.neg _          => LLVM.neg      (op.getN 0 (by simp [DialectSignature.sig, signature]))
-  | Op.trunc w w'    flags => LLVM.trunc w' (op.getN 0 (by simp [DialectSignature.sig, signature])) flags
-  | Op.zext w w' flag => LLVM.zext  w' (op.getN 0 (by simp [DialectSignature.sig, signature])) flag
-  | Op.sext w w'      => LLVM.sext  w' (op.getN 0 (by simp [DialectSignature.sig, signature]))
-  | Op.and _          => LLVM.and      (op.getN 0 (by simp [DialectSignature.sig, signature])) (op.getN 1 (by simp [DialectSignature.sig, signature]))
-  | Op.or _ flag      => LLVM.or       (op.getN 0 (by simp [DialectSignature.sig, signature])) (op.getN 1 (by simp [DialectSignature.sig, signature])) flag
-  | Op.xor _          => LLVM.xor      (op.getN 0 (by simp [DialectSignature.sig, signature])) (op.getN 1 (by simp [DialectSignature.sig, signature]))
-  | Op.shl _ flags    => LLVM.shl      (op.getN 0 (by simp [DialectSignature.sig, signature])) (op.getN 1 (by simp [DialectSignature.sig, signature])) flags
-  | Op.lshr _ flag    => LLVM.lshr     (op.getN 0 (by simp [DialectSignature.sig, signature])) (op.getN 1 (by simp [DialectSignature.sig, signature])) flag
-  | Op.ashr _ flag    => LLVM.ashr     (op.getN 0 (by simp [DialectSignature.sig, signature])) (op.getN 1 (by simp [DialectSignature.sig, signature])) flag
-  | Op.sub _ flags    => LLVM.sub      (op.getN 0 (by simp [DialectSignature.sig, signature])) (op.getN 1 (by simp [DialectSignature.sig, signature])) flags
-  | Op.add _ flags    => LLVM.add      (op.getN 0 (by simp [DialectSignature.sig, signature])) (op.getN 1 (by simp [DialectSignature.sig, signature])) flags
-  | Op.mul _ flags    => LLVM.mul      (op.getN 0 (by simp [DialectSignature.sig, signature])) (op.getN 1 (by simp [DialectSignature.sig, signature])) flags
-  | Op.sdiv _ flag    => LLVM.sdiv     (op.getN 0 (by simp [DialectSignature.sig, signature])) (op.getN 1 (by simp [DialectSignature.sig, signature])) flag
-  | Op.udiv _ flag    => LLVM.udiv     (op.getN 0 (by simp [DialectSignature.sig, signature])) (op.getN 1 (by simp [DialectSignature.sig, signature])) flag
-  | Op.urem _         => LLVM.urem     (op.getN 0 (by simp [DialectSignature.sig, signature])) (op.getN 1 (by simp [DialectSignature.sig, signature]))
-  | Op.srem _         => LLVM.srem     (op.getN 0 (by simp [DialectSignature.sig, signature])) (op.getN 1 (by simp [DialectSignature.sig, signature]))
-  | Op.icmp c _       => LLVM.icmp  c  (op.getN 0 (by simp [DialectSignature.sig, signature])) (op.getN 1 (by simp [DialectSignature.sig, signature]))
-  | Op.select _       => LLVM.select   (op.getN 0 (by simp [DialectSignature.sig, signature])) (op.getN 1 (by simp [DialectSignature.sig, signature])) (op.getN 2 (by simp [DialectSignature.sig, signature]))
+  | LLVM.Op.const _ val    => const? _ val
+  | LLVM.Op.copy _         =>               (op.getN 0 (by simp [DialectSignature.sig, signature]))
+  | LLVM.Op.not _          => LLVM.not      (op.getN 0 (by simp [DialectSignature.sig, signature]))
+  | LLVM.Op.neg _          => LLVM.neg      (op.getN 0 (by simp [DialectSignature.sig, signature]))
+  | LLVM.Op.trunc w w'    flags => LLVM.trunc w' (op.getN 0 (by simp [DialectSignature.sig, signature])) flags
+  | LLVM.Op.zext w w' flag => LLVM.zext  w' (op.getN 0 (by simp [DialectSignature.sig, signature])) flag
+  | LLVM.Op.sext w w'      => LLVM.sext  w' (op.getN 0 (by simp [DialectSignature.sig, signature]))
+  | LLVM.Op.and _          => LLVM.and      (op.getN 0 (by simp [DialectSignature.sig, signature])) (op.getN 1 (by simp [DialectSignature.sig, signature]))
+  | LLVM.Op.or _ flag      => LLVM.or       (op.getN 0 (by simp [DialectSignature.sig, signature])) (op.getN 1 (by simp [DialectSignature.sig, signature])) flag
+  | LLVM.Op.xor _          => LLVM.xor      (op.getN 0 (by simp [DialectSignature.sig, signature])) (op.getN 1 (by simp [DialectSignature.sig, signature]))
+  | LLVM.Op.shl _ flags    => LLVM.shl      (op.getN 0 (by simp [DialectSignature.sig, signature])) (op.getN 1 (by simp [DialectSignature.sig, signature])) flags
+  | LLVM.Op.lshr _ flag    => LLVM.lshr     (op.getN 0 (by simp [DialectSignature.sig, signature])) (op.getN 1 (by simp [DialectSignature.sig, signature])) flag
+  | LLVM.Op.ashr _ flag    => LLVM.ashr     (op.getN 0 (by simp [DialectSignature.sig, signature])) (op.getN 1 (by simp [DialectSignature.sig, signature])) flag
+  | LLVM.Op.sub _ flags    => LLVM.sub      (op.getN 0 (by simp [DialectSignature.sig, signature])) (op.getN 1 (by simp [DialectSignature.sig, signature])) flags
+  | LLVM.Op.add _ flags    => LLVM.add      (op.getN 0 (by simp [DialectSignature.sig, signature])) (op.getN 1 (by simp [DialectSignature.sig, signature])) flags
+  | LLVM.Op.mul _ flags    => LLVM.mul      (op.getN 0 (by simp [DialectSignature.sig, signature])) (op.getN 1 (by simp [DialectSignature.sig, signature])) flags
+  | LLVM.Op.sdiv _ flag    => LLVM.sdiv     (op.getN 0 (by simp [DialectSignature.sig, signature])) (op.getN 1 (by simp [DialectSignature.sig, signature])) flag
+  | LLVM.Op.udiv _ flag    => LLVM.udiv     (op.getN 0 (by simp [DialectSignature.sig, signature])) (op.getN 1 (by simp [DialectSignature.sig, signature])) flag
+  | LLVM.Op.urem _         => LLVM.urem     (op.getN 0 (by simp [DialectSignature.sig, signature])) (op.getN 1 (by simp [DialectSignature.sig, signature]))
+  | LLVM.Op.srem _         => LLVM.srem     (op.getN 0 (by simp [DialectSignature.sig, signature])) (op.getN 1 (by simp [DialectSignature.sig, signature]))
+  | LLVM.Op.icmp c _       => LLVM.icmp  c  (op.getN 0 (by simp [DialectSignature.sig, signature])) (op.getN 1 (by simp [DialectSignature.sig, signature]))
+  | LLVM.Op.select _       => LLVM.select   (op.getN 0 (by simp [DialectSignature.sig, signature])) (op.getN 1 (by simp [DialectSignature.sig, signature])) (op.getN 2 (by simp [DialectSignature.sig, signature]))
 
 instance : DialectDenote LLVM := ⟨
   fun o args _ => Op.denote o args

--- a/SSA/Projects/InstCombine/Base.lean
+++ b/SSA/Projects/InstCombine/Base.lean
@@ -248,14 +248,6 @@ instance : ToString (MOp φ) where
 
 abbrev Op := MOp 0
 
-def MOp.UnaryOp.instantiate (as : List.Vector Nat φ) : MOp.UnaryOp φ → MOp.UnaryOp 0
-| .trunc w' flags     => .trunc (.concrete <| w'.instantiate as) flags
-| .zext w' flag => .zext (.concrete <| w'.instantiate as) flag
-| .sext w'      => .sext (.concrete <| w'.instantiate as)
-| .neg          => .neg
-| .not          => .not
-| .copy         => .copy
-
 namespace Op
 
 @[match_pattern] abbrev unary   (w : Nat) (op : MOp.UnaryOp 0)  : Op := MOp.unary (.concrete w) op

--- a/SSA/Projects/InstCombine/Base.lean
+++ b/SSA/Projects/InstCombine/Base.lean
@@ -31,6 +31,8 @@ open BitVec
 
 open LLVM
 
+/-! ### Types -/
+
 abbrev Width φ := ConcreteOrMVar Nat φ
 
 inductive MTy (φ : Nat)
@@ -39,48 +41,7 @@ inductive MTy (φ : Nat)
 
 abbrev Ty := MTy 0
 
-@[match_pattern] abbrev Ty.bitvec (w : Nat) : Ty := MTy.bitvec (.concrete w)
-
-instance : Repr (MTy φ) where
-  reprPrec
-    | .bitvec (.concrete w), _ => "i" ++ repr w
-    | .bitvec (.mvar ⟨i, _⟩), _ => f!"i$\{%{i}}"
-
-instance : Lean.ToFormat (MTy φ) where
-  format := repr
-
-instance : ToString (MTy φ) where
-  toString t := repr t |>.pretty
-
-def Ty.width : Ty → Nat
-  | .bitvec w => w
-
-@[simp]
-theorem Ty.width_eq (ty : Ty) : .bitvec (ty.width) = ty := by
-  rcases ty with ⟨w|i⟩
-  · rfl
-  · exact i.elim0
-
-@[simp]
-def BitVec.width {n : Nat} (_ : BitVec n) : Nat := n
-
-instance : TyDenote Ty where
-  toType
-  | .bitvec w => LLVM.IntW w
-
-@[simp_denote] lemma toType_bitvec : TyDenote.toType (Ty.bitvec w) = LLVM.IntW w := rfl
-
-instance (ty : Ty) : Coe ℤ (TyDenote.toType ty) where
-  coe z := match ty with
-    | .bitvec w => some <| BitVec.ofInt w z
-
-instance (ty : Ty) : Inhabited (TyDenote.toType ty) where
-  default := match ty with
-    | .bitvec _ => pure default
-
-instance : Repr (BitVec n) where
-  reprPrec
-    | v, n => reprPrec (BitVec.toInt v) n
+/-! ### Operations -/
 
 /-- Homogeneous, unary operations -/
 inductive MOp.UnaryOp (φ : Nat) : Type
@@ -365,14 +326,23 @@ def MOp.outTy : MOp φ → MTy φ
 | .unary w op => op.outTy w
 | .icmp _ _ => .bitvec 1
 
+/-! ## Dialect -/
+
 /-- `MetaLLVM φ` is the `LLVM` dialect with at most `φ` metavariables -/
 abbrev MetaLLVM (φ : Nat) : Dialect where
   Op := MOp φ
   Ty := MTy φ
 
-abbrev LLVM : Dialect where
+def LLVM : Dialect where
   Op := Op
   Ty := Ty
+
+/-! ### Basic Instances -/
+
+instance : Monad (MetaLLVM φ).m := by unfold MetaLLVM; infer_instance
+instance : LawfulMonad (MetaLLVM φ).m := by unfold MetaLLVM; infer_instance
+instance : Monad LLVM.m := by unfold LLVM; infer_instance
+instance : LawfulMonad LLVM.m := by unfold LLVM; infer_instance
 
 instance {φ} : DialectSignature (MetaLLVM φ) where
   signature op := ⟨op.sig, [], op.outTy, .pure⟩
@@ -382,9 +352,66 @@ instance : DialectSignature LLVM where
 instance {φ} : DialectToExpr (MetaLLVM φ) where
   toExprM := .const ``Id [0]
   toExprDialect := .app (.const ``MetaLLVM []) (Lean.toExpr φ)
+
+instance : Lean.ToExpr (LLVM.Op) := by unfold LLVM; infer_instance
+instance : Lean.ToExpr (LLVM.Ty) := by unfold LLVM; infer_instance
 instance : DialectToExpr LLVM where
   toExprM := .const ``Id [0]
   toExprDialect := .const ``LLVM []
+
+/-! ### Type Formatting -/
+
+instance : Repr (MTy φ) where
+  reprPrec
+    | .bitvec (.concrete w), _ => "i" ++ repr w
+    | .bitvec (.mvar ⟨i, _⟩), _ => f!"i$\{%{i}}"
+instance : Repr LLVM.Ty := by unfold LLVM; infer_instance
+
+instance : Lean.ToFormat (MTy φ) where
+  format := repr
+instance : Lean.ToFormat LLVM.Ty := by unfold LLVM; infer_instance
+
+instance : ToString (MTy φ) where
+  toString t := repr t |>.pretty
+instance : ToString LLVM.Ty := by unfold LLVM; infer_instance
+
+/-! ### Type Semantics -/
+
+@[match_pattern] abbrev Ty.bitvec (w : Nat) : LLVM.Ty :=
+  MTy.bitvec (.concrete w)
+
+def Ty.width : LLVM.Ty → Nat
+  | .bitvec w => w
+
+@[simp]
+theorem Ty.width_eq (ty : LLVM.Ty) : .bitvec (width ty) = ty := by
+  rcases ty with ⟨w|i⟩
+  · rfl
+  · exact i.elim0
+
+@[simp] -- TODO: this def should not live here
+def BitVec.width {n : Nat} (_ : BitVec n) : Nat := n
+
+instance : TyDenote LLVM.Ty where
+  toType := fun
+    | .bitvec w => LLVM.IntW w
+
+@[simp_denote] lemma toType_bitvec : TyDenote.toType (Ty.bitvec w) = LLVM.IntW w := rfl
+
+instance (ty : LLVM.Ty) : Coe ℤ (TyDenote.toType ty) where
+  coe z := match ty with
+    | .bitvec w => some <| BitVec.ofInt w z
+
+instance (ty : LLVM.Ty) : Inhabited (TyDenote.toType ty) where
+  default := match ty with
+    | .bitvec _ => default
+
+-- TODO: this instance should not live here
+instance : Repr (BitVec n) where
+  reprPrec
+    | v, n => reprPrec (BitVec.toInt v) n
+
+/-! ### Operation Semantics -/
 
 @[simp]
 def Op.denote (o : LLVM.Op) (op : HVector TyDenote.toType (DialectSignature.sig o)) :

--- a/SSA/Projects/InstCombine/Base.lean
+++ b/SSA/Projects/InstCombine/Base.lean
@@ -329,6 +329,7 @@ instance : ToString (MOp φ) where
 --   toString o := repr o |>.pretty
 
 instance : ToString LLVM.Op := by unfold LLVM; infer_instance
+instance : Repr LLVM.Op := by unfold LLVM; infer_instance
 
 /-! ### Type Formatting -/
 

--- a/SSA/Projects/InstCombine/ComWrappers.lean
+++ b/SSA/Projects/InstCombine/ComWrappers.lean
@@ -6,12 +6,13 @@ import SSA.Projects.InstCombine.LLVM.SimpSet
 
 /- Wrapper around Com, Expr constructors to easily hand-write IR -/
 namespace ComWrappers
+open InstCombine (LLVM)
 
 macro_rules
 | `(tactic| get_elem_tactic_trivial) => `(tactic| simp [Ctxt.snoc])
 
 @[simp_llvm_wrap]
-def const {Γ : Ctxt _} (w : ℕ) (n : ℤ) : Expr InstCombine.LLVM Γ .pure (InstCombine.Ty.bitvec w) :=
+def const {Γ : Ctxt _} (w : ℕ) (n : ℤ) : Expr InstCombine.LLVM Γ .pure (LLVM.Ty.bitvec w) :=
   Expr.mk
     (op := InstCombine.MOp.const w n)
     (eff_le := by constructor)
@@ -23,7 +24,7 @@ def const {Γ : Ctxt _} (w : ℕ) (n : ℤ) : Expr InstCombine.LLVM Γ .pure (In
 def not {Γ : Ctxt _} (w : ℕ) (l : Nat)
     (lp : (Ctxt.get? Γ l = some (InstCombine.MTy.bitvec (ConcreteOrMVar.concrete w)))
       := by get_elem_tactic):
-    Expr InstCombine.LLVM Γ .pure (InstCombine.Ty.bitvec w) :=
+    Expr InstCombine.LLVM Γ .pure (LLVM.Ty.bitvec w) :=
   Expr.mk
     (op := InstCombine.MOp.not w)
     (eff_le := by constructor)
@@ -35,7 +36,7 @@ def not {Γ : Ctxt _} (w : ℕ) (l : Nat)
 def neg {Γ : Ctxt _} (w : ℕ) (l : Nat)
     (lp : (Ctxt.get? Γ l = some (InstCombine.MTy.bitvec (ConcreteOrMVar.concrete w)))
       := by get_elem_tactic):
-    Expr InstCombine.LLVM Γ .pure (InstCombine.Ty.bitvec w) :=
+    Expr InstCombine.LLVM Γ .pure (LLVM.Ty.bitvec w) :=
   Expr.mk
     (op := InstCombine.MOp.neg w)
     (eff_le := by constructor)
@@ -49,7 +50,7 @@ def and {Γ : Ctxt _} (w : ℕ) (l r : Nat)
       := by get_elem_tactic)
     (rp : (Ctxt.get? Γ r = some (InstCombine.MTy.bitvec (ConcreteOrMVar.concrete w)))
       := by get_elem_tactic) :
-    Expr InstCombine.LLVM Γ .pure (InstCombine.Ty.bitvec w) :=
+    Expr InstCombine.LLVM Γ .pure (LLVM.Ty.bitvec w) :=
   Expr.mk
     (op := InstCombine.MOp.and w)
     (eff_le := by constructor)
@@ -63,7 +64,7 @@ def or {Γ : Ctxt _} (w : ℕ) (l r : Nat)
       := by get_elem_tactic)
     (rp : (Ctxt.get? Γ r = some (InstCombine.MTy.bitvec (ConcreteOrMVar.concrete w)))
       := by get_elem_tactic) :
-    Expr InstCombine.LLVM Γ .pure (InstCombine.Ty.bitvec w) :=
+    Expr InstCombine.LLVM Γ .pure (LLVM.Ty.bitvec w) :=
   Expr.mk
     (op := InstCombine.MOp.or w)
     (eff_le := by constructor)
@@ -77,7 +78,7 @@ def xor {Γ : Ctxt _} (w : ℕ) (l r : Nat)
       := by get_elem_tactic)
     (rp : (Ctxt.get? Γ r = some (InstCombine.MTy.bitvec (ConcreteOrMVar.concrete w)))
       := by get_elem_tactic) :
-    Expr InstCombine.LLVM Γ .pure (InstCombine.Ty.bitvec w) :=
+    Expr InstCombine.LLVM Γ .pure (LLVM.Ty.bitvec w) :=
   Expr.mk
     (op := InstCombine.MOp.xor w)
     (eff_le := by constructor)
@@ -91,7 +92,7 @@ def shl {Γ : Ctxt _} (w : ℕ) (l r : Nat)
       := by get_elem_tactic)
     (rp : (Ctxt.get? Γ r = some (InstCombine.MTy.bitvec (ConcreteOrMVar.concrete w)))
       := by get_elem_tactic) :
-    Expr InstCombine.LLVM Γ .pure (InstCombine.Ty.bitvec w) :=
+    Expr InstCombine.LLVM Γ .pure (LLVM.Ty.bitvec w) :=
   Expr.mk
     (op := InstCombine.MOp.shl w)
     (eff_le := by constructor)
@@ -105,7 +106,7 @@ def lshr {Γ : Ctxt _} (w : ℕ) (l r : Nat)
       := by get_elem_tactic)
     (rp : (Ctxt.get? Γ r = some (InstCombine.MTy.bitvec (ConcreteOrMVar.concrete w)))
       := by get_elem_tactic) :
-    Expr InstCombine.LLVM Γ .pure (InstCombine.Ty.bitvec w) :=
+    Expr InstCombine.LLVM Γ .pure (LLVM.Ty.bitvec w) :=
   Expr.mk
     (op := InstCombine.MOp.lshr w)
     (eff_le := by constructor)
@@ -119,7 +120,7 @@ def ashr {Γ : Ctxt _} (w : ℕ) (l r : Nat)
       := by get_elem_tactic)
     (rp : (Ctxt.get? Γ r = some (InstCombine.MTy.bitvec (ConcreteOrMVar.concrete w)))
       := by get_elem_tactic) :
-    Expr InstCombine.LLVM Γ .pure (InstCombine.Ty.bitvec w) :=
+    Expr InstCombine.LLVM Γ .pure (LLVM.Ty.bitvec w) :=
   Expr.mk
     (op := InstCombine.MOp.ashr w)
     (eff_le := by constructor)
@@ -133,7 +134,7 @@ def sub {Γ : Ctxt _} (w : ℕ) (l r : Nat)
       := by get_elem_tactic)
     (rp : (Ctxt.get? Γ r = some (InstCombine.MTy.bitvec (ConcreteOrMVar.concrete w)))
       := by get_elem_tactic) :
-    Expr InstCombine.LLVM Γ .pure (InstCombine.Ty.bitvec w) :=
+    Expr InstCombine.LLVM Γ .pure (LLVM.Ty.bitvec w) :=
   Expr.mk
     (op := InstCombine.MOp.sub w)
     (eff_le := by constructor)
@@ -147,7 +148,7 @@ def add {Γ : Ctxt _} (w : ℕ) (l r : Nat)
       := by get_elem_tactic)
     (rp : (Ctxt.get? Γ r = some (InstCombine.MTy.bitvec (ConcreteOrMVar.concrete w)))
       := by get_elem_tactic) :
-    Expr InstCombine.LLVM Γ .pure (InstCombine.Ty.bitvec w) :=
+    Expr InstCombine.LLVM Γ .pure (LLVM.Ty.bitvec w) :=
   Expr.mk
     (op := InstCombine.MOp.add w)
     (eff_le := by constructor)
@@ -161,7 +162,7 @@ def mul {Γ : Ctxt _} (w : ℕ) (l r : Nat)
       := by get_elem_tactic)
     (rp : (Ctxt.get? Γ r = some (InstCombine.MTy.bitvec (ConcreteOrMVar.concrete w)))
       := by get_elem_tactic) :
-    Expr InstCombine.LLVM Γ .pure (InstCombine.Ty.bitvec w) :=
+    Expr InstCombine.LLVM Γ .pure (LLVM.Ty.bitvec w) :=
   Expr.mk
     (op := InstCombine.MOp.mul w)
     (eff_le := by constructor)
@@ -175,7 +176,7 @@ def sdiv {Γ : Ctxt _} (w : ℕ) (l r : Nat)
       := by get_elem_tactic)
     (rp : (Ctxt.get? Γ r = some (InstCombine.MTy.bitvec (ConcreteOrMVar.concrete w)))
       := by get_elem_tactic) :
-    Expr InstCombine.LLVM Γ .pure (InstCombine.Ty.bitvec w) :=
+    Expr InstCombine.LLVM Γ .pure (LLVM.Ty.bitvec w) :=
   Expr.mk
     (op := InstCombine.MOp.sdiv w)
     (eff_le := by constructor)
@@ -189,7 +190,7 @@ def udiv {Γ : Ctxt _} (w : ℕ) (l r : Nat)
       := by get_elem_tactic)
     (rp : (Ctxt.get? Γ r = some (InstCombine.MTy.bitvec (ConcreteOrMVar.concrete w)))
       := by get_elem_tactic) :
-    Expr InstCombine.LLVM Γ .pure (InstCombine.Ty.bitvec w) :=
+    Expr InstCombine.LLVM Γ .pure (LLVM.Ty.bitvec w) :=
   Expr.mk
     (op := InstCombine.MOp.udiv w)
     (eff_le := by constructor)
@@ -203,7 +204,7 @@ def srem {Γ : Ctxt _} (w : ℕ) (l r : Nat)
       := by get_elem_tactic)
     (rp : (Ctxt.get? Γ r = some (InstCombine.MTy.bitvec (ConcreteOrMVar.concrete w)))
       := by get_elem_tactic) :
-    Expr InstCombine.LLVM Γ .pure (InstCombine.Ty.bitvec w) :=
+    Expr InstCombine.LLVM Γ .pure (LLVM.Ty.bitvec w) :=
   Expr.mk
     (op := InstCombine.MOp.srem w)
     (eff_le := by constructor)
@@ -217,7 +218,7 @@ def urem {Γ : Ctxt _} (w : ℕ) (l r : Nat)
       := by get_elem_tactic)
     (rp : (Ctxt.get? Γ r = some (InstCombine.MTy.bitvec (ConcreteOrMVar.concrete w)))
       := by get_elem_tactic) :
-    Expr InstCombine.LLVM Γ .pure (InstCombine.Ty.bitvec w) :=
+    Expr InstCombine.LLVM Γ .pure (LLVM.Ty.bitvec w) :=
   Expr.mk
     (op := InstCombine.MOp.urem w)
     (eff_le := by constructor)
@@ -231,7 +232,7 @@ def icmp {Γ : Ctxt _} (w : ℕ) (pred : LLVM.IntPred) (l r : Nat)
       := by get_elem_tactic)
     (rp : (Ctxt.get? Γ r = some (InstCombine.MTy.bitvec (ConcreteOrMVar.concrete w)))
       := by get_elem_tactic) :
-    Expr InstCombine.LLVM Γ .pure (InstCombine.Ty.bitvec 1) :=
+    Expr InstCombine.LLVM Γ .pure (LLVM.Ty.bitvec 1) :=
   Expr.mk
     (op := InstCombine.MOp.icmp pred w)
     (eff_le := by constructor)
@@ -247,7 +248,7 @@ def select {Γ : Ctxt _} (w : ℕ) (l m r : Nat)
       := by get_elem_tactic)
     (rp : (Ctxt.get? Γ r = some (InstCombine.MTy.bitvec (ConcreteOrMVar.concrete w)))
       := by get_elem_tactic) :
-    Expr InstCombine.LLVM Γ .pure (InstCombine.Ty.bitvec w)  :=
+    Expr InstCombine.LLVM Γ .pure (LLVM.Ty.bitvec w)  :=
   Expr.mk
     (op := InstCombine.MOp.select w)
     (eff_le := by constructor)
@@ -256,7 +257,7 @@ def select {Γ : Ctxt _} (w : ℕ) (l m r : Nat)
     (regArgs := .nil)
 
 def test (w : ℕ) :
-    Com InstCombine.LLVM [InstCombine.Ty.bitvec w] .pure (InstCombine.Ty.bitvec w) :=
+    Com InstCombine.LLVM [LLVM.Ty.bitvec w] .pure (LLVM.Ty.bitvec w) :=
   .var (const  w 0  ) <|
   .var (not    w 0  ) <|
   .var (neg    w 0  ) <|

--- a/SSA/Projects/InstCombine/LLVM/CLITests.lean
+++ b/SSA/Projects/InstCombine/LLVM/CLITests.lean
@@ -200,6 +200,7 @@ def CliTest.eval (test : CliTest) (values : Vector ℤ test.context.length)
    concrete_test.eval values'
 -/
 
+open LLVM.Ty in
 def InstCombine.mkValuation (ctxt : Context)
   (values : List.Vector (Option Int) ctxt.length): Ctxt.Valuation ctxt :=
 match ctxt, values with
@@ -208,8 +209,8 @@ match ctxt, values with
     let valsVec : List.Vector (Option Int) tys.length := ⟨vals,by aesop⟩
     let valuation' := mkValuation tys valsVec
     match ty with
-      | .bitvec w =>
-        let newTy : ⟦Ty.bitvec w⟧ :=
+      | bitvec w =>
+        let newTy : ⟦bitvec w⟧ :=
           Option.map (BitVec.ofInt w) val
         Ctxt.Valuation.snoc valuation' newTy
 
@@ -239,10 +240,11 @@ def CocreteCliTest.signature (test : ConcreteCliTest) :
 def ConcreteCliTest.printSignature (test : ConcreteCliTest) : String :=
   s!"{test.context.reverse} → {test.ty}"
 
+open LLVM.Ty in
 instance {test : ConcreteCliTest} : ToString (toType test.ty) where
   toString :=
     match test.ty with
-    | .bitvec w => inferInstanceAs (ToString (Option <| BitVec w)) |>.toString
+    | bitvec w => inferInstanceAs (ToString (Option <| BitVec w)) |>.toString
 
 -- Define an attribute to add up all LLVM tests
 -- https://leanprover.zulipchat.com/#narrow/stream/270676-lean4/topic/.E2.9C.94.20Stateful.2FAggregating.20Macros.3F/near/301067121

--- a/SSA/Projects/InstCombine/LLVM/EDSL.lean
+++ b/SSA/Projects/InstCombine/LLVM/EDSL.lean
@@ -67,7 +67,9 @@ def mkTy : MLIR.AST.MLIRType φ → MLIR.AST.ExceptM (MetaLLVM φ) ((MetaLLVM φ
     return .bitvec w
   | _ => throw .unsupportedType -- "Unsupported type"
 
-instance instTransformTy : MLIR.AST.TransformTy (MetaLLVM φ) φ where
+instance instTransformTy : AST.TransformTy (MetaLLVM φ) φ where
+  mkTy := mkTy
+instance : AST.TransformTy (LLVM) 0 where
   mkTy := mkTy
 
 def getOutputWidth (opStx : MLIR.AST.Op φ) (op : String) :
@@ -230,6 +232,8 @@ def mkExpr (Γ : Ctxt (MetaLLVM φ).Ty) (opStx : MLIR.AST.Op φ) :
 
 instance : AST.TransformExpr (MetaLLVM φ) φ where
   mkExpr := mkExpr
+instance : AST.TransformExpr LLVM 0 where
+  mkExpr := mkExpr
 
 def mkReturn (Γ : Ctxt (MetaLLVM φ).Ty) (opStx : MLIR.AST.Op φ) :
     MLIR.AST.ReaderM (MetaLLVM φ) (Σ eff ty, Com (MetaLLVM φ) Γ eff ty) :=
@@ -243,6 +247,8 @@ def mkReturn (Γ : Ctxt (MetaLLVM φ).Ty) (opStx : MLIR.AST.Op φ) :
   else throw <| .generic s!"Tried to build return out of non-return statement {opStx.name}"
 
 instance : AST.TransformReturn (MetaLLVM φ) φ where
+  mkReturn := mkReturn
+instance : AST.TransformReturn LLVM 0 where
   mkReturn := mkReturn
 
 /-!

--- a/SSA/Projects/InstCombine/LLVM/EDSL.lean
+++ b/SSA/Projects/InstCombine/LLVM/EDSL.lean
@@ -250,7 +250,7 @@ instance : AST.TransformReturn (MetaLLVM φ) φ where
   Finally, we show how to instantiate a family of programs to a concrete program
 -/
 
-open InstCombine Qq in
+open InstCombine LLVM Qq in
 def MetaLLVM.instantiate (vals : Vector Expr φ) : DialectMetaMorphism (MetaLLVM φ) q(LLVM) where
   mapTy := fun
   | .bitvec w =>
@@ -317,7 +317,7 @@ macro "deftest" name:ident " := " test_reg:mlir_region : command => do
        { name := $(quote name.getId), ty := code.ty, context := code.ctxt, code := code, })
 
 section Test
-open InstCombine Ty
+open InstCombine.LLVM.Ty (bitvec)
 
 /-- Assert that the elaborator respects variable ordering correctly -/
 private def variable_order1 : Com LLVM [bitvec 2, bitvec 1]  .pure (bitvec 1) := [llvm()| {

--- a/SSA/Projects/InstCombine/LLVM/Parser.lean
+++ b/SSA/Projects/InstCombine/LLVM/Parser.lean
@@ -4,12 +4,12 @@ import Init.Data.Repr
 
 open MLIR AST InstCombine
 def regionTransform (region : Region 0) : Except ParseError
-  (Σ (Γ' : Context) (eff : EffectKind) (ty : Ty), Com LLVM Γ' eff ty) :=
+  (Σ (Γ' : Context) (eff : EffectKind) (ty : LLVM.Ty), Com LLVM Γ' eff ty) :=
     let res := mkCom (d:= LLVM) region
     match res with
       | Except.error e => Except.error s!"Error:\n{reprStr e}"
       | Except.ok res => Except.ok res
 
 def parseComFromFile (fileName : String) :
- IO (Option (Σ (Γ' : Context) (eff : EffectKind) (ty : InstCombine.Ty), Com LLVM Γ' eff ty)) := do
+ IO (Option (Σ (Γ' : Context) (eff : EffectKind) (ty : LLVM.Ty), Com LLVM Γ' eff ty)) := do
  parseRegionFromFile fileName regionTransform

--- a/SSA/Projects/InstCombine/Test.lean
+++ b/SSA/Projects/InstCombine/Test.lean
@@ -8,6 +8,8 @@ import SSA.Projects.InstCombine.ComWrappers
 import SSA.Projects.InstCombine.Tactic
 open MLIR AST
 
+open InstCombine (LLVM)
+
 /-
   TODO: infer the number of meta-variables in an AST, so that we can remove the `Op 0` annotation
   in the following
@@ -253,7 +255,7 @@ def one_inst_macro (w: Nat) :=
   }]
 
 def one_inst_com (w : ℕ) :
-    Com InstCombine.LLVM [InstCombine.Ty.bitvec w] .pure (InstCombine.Ty.bitvec w) :=
+    Com InstCombine.LLVM [LLVM.Ty.bitvec w] .pure (LLVM.Ty.bitvec w) :=
   Com.var (not w 0) <|
   Com.ret ⟨0, by simp [Ctxt.snoc]⟩
 
@@ -283,7 +285,7 @@ def two_inst_macro (w: Nat) :=
   }]
 
 def two_inst_com (w : ℕ) :
-    Com InstCombine.LLVM [InstCombine.Ty.bitvec w] .pure (InstCombine.Ty.bitvec w) :=
+    Com InstCombine.LLVM [LLVM.Ty.bitvec w] .pure (LLVM.Ty.bitvec w) :=
   Com.var (not w 0) <|
   Com.var (not w 1) <|
   Com.ret ⟨1, by simp [Ctxt.snoc]⟩
@@ -315,7 +317,7 @@ def three_inst_macro (w: Nat) :=
   }]
 
 def three_inst_com (w : ℕ) :
-    Com InstCombine.LLVM [InstCombine.Ty.bitvec w] .pure (InstCombine.Ty.bitvec w) :=
+    Com InstCombine.LLVM [LLVM.Ty.bitvec w] .pure (LLVM.Ty.bitvec w) :=
   Com.var (not w 0) <|
   Com.var (not w 0) <|
   Com.var (not w 0) <|
@@ -347,7 +349,7 @@ def one_inst_concrete_macro :=
   }]
 
 def one_inst_concrete_com :
-    Com InstCombine.LLVM [InstCombine.Ty.bitvec 1] .pure (InstCombine.Ty.bitvec 1) :=
+    Com InstCombine.LLVM [LLVM.Ty.bitvec 1] .pure (LLVM.Ty.bitvec 1) :=
   Com.var (not 1 0) <|
   Com.ret ⟨0, by simp [Ctxt.snoc]⟩
 
@@ -377,7 +379,7 @@ def two_inst_concrete_macro :=
   }]
 
 def two_inst_concrete_com (w : ℕ) :
-  Com InstCombine.LLVM [InstCombine.Ty.bitvec w] .pure (InstCombine.Ty.bitvec w) :=
+  Com InstCombine.LLVM [LLVM.Ty.bitvec w] .pure (LLVM.Ty.bitvec w) :=
   Com.var (not w 0) <|
   Com.var (not w 1) <|
   Com.ret ⟨1, by simp [Ctxt.snoc]⟩
@@ -409,7 +411,7 @@ def three_inst_concrete_macro :=
   }]
 
 def three_inst_concrete_com :
-  Com InstCombine.LLVM [InstCombine.Ty.bitvec 1] .pure (InstCombine.Ty.bitvec 1) :=
+  Com InstCombine.LLVM [LLVM.Ty.bitvec 1] .pure (LLVM.Ty.bitvec 1) :=
   Com.var (not 1 0) <|
   Com.var (not 1 0) <|
   Com.var (not 1 0) <|


### PR DESCRIPTION
This PR changes the `LLVM` dialect to be a def rather than an abbrev. As per https://github.com/leanprover/lean4/issues/7984, having reducible definitions in the type of instances causes problems:
> As with simp, there are some unavoidable indexing issues when using reducible patterns. Allowing reducible instances was never intended and should probably be denied.

Thus, we should move away from defining dialects as reducible abbrevs. As a result, instances on `InstCombine.Ty` will no longer be found when synthesizing an instance for `LLVM.Ty`. Thus, we refactor such instances to reinforce that `InstCombine.Ty` is an internal name, and `LLVM.Ty` is the preferred spelling (idem for `Op`).

For further motivation, consider the following MWE:
```lean
abbrev MweDialect : Dialect where
  Op := Empty
  Ty := Unit

def nat : MweDialect.Ty := ()

instance : Monad MweDialect.m := inferInstanceAs (Monad Id)
instance : TyDenote MweDialect.Ty where
  toType
  | () => Nat

instance : DialectHRefinement MweDialect MweDialect where
  IsTypeCompatible := Eq
  IsRefinedBy := @fun
    | (), (), _, x, y => x = y

instance : Fact (IsTypeCompatible nat nat) where
  out := rfl

-- The `#check` works, the instance exists
#check (instRefinementPure : HRefinement ⟦nat⟧ ⟦nat⟧)
-- Yet, it is unable to be synthesized
#synth HRefinement ⟦nat⟧ ⟦nat⟧
```

When we turn `MweDialect` from an `abbrev` into a `def`, the `#synth` line
starts working again!