### PR TITLE
refactor: replace alive_auto with bv_auto in AliveStatements

### DIFF
--- a/SSA/Projects/InstCombine/AliveStatements.lean
+++ b/SSA/Projects/InstCombine/AliveStatements.lean
@@ -15,8 +15,10 @@ theorem bv_AddSub_1043 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try bv_auto
-  all_goals sorry
+  all_goals
+    solve
+    | bv_auto
+    | sorry
 
 theorem bv_AddSub_1152 :
     ∀ (e e_1 : LLVM.IntW 1), LLVM.add e_1 e ⊑ LLVM.xor e_1 e := by
@@ -24,8 +26,10 @@ theorem bv_AddSub_1152 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try bv_auto
-  all_goals sorry
+  all_goals
+    solve
+    | bv_auto
+    | sorry
 
 theorem bv_AddSub_1156 :
     ∀ (e : LLVM.IntW w), LLVM.add e e ⊑ LLVM.shl e (LLVM.const? w 1) := by
@@ -33,8 +37,10 @@ theorem bv_AddSub_1156 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try bv_auto
-  all_goals sorry
+  all_goals
+    solve
+    | bv_auto
+    | sorry
 
 theorem bv_AddSub_1164 :
     ∀ (e e_1 : LLVM.IntW w), LLVM.add (LLVM.sub (LLVM.const? w 0) e) e_1 ⊑ LLVM.sub e_1 e := by
@@ -42,8 +48,10 @@ theorem bv_AddSub_1164 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try bv_auto
-  all_goals sorry
+  all_goals
+    solve
+    | bv_auto
+    | sorry
 
 theorem bv_AddSub_1165 :
     ∀ (e e_1 : LLVM.IntW w),
@@ -52,8 +60,10 @@ theorem bv_AddSub_1165 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try bv_auto
-  all_goals sorry
+  all_goals
+    solve
+    | bv_auto
+    | sorry
 
 theorem bv_AddSub_1176 :
     ∀ (e e_1 : LLVM.IntW w), LLVM.add e (LLVM.sub (LLVM.const? w 0) e_1) ⊑ LLVM.sub e e_1 := by
@@ -61,8 +71,10 @@ theorem bv_AddSub_1176 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try bv_auto
-  all_goals sorry
+  all_goals
+    solve
+    | bv_auto
+    | sorry
 
 theorem bv_AddSub_1202 :
     ∀ (e e_1 : LLVM.IntW w), LLVM.add (LLVM.xor e (LLVM.const? w (-1))) e_1 ⊑ LLVM.sub (LLVM.sub e_1 (LLVM.const? w 1)) e := by
@@ -70,8 +82,10 @@ theorem bv_AddSub_1202 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try bv_auto
-  all_goals sorry
+  all_goals
+    solve
+    | bv_auto
+    | sorry
 
 theorem bv_AddSub_1295 :
     ∀ (e e_1 : LLVM.IntW w), LLVM.add (LLVM.and e e_1) (LLVM.xor e e_1) ⊑ LLVM.or e e_1 := by
@@ -79,8 +93,10 @@ theorem bv_AddSub_1295 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try bv_auto
-  all_goals sorry
+  all_goals
+    solve
+    | bv_auto
+    | sorry
 
 theorem bv_AddSub_1309 :
     ∀ (e e_1 : LLVM.IntW w), LLVM.add (LLVM.and e e_1) (LLVM.or e e_1) ⊑ LLVM.add e e_1 := by
@@ -88,8 +104,10 @@ theorem bv_AddSub_1309 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try bv_auto
-  all_goals sorry
+  all_goals
+    solve
+    | bv_auto
+    | sorry
 
 theorem bv_AddSub_1539 :
     ∀ (e e_1 : LLVM.IntW w), LLVM.sub e_1 (LLVM.sub (LLVM.const? w 0) e) ⊑ LLVM.add e_1 e := by
@@ -97,8 +115,10 @@ theorem bv_AddSub_1539 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try bv_auto
-  all_goals sorry
+  all_goals
+    solve
+    | bv_auto
+    | sorry
 
 theorem bv_AddSub_1539_2 :
     ∀ (e e_1 : LLVM.IntW w), LLVM.sub e e_1 ⊑ LLVM.add e (LLVM.neg e_1) := by
@@ -106,8 +126,10 @@ theorem bv_AddSub_1539_2 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try bv_auto
-  all_goals sorry
+  all_goals
+    solve
+    | bv_auto
+    | sorry
 
 theorem bv_AddSub_1556 :
     ∀ (e e_1 : LLVM.IntW 1), LLVM.sub e_1 e ⊑ LLVM.xor e_1 e := by
@@ -115,8 +137,10 @@ theorem bv_AddSub_1556 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try bv_auto
-  all_goals sorry
+  all_goals
+    solve
+    | bv_auto
+    | sorry
 
 theorem bv_AddSub_1560 :
     ∀ (e : LLVM.IntW w), LLVM.sub (LLVM.const? w (-1)) e ⊑ LLVM.xor e (LLVM.const? w (-1)) := by
@@ -124,8 +148,10 @@ theorem bv_AddSub_1560 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try bv_auto
-  all_goals sorry
+  all_goals
+    solve
+    | bv_auto
+    | sorry
 
 theorem bv_AddSub_1564 :
     ∀ (e e_1 : LLVM.IntW w), LLVM.sub e_1 (LLVM.xor e (LLVM.const? w (-1))) ⊑ LLVM.add e (LLVM.add e_1 (LLVM.const? w 1)) := by
@@ -133,8 +159,10 @@ theorem bv_AddSub_1564 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try bv_auto
-  all_goals sorry
+  all_goals
+    solve
+    | bv_auto
+    | sorry
 
 theorem bv_AddSub_1574 :
     ∀ (e e_1 e_2 : LLVM.IntW w), LLVM.sub e_1 (LLVM.add e e_2) ⊑ LLVM.sub (LLVM.sub e_1 e_2) e := by
@@ -142,8 +170,10 @@ theorem bv_AddSub_1574 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try bv_auto
-  all_goals sorry
+  all_goals
+    solve
+    | bv_auto
+    | sorry
 
 theorem bv_AddSub_1614 :
     ∀ (e e_1 : LLVM.IntW w), LLVM.sub e_1 (LLVM.add e_1 e) ⊑ LLVM.sub (LLVM.const? w 0) e := by
@@ -151,8 +181,10 @@ theorem bv_AddSub_1614 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try bv_auto
-  all_goals sorry
+  all_goals
+    solve
+    | bv_auto
+    | sorry
 
 theorem bv_AddSub_1619 :
     ∀ (e e_1 : LLVM.IntW w), LLVM.sub (LLVM.sub e_1 e) e_1 ⊑ LLVM.sub (LLVM.const? w 0) e := by
@@ -160,8 +192,10 @@ theorem bv_AddSub_1619 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try bv_auto
-  all_goals sorry
+  all_goals
+    solve
+    | bv_auto
+    | sorry
 
 theorem bv_AddSub_1624 :
     ∀ (e e_1 : LLVM.IntW w), LLVM.sub (LLVM.or e e_1) (LLVM.xor e e_1) ⊑ LLVM.and e e_1 := by
