### PR TITLE
refactor: minimize imports in InstCombine.ForLean

### DIFF
--- a/SSA/Projects/InstCombine/ForLean.lean
+++ b/SSA/Projects/InstCombine/ForLean.lean
@@ -1,5 +1,6 @@
 import Mathlib.Data.Nat.Size -- TODO: remove and get rid of shiftLeft_eq_mul_pow use
-import SSA.Projects.InstCombine.LLVM.Semantics
+import SSA.Projects.InstCombine.ForStd
+import SSA.Projects.InstCombine.LLVM.SimpSet
 import Mathlib.Tactic.Ring
 import Mathlib.Data.BitVec
 


### PR DESCRIPTION
In particular, remove the dependency on LLVM.Semantics in favour of the transitive dependencies that were actually required. This is a huge improvement, as some very slow-building files import InstCombine.ForLean, and were thus unnecessarily being rebuilt while iterating on LLVM.Semantics