### PR TITLE
chore: explicitly load extensions in parser

### DIFF
--- a/.github/workflows/ci-tools.yml
+++ b/.github/workflows/ci-tools.yml
@@ -47,6 +47,10 @@ jobs:
         run: |
           lake -R build opt
 
+      - name: LLVM opt round trip test
+        run: |
+          lake exec opt test/LLVMDialect/InstCombine/bb0.mlir
+
       - name: Compile Alive Scaling
         run: |
           lake -R build SSA.Projects.InstCombine.ScalingTest

--- a/SSA/Core/MLIRSyntax/Parser.lean
+++ b/SSA/Core/MLIRSyntax/Parser.lean
@@ -130,7 +130,7 @@ def runParser (parser : @ParseFun ParseOutput) (fileName : String) : IO (Option 
     " Are you running via `lake exec opt`?")
   initSearchPath (← Lean.findSysroot) packagePaths
   let modules : Array Import := #[⟨`SSA.Core.MLIRSyntax.EDSL, false, false⟩]
-  let env ← importModules modules {}
+  let env ← importModules (loadExts := true)  modules {}
   let filePath := System.mkFilePath [fileName]
   if !(← isFile filePath) then
     throw <| IO.userError s!"File {fileName} does not exist"


### PR DESCRIPTION
Lean commit https://github.com/leanprover/lean4-nightly/commit/5df4e48dc disabled the loading of extensions by default, which broke our parsing code used in the `opt` tool when updating to lean 2024-04-03. This change re-enables the parsing code and consequently fixes the `opt` tool.

Warning: the documentation states that this is only safe to do in combination with `enableInitializersExecution`, which I am yet unsure how to enable. This is tracked in https://github.com/opencompl/lean-mlir/issues/1203.