### PR TITLE
feat: hybrid RiscV plus LLVM dialect [1/3]

### DIFF
--- a/SSA/Core/HVector.lean
+++ b/SSA/Core/HVector.lean
@@ -70,6 +70,24 @@ def foldld {β : Type*} (B : β → Type*) (fType : β → α → β)
   | [], .nil, _, init         => init
   | _::_, .cons a as, _, init => foldld B fType fElem as (fElem init a)
 
+
+def foldlM {B : Type*} [Monad m] (f : ∀ (a : α), B → A a → m B) :
+    ∀ {l : List α}, (init : B) → (as : HVector A l) → m B
+  | [],   b, .nil       => return b
+  | t::_, b, .cons a as => do foldlM f (← f t b a) as
+
+/--
+Simultaneous map on the type and value level of an HVector while
+performing monadic effects for value translation.-/
+def mapM' [Monad m] {α : Type 0} {A : α → Type} {B : β → Type}
+    {l : List α}
+    {F : α → β}
+    (f : (a : α) → (v : A a) → m (B (F a)) )
+    (as : HVector A l) : m (HVector B (F <$> l)) :=
+  match l, as with
+  | [], .nil => return .nil
+  | t :: _ts, .cons a as => do return HVector.cons (← f t a) (← HVector.mapM' f as)
+
 def get {as} : HVector A as → (i : Fin as.length) → A (as.get i)
   | .nil, i => i.elim0
   | .cons x  _, ⟨0,   _⟩  => x
@@ -221,30 +239,5 @@ instance [Lean.ToExpr α] [∀ a, Lean.ToExpr (A a)] [HVector.ToExprPi A]
     toExpr }
 
 end ToExprPi
