### PR TITLE
(WIP) Evaluate generalizer

### DIFF
--- a/SSA/Experimental/Bits/Fast/Generalize.lean
+++ b/SSA/Experimental/Bits/Fast/Generalize.lean
@@ -634,7 +634,7 @@ def enumerativeSynthesis (lhsSketch: BVExpr w)  (inputs: List Nat)  (constants: 
       let inputCombinations := productsList (List.replicate inputs.length specialConstants)
 
       let constantVars : List (BVExpr w) := constants.keys.map (λ c => BVExpr.var c)
-      let constantsPermutation := List.permutations constantVars
+      let constantsPermutation := productsList (List.replicate constantVars.length constantVars)
 
       let inputsAndConstants := List.product inputCombinations constantsPermutation
       logInfo m! "inputs and constants has length {inputsAndConstants.length}"
@@ -834,7 +834,6 @@ variable {x y : BitVec 32}
 
 def getNegativeExamples (bvExpr: BVLogicalExpr) (shiftConstraints: Option BVLogicalExpr) (consts: List Nat) (num: Nat) :
               TermElabM (List (Std.HashMap Nat BVExpr.PackedBitVec)) := do
-    -- expr is negated for helper
   let rec helper (expr: BVLogicalExpr) (depth : Nat)
           : TermElabM (List (Std.HashMap Nat BVExpr.PackedBitVec)) := do
         match depth with
@@ -952,6 +951,7 @@ def generatePreconditions (bvExpr: BVLogicalExpr) (positiveExample: Std.HashMap 
           let eqToZero (expr: BVExpr bitwidth) : BVLogicalExpr :=
             BoolExpr.literal (BVPred.bin expr BVBinPred.eq zero)
 
+
           let ltZero (expr: BVExpr bitwidth) : BVLogicalExpr :=
             BoolExpr.literal (BVPred.bin expr BVBinPred.ult zero)
 
@@ -985,8 +985,8 @@ def generatePreconditions (bvExpr: BVLogicalExpr) (positiveExample: Std.HashMap 
           logInfo m! "Precondition candidates: {preconditionCandidatesSet.toList}"
 
           for candidate in preconditionCandidatesSet do
-              let weightSubstitutedCandidate := substitute candidate widthSubstitutionVal
-              if let none ← solve (BoolExpr.gate Gate.and weightSubstitutedCandidate (BoolExpr.not bvExpr)) then
+              let widthtSubstitutedCandidate := substitute candidate widthSubstitutionVal
+              if let none ← solve (BoolExpr.gate Gate.and widthtSubstitutedCandidate (BoolExpr.not bvExpr)) then
                   validCandidates := candidate :: validCandidates
 
           if validCandidates.isEmpty then -- TODO: if we have precondition candidates but none is valid, we can then look at joining them with ands.
@@ -1099,12 +1099,11 @@ theorem test_precondition_synthesis : False := by
 elab "#generalize" expr:term: command =>
   open Lean Lean.Elab Command Term in
   withoutModifyingEnv <| runTermElabM fun _ => Term.withDeclName `_reduceWidth do
-      let targetWidth := 4 -- TODO: We should try a range of widths
+      let targetWidth := 4 -- TODO: Only reduce the width if it's more than 8 bits?
 
       let hExpr ← Term.elabTerm expr none
       -- let hExpr ← instantiateMVars (← whnfR  hExpr)
       logInfo m! "hexpr: {hExpr}"
-
 
       match_expr hExpr with
       | Eq _ lhsExpr rhsExpr =>
@@ -1163,6 +1162,7 @@ elab "#generalize" expr:term: command =>
 
                 let mut positiveExample := constantAssignment.filter (fun k  _  => ! zippedCombo.contains k)
 
+                logInfo m! "Finding negative examples for {substitutedBVLogicalExpr}"
                 let negativeExamples ← getNegativeExamples substitutedBVLogicalExpr shiftConstraints positiveExample.keys 3
 
                 if negativeExamples.isEmpty then
@@ -1181,30 +1181,43 @@ elab "#generalize" expr:term: command =>
       | _ => throwError m!"The top level constructor is not an equality predicate in {hExpr}"
       pure ()
 
-variable {x y : BitVec 32}
 
+#eval (0 ^^^ 33 ||| 7) ^^^ 12
+#eval (0 ^^^ 33) ||| 7
+
+variable {x y : BitVec 8}
+-- #generalize (0#8 - x ||| y) + y = (y ||| 0#8 - x) + y --- PASSED add_or_sub_comb_i8_negative_y_sub_thm
+#generalize (x ||| 33#8) ^^^ 12#8 ||| 7#8 = x &&& BitVec.ofInt 8 (-40) ^^^ 47#8 --- or_xor_or_thm
+-- #generalize (x ^^^ 33#8 ||| 7#8) ^^^ 12#8 = x &&& BitVec.ofInt 8 (-8) ^^^ 43#8 --- PASSED xor_or_xor_thm
+-- #generalize  x ^^^ 33#8 ||| 7#8 = x &&& BitVec.ofInt 8 (-8) ^^^ 39#8 --- PASSED xor_or2_thm
+#generalize x ^^^ 32#8 ||| 7#8 = x &&& BitVec.ofInt 8 (-8) ^^^ 39#8 --- xor_or_thm
+-- #generalize (x ^^^ -1#8 ||| 7#8) ^^^ 12#8 = x &&& BitVec.ofInt 8 (-8) ^^^ BitVec.ofInt 8 (-13) --  PASSED not_or_xor_thm
+#generalize 28#8 >>> x <<< 3#8 ||| 7#8 = BitVec.ofInt 8 (-32) >>> x ||| 7#8 -- lshr_shl_demand1_thm
+
+variable {x : BitVec 16}
+#generalize BitVec.ofInt 16 (-32624) <<< x >>> 4#16 &&& 4094#16 = 2057#16 <<< x &&& 4094#16 -- shl_lshr_demand6_thm
+
+variable {x y z: BitVec 32}
+#generalize (x &&& 32#32) + 145#32 ^^^ 153#32 = x &&& 32#32 ||| 8#32 -- gxor2_proof/test2_thm
+#generalize (x ||| 145#32) &&& 177#32 ^^^ 153#32 = x &&& 32#32 ||| 8#32 --- gxor2_proof/test3_thm
+-- #generalize ((x ^^^ 1234#32) >>> 8#32 ^^^ 1#32) + (x ^^^ 1234#32) = (x >>> 8#32 ^^^ 5#32) + (x ^^^ 1234#32) -- gxor2_proof/test5_thm
+#generalize (x ^^^ y) &&& 1#32 ||| y &&& BitVec.ofInt 32 (-2) = x &&& 1#32 ^^^ y --- or_and_xor_not_constant_commute0_thm
+#generalize x * 42#32 ^^^ (y * 42#32 ^^^ z * 42#32) ||| x * 42#32 ^^^ z * 42#32 = x * 42#32 ^^^ z * 42#32 ||| y * 42#32 -- or_xor_tree_1110_thm
+#generalize x * 42#32 ^^^ (y * 42#32 ^^^ z * 42#32) ||| z * 42#32 ^^^ x * 42#32 = z * 42#32 ^^^ x * 42#32 ||| y * 42#32 ---  or_xor_tree_1111_thm
+#generalize (0#32 - x ||| x) = x -- add_or_sub_comb_i32_commuted1_nuw_thm
+#generalize x <<< 6#32 <<< 28#32 = 0#32   --shl_shl_thm
+#generalize 1#32 <<< (31#32 - x) = BitVec.ofInt (32) (-2147483648) >>> x --  shl_sub_i32_thm
+#generalize BitVec.truncate 24 (x >>> 12#32) <<< 3#24 = BitVec.truncate 24 (x >>> 9#32) &&& BitVec.ofInt 24 -- shl_trunc_bigger_ashr_thm
+#generalize BitVec.truncate 8 (x >>> 5#32) <<< 3#8 = BitVec.truncate 8 (x >>> 2#32) &&& BitVec.ofInt 8 (-8) --- shl_trunc_bigger_lshr_thm
 #generalize  ~~~(BitVec.zeroExtend 128 (BitVec.allOnes 64) <<< 64) = 0x0000000000000000ffffffffffffffff#128
 #generalize (x + (-1)) >>> 1 = x >>> 1 -- #61223;
 #generalize (x + 5) - (y + 1)  =  x - y + 4
 #generalize (x + 5) + (y + 1)  =  x + y + 6
 #generalize (x <<< 3) <<< 4 = x <<< 7
-#generalize ((x <<< 8) >>> 16) <<< 8 = x &&& 0x00FFFF00
-
-
+#generalize BitVec.zeroExtend 32 ((BitVec.truncate 16 x) <<< 8) = (x <<< 8) &&& 0xFF00#32
 #generalize (x &&& 1 ||| (x  &&& 1 ||| (0#32 - x))) = x &&& (x - 1#32) -- #57351
 #generalize (x &&& ((BitVec.ofInt 32 (-1)) <<< (32 - y))) >>> (32 - y) = x >>> (32 - y) -- #41801
+#generalize ((x <<< 8) >>> 16) <<< 8 = x &&& 0x00FFFF00
 
-#generalize BitVec.zeroExtend 32 ((BitVec.truncate 16 x) <<< 8) == (x <<< 8) &&& 0xFF00#32
-
-/-
---- Examples -------
-(𝑥 : i32 & 15) ≠ 15) & (𝑥 <𝑢 16) ⇒ 𝑥 <𝑢 15
-(𝑥 : i32 & 1) ≠ 0 |= (𝑥 + (−1) ) ≫𝑢 1 ⇒ 𝑥 ≫𝑢 1
-𝑥 : i32 <𝑠 (𝑥 ⊕ (−1) ) ⇒ 𝑥 <𝑠 0
-(42 /𝑠 𝑥 : i8) = 0 ⇒ (𝑥 + 0xD5) <𝑢 0xAB
-( (𝑥 : i32 %𝑠 8) <𝑠 0) ? ( (𝑥 %𝑠 8) +nsw 8) : (𝑥 %𝑠 8) ⇒ 𝑥 & 7 --TODO: Dealing with conditionals?; Not sure how to deal with the ternary operator in Lean
-( (𝑥 : i32 & 0xFFFF0000) = 0x11220000) | ( (𝑥 & 0xFFFFFF00) = 0x11223300) ⇒ (𝑥 & 0xFFFF0000) = 0x11220000 -- TODO: need to deal with boolean equal and neq
-(y : i128 + (𝑥 : i128 × (−1) ≪𝑢 64) ) ≪ 64 ⇒ y ≪ 64 -- Hydra width-independence failure
--/
 
 end Generalize

--- a/SSA/Experimental/Bits/Fast/Generalize.lean
+++ b/SSA/Experimental/Bits/Fast/Generalize.lean
@@ -753,7 +753,7 @@ partial def deductiveSearch (expr: BVExpr w) (inputs: List Nat) (constants: Std.
                 if BitVec.not constVal.bv == targetBv then
                   res := BVExpr.un BVUnOp.not newVar :: res
 
-                -- C + X = Target
+                -- C + X = Target; New target = Target - X.
                 let addRes ← deductiveSearch expr inputs constants {bv := targetBv - constVal.bv} (depth-1) constId
                 res := res ++ addRes.map (λ resExpr => BVExpr.bin newVar BVBinOp.add resExpr)
 
@@ -791,7 +791,7 @@ def synthesizeExpressions (origWidthConstantsExpr reducedWidthConstantsExpr: Par
 
 
     for (targetId, targetVal) in origWidthConstantsExpr.rhs.symVars.toArray do
-        -- Deductive search can use the constants in original widths since it does not invoke the solver;
+        -- Deductive search can use the constants in original widths since it does not invoke the solver; -- TODO: we can keep this in the reduced bitwidth now that we generate multiple positive examples
         let exprs := (← deductiveSearch origWidthConstantsExpr.lhs.bvExpr origWidthConstantsExpr.lhs.inputVars.keys origWidthConstantsExpr.lhs.symVars targetVal depth 1234).map (λ c => changeBVExprWidth c reducedWidth)
 
         let mut filteredExprs ← filterExprs exprs targetVal

--- a/SSA/Experimental/Bits/Fast/Generalize.lean
+++ b/SSA/Experimental/Bits/Fast/Generalize.lean
@@ -1192,12 +1192,20 @@ variable {x y : BitVec 8}
 -- #generalize  x ^^^ 33#8 ||| 7#8 = x &&& BitVec.ofInt 8 (-8) ^^^ 39#8 --- PASSED xor_or2_thm
 #generalize x ^^^ 32#8 ||| 7#8 = x &&& BitVec.ofInt 8 (-8) ^^^ 39#8 --- xor_or_thm
 -- #generalize (x ^^^ -1#8 ||| 7#8) ^^^ 12#8 = x &&& BitVec.ofInt 8 (-8) ^^^ BitVec.ofInt 8 (-13) --  PASSED not_or_xor_thm
-#generalize 28#8 >>> x <<< 3#8 ||| 7#8 = BitVec.ofInt 8 (-32) >>> x ||| 7#8 -- lshr_shl_demand1_thm
+-- #generalize 28#8 >>> x <<< 3#8 ||| 7#8 = BitVec.ofInt 8 (-32) >>> x ||| 7#8 -- lshr_shl_demand1_thm
 
-variable {x : BitVec 16}
-#generalize BitVec.ofInt 16 (-32624) <<< x >>> 4#16 &&& 4094#16 = 2057#16 <<< x &&& 4094#16 -- shl_lshr_demand6_thm
+-- variable {x : BitVec 16}
+-- #generalize BitVec.ofInt 16 (-32624) <<< x >>> 4#16 &&& 4094#16 = 2057#16 <<< x &&& 4094#16 -- shl_lshr_demand6_thm
 
 variable {x y z: BitVec 32}
+#generalize (x + (-1)) >>> 1 = x >>> 1 -- #61223;
+#generalize (x + 5) - (y + 1)  =  x - y + 4
+#generalize (x + 5) + (y + 1)  =  x + y + 6
+#generalize (x <<< 3) <<< 4 = x <<< 7
+-- #generalize BitVec.zeroExtend 32 ((BitVec.truncate 16 x) <<< 8) = (x <<< 8) &&& 0xFF00#32
+-- #generalize (x &&& 1 ||| (x  &&& 1 ||| (0#32 - x))) = x &&& (x - 1#32) -- #57351
+-- #generalize (x &&& ((BitVec.ofInt 32 (-1)) <<< (32 - y))) >>> (32 - y) = x >>> (32 - y) -- SLOW and failing#41801
+-- #generalize ((x <<< 8) >>> 16) <<< 8 = x &&& 0x00FFFF00 -- PASSED
 #generalize (x &&& 32#32) + 145#32 ^^^ 153#32 = x &&& 32#32 ||| 8#32 -- gxor2_proof/test2_thm
 #generalize (x ||| 145#32) &&& 177#32 ^^^ 153#32 = x &&& 32#32 ||| 8#32 --- gxor2_proof/test3_thm
 -- #generalize ((x ^^^ 1234#32) >>> 8#32 ^^^ 1#32) + (x ^^^ 1234#32) = (x >>> 8#32 ^^^ 5#32) + (x ^^^ 1234#32) -- gxor2_proof/test5_thm
@@ -1210,14 +1218,7 @@ variable {x y z: BitVec 32}
 #generalize BitVec.truncate 24 (x >>> 12#32) <<< 3#24 = BitVec.truncate 24 (x >>> 9#32) &&& BitVec.ofInt 24 -- shl_trunc_bigger_ashr_thm
 #generalize BitVec.truncate 8 (x >>> 5#32) <<< 3#8 = BitVec.truncate 8 (x >>> 2#32) &&& BitVec.ofInt 8 (-8) --- shl_trunc_bigger_lshr_thm
 #generalize  ~~~(BitVec.zeroExtend 128 (BitVec.allOnes 64) <<< 64) = 0x0000000000000000ffffffffffffffff#128
-#generalize (x + (-1)) >>> 1 = x >>> 1 -- #61223;
-#generalize (x + 5) - (y + 1)  =  x - y + 4
-#generalize (x + 5) + (y + 1)  =  x + y + 6
-#generalize (x <<< 3) <<< 4 = x <<< 7
-#generalize BitVec.zeroExtend 32 ((BitVec.truncate 16 x) <<< 8) = (x <<< 8) &&& 0xFF00#32
-#generalize (x &&& 1 ||| (x  &&& 1 ||| (0#32 - x))) = x &&& (x - 1#32) -- #57351
-#generalize (x &&& ((BitVec.ofInt 32 (-1)) <<< (32 - y))) >>> (32 - y) = x >>> (32 - y) -- #41801
-#generalize ((x <<< 8) >>> 16) <<< 8 = x &&& 0x00FFFF00
+
 
 
 end Generalize

--- a/SSA/Experimental/Bits/Fast/Generalize.lean
+++ b/SSA/Experimental/Bits/Fast/Generalize.lean
@@ -1206,13 +1206,13 @@ variable {x y z: BitVec 32}
 -- #generalize (x &&& 1 ||| (x  &&& 1 ||| (0#32 - x))) = x &&& (x - 1#32) -- #57351
 -- #generalize (x &&& ((BitVec.ofInt 32 (-1)) <<< (32 - y))) >>> (32 - y) = x >>> (32 - y) -- SLOW and failing#41801
 -- #generalize ((x <<< 8) >>> 16) <<< 8 = x &&& 0x00FFFF00 -- PASSED
-#generalize (x &&& 32#32) + 145#32 ^^^ 153#32 = x &&& 32#32 ||| 8#32 -- gxor2_proof/test2_thm
-#generalize (x ||| 145#32) &&& 177#32 ^^^ 153#32 = x &&& 32#32 ||| 8#32 --- gxor2_proof/test3_thm
--- #generalize ((x ^^^ 1234#32) >>> 8#32 ^^^ 1#32) + (x ^^^ 1234#32) = (x >>> 8#32 ^^^ 5#32) + (x ^^^ 1234#32) -- gxor2_proof/test5_thm
-#generalize (x ^^^ y) &&& 1#32 ||| y &&& BitVec.ofInt 32 (-2) = x &&& 1#32 ^^^ y --- or_and_xor_not_constant_commute0_thm
 #generalize x * 42#32 ^^^ (y * 42#32 ^^^ z * 42#32) ||| x * 42#32 ^^^ z * 42#32 = x * 42#32 ^^^ z * 42#32 ||| y * 42#32 -- or_xor_tree_1110_thm
 #generalize x * 42#32 ^^^ (y * 42#32 ^^^ z * 42#32) ||| z * 42#32 ^^^ x * 42#32 = z * 42#32 ^^^ x * 42#32 ||| y * 42#32 ---  or_xor_tree_1111_thm
-#generalize (0#32 - x ||| x) = x -- add_or_sub_comb_i32_commuted1_nuw_thm
+#generalize (x &&& 32#32) + 145#32 ^^^ 153#32 = x &&& 32#32 ||| 8#32 -- gxor2_proof/test2_thm
+#generalize (x ||| 145#32) &&& 177#32 ^^^ 153#32 = x &&& 32#32 ||| 8#32 --- gxor2_proof/test3_thm
+
+-- #generalize ((x ^^^ 1234#32) >>> 8#32 ^^^ 1#32) + (x ^^^ 1234#32) = (x >>> 8#32 ^^^ 5#32) + (x ^^^ 1234#32) -- gxor2_proof/test5_thm
+-- #generalize (x ^^^ y) &&& 1#32 ||| y &&& BitVec.ofInt 32 (-2) = x &&& 1#32 ^^^ y --- PASSED or_and_xor_not_constant_commute0_thm
 #generalize x <<< 6#32 <<< 28#32 = 0#32   --shl_shl_thm
 #generalize 1#32 <<< (31#32 - x) = BitVec.ofInt (32) (-2147483648) >>> x --  shl_sub_i32_thm
 #generalize BitVec.truncate 24 (x >>> 12#32) <<< 3#24 = BitVec.truncate 24 (x >>> 9#32) &&& BitVec.ofInt 24 -- shl_trunc_bigger_ashr_thm

--- a/SSA/Experimental/Bits/Fast/Generalize.lean
+++ b/SSA/Experimental/Bits/Fast/Generalize.lean
@@ -999,8 +999,9 @@ def generatePreconditions (originalBVLogicalExpr : ParsedBVLogicalExpr) (reduced
 
                 sketchResults := sketchResults.insert resultsString
 
-                if (evaluatedPositiveExs.any ( λ val => val == 0)) && evaluatedNegativeExs.all (λ val => val != 0) then
+                if (evaluatedPositiveExs.all ( λ val => val == 0)) && evaluatedNegativeExs.all (λ val => val != 0) then
                   preconditionCandidates := eqToZero substitutedExpr :: preconditionCandidates
+                  continue
 
                 if (evaluatedPositiveExs.any ( λ val => val < 0 || val == 0)) && evaluatedNegativeExs.all (λ val => val > 0) then
                   let mut cand := lteZero substitutedExpr

--- a/SSA/Experimental/Bits/Fast/Generalize.lean
+++ b/SSA/Experimental/Bits/Fast/Generalize.lean
@@ -1195,7 +1195,8 @@ elab "#generalize" expr:term: command =>
            let positiveExamples := constantAssignments.map (fun assignment => assignment.filter (fun key _ => parsedBVLogicalExpr.lhs.symVars.contains key))
 
            let preconditionSuccess : TermElabM Bool :=  withTraceNode `Generalize (fun _ => return "Attempted to generate weak precondition for all expression combos") do
-              for combo in resultsCombo do
+              for combo in resultsCombo do -- TODO: We can make this more clever and first see if there's any combination that does not need a precondition before we attempt to generate preconditions
+
                   -- Substitute the generated expressions into the main one, so the constants on the RHS are expressed in terms of the left.
                   let zippedCombo := Std.HashMap.ofList (List.zip parsedBVLogicalExpr.rhs.symVars.keys combo)
                   let substitutedBVLogicalExpr := substitute bvLogicalExpr (bvExprToSubstitutionValue zippedCombo)

--- a/SSA/Experimental/Bits/Fast/Generalize.lean
+++ b/SSA/Experimental/Bits/Fast/Generalize.lean
@@ -978,7 +978,7 @@ def generatePreconditions (originalBVLogicalExpr : ParsedBVLogicalExpr) (reduced
               let powerOf2Expr :=  BVExpr.bin (BVExpr.var const) BVBinOp.and (BVExpr.bin (BVExpr.var const) BVBinOp.add minusOne)
               let powerOfTwoResults := positiveExamples.map (λ pos => evalBVExpr pos bitwidth powerOf2Expr)
 
-              if powerOfTwoResults.all (λ val => val == 0) then
+              if powerOfTwoResults.any (λ val => val == 0) then
                 let powerOf2 := BoolExpr.literal (BVPred.bin powerOf2Expr BVBinPred.eq zero)
                 preconditionCandidates := powerOf2 :: preconditionCandidates
 
@@ -999,17 +999,17 @@ def generatePreconditions (originalBVLogicalExpr : ParsedBVLogicalExpr) (reduced
 
                 sketchResults := sketchResults.insert resultsString
 
-                if (evaluatedPositiveExs.all ( λ val => val == 0)) && evaluatedNegativeExs.all (λ val => val != 0) then
+                if (evaluatedPositiveExs.any ( λ val => val == 0)) && evaluatedNegativeExs.all (λ val => val != 0) then
                   preconditionCandidates := eqToZero substitutedExpr :: preconditionCandidates
 
-                if (evaluatedPositiveExs.all ( λ val => val < 0 || val == 0)) && evaluatedNegativeExs.all (λ val => val > 0) then
+                if (evaluatedPositiveExs.any ( λ val => val < 0 || val == 0)) && evaluatedNegativeExs.all (λ val => val > 0) then
                   let mut cand := lteZero substitutedExpr
                   if (evaluatedPositiveExs.all ( λ val => val < 0)) then
                     cand := ltZero substitutedExpr
 
                   preconditionCandidates := cand :: preconditionCandidates
 
-                if (evaluatedPositiveExs.all ( λ val => val > 0 || val == 0)) && evaluatedNegativeExs.all (λ val => val < 0) then
+                if (evaluatedPositiveExs.any ( λ val => val > 0 || val == 0)) && evaluatedNegativeExs.all (λ val => val < 0) then
                   let mut cand := gteZero substitutedExpr
                   if (evaluatedPositiveExs.all ( λ val => val > 0)) then
                       cand := gtZero substitutedExpr

--- a/SSA/Experimental/Bits/Fast/GeneralizeTest.lean
+++ b/SSA/Experimental/Bits/Fast/GeneralizeTest.lean
@@ -4,14 +4,22 @@ set_option trace.profiler true
 set_option trace.profiler.threshold 1
 set_option trace.Generalize true
 
+variable {x y : BitVec 4}
+-- #generalize (x ^^^ -1#4 ||| y) &&& (x ^^^ y) = y &&& (x ^^^ -1#4) -- PASSED but trivial precondition
+
 variable {x y : BitVec 8}
 -- #generalize (0#8 - x ||| y) + y = (y ||| 0#8 - x) + y --- PASSED add_or_sub_comb_i8_negative_y_sub_thm
+-- #generalize (0#8 - x ||| y) + x = (y ||| 0#8 - x) + x -- PASSED add_or_sub_comb_i8_negative_y_or_thm
+-- #generalize (0#8 - x ^^^ x) + x = (x ^^^ 0#8 - x) + x -- PASSED add_or_sub_comb_i8_negative_xor_instead_or_thm
+-- #generalize (0#8 - x ||| x) + y = (x ||| 0#8 - x) + y -- PASSED  add_or_sub_comb_i8_negative_y_add_thm
 -- #generalize (x ^^^ -1#8 ||| 7#8) ^^^ 12#8 = x &&& BitVec.ofInt 8 (-8) ^^^ BitVec.ofInt 8 (-13) --  PASSED not_or_xor_thm
 -- #generalize (x ^^^ 33#8 ||| 7#8) ^^^ 12#8 = x &&& BitVec.ofInt 8 (-8) ^^^ 43#8 --- PASSED xor_or_xor_thm
 -- #generalize  x ^^^ 33#8 ||| 7#8 = x &&& BitVec.ofInt 8 (-8) ^^^ 39#8 --- PASSED xor_or2_thm
+-- #generalize x ^^^ 32#8 ||| 7#8 = x &&& BitVec.ofInt 8 (-8) ^^^ 39#8  ---PASSED
 -- #generalize (x <<< 3) <<< 4 = x <<< 7
 
--- #generalize x ^^^ 32#8 ||| 7#8 = x &&& BitVec.ofInt 8 (-8) ^^^ 39#8 --- xor_or_thm. Can't generate precondition
+
+
 -- #generalize (x ||| 33#8) ^^^ 12#8 ||| 7#8 = x &&& BitVec.ofInt 8 (-40) ^^^ 47#8 --- or_xor_or_thm. Can't generate precondition
 -- #generalize 28#8 >>> x <<< 3#8 ||| 7#8 = BitVec.ofInt 8 (-32) >>> x ||| 7#8 -- lshr_shl_demand1_thm. Can't generate precondition
 
@@ -22,19 +30,24 @@ variable {x y z: BitVec 32}
 -- #generalize ((x >>> 4#32 &&& 8#32) + y) <<< 4#32 = (x &&& 128#32) + y <<< 4#32 --#PASSED gshlhbo_proof/shl_add_and_lshr_thm
 -- #generalize (x + (y >>> 5#32 &&& 127#32)) <<< 5#32 = (y &&& 4064#32) + x <<< 5#32 --- PASSED gshlhbo_proof/lshr_add_and_shl_thm
 -- #generalize x <<< 6#32 <<< 28#32 = 0#32   -- PASSED but takes seven minutes to run due to model counting; shl_shl_thm
- #generalize x + (x ||| (0 - x )) = x &&& (x + BitVec.ofInt 32 (-1))
+-- #generalize x + (x ||| (0 - x )) = x &&& (x + BitVec.ofInt 32 (-1))
 -- #generalize (x + 5) - (y + 1)  =  x - y + 4
 -- #generalize (x + 5) + (y + 1)  =  x + y + 6
 -- #generalize (x <<< 3) <<< 4 = x <<< 7
 
 
--- Failing
 
+-- Failing
+#generalize (x * x ^^^ y * y) &&& (x * x ||| y * y ^^^ -1#32) = x * x &&& (y * y ^^^ -1#32) -- and_orn_xor_commute8_thm
 -- #generalize 8#32 - x &&& 7#32 = 0#32 - x &&& 7#32 -- Precondition synthesis failure g2008h07h08hSubAnd_proof#a_thm --Can't generate preconditions
 -- #generalize BitVec.sshiftRight' (x &&& ((BitVec.ofInt 32 (-1)) <<< (32 - y))) (BitVec.ofInt 32 32 - y) = BitVec.sshiftRight' x (BitVec.ofInt 32 32 - y) -- Precondition synthesis failure #41801
 
 -- #generalize ((x ^^^ 1234#32) >>> 8#32 ^^^ 1#32) + (x ^^^ 1234#32) = (x >>> 8#32 ^^^ 5#32) + (x ^^^ 1234#32) -- gxor2_proof/test5_thm -- Timeout
 
+variable {x y z: BitVec 64}
+ -- #generalize x * x + (x * x ||| 0#64 - x * x) = x * x + -1#64 &&& x * x -- Passing but trivial result add_or_sub_comb_i64_commuted4_thm
+
+
 
  variable {x y z: BitVec 232}
- #generalize x >>> 231#232 >>> 1#232 = 0#232 -- PASSED - lshr_lshr_thm
+--  #generalize x >>> 231#232 >>> 1#232 = 0#232 -- PASSED - lshr_lshr_thm

--- a/SSA/Experimental/Bits/Fast/GeneralizeTest.lean
+++ b/SSA/Experimental/Bits/Fast/GeneralizeTest.lean
@@ -4,40 +4,35 @@ set_option trace.profiler true
 set_option trace.profiler.threshold 1
 set_option trace.Generalize true
 
-#eval (0 ^^^ 33 ||| 7) ^^^ 12
-#eval (0 ^^^ 33) ||| 7
-
-#eval 3#4 + (1#4 + (BitVec.not (4#4 + 3#4)))
-
 variable {x y : BitVec 8}
--- #generalize (0#8 - x ||| y) + y = (y ||| 0#8 - x) + y --- PASSED add_or_sub_comb_i8_negative_y_sub_thm
--- #generalize (x ^^^ -1#8 ||| 7#8) ^^^ 12#8 = x &&& BitVec.ofInt 8 (-8) ^^^ BitVec.ofInt 8 (-13) --  PASSED not_or_xor_thm
--- #generalize (x ^^^ 33#8 ||| 7#8) ^^^ 12#8 = x &&& BitVec.ofInt 8 (-8) ^^^ 43#8 --- PASSED xor_or_xor_thm
--- #generalize  x ^^^ 33#8 ||| 7#8 = x &&& BitVec.ofInt 8 (-8) ^^^ 39#8 --- PASSED xor_or2_thm
+#generalize (0#8 - x ||| y) + y = (y ||| 0#8 - x) + y --- PASSED add_or_sub_comb_i8_negative_y_sub_thm
+#generalize (x ^^^ -1#8 ||| 7#8) ^^^ 12#8 = x &&& BitVec.ofInt 8 (-8) ^^^ BitVec.ofInt 8 (-13) --  PASSED not_or_xor_thm
+#generalize (x ^^^ 33#8 ||| 7#8) ^^^ 12#8 = x &&& BitVec.ofInt 8 (-8) ^^^ 43#8 --- PASSED xor_or_xor_thm
+#generalize  x ^^^ 33#8 ||| 7#8 = x &&& BitVec.ofInt 8 (-8) ^^^ 39#8 --- PASSED xor_or2_thm
 
 
 -- #generalize x ^^^ 32#8 ||| 7#8 = x &&& BitVec.ofInt 8 (-8) ^^^ 39#8 --- xor_or_thm. Can't generate precondition
 -- #generalize (x ||| 33#8) ^^^ 12#8 ||| 7#8 = x &&& BitVec.ofInt 8 (-40) ^^^ 47#8 --- or_xor_or_thm. Can't generate precondition
 -- #generalize 28#8 >>> x <<< 3#8 ||| 7#8 = BitVec.ofInt 8 (-32) >>> x ||| 7#8 -- lshr_shl_demand1_thm. Can't generate precondition
 
--- variable {x : BitVec 16}
+variable {x : BitVec 16}
 -- #generalize BitVec.ofInt 16 (-32624) <<< x >>> 4#16 &&& 4094#16 = 2057#16 <<< x &&& 4094#16 -- shl_lshr_demand6_thm
 
 variable {x y z: BitVec 32}
--- #generalize (x ^^^ y) &&& 1#32 ||| y &&& BitVec.ofInt 32 (-2) = x &&& 1#32 ^^^ y --- PASSED or_and_xor_not_constant_commute0_thm
--- #generalize ((x <<< 8) >>> 16) <<< 8 = x &&& 0x00FFFF00 -- PASSED but takes 15 minutes to run due to model counting taking up most of the time.
--- #generalize x <<< 6#32 <<< 28#32 = 0#32   -- PASSED shl_shl_thm
--- #generalize (42#32 - x) <<< 3#32 = 336#32 - x <<< 3#32 -- PASSED gshlhsub_proof/shl_const_op1_sub_const_op0_thm
--- #generalize ((x >>> 4#32 &&& 8#32) + y) <<< 4#32 = (x &&& 128#32) + y <<< 4#32 #PASSED gshlhbo_proof/shl_add_and_lshr_thm
--- #generalize (x + (y >>> 5#32 &&& 127#32)) <<< 5#32 = (y &&& 4064#32) + x <<< 5#32 --- PASSED gshlhbo_proof/lshr_add_and_shl_thm
+#generalize (x ^^^ y) &&& 1#32 ||| y &&& BitVec.ofInt 32 (-2) = x &&& 1#32 ^^^ y --- PASSED or_and_xor_not_constant_commute0_thm
+#generalize ((x <<< 8) >>> 16) <<< 8 = x &&& 0x00FFFF00 -- PASSED
+#generalize (42#32 - x) <<< 3#32 = 336#32 - x <<< 3#32 -- PASSED gshlhsub_proof/shl_const_op1_sub_const_op0_thm
+#generalize ((x >>> 4#32 &&& 8#32) + y) <<< 4#32 = (x &&& 128#32) + y <<< 4#32 --#PASSED gshlhbo_proof/shl_add_and_lshr_thm
+#generalize (x + (y >>> 5#32 &&& 127#32)) <<< 5#32 = (y &&& 4064#32) + x <<< 5#32 --- PASSED gshlhbo_proof/lshr_add_and_shl_thm
+#generalize x <<< 6#32 <<< 28#32 = 0#32   -- PASSED but takes seven minutes to run due to model counting; shl_shl_thm
 
--- #generalize (x + 5) - (y + 1)  =  x - y + 4
--- #generalize (x + 5) + (y + 1)  =  x + y + 6
--- #generalize (x <<< 3) <<< 4 = x <<< 7
+#generalize (x + 5) - (y + 1)  =  x - y + 4
+#generalize (x + 5) + (y + 1)  =  x + y + 6
+#generalize (x <<< 3) <<< 4 = x <<< 7
 
 
 -- Failing
--- #generalize 8#32 - x &&& 7#32 = 0#32 - x &&& 7#32 -- g2008h07h08hSubAnd_proof#a_thm --Can't generate preconditions
--- #generalize BitVec.sshiftRight' (x &&& ((BitVec.ofInt 32 (-1)) <<< (32 - y))) (BitVec.ofInt 32 32 - y) = BitVec.sshiftRight' x (BitVec.ofInt 32 32 - y) -- SLOW and failing#41801
+#generalize 8#32 - x &&& 7#32 = 0#32 - x &&& 7#32 -- g2008h07h08hSubAnd_proof#a_thm --Can't generate preconditions
+#generalize BitVec.sshiftRight' (x &&& ((BitVec.ofInt 32 (-1)) <<< (32 - y))) (BitVec.ofInt 32 32 - y) = BitVec.sshiftRight' x (BitVec.ofInt 32 32 - y) -- SLOW and failing#41801
 
--- #generalize ((x ^^^ 1234#32) >>> 8#32 ^^^ 1#32) + (x ^^^ 1234#32) = (x >>> 8#32 ^^^ 5#32) + (x ^^^ 1234#32) -- gxor2_proof/test5_thm
+#generalize ((x ^^^ 1234#32) >>> 8#32 ^^^ 1#32) + (x ^^^ 1234#32) = (x >>> 8#32 ^^^ 5#32) + (x ^^^ 1234#32) -- gxor2_proof/test5_thm

--- a/SSA/Experimental/Bits/Fast/GeneralizeTest.lean
+++ b/SSA/Experimental/Bits/Fast/GeneralizeTest.lean
@@ -4,9 +4,6 @@ set_option trace.profiler true
 set_option trace.profiler.threshold 1
 set_option trace.Generalize true
 
-variable {x y : BitVec 4}
-#generalize (x ^^^ -1#4 ||| y) &&& (x ^^^ y) = y &&& (x ^^^ -1#4) -- PASSED but trivial precondition
-
 variable {x y : BitVec 8}
 #generalize (0#8 - x ||| y) + y = (y ||| 0#8 - x) + y --- PASSED add_or_sub_comb_i8_negative_y_sub_thm
 #generalize (0#8 - x ||| y) + x = (y ||| 0#8 - x) + x -- PASSED add_or_sub_comb_i8_negative_y_or_thm
@@ -17,25 +14,23 @@ variable {x y : BitVec 8}
 #generalize  x ^^^ 33#8 ||| 7#8 = x &&& BitVec.ofInt 8 (-8) ^^^ 39#8 --- PASSED xor_or2_thm
 #generalize x ^^^ 32#8 ||| 7#8 = x &&& BitVec.ofInt 8 (-8) ^^^ 39#8  ---PASSED
 #generalize x <<< 4#8 &&& (y <<< 5#8 &&& 88#8) = x <<< 4#8 &&& (y <<< 5#8 &&& 64#8) --- PASSED gbinophandhshifts_proof/ shl_and_and_fail_thm
-#generalize x <<< 2#8 + (y <<< 2#8 + 48#8) = (y + x) <<< 2#8 + 48#8 ---  PASSED gbinophandhshifts_proof/shl_add_add_thm
+#generalize x >>> 5#8 ||| (y >>> 5#8 ||| BitVec.ofInt 8 (-58)) = (y ||| x) >>> 5#8 ||| BitVec.ofInt 8 (-58) --- PASSED gbinophandhshifts_proof/lshr_or_or_fail_thm
 #generalize x <<< 1#8 &&& y <<< 1#8 + 123#8 = (x &&& y + 61#8) <<< 1#8 ---PASSED gbinophandhshifts_proof/shl_add_and_thm
+#generalize x <<< 2#8 + (y <<< 2#8 + 48#8) = (y + x) <<< 2#8 + 48#8 ---  PASSED gbinophandhshifts_proof/shl_add_add_thm
 #generalize x <<< 1#8 ^^^ (y <<< 1#8 ^^^ 88#8) = (y ^^^ x) <<< 1#8 ^^^ 88#8 --- PASSED gbinophandhshifts_proof/shl_xor_xor_good_mask_thm
 #generalize x <<< 1#8 + (y <<< 1#8 &&& 119#8) = (x + (y &&& 59#8)) <<< 1#8 --- PASSED gbinophandhshifts_proof/shl_and_add_thm
 #generalize x <<< 1#8 ^^^ (y <<< 1#8 ^^^ BitVec.ofInt 8 (-68)) = (y ^^^ x) <<< 1#8 ^^^ BitVec.ofInt 8 (-68) ---PASSED gbinophandhshifts_proof/shl_xor_xor_bad_mask_distribute_thm
+#generalize x <<< 1#8 ^^^ y <<< 1#8 &&& 20#8 = (x ^^^ y &&& 10#8) <<< 1#8  --- PASSED gbinophandhshifts_proof/shl_and_xor_thm
+#generalize x <<< 7#8 ||| BitVec.ofInt 8 (-128) = BitVec.ofInt 8 (-128) -- PASSED gandhorand_proof/or_test2_thm
+#generalize x &&& 3#8 &&& 4#8 = 0#8 --PASSED gand_proof/test8_thm
+#generalize x ^^^ 5#8 ||| x ^^^ 5#8 ^^^ y = x ^^^ 5#8 ||| y -- PASSED gorhxor_proof/xor_common_op_commute2_thm
+#generalize ((x ||| BitVec.ofInt 8 (-2)) ^^^ 13#8 ||| 1#8) ^^^ 12#8 = -1#8 -- PASSED gorhxor_proof/test23_thm
+#generalize x <<< 4#8 &&& (y <<< 4#8 &&& 88#8) = (y &&& x) <<< 4#8 &&& 80#8 ---PASSED  gbinophandhshifts_proof/shl_and_and_th
 #generalize (x <<< 3) <<< 4 = x <<< 7
 
 
 -- -- Failing
-#generalize x <<< 1#8 ^^^ y <<< 1#8 &&& 20#8 = (x ^^^ y &&& 10#8) <<< 1#8  --- gbinophandhshifts_proof/shl_and_xor_thm
-#generalize x <<< 4#8 &&& (y <<< 4#8 &&& 88#8) = (y &&& x) <<< 4#8 &&& 80#8 --- gbinophandhshifts_proof/shl_and_and_thm
 #generalize (x >>> 5#8 ||| BitVec.ofInt 8 (-58)) &&& y >>> 5#8 = (y &&& (x ||| BitVec.ofInt 8 (-64))) >>> 5#8 --- gbinophandhshifts_proof/lshr_or_and_thm
-#generalize x >>> 5#8 ||| (y >>> 5#8 ||| BitVec.ofInt 8 (-58)) = (y ||| x) >>> 5#8 ||| BitVec.ofInt 8 (-58) --- gbinophandhshifts_proof/lshr_or_or_fail_thm
-
-#generalize x <<< 7#8 ||| BitVec.ofInt 8 (-128) = BitVec.ofInt 8 (-128) -- gandhorand_proof/or_test2_thm
-#generalize x &&& 3#8 &&& 4#8 = 0#8 -- gand_proof/test8_thm
-#generalize x ^^^ 5#8 ||| x ^^^ 5#8 ^^^ y = x ^^^ 5#8 ||| y -- gorhxor_proof/xor_common_op_commute2_thm
-#generalize ((x ||| BitVec.ofInt 8 (-2)) ^^^ 13#8 ||| 1#8) ^^^ 12#8 = -1#8 -- gorhxor_proof/test23_thm
-
 #generalize (x ||| 33#8) ^^^ 12#8 ||| 7#8 = x &&& BitVec.ofInt 8 (-40) ^^^ 47#8 --- or_xor_or_thm. Can't generate precondition
 #generalize 28#8 >>> x <<< 3#8 ||| 7#8 = BitVec.ofInt 8 (-32) >>> x ||| 7#8 -- lshr_shl_demand1_thm. Can't generate precondition
 
@@ -72,5 +67,5 @@ variable {x y z: BitVec 32}
 variable {x y z: BitVec 64}
 #generalize x * x + (x * x ||| 0#64 - x * x) = x * x + -1#64 &&& x * x -- Passing but trivial result add_or_sub_comb_i64_commuted4_thm
 
- variable {x y z: BitVec 232}
- #generalize x >>> 231#232 >>> 1#232 = 0#232 -- PASSED - lshr_lshr_thm
+variable {x y z: BitVec 232}
+#generalize x >>> 231#232 >>> 1#232 = 0#232 -- PASSED - lshr_lshr_thm

--- a/SSA/Experimental/Bits/Fast/GeneralizeTest.lean
+++ b/SSA/Experimental/Bits/Fast/GeneralizeTest.lean
@@ -9,14 +9,11 @@ variable {x y : BitVec 8}
 -- #generalize (x ^^^ -1#8 ||| 7#8) ^^^ 12#8 = x &&& BitVec.ofInt 8 (-8) ^^^ BitVec.ofInt 8 (-13) --  PASSED not_or_xor_thm
 -- #generalize (x ^^^ 33#8 ||| 7#8) ^^^ 12#8 = x &&& BitVec.ofInt 8 (-8) ^^^ 43#8 --- PASSED xor_or_xor_thm
 -- #generalize  x ^^^ 33#8 ||| 7#8 = x &&& BitVec.ofInt 8 (-8) ^^^ 39#8 --- PASSED xor_or2_thm
+-- #generalize (x <<< 3) <<< 4 = x <<< 7
 
-
-#generalize x ^^^ 32#8 ||| 7#8 = x &&& BitVec.ofInt 8 (-8) ^^^ 39#8 --- xor_or_thm. Can't generate precondition
-#generalize (x ||| 33#8) ^^^ 12#8 ||| 7#8 = x &&& BitVec.ofInt 8 (-40) ^^^ 47#8 --- or_xor_or_thm. Can't generate precondition
-#generalize 28#8 >>> x <<< 3#8 ||| 7#8 = BitVec.ofInt 8 (-32) >>> x ||| 7#8 -- lshr_shl_demand1_thm. Can't generate precondition
-
-variable {x : BitVec 16}
-#generalize BitVec.ofInt 16 (-32624) <<< x >>> 4#16 &&& 4094#16 = 2057#16 <<< x &&& 4094#16 -- Expression synthesis failure. shl_lshr_demand6_thm
+-- #generalize x ^^^ 32#8 ||| 7#8 = x &&& BitVec.ofInt 8 (-8) ^^^ 39#8 --- xor_or_thm. Can't generate precondition
+-- #generalize (x ||| 33#8) ^^^ 12#8 ||| 7#8 = x &&& BitVec.ofInt 8 (-40) ^^^ 47#8 --- or_xor_or_thm. Can't generate precondition
+-- #generalize 28#8 >>> x <<< 3#8 ||| 7#8 = BitVec.ofInt 8 (-32) >>> x ||| 7#8 -- lshr_shl_demand1_thm. Can't generate precondition
 
 variable {x y z: BitVec 32}
 -- #generalize (x ^^^ y) &&& 1#32 ||| y &&& BitVec.ofInt 32 (-2) = x &&& 1#32 ^^^ y --- PASSED or_and_xor_not_constant_commute0_thm
@@ -25,13 +22,14 @@ variable {x y z: BitVec 32}
 -- #generalize ((x >>> 4#32 &&& 8#32) + y) <<< 4#32 = (x &&& 128#32) + y <<< 4#32 --#PASSED gshlhbo_proof/shl_add_and_lshr_thm
 -- #generalize (x + (y >>> 5#32 &&& 127#32)) <<< 5#32 = (y &&& 4064#32) + x <<< 5#32 --- PASSED gshlhbo_proof/lshr_add_and_shl_thm
 -- #generalize x <<< 6#32 <<< 28#32 = 0#32   -- PASSED but takes seven minutes to run due to model counting; shl_shl_thm
-
+ #generalize x + (x ||| (0 - x )) = x &&& (x + BitVec.ofInt 32 (-1))
 -- #generalize (x + 5) - (y + 1)  =  x - y + 4
 -- #generalize (x + 5) + (y + 1)  =  x + y + 6
 -- #generalize (x <<< 3) <<< 4 = x <<< 7
 
 
 -- Failing
+
 -- #generalize 8#32 - x &&& 7#32 = 0#32 - x &&& 7#32 -- Precondition synthesis failure g2008h07h08hSubAnd_proof#a_thm --Can't generate preconditions
 -- #generalize BitVec.sshiftRight' (x &&& ((BitVec.ofInt 32 (-1)) <<< (32 - y))) (BitVec.ofInt 32 32 - y) = BitVec.sshiftRight' x (BitVec.ofInt 32 32 - y) -- Precondition synthesis failure #41801
 

--- a/SSA/Experimental/Bits/Fast/GeneralizeTest.lean
+++ b/SSA/Experimental/Bits/Fast/GeneralizeTest.lean
@@ -7,41 +7,44 @@ set_option trace.Generalize true
 #eval (0 ^^^ 33 ||| 7) ^^^ 12
 #eval (0 ^^^ 33) ||| 7
 
+#eval 3#4 + (1#4 + (BitVec.not (4#4 + 3#4)))
+
 variable {x y : BitVec 8}
-#generalize (0#8 - x ||| y) + y = (y ||| 0#8 - x) + y --- PASSED add_or_sub_comb_i8_negative_y_sub_thm
-#generalize (x ^^^ -1#8 ||| 7#8) ^^^ 12#8 = x &&& BitVec.ofInt 8 (-8) ^^^ BitVec.ofInt 8 (-13) --  PASSED not_or_xor_thm
-#generalize (x ^^^ 33#8 ||| 7#8) ^^^ 12#8 = x &&& BitVec.ofInt 8 (-8) ^^^ 43#8 --- PASSED xor_or_xor_thm
-#generalize  x ^^^ 33#8 ||| 7#8 = x &&& BitVec.ofInt 8 (-8) ^^^ 39#8 --- PASSED xor_or2_thm
+-- #generalize (0#8 - x ||| y) + y = (y ||| 0#8 - x) + y --- PASSED add_or_sub_comb_i8_negative_y_sub_thm
+-- #generalize (x ^^^ -1#8 ||| 7#8) ^^^ 12#8 = x &&& BitVec.ofInt 8 (-8) ^^^ BitVec.ofInt 8 (-13) --  PASSED not_or_xor_thm
+-- #generalize (x ^^^ 33#8 ||| 7#8) ^^^ 12#8 = x &&& BitVec.ofInt 8 (-8) ^^^ 43#8 --- PASSED xor_or_xor_thm
+-- #generalize  x ^^^ 33#8 ||| 7#8 = x &&& BitVec.ofInt 8 (-8) ^^^ 39#8 --- PASSED xor_or2_thm
 
 
 #generalize x ^^^ 32#8 ||| 7#8 = x &&& BitVec.ofInt 8 (-8) ^^^ 39#8 --- xor_or_thm
 #generalize (x ||| 33#8) ^^^ 12#8 ||| 7#8 = x &&& BitVec.ofInt 8 (-40) ^^^ 47#8 --- or_xor_or_thm
 #generalize 28#8 >>> x <<< 3#8 ||| 7#8 = BitVec.ofInt 8 (-32) >>> x ||| 7#8 -- lshr_shl_demand1_thm
 
-variable {x : BitVec 16}
+-- variable {x : BitVec 16}
 #generalize BitVec.ofInt 16 (-32624) <<< x >>> 4#16 &&& 4094#16 = 2057#16 <<< x &&& 4094#16 -- shl_lshr_demand6_thm
 
 variable {x y z: BitVec 32}
-#generalize ((x <<< 8) >>> 16) <<< 8 = x &&& 0x00FFFF00 -- PASSED
+-- #generalize (x ^^^ y) &&& 1#32 ||| y &&& BitVec.ofInt 32 (-2) = x &&& 1#32 ^^^ y --- PASSED or_and_xor_not_constant_commute0_thm
+-- #generalize ((x <<< 8) >>> 16) <<< 8 = x &&& 0x00FFFF00 -- PASSED but takes 15 minutes to run due to model counting taking up most of the time.
+-- #generalize x <<< 6#32 <<< 28#32 = 0#32   -- PASSED shl_shl_thm
 
-#generalize (x &&& 32#32) + 145#32 ^^^ 153#32 = x &&& 32#32 ||| 8#32 -- gxor2_proof/test2_thm
 #generalize (x + (-1)) >>> 1 = x >>> 1 -- #61223;
 #generalize (x + 5) - (y + 1)  =  x - y + 4
 #generalize (x + 5) + (y + 1)  =  x + y + 6
+#generalize 8#32 - x &&& 7#32 = 0#32 - x &&& 7#32 -- g2008h07h08hSubAnd_proof#a_thm -- I think this should be IsPowerOf2(C1) && C1-C2 = 1
 #generalize (x <<< 3) <<< 4 = x <<< 7
-#generalize BitVec.zeroExtend 32 ((BitVec.truncate 16 x) <<< 8) = (x <<< 8) &&& 0xFF00#32
 #generalize (x &&& 1 ||| (x  &&& 1 ||| (0#32 - x))) = x &&& (x - 1#32) -- #57351
 #generalize (x &&& ((BitVec.ofInt 32 (-1)) <<< (32 - y))) >>> (32 - y) = x >>> (32 - y) -- SLOW and failing#41801
 
 
-#generalize (x ||| 145#32) &&& 177#32 ^^^ 153#32 = x &&& 32#32 ||| 8#32 --- gxor2_proof/test3_thm
--- #generalize x * 42#32 ^^^ (y * 42#32 ^^^ z * 42#32) ||| z * 42#32 ^^^ x * 42#32 = z * 42#32 ^^^ x * 42#32 ||| y * 42#32 ---  or_xor_tree_1111_thm
-#generalize x * 42#32 ^^^ (y * 42#32 ^^^ z * 42#32) ||| x * 42#32 ^^^ z * 42#32 = x * 42#32 ^^^ z * 42#32 ||| y * 42#32 -- or_xor_tree_1110_thm
-
--- #generalize ((x ^^^ 1234#32) >>> 8#32 ^^^ 1#32) + (x ^^^ 1234#32) = (x >>> 8#32 ^^^ 5#32) + (x ^^^ 1234#32) -- gxor2_proof/test5_thm
--- #generalize (x ^^^ y) &&& 1#32 ||| y &&& BitVec.ofInt 32 (-2) = x &&& 1#32 ^^^ y --- PASSED or_and_xor_not_constant_commute0_thm
-#generalize x <<< 6#32 <<< 28#32 = 0#32   --shl_shl_thm
 #generalize 1#32 <<< (31#32 - x) = BitVec.ofInt (32) (-2147483648) >>> x --  shl_sub_i32_thm
+#generalize ((x ^^^ 1234#32) >>> 8#32 ^^^ 1#32) + (x ^^^ 1234#32) = (x >>> 8#32 ^^^ 5#32) + (x ^^^ 1234#32) -- gxor2_proof/test5_thm
 #generalize BitVec.truncate 24 (x >>> 12#32) <<< 3#24 = BitVec.truncate 24 (x >>> 9#32) &&& BitVec.ofInt 24 -- shl_trunc_bigger_ashr_thm
 #generalize BitVec.truncate 8 (x >>> 5#32) <<< 3#8 = BitVec.truncate 8 (x >>> 2#32) &&& BitVec.ofInt 8 (-8) --- shl_trunc_bigger_lshr_thm
+
+
+-- #generalize x * 42#32 ^^^ (y * 42#32 ^^^ z * 42#32) ||| z * 42#32 ^^^ x * 42#32 = z * 42#32 ^^^ x * 42#32 ||| y * 42#32 ---  or_xor_tree_1111_thm - This might work once we disable model counting for > 12 bits
+-- #generalize x * 42#32 ^^^ (y * 42#32 ^^^ z * 42#32) ||| x * 42#32 ^^^ z * 42#32 = x * 42#32 ^^^ z * 42#32 ||| y * 42#32 -- or_xor_tree_1110_thm
+
+
 #generalize  ~~~(BitVec.zeroExtend 128 (BitVec.allOnes 64) <<< 64) = 0x0000000000000000ffffffffffffffff#128

--- a/SSA/Experimental/Bits/Fast/GeneralizeTest.lean
+++ b/SSA/Experimental/Bits/Fast/GeneralizeTest.lean
@@ -20,8 +20,9 @@ variable {x y : BitVec 8}
 -- #generalize BitVec.ofInt 16 (-32624) <<< x >>> 4#16 &&& 4094#16 = 2057#16 <<< x &&& 4094#16 -- shl_lshr_demand6_thm
 
 variable {x y z: BitVec 32}
-#generalize ((x <<< 8) >>> 16) <<< 8 = x &&& 0x00FFFF00
-#exit
+-- #generalize ((x <<< 8) >>> 16) <<< 8 = x &&& 0x00FFFF00
+#generalize (x &&& ((BitVec.ofInt 32 (-1)) <<< (32 - y))) >>> (32 - y) = x >>> (32 - y) -- SLOW and failing#41801
+
 #generalize (x + (-1)) >>> 1 = x >>> 1 -- #61223;
 #generalize (x + 5) - (y + 1)  =  x - y + 4
 #generalize (x + 5) + (y + 1)  =  x + y + 6
@@ -34,7 +35,7 @@ variable {x y z: BitVec 32}
 #generalize x * 42#32 ^^^ (y * 42#32 ^^^ z * 42#32) ||| z * 42#32 ^^^ x * 42#32 = z * 42#32 ^^^ x * 42#32 ||| y * 42#32 ---  or_xor_tree_1111_thm
 #generalize (x &&& 32#32) + 145#32 ^^^ 153#32 = x &&& 32#32 ||| 8#32 -- gxor2_proof/test2_thm
 #generalize (x ||| 145#32) &&& 177#32 ^^^ 153#32 = x &&& 32#32 ||| 8#32 --- gxor2_proof/test3_thm
-
+#exit
 -- #generalize ((x ^^^ 1234#32) >>> 8#32 ^^^ 1#32) + (x ^^^ 1234#32) = (x >>> 8#32 ^^^ 5#32) + (x ^^^ 1234#32) -- gxor2_proof/test5_thm
 -- #generalize (x ^^^ y) &&& 1#32 ||| y &&& BitVec.ofInt 32 (-2) = x &&& 1#32 ^^^ y --- PASSED or_and_xor_not_constant_commute0_thm
 #generalize x <<< 6#32 <<< 28#32 = 0#32   --shl_shl_thm

--- a/SSA/Experimental/Bits/Fast/GeneralizeTest.lean
+++ b/SSA/Experimental/Bits/Fast/GeneralizeTest.lean
@@ -1,7 +1,7 @@
 import SSA.Experimental.Bits.Fast.Generalize
 
 set_option trace.profiler true
--- set_option trace.profiler.threshold 1
+set_option trace.profiler.threshold 1
 set_option trace.Generalize true
 
 #eval (0 ^^^ 33 ||| 7) ^^^ 12
@@ -9,7 +9,7 @@ set_option trace.Generalize true
 
 variable {x y : BitVec 8}
 -- #generalize (0#8 - x ||| y) + y = (y ||| 0#8 - x) + y --- PASSED add_or_sub_comb_i8_negative_y_sub_thm
--- #generalize (x ||| 33#8) ^^^ 12#8 ||| 7#8 = x &&& BitVec.ofInt 8 (-40) ^^^ 47#8 --- or_xor_or_thm
+#generalize (x ||| 33#8) ^^^ 12#8 ||| 7#8 = x &&& BitVec.ofInt 8 (-40) ^^^ 47#8 --- or_xor_or_thm
 -- #generalize (x ^^^ 33#8 ||| 7#8) ^^^ 12#8 = x &&& BitVec.ofInt 8 (-8) ^^^ 43#8 --- PASSED xor_or_xor_thm
 -- #generalize  x ^^^ 33#8 ||| 7#8 = x &&& BitVec.ofInt 8 (-8) ^^^ 39#8 --- PASSED xor_or2_thm
 #generalize x ^^^ 32#8 ||| 7#8 = x &&& BitVec.ofInt 8 (-8) ^^^ 39#8 --- xor_or_thm
@@ -20,22 +20,22 @@ variable {x y : BitVec 8}
 -- #generalize BitVec.ofInt 16 (-32624) <<< x >>> 4#16 &&& 4094#16 = 2057#16 <<< x &&& 4094#16 -- shl_lshr_demand6_thm
 
 variable {x y z: BitVec 32}
--- #generalize ((x <<< 8) >>> 16) <<< 8 = x &&& 0x00FFFF00
-#generalize (x &&& ((BitVec.ofInt 32 (-1)) <<< (32 - y))) >>> (32 - y) = x >>> (32 - y) -- SLOW and failing#41801
+#generalize (x &&& 32#32) + 145#32 ^^^ 153#32 = x &&& 32#32 ||| 8#32 -- gxor2_proof/test2_thm
 
 #generalize (x + (-1)) >>> 1 = x >>> 1 -- #61223;
 #generalize (x + 5) - (y + 1)  =  x - y + 4
 #generalize (x + 5) + (y + 1)  =  x + y + 6
 #generalize (x <<< 3) <<< 4 = x <<< 7
+
 -- #generalize BitVec.zeroExtend 32 ((BitVec.truncate 16 x) <<< 8) = (x <<< 8) &&& 0xFF00#32
 -- #generalize (x &&& 1 ||| (x  &&& 1 ||| (0#32 - x))) = x &&& (x - 1#32) -- #57351
 -- #generalize (x &&& ((BitVec.ofInt 32 (-1)) <<< (32 - y))) >>> (32 - y) = x >>> (32 - y) -- SLOW and failing#41801
 -- #generalize ((x <<< 8) >>> 16) <<< 8 = x &&& 0x00FFFF00 -- PASSED
-#generalize x * 42#32 ^^^ (y * 42#32 ^^^ z * 42#32) ||| x * 42#32 ^^^ z * 42#32 = x * 42#32 ^^^ z * 42#32 ||| y * 42#32 -- or_xor_tree_1110_thm
-#generalize x * 42#32 ^^^ (y * 42#32 ^^^ z * 42#32) ||| z * 42#32 ^^^ x * 42#32 = z * 42#32 ^^^ x * 42#32 ||| y * 42#32 ---  or_xor_tree_1111_thm
-#generalize (x &&& 32#32) + 145#32 ^^^ 153#32 = x &&& 32#32 ||| 8#32 -- gxor2_proof/test2_thm
+
 #generalize (x ||| 145#32) &&& 177#32 ^^^ 153#32 = x &&& 32#32 ||| 8#32 --- gxor2_proof/test3_thm
-#exit
+#generalize x * 42#32 ^^^ (y * 42#32 ^^^ z * 42#32) ||| z * 42#32 ^^^ x * 42#32 = z * 42#32 ^^^ x * 42#32 ||| y * 42#32 ---  or_xor_tree_1111_thm
+#generalize x * 42#32 ^^^ (y * 42#32 ^^^ z * 42#32) ||| x * 42#32 ^^^ z * 42#32 = x * 42#32 ^^^ z * 42#32 ||| y * 42#32 -- or_xor_tree_1110_thm
+
 -- #generalize ((x ^^^ 1234#32) >>> 8#32 ^^^ 1#32) + (x ^^^ 1234#32) = (x >>> 8#32 ^^^ 5#32) + (x ^^^ 1234#32) -- gxor2_proof/test5_thm
 -- #generalize (x ^^^ y) &&& 1#32 ||| y &&& BitVec.ofInt 32 (-2) = x &&& 1#32 ^^^ y --- PASSED or_and_xor_not_constant_commute0_thm
 #generalize x <<< 6#32 <<< 28#32 = 0#32   --shl_shl_thm

--- a/SSA/Experimental/Bits/Fast/GeneralizeTest.lean
+++ b/SSA/Experimental/Bits/Fast/GeneralizeTest.lean
@@ -16,35 +16,28 @@ variable {x y : BitVec 8}
 -- #generalize  x ^^^ 33#8 ||| 7#8 = x &&& BitVec.ofInt 8 (-8) ^^^ 39#8 --- PASSED xor_or2_thm
 
 
-#generalize x ^^^ 32#8 ||| 7#8 = x &&& BitVec.ofInt 8 (-8) ^^^ 39#8 --- xor_or_thm
-#generalize (x ||| 33#8) ^^^ 12#8 ||| 7#8 = x &&& BitVec.ofInt 8 (-40) ^^^ 47#8 --- or_xor_or_thm
-#generalize 28#8 >>> x <<< 3#8 ||| 7#8 = BitVec.ofInt 8 (-32) >>> x ||| 7#8 -- lshr_shl_demand1_thm
+-- #generalize x ^^^ 32#8 ||| 7#8 = x &&& BitVec.ofInt 8 (-8) ^^^ 39#8 --- xor_or_thm. Can't generate precondition
+-- #generalize (x ||| 33#8) ^^^ 12#8 ||| 7#8 = x &&& BitVec.ofInt 8 (-40) ^^^ 47#8 --- or_xor_or_thm. Can't generate precondition
+-- #generalize 28#8 >>> x <<< 3#8 ||| 7#8 = BitVec.ofInt 8 (-32) >>> x ||| 7#8 -- lshr_shl_demand1_thm. Can't generate precondition
 
 -- variable {x : BitVec 16}
-#generalize BitVec.ofInt 16 (-32624) <<< x >>> 4#16 &&& 4094#16 = 2057#16 <<< x &&& 4094#16 -- shl_lshr_demand6_thm
+-- #generalize BitVec.ofInt 16 (-32624) <<< x >>> 4#16 &&& 4094#16 = 2057#16 <<< x &&& 4094#16 -- shl_lshr_demand6_thm
 
 variable {x y z: BitVec 32}
 -- #generalize (x ^^^ y) &&& 1#32 ||| y &&& BitVec.ofInt 32 (-2) = x &&& 1#32 ^^^ y --- PASSED or_and_xor_not_constant_commute0_thm
 -- #generalize ((x <<< 8) >>> 16) <<< 8 = x &&& 0x00FFFF00 -- PASSED but takes 15 minutes to run due to model counting taking up most of the time.
 -- #generalize x <<< 6#32 <<< 28#32 = 0#32   -- PASSED shl_shl_thm
+-- #generalize (42#32 - x) <<< 3#32 = 336#32 - x <<< 3#32 -- PASSED gshlhsub_proof/shl_const_op1_sub_const_op0_thm
+-- #generalize ((x >>> 4#32 &&& 8#32) + y) <<< 4#32 = (x &&& 128#32) + y <<< 4#32 #PASSED gshlhbo_proof/shl_add_and_lshr_thm
+-- #generalize (x + (y >>> 5#32 &&& 127#32)) <<< 5#32 = (y &&& 4064#32) + x <<< 5#32 --- PASSED gshlhbo_proof/lshr_add_and_shl_thm
 
-#generalize (x + (-1)) >>> 1 = x >>> 1 -- #61223;
-#generalize (x + 5) - (y + 1)  =  x - y + 4
-#generalize (x + 5) + (y + 1)  =  x + y + 6
-#generalize 8#32 - x &&& 7#32 = 0#32 - x &&& 7#32 -- g2008h07h08hSubAnd_proof#a_thm -- I think this should be IsPowerOf2(C1) && C1-C2 = 1
-#generalize (x <<< 3) <<< 4 = x <<< 7
-#generalize (x &&& 1 ||| (x  &&& 1 ||| (0#32 - x))) = x &&& (x - 1#32) -- #57351
-#generalize (x &&& ((BitVec.ofInt 32 (-1)) <<< (32 - y))) >>> (32 - y) = x >>> (32 - y) -- SLOW and failing#41801
-
-
-#generalize 1#32 <<< (31#32 - x) = BitVec.ofInt (32) (-2147483648) >>> x --  shl_sub_i32_thm
-#generalize ((x ^^^ 1234#32) >>> 8#32 ^^^ 1#32) + (x ^^^ 1234#32) = (x >>> 8#32 ^^^ 5#32) + (x ^^^ 1234#32) -- gxor2_proof/test5_thm
-#generalize BitVec.truncate 24 (x >>> 12#32) <<< 3#24 = BitVec.truncate 24 (x >>> 9#32) &&& BitVec.ofInt 24 -- shl_trunc_bigger_ashr_thm
-#generalize BitVec.truncate 8 (x >>> 5#32) <<< 3#8 = BitVec.truncate 8 (x >>> 2#32) &&& BitVec.ofInt 8 (-8) --- shl_trunc_bigger_lshr_thm
+-- #generalize (x + 5) - (y + 1)  =  x - y + 4
+-- #generalize (x + 5) + (y + 1)  =  x + y + 6
+-- #generalize (x <<< 3) <<< 4 = x <<< 7
 
 
--- #generalize x * 42#32 ^^^ (y * 42#32 ^^^ z * 42#32) ||| z * 42#32 ^^^ x * 42#32 = z * 42#32 ^^^ x * 42#32 ||| y * 42#32 ---  or_xor_tree_1111_thm - This might work once we disable model counting for > 12 bits
--- #generalize x * 42#32 ^^^ (y * 42#32 ^^^ z * 42#32) ||| x * 42#32 ^^^ z * 42#32 = x * 42#32 ^^^ z * 42#32 ||| y * 42#32 -- or_xor_tree_1110_thm
+-- Failing
+-- #generalize 8#32 - x &&& 7#32 = 0#32 - x &&& 7#32 -- g2008h07h08hSubAnd_proof#a_thm --Can't generate preconditions
+-- #generalize BitVec.sshiftRight' (x &&& ((BitVec.ofInt 32 (-1)) <<< (32 - y))) (BitVec.ofInt 32 32 - y) = BitVec.sshiftRight' x (BitVec.ofInt 32 32 - y) -- SLOW and failing#41801
 
-
-#generalize  ~~~(BitVec.zeroExtend 128 (BitVec.allOnes 64) <<< 64) = 0x0000000000000000ffffffffffffffff#128
+-- #generalize ((x ^^^ 1234#32) >>> 8#32 ^^^ 1#32) + (x ^^^ 1234#32) = (x >>> 8#32 ^^^ 5#32) + (x ^^^ 1234#32) -- gxor2_proof/test5_thm

--- a/SSA/Experimental/Bits/Fast/GeneralizeTest.lean
+++ b/SSA/Experimental/Bits/Fast/GeneralizeTest.lean
@@ -5,34 +5,38 @@ set_option trace.profiler.threshold 1
 set_option trace.Generalize true
 
 variable {x y : BitVec 8}
-#generalize (0#8 - x ||| y) + y = (y ||| 0#8 - x) + y --- PASSED add_or_sub_comb_i8_negative_y_sub_thm
-#generalize (x ^^^ -1#8 ||| 7#8) ^^^ 12#8 = x &&& BitVec.ofInt 8 (-8) ^^^ BitVec.ofInt 8 (-13) --  PASSED not_or_xor_thm
-#generalize (x ^^^ 33#8 ||| 7#8) ^^^ 12#8 = x &&& BitVec.ofInt 8 (-8) ^^^ 43#8 --- PASSED xor_or_xor_thm
-#generalize  x ^^^ 33#8 ||| 7#8 = x &&& BitVec.ofInt 8 (-8) ^^^ 39#8 --- PASSED xor_or2_thm
+-- #generalize (0#8 - x ||| y) + y = (y ||| 0#8 - x) + y --- PASSED add_or_sub_comb_i8_negative_y_sub_thm
+-- #generalize (x ^^^ -1#8 ||| 7#8) ^^^ 12#8 = x &&& BitVec.ofInt 8 (-8) ^^^ BitVec.ofInt 8 (-13) --  PASSED not_or_xor_thm
+-- #generalize (x ^^^ 33#8 ||| 7#8) ^^^ 12#8 = x &&& BitVec.ofInt 8 (-8) ^^^ 43#8 --- PASSED xor_or_xor_thm
+-- #generalize  x ^^^ 33#8 ||| 7#8 = x &&& BitVec.ofInt 8 (-8) ^^^ 39#8 --- PASSED xor_or2_thm
 
 
--- #generalize x ^^^ 32#8 ||| 7#8 = x &&& BitVec.ofInt 8 (-8) ^^^ 39#8 --- xor_or_thm. Can't generate precondition
--- #generalize (x ||| 33#8) ^^^ 12#8 ||| 7#8 = x &&& BitVec.ofInt 8 (-40) ^^^ 47#8 --- or_xor_or_thm. Can't generate precondition
--- #generalize 28#8 >>> x <<< 3#8 ||| 7#8 = BitVec.ofInt 8 (-32) >>> x ||| 7#8 -- lshr_shl_demand1_thm. Can't generate precondition
+#generalize x ^^^ 32#8 ||| 7#8 = x &&& BitVec.ofInt 8 (-8) ^^^ 39#8 --- xor_or_thm. Can't generate precondition
+#generalize (x ||| 33#8) ^^^ 12#8 ||| 7#8 = x &&& BitVec.ofInt 8 (-40) ^^^ 47#8 --- or_xor_or_thm. Can't generate precondition
+#generalize 28#8 >>> x <<< 3#8 ||| 7#8 = BitVec.ofInt 8 (-32) >>> x ||| 7#8 -- lshr_shl_demand1_thm. Can't generate precondition
 
 variable {x : BitVec 16}
--- #generalize BitVec.ofInt 16 (-32624) <<< x >>> 4#16 &&& 4094#16 = 2057#16 <<< x &&& 4094#16 -- shl_lshr_demand6_thm
+#generalize BitVec.ofInt 16 (-32624) <<< x >>> 4#16 &&& 4094#16 = 2057#16 <<< x &&& 4094#16 -- Expression synthesis failure. shl_lshr_demand6_thm
 
 variable {x y z: BitVec 32}
-#generalize (x ^^^ y) &&& 1#32 ||| y &&& BitVec.ofInt 32 (-2) = x &&& 1#32 ^^^ y --- PASSED or_and_xor_not_constant_commute0_thm
-#generalize ((x <<< 8) >>> 16) <<< 8 = x &&& 0x00FFFF00 -- PASSED
-#generalize (42#32 - x) <<< 3#32 = 336#32 - x <<< 3#32 -- PASSED gshlhsub_proof/shl_const_op1_sub_const_op0_thm
-#generalize ((x >>> 4#32 &&& 8#32) + y) <<< 4#32 = (x &&& 128#32) + y <<< 4#32 --#PASSED gshlhbo_proof/shl_add_and_lshr_thm
-#generalize (x + (y >>> 5#32 &&& 127#32)) <<< 5#32 = (y &&& 4064#32) + x <<< 5#32 --- PASSED gshlhbo_proof/lshr_add_and_shl_thm
-#generalize x <<< 6#32 <<< 28#32 = 0#32   -- PASSED but takes seven minutes to run due to model counting; shl_shl_thm
+-- #generalize (x ^^^ y) &&& 1#32 ||| y &&& BitVec.ofInt 32 (-2) = x &&& 1#32 ^^^ y --- PASSED or_and_xor_not_constant_commute0_thm
+-- #generalize ((x <<< 8) >>> 16) <<< 8 = x &&& 0x00FFFF00 -- PASSED
+-- #generalize (42#32 - x) <<< 3#32 = 336#32 - x <<< 3#32 -- PASSED gshlhsub_proof/shl_const_op1_sub_const_op0_thm
+-- #generalize ((x >>> 4#32 &&& 8#32) + y) <<< 4#32 = (x &&& 128#32) + y <<< 4#32 --#PASSED gshlhbo_proof/shl_add_and_lshr_thm
+-- #generalize (x + (y >>> 5#32 &&& 127#32)) <<< 5#32 = (y &&& 4064#32) + x <<< 5#32 --- PASSED gshlhbo_proof/lshr_add_and_shl_thm
+-- #generalize x <<< 6#32 <<< 28#32 = 0#32   -- PASSED but takes seven minutes to run due to model counting; shl_shl_thm
 
-#generalize (x + 5) - (y + 1)  =  x - y + 4
-#generalize (x + 5) + (y + 1)  =  x + y + 6
-#generalize (x <<< 3) <<< 4 = x <<< 7
+-- #generalize (x + 5) - (y + 1)  =  x - y + 4
+-- #generalize (x + 5) + (y + 1)  =  x + y + 6
+-- #generalize (x <<< 3) <<< 4 = x <<< 7
 
 
 -- Failing
-#generalize 8#32 - x &&& 7#32 = 0#32 - x &&& 7#32 -- g2008h07h08hSubAnd_proof#a_thm --Can't generate preconditions
-#generalize BitVec.sshiftRight' (x &&& ((BitVec.ofInt 32 (-1)) <<< (32 - y))) (BitVec.ofInt 32 32 - y) = BitVec.sshiftRight' x (BitVec.ofInt 32 32 - y) -- SLOW and failing#41801
+-- #generalize 8#32 - x &&& 7#32 = 0#32 - x &&& 7#32 -- Precondition synthesis failure g2008h07h08hSubAnd_proof#a_thm --Can't generate preconditions
+-- #generalize BitVec.sshiftRight' (x &&& ((BitVec.ofInt 32 (-1)) <<< (32 - y))) (BitVec.ofInt 32 32 - y) = BitVec.sshiftRight' x (BitVec.ofInt 32 32 - y) -- Precondition synthesis failure #41801
 
-#generalize ((x ^^^ 1234#32) >>> 8#32 ^^^ 1#32) + (x ^^^ 1234#32) = (x >>> 8#32 ^^^ 5#32) + (x ^^^ 1234#32) -- gxor2_proof/test5_thm
+-- #generalize ((x ^^^ 1234#32) >>> 8#32 ^^^ 1#32) + (x ^^^ 1234#32) = (x >>> 8#32 ^^^ 5#32) + (x ^^^ 1234#32) -- gxor2_proof/test5_thm -- Timeout
+
+
+ variable {x y z: BitVec 232}
+ #generalize x >>> 231#232 >>> 1#232 = 0#232 -- PASSED - lshr_lshr_thm

--- a/SSA/Experimental/Bits/Fast/GeneralizeTest.lean
+++ b/SSA/Experimental/Bits/Fast/GeneralizeTest.lean
@@ -5,49 +5,72 @@ set_option trace.profiler.threshold 1
 set_option trace.Generalize true
 
 variable {x y : BitVec 4}
--- #generalize (x ^^^ -1#4 ||| y) &&& (x ^^^ y) = y &&& (x ^^^ -1#4) -- PASSED but trivial precondition
+#generalize (x ^^^ -1#4 ||| y) &&& (x ^^^ y) = y &&& (x ^^^ -1#4) -- PASSED but trivial precondition
 
 variable {x y : BitVec 8}
--- #generalize (0#8 - x ||| y) + y = (y ||| 0#8 - x) + y --- PASSED add_or_sub_comb_i8_negative_y_sub_thm
--- #generalize (0#8 - x ||| y) + x = (y ||| 0#8 - x) + x -- PASSED add_or_sub_comb_i8_negative_y_or_thm
--- #generalize (0#8 - x ^^^ x) + x = (x ^^^ 0#8 - x) + x -- PASSED add_or_sub_comb_i8_negative_xor_instead_or_thm
--- #generalize (0#8 - x ||| x) + y = (x ||| 0#8 - x) + y -- PASSED  add_or_sub_comb_i8_negative_y_add_thm
--- #generalize (x ^^^ -1#8 ||| 7#8) ^^^ 12#8 = x &&& BitVec.ofInt 8 (-8) ^^^ BitVec.ofInt 8 (-13) --  PASSED not_or_xor_thm
--- #generalize (x ^^^ 33#8 ||| 7#8) ^^^ 12#8 = x &&& BitVec.ofInt 8 (-8) ^^^ 43#8 --- PASSED xor_or_xor_thm
--- #generalize  x ^^^ 33#8 ||| 7#8 = x &&& BitVec.ofInt 8 (-8) ^^^ 39#8 --- PASSED xor_or2_thm
--- #generalize x ^^^ 32#8 ||| 7#8 = x &&& BitVec.ofInt 8 (-8) ^^^ 39#8  ---PASSED
--- #generalize (x <<< 3) <<< 4 = x <<< 7
+#generalize (0#8 - x ||| y) + y = (y ||| 0#8 - x) + y --- PASSED add_or_sub_comb_i8_negative_y_sub_thm
+#generalize (0#8 - x ||| y) + x = (y ||| 0#8 - x) + x -- PASSED add_or_sub_comb_i8_negative_y_or_thm
+#generalize (0#8 - x ^^^ x) + x = (x ^^^ 0#8 - x) + x -- PASSED add_or_sub_comb_i8_negative_xor_instead_or_thm
+#generalize (0#8 - x ||| x) + y = (x ||| 0#8 - x) + y -- PASSED  add_or_sub_comb_i8_negative_y_add_thm
+#generalize (x ^^^ -1#8 ||| 7#8) ^^^ 12#8 = x &&& BitVec.ofInt 8 (-8) ^^^ BitVec.ofInt 8 (-13) --  PASSED not_or_xor_thm
+#generalize (x ^^^ 33#8 ||| 7#8) ^^^ 12#8 = x &&& BitVec.ofInt 8 (-8) ^^^ 43#8 --- PASSED xor_or_xor_thm
+#generalize  x ^^^ 33#8 ||| 7#8 = x &&& BitVec.ofInt 8 (-8) ^^^ 39#8 --- PASSED xor_or2_thm
+#generalize x ^^^ 32#8 ||| 7#8 = x &&& BitVec.ofInt 8 (-8) ^^^ 39#8  ---PASSED
+#generalize x <<< 4#8 &&& (y <<< 5#8 &&& 88#8) = x <<< 4#8 &&& (y <<< 5#8 &&& 64#8) --- PASSED gbinophandhshifts_proof/ shl_and_and_fail_thm
+#generalize x <<< 2#8 + (y <<< 2#8 + 48#8) = (y + x) <<< 2#8 + 48#8 ---  PASSED gbinophandhshifts_proof/shl_add_add_thm
+#generalize x <<< 1#8 &&& y <<< 1#8 + 123#8 = (x &&& y + 61#8) <<< 1#8 ---PASSED gbinophandhshifts_proof/shl_add_and_thm
+#generalize x <<< 1#8 ^^^ (y <<< 1#8 ^^^ 88#8) = (y ^^^ x) <<< 1#8 ^^^ 88#8 --- PASSED gbinophandhshifts_proof/shl_xor_xor_good_mask_thm
+#generalize x <<< 1#8 + (y <<< 1#8 &&& 119#8) = (x + (y &&& 59#8)) <<< 1#8 --- PASSED gbinophandhshifts_proof/shl_and_add_thm
+#generalize x <<< 1#8 ^^^ (y <<< 1#8 ^^^ BitVec.ofInt 8 (-68)) = (y ^^^ x) <<< 1#8 ^^^ BitVec.ofInt 8 (-68) ---PASSED gbinophandhshifts_proof/shl_xor_xor_bad_mask_distribute_thm
+#generalize (x <<< 3) <<< 4 = x <<< 7
 
 
+-- -- Failing
+#generalize x <<< 1#8 ^^^ y <<< 1#8 &&& 20#8 = (x ^^^ y &&& 10#8) <<< 1#8  --- gbinophandhshifts_proof/shl_and_xor_thm
+#generalize x <<< 4#8 &&& (y <<< 4#8 &&& 88#8) = (y &&& x) <<< 4#8 &&& 80#8 --- gbinophandhshifts_proof/shl_and_and_thm
+#generalize (x >>> 5#8 ||| BitVec.ofInt 8 (-58)) &&& y >>> 5#8 = (y &&& (x ||| BitVec.ofInt 8 (-64))) >>> 5#8 --- gbinophandhshifts_proof/lshr_or_and_thm
+#generalize x >>> 5#8 ||| (y >>> 5#8 ||| BitVec.ofInt 8 (-58)) = (y ||| x) >>> 5#8 ||| BitVec.ofInt 8 (-58) --- gbinophandhshifts_proof/lshr_or_or_fail_thm
 
--- #generalize (x ||| 33#8) ^^^ 12#8 ||| 7#8 = x &&& BitVec.ofInt 8 (-40) ^^^ 47#8 --- or_xor_or_thm. Can't generate precondition
--- #generalize 28#8 >>> x <<< 3#8 ||| 7#8 = BitVec.ofInt 8 (-32) >>> x ||| 7#8 -- lshr_shl_demand1_thm. Can't generate precondition
+#generalize x <<< 7#8 ||| BitVec.ofInt 8 (-128) = BitVec.ofInt 8 (-128) -- gandhorand_proof/or_test2_thm
+#generalize x &&& 3#8 &&& 4#8 = 0#8 -- gand_proof/test8_thm
+#generalize x ^^^ 5#8 ||| x ^^^ 5#8 ^^^ y = x ^^^ 5#8 ||| y -- gorhxor_proof/xor_common_op_commute2_thm
+#generalize ((x ||| BitVec.ofInt 8 (-2)) ^^^ 13#8 ||| 1#8) ^^^ 12#8 = -1#8 -- gorhxor_proof/test23_thm
+
+#generalize (x ||| 33#8) ^^^ 12#8 ||| 7#8 = x &&& BitVec.ofInt 8 (-40) ^^^ 47#8 --- or_xor_or_thm. Can't generate precondition
+#generalize 28#8 >>> x <<< 3#8 ||| 7#8 = BitVec.ofInt 8 (-32) >>> x ||| 7#8 -- lshr_shl_demand1_thm. Can't generate precondition
+
+variable {x y : BitVec 9}
+#generalize (x ^^^ y) &&& 42#9 ||| x &&& BitVec.ofInt 9 (-43) = y &&& 42#9 ^^^ x -- PASSED or_and_xor_not_constant_commute1_thm
 
 variable {x y z: BitVec 32}
--- #generalize (x ^^^ y) &&& 1#32 ||| y &&& BitVec.ofInt 32 (-2) = x &&& 1#32 ^^^ y --- PASSED or_and_xor_not_constant_commute0_thm
--- #generalize ((x <<< 8) >>> 16) <<< 8 = x &&& 0x00FFFF00 -- PASSED
--- #generalize (42#32 - x) <<< 3#32 = 336#32 - x <<< 3#32 -- PASSED gshlhsub_proof/shl_const_op1_sub_const_op0_thm
--- #generalize ((x >>> 4#32 &&& 8#32) + y) <<< 4#32 = (x &&& 128#32) + y <<< 4#32 --#PASSED gshlhbo_proof/shl_add_and_lshr_thm
--- #generalize (x + (y >>> 5#32 &&& 127#32)) <<< 5#32 = (y &&& 4064#32) + x <<< 5#32 --- PASSED gshlhbo_proof/lshr_add_and_shl_thm
--- #generalize x <<< 6#32 <<< 28#32 = 0#32   -- PASSED but takes seven minutes to run due to model counting; shl_shl_thm
--- #generalize x + (x ||| (0 - x )) = x &&& (x + BitVec.ofInt 32 (-1))
--- #generalize (x + 5) - (y + 1)  =  x - y + 4
--- #generalize (x + 5) + (y + 1)  =  x + y + 6
--- #generalize (x <<< 3) <<< 4 = x <<< 7
-
+#generalize (x ^^^ y) &&& 1#32 ||| y &&& BitVec.ofInt 32 (-2) = x &&& 1#32 ^^^ y --- PASSED or_and_xor_not_constant_commute0_thm
+#generalize ((x <<< 8) >>> 16) <<< 8 = x &&& 0x00FFFF00 -- PASSED
+#generalize (42#32 - x) <<< 3#32 = 336#32 - x <<< 3#32 -- PASSED gshlhsub_proof/shl_const_op1_sub_const_op0_thm
+#generalize ((x >>> 4#32 &&& 8#32) + y) <<< 4#32 = (x &&& 128#32) + y <<< 4#32 --#PASSED gshlhbo_proof/shl_add_and_lshr_thm
+#generalize (x + (y >>> 5#32 &&& 127#32)) <<< 5#32 = (y &&& 4064#32) + x <<< 5#32 --- PASSED gshlhbo_proof/lshr_add_and_shl_thm
+#generalize x <<< 6#32 <<< 28#32 = 0#32   -- PASSED but takes seven minutes to run due to model counting; shl_shl_thm
+#generalize 8#32 - x &&& 7#32 = 0#32 - x &&& 7#32 -- PASSED g2008h07h08hSubAnd_proof#a_thm
+#generalize x &&& 1#32 ||| 1#32 = 1#32 -- PASSED gandhorand_proof/or_test1_thm
+#generalize (x ||| y <<< 1#32) &&& 1#32 = x &&& 1#32 --- PASSED gandhorand_proof/test3_thm
+#generalize x + (x ||| (0 - x )) = x &&& (x + BitVec.ofInt 32 (-1))
+#generalize (x + 5) - (y + 1)  =  x - y + 4
+#generalize (x + 5) + (y + 1)  =  x + y + 6
+#generalize (x <<< 3) <<< 4 = x <<< 7
 
 
 -- Failing
-#generalize (x * x ^^^ y * y) &&& (x * x ||| y * y ^^^ -1#32) = x * x &&& (y * y ^^^ -1#32) -- and_orn_xor_commute8_thm
--- #generalize 8#32 - x &&& 7#32 = 0#32 - x &&& 7#32 -- Precondition synthesis failure g2008h07h08hSubAnd_proof#a_thm --Can't generate preconditions
--- #generalize BitVec.sshiftRight' (x &&& ((BitVec.ofInt 32 (-1)) <<< (32 - y))) (BitVec.ofInt 32 32 - y) = BitVec.sshiftRight' x (BitVec.ofInt 32 32 - y) -- Precondition synthesis failure #41801
+#generalize BitVec.sshiftRight' (x &&& ((BitVec.ofInt 32 (-1)) <<< (32 - y))) (BitVec.ofInt 32 32 - y) = BitVec.sshiftRight' x (BitVec.ofInt 32 32 - y) -- Precondition synthesis failure #41801
+#generalize ((x ^^^ 1234#32) >>> 8#32 ^^^ 1#32) + (x ^^^ 1234#32) = (x >>> 8#32 ^^^ 5#32) + (x ^^^ 1234#32) -- gxor2_proof/test5_thm -- Timeout
 
--- #generalize ((x ^^^ 1234#32) >>> 8#32 ^^^ 1#32) + (x ^^^ 1234#32) = (x >>> 8#32 ^^^ 5#32) + (x ^^^ 1234#32) -- gxor2_proof/test5_thm -- Timeout
+#generalize (x &&& 7#32 ||| y &&& 8#32) &&& 7#32 = x &&& 7#32 ---  gandhorand_proof/test1_thm
+#generalize (x ||| y >>> 31#32) &&& 2#32 = x &&& 2#32 ---  gandhorand_proof/test4_thm
+#generalize (x &&& 12#32 ^^^ 15#32) &&& 1#32 = 1#32 -- gand_proof/test10_thm
+#generalize (x * x ^^^ y * y) &&& (x * x ||| y * y ^^^ -1#32) = x * x &&& (y * y ^^^ -1#32) -- and_orn_xor_commute8_thm
+
+
 
 variable {x y z: BitVec 64}
- -- #generalize x * x + (x * x ||| 0#64 - x * x) = x * x + -1#64 &&& x * x -- Passing but trivial result add_or_sub_comb_i64_commuted4_thm
-
-
+#generalize x * x + (x * x ||| 0#64 - x * x) = x * x + -1#64 &&& x * x -- Passing but trivial result add_or_sub_comb_i64_commuted4_thm
 
  variable {x y z: BitVec 232}
---  #generalize x >>> 231#232 >>> 1#232 = 0#232 -- PASSED - lshr_lshr_thm
+ #generalize x >>> 231#232 >>> 1#232 = 0#232 -- PASSED - lshr_lshr_thm

--- a/SSA/Experimental/Bits/Fast/GeneralizeTest.lean
+++ b/SSA/Experimental/Bits/Fast/GeneralizeTest.lean
@@ -8,32 +8,34 @@ set_option trace.Generalize true
 #eval (0 ^^^ 33) ||| 7
 
 variable {x y : BitVec 8}
--- #generalize (0#8 - x ||| y) + y = (y ||| 0#8 - x) + y --- PASSED add_or_sub_comb_i8_negative_y_sub_thm
-#generalize (x ||| 33#8) ^^^ 12#8 ||| 7#8 = x &&& BitVec.ofInt 8 (-40) ^^^ 47#8 --- or_xor_or_thm
--- #generalize (x ^^^ 33#8 ||| 7#8) ^^^ 12#8 = x &&& BitVec.ofInt 8 (-8) ^^^ 43#8 --- PASSED xor_or_xor_thm
--- #generalize  x ^^^ 33#8 ||| 7#8 = x &&& BitVec.ofInt 8 (-8) ^^^ 39#8 --- PASSED xor_or2_thm
-#generalize x ^^^ 32#8 ||| 7#8 = x &&& BitVec.ofInt 8 (-8) ^^^ 39#8 --- xor_or_thm
--- #generalize (x ^^^ -1#8 ||| 7#8) ^^^ 12#8 = x &&& BitVec.ofInt 8 (-8) ^^^ BitVec.ofInt 8 (-13) --  PASSED not_or_xor_thm
--- #generalize 28#8 >>> x <<< 3#8 ||| 7#8 = BitVec.ofInt 8 (-32) >>> x ||| 7#8 -- lshr_shl_demand1_thm
+#generalize (0#8 - x ||| y) + y = (y ||| 0#8 - x) + y --- PASSED add_or_sub_comb_i8_negative_y_sub_thm
+#generalize (x ^^^ -1#8 ||| 7#8) ^^^ 12#8 = x &&& BitVec.ofInt 8 (-8) ^^^ BitVec.ofInt 8 (-13) --  PASSED not_or_xor_thm
+#generalize (x ^^^ 33#8 ||| 7#8) ^^^ 12#8 = x &&& BitVec.ofInt 8 (-8) ^^^ 43#8 --- PASSED xor_or_xor_thm
+#generalize  x ^^^ 33#8 ||| 7#8 = x &&& BitVec.ofInt 8 (-8) ^^^ 39#8 --- PASSED xor_or2_thm
 
--- variable {x : BitVec 16}
--- #generalize BitVec.ofInt 16 (-32624) <<< x >>> 4#16 &&& 4094#16 = 2057#16 <<< x &&& 4094#16 -- shl_lshr_demand6_thm
+
+#generalize x ^^^ 32#8 ||| 7#8 = x &&& BitVec.ofInt 8 (-8) ^^^ 39#8 --- xor_or_thm
+#generalize (x ||| 33#8) ^^^ 12#8 ||| 7#8 = x &&& BitVec.ofInt 8 (-40) ^^^ 47#8 --- or_xor_or_thm
+#generalize 28#8 >>> x <<< 3#8 ||| 7#8 = BitVec.ofInt 8 (-32) >>> x ||| 7#8 -- lshr_shl_demand1_thm
+
+variable {x : BitVec 16}
+#generalize BitVec.ofInt 16 (-32624) <<< x >>> 4#16 &&& 4094#16 = 2057#16 <<< x &&& 4094#16 -- shl_lshr_demand6_thm
 
 variable {x y z: BitVec 32}
-#generalize (x &&& 32#32) + 145#32 ^^^ 153#32 = x &&& 32#32 ||| 8#32 -- gxor2_proof/test2_thm
+#generalize ((x <<< 8) >>> 16) <<< 8 = x &&& 0x00FFFF00 -- PASSED
 
+#generalize (x &&& 32#32) + 145#32 ^^^ 153#32 = x &&& 32#32 ||| 8#32 -- gxor2_proof/test2_thm
 #generalize (x + (-1)) >>> 1 = x >>> 1 -- #61223;
 #generalize (x + 5) - (y + 1)  =  x - y + 4
 #generalize (x + 5) + (y + 1)  =  x + y + 6
 #generalize (x <<< 3) <<< 4 = x <<< 7
+#generalize BitVec.zeroExtend 32 ((BitVec.truncate 16 x) <<< 8) = (x <<< 8) &&& 0xFF00#32
+#generalize (x &&& 1 ||| (x  &&& 1 ||| (0#32 - x))) = x &&& (x - 1#32) -- #57351
+#generalize (x &&& ((BitVec.ofInt 32 (-1)) <<< (32 - y))) >>> (32 - y) = x >>> (32 - y) -- SLOW and failing#41801
 
--- #generalize BitVec.zeroExtend 32 ((BitVec.truncate 16 x) <<< 8) = (x <<< 8) &&& 0xFF00#32
--- #generalize (x &&& 1 ||| (x  &&& 1 ||| (0#32 - x))) = x &&& (x - 1#32) -- #57351
--- #generalize (x &&& ((BitVec.ofInt 32 (-1)) <<< (32 - y))) >>> (32 - y) = x >>> (32 - y) -- SLOW and failing#41801
--- #generalize ((x <<< 8) >>> 16) <<< 8 = x &&& 0x00FFFF00 -- PASSED
 
 #generalize (x ||| 145#32) &&& 177#32 ^^^ 153#32 = x &&& 32#32 ||| 8#32 --- gxor2_proof/test3_thm
-#generalize x * 42#32 ^^^ (y * 42#32 ^^^ z * 42#32) ||| z * 42#32 ^^^ x * 42#32 = z * 42#32 ^^^ x * 42#32 ||| y * 42#32 ---  or_xor_tree_1111_thm
+-- #generalize x * 42#32 ^^^ (y * 42#32 ^^^ z * 42#32) ||| z * 42#32 ^^^ x * 42#32 = z * 42#32 ^^^ x * 42#32 ||| y * 42#32 ---  or_xor_tree_1111_thm
 #generalize x * 42#32 ^^^ (y * 42#32 ^^^ z * 42#32) ||| x * 42#32 ^^^ z * 42#32 = x * 42#32 ^^^ z * 42#32 ||| y * 42#32 -- or_xor_tree_1110_thm
 
 -- #generalize ((x ^^^ 1234#32) >>> 8#32 ^^^ 1#32) + (x ^^^ 1234#32) = (x >>> 8#32 ^^^ 5#32) + (x ^^^ 1234#32) -- gxor2_proof/test5_thm

--- a/SSA/Experimental/Bits/Fast/GeneralizeTest.lean
+++ b/SSA/Experimental/Bits/Fast/GeneralizeTest.lean
@@ -1,0 +1,44 @@
+import SSA.Experimental.Bits.Fast.Generalize
+
+set_option trace.profiler true
+-- set_option trace.profiler.threshold 1
+set_option trace.Generalize true
+
+#eval (0 ^^^ 33 ||| 7) ^^^ 12
+#eval (0 ^^^ 33) ||| 7
+
+variable {x y : BitVec 8}
+-- #generalize (0#8 - x ||| y) + y = (y ||| 0#8 - x) + y --- PASSED add_or_sub_comb_i8_negative_y_sub_thm
+-- #generalize (x ||| 33#8) ^^^ 12#8 ||| 7#8 = x &&& BitVec.ofInt 8 (-40) ^^^ 47#8 --- or_xor_or_thm
+-- #generalize (x ^^^ 33#8 ||| 7#8) ^^^ 12#8 = x &&& BitVec.ofInt 8 (-8) ^^^ 43#8 --- PASSED xor_or_xor_thm
+-- #generalize  x ^^^ 33#8 ||| 7#8 = x &&& BitVec.ofInt 8 (-8) ^^^ 39#8 --- PASSED xor_or2_thm
+#generalize x ^^^ 32#8 ||| 7#8 = x &&& BitVec.ofInt 8 (-8) ^^^ 39#8 --- xor_or_thm
+-- #generalize (x ^^^ -1#8 ||| 7#8) ^^^ 12#8 = x &&& BitVec.ofInt 8 (-8) ^^^ BitVec.ofInt 8 (-13) --  PASSED not_or_xor_thm
+-- #generalize 28#8 >>> x <<< 3#8 ||| 7#8 = BitVec.ofInt 8 (-32) >>> x ||| 7#8 -- lshr_shl_demand1_thm
+
+-- variable {x : BitVec 16}
+-- #generalize BitVec.ofInt 16 (-32624) <<< x >>> 4#16 &&& 4094#16 = 2057#16 <<< x &&& 4094#16 -- shl_lshr_demand6_thm
+
+variable {x y z: BitVec 32}
+#generalize ((x <<< 8) >>> 16) <<< 8 = x &&& 0x00FFFF00
+#exit
+#generalize (x + (-1)) >>> 1 = x >>> 1 -- #61223;
+#generalize (x + 5) - (y + 1)  =  x - y + 4
+#generalize (x + 5) + (y + 1)  =  x + y + 6
+#generalize (x <<< 3) <<< 4 = x <<< 7
+-- #generalize BitVec.zeroExtend 32 ((BitVec.truncate 16 x) <<< 8) = (x <<< 8) &&& 0xFF00#32
+-- #generalize (x &&& 1 ||| (x  &&& 1 ||| (0#32 - x))) = x &&& (x - 1#32) -- #57351
+-- #generalize (x &&& ((BitVec.ofInt 32 (-1)) <<< (32 - y))) >>> (32 - y) = x >>> (32 - y) -- SLOW and failing#41801
+-- #generalize ((x <<< 8) >>> 16) <<< 8 = x &&& 0x00FFFF00 -- PASSED
+#generalize x * 42#32 ^^^ (y * 42#32 ^^^ z * 42#32) ||| x * 42#32 ^^^ z * 42#32 = x * 42#32 ^^^ z * 42#32 ||| y * 42#32 -- or_xor_tree_1110_thm
+#generalize x * 42#32 ^^^ (y * 42#32 ^^^ z * 42#32) ||| z * 42#32 ^^^ x * 42#32 = z * 42#32 ^^^ x * 42#32 ||| y * 42#32 ---  or_xor_tree_1111_thm
+#generalize (x &&& 32#32) + 145#32 ^^^ 153#32 = x &&& 32#32 ||| 8#32 -- gxor2_proof/test2_thm
+#generalize (x ||| 145#32) &&& 177#32 ^^^ 153#32 = x &&& 32#32 ||| 8#32 --- gxor2_proof/test3_thm
+
+-- #generalize ((x ^^^ 1234#32) >>> 8#32 ^^^ 1#32) + (x ^^^ 1234#32) = (x >>> 8#32 ^^^ 5#32) + (x ^^^ 1234#32) -- gxor2_proof/test5_thm
+-- #generalize (x ^^^ y) &&& 1#32 ||| y &&& BitVec.ofInt 32 (-2) = x &&& 1#32 ^^^ y --- PASSED or_and_xor_not_constant_commute0_thm
+#generalize x <<< 6#32 <<< 28#32 = 0#32   --shl_shl_thm
+#generalize 1#32 <<< (31#32 - x) = BitVec.ofInt (32) (-2147483648) >>> x --  shl_sub_i32_thm
+#generalize BitVec.truncate 24 (x >>> 12#32) <<< 3#24 = BitVec.truncate 24 (x >>> 9#32) &&& BitVec.ofInt 24 -- shl_trunc_bigger_ashr_thm
+#generalize BitVec.truncate 8 (x >>> 5#32) <<< 3#8 = BitVec.truncate 8 (x >>> 2#32) &&& BitVec.ofInt 8 (-8) --- shl_trunc_bigger_lshr_thm
+#generalize  ~~~(BitVec.zeroExtend 128 (BitVec.allOnes 64) <<< 64) = 0x0000000000000000ffffffffffffffff#128


### PR DESCRIPTION
Introduces several updates to the generalizer, including:

- Reducing the number of solver calls for precondition synthesis through "progressive filtering"
- Refactoring the constant expressions synthesis code for reuse between the `#iosynthesize` and `#generalize` commands.
- Pruning equivalent constant expressions.
- Adding new binary operators: mul, udiv, and umod.
- Implementing a timeout for generalization.
- Adding profiling code.
- Moving the evaluation test cases to a separate file. 