### PR TITLE
feat: typeclass driven refinement notation, with initial dialect-generic refinement support in the framework

### DIFF
--- a/SSA/Core/EffectKind.lean
+++ b/SSA/Core/EffectKind.lean
@@ -234,3 +234,16 @@ def liftEffect_compose {e1 e2 e3 : EffectKind} {α : Type} [Pure m]
     (h13 : e1 ≤ e3 := le_trans h12 h23) :
     ((liftEffect (α := α) h23) ∘ (liftEffect h12)) = liftEffect (m := m) h13 := by
   cases e1 <;> cases e2 <;> cases e3 <;> (solve | rfl | contradiction)
+
+/-!
+## `toMonad` coercion
+-/
+
+/--
+Coerce a value of type `eff.toMonad m α` into a monadic value `m α`, by applying
+either `pure` or the identity, depending on the effect `eff`.
+
+NOTE: This is simply `liftEffect` with the second effect fixed to be impure.
+-/
+abbrev coe_toMonad [Pure m] {eff : EffectKind} : eff.toMonad m α → m α :=
+  liftEffect (le_impure eff)

--- a/SSA/Core/EffectKind.lean
+++ b/SSA/Core/EffectKind.lean
@@ -245,5 +245,6 @@ either `pure` or the identity, depending on the effect `eff`.
 
 NOTE: This is simply `liftEffect` with the second effect fixed to be impure.
 -/
-abbrev coe_toMonad [Pure m] {eff : EffectKind} : eff.toMonad m α → m α :=
+@[simp]
+def coe_toMonad [Pure m] {eff : EffectKind} : eff.toMonad m α → m α :=
   liftEffect (le_impure eff)

--- a/SSA/Core/Framework.lean
+++ b/SSA/Core/Framework.lean
@@ -751,7 +751,7 @@ end Lemmas
 ## Refinement
 -/
 section Refinement
-variable [DialectHRefinement d d] [LawfulDialectRefinement d]
+variable [DialectHRefinement d d]
 open RefinementNotation
 
 /--

--- a/SSA/Core/Framework.lean
+++ b/SSA/Core/Framework.lean
@@ -6,8 +6,10 @@ Released under Apache 2.0 license as described in the file LICENSE.
 import SSA.Core.ErasedContext
 import SSA.Core.HVector
 import SSA.Core.EffectKind
-import Mathlib.Control.Monad.Basic
 import SSA.Core.Framework.Dialect
+import SSA.Core.Framework.Refinement
+
+import Mathlib.Control.Monad.Basic
 import Mathlib.Data.List.AList
 import Mathlib.Data.Finset.Piecewise
 