@@ -169,8 +203,10 @@ theorem bv_AddSub_1624 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try bv_auto
-  all_goals sorry
+  all_goals
+    solve
+    | bv_auto
+    | sorry
 
 theorem bv_AndOrXor_135 :
     ∀ (e e_1 e_2 : LLVM.IntW w), LLVM.and (LLVM.xor e e_1) e_2 ⊑ LLVM.xor (LLVM.and e e_2) (LLVM.and e_1 e_2) := by
@@ -178,8 +214,10 @@ theorem bv_AndOrXor_135 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try bv_auto
-  all_goals sorry
+  all_goals
+    solve
+    | bv_auto
+    | sorry
 
 theorem bv_AndOrXor_144 :
     ∀ (e e_1 e_2 : LLVM.IntW w), LLVM.and (LLVM.or e e_1) e_2 ⊑ LLVM.and (LLVM.or e (LLVM.and e_1 e_2)) e_2 := by
@@ -187,8 +225,10 @@ theorem bv_AndOrXor_144 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try bv_auto
-  all_goals sorry
+  all_goals
+    solve
+    | bv_auto
+    | sorry
 
 theorem bv_AndOrXor_698 :
     ∀ (e e_1 e_2 : LLVM.IntW w),
@@ -199,8 +239,10 @@ theorem bv_AndOrXor_698 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try bv_auto
-  all_goals sorry
+  all_goals
+    solve
+    | bv_auto
+    | sorry
 
 theorem bv_AndOrXor_709 :
     ∀ (e e_1 e_2 : LLVM.IntW w),
@@ -210,8 +252,10 @@ theorem bv_AndOrXor_709 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try bv_auto
-  all_goals sorry
+  all_goals
+    solve
+    | bv_auto
+    | sorry
 
 theorem bv_AndOrXor_716 :
     ∀ (e e_1 e_2 : LLVM.IntW w),
@@ -221,8 +265,10 @@ theorem bv_AndOrXor_716 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try bv_auto
-  all_goals sorry
+  all_goals
+    solve
+    | bv_auto
+    | sorry
 
 theorem bv_AndOrXor_794 :
     ∀ (e e_1 : LLVM.IntW w),
@@ -231,8 +277,10 @@ theorem bv_AndOrXor_794 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try bv_auto
-  all_goals sorry
+  all_goals
+    solve
+    | bv_auto
+    | sorry
 
 theorem bv_AndOrXor_827 :
     ∀ (e e_1 : LLVM.IntW w),
@@ -242,8 +290,10 @@ theorem bv_AndOrXor_827 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try bv_auto
-  all_goals sorry
+  all_goals
+    solve
+    | bv_auto
+    | sorry
 
 theorem bv_AndOrXor_887_2 :
     ∀ (e e_1 : LLVM.IntW w), LLVM.and (LLVM.icmp LLVM.IntPred.eq e e_1) (LLVM.icmp LLVM.IntPred.ne e e_1) ⊑ LLVM.const? 1 0 := by
@@ -251,8 +301,10 @@ theorem bv_AndOrXor_887_2 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try bv_auto
-  all_goals sorry
+  all_goals
+    solve
+    | bv_auto
+    | sorry
 
 theorem bv_AndOrXor_1230__A__B___A__B :
     ∀ (e e_1 : LLVM.IntW w),
@@ -262,8 +314,10 @@ theorem bv_AndOrXor_1230__A__B___A__B :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try bv_auto
-  all_goals sorry
+  all_goals
+    solve
+    | bv_auto
+    | sorry
 
 theorem bv_AndOrXor_1241_AB__AB__AB :
     ∀ (e e_1 : LLVM.IntW w), LLVM.and (LLVM.or e e_1) (LLVM.xor (LLVM.and e e_1) (LLVM.const? w (-1))) ⊑ LLVM.xor e e_1 := by
@@ -271,8 +325,10 @@ theorem bv_AndOrXor_1241_AB__AB__AB :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try bv_auto
-  all_goals sorry
+  all_goals
+    solve
+    | bv_auto
+    | sorry
 
 theorem bv_AndOrXor_1247_AB__AB__AB :
     ∀ (e e_1 : LLVM.IntW w), LLVM.and (LLVM.xor (LLVM.and e e_1) (LLVM.const? w (-1))) (LLVM.or e e_1) ⊑ LLVM.xor e e_1 := by
@@ -280,8 +336,10 @@ theorem bv_AndOrXor_1247_AB__AB__AB :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try bv_auto
-  all_goals sorry
+  all_goals
+    solve
+    | bv_auto
+    | sorry
 
 theorem bv_AndOrXor_1253_A__AB___A__B :
     ∀ (e e_1 : LLVM.IntW w), LLVM.and (LLVM.xor e e_1) e ⊑ LLVM.and e (LLVM.xor e_1 (LLVM.const? w (-1))) := by
@@ -289,8 +347,10 @@ theorem bv_AndOrXor_1253_A__AB___A__B :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try bv_auto
-  all_goals sorry
+  all_goals
+    solve
+    | bv_auto
+    | sorry
 
 theorem bv_AndOrXor_1280_ABA___AB :
     ∀ (e e_1 : LLVM.IntW w), LLVM.and (LLVM.or (LLVM.xor e (LLVM.const? w (-1))) e_1) e ⊑ LLVM.and e e_1 := by
@@ -298,8 +358,10 @@ theorem bv_AndOrXor_1280_ABA___AB :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try bv_auto
-  all_goals sorry
+  all_goals
+    solve
+    | bv_auto
+    | sorry
 
 theorem bv_AndOrXor_1288_A__B__B__C__A___A__B__C :
     ∀ (e e_1 e_2 : LLVM.IntW w),
@@ -309,8 +371,10 @@ theorem bv_AndOrXor_1288_A__B__B__C__A___A__B__C :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try bv_auto
-  all_goals sorry
+  all_goals
+    solve
+    | bv_auto
+    | sorry
 
 theorem bv_AndOrXor_1294_A__B__A__B___A__B :
     ∀ (e e_1 : LLVM.IntW w), LLVM.and (LLVM.or e e_1) (LLVM.xor (LLVM.xor e (LLVM.const? w (-1))) e_1) ⊑ LLVM.and e e_1 := by
@@ -318,8 +382,10 @@ theorem bv_AndOrXor_1294_A__B__A__B___A__B :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try bv_auto
-  all_goals sorry
+  all_goals
+    solve
+    | bv_auto
+    | sorry
 
 theorem bv_AndOrXor_1683_1 :
     ∀ (e e_1 : LLVM.IntW w),
@@ -328,8 +394,10 @@ theorem bv_AndOrXor_1683_1 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try bv_auto
-  all_goals sorry
+  all_goals
+    solve
+    | bv_auto
+    | sorry
 
 theorem bv_AndOrXor_1683_2 :
     ∀ (e e_1 : LLVM.IntW w), LLVM.or (LLVM.icmp LLVM.IntPred.uge e e_1) (LLVM.icmp LLVM.IntPred.ne e e_1) ⊑ LLVM.const? 1 1 := by