-
-/-!
-  ## Folding and mapping over HVectors, monadic and non-monadic.
--/
-section mapHVec
-
-def foldlM {B : Type*} [Monad m] (f : ∀ (a : α), B → A a → m B) :
-    ∀ {l : List α}, (init : B) → (as : HVector A l) → m B
-  | [],   b, .nil       => return b
-  | t::_, b, .cons a as => do foldlM f (← f t b a) as
-
-/-!
-Simultaneous map on the type and value level of an HVector while
-performing monadic effects for value translation.-/
-def mapM' [Monad m] {α : Type 0} {A : α → Type} {B : β → Type}
-    {l : List α}
-    {F : α → β}
-    (f : (a : α) → (v : A a) → m (B (F a)) )
-    (as : HVector A l) : m (HVector B (F <$> l)) :=
-  match l, as with
-  | [], .nil => return .nil
-  | t :: _ts, .cons a as => do return HVector.cons (← f t a) (← HVector.mapM' f as)
-
-end mapHVec
-
 
 end HVector

--- a/SSA/Core/HVector.lean
+++ b/SSA/Core/HVector.lean
@@ -226,13 +226,13 @@ end ToExprPi
   ## Folding and mapping over HVectors, monadic and non-monadic.
 -/
 section mapHVec
-def _root_.HVector.foldlM {B : Type*} [Monad m] (f : ∀ (a : α), B → A a → m B) :
+def foldlM {B : Type*} [Monad m] (f : ∀ (a : α), B → A a → m B) :
     ∀ {l : List α}, (init : B) → (as : HVector A l) → m B
   | [],   b, .nil       => return b
   | t::_, b, .cons a as => do foldlM f (← f t b a) as
 
 /-! Simultaneous map on the type and value level of an HVector. -/
-def _root_.HVector.ubermap {A : α → Type} {B : β → Type}
+def ubermap {A : α → Type} {B : β → Type}
     {l : List α}
     (F : α → β)
     (f : {a : α} → (v : A a) → B (F a) )
@@ -244,7 +244,7 @@ def _root_.HVector.ubermap {A : α → Type} {B : β → Type}
 /-!
 Simultaneous map on the type and value level of an HVector while
 performing monadic effects for value translation.-/
-def _root_.HVector.ubermapM [Monad m] {α : Type 0} {A : α → Type} {B : β → Type}
+def ubermapM [Monad m] {α : Type 0} {A : α → Type} {B : β → Type}
     {l : List α}
     {F : α → β}
     (f : (a : α) → (v : A a) → m (B (F a)) )

--- a/SSA/Core/HVector.lean
+++ b/SSA/Core/HVector.lean
@@ -232,27 +232,17 @@ def foldlM {B : Type*} [Monad m] (f : ∀ (a : α), B → A a → m B) :
   | [],   b, .nil       => return b
   | t::_, b, .cons a as => do foldlM f (← f t b a) as
 
-/-! Simultaneous map on the type and value level of an HVector. -/
-def ubermap {A : α → Type} {B : β → Type}
-    {l : List α}
-    (F : α → β)
-    (f : {a : α} → (v : A a) → B (F a) )
-    (as : HVector A l) : (HVector B (F <$> l)) :=
-  match l, as with
-  | [], .nil => .nil
-  | _t :: _ts, .cons a as => HVector.cons (f a) (HVector.ubermap F f as)
-
 /-!
 Simultaneous map on the type and value level of an HVector while
 performing monadic effects for value translation.-/
-def ubermapM [Monad m] {α : Type 0} {A : α → Type} {B : β → Type}
+def mapM' [Monad m] {α : Type 0} {A : α → Type} {B : β → Type}
     {l : List α}
     {F : α → β}
     (f : (a : α) → (v : A a) → m (B (F a)) )
     (as : HVector A l) : m (HVector B (F <$> l)) :=
   match l, as with
   | [], .nil => return .nil
-  | t :: _ts, .cons a as => do return HVector.cons (← f t a) (← HVector.ubermapM f as)
+  | t :: _ts, .cons a as => do return HVector.cons (← f t a) (← HVector.mapM' f as)
 
 end mapHVec
 

--- a/SSA/Core/HVector.lean
+++ b/SSA/Core/HVector.lean
@@ -70,7 +70,6 @@ def foldld {β : Type*} (B : β → Type*) (fType : β → α → β)
   | [], .nil, _, init         => init
   | _::_, .cons a as, _, init => foldld B fType fElem as (fElem init a)
 
-
 def foldlM {B : Type*} [Monad m] (f : ∀ (a : α), B → A a → m B) :
     ∀ {l : List α}, (init : B) → (as : HVector A l) → m B
   | [],   b, .nil       => return b

--- a/SSA/Core/HVector.lean
+++ b/SSA/Core/HVector.lean
@@ -226,6 +226,7 @@ end ToExprPi
   ## Folding and mapping over HVectors, monadic and non-monadic.
 -/
 section mapHVec
+
 def foldlM {B : Type*} [Monad m] (f : ∀ (a : α), B → A a → m B) :
     ∀ {l : List α}, (init : B) → (as : HVector A l) → m B
   | [],   b, .nil       => return b

--- a/SSA/Projects/InstCombine/Base.lean
+++ b/SSA/Projects/InstCombine/Base.lean
@@ -134,7 +134,6 @@ instance : DecidableEq LLVM.Ty :=
 instance : DecidableEq LLVM.Op :=
     inferInstanceAs <| DecidableEq (InstCombine.MOp 0)
 
-
 @[deprecated "Use `LLVM.Op` instead" (since:="2025-04-30")] abbrev Op := LLVM.Op
 @[deprecated "Use `LLVM.Ty` instead" (since:="2025-04-30")] abbrev Ty := LLVM.Ty
 

--- a/SSA/Projects/InstCombine/Base.lean
+++ b/SSA/Projects/InstCombine/Base.lean
@@ -126,6 +126,15 @@ def LLVM : Dialect where
   Op := MOp 0
   Ty := MTy 0
 
+/-- Defining an instance for LLVM.Ty from InstCombine.Ty instance.-/
+instance : DecidableEq LLVM.Ty :=
+  inferInstanceAs <| DecidableEq (InstCombine.MTy _)
+
+/-- Defining an instance for LLVM.Op from InstCombine.Op instance. -/
+instance : DecidableEq LLVM.Op :=
+    inferInstanceAs <| DecidableEq (InstCombine.MOp 0)
+
+
 @[deprecated "Use `LLVM.Op` instead" (since:="2025-04-30")] abbrev Op := LLVM.Op
 @[deprecated "Use `LLVM.Ty` instead" (since:="2025-04-30")] abbrev Ty := LLVM.Ty
 

--- a/SSA/Projects/LLVMAndRiscv.lean
+++ b/SSA/Projects/LLVMAndRiscv.lean
@@ -16,8 +16,9 @@ open InstCombine(LLVM)
 namespace LLVMRiscV
 
 
-/-! # Hybrid dialect -/
-/-
+/-! 
+# Hybrid dialect 
+
 This file contains a hybrid dialect combining
 SSA.Projects.RISCV64 and SSA.Projects.InstCombine.
 Modelling two dialects within a larger hybrid dialect allows us

--- a/SSA/Projects/LLVMAndRiscv.lean
+++ b/SSA/Projects/LLVMAndRiscv.lean
@@ -31,33 +31,22 @@ see: section (UnrealizedConversionCastOp)
 https://mlir.llvm.org/docs/Dialects/Builtin/#builtinunrealized_conversion_cast-unrealizedconversioncastop
  -/
 
-/-- Defining an instance for LLVM.Ty from InstCombine.Ty instance.-/
-instance : DecidableEq LLVM.Ty :=
-  fun a b => by
-    simp only [LLVM] at a b
-    exact (inferInstanceAs (DecidableEq (InstCombine.MTy 0)) a b)
-
-/-- Defining an instance for LLVM.Op from InstCombine.Op instance. -/
-instance : DecidableEq LLVM.Op :=
-  fun a b => by
-    simp only [LLVM] at a b
-    exact (inferInstanceAs (DecidableEq (InstCombine.MOp 0)) a b)
-
 inductive Ty where
-  | llvm : (LLVM.Ty) -> Ty
-  | riscv : (Dialect.Ty RISCV64.RV64) -> Ty
+  | llvm : LLVM.Ty -> Ty
+  | riscv : RISCV64.RV64.Ty -> Ty
   deriving DecidableEq, Repr
 
 inductive Op where
-  | llvm : (Dialect.Op LLVM) -> Op
-  | riscv : (Dialect.Op RISCV64.RV64) -> Op
+  | llvm : LLVM.Op -> Op
+  | riscv : RISCV64.RV64.Op -> Op
   | builtin.unrealized_conversion_cast.riscvToLLVM : Op
   | builtin.unrealized_conversion_cast.LLVMToriscv : Op
   deriving DecidableEq, Repr
 
 /-- Semantics of an unrealized conversion cast from RISC-V 64 to LLVM.
 We wrap `BitVec 64`in `Option (BitVec 64)` -/
-def builtin.unrealized_conversion_cast.riscvToLLVM (toCast : BitVec 64 ) : Option (BitVec 64 ) := some toCast
+def builtin.unrealized_conversion_cast.riscvToLLVM (toCast : BitVec 64) : PoisonOr (BitVec 64) :=
+  .value toCast
 
 /--
 Semantics of an unrealized conversion cast from LLVM to RISC-V.
@@ -65,14 +54,15 @@ This cast attempts to lower an `(Option (BitVec 64))` to a concrete `(BitVec 64)
 If the value is `some`, we extract the underlying `BitVec`.
 If it is `none` (e.g., an LLVM poison value), we default to the zero `BitVec`.
 -/
-def builtin.unrealized_conversion_cast.LLVMToriscv (toCast : Option (BitVec 64)) : BitVec 64 := toCast.getD 0#64
+def builtin.unrealized_conversion_cast.LLVMToriscv (toCast : PoisonOr (BitVec 64)) : BitVec 64 :=
+  toCast.toOption.getD 0#64
 
 @[simp]
 abbrev LLVMPlusRiscV : Dialect where
   Op := Op
   Ty := Ty
 
-instance : TyDenote (Dialect.Ty LLVMPlusRiscV) where
+instance : TyDenote LLVMPlusRiscV.Ty where
   toType := fun
     | .llvm llvmTy => TyDenote.toType llvmTy
     | .riscv riscvTy => TyDenote.toType riscvTy
@@ -87,32 +77,37 @@ instance LLVMPlusRiscVSignature : DialectSignature LLVMPlusRiscV where
   | .builtin.unrealized_conversion_cast.LLVMToriscv =>
       {sig := [Ty.llvm (.bitvec 64)], outTy := (Ty.riscv .bv), regSig := []}
 
-instance : ToString (Dialect.Ty LLVMPlusRiscV)  where
+instance : ToString LLVMPlusRiscV.Ty  where
   toString t := repr t |>.pretty
 
 @[simp_denote]
-def llvmArgsFromHybrid : {tys : List LLVM.Ty} → HVector TyDenote.toType (tys.map LLVMRiscV.Ty.llvm) → HVector TyDenote.toType tys
+def llvmArgsFromHybrid : {tys : List LLVM.Ty} →
+  HVector TyDenote.toType (tys.map LLVMRiscV.Ty.llvm) → HVector TyDenote.toType tys
   | [], .nil => .nil
   | _ :: _, .cons x xs => .cons x (llvmArgsFromHybrid xs)
 
 @[simp_denote]
-def riscvArgsFromHybrid : {tys : List RISCV64.RV64.Ty} → HVector TyDenote.toType (tys.map LLVMRiscV.Ty.riscv) → HVector TyDenote.toType tys
+def riscvArgsFromHybrid : {tys : List RISCV64.RV64.Ty} →
+  HVector TyDenote.toType (tys.map LLVMRiscV.Ty.riscv) → HVector TyDenote.toType tys
   | [], .nil => .nil
   | _ :: _, .cons x xs => .cons x (riscvArgsFromHybrid xs)
 
 @[simp, reducible]
 instance : DialectDenote (LLVMPlusRiscV) where
   denote
-  | .llvm (llvmOp), args , .nil => DialectDenote.denote llvmOp (llvmArgsFromHybrid args) .nil
-  | .riscv (riscvOp), args , .nil => DialectDenote.denote riscvOp (riscvArgsFromHybrid args) .nil
+  | .llvm (llvmOp), args, .nil =>
+      DialectDenote.denote llvmOp (llvmArgsFromHybrid args) .nil
+  | .riscv (riscvOp), args, .nil =>
+      DialectDenote.denote riscvOp (riscvArgsFromHybrid args) .nil
   | .builtin.unrealized_conversion_cast.riscvToLLVM, elemToCast, _ =>
-    let toCast : (BitVec 64) := (elemToCast.getN 0 (by simp [DialectSignature.sig, signature])) -- adapting to the newly introduced PoisonOr wrapper.
-    let casted : Option (BitVec 64) := builtin.unrealized_conversion_cast.riscvToLLVM toCast
-    PoisonOr.ofOption casted
+    let toCast : BitVec 64 :=
+      elemToCast.getN 0 (by simp [DialectSignature.sig, signature]) -- adapting to the newly introduced PoisonOr wrapper.
+    builtin.unrealized_conversion_cast.riscvToLLVM toCast
   | .builtin.unrealized_conversion_cast.LLVMToriscv,
     (elemToCast : HVector TyDenote.toType [Ty.llvm (.bitvec 64)]), _ =>
-    let toCast : PoisonOr (BitVec 64) := (elemToCast.getN 0 (by simp [DialectSignature.sig, signature]))
-    builtin.unrealized_conversion_cast.LLVMToriscv toCast.toOption
+    let toCast : PoisonOr (BitVec 64) :=
+      elemToCast.getN 0 (by simp [DialectSignature.sig, signature])
+    builtin.unrealized_conversion_cast.LLVMToriscv toCast
 
 @[simp_denote]
 def ctxtTransformToLLVM  (Γ : Ctxt LLVMPlusRiscV.Ty) :=
@@ -138,8 +133,7 @@ theorem outTy_map_signature_eq {s : Signature α} {f : α → β} :
 /- We tag the following definitions as `simp` and `simp_denote`
    so that `simp_peephole` and `simp` include them during simplification. -/
 attribute [simp, simp_denote] outTy_map_signature_eq
-
-attribute [simp, simp_denote] HVector.ubermapM
-attribute [simp, simp_denote] HVector.ubermap
+attribute [simp, simp_denote] HVector.mapM'
+attribute [simp, simp_denote] HVector.map'
 
 end LLVMRiscV

--- a/SSA/Projects/LLVMAndRiscv.lean
+++ b/SSA/Projects/LLVMAndRiscv.lean
@@ -15,6 +15,7 @@ import SSA.Core.HVector
 open InstCombine(LLVM)
 namespace LLVMRiscV
 
+
 /-! # Hybrid dialect -/
 /-
 This file contains a hybrid dialect combining
@@ -133,11 +134,11 @@ def ctxtTransformToRiscV (Γ : Ctxt LLVMPlusRiscV.Ty) :=
 theorem outTy_map_signature_eq {s : Signature α} {f : α → β} :
   Signature.outTy (f <$> s) = f s.outTy := rfl
 
-
 /- We tag the following definitions as `simp` and `simp_denote`
    so that `simp_peephole` and `simp` include them during simplification. -/
 attribute [simp, simp_denote] outTy_map_signature_eq
-attribute [simp, simp_denote] _root_.HVector.ubermapM
-attribute [simp, simp_denote] _root_.HVector.ubermap
+
+attribute [simp, simp_denote] HVector.ubermapM
+attribute [simp, simp_denote] HVector.ubermap
 
 end LLVMRiscV

--- a/SSA/Projects/LLVMAndRiscv.lean
+++ b/SSA/Projects/LLVMAndRiscv.lean
@@ -161,5 +161,4 @@ def _root_.HVector.ubermapM [Monad m] {A : α → Type} {B : β → Type}
   | [], .nil => return .nil
   | t :: _ts, .cons a as => do return HVector.cons (← f t a) (← HVector.ubermapM f as)
 
-
 end LLVMRiscV

--- a/SSA/Projects/LLVMAndRiscv.lean
+++ b/SSA/Projects/LLVMAndRiscv.lean
@@ -1,0 +1,165 @@
+import SSA.Core.MLIRSyntax.EDSL
+import SSA.Projects.InstCombine.LLVM.PrettyEDSL
+import SSA.Core.Framework
+import SSA.Core.Util
+import SSA.Core.Util.ConcreteOrMVar
+import SSA.Projects.InstCombine.ForStd
+import SSA.Projects.InstCombine.LLVM.Semantics
+import SSA.Projects.InstCombine.Tactic
+import SSA.Projects.RISCV64.Syntax
+import SSA.Projects.RISCV64.Base
+import SSA.Projects.RISCV64.Semantics
+import SSA.Projects.RISCV64.PrettyEDSL
+
+open InstCombine(LLVM)
+namespace LLVMRiscV
+
+/-! # Hybrid dialect -/
+/-
+This file contains a hybrid dialect combining
+SSA.Projects.RISCV64 and SSA.Projects.InstCombine.
+Modelling two dialects within a larger hybrid dialect allows us
+to reuse existing infrastructure such as the Peephole Rewriter which
+currently only operates within one dialect.
+
+To make the intermixing of the type system across the dialects work,
+we insert unrealized_conversion_cast like MLIR does during lowering.
+see: section (UnrealizedConversionCastOp)
+https://mlir.llvm.org/docs/Dialects/Builtin/#builtinunrealized_conversion_cast-unrealizedconversioncastop
+ -/
+
+/-- Defining an instance for LLVM.Ty from InstCombine.Ty instance.-/
+instance : DecidableEq LLVM.Ty :=
+  fun a b => by
+    simp only [LLVM] at a b
+    exact (inferInstanceAs (DecidableEq (InstCombine.MTy 0)) a b)
+
+/-- Defining an instance for LLVM.Op from InstCombine.Op instance. -/
+instance : DecidableEq LLVM.Op :=
+  fun a b => by
+    simp only [LLVM] at a b
+    exact (inferInstanceAs (DecidableEq (InstCombine.MOp 0)) a b)
+
+inductive Ty where
+  | llvm : (LLVM.Ty) -> Ty
+  | riscv : (Dialect.Ty RISCV64.RV64) -> Ty
+  deriving DecidableEq, Repr
+
+inductive Op where
+  | llvm : (Dialect.Op LLVM) -> Op
+  | riscv : (Dialect.Op RISCV64.RV64) -> Op
+  | builtin.unrealized_conversion_cast.riscvToLLVM : Op
+  | builtin.unrealized_conversion_cast.LLVMToriscv : Op
+  deriving DecidableEq, Repr
+
+/-- Semantics of an unrealized conversion cast from RISC-V 64 to LLVM.
+We wrap `BitVec 64`in `Option (BitVec 64)` -/
+def builtin.unrealized_conversion_cast.riscvToLLVM (toCast : BitVec 64 ) : Option (BitVec 64 ) := some toCast
+
+/--
+Semantics of an unrealized conversion cast from LLVM to RISC-V.
+This cast attempts to lower an `(Option (BitVec 64))` to a concrete `(BitVec 64)`.
+If the value is `some`, we extract the underlying `BitVec`.
+If it is `none` (e.g., an LLVM poison value), we default to the zero `BitVec`.
+-/
+def builtin.unrealized_conversion_cast.LLVMToriscv (toCast : Option (BitVec 64)) : BitVec 64 := toCast.getD 0#64
+
+@[simp]
+abbrev LLVMPlusRiscV : Dialect where
+  Op := Op
+  Ty := Ty
+
+instance : TyDenote (Dialect.Ty LLVMPlusRiscV) where
+  toType := fun
+    | .llvm llvmTy => TyDenote.toType llvmTy
+    | .riscv riscvTy => TyDenote.toType riscvTy
+
+@[simp]
+instance LLVMPlusRiscVSignature : DialectSignature LLVMPlusRiscV where
+  signature
+  | .llvm llvmOp => .llvm <$> DialectSignature.signature llvmOp
+  | .riscv riscvOp => .riscv <$> DialectSignature.signature riscvOp
+  | .builtin.unrealized_conversion_cast.riscvToLLVM =>
+      {sig := [Ty.riscv .bv], outTy := Ty.llvm (.bitvec 64), regSig := []}
+  | .builtin.unrealized_conversion_cast.LLVMToriscv =>
+      {sig := [Ty.llvm (.bitvec 64)], outTy := (Ty.riscv .bv), regSig := []}
+
+instance : ToString (Dialect.Ty LLVMPlusRiscV)  where
+  toString t := repr t |>.pretty
+
+@[simp_denote]
+def llvmArgsFromHybrid : {tys : List LLVM.Ty} → HVector TyDenote.toType (tys.map LLVMRiscV.Ty.llvm) → HVector TyDenote.toType tys
+  | [], .nil => .nil
+  | _ :: _, .cons x xs => .cons x (llvmArgsFromHybrid xs)
+
+@[simp_denote]
+def riscvArgsFromHybrid : {tys : List RISCV64.RV64.Ty} → HVector TyDenote.toType (tys.map LLVMRiscV.Ty.riscv) → HVector TyDenote.toType tys
+  | [], .nil => .nil
+  | _ :: _, .cons x xs => .cons x (riscvArgsFromHybrid xs)
+
+@[simp, reducible]
+instance : DialectDenote (LLVMPlusRiscV) where
+  denote
+  | .llvm (llvmOp), args , .nil => DialectDenote.denote llvmOp (llvmArgsFromHybrid args) .nil
+  | .riscv (riscvOp), args , .nil => DialectDenote.denote riscvOp (riscvArgsFromHybrid args) .nil
+  | .builtin.unrealized_conversion_cast.riscvToLLVM, elemToCast, _ =>
+    let toCast : (BitVec 64) := (elemToCast.getN 0 (by simp [DialectSignature.sig, signature])) -- adapting to the newly introduced PoisonOr wrapper.
+    let casted : Option (BitVec 64) := builtin.unrealized_conversion_cast.riscvToLLVM toCast
+    PoisonOr.ofOption casted
+  | .builtin.unrealized_conversion_cast.LLVMToriscv,
+    (elemToCast : HVector TyDenote.toType [Ty.llvm (.bitvec 64)]), _ =>
+    let toCast : PoisonOr (BitVec 64) := (elemToCast.getN 0 (by simp [DialectSignature.sig, signature]))
+    builtin.unrealized_conversion_cast.LLVMToriscv toCast.toOption
+
+@[simp_denote]
+def ctxtTransformToLLVM  (Γ : Ctxt LLVMPlusRiscV.Ty) :=
+  Ctxt.map  (fun ty  =>
+    match ty with
+    | .llvm someLLVMTy => someLLVMTy
+    | .riscv _  => .bitvec 999 -- To identify non llvm type values.
+  ) Γ
+
+@[simp_denote]
+def ctxtTransformToRiscV (Γ : Ctxt LLVMPlusRiscV.Ty) :=
+  Ctxt.map  (fun ty  =>
+    match ty with
+    | .riscv someRiscVTy => someRiscVTy
+    | _  => .bv
+  ) Γ
+
+/-- Projection of `outTy` commutes with `Signature.map`. -/
+@[simp, simp_denote]
+theorem outTy_map_signature_eq {s : Signature α} {f : α → β} :
+  Signature.outTy (f <$> s) = f s.outTy := rfl
+
+def _root_.HVector.foldlM {B : Type*} [Monad m] (f : ∀ (a : α), B → A a → m B) :
+    ∀ {l : List α}, (init : B) → (as : HVector A l) → m B
+  | [],   b, .nil       => return b
+  | t::_, b, .cons a as => do foldlM f (← f t b a) as
+
+/-! Simultaneous map on the type and value level of an HVector. -/
+@[simp_denote]
+def _root_.HVector.ubermap {A : α → Type} {B : β → Type}
+    {l : List α}
+    (F : α → β)
+    (f : {a : α} → (v : A a) → B (F a) )
+    (as : HVector A l) : (HVector B (F <$> l)) :=
+  match l, as with
+  | [], .nil => .nil
+  | _t :: _ts, .cons a as => HVector.cons (f a) (HVector.ubermap F f as)
+
+/-!
+Simultaneous map on the type and value level of an HVector while
+performing monadic effects for value translation.-/
+@[simp_denote]
+def _root_.HVector.ubermapM [Monad m] {A : α → Type} {B : β → Type}
+    {l : List α}
+    {F : α → β}
+    (f : (a : α) → (v : A a) → m (B (F a)) )
+    (as : HVector A l) : m (HVector B (F <$> l)) :=
+  match l, as with
+  | [], .nil => return .nil
+  | t :: _ts, .cons a as => do return HVector.cons (← f t a) (← HVector.ubermapM f as)
+
+
+end LLVMRiscV

--- a/SSA/Projects/LLVMAndRiscv.lean
+++ b/SSA/Projects/LLVMAndRiscv.lean
@@ -10,6 +10,7 @@ import SSA.Projects.RISCV64.Syntax
 import SSA.Projects.RISCV64.Base
 import SSA.Projects.RISCV64.Semantics
 import SSA.Projects.RISCV64.PrettyEDSL
+import SSA.Core.HVector
 
 open InstCombine(LLVM)
 namespace LLVMRiscV
@@ -132,33 +133,11 @@ def ctxtTransformToRiscV (Γ : Ctxt LLVMPlusRiscV.Ty) :=
 theorem outTy_map_signature_eq {s : Signature α} {f : α → β} :
   Signature.outTy (f <$> s) = f s.outTy := rfl
 
-def _root_.HVector.foldlM {B : Type*} [Monad m] (f : ∀ (a : α), B → A a → m B) :
-    ∀ {l : List α}, (init : B) → (as : HVector A l) → m B
-  | [],   b, .nil       => return b
-  | t::_, b, .cons a as => do foldlM f (← f t b a) as
 
-/-! Simultaneous map on the type and value level of an HVector. -/
-@[simp_denote]
-def _root_.HVector.ubermap {A : α → Type} {B : β → Type}
-    {l : List α}
-    (F : α → β)
-    (f : {a : α} → (v : A a) → B (F a) )
-    (as : HVector A l) : (HVector B (F <$> l)) :=
-  match l, as with
-  | [], .nil => .nil
-  | _t :: _ts, .cons a as => HVector.cons (f a) (HVector.ubermap F f as)
-
-/-!
-Simultaneous map on the type and value level of an HVector while
-performing monadic effects for value translation.-/
-@[simp_denote]
-def _root_.HVector.ubermapM [Monad m] {A : α → Type} {B : β → Type}
-    {l : List α}
-    {F : α → β}
-    (f : (a : α) → (v : A a) → m (B (F a)) )
-    (as : HVector A l) : m (HVector B (F <$> l)) :=
-  match l, as with
-  | [], .nil => return .nil
-  | t :: _ts, .cons a as => do return HVector.cons (← f t a) (← HVector.ubermapM f as)
+/- We tag the following definitions as `simp` and `simp_denote`
+   so that `simp_peephole` and `simp` include them during simplification. -/
+attribute [simp, simp_denote] outTy_map_signature_eq
+attribute [simp, simp_denote] _root_.HVector.ubermapM
+attribute [simp, simp_denote] _root_.HVector.ubermap
 
 end LLVMRiscV

--- a/SSA/Projects/LLVMAndRiscv.lean
+++ b/SSA/Projects/LLVMAndRiscv.lean
@@ -1,15 +1,5 @@
-import SSA.Core.MLIRSyntax.EDSL
-import SSA.Projects.InstCombine.LLVM.PrettyEDSL
-import SSA.Core.Framework
-import SSA.Core.Util
-import SSA.Core.Util.ConcreteOrMVar
-import SSA.Projects.InstCombine.ForStd
-import SSA.Projects.InstCombine.LLVM.Semantics
-import SSA.Projects.InstCombine.Tactic
-import SSA.Projects.RISCV64.Syntax
+import SSA.Projects.InstCombine.Base
 import SSA.Projects.RISCV64.Base
-import SSA.Projects.RISCV64.Semantics
-import SSA.Projects.RISCV64.PrettyEDSL
 import SSA.Core.HVector
 
 open InstCombine(LLVM)

--- a/SSA/Projects/LLVMAndRiscv.lean
+++ b/SSA/Projects/LLVMAndRiscv.lean
@@ -1,6 +1,5 @@
 import SSA.Projects.InstCombine.Base
 import SSA.Projects.RISCV64.Base
-import SSA.Core.HVector
 
 open InstCombine(LLVM)
 namespace LLVMRiscV


### PR DESCRIPTION
This PR introduces the core definitions for the Hybrid Dialect, which merges functionality from both the RV64 and InstCombine dialects. It includes:
-Definitions of types and operands.
-Implementations of typeclass instances for the dialect.
-functions to assist with dialect parsing, specifically for simultaneously mapping values and types.
The full parsing infrastructure will be included in a follow-up PR.