@@ -189,6 +191,7 @@ structure Zipper (Γ_in : Ctxt d.Ty) (eff : EffectKind) (Γ_mid : Ctxt d.Ty) (ty
 
 
 
+/-! ### Repr instance -/
 section Repr
 open Std (Format)
 variable {d} [DialectSignature d] [Repr d.Op] [Repr d.Ty]
@@ -267,6 +270,7 @@ instance : Repr (Lets d Γ eff t) := ⟨flip Lets.repr⟩
 
 end Repr
 
+/-! ### DecidableEq instance -/
 --TODO: this should be derived later on when a derive handler is implemented
 mutual -- DecEq
 
@@ -652,7 +656,7 @@ Moreover, recall that `simp only` **does not** generate equation lemmas.
 *but* if equation lemmas are present, then `simp only` *uses* the equation lemmas.
 
 Hence, we build the equation lemmas by invoking the correct Lean meta magic,
-so that `simp only` (which we use in `simp_peephole` can find them!)
+so that `simp only` (which we use in `simp_peephole`) can find them!
 
 This allows `simp only [HVector.denote]` to correctly simplify `HVector.denote`
 args, since there now are equation lemmas for it.
@@ -742,6 +746,31 @@ theorem Com.denoteLets_eq {com : Com d Γ eff t} : com.denoteLets = com.toLets.d
   simp only [toLets]; induction com using Com.rec' <;> simp [Lets.denote_var]
 
 end Lemmas
+
+/-!
+## Refinement
+-/
+section Refinement
+variable [DialectHRefinement d d] [LawfulDialectRefinement d]
+open RefinementNotation
+
+/--
+An expression `e₁` is refined by an expression `e₂` (of the same dialect) if their
+respective denotations under every valuation are in the refinement relation.
+-/
+instance: Refinement (Expr d Γ eff t) where
+  IsRefinedBy e₁ e₂ :=
+    ∀ V, e₁.denote V ⊑ e₂.denote V
+
+/--
+A program `c₁` is refined by a program `c₂` (of the same dialect) if their
+respective denotations under every valuation are in the refinement relation.
+-/
+instance: Refinement (Com d Γ eff t) where
+  IsRefinedBy c₁ c₂ :=
+    ∀ V, c₁.denote V ⊑ c₂.denote V
+
+end Refinement
 
 /-!
 ## `changeVars`

--- a/SSA/Core/Framework/Refinement.lean
+++ b/SSA/Core/Framework/Refinement.lean
@@ -115,7 +115,7 @@ end DialectHRefinement
 A lawful homogenous (i.e., within a single dialect) refinement instance is one
 where refinement is reflexive and transitive (i.e., it is a preorder).
 -/
-class LawfulDialectRefinement (d : Dialect) [TyDenote d.Ty] [DialectHRefinement d d] where
+class PreorderDialectRefinement (d : Dialect) [TyDenote d.Ty] [DialectHRefinement d d] where
   isRefinedBy_rfl : ∀ {t : d.Ty} (x : d.m ⟦t⟧), x ⊑ x
   isRefinedBy_trans : ∀ {t u v : d.Ty} (x : d.m ⟦t⟧) (y : d.m ⟦u⟧) (z : d.m ⟦v⟧),
     x ⊑ y → y ⊑ z → x ⊑ z

--- a/SSA/Core/Framework/Refinement.lean
+++ b/SSA/Core/Framework/Refinement.lean
@@ -1,0 +1,159 @@
+/-
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import SSA.Core.Framework.Dialect
+import SSA.Core.EffectKind
+import SSA.Core.ErasedContext
+
+/-!
+## Generic Refinement Relation
+-/
+
+
+/-! ### Syntax -/
+
+/--
+The notation typeclass for heterogenous refinement relations.
+This enables the notation `a ⊑ b`, where `a : α` and `b : β`.
+
+NOTE: This typeclass is not intended for dialect implementors. Please implement
+`DialectRefinement` instead, from which appropriate `HRefinement` instances will
+be inferred.
+-/
+class HRefinement (α β : Type) where
+  /--
+  We say that `a` is refined by `b`, written as `a ⊑ b`, when
+  every observable behaviour of `b` is allowed by `a`.
+
+  Note that this notation is driven by a typeclass, thus the exact meaning
+  is type-dependent.
+  -/
+  IsRefinedBy : α → β → Prop
+
+/-!
+For now, we define `· ⊑ ·` as a *scoped* notation, meaning you have to write
+`open RefinementNotation` to use it. This is an interim solution until we finish
+porting the existing LLVM dialect automation to use the generic refinement
+typeclass rather than it's own `⊑` notation.
+Once that is done, we will make the notation global.
+-/
+namespace RefinementNotation
+@[inherit_doc] scoped infix:50 " ⊑ "  => HRefinement.IsRefinedBy
+end RefinementNotation
+open RefinementNotation
+
+/--
+The homogenous version of `HRefinement`.
+This enables the notation `a ⊑ b`, where `a, b : α`.
+
+NOTE: This typeclass is not intended for dialect implementors. Please implement
+`DialectRefinement` instead.
+-/
+class Refinement (α : Type) where
+  IsRefinedBy : α → α → Prop
+
+instance [Refinement α] : HRefinement α α where
+  IsRefinedBy := Refinement.IsRefinedBy
+
+/-- Equality induces a trivial (homogenous) refinement relation on any type `α`. -/
+def Refinement.ofEq : Refinement α where
+  IsRefinedBy := Eq
+
+/-! ### Dialect Refinement -/
+
+/--
+`DialectHRefinement` defines an heterogenous refinement relation accross two dialects.
+
+Various instances of the ` ⊑ ` refinement notation will be derived from `DialectHRefinement`.
+In particular, this class defines refinement for monadic values, from which
+refinement of pure values `x, y` is defined as `pure x ⊑ pure y.`
+-/
+class DialectHRefinement (d : Dialect) (d' : Dialect) [TyDenote d.Ty] [TyDenote d'.Ty] where
+  /--
+  We say that `a` is refined by `b`, written as `a ⊑ b`, when
+  every observable behaviour of `b` is allowed by `a`.
+  -/
+  IsRefinedBy {t : d.Ty} {u : d'.Ty} : d.m ⟦t⟧ → d'.m ⟦u⟧ → Prop
+open DialectHRefinement
+
+namespace DialectHRefinement
+variable {d d' : Dialect} [TyDenote d.Ty] [TyDenote d'.Ty] [DialectHRefinement d d']
+variable {t : d.Ty} {u : d'.Ty}
+
+/-- Refinement for monadic values -/
+instance instRefinementMonadic : HRefinement (d.m ⟦t⟧) (d'.m ⟦u⟧) where
+  IsRefinedBy := DialectHRefinement.IsRefinedBy
+
+variable [Pure d.m] [Pure d'.m]
+
+/-- Refinement for pure values -/
+instance instRefinementPure : HRefinement ⟦t⟧ ⟦u⟧ where
+  IsRefinedBy x y := (pure x : d.m _) ⊑ (pure y : d'.m _)
+
+/-- Refinement for *potentially* monadic values -/
+instance instRefinementEffect {eff eff' : EffectKind} :
+    HRefinement (eff.toMonad d.m ⟦t⟧) (eff'.toMonad d'.m ⟦u⟧) where
+  IsRefinedBy x y := eff.coe_toMonad x ⊑ eff'.coe_toMonad y
+
+section Lemmas
+
+@[simp] theorem toMonad_pure_IsRefinedBy_toMonad_pure_iff
+    {x : EffectKind.pure.toMonad d.m ⟦t⟧} {y : EffectKind.pure.toMonad d'.m ⟦u⟧} :
+    (x ⊑ y) ↔ (HRefinement.IsRefinedBy (α := ⟦t⟧) (β := ⟦u⟧) x y) := by
+  rfl
+
+@[simp] theorem toMonad_impure_IsRefinedBy_toMonad_impure_iff
+    {x : EffectKind.impure.toMonad d.m ⟦t⟧} {y : EffectKind.impure.toMonad d'.m ⟦u⟧} :
+    (x ⊑ y) ↔ (HRefinement.IsRefinedBy (α := d.m ⟦t⟧) (β := d'.m ⟦u⟧) x y) := by
+  rfl
+
+end Lemmas
+
+end DialectHRefinement
+
+/--
+A lawful homogenous (i.e., within a single dialect) refinement instance is one
+where refinement is reflexive and transitive (i.e., it is a preorder).
+-/
+class LawfulDialectRefinement (d : Dialect) [TyDenote d.Ty] [DialectHRefinement d d] where
+  isRefinedBy_rfl : ∀ {t : d.Ty} (x : d.m ⟦t⟧), x ⊑ x
+  isRefinedBy_trans : ∀ {t u v : d.Ty} (x : d.m ⟦t⟧) (y : d.m ⟦u⟧) (z : d.m ⟦v⟧),
+    x ⊑ y → y ⊑ z → x ⊑ z
+
+
+/-!
+**How to define refinement on computations?**
+
+So far, when verifying the Alive peephole rewrites, we've used the following
+definition of refinement, where `c` and `d` are LLVM programs with the same
+context and return type:
+```
+  ∀ V, c.denote V ⊑ d.denote V
+```
+Saying that `c` is refined by `d` when for any valuation `V` the denotation of
+`c` under `V` is refined by the denotation of `d` under `V`.
+
+Of course, this definition really only makes sense if `c` and `d` can be evaluated
+under the exact same contexts. Thus, to generalize this to multiple dialects, we'd
+instead write something like
+```
+  ∀ V₁ V₂, V₁ ⊑ V₂ → c.denote V₁ ⊑ d.denote V₂
+```
+
+Now, the second definition is *not* in general equivalent to the first.
+However, if we add the following assumption, that the denotation is monotone
+w.r.t. refinement, then we can prove that the two definitions are logically
+equivalent:
+```
+  ∀ V₁ V₂, V₁ ⊑ V₂ → c.denote V₁ ⊑ c.denote V₂
+```
+
+It's slightly annoying to have this extra proof burden. Then again, semantics
+really ought to be monotone in this way, so it might not be bad to force a proof.
+In particular, VeLLVM had a bug in it's semantics which meant it was *not* monotone,
+but this really was a bug. The intention of LLVM semantics is that they are monotone.
+
+Note that regardless, the statement of this property requires a notion of semantics,
+and thus cannot be stated in the current file, unless we re-order the imports,
+which might not actually be a bad idea.
+-/


### PR DESCRIPTION
This PR adds HRefinement and Refinement typeclasses to drive the ⊑ relation notation, in the same way core Lean uses HAdd/Add classes for +. Then, we build on this with a DialectRefinement typeclass that we expect dialect-implementors to implement. From this second class, we then derive a few HRefinement typeclasses for the various things we might want to compare (e.g., pure values, monadic values, or even Com and Exprs).

Furthermore, we replace the hardcoded ⊑ notation in the InstCombine project with an instance of this generic notation.