@@ -337,8 +405,10 @@ theorem bv_AndOrXor_1683_2 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try bv_auto
-  all_goals sorry
+  all_goals
+    solve
+    | bv_auto
+    | sorry
 
 theorem bv_AndOrXor_1704 :
     ∀ (e e_1 : LLVM.IntW w),
@@ -348,8 +418,10 @@ theorem bv_AndOrXor_1704 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try bv_auto
-  all_goals sorry
+  all_goals
+    solve
+    | bv_auto
+    | sorry
 
 theorem bv_AndOrXor_1705 :
     ∀ (e e_1 : LLVM.IntW w),
@@ -359,8 +431,10 @@ theorem bv_AndOrXor_1705 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try bv_auto
-  all_goals sorry
+  all_goals
+    solve
+    | bv_auto
+    | sorry
 
 theorem bv_AndOrXor_1733 :
     ∀ (e e_1 : LLVM.IntW w),
@@ -370,8 +444,10 @@ theorem bv_AndOrXor_1733 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try bv_auto
-  all_goals sorry
+  all_goals
+    solve
+    | bv_auto
+    | sorry
 
 theorem bv_AndOrXor_2063__X__C1__C2____X__C2__C1__C2 :
     ∀ (e e_1 e_2 : LLVM.IntW w), LLVM.or (LLVM.xor e e_1) e_2 ⊑ LLVM.xor (LLVM.or e e_2) (LLVM.and e_1 (LLVM.not e_2)) := by
@@ -379,8 +455,10 @@ theorem bv_AndOrXor_2063__X__C1__C2____X__C2__C1__C2 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try bv_auto
-  all_goals sorry
+  all_goals
+    solve
+    | bv_auto
+    | sorry
 
 theorem bv_AndOrXor_2113___A__B__A___A__B :
     ∀ (e e_1 : LLVM.IntW w), LLVM.or (LLVM.and (LLVM.xor e (LLVM.const? w (-1))) e_1) e ⊑ LLVM.or e e_1 := by
@@ -388,8 +466,10 @@ theorem bv_AndOrXor_2113___A__B__A___A__B :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try bv_auto
-  all_goals sorry
+  all_goals
+    solve
+    | bv_auto
+    | sorry
 
 theorem bv_AndOrXor_2118___A__B__A___A__B :
     ∀ (e e_1 : LLVM.IntW w),
@@ -398,8 +478,10 @@ theorem bv_AndOrXor_2118___A__B__A___A__B :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try bv_auto
-  all_goals sorry
+  all_goals
+    solve
+    | bv_auto
+    | sorry
 
 theorem bv_AndOrXor_2123___A__B__A__B___A__B :
     ∀ (e e_1 : LLVM.IntW w), LLVM.or (LLVM.and e (LLVM.xor e_1 (LLVM.const? w (-1)))) (LLVM.xor e e_1) ⊑ LLVM.xor e e_1 := by
@@ -407,8 +489,10 @@ theorem bv_AndOrXor_2123___A__B__A__B___A__B :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try bv_auto
-  all_goals sorry
+  all_goals
+    solve
+    | bv_auto
+    | sorry
 
 theorem bv_AndOrXor_2188 :
     ∀ (e e_1 : LLVM.IntW w),
@@ -418,8 +502,10 @@ theorem bv_AndOrXor_2188 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try bv_auto
-  all_goals sorry
+  all_goals
+    solve
+    | bv_auto
+    | sorry
 
 theorem bv_AndOrXor_2231__A__B__B__C__A___A__B__C :
     ∀ (e e_1 e_2 : LLVM.IntW w), LLVM.or (LLVM.xor e e_2) (LLVM.xor (LLVM.xor e_2 e_1) e) ⊑ LLVM.or (LLVM.xor e e_2) e_1 := by
@@ -427,8 +513,10 @@ theorem bv_AndOrXor_2231__A__B__B__C__A___A__B__C :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try bv_auto
-  all_goals sorry
+  all_goals
+    solve
+    | bv_auto
+    | sorry
 
 theorem bv_AndOrXor_2243__B__C__A__B___B__A__C :
     ∀ (e e_1 e_2 : LLVM.IntW w), LLVM.or (LLVM.and (LLVM.or e_2 e_1) e) e_2 ⊑ LLVM.or e_2 (LLVM.and e e_1) := by
@@ -436,8 +524,10 @@ theorem bv_AndOrXor_2243__B__C__A__B___B__A__C :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try bv_auto
-  all_goals sorry
+  all_goals
+    solve
+    | bv_auto
+    | sorry
 
 theorem bv_AndOrXor_2247__A__B__A__B :
     ∀ (e e_1 : LLVM.IntW w),
@@ -447,8 +537,10 @@ theorem bv_AndOrXor_2247__A__B__A__B :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try bv_auto
-  all_goals sorry
+  all_goals
+    solve
+    | bv_auto
+    | sorry
 
 theorem bv_AndOrXor_2263 :
     ∀ (e e_1 : LLVM.IntW w), LLVM.or e_1 (LLVM.xor e_1 e) ⊑ LLVM.or e_1 e := by
@@ -456,8 +548,10 @@ theorem bv_AndOrXor_2263 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try bv_auto
-  all_goals sorry
+  all_goals
+    solve
+    | bv_auto
+    | sorry
 
 theorem bv_AndOrXor_2264 :
     ∀ (e e_1 : LLVM.IntW w),
@@ -466,8 +560,10 @@ theorem bv_AndOrXor_2264 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try bv_auto
-  all_goals sorry
+  all_goals
+    solve
+    | bv_auto
+    | sorry
 
 theorem bv_AndOrXor_2265 :
     ∀ (e e_1 : LLVM.IntW w), LLVM.or (LLVM.and e e_1) (LLVM.xor e e_1) ⊑ LLVM.or e e_1 := by
@@ -475,8 +571,10 @@ theorem bv_AndOrXor_2265 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try bv_auto
-  all_goals sorry
+  all_goals
+    solve
+    | bv_auto
+    | sorry
 
 theorem bv_AndOrXor_2284 :
     ∀ (e e_1 : LLVM.IntW w),
@@ -485,8 +583,10 @@ theorem bv_AndOrXor_2284 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try bv_auto
-  all_goals sorry
+  all_goals
+    solve
+    | bv_auto
+    | sorry
 
 theorem bv_AndOrXor_2285 :
     ∀ (e e_1 : LLVM.IntW w),
@@ -495,8 +595,10 @@ theorem bv_AndOrXor_2285 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try bv_auto
-  all_goals sorry
+  all_goals
+    solve
+    | bv_auto
+    | sorry
 
 theorem bv_AndOrXor_2297 :
     ∀ (e e_1 : LLVM.IntW w),
@@ -506,8 +608,10 @@ theorem bv_AndOrXor_2297 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try bv_auto
-  all_goals sorry
+  all_goals
+    solve
+    | bv_auto
+    | sorry
 
 theorem bv_AndOrXor_2367 :
     ∀ (e e_1 e_2 : LLVM.IntW w), LLVM.or (LLVM.or e e_1) e_2 ⊑ LLVM.or (LLVM.or e e_2) e_1 := by
