### PR TITLE
fix: remove transform error type dependency

### DIFF
--- a/SSA/Core/MLIRSyntax/EDSL2.lean
+++ b/SSA/Core/MLIRSyntax/EDSL2.lean
@@ -50,7 +50,7 @@ def elabIntoComObj (region : TSyntax `mlir_region) (d : Dialect) {φ : Nat}
 
   withTraceNode `LeanMLIR.Elab (return m!"{exceptEmoji ·} parsing AST") <| do
     let res ← match mkCom ast with
-      | .error (e : TransformError d.Ty) => throwError (repr e)
+      | .error (e : TransformError) => throwError (repr e)
       | .ok res => pure res
     trace[LeanMLIR.Elab] "context: {repr res.1}"
     pure res

--- a/SSA/Core/MLIRSyntax/Transform.lean
+++ b/SSA/Core/MLIRSyntax/Transform.lean
@@ -35,7 +35,7 @@ section Monads
   errors.
 -/
 
-abbrev ExceptM  (d : Dialect) := Except (TransformError d.Ty)
+abbrev ExceptM  (d : Dialect) := Except TransformError
 abbrev BuilderM (d : Dialect) := StateT NameMapping (ExceptM d)
 abbrev ReaderM  (d : Dialect) := ReaderT NameMapping (ExceptM d)
 
@@ -92,6 +92,8 @@ def addValToMapping (Γ : Ctxt d.Ty) (name : String) (ty : d.Ty) :
   set nm
   return ⟨DerivedCtxt.ofCtxt Γ |>.snoc ty, Ctxt.Var.last ..⟩
 
+variable [ToString d.Ty]
+
 /--
   Look up a name from the name mapping, and return the corresponding variable in the given context.
 
@@ -112,7 +114,7 @@ def getValFromCtxt (Γ : Ctxt d.Ty) (name : String) (expectedType : d.Ty) :
     if h : t = expectedType then
       return ⟨index, by simp only [get?, ← h]; rw [←List.getElem?_eq_getElem]⟩
     else
-      throw <| .typeError expectedType t
+      throw <| .typeError (toString expectedType) (toString t)
 
 def BuilderM.isOk {α : Type} (x : BuilderM d α) : Bool :=
   match x.run [] with

--- a/SSA/Core/MLIRSyntax/Transform/TransformError.lean
+++ b/SSA/Core/MLIRSyntax/Transform/TransformError.lean
@@ -5,11 +5,11 @@ import SSA.Core.MLIRSyntax.AST
 
 namespace MLIR.AST
 
-inductive TransformError (Ty : Type)
+inductive TransformError
   | nameAlreadyDeclared (var : String)
   | undeclaredName (var : String)
   | indexOutOfBounds (name : String) (index len : Nat)
-  | typeError (expected got : Ty)
+  | typeError (expected got : String)
   | widthError {φ} (expected got : Width φ)
   -- TODO: `unsupportedUnaryOp` or `unsupportedBinaryOp` should just be instances
   --       of `unsupportedOp`
@@ -21,7 +21,7 @@ inductive TransformError (Ty : Type)
 
 namespace TransformError
 
-instance [Repr Ty] : Repr (TransformError Ty) where
+instance : Repr (TransformError) where
   reprPrec err _ := match err with
     | nameAlreadyDeclared var => f!"Already declared {var}, shadowing is not allowed"
     | undeclaredName name => f!"Undeclared name '{name}'"

--- a/SSA/Core/MLIRSyntax/Transform/Utils.lean
+++ b/SSA/Core/MLIRSyntax/Transform/Utils.lean
@@ -10,14 +10,14 @@ namespace MLIR.AST
 
 namespace Op
 variable {φ} (op : Op φ)
-variable {d : Dialect} [DialectSignature d] [DecidableEq d.Ty] [TransformTy d φ][ToString d.Ty]
+variable {d : Dialect} [DialectSignature d] [DecidableEq d.Ty] [TransformTy d φ] [ToString d.Ty]
 
 /-! ## Attributes-/
 
 /--
 `op.getAttr attr` returns the value of an attribute, if present,
 or throw an error otherwise. -/
-def getAttr (attr : String) : Except (TransformError) (AttrValue φ) := do
+def getAttr (attr : String) : Except TransformError (AttrValue φ) := do
   let some val := op.getAttr? attr
     | .error <| .generic s!"Missing attribute `{attr}`"
   return val
@@ -34,7 +34,19 @@ def hasAttr (attr : String) : Bool :=
 Throws an error if the attribute is not present, or if the value of the attribute
 has the wrong type.
 -/
-def getBoolAttr (attr : String) : Except (TransformError) (Int × MLIRType φ) := do
+def getBoolAttr (attr : String) : Except TransformError Bool := do
+  let .bool b ← op.getAttr attr
+    | .error <| .generic s!"Expected attribute `{attr}` to be of type Bool, but found:\n\
+        \t{attr}"
+  return b
+
+/--
+`op.getIntAttr attr` returns the value of an integer attribute.
+
+Throws an error if the attribute is not present, or if the value of the attribute
+has the wrong type.
+-/
+def getIntAttr (attr : String) : Except TransformError (Int × MLIRType φ) := do
   let .int val ty ← op.getAttr attr
     | .error <| .generic s!"Expected attribute `{attr}` to be of type Int, but found:\n\
         \t{attr}"

--- a/SSA/Core/MLIRSyntax/Transform/Utils.lean
+++ b/SSA/Core/MLIRSyntax/Transform/Utils.lean
@@ -10,14 +10,14 @@ namespace MLIR.AST
 
 namespace Op
 variable {φ} (op : Op φ)
-variable {d : Dialect} [DialectSignature d] [DecidableEq d.Ty] [TransformTy d φ]
+variable {d : Dialect} [DialectSignature d] [DecidableEq d.Ty] [TransformTy d φ][ToString d.Ty]
 
 /-! ## Attributes-/
 
 /--
 `op.getAttr attr` returns the value of an attribute, if present,
 or throw an error otherwise. -/
-def getAttr (attr : String) : Except (TransformError Ty) (AttrValue φ) := do
+def getAttr (attr : String) : Except (TransformError) (AttrValue φ) := do
   let some val := op.getAttr? attr
     | .error <| .generic s!"Missing attribute `{attr}`"
   return val
@@ -34,19 +34,7 @@ def hasAttr (attr : String) : Bool :=
 Throws an error if the attribute is not present, or if the value of the attribute
 has the wrong type.
 -/
-def getBoolAttr (attr : String) : Except (TransformError Ty) Bool := do
-  let .bool b ← op.getAttr attr
-    | .error <| .generic s!"Expected attribute `{attr}` to be of type Bool, but found:\n\
-        \t{attr}"
-  return b
-
-/--
-`op.getIntAttr attr` returns the value of an integer attribute.
-
-Throws an error if the attribute is not present, or if the value of the attribute
-has the wrong type.
--/
-def getIntAttr (attr : String) : Except (TransformError Ty) (Int × MLIRType φ) := do
+def getBoolAttr (attr : String) : Except (TransformError) (Int × MLIRType φ) := do
   let .int val ty ← op.getAttr attr
     | .error <| .generic s!"Expected attribute `{attr}` to be of type Int, but found:\n\
         \t{attr}"
@@ -96,7 +84,7 @@ signature, assuming that:
 
 Throws an error if either of these assumptions is broken.
 -/
-def withSignature (sig : List d.Ty) : Except (TransformError d.Ty) (HVector Γ.Var sig) := do
+def withSignature (sig : List d.Ty) : Except TransformError (HVector Γ.Var sig) := do
   if h : args.types = sig then
     return h ▸ args.toHVector
   else
@@ -108,7 +96,7 @@ def withSignature (sig : List d.Ty) : Except (TransformError d.Ty) (HVector Γ.V
 /-! ### Arity -/
 
 /-- Throw an error if there are not exactly `n` arguments -/
-def assumeArity (n : Nat) : Except (TransformError d.Ty) (ParsedArgs Γ n) :=
+def assumeArity (n : Nat) : Except TransformError (ParsedArgs Γ n) :=
   if h : n? = some n then
     return h ▸ args
   else if h : args.toList.length = n then

--- a/SSA/Projects/CIRCT/Comb/Comb.lean
+++ b/SSA/Projects/CIRCT/Comb/Comb.lean
@@ -44,6 +44,9 @@ abbrev Comb : Dialect where
   Op := Op
   Ty := Ty
 
+instance : ToString Ty where
+  toString t := repr t |>.pretty
+  
 def_signature for Comb where
   | .add w n => ${List.replicate n (Ty.bv w)} → (Ty.bv w)
   | .and w n => ${List.replicate n (Ty.bv w)} → (Ty.bv w)

--- a/SSA/Projects/CIRCT/DC/DC.lean
+++ b/SSA/Projects/CIRCT/DC/DC.lean
@@ -106,6 +106,9 @@ inductive Ty
 | valuetokenstream (Ty2 : Ty2) : Ty -- A product of streams of values of type `Ty2`.
 deriving Inhabited, DecidableEq, Repr, Lean.ToExpr
 
+instance : ToString Ty where
+  toString t := repr t |>.pretty
+  
 inductive Op
 | fst
 | snd

--- a/SSA/Projects/CIRCT/Handshake/Handshake.lean
+++ b/SSA/Projects/CIRCT/Handshake/Handshake.lean
@@ -206,6 +206,9 @@ toType := fun
 |  Ty2.bool => Bool
 |  Ty2.token => Unit
 
+instance : ToString Ty where
+  toString t := repr t |>.pretty
+
 inductive Op
 | fst (t : Ty2)
 | snd (t : Ty2)

--- a/SSA/Projects/FullyHomomorphicEncryption/Basic.lean
+++ b/SSA/Projects/FullyHomomorphicEncryption/Basic.lean
@@ -707,7 +707,8 @@ toType := fun
   | .tensor => List Int
   | .polynomialLike => (R q n)
 
-
+instance : ToString (Ty q n) where
+  toString t := repr t |>.pretty
 /--
 The operation type of the `Poly` dialect. Operations are parametrized by the
 two parameters `p` and `n` that characterize the ring `R q n`.

--- a/SSA/Projects/InstCombine/LLVM/EDSL.lean
+++ b/SSA/Projects/InstCombine/LLVM/EDSL.lean
@@ -24,7 +24,7 @@ instance instTransformTy : AST.TransformTy (MetaLLVM φ) φ := { mkTy }
 instance : AST.TransformTy (LLVM) 0 := { mkTy }
 
 def getOutputWidth (opStx : MLIR.AST.Op φ) (op : String) :
-    Except (TransformError) (Width φ) := do
+    Except TransformError (Width φ) := do
   match opStx.res with
   | res::[] =>
     match res.2 with

--- a/SSA/Projects/InstCombine/LLVM/EDSL.lean
+++ b/SSA/Projects/InstCombine/LLVM/EDSL.lean
@@ -110,7 +110,7 @@ def mkExpr (Γ : Ctxt (MetaLLVM φ).Ty) (opStx : MLIR.AST.Op φ) :
     | "llvm.trunc" => mkExprOf <| trunc (← unW) (← getOutputWidth opStx "trunc") (← parseOverflowFlags opStx)
     -- Constant
     | "llvm.mlir.constant" =>
-      let ⟨val, ty⟩ ← opStx.getIntAttr (Ty := (MetaLLVM φ).Ty) "value"
+      let ⟨val, ty⟩ ← opStx.getIntAttr "value"
       let opTy@(.bitvec w) ← mkTy ty
       mkExprOf <| const w val
     -- Fallback

--- a/SSA/Projects/InstCombine/LLVM/EDSL.lean
+++ b/SSA/Projects/InstCombine/LLVM/EDSL.lean
@@ -24,7 +24,7 @@ instance instTransformTy : AST.TransformTy (MetaLLVM φ) φ := { mkTy }
 instance : AST.TransformTy (LLVM) 0 := { mkTy }
 
 def getOutputWidth (opStx : MLIR.AST.Op φ) (op : String) :
-    Except (TransformError (MetaLLVM φ).Ty) (Width φ) := do
+    Except (TransformError) (Width φ) := do
   match opStx.res with
   | res::[] =>
     match res.2 with

--- a/SSA/Projects/PaperExamples/PaperExamples.lean
+++ b/SSA/Projects/PaperExamples/PaperExamples.lean
@@ -41,6 +41,9 @@ abbrev Simple : Dialect where
   Op := Op
   Ty := Ty
 
+instance : ToString Ty where
+  toString t := repr t |>.pretty
+
 instance : DialectToExpr Simple where
   toExprM := .const ``Id [0]
   toExprDialect := .const ``Simple []


### PR DESCRIPTION
This PR removes the type dependency from TransformError. Instead of taking an input argument of type d.Ty, TransformError now takes no arguments. This change was necessary to enable staged parsing, as previously each dialect had its own ExceptM monad. By removing the dependency from TransformError, it's no longer required for each dialect to throw exceptions using its own monad.
To support this change, the PR adds ToString instances to existing projects such as the FHE and the PaperExample/Simple dialects.