### PR TITLE
refactor: remove simp_llvm_wrap simpset

### DIFF
--- a/SSA/Projects/InstCombine/AliveHandwrittenLargeExamples.lean
+++ b/SSA/Projects/InstCombine/AliveHandwrittenLargeExamples.lean
@@ -498,7 +498,7 @@ private theorem zero_lt_toInt_iff {x : BitVec w} :
 
 def alive_simplifySelect764 (w : Nat) :
     Select746_lhs w ⊑ Select746_rhs w := by
-  simp only [Select746_lhs, Select746_rhs, simp_llvm_wrap]
+  simp only [Select746_lhs, Select746_rhs]
   simp_alive_ssa
   simp_alive_undef
   simp_alive_ops

--- a/SSA/Projects/InstCombine/AliveHandwrittenLargeExamples.lean
+++ b/SSA/Projects/InstCombine/AliveHandwrittenLargeExamples.lean
@@ -114,7 +114,6 @@ def MulDivRem805_rhs (w : ℕ) : Com InstCombine.LLVM
 def alive_simplifyMulDivRem805 (w : Nat) :
   MulDivRem805_lhs w ⊑ MulDivRem805_rhs w := by
   unfold MulDivRem805_lhs MulDivRem805_rhs
-  simp only [simp_llvm_wrap]
   simp_alive_ssa
   simp_alive_ops
   simp_alive_undef
@@ -220,7 +219,6 @@ info: 'AliveHandwritten.MulDivRem.alive_simplifyMulDivRem805' depends on axioms:
 def alive_simplifyMulDivRem805' (w : Nat) :
   MulDivRem805_lhs w ⊑ MulDivRem805_rhs w := by
   unfold MulDivRem805_lhs MulDivRem805_rhs
-  simp only [simp_llvm_wrap]
   simp_alive_ssa
   simp_alive_ops
   simp_alive_undef
@@ -355,7 +353,6 @@ def MulDivRem290_rhs (w : ℕ) :
 def alive_simplifyMulDivRem290 (w : Nat) :
   MulDivRem290_lhs w ⊑ MulDivRem290_rhs w := by
   unfold MulDivRem290_lhs MulDivRem290_rhs
-  simp only [simp_llvm_wrap]
   simp_alive_ssa
   simp_alive_undef
   simp_alive_ops
@@ -408,7 +405,6 @@ def AndOrXor2515_rhs (w : ℕ) :
 def alive_simplifyAndOrXor2515 (w : Nat) :
   AndOrXor2515_lhs w ⊑ AndOrXor2515_rhs w := by
   simp only [AndOrXor2515_lhs, AndOrXor2515_rhs]
-  simp only [simp_llvm_wrap]
   simp_alive_ssa
   simp_alive_undef
   simp_alive_ops

--- a/SSA/Projects/InstCombine/ComWrappers.lean
+++ b/SSA/Projects/InstCombine/ComWrappers.lean
@@ -11,7 +11,7 @@ open InstCombine (LLVM)
 macro_rules
 | `(tactic| get_elem_tactic_trivial) => `(tactic| simp [Ctxt.snoc])
 
-@[simp_llvm_wrap]
+@[simp_denote]
 def const {Γ : Ctxt _} (w : ℕ) (n : ℤ) : Expr InstCombine.LLVM Γ .pure (LLVM.Ty.bitvec w) :=
   Expr.mk
     (op := InstCombine.MOp.const w n)