@@ -515,8 +619,10 @@ theorem bv_AndOrXor_2367 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try bv_auto
-  all_goals sorry
+  all_goals
+    solve
+    | bv_auto
+    | sorry
 
 theorem bv_AndOrXor_2416 :
     ∀ (e e_1 : LLVM.IntW w),
@@ -526,8 +632,10 @@ theorem bv_AndOrXor_2416 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try bv_auto
-  all_goals sorry
+  all_goals
+    solve
+    | bv_auto
+    | sorry
 
 theorem bv_AndOrXor_2417 :
     ∀ (e e_1 : LLVM.IntW w),
@@ -537,8 +645,10 @@ theorem bv_AndOrXor_2417 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try bv_auto
-  all_goals sorry
+  all_goals
+    solve
+    | bv_auto
+    | sorry
 
 theorem bv_AndOrXor_2429 :
     ∀ (e e_1 : LLVM.IntW w),
@@ -548,8 +658,10 @@ theorem bv_AndOrXor_2429 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try bv_auto
-  all_goals sorry
+  all_goals
+    solve
+    | bv_auto
+    | sorry
 
 theorem bv_AndOrXor_2430 :
     ∀ (e e_1 : LLVM.IntW w),
@@ -559,8 +671,10 @@ theorem bv_AndOrXor_2430 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try bv_auto
-  all_goals sorry
+  all_goals
+    solve
+    | bv_auto
+    | sorry
 
 theorem bv_AndOrXor_2443 :
     ∀ (e e_1 : LLVM.IntW w),
@@ -569,8 +683,10 @@ theorem bv_AndOrXor_2443 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try bv_auto
-  all_goals sorry
+  all_goals
+    solve
+    | bv_auto
+    | sorry
 
 theorem bv_AndOrXor_2453 :
     ∀ (e e_1 : LLVM.IntW w),
@@ -579,8 +695,10 @@ theorem bv_AndOrXor_2453 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try bv_auto
-  all_goals sorry
+  all_goals
+    solve
+    | bv_auto
+    | sorry
 
 theorem bv_AndOrXor_2475 :
     ∀ (e e_1 : LLVM.IntW w), LLVM.xor (LLVM.sub e_1 e) (LLVM.const? w (-1)) ⊑ LLVM.add e (LLVM.sub (LLVM.const? w (-1)) e_1) := by
@@ -588,8 +706,10 @@ theorem bv_AndOrXor_2475 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try bv_auto
-  all_goals sorry
+  all_goals
+    solve
+    | bv_auto
+    | sorry
 
 theorem bv_AndOrXor_2486 :
     ∀ (e e_1 : LLVM.IntW w), LLVM.xor (LLVM.add e e_1) (LLVM.const? w (-1)) ⊑ LLVM.sub (LLVM.sub (LLVM.const? w (-1)) e_1) e := by
@@ -597,8 +717,10 @@ theorem bv_AndOrXor_2486 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try bv_auto
-  all_goals sorry
+  all_goals
+    solve
+    | bv_auto
+    | sorry
 
 theorem bv_AndOrXor_2581__BAB___A__B :
     ∀ (e e_1 : LLVM.IntW w), LLVM.xor (LLVM.or e e_1) e_1 ⊑ LLVM.and e (LLVM.xor e_1 (LLVM.const? w (-1))) := by
@@ -606,8 +728,10 @@ theorem bv_AndOrXor_2581__BAB___A__B :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try bv_auto
-  all_goals sorry
+  all_goals
+    solve
+    | bv_auto
+    | sorry
 
 theorem bv_AndOrXor_2587__BAA___B__A :
     ∀ (e e_1 : LLVM.IntW w), LLVM.xor (LLVM.and e e_1) e_1 ⊑ LLVM.and (LLVM.xor e (LLVM.const? w (-1))) e_1 := by
@@ -615,8 +739,10 @@ theorem bv_AndOrXor_2587__BAA___B__A :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try bv_auto
-  all_goals sorry
+  all_goals
+    solve
+    | bv_auto
+    | sorry
 
 theorem bv_AndOrXor_2595 :
     ∀ (e e_1 : LLVM.IntW w), LLVM.xor (LLVM.and e e_1) (LLVM.or e e_1) ⊑ LLVM.xor e e_1 := by
@@ -624,8 +750,10 @@ theorem bv_AndOrXor_2595 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try bv_auto
-  all_goals sorry
+  all_goals
+    solve
+    | bv_auto
+    | sorry
 
 theorem bv_AndOrXor_2607 :
     ∀ (e e_1 : LLVM.IntW w),
@@ -635,8 +763,10 @@ theorem bv_AndOrXor_2607 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try bv_auto
-  all_goals sorry
+  all_goals
+    solve
+    | bv_auto
+    | sorry
 
 theorem bv_AndOrXor_2617 :
     ∀ (e e_1 : LLVM.IntW w),
@@ -646,8 +776,10 @@ theorem bv_AndOrXor_2617 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try bv_auto
-  all_goals sorry
+  all_goals
+    solve
+    | bv_auto
+    | sorry
 
 theorem bv_AndOrXor_2627 :
     ∀ (e e_1 e_2 : LLVM.IntW w),
@@ -656,8 +788,10 @@ theorem bv_AndOrXor_2627 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try bv_auto
-  all_goals sorry
+  all_goals
+    solve
+    | bv_auto
+    | sorry
 
 theorem bv_AndOrXor_2647 :
     ∀ (e e_1 : LLVM.IntW w), LLVM.xor (LLVM.and e e_1) (LLVM.xor e e_1) ⊑ LLVM.or e e_1 := by
@@ -665,8 +799,10 @@ theorem bv_AndOrXor_2647 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try bv_auto
-  all_goals sorry
+  all_goals
+    solve
+    | bv_auto
+    | sorry
 
 theorem bv_AndOrXor_2658 :
     ∀ (e e_1 : LLVM.IntW w),
@@ -676,8 +812,10 @@ theorem bv_AndOrXor_2658 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try bv_auto
-  all_goals sorry
+  all_goals
+    solve
+    | bv_auto
+    | sorry
 
 theorem bv_AndOrXor_2663 :
     ∀ (e e_1 : LLVM.IntW w),
@@ -686,8 +824,10 @@ theorem bv_AndOrXor_2663 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try bv_auto
-  all_goals sorry
+  all_goals
+    solve
+    | bv_auto
+    | sorry
 
 theorem bv_152 :
     ∀ (e : LLVM.IntW w), LLVM.mul e (LLVM.const? w (-1)) ⊑ LLVM.sub (LLVM.const? w 0) e := by
@@ -695,8 +835,10 @@ theorem bv_152 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try bv_auto
-  all_goals sorry
+  all_goals
+    solve
+    | bv_auto
+    | sorry
 
 theorem bv_229 :
     ∀ (e e_1 e_2 : LLVM.IntW w), LLVM.mul (LLVM.add e e_1) e_2 ⊑ LLVM.add (LLVM.mul e e_2) (LLVM.mul e_1 e_2) := by
