### PR TITLE
ci: use bash for mathlib update

### DIFF
--- a/.github/workflows/update-mathlib-version.yml
+++ b/.github/workflows/update-mathlib-version.yml
@@ -37,6 +37,7 @@ jobs:
            echo "date=`date -d '-${{matrix.daysbefore}} day' +20%y-%m-%d`" >> $GITHUB_OUTPUT
 
       - name: Check if lean toolchain is already newer or equally old
+        shell: bash
         run: |
            if [[ `cat lean-toolchain | sed -e 's/leanprover\/lean4:nightly-//' | sed -e '/$^/d'` -le ${{steps.mldate.outputs.date}} ]]; then echo "abort: lean-toolchain is newer than proposed date"; false ; fi
 


### PR DESCRIPTION
This fixes an error in the CI due to the version-being-new-enough check not working in non-bash shells.