@@ -20,7 +20,7 @@ def const {Γ : Ctxt _} (w : ℕ) (n : ℤ) : Expr InstCombine.LLVM Γ .pure (LL
     (args := .nil)
     (regArgs := .nil)
 
-@[simp_llvm_wrap]
+@[simp_denote]
 def not {Γ : Ctxt _} (w : ℕ) (l : Nat)
     (lp : (Ctxt.get? Γ l = some (InstCombine.MTy.bitvec (ConcreteOrMVar.concrete w)))
       := by get_elem_tactic):
@@ -32,7 +32,7 @@ def not {Γ : Ctxt _} (w : ℕ) (l : Nat)
     (args := .cons ⟨l, lp⟩ .nil)
     (regArgs := .nil)
 
-@[simp_llvm_wrap]
+@[simp_denote]
 def neg {Γ : Ctxt _} (w : ℕ) (l : Nat)
     (lp : (Ctxt.get? Γ l = some (InstCombine.MTy.bitvec (ConcreteOrMVar.concrete w)))
       := by get_elem_tactic):
@@ -44,7 +44,7 @@ def neg {Γ : Ctxt _} (w : ℕ) (l : Nat)
     (args := .cons ⟨l, lp⟩ .nil)
     (regArgs := .nil)
 
-@[simp_llvm_wrap]
+@[simp_denote]
 def and {Γ : Ctxt _} (w : ℕ) (l r : Nat)
     (lp : (Ctxt.get? Γ l = some (InstCombine.MTy.bitvec (ConcreteOrMVar.concrete w)))
       := by get_elem_tactic)
@@ -58,7 +58,7 @@ def and {Γ : Ctxt _} (w : ℕ) (l r : Nat)
     (args := .cons ⟨l, lp⟩ <| .cons ⟨r, rp⟩ .nil)
     (regArgs := .nil)
 
-@[simp_llvm_wrap]
+@[simp_denote]
 def or {Γ : Ctxt _} (w : ℕ) (l r : Nat)
     (lp : (Ctxt.get? Γ l = some (InstCombine.MTy.bitvec (ConcreteOrMVar.concrete w)))
       := by get_elem_tactic)
@@ -72,7 +72,7 @@ def or {Γ : Ctxt _} (w : ℕ) (l r : Nat)
     (args := .cons ⟨l, lp⟩ <| .cons ⟨r, rp⟩ .nil)
     (regArgs := .nil)
 
-@[simp_llvm_wrap]
+@[simp_denote]
 def xor {Γ : Ctxt _} (w : ℕ) (l r : Nat)
     (lp : (Ctxt.get? Γ l = some (InstCombine.MTy.bitvec (ConcreteOrMVar.concrete w)))
       := by get_elem_tactic)
@@ -86,7 +86,7 @@ def xor {Γ : Ctxt _} (w : ℕ) (l r : Nat)
     (args := .cons ⟨l, lp⟩ <| .cons ⟨r, rp⟩ .nil)
     (regArgs := .nil)
 
-@[simp_llvm_wrap]
+@[simp_denote]
 def shl {Γ : Ctxt _} (w : ℕ) (l r : Nat)
     (lp : (Ctxt.get? Γ l = some (InstCombine.MTy.bitvec (ConcreteOrMVar.concrete w)))
       := by get_elem_tactic)
@@ -100,7 +100,7 @@ def shl {Γ : Ctxt _} (w : ℕ) (l r : Nat)
     (args := .cons ⟨l, lp⟩ <| .cons ⟨r, rp⟩ .nil)
     (regArgs := .nil)
 
-@[simp_llvm_wrap]
+@[simp_denote]
 def lshr {Γ : Ctxt _} (w : ℕ) (l r : Nat)
     (lp : (Ctxt.get? Γ l = some (InstCombine.MTy.bitvec (ConcreteOrMVar.concrete w)))
       := by get_elem_tactic)
@@ -114,7 +114,7 @@ def lshr {Γ : Ctxt _} (w : ℕ) (l r : Nat)
     (args := .cons ⟨l, lp⟩ <| .cons ⟨r, rp⟩ .nil)
     (regArgs := .nil)
 
-@[simp_llvm_wrap]
+@[simp_denote]
 def ashr {Γ : Ctxt _} (w : ℕ) (l r : Nat)
     (lp : (Ctxt.get? Γ l = some (InstCombine.MTy.bitvec (ConcreteOrMVar.concrete w)))
       := by get_elem_tactic)
@@ -128,7 +128,7 @@ def ashr {Γ : Ctxt _} (w : ℕ) (l r : Nat)
     (args := .cons ⟨l, lp⟩ <| .cons ⟨r, rp⟩ .nil)
     (regArgs := .nil)
 
-@[simp_llvm_wrap]
+@[simp_denote]
 def sub {Γ : Ctxt _} (w : ℕ) (l r : Nat)
     (lp : (Ctxt.get? Γ l = some (InstCombine.MTy.bitvec (ConcreteOrMVar.concrete w)))
       := by get_elem_tactic)
@@ -142,7 +142,7 @@ def sub {Γ : Ctxt _} (w : ℕ) (l r : Nat)
     (args := .cons ⟨l, lp⟩ <| .cons ⟨r, rp⟩ .nil)
     (regArgs := .nil)
 
-@[simp_llvm_wrap]
+@[simp_denote]
 def add {Γ : Ctxt _} (w : ℕ) (l r : Nat)
     (lp : (Ctxt.get? Γ l = some (InstCombine.MTy.bitvec (ConcreteOrMVar.concrete w)))
       := by get_elem_tactic)
@@ -156,7 +156,7 @@ def add {Γ : Ctxt _} (w : ℕ) (l r : Nat)
     (args := .cons ⟨l, lp⟩ <| .cons ⟨r, rp⟩ .nil)
     (regArgs := .nil)
 
-@[simp_llvm_wrap]
+@[simp_denote]
 def mul {Γ : Ctxt _} (w : ℕ) (l r : Nat)
     (lp : (Ctxt.get? Γ l = some (InstCombine.MTy.bitvec (ConcreteOrMVar.concrete w)))
       := by get_elem_tactic)
@@ -170,7 +170,7 @@ def mul {Γ : Ctxt _} (w : ℕ) (l r : Nat)
     (args := .cons ⟨l, lp⟩ <| .cons ⟨r, rp⟩ .nil)
     (regArgs := .nil)
 
-@[simp_llvm_wrap]
+@[simp_denote]
 def sdiv {Γ : Ctxt _} (w : ℕ) (l r : Nat)
     (lp : (Ctxt.get? Γ l = some (InstCombine.MTy.bitvec (ConcreteOrMVar.concrete w)))
       := by get_elem_tactic)
@@ -184,7 +184,7 @@ def sdiv {Γ : Ctxt _} (w : ℕ) (l r : Nat)
     (args := .cons ⟨l, lp⟩ <| .cons ⟨r, rp⟩ .nil)
     (regArgs := .nil)
 
-@[simp_llvm_wrap]
+@[simp_denote]
 def udiv {Γ : Ctxt _} (w : ℕ) (l r : Nat)
     (lp : (Ctxt.get? Γ l = some (InstCombine.MTy.bitvec (ConcreteOrMVar.concrete w)))
       := by get_elem_tactic)
@@ -198,7 +198,7 @@ def udiv {Γ : Ctxt _} (w : ℕ) (l r : Nat)
     (args := .cons ⟨l, lp⟩ <| .cons ⟨r, rp⟩ .nil)
     (regArgs := .nil)
 
-@[simp_llvm_wrap]
+@[simp_denote]
 def srem {Γ : Ctxt _} (w : ℕ) (l r : Nat)
     (lp : (Ctxt.get? Γ l = some (InstCombine.MTy.bitvec (ConcreteOrMVar.concrete w)))
       := by get_elem_tactic)
@@ -212,7 +212,7 @@ def srem {Γ : Ctxt _} (w : ℕ) (l r : Nat)
     (args := .cons ⟨l, lp⟩ <| .cons ⟨r, rp⟩ .nil)
     (regArgs := .nil)
 
-@[simp_llvm_wrap]
+@[simp_denote]
 def urem {Γ : Ctxt _} (w : ℕ) (l r : Nat)
     (lp : (Ctxt.get? Γ l = some (InstCombine.MTy.bitvec (ConcreteOrMVar.concrete w)))
       := by get_elem_tactic)
@@ -226,7 +226,7 @@ def urem {Γ : Ctxt _} (w : ℕ) (l r : Nat)
     (args := .cons ⟨l, lp⟩ <| .cons ⟨r, rp⟩ .nil)
     (regArgs := .nil)
 
-@[simp_llvm_wrap]
+@[simp_denote]
 def icmp {Γ : Ctxt _} (w : ℕ) (pred : LLVM.IntPred) (l r : Nat)
     (lp : (Ctxt.get? Γ l = some (InstCombine.MTy.bitvec (ConcreteOrMVar.concrete w)))
       := by get_elem_tactic)
@@ -240,7 +240,7 @@ def icmp {Γ : Ctxt _} (w : ℕ) (pred : LLVM.IntPred) (l r : Nat)
     (args := .cons ⟨l, lp⟩ <| .cons ⟨r, rp⟩ .nil)
     (regArgs := .nil)
 
-@[simp_llvm_wrap]
+@[simp_denote]
 def select {Γ : Ctxt _} (w : ℕ) (l m r : Nat)
     (lp : (Ctxt.get? Γ l = some (InstCombine.MTy.bitvec (ConcreteOrMVar.concrete 1)))
       := by get_elem_tactic)

--- a/SSA/Projects/InstCombine/LLVM/SimpSet.lean
+++ b/SSA/Projects/InstCombine/LLVM/SimpSet.lean
@@ -7,7 +7,6 @@ import Lean.LabelAttribute
 
 register_simp_attr simp_llvm
 register_simp_attr simp_llvm_option
-register_simp_attr simp_llvm_wrap
 
 /-- The simp-set used in `simp_alive_case_bash` to attempt to discharge trivial `none` cases -/
 register_simp_attr simp_llvm_case_bash

--- a/SSA/Projects/InstCombine/Test.lean
+++ b/SSA/Projects/InstCombine/Test.lean
@@ -273,7 +273,6 @@ def one_inst_stmt (e : LLVM.IntW w) :
 def one_inst_com_proof (w : Nat) :
     one_inst_com w ⊑ one_inst_com w := by
   unfold one_inst_com
-  simp only [simp_llvm_wrap]
   simp_alive_ssa
   apply one_inst_stmt
 
@@ -304,7 +303,6 @@ def two_inst_stmt (e : LLVM.IntW w) :
 def two_inst_com_proof (w : Nat) :
     two_inst_com w ⊑ two_inst_com w := by
   unfold two_inst_com
-  simp only [simp_llvm_wrap]
   simp_alive_ssa
   apply two_inst_stmt
 
@@ -338,7 +336,6 @@ def three_inst_stmt (e : LLVM.IntW w) :
 def three_inst_com_proof (w : Nat) :
     three_inst_com w ⊑ three_inst_com w := by
   unfold three_inst_com
-  simp only [simp_llvm_wrap]
   simp_alive_ssa
   apply three_inst_stmt
 
@@ -367,7 +364,6 @@ def one_inst_concrete_stmt :
 def one_inst_concrete_com_proof :
     one_inst_concrete_com ⊑ one_inst_concrete_com := by
   unfold one_inst_concrete_com
-  simp only [simp_llvm_wrap]
   simp_alive_ssa
   apply one_inst_concrete_stmt
 
@@ -398,7 +394,6 @@ def two_inst_concrete_stmt (e : LLVM.IntW w) :
 def two_inst_concrete_com_proof :
     two_inst_concrete_com w ⊑ two_inst_concrete_com w := by
   unfold two_inst_concrete_com
-  simp only [simp_llvm_wrap]
   simp_alive_ssa
   apply two_inst_concrete_stmt
 
@@ -432,7 +427,6 @@ def three_inst_concrete_stmt (e : LLVM.IntW 1) :
 def three_inst_concrete_com_proof :
     three_inst_concrete_com ⊑ three_inst_concrete_com := by
   unfold three_inst_concrete_com
-  simp only [simp_llvm_wrap]
   simp_alive_ssa
   apply three_inst_concrete_stmt
 


### PR DESCRIPTION
This PR moves all `simp_llvm_wrap`-tagged definitions to the `simp_denote` simpset and removes the `simp_llvm_wrap`. Since all usages of the latter were followed by `simp_peephole` (or one of it's aliasses), we just remove all usages as well and no proofs break.