@@ -704,8 +846,10 @@ theorem bv_229 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try bv_auto
-  all_goals sorry
+  all_goals
+    solve
+    | bv_auto
+    | sorry
 
 theorem bv_239 :
     ∀ (e e_1 : LLVM.IntW w), LLVM.mul (LLVM.sub (LLVM.const? w 0) e_1) (LLVM.sub (LLVM.const? w 0) e) ⊑ LLVM.mul e_1 e := by
@@ -713,8 +857,10 @@ theorem bv_239 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try bv_auto
-  all_goals sorry
+  all_goals
+    solve
+    | bv_auto
+    | sorry
 
 theorem bv_275 :
     ∀ (e e_1 : LLVM.IntW 5), LLVM.mul (LLVM.udiv e_1 e) e ⊑ LLVM.sub e_1 (LLVM.urem e_1 e) := by
@@ -722,8 +868,10 @@ theorem bv_275 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try bv_auto
-  all_goals sorry
+  all_goals
+    solve
+    | bv_auto
+    | sorry
 
 theorem bv_275_2 :
     ∀ (e e_1 : LLVM.IntW 5), LLVM.mul (LLVM.sdiv e_1 e) e ⊑ LLVM.sub e_1 (LLVM.srem e_1 e) := by
@@ -731,8 +879,10 @@ theorem bv_275_2 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try bv_auto
-  all_goals sorry
+  all_goals
+    solve
+    | bv_auto
+    | sorry
 
 theorem bv_276 :
     ∀ (e e_1 : LLVM.IntW 5), LLVM.mul (LLVM.sdiv e_1 e) (LLVM.sub (LLVM.const? 5 0) e) ⊑ LLVM.sub (LLVM.srem e_1 e) e_1 := by
@@ -740,8 +890,10 @@ theorem bv_276 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try bv_auto
-  all_goals sorry
+  all_goals
+    solve
+    | bv_auto
+    | sorry
 
 theorem bv_276_2 :
     ∀ (e e_1 : LLVM.IntW 5), LLVM.mul (LLVM.udiv e_1 e) (LLVM.sub (LLVM.const? 5 0) e) ⊑ LLVM.sub (LLVM.urem e_1 e) e_1 := by
@@ -749,8 +901,10 @@ theorem bv_276_2 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try bv_auto
-  all_goals sorry
+  all_goals
+    solve
+    | bv_auto
+    | sorry
 
 theorem bv_283 :
     ∀ (e e_1 : LLVM.IntW 1), LLVM.mul e_1 e ⊑ LLVM.and e_1 e := by
@@ -758,8 +912,10 @@ theorem bv_283 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try bv_auto
-  all_goals sorry
+  all_goals
+    solve
+    | bv_auto
+    | sorry
 
 theorem bv_290__292 :
     ∀ (e e_1 : LLVM.IntW w), LLVM.mul (LLVM.shl (LLVM.const? w 1) e) e_1 ⊑ LLVM.shl e_1 e := by
@@ -767,8 +923,10 @@ theorem bv_290__292 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try bv_auto
-  all_goals sorry
+  all_goals
+    solve
+    | bv_auto
+    | sorry
 
 theorem bv_820 :
     ∀ (e e_1 : LLVM.IntW 9), LLVM.sdiv (LLVM.sub e (LLVM.srem e e_1)) e_1 ⊑ LLVM.sdiv e e_1 := by
@@ -776,8 +934,10 @@ theorem bv_820 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try bv_auto
-  all_goals sorry
+  all_goals
+    solve
+    | bv_auto
+    | sorry
 
 theorem bv_820' :
     ∀ (e e_1 : LLVM.IntW 9), LLVM.udiv (LLVM.sub e (LLVM.urem e e_1)) e_1 ⊑ LLVM.udiv e e_1 := by
@@ -785,8 +945,10 @@ theorem bv_820' :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try bv_auto
-  all_goals sorry
+  all_goals
+    solve
+    | bv_auto
+    | sorry
 
 theorem bv_1030 :
     ∀ (e : LLVM.IntW w), LLVM.sdiv e (LLVM.const? w (-1)) ⊑ LLVM.sub (LLVM.const? w 0) e := by
@@ -794,8 +956,10 @@ theorem bv_1030 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try bv_auto
-  all_goals sorry
+  all_goals
+    solve
+    | bv_auto
+    | sorry
 
 theorem bv_Select_858 :
     ∀ (e e_1 : LLVM.IntW 1),
@@ -804,8 +968,10 @@ theorem bv_Select_858 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try bv_auto
-  all_goals sorry
+  all_goals
+    solve
+    | bv_auto
+    | sorry
 
 theorem bv_Select_859' :
     ∀ (e e_1 : LLVM.IntW 1),
@@ -814,8 +980,10 @@ theorem bv_Select_859' :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try bv_auto
-  all_goals sorry
+  all_goals
+    solve
+    | bv_auto
+    | sorry
 
 theorem bv_select_1100 :
     ∀ (e e_1 : LLVM.IntW w), LLVM.select (LLVM.const? 1 1) e_1 e ⊑ e_1 := by
@@ -823,8 +991,10 @@ theorem bv_select_1100 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try bv_auto
-  all_goals sorry
+  all_goals
+    solve
+    | bv_auto
+    | sorry
 
 theorem bv_Select_1105 :
     ∀ (e e_1 : LLVM.IntW w), LLVM.select (LLVM.const? 1 0) e_1 e ⊑ e := by
@@ -832,8 +1002,10 @@ theorem bv_Select_1105 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try bv_auto
-  all_goals sorry
+  all_goals
+    solve
+    | bv_auto
+    | sorry
 
 theorem bv_InstCombineShift__239 :
     ∀ (e e_1 : LLVM.IntW w), LLVM.lshr (LLVM.shl e e_1) e_1 ⊑ LLVM.and e (LLVM.lshr (LLVM.const? w (-1)) e_1) := by
@@ -841,8 +1013,10 @@ theorem bv_InstCombineShift__239 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try bv_auto
-  all_goals sorry
+  all_goals
+    solve
+    | bv_auto
+    | sorry
 
 theorem bv_InstCombineShift__279 :
     ∀ (e e_1 : LLVM.IntW w), LLVM.shl (LLVM.lshr e e_1) e_1 ⊑ LLVM.and e (LLVM.shl (LLVM.const? w (-1)) e_1) := by
@@ -850,8 +1024,10 @@ theorem bv_InstCombineShift__279 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try bv_auto
-  all_goals sorry
+  all_goals
+    solve
+    | bv_auto
+    | sorry
 
 theorem bv_InstCombineShift__440 :
     ∀ (e e_1 e_2 e_3 : LLVM.IntW w),
@@ -861,8 +1037,10 @@ theorem bv_InstCombineShift__440 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try bv_auto
-  all_goals sorry
+  all_goals
+    solve
+    | bv_auto
+    | sorry
 
 theorem bv_InstCombineShift__476 :
     ∀ (e e_1 e_2 e_3 : LLVM.IntW w),
@@ -872,8 +1050,10 @@ theorem bv_InstCombineShift__476 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try bv_auto
-  all_goals sorry
+  all_goals
+    solve
+    | bv_auto
+    | sorry
 
 theorem bv_InstCombineShift__497 :
     ∀ (e e_1 e_2 : LLVM.IntW w), LLVM.lshr (LLVM.xor e e_2) e_1 ⊑ LLVM.xor (LLVM.lshr e e_1) (LLVM.lshr e_2 e_1) := by
@@ -881,8 +1061,10 @@ theorem bv_InstCombineShift__497 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try bv_auto
-  all_goals sorry
+  all_goals
+    solve
+    | bv_auto
+    | sorry
 
 theorem bv_InstCombineShift__497''' :
     ∀ (e e_1 e_2 : LLVM.IntW w), LLVM.shl (LLVM.add e e_2) e_1 ⊑ LLVM.add (LLVM.shl e e_1) (LLVM.shl e_2 e_1) := by
@@ -890,8 +1072,10 @@ theorem bv_InstCombineShift__497''' :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try bv_auto
-  all_goals sorry
+  all_goals
+    solve
+    | bv_auto
+    | sorry
 
 theorem bv_InstCombineShift__582 :
     ∀ (e e_1 : LLVM.IntW w), LLVM.lshr (LLVM.shl e e_1) e_1 ⊑ LLVM.and e (LLVM.lshr (LLVM.const? w (-1)) e_1) := by
@@ -899,5 +1083,7 @@ theorem bv_InstCombineShift__582 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try bv_auto
-  all_goals sorry
+  all_goals
+    solve
+    | bv_auto
+    | sorry

--- a/SSA/Projects/InstCombine/AliveStatements.lean
+++ b/SSA/Projects/InstCombine/AliveStatements.lean
@@ -15,7 +15,7 @@ theorem bv_AddSub_1043 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try alive_auto
+  try bv_auto
   all_goals sorry
 
 theorem bv_AddSub_1152 :
@@ -24,7 +24,7 @@ theorem bv_AddSub_1152 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try alive_auto
+  try bv_auto
   all_goals sorry
 
 theorem bv_AddSub_1156 :
@@ -33,7 +33,7 @@ theorem bv_AddSub_1156 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try alive_auto
+  try bv_auto
   all_goals sorry
 
 theorem bv_AddSub_1164 :
@@ -42,7 +42,7 @@ theorem bv_AddSub_1164 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try alive_auto
+  try bv_auto
   all_goals sorry
 
 theorem bv_AddSub_1165 :
@@ -52,7 +52,7 @@ theorem bv_AddSub_1165 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try alive_auto
+  try bv_auto
   all_goals sorry
 
 theorem bv_AddSub_1176 :
@@ -61,7 +61,7 @@ theorem bv_AddSub_1176 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try alive_auto
+  try bv_auto
   all_goals sorry
 
 theorem bv_AddSub_1202 :
@@ -70,7 +70,7 @@ theorem bv_AddSub_1202 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try alive_auto
+  try bv_auto
   all_goals sorry
 
 theorem bv_AddSub_1295 :
@@ -79,7 +79,7 @@ theorem bv_AddSub_1295 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try alive_auto
+  try bv_auto
   all_goals sorry
 
 theorem bv_AddSub_1309 :
@@ -88,7 +88,7 @@ theorem bv_AddSub_1309 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try alive_auto
+  try bv_auto
   all_goals sorry
 
 theorem bv_AddSub_1539 :
@@ -97,7 +97,7 @@ theorem bv_AddSub_1539 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try alive_auto
+  try bv_auto
   all_goals sorry
 
 theorem bv_AddSub_1539_2 :
@@ -106,7 +106,7 @@ theorem bv_AddSub_1539_2 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try alive_auto
+  try bv_auto
   all_goals sorry
 
 theorem bv_AddSub_1556 :
@@ -115,7 +115,7 @@ theorem bv_AddSub_1556 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try alive_auto
+  try bv_auto
   all_goals sorry
 
 theorem bv_AddSub_1560 :
@@ -124,7 +124,7 @@ theorem bv_AddSub_1560 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try alive_auto
+  try bv_auto
   all_goals sorry
 
 theorem bv_AddSub_1564 :
@@ -133,7 +133,7 @@ theorem bv_AddSub_1564 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try alive_auto
+  try bv_auto
   all_goals sorry
 
 theorem bv_AddSub_1574 :
@@ -142,7 +142,7 @@ theorem bv_AddSub_1574 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try alive_auto
+  try bv_auto
   all_goals sorry
 
 theorem bv_AddSub_1614 :
@@ -151,7 +151,7 @@ theorem bv_AddSub_1614 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try alive_auto
+  try bv_auto
   all_goals sorry
 
 theorem bv_AddSub_1619 :
@@ -160,7 +160,7 @@ theorem bv_AddSub_1619 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try alive_auto
+  try bv_auto
   all_goals sorry
 
 theorem bv_AddSub_1624 :
@@ -169,7 +169,7 @@ theorem bv_AddSub_1624 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try alive_auto
+  try bv_auto
   all_goals sorry
 
 theorem bv_AndOrXor_135 :
@@ -178,7 +178,7 @@ theorem bv_AndOrXor_135 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try alive_auto
+  try bv_auto
   all_goals sorry
 
 theorem bv_AndOrXor_144 :
@@ -187,7 +187,7 @@ theorem bv_AndOrXor_144 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try alive_auto
+  try bv_auto
   all_goals sorry
 
 theorem bv_AndOrXor_698 :
@@ -199,7 +199,7 @@ theorem bv_AndOrXor_698 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try alive_auto
+  try bv_auto
   all_goals sorry
 
 theorem bv_AndOrXor_709 :
@@ -210,7 +210,7 @@ theorem bv_AndOrXor_709 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try alive_auto
+  try bv_auto
   all_goals sorry
 
 theorem bv_AndOrXor_716 :
@@ -221,7 +221,7 @@ theorem bv_AndOrXor_716 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try alive_auto
+  try bv_auto
   all_goals sorry
 
 theorem bv_AndOrXor_794 :
@@ -231,7 +231,7 @@ theorem bv_AndOrXor_794 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try alive_auto
+  try bv_auto
   all_goals sorry
 
 theorem bv_AndOrXor_827 :
@@ -242,7 +242,7 @@ theorem bv_AndOrXor_827 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try alive_auto
+  try bv_auto
   all_goals sorry
 
 theorem bv_AndOrXor_887_2 :
@@ -251,7 +251,7 @@ theorem bv_AndOrXor_887_2 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try alive_auto
+  try bv_auto
   all_goals sorry
 
 theorem bv_AndOrXor_1230__A__B___A__B :
@@ -262,7 +262,7 @@ theorem bv_AndOrXor_1230__A__B___A__B :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try alive_auto
+  try bv_auto
   all_goals sorry
 
 theorem bv_AndOrXor_1241_AB__AB__AB :
@@ -271,7 +271,7 @@ theorem bv_AndOrXor_1241_AB__AB__AB :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try alive_auto
+  try bv_auto
   all_goals sorry
 
 theorem bv_AndOrXor_1247_AB__AB__AB :
@@ -280,7 +280,7 @@ theorem bv_AndOrXor_1247_AB__AB__AB :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try alive_auto
+  try bv_auto
   all_goals sorry
 
 theorem bv_AndOrXor_1253_A__AB___A__B :
@@ -289,7 +289,7 @@ theorem bv_AndOrXor_1253_A__AB___A__B :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try alive_auto
+  try bv_auto
   all_goals sorry
 
 theorem bv_AndOrXor_1280_ABA___AB :
@@ -298,7 +298,7 @@ theorem bv_AndOrXor_1280_ABA___AB :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try alive_auto
+  try bv_auto
   all_goals sorry
 
 theorem bv_AndOrXor_1288_A__B__B__C__A___A__B__C :
@@ -309,7 +309,7 @@ theorem bv_AndOrXor_1288_A__B__B__C__A___A__B__C :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try alive_auto
+  try bv_auto
   all_goals sorry
 
 theorem bv_AndOrXor_1294_A__B__A__B___A__B :
@@ -318,7 +318,7 @@ theorem bv_AndOrXor_1294_A__B__A__B___A__B :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try alive_auto
+  try bv_auto
   all_goals sorry
 
 theorem bv_AndOrXor_1683_1 :
@@ -328,7 +328,7 @@ theorem bv_AndOrXor_1683_1 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try alive_auto
+  try bv_auto
   all_goals sorry
 
 theorem bv_AndOrXor_1683_2 :
@@ -337,7 +337,7 @@ theorem bv_AndOrXor_1683_2 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try alive_auto
+  try bv_auto
   all_goals sorry
 
 theorem bv_AndOrXor_1704 :
@@ -348,7 +348,7 @@ theorem bv_AndOrXor_1704 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try alive_auto
+  try bv_auto
   all_goals sorry
 
 theorem bv_AndOrXor_1705 :
@@ -359,7 +359,7 @@ theorem bv_AndOrXor_1705 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try alive_auto
+  try bv_auto
   all_goals sorry
 
 theorem bv_AndOrXor_1733 :
@@ -370,7 +370,7 @@ theorem bv_AndOrXor_1733 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try alive_auto
+  try bv_auto
   all_goals sorry
 
 theorem bv_AndOrXor_2063__X__C1__C2____X__C2__C1__C2 :
@@ -379,7 +379,7 @@ theorem bv_AndOrXor_2063__X__C1__C2____X__C2__C1__C2 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try alive_auto
+  try bv_auto
   all_goals sorry
 
 theorem bv_AndOrXor_2113___A__B__A___A__B :
@@ -388,7 +388,7 @@ theorem bv_AndOrXor_2113___A__B__A___A__B :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try alive_auto
+  try bv_auto
   all_goals sorry
 
 theorem bv_AndOrXor_2118___A__B__A___A__B :
@@ -398,7 +398,7 @@ theorem bv_AndOrXor_2118___A__B__A___A__B :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try alive_auto
+  try bv_auto
   all_goals sorry
 
 theorem bv_AndOrXor_2123___A__B__A__B___A__B :
@@ -407,7 +407,7 @@ theorem bv_AndOrXor_2123___A__B__A__B___A__B :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try alive_auto
+  try bv_auto
   all_goals sorry
 
 theorem bv_AndOrXor_2188 :
@@ -418,7 +418,7 @@ theorem bv_AndOrXor_2188 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try alive_auto
+  try bv_auto
   all_goals sorry
 
 theorem bv_AndOrXor_2231__A__B__B__C__A___A__B__C :
@@ -427,7 +427,7 @@ theorem bv_AndOrXor_2231__A__B__B__C__A___A__B__C :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try alive_auto
+  try bv_auto
   all_goals sorry
 
 theorem bv_AndOrXor_2243__B__C__A__B___B__A__C :
@@ -436,7 +436,7 @@ theorem bv_AndOrXor_2243__B__C__A__B___B__A__C :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try alive_auto
+  try bv_auto
   all_goals sorry
 
 theorem bv_AndOrXor_2247__A__B__A__B :
@@ -447,7 +447,7 @@ theorem bv_AndOrXor_2247__A__B__A__B :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try alive_auto
+  try bv_auto
   all_goals sorry
 
 theorem bv_AndOrXor_2263 :
@@ -456,7 +456,7 @@ theorem bv_AndOrXor_2263 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try alive_auto
+  try bv_auto
   all_goals sorry
 
 theorem bv_AndOrXor_2264 :
@@ -466,7 +466,7 @@ theorem bv_AndOrXor_2264 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try alive_auto
+  try bv_auto
   all_goals sorry
 
 theorem bv_AndOrXor_2265 :
@@ -475,7 +475,7 @@ theorem bv_AndOrXor_2265 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try alive_auto
+  try bv_auto
   all_goals sorry
 
 theorem bv_AndOrXor_2284 :
@@ -485,7 +485,7 @@ theorem bv_AndOrXor_2284 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try alive_auto
+  try bv_auto
   all_goals sorry
 
 theorem bv_AndOrXor_2285 :
@@ -495,7 +495,7 @@ theorem bv_AndOrXor_2285 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try alive_auto
+  try bv_auto
   all_goals sorry
 
 theorem bv_AndOrXor_2297 :
@@ -506,7 +506,7 @@ theorem bv_AndOrXor_2297 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try alive_auto
+  try bv_auto
   all_goals sorry
 
 theorem bv_AndOrXor_2367 :
@@ -515,7 +515,7 @@ theorem bv_AndOrXor_2367 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try alive_auto
+  try bv_auto
   all_goals sorry
 
 theorem bv_AndOrXor_2416 :
@@ -526,7 +526,7 @@ theorem bv_AndOrXor_2416 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try alive_auto
+  try bv_auto
   all_goals sorry
 
 theorem bv_AndOrXor_2417 :
@@ -537,7 +537,7 @@ theorem bv_AndOrXor_2417 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try alive_auto
+  try bv_auto
   all_goals sorry
 
 theorem bv_AndOrXor_2429 :
@@ -548,7 +548,7 @@ theorem bv_AndOrXor_2429 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try alive_auto
+  try bv_auto
   all_goals sorry
 
 theorem bv_AndOrXor_2430 :
@@ -559,7 +559,7 @@ theorem bv_AndOrXor_2430 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try alive_auto
+  try bv_auto
   all_goals sorry
 
 theorem bv_AndOrXor_2443 :
@@ -569,7 +569,7 @@ theorem bv_AndOrXor_2443 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try alive_auto
+  try bv_auto
   all_goals sorry
 
 theorem bv_AndOrXor_2453 :
@@ -579,7 +579,7 @@ theorem bv_AndOrXor_2453 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try alive_auto
+  try bv_auto
   all_goals sorry
 
 theorem bv_AndOrXor_2475 :
@@ -588,7 +588,7 @@ theorem bv_AndOrXor_2475 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try alive_auto
+  try bv_auto
   all_goals sorry
 
 theorem bv_AndOrXor_2486 :
@@ -597,7 +597,7 @@ theorem bv_AndOrXor_2486 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try alive_auto
+  try bv_auto
   all_goals sorry
 
 theorem bv_AndOrXor_2581__BAB___A__B :
@@ -606,7 +606,7 @@ theorem bv_AndOrXor_2581__BAB___A__B :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try alive_auto
+  try bv_auto
   all_goals sorry
 
 theorem bv_AndOrXor_2587__BAA___B__A :
@@ -615,7 +615,7 @@ theorem bv_AndOrXor_2587__BAA___B__A :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try alive_auto
+  try bv_auto
   all_goals sorry
 
 theorem bv_AndOrXor_2595 :
@@ -624,7 +624,7 @@ theorem bv_AndOrXor_2595 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try alive_auto
+  try bv_auto
   all_goals sorry
 
 theorem bv_AndOrXor_2607 :
@@ -635,7 +635,7 @@ theorem bv_AndOrXor_2607 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try alive_auto
+  try bv_auto
   all_goals sorry
 
 theorem bv_AndOrXor_2617 :
@@ -646,7 +646,7 @@ theorem bv_AndOrXor_2617 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try alive_auto
+  try bv_auto
   all_goals sorry
 
 theorem bv_AndOrXor_2627 :
@@ -656,7 +656,7 @@ theorem bv_AndOrXor_2627 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try alive_auto
+  try bv_auto
   all_goals sorry
 
 theorem bv_AndOrXor_2647 :
@@ -665,7 +665,7 @@ theorem bv_AndOrXor_2647 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try alive_auto
+  try bv_auto
   all_goals sorry
 
 theorem bv_AndOrXor_2658 :
@@ -676,7 +676,7 @@ theorem bv_AndOrXor_2658 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try alive_auto
+  try bv_auto
   all_goals sorry
 
 theorem bv_AndOrXor_2663 :
@@ -686,7 +686,7 @@ theorem bv_AndOrXor_2663 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try alive_auto
+  try bv_auto
   all_goals sorry
 
 theorem bv_152 :
@@ -695,7 +695,7 @@ theorem bv_152 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try alive_auto
+  try bv_auto
   all_goals sorry
 
 theorem bv_229 :
@@ -704,7 +704,7 @@ theorem bv_229 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try alive_auto
+  try bv_auto
   all_goals sorry
 
 theorem bv_239 :
@@ -713,7 +713,7 @@ theorem bv_239 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try alive_auto
+  try bv_auto
   all_goals sorry
 
 theorem bv_275 :
@@ -722,7 +722,7 @@ theorem bv_275 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try alive_auto
+  try bv_auto
   all_goals sorry
 
 theorem bv_275_2 :
@@ -731,7 +731,7 @@ theorem bv_275_2 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try alive_auto
+  try bv_auto
   all_goals sorry
 
 theorem bv_276 :
@@ -740,7 +740,7 @@ theorem bv_276 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try alive_auto
+  try bv_auto
   all_goals sorry
 
 theorem bv_276_2 :
@@ -749,7 +749,7 @@ theorem bv_276_2 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try alive_auto
+  try bv_auto
   all_goals sorry
 
 theorem bv_283 :
@@ -758,7 +758,7 @@ theorem bv_283 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try alive_auto
+  try bv_auto
   all_goals sorry
 
 theorem bv_290__292 :
@@ -767,7 +767,7 @@ theorem bv_290__292 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try alive_auto
+  try bv_auto
   all_goals sorry
 
 theorem bv_820 :
@@ -776,7 +776,7 @@ theorem bv_820 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try alive_auto
+  try bv_auto
   all_goals sorry
 
 theorem bv_820' :
@@ -785,7 +785,7 @@ theorem bv_820' :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try alive_auto
+  try bv_auto
   all_goals sorry
 
 theorem bv_1030 :
@@ -794,7 +794,7 @@ theorem bv_1030 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try alive_auto
+  try bv_auto
   all_goals sorry
 
 theorem bv_Select_858 :
@@ -804,7 +804,7 @@ theorem bv_Select_858 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try alive_auto
+  try bv_auto
   all_goals sorry
 
 theorem bv_Select_859' :
@@ -814,7 +814,7 @@ theorem bv_Select_859' :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try alive_auto
+  try bv_auto
   all_goals sorry
 
 theorem bv_select_1100 :
@@ -823,7 +823,7 @@ theorem bv_select_1100 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try alive_auto
+  try bv_auto
   all_goals sorry
 
 theorem bv_Select_1105 :
@@ -832,7 +832,7 @@ theorem bv_Select_1105 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try alive_auto
+  try bv_auto
   all_goals sorry
 
 theorem bv_InstCombineShift__239 :
@@ -841,7 +841,7 @@ theorem bv_InstCombineShift__239 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try alive_auto
+  try bv_auto
   all_goals sorry
 
 theorem bv_InstCombineShift__279 :
@@ -850,7 +850,7 @@ theorem bv_InstCombineShift__279 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try alive_auto
+  try bv_auto
   all_goals sorry
 
 theorem bv_InstCombineShift__440 :
@@ -861,7 +861,7 @@ theorem bv_InstCombineShift__440 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try alive_auto
+  try bv_auto
   all_goals sorry
 
 theorem bv_InstCombineShift__476 :
@@ -872,7 +872,7 @@ theorem bv_InstCombineShift__476 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try alive_auto
+  try bv_auto
   all_goals sorry
 
 theorem bv_InstCombineShift__497 :
@@ -881,7 +881,7 @@ theorem bv_InstCombineShift__497 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try alive_auto
+  try bv_auto
   all_goals sorry
 
 theorem bv_InstCombineShift__497''' :
@@ -890,7 +890,7 @@ theorem bv_InstCombineShift__497''' :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try alive_auto
+  try bv_auto
   all_goals sorry
 
 theorem bv_InstCombineShift__582 :
@@ -899,5 +899,5 @@ theorem bv_InstCombineShift__582 :
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try alive_auto
+  try bv_auto
   all_goals sorry

--- a/SSA/Projects/InstCombine/update_alive_statements.py
+++ b/SSA/Projects/InstCombine/update_alive_statements.py
@@ -102,8 +102,10 @@ def getStatement(preamble: List[str], id : int, proof: List[str]) -> (str, str):
   simp_alive_ops
   simp_alive_case_bash
   simp_alive_split
-  try bv_auto
-  all_goals sorry'''
+  all_goals
+    solve
+    | bv_auto
+    | sorry'''
 
     print(stmt)
 

--- a/SSA/Projects/InstCombine/update_alive_statements.py
+++ b/SSA/Projects/InstCombine/update_alive_statements.py
@@ -97,7 +97,13 @@ def getStatement(preamble: List[str], id : int, proof: List[str]) -> (str, str):
     stmt = name
     stmt += msg
     stmt_sorry = stmt + " := by\n  sorry"
-    stmt += " := by\n  simp_alive_undef\n  simp_alive_ops\n  simp_alive_case_bash\n  simp_alive_split\n  try alive_auto\n  all_goals sorry"
+    stmt += ''' := by
+  simp_alive_undef
+  simp_alive_ops
+  simp_alive_case_bash
+  simp_alive_split
+  try bv_auto
+  all_goals sorry'''
 
     print(stmt)
 


### PR DESCRIPTION
alive_auto is a tactic that runs the whole stack of `simp_alive_{ops, undef, etc.}` simplification tactics before finally calling out to `bv_auto` (the actual bitvec level solver tactic). Since we already run through the simplification stack of tactics in AliveStatements, the latter is thus much more appropriate.