### PR TITLE
chore: rename IntPredicate -> IntPred in LLVM tests

### DIFF
--- a/SSA/Projects/InstCombine/tests/proofs/g2004h08h10hBoolSetCC_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/g2004h08h10hBoolSetCC_proof.lean
@@ -11,7 +11,7 @@ set_option maxRecDepth 1000000
 set_option Elab.async false
 
 section g2004h08h10hBoolSetCC_proof
-theorem test_thm (e : IntW 1) : icmp IntPredicate.ult e (const? 1 0) ⊑ const? 1 0 := by
+theorem test_thm (e : IntW 1) : icmp IntPred.ult e (const? 1 0) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/g2004h09h28hBadShiftAndSetCC_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/g2004h09h28hBadShiftAndSetCC_proof.lean
@@ -12,8 +12,8 @@ set_option Elab.async false
 
 section g2004h09h28hBadShiftAndSetCC_proof
 theorem test_thm (e : IntW 32) :
-  icmp IntPredicate.eq (LLVM.and (shl e (const? 32 8)) (const? 32 (-16777216))) (const? 32 167772160) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 32 16711680)) (const? 32 655360) := by
+  icmp IntPred.eq (LLVM.and (shl e (const? 32 8)) (const? 32 (-16777216))) (const? 32 167772160) ⊑
+    icmp IntPred.eq (LLVM.and e (const? 32 16711680)) (const? 32 655360) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/g2004h11h27hSetCCForCastLargerAndConstant_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/g2004h11h27hSetCCForCastLargerAndConstant_proof.lean
@@ -12,7 +12,7 @@ set_option Elab.async false
 
 section g2004h11h27hSetCCForCastLargerAndConstant_proof
 theorem lt_signed_to_large_unsigned_thm (e : IntW 8) :
-  icmp IntPredicate.ult (sext 32 e) (const? 32 1024) ⊑ icmp IntPredicate.sgt e (const? 8 (-1)) := by
+  icmp IntPred.ult (sext 32 e) (const? 32 1024) ⊑ icmp IntPred.sgt e (const? 8 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -21,7 +21,7 @@ theorem lt_signed_to_large_unsigned_thm (e : IntW 8) :
     all_goals sorry
 
 
-theorem lt_signed_to_large_signed_thm (e : IntW 8) : icmp IntPredicate.slt (sext 32 e) (const? 32 1024) ⊑ const? 1 1 := by
+theorem lt_signed_to_large_signed_thm (e : IntW 8) : icmp IntPred.slt (sext 32 e) (const? 32 1024) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -30,7 +30,7 @@ theorem lt_signed_to_large_signed_thm (e : IntW 8) : icmp IntPredicate.slt (sext
     all_goals sorry
 
 
-theorem lt_signed_to_large_negative_thm (e : IntW 8) : icmp IntPredicate.slt (sext 32 e) (const? 32 (-1024)) ⊑ const? 1 0 := by
+theorem lt_signed_to_large_negative_thm (e : IntW 8) : icmp IntPred.slt (sext 32 e) (const? 32 (-1024)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -40,7 +40,7 @@ theorem lt_signed_to_large_negative_thm (e : IntW 8) : icmp IntPredicate.slt (se
 
 
 theorem lt_signed_to_small_unsigned_thm (e : IntW 8) :
-  icmp IntPredicate.ult (sext 32 e) (const? 32 17) ⊑ icmp IntPredicate.ult e (const? 8 17) := by
+  icmp IntPred.ult (sext 32 e) (const? 32 17) ⊑ icmp IntPred.ult e (const? 8 17) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -50,7 +50,7 @@ theorem lt_signed_to_small_unsigned_thm (e : IntW 8) :
 
 
 theorem lt_signed_to_small_signed_thm (e : IntW 8) :
-  icmp IntPredicate.slt (sext 32 e) (const? 32 17) ⊑ icmp IntPredicate.slt e (const? 8 17) := by
+  icmp IntPred.slt (sext 32 e) (const? 32 17) ⊑ icmp IntPred.slt e (const? 8 17) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -60,7 +60,7 @@ theorem lt_signed_to_small_signed_thm (e : IntW 8) :
 
 
 theorem lt_signed_to_small_negative_thm (e : IntW 8) :
-  icmp IntPredicate.slt (sext 32 e) (const? 32 (-17)) ⊑ icmp IntPredicate.slt e (const? 8 (-17)) := by
+  icmp IntPred.slt (sext 32 e) (const? 32 (-17)) ⊑ icmp IntPred.slt e (const? 8 (-17)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -69,7 +69,7 @@ theorem lt_signed_to_small_negative_thm (e : IntW 8) :
     all_goals sorry
 
 
-theorem lt_unsigned_to_large_unsigned_thm (e : IntW 8) : icmp IntPredicate.ult (zext 32 e) (const? 32 1024) ⊑ const? 1 1 := by
+theorem lt_unsigned_to_large_unsigned_thm (e : IntW 8) : icmp IntPred.ult (zext 32 e) (const? 32 1024) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -78,7 +78,7 @@ theorem lt_unsigned_to_large_unsigned_thm (e : IntW 8) : icmp IntPredicate.ult (
     all_goals sorry
 
 
-theorem lt_unsigned_to_large_signed_thm (e : IntW 8) : icmp IntPredicate.slt (zext 32 e) (const? 32 1024) ⊑ const? 1 1 := by
+theorem lt_unsigned_to_large_signed_thm (e : IntW 8) : icmp IntPred.slt (zext 32 e) (const? 32 1024) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -87,7 +87,7 @@ theorem lt_unsigned_to_large_signed_thm (e : IntW 8) : icmp IntPredicate.slt (ze
     all_goals sorry
 
 
-theorem lt_unsigned_to_large_negative_thm (e : IntW 8) : icmp IntPredicate.slt (zext 32 e) (const? 32 (-1024)) ⊑ const? 1 0 := by
+theorem lt_unsigned_to_large_negative_thm (e : IntW 8) : icmp IntPred.slt (zext 32 e) (const? 32 (-1024)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -97,7 +97,7 @@ theorem lt_unsigned_to_large_negative_thm (e : IntW 8) : icmp IntPredicate.slt (
 
 
 theorem lt_unsigned_to_small_unsigned_thm (e : IntW 8) :
-  icmp IntPredicate.ult (zext 32 e) (const? 32 17) ⊑ icmp IntPredicate.ult e (const? 8 17) := by
+  icmp IntPred.ult (zext 32 e) (const? 32 17) ⊑ icmp IntPred.ult e (const? 8 17) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -107,7 +107,7 @@ theorem lt_unsigned_to_small_unsigned_thm (e : IntW 8) :
 
 
 theorem lt_unsigned_to_small_signed_thm (e : IntW 8) :
-  icmp IntPredicate.slt (zext 32 e) (const? 32 17) ⊑ icmp IntPredicate.ult e (const? 8 17) := by
+  icmp IntPred.slt (zext 32 e) (const? 32 17) ⊑ icmp IntPred.ult e (const? 8 17) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -116,7 +116,7 @@ theorem lt_unsigned_to_small_signed_thm (e : IntW 8) :
     all_goals sorry
 
 
-theorem lt_unsigned_to_small_negative_thm (e : IntW 8) : icmp IntPredicate.slt (zext 32 e) (const? 32 (-17)) ⊑ const? 1 0 := by
+theorem lt_unsigned_to_small_negative_thm (e : IntW 8) : icmp IntPred.slt (zext 32 e) (const? 32 (-17)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -126,7 +126,7 @@ theorem lt_unsigned_to_small_negative_thm (e : IntW 8) : icmp IntPredicate.slt (
 
 
 theorem gt_signed_to_large_unsigned_thm (e : IntW 8) :
-  icmp IntPredicate.ugt (sext 32 e) (const? 32 1024) ⊑ icmp IntPredicate.slt e (const? 8 0) := by
+  icmp IntPred.ugt (sext 32 e) (const? 32 1024) ⊑ icmp IntPred.slt e (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -135,7 +135,7 @@ theorem gt_signed_to_large_unsigned_thm (e : IntW 8) :
     all_goals sorry
 
 
-theorem gt_signed_to_large_signed_thm (e : IntW 8) : icmp IntPredicate.sgt (sext 32 e) (const? 32 1024) ⊑ const? 1 0 := by
+theorem gt_signed_to_large_signed_thm (e : IntW 8) : icmp IntPred.sgt (sext 32 e) (const? 32 1024) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -144,7 +144,7 @@ theorem gt_signed_to_large_signed_thm (e : IntW 8) : icmp IntPredicate.sgt (sext
     all_goals sorry
 
 
-theorem gt_signed_to_large_negative_thm (e : IntW 8) : icmp IntPredicate.sgt (sext 32 e) (const? 32 (-1024)) ⊑ const? 1 1 := by
+theorem gt_signed_to_large_negative_thm (e : IntW 8) : icmp IntPred.sgt (sext 32 e) (const? 32 (-1024)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -154,7 +154,7 @@ theorem gt_signed_to_large_negative_thm (e : IntW 8) : icmp IntPredicate.sgt (se
 
 
 theorem gt_signed_to_small_unsigned_thm (e : IntW 8) :
-  icmp IntPredicate.ugt (sext 32 e) (const? 32 17) ⊑ icmp IntPredicate.ugt e (const? 8 17) := by
+  icmp IntPred.ugt (sext 32 e) (const? 32 17) ⊑ icmp IntPred.ugt e (const? 8 17) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -164,7 +164,7 @@ theorem gt_signed_to_small_unsigned_thm (e : IntW 8) :
 
 
 theorem gt_signed_to_small_signed_thm (e : IntW 8) :
-  icmp IntPredicate.sgt (sext 32 e) (const? 32 17) ⊑ icmp IntPredicate.sgt e (const? 8 17) := by
+  icmp IntPred.sgt (sext 32 e) (const? 32 17) ⊑ icmp IntPred.sgt e (const? 8 17) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -174,7 +174,7 @@ theorem gt_signed_to_small_signed_thm (e : IntW 8) :
 
 
 theorem gt_signed_to_small_negative_thm (e : IntW 8) :
-  icmp IntPredicate.sgt (sext 32 e) (const? 32 (-17)) ⊑ icmp IntPredicate.sgt e (const? 8 (-17)) := by
+  icmp IntPred.sgt (sext 32 e) (const? 32 (-17)) ⊑ icmp IntPred.sgt e (const? 8 (-17)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -183,7 +183,7 @@ theorem gt_signed_to_small_negative_thm (e : IntW 8) :
     all_goals sorry
 
 
-theorem gt_unsigned_to_large_unsigned_thm (e : IntW 8) : icmp IntPredicate.ugt (zext 32 e) (const? 32 1024) ⊑ const? 1 0 := by
+theorem gt_unsigned_to_large_unsigned_thm (e : IntW 8) : icmp IntPred.ugt (zext 32 e) (const? 32 1024) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -192,7 +192,7 @@ theorem gt_unsigned_to_large_unsigned_thm (e : IntW 8) : icmp IntPredicate.ugt (
     all_goals sorry
 
 
-theorem gt_unsigned_to_large_signed_thm (e : IntW 8) : icmp IntPredicate.sgt (zext 32 e) (const? 32 1024) ⊑ const? 1 0 := by
+theorem gt_unsigned_to_large_signed_thm (e : IntW 8) : icmp IntPred.sgt (zext 32 e) (const? 32 1024) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -201,7 +201,7 @@ theorem gt_unsigned_to_large_signed_thm (e : IntW 8) : icmp IntPredicate.sgt (ze
     all_goals sorry
 
 
-theorem gt_unsigned_to_large_negative_thm (e : IntW 8) : icmp IntPredicate.sgt (zext 32 e) (const? 32 (-1024)) ⊑ const? 1 1 := by
+theorem gt_unsigned_to_large_negative_thm (e : IntW 8) : icmp IntPred.sgt (zext 32 e) (const? 32 (-1024)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -211,7 +211,7 @@ theorem gt_unsigned_to_large_negative_thm (e : IntW 8) : icmp IntPredicate.sgt (
 
 
 theorem gt_unsigned_to_small_unsigned_thm (e : IntW 8) :
-  icmp IntPredicate.ugt (zext 32 e) (const? 32 17) ⊑ icmp IntPredicate.ugt e (const? 8 17) := by
+  icmp IntPred.ugt (zext 32 e) (const? 32 17) ⊑ icmp IntPred.ugt e (const? 8 17) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -221,7 +221,7 @@ theorem gt_unsigned_to_small_unsigned_thm (e : IntW 8) :
 
 
 theorem gt_unsigned_to_small_signed_thm (e : IntW 8) :
-  icmp IntPredicate.sgt (zext 32 e) (const? 32 17) ⊑ icmp IntPredicate.ugt e (const? 8 17) := by
+  icmp IntPred.sgt (zext 32 e) (const? 32 17) ⊑ icmp IntPred.ugt e (const? 8 17) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -230,7 +230,7 @@ theorem gt_unsigned_to_small_signed_thm (e : IntW 8) :
     all_goals sorry
 
 
-theorem gt_unsigned_to_small_negative_thm (e : IntW 8) : icmp IntPredicate.sgt (zext 32 e) (const? 32 (-17)) ⊑ const? 1 1 := by
+theorem gt_unsigned_to_small_negative_thm (e : IntW 8) : icmp IntPred.sgt (zext 32 e) (const? 32 (-17)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -240,7 +240,7 @@ theorem gt_unsigned_to_small_negative_thm (e : IntW 8) : icmp IntPredicate.sgt (
 
 
 theorem different_size_zext_zext_ugt_thm (e : IntW 4) (e_1 : IntW 7) :
-  icmp IntPredicate.ugt (zext 25 e_1) (zext 25 e) ⊑ icmp IntPredicate.ugt e_1 (zext 7 e) := by
+  icmp IntPred.ugt (zext 25 e_1) (zext 25 e) ⊑ icmp IntPred.ugt e_1 (zext 7 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -250,7 +250,7 @@ theorem different_size_zext_zext_ugt_thm (e : IntW 4) (e_1 : IntW 7) :
 
 
 theorem different_size_zext_zext_ult_thm (e : IntW 7) (e_1 : IntW 4) :
-  icmp IntPredicate.ult (zext 25 e_1) (zext 25 e) ⊑ icmp IntPredicate.ugt e (zext 7 e_1) := by
+  icmp IntPred.ult (zext 25 e_1) (zext 25 e) ⊑ icmp IntPred.ugt e (zext 7 e_1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -260,7 +260,7 @@ theorem different_size_zext_zext_ult_thm (e : IntW 7) (e_1 : IntW 4) :
 
 
 theorem different_size_zext_zext_eq_thm (e : IntW 7) (e_1 : IntW 4) :
-  icmp IntPredicate.eq (zext 25 e_1) (zext 25 e) ⊑ icmp IntPredicate.eq e (zext 7 e_1) := by
+  icmp IntPred.eq (zext 25 e_1) (zext 25 e) ⊑ icmp IntPred.eq e (zext 7 e_1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -270,7 +270,7 @@ theorem different_size_zext_zext_eq_thm (e : IntW 7) (e_1 : IntW 4) :
 
 
 theorem different_size_zext_zext_ne_commute_thm (e : IntW 4) (e_1 : IntW 7) :
-  icmp IntPredicate.ne (zext 25 e_1) (zext 25 e) ⊑ icmp IntPredicate.ne e_1 (zext 7 e) := by
+  icmp IntPred.ne (zext 25 e_1) (zext 25 e) ⊑ icmp IntPred.ne e_1 (zext 7 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -280,7 +280,7 @@ theorem different_size_zext_zext_ne_commute_thm (e : IntW 4) (e_1 : IntW 7) :
 
 
 theorem different_size_zext_zext_slt_thm (e : IntW 4) (e_1 : IntW 7) :
-  icmp IntPredicate.slt (zext 25 e_1) (zext 25 e) ⊑ icmp IntPredicate.ult e_1 (zext 7 e) := by
+  icmp IntPred.slt (zext 25 e_1) (zext 25 e) ⊑ icmp IntPred.ult e_1 (zext 7 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -290,7 +290,7 @@ theorem different_size_zext_zext_slt_thm (e : IntW 4) (e_1 : IntW 7) :
 
 
 theorem different_size_zext_zext_sgt_thm (e : IntW 4) (e_1 : IntW 7) :
-  icmp IntPredicate.sgt (zext 25 e_1) (zext 25 e) ⊑ icmp IntPredicate.ugt e_1 (zext 7 e) := by
+  icmp IntPred.sgt (zext 25 e_1) (zext 25 e) ⊑ icmp IntPred.ugt e_1 (zext 7 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -300,7 +300,7 @@ theorem different_size_zext_zext_sgt_thm (e : IntW 4) (e_1 : IntW 7) :
 
 
 theorem different_size_sext_sext_sgt_thm (e : IntW 4) (e_1 : IntW 7) :
-  icmp IntPredicate.sgt (sext 25 e_1) (sext 25 e) ⊑ icmp IntPredicate.sgt e_1 (sext 7 e) := by
+  icmp IntPred.sgt (sext 25 e_1) (sext 25 e) ⊑ icmp IntPred.sgt e_1 (sext 7 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -310,7 +310,7 @@ theorem different_size_sext_sext_sgt_thm (e : IntW 4) (e_1 : IntW 7) :
 
 
 theorem different_size_sext_sext_sle_thm (e : IntW 4) (e_1 : IntW 7) :
-  icmp IntPredicate.sle (sext 25 e_1) (sext 25 e) ⊑ icmp IntPredicate.sle e_1 (sext 7 e) := by
+  icmp IntPred.sle (sext 25 e_1) (sext 25 e) ⊑ icmp IntPred.sle e_1 (sext 7 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -320,7 +320,7 @@ theorem different_size_sext_sext_sle_thm (e : IntW 4) (e_1 : IntW 7) :
 
 
 theorem different_size_sext_sext_eq_thm (e : IntW 4) (e_1 : IntW 7) :
-  icmp IntPredicate.eq (sext 25 e_1) (sext 25 e) ⊑ icmp IntPredicate.eq e_1 (sext 7 e) := by
+  icmp IntPred.eq (sext 25 e_1) (sext 25 e) ⊑ icmp IntPred.eq e_1 (sext 7 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -330,7 +330,7 @@ theorem different_size_sext_sext_eq_thm (e : IntW 4) (e_1 : IntW 7) :
 
 
 theorem different_size_sext_sext_ule_thm (e : IntW 4) (e_1 : IntW 7) :
-  icmp IntPredicate.ule (sext 25 e_1) (sext 25 e) ⊑ icmp IntPredicate.ule e_1 (sext 7 e) := by
+  icmp IntPred.ule (sext 25 e_1) (sext 25 e) ⊑ icmp IntPred.ule e_1 (sext 7 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/g2005h03h04hShiftOverflow_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/g2005h03h04hShiftOverflow_proof.lean
@@ -12,7 +12,7 @@ set_option Elab.async false
 
 section g2005h03h04hShiftOverflow_proof
 theorem test_thm (e : IntW 64) :
-  icmp IntPredicate.ugt (lshr e (const? 64 1)) (const? 64 0) ⊑ icmp IntPredicate.ugt e (const? 64 1) := by
+  icmp IntPred.ugt (lshr e (const? 64 1)) (const? 64 0) ⊑ icmp IntPred.ugt e (const? 64 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/g2005h06h16hRangeCrash_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/g2005h06h16hRangeCrash_proof.lean
@@ -12,7 +12,7 @@ set_option Elab.async false
 
 section g2005h06h16hRangeCrash_proof
 theorem test_thm :
-  icmp IntPredicate.eq (LLVM.sdiv (const? 32 0) (const? 32 (-2147483648))) (const? 32 0) ⊑ const? 1 1 := by
+  icmp IntPred.eq (LLVM.sdiv (const? 32 0) (const? 32 (-2147483648))) (const? 32 0) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/g2006h02h28hCrash_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/g2006h02h28hCrash_proof.lean
@@ -11,7 +11,7 @@ set_option maxRecDepth 1000000
 set_option Elab.async false
 
 section g2006h02h28hCrash_proof
-theorem test_thm : zext 32 (icmp IntPredicate.eq (const? 32 1) (const? 32 2)) ⊑ const? 32 0 := by
+theorem test_thm : zext 32 (icmp IntPred.eq (const? 32 1) (const? 32 2)) ⊑ const? 32 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/g2006h10h19hSignedToUnsignedCastAndConsth2_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/g2006h10h19hSignedToUnsignedCastAndConsth2_proof.lean
@@ -12,7 +12,7 @@ set_option Elab.async false
 
 section g2006h10h19hSignedToUnsignedCastAndConsth2_proof
 theorem eq_signed_to_small_unsigned_thm (e : IntW 8) :
-  icmp IntPredicate.eq (sext 32 e) (const? 32 17) ⊑ icmp IntPredicate.eq e (const? 8 17) := by
+  icmp IntPred.eq (sext 32 e) (const? 32 17) ⊑ icmp IntPred.eq e (const? 8 17) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/g2007h01h13hExtCompareMiscompile_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/g2007h01h13hExtCompareMiscompile_proof.lean
@@ -12,7 +12,7 @@ set_option Elab.async false
 
 section g2007h01h13hExtCompareMiscompile_proof
 theorem test_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.sgt (zext 32 e_1) (zext 32 e) ⊑ icmp IntPredicate.ugt e_1 e := by
+  icmp IntPred.sgt (zext 32 e_1) (zext 32 e) ⊑ icmp IntPred.ugt e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/g2007h03h13hCompareMerge_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/g2007h03h13hCompareMerge_proof.lean
@@ -12,7 +12,7 @@ set_option Elab.async false
 
 section g2007h03h13hCompareMerge_proof
 theorem test_thm (e e_1 : IntW 32) :
-  LLVM.or (icmp IntPredicate.slt e_1 e) (icmp IntPredicate.eq e_1 e) ⊑ icmp IntPredicate.sle e_1 e := by
+  LLVM.or (icmp IntPred.slt e_1 e) (icmp IntPred.eq e_1 e) ⊑ icmp IntPred.sle e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -22,7 +22,7 @@ theorem test_thm (e e_1 : IntW 32) :
 
 
 theorem test_logical_thm (e e_1 : IntW 32) :
-  select (icmp IntPredicate.slt e_1 e) (const? 1 1) (icmp IntPredicate.eq e_1 e) ⊑ icmp IntPredicate.sle e_1 e := by
+  select (icmp IntPred.slt e_1 e) (const? 1 1) (icmp IntPred.eq e_1 e) ⊑ icmp IntPred.sle e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/g2007h03h21hSignedRangeTest_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/g2007h03h21hSignedRangeTest_proof.lean
@@ -12,8 +12,8 @@ set_option Elab.async false
 
 section g2007h03h21hSignedRangeTest_proof
 theorem test_thm (e : IntW 32) :
-  icmp IntPredicate.ne (LLVM.sdiv e (const? 32 12)) (const? 32 (-6)) ⊑
-    icmp IntPredicate.ult (add e (const? 32 71)) (const? 32 (-12)) := by
+  icmp IntPred.ne (LLVM.sdiv e (const? 32 12)) (const? 32 (-6)) ⊑
+    icmp IntPred.ult (add e (const? 32 71)) (const? 32 (-12)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/g2007h03h25hDoubleShift_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/g2007h03h25hDoubleShift_proof.lean
@@ -12,8 +12,8 @@ set_option Elab.async false
 
 section g2007h03h25hDoubleShift_proof
 theorem test_thm (e : IntW 32) :
-  icmp IntPredicate.ne (lshr (shl e (const? 32 12)) (const? 32 12)) (const? 32 0) ⊑
-    icmp IntPredicate.ne (LLVM.and e (const? 32 1048575)) (const? 32 0) := by
+  icmp IntPred.ne (lshr (shl e (const? 32 12)) (const? 32 12)) (const? 32 0) ⊑
+    icmp IntPred.ne (LLVM.and e (const? 32 1048575)) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/g2007h05h10hicmphor_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/g2007h05h10hicmphor_proof.lean
@@ -12,8 +12,8 @@ set_option Elab.async false
 
 section g2007h05h10hicmphor_proof
 theorem test_thm (e : IntW 32) :
-  LLVM.or (icmp IntPredicate.ugt e (const? 32 255)) (icmp IntPredicate.sgt e (const? 32 255)) ⊑
-    icmp IntPredicate.ugt e (const? 32 255) := by
+  LLVM.or (icmp IntPred.ugt e (const? 32 255)) (icmp IntPred.sgt e (const? 32 255)) ⊑
+    icmp IntPred.ugt e (const? 32 255) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -23,8 +23,8 @@ theorem test_thm (e : IntW 32) :
 
 
 theorem test_logical_thm (e : IntW 32) :
-  select (icmp IntPredicate.ugt e (const? 32 255)) (const? 1 1) (icmp IntPredicate.sgt e (const? 32 255)) ⊑
-    icmp IntPredicate.ugt e (const? 32 255) := by
+  select (icmp IntPred.ugt e (const? 32 255)) (const? 1 1) (icmp IntPred.sgt e (const? 32 255)) ⊑
+    icmp IntPred.ugt e (const? 32 255) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/g2007h06h21hDivCompareMiscomp_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/g2007h06h21hDivCompareMiscomp_proof.lean
@@ -12,7 +12,7 @@ set_option Elab.async false
 
 section g2007h06h21hDivCompareMiscomp_proof
 theorem test_thm (e : IntW 32) :
-  icmp IntPredicate.ult (LLVM.udiv e (const? 32 4)) (const? 32 1073741824) ⊑ const? 1 1 := by
+  icmp IntPred.ult (LLVM.udiv e (const? 32 4)) (const? 32 1073741824) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/g2007h11h15hCompareMiscomp_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/g2007h11h15hCompareMiscomp_proof.lean
@@ -12,8 +12,8 @@ set_option Elab.async false
 
 section g2007h11h15hCompareMiscomp_proof
 theorem test_thm (e : IntW 32) :
-  LLVM.and (icmp IntPredicate.sgt e (const? 32 (-1))) (icmp IntPredicate.eq e (const? 32 1)) ⊑
-    icmp IntPredicate.eq e (const? 32 1) := by
+  LLVM.and (icmp IntPred.sgt e (const? 32 (-1))) (icmp IntPred.eq e (const? 32 1)) ⊑
+    icmp IntPred.eq e (const? 32 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -23,8 +23,8 @@ theorem test_thm (e : IntW 32) :
 
 
 theorem test_logical_thm (e : IntW 32) :
-  select (icmp IntPredicate.sgt e (const? 32 (-1))) (icmp IntPredicate.eq e (const? 32 1)) (const? 1 0) ⊑
-    icmp IntPredicate.eq e (const? 32 1) := by
+  select (icmp IntPred.sgt e (const? 32 (-1))) (icmp IntPred.eq e (const? 32 1)) (const? 1 0) ⊑
+    icmp IntPred.eq e (const? 32 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/g2008h01h13hAndCmpCmp_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/g2008h01h13hAndCmpCmp_proof.lean
@@ -12,8 +12,8 @@ set_option Elab.async false
 
 section g2008h01h13hAndCmpCmp_proof
 theorem test_logical_thm (e : IntW 32) :
-  select (icmp IntPredicate.ne e (const? 32 34)) (icmp IntPredicate.sgt e (const? 32 (-1))) (const? 1 0) ⊑
-    LLVM.and (icmp IntPredicate.ne e (const? 32 34)) (icmp IntPredicate.sgt e (const? 32 (-1))) := by
+  select (icmp IntPred.ne e (const? 32 34)) (icmp IntPred.sgt e (const? 32 (-1))) (const? 1 0) ⊑
+    LLVM.and (icmp IntPred.ne e (const? 32 34)) (icmp IntPred.sgt e (const? 32 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/g2008h06h21hCompareMiscomp_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/g2008h06h21hCompareMiscomp_proof.lean
@@ -12,8 +12,8 @@ set_option Elab.async false
 
 section g2008h06h21hCompareMiscomp_proof
 theorem test_thm (e : IntW 32) :
-  LLVM.and (icmp IntPredicate.ugt e (const? 32 13)) (icmp IntPredicate.eq e (const? 32 15)) ⊑
-    icmp IntPredicate.eq e (const? 32 15) := by
+  LLVM.and (icmp IntPred.ugt e (const? 32 13)) (icmp IntPred.eq e (const? 32 15)) ⊑
+    icmp IntPred.eq e (const? 32 15) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -23,8 +23,8 @@ theorem test_thm (e : IntW 32) :
 
 
 theorem test_logical_thm (e : IntW 32) :
-  select (icmp IntPredicate.ugt e (const? 32 13)) (icmp IntPredicate.eq e (const? 32 15)) (const? 1 0) ⊑
-    icmp IntPredicate.eq e (const? 32 15) := by
+  select (icmp IntPred.ugt e (const? 32 13)) (icmp IntPred.eq e (const? 32 15)) (const? 1 0) ⊑
+    icmp IntPred.eq e (const? 32 15) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/g2008h07h08hShiftOneAndOne_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/g2008h07h08hShiftOneAndOne_proof.lean
@@ -12,8 +12,8 @@ set_option Elab.async false
 
 section g2008h07h08hShiftOneAndOne_proof
 theorem PR2330_thm (e : IntW 32) :
-  icmp IntPredicate.eq (LLVM.and (shl (const? 32 1) e) (const? 32 1)) (const? 32 0) ⊑
-    icmp IntPredicate.ne e (const? 32 0) := by
+  icmp IntPred.eq (LLVM.and (shl (const? 32 1) e) (const? 32 1)) (const? 32 0) ⊑
+    icmp IntPred.ne e (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/g2008h07h10hCastSextBool_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/g2008h07h10hCastSextBool_proof.lean
@@ -11,7 +11,7 @@ set_option maxRecDepth 1000000
 set_option Elab.async false
 
 section g2008h07h10hCastSextBool_proof
-theorem PR2539_A_thm (e : IntW 1) : icmp IntPredicate.slt (zext 32 e) (const? 32 1) ⊑ LLVM.xor e (const? 1 1) := by
+theorem PR2539_A_thm (e : IntW 1) : icmp IntPred.slt (zext 32 e) (const? 32 1) ⊑ LLVM.xor e (const? 1 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -20,7 +20,7 @@ theorem PR2539_A_thm (e : IntW 1) : icmp IntPredicate.slt (zext 32 e) (const? 32
     all_goals sorry
 
 
-theorem PR2539_B_thm (e : IntW 1) : icmp IntPredicate.slt e (const? 1 1) ⊑ const? 1 0 := by
+theorem PR2539_B_thm (e : IntW 1) : icmp IntPred.slt e (const? 1 1) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/g2008h10h11hDivCompareFold_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/g2008h10h11hDivCompareFold_proof.lean
@@ -12,7 +12,7 @@ set_option Elab.async false
 
 section g2008h10h11hDivCompareFold_proof
 theorem x_thm (e : IntW 32) :
-  icmp IntPredicate.slt (LLVM.sdiv e (const? 32 65536)) (const? 32 (-65536)) ⊑ const? 1 0 := by
+  icmp IntPred.slt (LLVM.sdiv e (const? 32 65536)) (const? 32 (-65536)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/g2008h11h01hSRemDemandedBits_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/g2008h11h01hSRemDemandedBits_proof.lean
@@ -12,7 +12,7 @@ set_option Elab.async false
 
 section g2008h11h01hSRemDemandedBits_proof
 theorem foo_thm (e : IntW 32) :
-  icmp IntPredicate.eq (LLVM.srem e (const? 32 (-1))) (const? 32 0) ⊑ const? 1 1 := by
+  icmp IntPred.eq (LLVM.srem e (const? 32 (-1))) (const? 32 0) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/g2009h03h24hInfLoop_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/g2009h03h24hInfLoop_proof.lean
@@ -12,8 +12,8 @@ set_option Elab.async false
 
 section g2009h03h24hInfLoop_proof
 theorem test_thm (e : IntW 32) :
-  icmp IntPredicate.eq (LLVM.and (lshr (const? 32 3968) e) (const? 32 1)) (const? 32 0) ⊑
-    icmp IntPredicate.eq (LLVM.and (shl (const? 32 1) e { «nsw» := false, «nuw» := true }) (const? 32 3968))
+  icmp IntPred.eq (LLVM.and (lshr (const? 32 3968) e) (const? 32 1)) (const? 32 0) ⊑
+    icmp IntPred.eq (LLVM.and (shl (const? 32 1) e { «nsw» := false, «nuw» := true }) (const? 32 3968))
       (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops

--- a/SSA/Projects/InstCombine/tests/proofs/g2010h11h23hDistributed_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/g2010h11h23hDistributed_proof.lean
@@ -24,8 +24,8 @@ theorem foo_thm (e e_1 : IntW 32) :
 
 
 theorem bar_thm (e e_1 : IntW 64) :
-  icmp IntPredicate.eq (LLVM.and e_1 (LLVM.xor (LLVM.and e_1 e) (const? 64 (-1)))) (const? 64 0) ⊑
-    icmp IntPredicate.eq (LLVM.and e_1 (LLVM.xor e (const? 64 (-1)))) (const? 64 0) := by
+  icmp IntPred.eq (LLVM.and e_1 (LLVM.xor (LLVM.and e_1 e) (const? 64 (-1)))) (const? 64 0) ⊑
+    icmp IntPred.eq (LLVM.and e_1 (LLVM.xor e (const? 64 (-1)))) (const? 64 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/g2012h02h28hICmp_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/g2012h02h28hICmp_proof.lean
@@ -12,10 +12,10 @@ set_option Elab.async false
 
 section g2012h02h28hICmp_proof
 theorem f1_logical_thm (e : IntW 32) :
-  select (icmp IntPredicate.ne (trunc 8 e) (const? 8 0))
-      (icmp IntPredicate.ne (LLVM.and e (const? 32 16711680)) (const? 32 0)) (const? 1 0) ⊑
-    LLVM.and (icmp IntPredicate.ne (trunc 8 e) (const? 8 0))
-      (icmp IntPredicate.ne (LLVM.and e (const? 32 16711680)) (const? 32 0)) := by
+  select (icmp IntPred.ne (trunc 8 e) (const? 8 0))
+      (icmp IntPred.ne (LLVM.and e (const? 32 16711680)) (const? 32 0)) (const? 1 0) ⊑
+    LLVM.and (icmp IntPred.ne (trunc 8 e) (const? 8 0))
+      (icmp IntPred.ne (LLVM.and e (const? 32 16711680)) (const? 32 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gJavaCompare_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gJavaCompare_proof.lean
@@ -12,11 +12,11 @@ set_option Elab.async false
 
 section gJavaCompare_proof
 theorem le_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.sle
-      (select (icmp IntPredicate.slt e_1 e) (const? 32 (-1))
-        (select (icmp IntPredicate.sgt e_1 e) (const? 32 1) (const? 32 0)))
+  icmp IntPred.sle
+      (select (icmp IntPred.slt e_1 e) (const? 32 (-1))
+        (select (icmp IntPred.sgt e_1 e) (const? 32 1) (const? 32 0)))
       (const? 32 0) ⊑
-    icmp IntPredicate.sle e_1 e := by
+    icmp IntPred.sle e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gabsh1_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gabsh1_proof.lean
@@ -12,8 +12,8 @@ set_option Elab.async false
 
 section gabsh1_proof
 theorem abs_must_be_positive_thm (e : IntW 32) :
-  icmp IntPredicate.sge
-      (select (icmp IntPredicate.sge e (const? 32 0)) e (sub (const? 32 0) e { «nsw» := true, «nuw» := false }))
+  icmp IntPred.sge
+      (select (icmp IntPred.sge e (const? 32 0)) e (sub (const? 32 0) e { «nsw» := true, «nuw» := false }))
       (const? 32 0) ⊑
     const? 1 1 := by
     simp_alive_undef
@@ -25,7 +25,7 @@ theorem abs_must_be_positive_thm (e : IntW 32) :
 
 
 theorem abs_diff_signed_slt_swap_wrong_pred1_thm (e e_1 : IntW 32) :
-  select (icmp IntPredicate.eq e_1 e) (sub e e_1 { «nsw» := true, «nuw» := false })
+  select (icmp IntPred.eq e_1 e) (sub e e_1 { «nsw» := true, «nuw» := false })
       (sub e_1 e { «nsw» := true, «nuw» := false }) ⊑
     sub e_1 e { «nsw» := true, «nuw» := false } := by
     simp_alive_undef

--- a/SSA/Projects/InstCombine/tests/proofs/gaddhmask_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gaddhmask_proof.lean
@@ -13,7 +13,7 @@ set_option Elab.async false
 section gaddhmask_proof
 theorem add_mask_sign_i32_thm (e : IntW 32) :
   add (LLVM.and (ashr e (const? 32 31)) (const? 32 8)) (ashr e (const? 32 31)) ⊑
-    select (icmp IntPredicate.slt e (const? 32 0)) (const? 32 7) (const? 32 0) := by
+    select (icmp IntPred.slt e (const? 32 0)) (const? 32 7) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -24,7 +24,7 @@ theorem add_mask_sign_i32_thm (e : IntW 32) :
 
 theorem add_mask_sign_commute_i32_thm (e : IntW 32) :
   add (ashr e (const? 32 31)) (LLVM.and (ashr e (const? 32 31)) (const? 32 8)) ⊑
-    select (icmp IntPredicate.slt e (const? 32 0)) (const? 32 7) (const? 32 0) := by
+    select (icmp IntPred.slt e (const? 32 0)) (const? 32 7) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gaddhshlhsdivhtohsrem_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gaddhshlhsdivhtohsrem_proof.lean
@@ -64,7 +64,7 @@ theorem addhshlhsdivhnegative1_thm (e : IntW 32) :
 
 theorem addhshlhsdivhnegative2_thm (e : IntW 32) :
   add (shl (LLVM.sdiv e (const? 32 (-2147483648))) (const? 32 31)) e ⊑
-    add (select (icmp IntPredicate.eq e (const? 32 (-2147483648))) (const? 32 (-2147483648)) (const? 32 0)) e := by
+    add (select (icmp IntPred.eq e (const? 32 (-2147483648))) (const? 32 (-2147483648)) (const? 32 0)) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gand2_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gand2_proof.lean
@@ -40,8 +40,8 @@ theorem test3_thm (e e_1 : IntW 32) : LLVM.and e_1 (LLVM.and e e_1) ⊑ LLVM.and
 
 
 theorem test7_thm (e : IntW 1) (e_1 : IntW 32) :
-  LLVM.and (LLVM.and (icmp IntPredicate.slt e_1 (const? 32 1)) e) (icmp IntPredicate.sgt e_1 (const? 32 (-1))) ⊑
-    LLVM.and (icmp IntPredicate.eq e_1 (const? 32 0)) e := by
+  LLVM.and (LLVM.and (icmp IntPred.slt e_1 (const? 32 1)) e) (icmp IntPred.sgt e_1 (const? 32 (-1))) ⊑
+    LLVM.and (icmp IntPred.eq e_1 (const? 32 0)) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -51,9 +51,9 @@ theorem test7_thm (e : IntW 1) (e_1 : IntW 32) :
 
 
 theorem test7_logical_thm (e : IntW 1) (e_1 : IntW 32) :
-  select (select (icmp IntPredicate.slt e_1 (const? 32 1)) e (const? 1 0)) (icmp IntPredicate.sgt e_1 (const? 32 (-1)))
+  select (select (icmp IntPred.slt e_1 (const? 32 1)) e (const? 1 0)) (icmp IntPred.sgt e_1 (const? 32 (-1)))
       (const? 1 0) ⊑
-    select (icmp IntPredicate.eq e_1 (const? 32 0)) e (const? 1 0) := by
+    select (icmp IntPred.eq e_1 (const? 32 0)) e (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -63,8 +63,8 @@ theorem test7_logical_thm (e : IntW 1) (e_1 : IntW 32) :
 
 
 theorem test8_thm (e : IntW 32) :
-  LLVM.and (icmp IntPredicate.ne e (const? 32 0)) (icmp IntPredicate.ult e (const? 32 14)) ⊑
-    icmp IntPredicate.ult (add e (const? 32 (-1))) (const? 32 13) := by
+  LLVM.and (icmp IntPred.ne e (const? 32 0)) (icmp IntPred.ult e (const? 32 14)) ⊑
+    icmp IntPred.ult (add e (const? 32 (-1))) (const? 32 13) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -74,8 +74,8 @@ theorem test8_thm (e : IntW 32) :
 
 
 theorem test8_logical_thm (e : IntW 32) :
-  select (icmp IntPredicate.ne e (const? 32 0)) (icmp IntPredicate.ult e (const? 32 14)) (const? 1 0) ⊑
-    icmp IntPredicate.ult (add e (const? 32 (-1))) (const? 32 13) := by
+  select (icmp IntPred.ne e (const? 32 0)) (icmp IntPred.ult e (const? 32 14)) (const? 1 0) ⊑
+    icmp IntPred.ult (add e (const? 32 (-1))) (const? 32 13) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -107,7 +107,7 @@ theorem test10_thm (e : IntW 64) :
 
 
 theorem and1_shl1_is_cmp_eq_0_thm (e : IntW 8) :
-  LLVM.and (shl (const? 8 1) e) (const? 8 1) ⊑ zext 8 (icmp IntPredicate.eq e (const? 8 0)) := by
+  LLVM.and (shl (const? 8 1) e) (const? 8 1) ⊑ zext 8 (icmp IntPred.eq e (const? 8 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gand_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gand_proof.lean
@@ -12,7 +12,7 @@ set_option Elab.async false
 
 section gand_proof
 theorem test_with_1_thm (e : IntW 32) :
-  LLVM.and (shl (const? 32 1) e) (const? 32 1) ⊑ zext 32 (icmp IntPredicate.eq e (const? 32 0)) := by
+  LLVM.and (shl (const? 32 1) e) (const? 32 1) ⊑ zext 32 (icmp IntPred.eq e (const? 32 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -22,7 +22,7 @@ theorem test_with_1_thm (e : IntW 32) :
 
 
 theorem test_with_3_thm (e : IntW 32) :
-  LLVM.and (shl (const? 32 3) e) (const? 32 1) ⊑ zext 32 (icmp IntPredicate.eq e (const? 32 0)) := by
+  LLVM.and (shl (const? 32 3) e) (const? 32 1) ⊑ zext 32 (icmp IntPred.eq e (const? 32 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -32,7 +32,7 @@ theorem test_with_3_thm (e : IntW 32) :
 
 
 theorem test_with_5_thm (e : IntW 32) :
-  LLVM.and (shl (const? 32 5) e) (const? 32 1) ⊑ zext 32 (icmp IntPredicate.eq e (const? 32 0)) := by
+  LLVM.and (shl (const? 32 5) e) (const? 32 1) ⊑ zext 32 (icmp IntPred.eq e (const? 32 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -42,7 +42,7 @@ theorem test_with_5_thm (e : IntW 32) :
 
 
 theorem test_with_neg_5_thm (e : IntW 32) :
-  LLVM.and (shl (const? 32 (-5)) e) (const? 32 1) ⊑ zext 32 (icmp IntPredicate.eq e (const? 32 0)) := by
+  LLVM.and (shl (const? 32 (-5)) e) (const? 32 1) ⊑ zext 32 (icmp IntPred.eq e (const? 32 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -169,8 +169,8 @@ theorem test8_thm (e : IntW 8) : LLVM.and (LLVM.and e (const? 8 3)) (const? 8 4)
 
 
 theorem test9_thm (e : IntW 32) :
-  icmp IntPredicate.ne (LLVM.and e (const? 32 (-2147483648))) (const? 32 0) ⊑
-    icmp IntPredicate.slt e (const? 32 0) := by
+  icmp IntPred.ne (LLVM.and e (const? 32 (-2147483648))) (const? 32 0) ⊑
+    icmp IntPred.slt e (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -180,8 +180,8 @@ theorem test9_thm (e : IntW 32) :
 
 
 theorem test9a_thm (e : IntW 32) :
-  icmp IntPredicate.ne (LLVM.and e (const? 32 (-2147483648))) (const? 32 0) ⊑
-    icmp IntPredicate.slt e (const? 32 0) := by
+  icmp IntPred.ne (LLVM.and e (const? 32 (-2147483648))) (const? 32 0) ⊑
+    icmp IntPred.slt e (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -201,7 +201,7 @@ theorem test10_thm (e : IntW 32) :
 
 
 theorem test12_thm (e e_1 : IntW 32) :
-  LLVM.and (icmp IntPredicate.ult e_1 e) (icmp IntPredicate.ule e_1 e) ⊑ icmp IntPredicate.ult e_1 e := by
+  LLVM.and (icmp IntPred.ult e_1 e) (icmp IntPred.ule e_1 e) ⊑ icmp IntPred.ult e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -211,7 +211,7 @@ theorem test12_thm (e e_1 : IntW 32) :
 
 
 theorem test12_logical_thm (e e_1 : IntW 32) :
-  select (icmp IntPredicate.ult e_1 e) (icmp IntPredicate.ule e_1 e) (const? 1 0) ⊑ icmp IntPredicate.ult e_1 e := by
+  select (icmp IntPred.ult e_1 e) (icmp IntPred.ule e_1 e) (const? 1 0) ⊑ icmp IntPred.ult e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -221,7 +221,7 @@ theorem test12_logical_thm (e e_1 : IntW 32) :
 
 
 theorem test13_thm (e e_1 : IntW 32) :
-  LLVM.and (icmp IntPredicate.ult e_1 e) (icmp IntPredicate.ugt e_1 e) ⊑ const? 1 0 := by
+  LLVM.and (icmp IntPred.ult e_1 e) (icmp IntPred.ugt e_1 e) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -231,7 +231,7 @@ theorem test13_thm (e e_1 : IntW 32) :
 
 
 theorem test13_logical_thm (e e_1 : IntW 32) :
-  select (icmp IntPredicate.ult e_1 e) (icmp IntPredicate.ugt e_1 e) (const? 1 0) ⊑ const? 1 0 := by
+  select (icmp IntPred.ult e_1 e) (icmp IntPred.ugt e_1 e) (const? 1 0) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -241,7 +241,7 @@ theorem test13_logical_thm (e e_1 : IntW 32) :
 
 
 theorem test14_thm (e : IntW 8) :
-  icmp IntPredicate.ne (LLVM.and e (const? 8 (-128))) (const? 8 0) ⊑ icmp IntPredicate.slt e (const? 8 0) := by
+  icmp IntPred.ne (LLVM.and e (const? 8 (-128))) (const? 8 0) ⊑ icmp IntPred.slt e (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -269,7 +269,7 @@ theorem test16_thm (e : IntW 8) : LLVM.and (shl e (const? 8 2)) (const? 8 3) ⊑
 
 
 theorem test18_thm (e : IntW 32) :
-  icmp IntPredicate.ne (LLVM.and e (const? 32 (-128))) (const? 32 0) ⊑ icmp IntPredicate.ugt e (const? 32 127) := by
+  icmp IntPred.ne (LLVM.and e (const? 32 (-128))) (const? 32 0) ⊑ icmp IntPred.ugt e (const? 32 127) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -279,7 +279,7 @@ theorem test18_thm (e : IntW 32) :
 
 
 theorem test18a_thm (e : IntW 8) :
-  icmp IntPredicate.eq (LLVM.and e (const? 8 (-2))) (const? 8 0) ⊑ icmp IntPredicate.ult e (const? 8 2) := by
+  icmp IntPred.eq (LLVM.and e (const? 8 (-2))) (const? 8 0) ⊑ icmp IntPred.ult e (const? 8 2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -307,8 +307,8 @@ theorem test20_thm (e : IntW 8) : LLVM.and (lshr e (const? 8 7)) (const? 8 1) �
 
 
 theorem test23_thm (e : IntW 32) :
-  LLVM.and (icmp IntPredicate.sgt e (const? 32 1)) (icmp IntPredicate.sle e (const? 32 2)) ⊑
-    icmp IntPredicate.eq e (const? 32 2) := by
+  LLVM.and (icmp IntPred.sgt e (const? 32 1)) (icmp IntPred.sle e (const? 32 2)) ⊑
+    icmp IntPred.eq e (const? 32 2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -318,8 +318,8 @@ theorem test23_thm (e : IntW 32) :
 
 
 theorem test23_logical_thm (e : IntW 32) :
-  select (icmp IntPredicate.sgt e (const? 32 1)) (icmp IntPredicate.sle e (const? 32 2)) (const? 1 0) ⊑
-    icmp IntPredicate.eq e (const? 32 2) := by
+  select (icmp IntPred.sgt e (const? 32 1)) (icmp IntPred.sle e (const? 32 2)) (const? 1 0) ⊑
+    icmp IntPred.eq e (const? 32 2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -329,8 +329,8 @@ theorem test23_logical_thm (e : IntW 32) :
 
 
 theorem test24_thm (e : IntW 32) :
-  LLVM.and (icmp IntPredicate.sgt e (const? 32 1)) (icmp IntPredicate.ne e (const? 32 2)) ⊑
-    icmp IntPredicate.sgt e (const? 32 2) := by
+  LLVM.and (icmp IntPred.sgt e (const? 32 1)) (icmp IntPred.ne e (const? 32 2)) ⊑
+    icmp IntPred.sgt e (const? 32 2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -340,8 +340,8 @@ theorem test24_thm (e : IntW 32) :
 
 
 theorem test24_logical_thm (e : IntW 32) :
-  select (icmp IntPredicate.sgt e (const? 32 1)) (icmp IntPredicate.ne e (const? 32 2)) (const? 1 0) ⊑
-    icmp IntPredicate.sgt e (const? 32 2) := by
+  select (icmp IntPred.sgt e (const? 32 1)) (icmp IntPred.ne e (const? 32 2)) (const? 1 0) ⊑
+    icmp IntPred.sgt e (const? 32 2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -351,8 +351,8 @@ theorem test24_logical_thm (e : IntW 32) :
 
 
 theorem test25_thm (e : IntW 32) :
-  LLVM.and (icmp IntPredicate.sge e (const? 32 50)) (icmp IntPredicate.slt e (const? 32 100)) ⊑
-    icmp IntPredicate.ult (add e (const? 32 (-50))) (const? 32 50) := by
+  LLVM.and (icmp IntPred.sge e (const? 32 50)) (icmp IntPred.slt e (const? 32 100)) ⊑
+    icmp IntPred.ult (add e (const? 32 (-50))) (const? 32 50) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -362,8 +362,8 @@ theorem test25_thm (e : IntW 32) :
 
 
 theorem test25_logical_thm (e : IntW 32) :
-  select (icmp IntPredicate.sge e (const? 32 50)) (icmp IntPredicate.slt e (const? 32 100)) (const? 1 0) ⊑
-    icmp IntPredicate.ult (add e (const? 32 (-50))) (const? 32 50) := by
+  select (icmp IntPred.sge e (const? 32 50)) (icmp IntPred.slt e (const? 32 100)) (const? 1 0) ⊑
+    icmp IntPred.ult (add e (const? 32 (-50))) (const? 32 50) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -668,9 +668,9 @@ theorem test47_thm (e e_1 : IntW 32) :
 
 
 theorem and_orn_cmp_1_thm (e e_1 e_2 : IntW 32) :
-  LLVM.and (icmp IntPredicate.sgt e_2 e_1)
-      (LLVM.or (icmp IntPredicate.ugt e (const? 32 42)) (icmp IntPredicate.sle e_2 e_1)) ⊑
-    LLVM.and (icmp IntPredicate.sgt e_2 e_1) (icmp IntPredicate.ugt e (const? 32 42)) := by
+  LLVM.and (icmp IntPred.sgt e_2 e_1)
+      (LLVM.or (icmp IntPred.ugt e (const? 32 42)) (icmp IntPred.sle e_2 e_1)) ⊑
+    LLVM.and (icmp IntPred.sgt e_2 e_1) (icmp IntPred.ugt e (const? 32 42)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -680,9 +680,9 @@ theorem and_orn_cmp_1_thm (e e_1 e_2 : IntW 32) :
 
 
 theorem and_orn_cmp_1_logical_thm (e e_1 e_2 : IntW 32) :
-  select (icmp IntPredicate.sgt e_2 e_1)
-      (select (icmp IntPredicate.ugt e (const? 32 42)) (const? 1 1) (icmp IntPredicate.sle e_2 e_1)) (const? 1 0) ⊑
-    select (icmp IntPredicate.sgt e_2 e_1) (icmp IntPredicate.ugt e (const? 32 42)) (const? 1 0) := by
+  select (icmp IntPred.sgt e_2 e_1)
+      (select (icmp IntPred.ugt e (const? 32 42)) (const? 1 1) (icmp IntPred.sle e_2 e_1)) (const? 1 0) ⊑
+    select (icmp IntPred.sgt e_2 e_1) (icmp IntPred.ugt e (const? 32 42)) (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -692,9 +692,9 @@ theorem and_orn_cmp_1_logical_thm (e e_1 e_2 : IntW 32) :
 
 
 theorem and_orn_cmp_3_thm (e e_1 e_2 : IntW 72) :
-  LLVM.and (icmp IntPredicate.ugt e_2 e_1)
-      (LLVM.or (icmp IntPredicate.ule e_2 e_1) (icmp IntPredicate.ugt e (const? 72 42))) ⊑
-    LLVM.and (icmp IntPredicate.ugt e_2 e_1) (icmp IntPredicate.ugt e (const? 72 42)) := by
+  LLVM.and (icmp IntPred.ugt e_2 e_1)
+      (LLVM.or (icmp IntPred.ule e_2 e_1) (icmp IntPred.ugt e (const? 72 42))) ⊑
+    LLVM.and (icmp IntPred.ugt e_2 e_1) (icmp IntPred.ugt e (const? 72 42)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -704,9 +704,9 @@ theorem and_orn_cmp_3_thm (e e_1 e_2 : IntW 72) :
 
 
 theorem and_orn_cmp_3_logical_thm (e e_1 e_2 : IntW 72) :
-  select (icmp IntPredicate.ugt e_2 e_1)
-      (select (icmp IntPredicate.ule e_2 e_1) (const? 1 1) (icmp IntPredicate.ugt e (const? 72 42))) (const? 1 0) ⊑
-    select (icmp IntPredicate.ugt e_2 e_1) (icmp IntPredicate.ugt e (const? 72 42)) (const? 1 0) := by
+  select (icmp IntPred.ugt e_2 e_1)
+      (select (icmp IntPred.ule e_2 e_1) (const? 1 1) (icmp IntPred.ugt e (const? 72 42))) (const? 1 0) ⊑
+    select (icmp IntPred.ugt e_2 e_1) (icmp IntPred.ugt e (const? 72 42)) (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -716,9 +716,9 @@ theorem and_orn_cmp_3_logical_thm (e e_1 e_2 : IntW 72) :
 
 
 theorem andn_or_cmp_1_thm (e e_1 e_2 : IntW 37) :
-  LLVM.and (icmp IntPredicate.sle e_2 e_1)
-      (LLVM.or (icmp IntPredicate.ugt e (const? 37 42)) (icmp IntPredicate.sgt e_2 e_1)) ⊑
-    LLVM.and (icmp IntPredicate.sle e_2 e_1) (icmp IntPredicate.ugt e (const? 37 42)) := by
+  LLVM.and (icmp IntPred.sle e_2 e_1)
+      (LLVM.or (icmp IntPred.ugt e (const? 37 42)) (icmp IntPred.sgt e_2 e_1)) ⊑
+    LLVM.and (icmp IntPred.sle e_2 e_1) (icmp IntPred.ugt e (const? 37 42)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -728,9 +728,9 @@ theorem andn_or_cmp_1_thm (e e_1 e_2 : IntW 37) :
 
 
 theorem andn_or_cmp_1_logical_thm (e e_1 e_2 : IntW 37) :
-  select (icmp IntPredicate.sle e_2 e_1)
-      (select (icmp IntPredicate.ugt e (const? 37 42)) (const? 1 1) (icmp IntPredicate.sgt e_2 e_1)) (const? 1 0) ⊑
-    select (icmp IntPredicate.sle e_2 e_1) (icmp IntPredicate.ugt e (const? 37 42)) (const? 1 0) := by
+  select (icmp IntPred.sle e_2 e_1)
+      (select (icmp IntPred.ugt e (const? 37 42)) (const? 1 1) (icmp IntPred.sgt e_2 e_1)) (const? 1 0) ⊑
+    select (icmp IntPred.sle e_2 e_1) (icmp IntPred.ugt e (const? 37 42)) (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -740,9 +740,9 @@ theorem andn_or_cmp_1_logical_thm (e e_1 e_2 : IntW 37) :
 
 
 theorem andn_or_cmp_2_thm (e e_1 e_2 : IntW 16) :
-  LLVM.and (LLVM.or (icmp IntPredicate.ugt e_2 (const? 16 42)) (icmp IntPredicate.sge e_1 e))
-      (icmp IntPredicate.slt e_1 e) ⊑
-    LLVM.and (icmp IntPredicate.ugt e_2 (const? 16 42)) (icmp IntPredicate.slt e_1 e) := by
+  LLVM.and (LLVM.or (icmp IntPred.ugt e_2 (const? 16 42)) (icmp IntPred.sge e_1 e))
+      (icmp IntPred.slt e_1 e) ⊑
+    LLVM.and (icmp IntPred.ugt e_2 (const? 16 42)) (icmp IntPred.slt e_1 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -752,9 +752,9 @@ theorem andn_or_cmp_2_thm (e e_1 e_2 : IntW 16) :
 
 
 theorem andn_or_cmp_2_logical_thm (e e_1 e_2 : IntW 16) :
-  select (select (icmp IntPredicate.ugt e_2 (const? 16 42)) (const? 1 1) (icmp IntPredicate.sge e_1 e))
-      (icmp IntPredicate.slt e_1 e) (const? 1 0) ⊑
-    select (icmp IntPredicate.ugt e_2 (const? 16 42)) (icmp IntPredicate.slt e_1 e) (const? 1 0) := by
+  select (select (icmp IntPred.ugt e_2 (const? 16 42)) (const? 1 1) (icmp IntPred.sge e_1 e))
+      (icmp IntPred.slt e_1 e) (const? 1 0) ⊑
+    select (icmp IntPred.ugt e_2 (const? 16 42)) (icmp IntPred.slt e_1 e) (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -764,9 +764,9 @@ theorem andn_or_cmp_2_logical_thm (e e_1 e_2 : IntW 16) :
 
 
 theorem andn_or_cmp_4_thm (e e_1 e_2 : IntW 32) :
-  LLVM.and (LLVM.or (icmp IntPredicate.eq e_2 e_1) (icmp IntPredicate.ugt e (const? 32 42)))
-      (icmp IntPredicate.ne e_2 e_1) ⊑
-    LLVM.and (icmp IntPredicate.ugt e (const? 32 42)) (icmp IntPredicate.ne e_2 e_1) := by
+  LLVM.and (LLVM.or (icmp IntPred.eq e_2 e_1) (icmp IntPred.ugt e (const? 32 42)))
+      (icmp IntPred.ne e_2 e_1) ⊑
+    LLVM.and (icmp IntPred.ugt e (const? 32 42)) (icmp IntPred.ne e_2 e_1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -776,9 +776,9 @@ theorem andn_or_cmp_4_thm (e e_1 e_2 : IntW 32) :
 
 
 theorem andn_or_cmp_4_logical_thm (e e_1 e_2 : IntW 32) :
-  select (select (icmp IntPredicate.eq e_2 e_1) (const? 1 1) (icmp IntPredicate.ugt e (const? 32 42)))
-      (icmp IntPredicate.ne e_2 e_1) (const? 1 0) ⊑
-    select (icmp IntPredicate.ne e_2 e_1) (icmp IntPredicate.ugt e (const? 32 42)) (const? 1 0) := by
+  select (select (icmp IntPred.eq e_2 e_1) (const? 1 1) (icmp IntPred.ugt e (const? 32 42)))
+      (icmp IntPred.ne e_2 e_1) (const? 1 0) ⊑
+    select (icmp IntPred.ne e_2 e_1) (icmp IntPred.ugt e (const? 32 42)) (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -817,7 +817,7 @@ theorem flip_masked_bit_thm (e : IntW 8) :
 
 
 theorem ashr_bitwidth_mask_thm (e e_1 : IntW 8) :
-  LLVM.and (ashr e_1 (const? 8 7)) e ⊑ select (icmp IntPredicate.slt e_1 (const? 8 0)) e (const? 8 0) := by
+  LLVM.and (ashr e_1 (const? 8 7)) e ⊑ select (icmp IntPred.slt e_1 (const? 8 0)) e (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -828,7 +828,7 @@ theorem ashr_bitwidth_mask_thm (e e_1 : IntW 8) :
 
 theorem signbit_splat_mask_thm (e : IntW 16) (e_1 : IntW 8) :
   LLVM.and (sext 16 (ashr e_1 (const? 8 7))) e ⊑
-    select (icmp IntPredicate.slt e_1 (const? 8 0)) e (const? 16 0) := by
+    select (icmp IntPred.slt e_1 (const? 8 0)) e (const? 16 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -859,7 +859,7 @@ theorem not_signbit_splat_mask2_thm (e : IntW 16) (e_1 : IntW 8) :
 
 theorem not_ashr_bitwidth_mask_thm (e e_1 : IntW 8) :
   LLVM.and (LLVM.xor (ashr e_1 (const? 8 7)) (const? 8 (-1))) e ⊑
-    select (icmp IntPredicate.slt e_1 (const? 8 0)) (const? 8 0) e := by
+    select (icmp IntPred.slt e_1 (const? 8 0)) (const? 8 0) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -892,7 +892,7 @@ theorem not_lshr_bitwidth_mask_thm (e e_1 : IntW 8) :
 
 theorem invert_signbit_splat_mask_thm (e : IntW 16) (e_1 : IntW 8) :
   LLVM.and (sext 16 (LLVM.xor (ashr e_1 (const? 8 7)) (const? 8 (-1)))) e ⊑
-    select (icmp IntPredicate.sgt e_1 (const? 8 (-1))) e (const? 16 0) := by
+    select (icmp IntPred.sgt e_1 (const? 8 (-1))) e (const? 16 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -903,7 +903,7 @@ theorem invert_signbit_splat_mask_thm (e : IntW 16) (e_1 : IntW 8) :
 
 theorem not_invert_signbit_splat_mask1_thm (e : IntW 16) (e_1 : IntW 8) :
   LLVM.and (zext 16 (LLVM.xor (ashr e_1 (const? 8 7)) (const? 8 (-1)))) e ⊑
-    LLVM.and e (zext 16 (sext 8 (icmp IntPredicate.sgt e_1 (const? 8 (-1))))) := by
+    LLVM.and e (zext 16 (sext 8 (icmp IntPred.sgt e_1 (const? 8 (-1))))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -925,7 +925,7 @@ theorem not_invert_signbit_splat_mask2_thm (e : IntW 16) (e_1 : IntW 8) :
 
 theorem shl_lshr_pow2_const_case1_thm (e : IntW 16) :
   LLVM.and (lshr (shl (const? 16 4) e) (const? 16 6)) (const? 16 8) ⊑
-    select (icmp IntPredicate.eq e (const? 16 7)) (const? 16 8) (const? 16 0) := by
+    select (icmp IntPred.eq e (const? 16 7)) (const? 16 8) (const? 16 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -936,7 +936,7 @@ theorem shl_lshr_pow2_const_case1_thm (e : IntW 16) :
 
 theorem shl_ashr_pow2_const_case1_thm (e : IntW 16) :
   LLVM.and (ashr (shl (const? 16 4) e) (const? 16 6)) (const? 16 8) ⊑
-    select (icmp IntPredicate.eq e (const? 16 7)) (const? 16 8) (const? 16 0) := by
+    select (icmp IntPred.eq e (const? 16 7)) (const? 16 8) (const? 16 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -947,7 +947,7 @@ theorem shl_ashr_pow2_const_case1_thm (e : IntW 16) :
 
 theorem shl_lshr_pow2_const_case2_thm (e : IntW 16) :
   LLVM.and (lshr (shl (const? 16 16) e) (const? 16 3)) (const? 16 8) ⊑
-    select (icmp IntPredicate.eq e (const? 16 2)) (const? 16 8) (const? 16 0) := by
+    select (icmp IntPred.eq e (const? 16 2)) (const? 16 8) (const? 16 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -958,7 +958,7 @@ theorem shl_lshr_pow2_const_case2_thm (e : IntW 16) :
 
 theorem shl_lshr_pow2_not_const_case2_thm (e : IntW 16) :
   LLVM.xor (LLVM.and (lshr (shl (const? 16 16) e) (const? 16 3)) (const? 16 8)) (const? 16 8) ⊑
-    select (icmp IntPredicate.eq e (const? 16 2)) (const? 16 0) (const? 16 8) := by
+    select (icmp IntPred.eq e (const? 16 2)) (const? 16 0) (const? 16 8) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -989,7 +989,7 @@ theorem shl_lshr_pow2_const_negative_overflow2_thm (e : IntW 16) :
 
 theorem lshr_lshr_pow2_const_thm (e : IntW 16) :
   LLVM.and (lshr (lshr (const? 16 2048) e) (const? 16 6)) (const? 16 4) ⊑
-    select (icmp IntPredicate.eq e (const? 16 3)) (const? 16 4) (const? 16 0) := by
+    select (icmp IntPred.eq e (const? 16 3)) (const? 16 4) (const? 16 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1032,7 +1032,7 @@ theorem lshr_lshr_pow2_const_negative_overflow_thm (e : IntW 16) :
 
 theorem lshr_shl_pow2_const_case1_thm (e : IntW 16) :
   LLVM.and (shl (lshr (const? 16 256) e) (const? 16 2)) (const? 16 8) ⊑
-    select (icmp IntPredicate.eq e (const? 16 7)) (const? 16 8) (const? 16 0) := by
+    select (icmp IntPred.eq e (const? 16 7)) (const? 16 8) (const? 16 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1043,7 +1043,7 @@ theorem lshr_shl_pow2_const_case1_thm (e : IntW 16) :
 
 theorem lshr_shl_pow2_const_xor_thm (e : IntW 16) :
   LLVM.xor (LLVM.and (shl (lshr (const? 16 256) e) (const? 16 2)) (const? 16 8)) (const? 16 8) ⊑
-    select (icmp IntPredicate.eq e (const? 16 7)) (const? 16 0) (const? 16 8) := by
+    select (icmp IntPred.eq e (const? 16 7)) (const? 16 0) (const? 16 8) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1054,7 +1054,7 @@ theorem lshr_shl_pow2_const_xor_thm (e : IntW 16) :
 
 theorem lshr_shl_pow2_const_case2_thm (e : IntW 16) :
   LLVM.and (shl (lshr (const? 16 8192) e) (const? 16 4)) (const? 16 32) ⊑
-    select (icmp IntPredicate.eq e (const? 16 12)) (const? 16 32) (const? 16 0) := by
+    select (icmp IntPred.eq e (const? 16 12)) (const? 16 32) (const? 16 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1075,7 +1075,7 @@ theorem lshr_shl_pow2_const_overflow_thm (e : IntW 16) :
 
 theorem negate_lowbitmask_thm (e e_1 : IntW 8) :
   LLVM.and (sub (const? 8 0) (LLVM.and e_1 (const? 8 1))) e ⊑
-    select (icmp IntPredicate.eq (LLVM.and e_1 (const? 8 1)) (const? 8 0)) (const? 8 0) e := by
+    select (icmp IntPred.eq (LLVM.and e_1 (const? 8 1)) (const? 8 0)) (const? 8 0) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1104,7 +1104,7 @@ theorem and_zext_commuted_thm (e : IntW 32) (e_1 : IntW 1) :
     all_goals sorry
 
 
-theorem and_zext_eq_even_thm (e : IntW 32) : LLVM.and e (zext 32 (icmp IntPredicate.eq e (const? 32 2))) ⊑ const? 32 0 := by
+theorem and_zext_eq_even_thm (e : IntW 32) : LLVM.and e (zext 32 (icmp IntPred.eq e (const? 32 2))) ⊑ const? 32 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1113,7 +1113,7 @@ theorem and_zext_eq_even_thm (e : IntW 32) : LLVM.and e (zext 32 (icmp IntPredic
     all_goals sorry
 
 
-theorem and_zext_eq_even_commuted_thm (e : IntW 32) : LLVM.and (zext 32 (icmp IntPredicate.eq e (const? 32 2))) e ⊑ const? 32 0 := by
+theorem and_zext_eq_even_commuted_thm (e : IntW 32) : LLVM.and (zext 32 (icmp IntPred.eq e (const? 32 2))) e ⊑ const? 32 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1123,7 +1123,7 @@ theorem and_zext_eq_even_commuted_thm (e : IntW 32) : LLVM.and (zext 32 (icmp In
 
 
 theorem and_zext_eq_odd_thm (e : IntW 32) :
-  LLVM.and e (zext 32 (icmp IntPredicate.eq e (const? 32 3))) ⊑ zext 32 (icmp IntPredicate.eq e (const? 32 3)) := by
+  LLVM.and e (zext 32 (icmp IntPred.eq e (const? 32 3))) ⊑ zext 32 (icmp IntPred.eq e (const? 32 3)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1133,7 +1133,7 @@ theorem and_zext_eq_odd_thm (e : IntW 32) :
 
 
 theorem and_zext_eq_odd_commuted_thm (e : IntW 32) :
-  LLVM.and (zext 32 (icmp IntPredicate.eq e (const? 32 3))) e ⊑ zext 32 (icmp IntPredicate.eq e (const? 32 3)) := by
+  LLVM.and (zext 32 (icmp IntPred.eq e (const? 32 3))) e ⊑ zext 32 (icmp IntPred.eq e (const? 32 3)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1143,8 +1143,8 @@ theorem and_zext_eq_odd_commuted_thm (e : IntW 32) :
 
 
 theorem and_zext_eq_zero_thm (e e_1 : IntW 32) :
-  LLVM.and (zext 32 (icmp IntPredicate.eq e_1 (const? 32 0))) (LLVM.xor (lshr e_1 e) (const? 32 (-1))) ⊑
-    zext 32 (icmp IntPredicate.eq e_1 (const? 32 0)) := by
+  LLVM.and (zext 32 (icmp IntPred.eq e_1 (const? 32 0))) (LLVM.xor (lshr e_1 e) (const? 32 (-1))) ⊑
+    zext 32 (icmp IntPred.eq e_1 (const? 32 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1175,8 +1175,8 @@ theorem add_constant_equal_with_the_top_bit_of_demandedbits_insertpt_thm (e e_1 
 
 
 theorem and_sext_multiuse_thm (e e_1 e_2 e_3 : IntW 32) :
-  add (LLVM.and (sext 32 (icmp IntPredicate.sgt e_3 e_2)) e_1) (LLVM.and (sext 32 (icmp IntPredicate.sgt e_3 e_2)) e) ⊑
-    select (icmp IntPredicate.sgt e_3 e_2) (add e_1 e) (const? 32 0) := by
+  add (LLVM.and (sext 32 (icmp IntPred.sgt e_3 e_2)) e_1) (LLVM.and (sext 32 (icmp IntPred.sgt e_3 e_2)) e) ⊑
+    select (icmp IntPred.sgt e_3 e_2) (add e_1 e) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gandhcompare_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gandhcompare_proof.lean
@@ -12,8 +12,8 @@ set_option Elab.async false
 
 section gandhcompare_proof
 theorem test1_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.ne (LLVM.and e_1 (const? 32 65280)) (LLVM.and e (const? 32 65280)) ⊑
-    icmp IntPredicate.ne (LLVM.and (LLVM.xor e_1 e) (const? 32 65280)) (const? 32 0) := by
+  icmp IntPred.ne (LLVM.and e_1 (const? 32 65280)) (LLVM.and e (const? 32 65280)) ⊑
+    icmp IntPred.ne (LLVM.and (LLVM.xor e_1 e) (const? 32 65280)) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -23,8 +23,8 @@ theorem test1_thm (e e_1 : IntW 32) :
 
 
 theorem test_eq_0_and_15_add_1_thm (e : IntW 8) :
-  icmp IntPredicate.eq (LLVM.and (add e (const? 8 1)) (const? 8 15)) (const? 8 0) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 8 15)) (const? 8 15) := by
+  icmp IntPred.eq (LLVM.and (add e (const? 8 1)) (const? 8 15)) (const? 8 0) ⊑
+    icmp IntPred.eq (LLVM.and e (const? 8 15)) (const? 8 15) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -34,8 +34,8 @@ theorem test_eq_0_and_15_add_1_thm (e : IntW 8) :
 
 
 theorem test_ne_0_and_15_add_1_thm (e : IntW 8) :
-  icmp IntPredicate.ne (LLVM.and (add e (const? 8 1)) (const? 8 15)) (const? 8 0) ⊑
-    icmp IntPredicate.ne (LLVM.and e (const? 8 15)) (const? 8 15) := by
+  icmp IntPred.ne (LLVM.and (add e (const? 8 1)) (const? 8 15)) (const? 8 0) ⊑
+    icmp IntPred.ne (LLVM.and e (const? 8 15)) (const? 8 15) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -45,8 +45,8 @@ theorem test_ne_0_and_15_add_1_thm (e : IntW 8) :
 
 
 theorem test_eq_0_and_15_add_3_thm (e : IntW 8) :
-  icmp IntPredicate.eq (LLVM.and (add e (const? 8 3)) (const? 8 15)) (const? 8 0) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 8 15)) (const? 8 13) := by
+  icmp IntPred.eq (LLVM.and (add e (const? 8 3)) (const? 8 15)) (const? 8 0) ⊑
+    icmp IntPred.eq (LLVM.and e (const? 8 15)) (const? 8 13) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -56,8 +56,8 @@ theorem test_eq_0_and_15_add_3_thm (e : IntW 8) :
 
 
 theorem test_ne_0_and_15_add_3_thm (e : IntW 8) :
-  icmp IntPredicate.ne (LLVM.and (add e (const? 8 3)) (const? 8 15)) (const? 8 0) ⊑
-    icmp IntPredicate.ne (LLVM.and e (const? 8 15)) (const? 8 13) := by
+  icmp IntPred.ne (LLVM.and (add e (const? 8 3)) (const? 8 15)) (const? 8 0) ⊑
+    icmp IntPred.ne (LLVM.and e (const? 8 15)) (const? 8 13) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -67,8 +67,8 @@ theorem test_ne_0_and_15_add_3_thm (e : IntW 8) :
 
 
 theorem test_eq_11_and_15_add_10_thm (e : IntW 8) :
-  icmp IntPredicate.eq (LLVM.and (add e (const? 8 10)) (const? 8 15)) (const? 8 11) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 8 15)) (const? 8 1) := by
+  icmp IntPred.eq (LLVM.and (add e (const? 8 10)) (const? 8 15)) (const? 8 11) ⊑
+    icmp IntPred.eq (LLVM.and e (const? 8 15)) (const? 8 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -78,8 +78,8 @@ theorem test_eq_11_and_15_add_10_thm (e : IntW 8) :
 
 
 theorem test_ne_11_and_15_add_10_thm (e : IntW 8) :
-  icmp IntPredicate.ne (LLVM.and (add e (const? 8 10)) (const? 8 15)) (const? 8 11) ⊑
-    icmp IntPredicate.ne (LLVM.and e (const? 8 15)) (const? 8 1) := by
+  icmp IntPred.ne (LLVM.and (add e (const? 8 10)) (const? 8 15)) (const? 8 11) ⊑
+    icmp IntPred.ne (LLVM.and e (const? 8 15)) (const? 8 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gandhorhicmphconsthicmp_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gandhorhicmphconsthicmp_proof.lean
@@ -12,8 +12,8 @@ set_option Elab.async false
 
 section gandhorhicmphconsthicmp_proof
 theorem eq_basic_thm (e e_1 : IntW 8) :
-  LLVM.or (icmp IntPredicate.eq e_1 (const? 8 0)) (icmp IntPredicate.ugt e_1 e) ⊑
-    icmp IntPredicate.uge (add e_1 (const? 8 (-1))) e := by
+  LLVM.or (icmp IntPred.eq e_1 (const? 8 0)) (icmp IntPred.ugt e_1 e) ⊑
+    icmp IntPred.uge (add e_1 (const? 8 (-1))) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -23,8 +23,8 @@ theorem eq_basic_thm (e e_1 : IntW 8) :
 
 
 theorem ne_basic_equal_5_thm (e e_1 : IntW 8) :
-  LLVM.and (icmp IntPredicate.ne e_1 (const? 8 5)) (icmp IntPredicate.ule (add e_1 (const? 8 (-5))) e) ⊑
-    icmp IntPredicate.ult (add e_1 (const? 8 (-6))) e := by
+  LLVM.and (icmp IntPred.ne e_1 (const? 8 5)) (icmp IntPred.ule (add e_1 (const? 8 (-5))) e) ⊑
+    icmp IntPred.ult (add e_1 (const? 8 (-6))) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -34,8 +34,8 @@ theorem ne_basic_equal_5_thm (e e_1 : IntW 8) :
 
 
 theorem eq_basic_equal_minus_1_thm (e e_1 : IntW 8) :
-  LLVM.or (icmp IntPredicate.eq e_1 (const? 8 (-1))) (icmp IntPredicate.ugt (add e_1 (const? 8 1)) e) ⊑
-    icmp IntPredicate.uge e_1 e := by
+  LLVM.or (icmp IntPred.eq e_1 (const? 8 (-1))) (icmp IntPred.ugt (add e_1 (const? 8 1)) e) ⊑
+    icmp IntPred.uge e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -45,8 +45,8 @@ theorem eq_basic_equal_minus_1_thm (e e_1 : IntW 8) :
 
 
 theorem ne_basic_equal_minus_7_thm (e e_1 : IntW 8) :
-  LLVM.and (icmp IntPredicate.ne e_1 (const? 8 (-7))) (icmp IntPredicate.ule (add e_1 (const? 8 7)) e) ⊑
-    icmp IntPredicate.ult (add e_1 (const? 8 6)) e := by
+  LLVM.and (icmp IntPred.ne e_1 (const? 8 (-7))) (icmp IntPred.ule (add e_1 (const? 8 7)) e) ⊑
+    icmp IntPred.ult (add e_1 (const? 8 6)) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -56,8 +56,8 @@ theorem ne_basic_equal_minus_7_thm (e e_1 : IntW 8) :
 
 
 theorem eq_commuted_thm (e e_1 : IntW 8) :
-  LLVM.or (icmp IntPredicate.eq e_1 (const? 8 0)) (icmp IntPredicate.ult (LLVM.sdiv (const? 8 43) e) e_1) ⊑
-    icmp IntPredicate.uge (add e_1 (const? 8 (-1))) (LLVM.sdiv (const? 8 43) e) := by
+  LLVM.or (icmp IntPred.eq e_1 (const? 8 0)) (icmp IntPred.ult (LLVM.sdiv (const? 8 43) e) e_1) ⊑
+    icmp IntPred.uge (add e_1 (const? 8 (-1))) (LLVM.sdiv (const? 8 43) e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -67,9 +67,9 @@ theorem eq_commuted_thm (e e_1 : IntW 8) :
 
 
 theorem ne_commuted_equal_minus_1_thm (e e_1 : IntW 8) :
-  LLVM.and (icmp IntPredicate.ne e_1 (const? 8 (-1)))
-      (icmp IntPredicate.uge (LLVM.sdiv (const? 8 42) e) (add e_1 (const? 8 1))) ⊑
-    icmp IntPredicate.ult e_1 (LLVM.sdiv (const? 8 42) e) := by
+  LLVM.and (icmp IntPred.ne e_1 (const? 8 (-1)))
+      (icmp IntPred.uge (LLVM.sdiv (const? 8 42) e) (add e_1 (const? 8 1))) ⊑
+    icmp IntPred.ult e_1 (LLVM.sdiv (const? 8 42) e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gandhorhicmphminhmax_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gandhorhicmphminhmax_proof.lean
@@ -12,7 +12,7 @@ set_option Elab.async false
 
 section gandhorhicmphminhmax_proof
 theorem slt_and_max_thm (e e_1 : IntW 8) :
-  LLVM.and (icmp IntPredicate.slt e_1 e) (icmp IntPredicate.eq e_1 (const? 8 127)) ⊑ const? 1 0 := by
+  LLVM.and (icmp IntPred.slt e_1 e) (icmp IntPred.eq e_1 (const? 8 127)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -22,7 +22,7 @@ theorem slt_and_max_thm (e e_1 : IntW 8) :
 
 
 theorem slt_and_max_logical_thm (e e_1 : IntW 8) :
-  select (icmp IntPredicate.slt e_1 e) (icmp IntPredicate.eq e_1 (const? 8 127)) (const? 1 0) ⊑ const? 1 0 := by
+  select (icmp IntPred.slt e_1 e) (icmp IntPred.eq e_1 (const? 8 127)) (const? 1 0) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -32,7 +32,7 @@ theorem slt_and_max_logical_thm (e e_1 : IntW 8) :
 
 
 theorem slt_swap_and_max_thm (e e_1 : IntW 8) :
-  LLVM.and (icmp IntPredicate.sgt e_1 e) (icmp IntPredicate.eq e (const? 8 127)) ⊑ const? 1 0 := by
+  LLVM.and (icmp IntPred.sgt e_1 e) (icmp IntPred.eq e (const? 8 127)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -42,7 +42,7 @@ theorem slt_swap_and_max_thm (e e_1 : IntW 8) :
 
 
 theorem slt_swap_and_max_logical_thm (e e_1 : IntW 8) :
-  select (icmp IntPredicate.sgt e_1 e) (icmp IntPredicate.eq e (const? 8 127)) (const? 1 0) ⊑ const? 1 0 := by
+  select (icmp IntPred.sgt e_1 e) (icmp IntPred.eq e (const? 8 127)) (const? 1 0) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -52,7 +52,7 @@ theorem slt_swap_and_max_logical_thm (e e_1 : IntW 8) :
 
 
 theorem slt_swap_and_max_commute_thm (e e_1 : IntW 8) :
-  LLVM.and (icmp IntPredicate.eq e_1 (const? 8 127)) (icmp IntPredicate.sgt e e_1) ⊑ const? 1 0 := by
+  LLVM.and (icmp IntPred.eq e_1 (const? 8 127)) (icmp IntPred.sgt e e_1) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -62,7 +62,7 @@ theorem slt_swap_and_max_commute_thm (e e_1 : IntW 8) :
 
 
 theorem slt_swap_and_max_commute_logical_thm (e e_1 : IntW 8) :
-  select (icmp IntPredicate.eq e_1 (const? 8 127)) (icmp IntPredicate.sgt e e_1) (const? 1 0) ⊑ const? 1 0 := by
+  select (icmp IntPred.eq e_1 (const? 8 127)) (icmp IntPred.sgt e e_1) (const? 1 0) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -72,7 +72,7 @@ theorem slt_swap_and_max_commute_logical_thm (e e_1 : IntW 8) :
 
 
 theorem ult_and_max_thm (e e_1 : IntW 8) :
-  LLVM.and (icmp IntPredicate.ult e_1 e) (icmp IntPredicate.eq e_1 (const? 8 (-1))) ⊑ const? 1 0 := by
+  LLVM.and (icmp IntPred.ult e_1 e) (icmp IntPred.eq e_1 (const? 8 (-1))) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -82,7 +82,7 @@ theorem ult_and_max_thm (e e_1 : IntW 8) :
 
 
 theorem ult_and_max_logical_thm (e e_1 : IntW 8) :
-  select (icmp IntPredicate.ult e_1 e) (icmp IntPredicate.eq e_1 (const? 8 (-1))) (const? 1 0) ⊑ const? 1 0 := by
+  select (icmp IntPred.ult e_1 e) (icmp IntPred.eq e_1 (const? 8 (-1))) (const? 1 0) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -92,7 +92,7 @@ theorem ult_and_max_logical_thm (e e_1 : IntW 8) :
 
 
 theorem ult_and_max_commute_thm (e e_1 : IntW 8) :
-  LLVM.and (icmp IntPredicate.eq e_1 (const? 8 (-1))) (icmp IntPredicate.ult e_1 e) ⊑ const? 1 0 := by
+  LLVM.and (icmp IntPred.eq e_1 (const? 8 (-1))) (icmp IntPred.ult e_1 e) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -102,7 +102,7 @@ theorem ult_and_max_commute_thm (e e_1 : IntW 8) :
 
 
 theorem ult_and_max_commute_logical_thm (e e_1 : IntW 8) :
-  select (icmp IntPredicate.eq e_1 (const? 8 (-1))) (icmp IntPredicate.ult e_1 e) (const? 1 0) ⊑ const? 1 0 := by
+  select (icmp IntPred.eq e_1 (const? 8 (-1))) (icmp IntPred.ult e_1 e) (const? 1 0) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -112,7 +112,7 @@ theorem ult_and_max_commute_logical_thm (e e_1 : IntW 8) :
 
 
 theorem ult_swap_and_max_thm (e e_1 : IntW 8) :
-  LLVM.and (icmp IntPredicate.ugt e_1 e) (icmp IntPredicate.eq e (const? 8 (-1))) ⊑ const? 1 0 := by
+  LLVM.and (icmp IntPred.ugt e_1 e) (icmp IntPred.eq e (const? 8 (-1))) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -122,7 +122,7 @@ theorem ult_swap_and_max_thm (e e_1 : IntW 8) :
 
 
 theorem ult_swap_and_max_logical_thm (e e_1 : IntW 8) :
-  select (icmp IntPredicate.ugt e_1 e) (icmp IntPredicate.eq e (const? 8 (-1))) (const? 1 0) ⊑ const? 1 0 := by
+  select (icmp IntPred.ugt e_1 e) (icmp IntPred.eq e (const? 8 (-1))) (const? 1 0) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -132,7 +132,7 @@ theorem ult_swap_and_max_logical_thm (e e_1 : IntW 8) :
 
 
 theorem ult_swap_and_max_commute_thm (e e_1 : IntW 8) :
-  LLVM.and (icmp IntPredicate.eq e_1 (const? 8 (-1))) (icmp IntPredicate.ugt e e_1) ⊑ const? 1 0 := by
+  LLVM.and (icmp IntPred.eq e_1 (const? 8 (-1))) (icmp IntPred.ugt e e_1) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -142,7 +142,7 @@ theorem ult_swap_and_max_commute_thm (e e_1 : IntW 8) :
 
 
 theorem ult_swap_and_max_commute_logical_thm (e e_1 : IntW 8) :
-  select (icmp IntPredicate.eq e_1 (const? 8 (-1))) (icmp IntPredicate.ugt e e_1) (const? 1 0) ⊑ const? 1 0 := by
+  select (icmp IntPred.eq e_1 (const? 8 (-1))) (icmp IntPred.ugt e e_1) (const? 1 0) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -152,7 +152,7 @@ theorem ult_swap_and_max_commute_logical_thm (e e_1 : IntW 8) :
 
 
 theorem sgt_and_min_thm (e e_1 : IntW 9) :
-  LLVM.and (icmp IntPredicate.sgt e_1 e) (icmp IntPredicate.eq e_1 (const? 9 (-256))) ⊑ const? 1 0 := by
+  LLVM.and (icmp IntPred.sgt e_1 e) (icmp IntPred.eq e_1 (const? 9 (-256))) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -162,7 +162,7 @@ theorem sgt_and_min_thm (e e_1 : IntW 9) :
 
 
 theorem sgt_and_min_logical_thm (e e_1 : IntW 9) :
-  select (icmp IntPredicate.sgt e_1 e) (icmp IntPredicate.eq e_1 (const? 9 (-256))) (const? 1 0) ⊑ const? 1 0 := by
+  select (icmp IntPred.sgt e_1 e) (icmp IntPred.eq e_1 (const? 9 (-256))) (const? 1 0) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -172,7 +172,7 @@ theorem sgt_and_min_logical_thm (e e_1 : IntW 9) :
 
 
 theorem sgt_and_min_commute_thm (e e_1 : IntW 8) :
-  LLVM.and (icmp IntPredicate.eq e_1 (const? 8 (-128))) (icmp IntPredicate.sgt e_1 e) ⊑ const? 1 0 := by
+  LLVM.and (icmp IntPred.eq e_1 (const? 8 (-128))) (icmp IntPred.sgt e_1 e) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -182,7 +182,7 @@ theorem sgt_and_min_commute_thm (e e_1 : IntW 8) :
 
 
 theorem sgt_and_min_commute_logical_thm (e e_1 : IntW 8) :
-  select (icmp IntPredicate.eq e_1 (const? 8 (-128))) (icmp IntPredicate.sgt e_1 e) (const? 1 0) ⊑ const? 1 0 := by
+  select (icmp IntPred.eq e_1 (const? 8 (-128))) (icmp IntPred.sgt e_1 e) (const? 1 0) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -192,7 +192,7 @@ theorem sgt_and_min_commute_logical_thm (e e_1 : IntW 8) :
 
 
 theorem sgt_swap_and_min_thm (e e_1 : IntW 8) :
-  LLVM.and (icmp IntPredicate.slt e_1 e) (icmp IntPredicate.eq e (const? 8 (-128))) ⊑ const? 1 0 := by
+  LLVM.and (icmp IntPred.slt e_1 e) (icmp IntPred.eq e (const? 8 (-128))) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -202,7 +202,7 @@ theorem sgt_swap_and_min_thm (e e_1 : IntW 8) :
 
 
 theorem sgt_swap_and_min_logical_thm (e e_1 : IntW 8) :
-  select (icmp IntPredicate.slt e_1 e) (icmp IntPredicate.eq e (const? 8 (-128))) (const? 1 0) ⊑ const? 1 0 := by
+  select (icmp IntPred.slt e_1 e) (icmp IntPred.eq e (const? 8 (-128))) (const? 1 0) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -212,7 +212,7 @@ theorem sgt_swap_and_min_logical_thm (e e_1 : IntW 8) :
 
 
 theorem sgt_swap_and_min_commute_thm (e e_1 : IntW 8) :
-  LLVM.and (icmp IntPredicate.eq e_1 (const? 8 (-128))) (icmp IntPredicate.slt e e_1) ⊑ const? 1 0 := by
+  LLVM.and (icmp IntPred.eq e_1 (const? 8 (-128))) (icmp IntPred.slt e e_1) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -222,7 +222,7 @@ theorem sgt_swap_and_min_commute_thm (e e_1 : IntW 8) :
 
 
 theorem sgt_swap_and_min_commute_logical_thm (e e_1 : IntW 8) :
-  select (icmp IntPredicate.eq e_1 (const? 8 (-128))) (icmp IntPredicate.slt e e_1) (const? 1 0) ⊑ const? 1 0 := by
+  select (icmp IntPred.eq e_1 (const? 8 (-128))) (icmp IntPred.slt e e_1) (const? 1 0) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -232,7 +232,7 @@ theorem sgt_swap_and_min_commute_logical_thm (e e_1 : IntW 8) :
 
 
 theorem ugt_and_min_thm (e e_1 : IntW 8) :
-  LLVM.and (icmp IntPredicate.ugt e_1 e) (icmp IntPredicate.eq e_1 (const? 8 0)) ⊑ const? 1 0 := by
+  LLVM.and (icmp IntPred.ugt e_1 e) (icmp IntPred.eq e_1 (const? 8 0)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -242,7 +242,7 @@ theorem ugt_and_min_thm (e e_1 : IntW 8) :
 
 
 theorem ugt_and_min_logical_thm (e e_1 : IntW 8) :
-  select (icmp IntPredicate.ugt e_1 e) (icmp IntPredicate.eq e_1 (const? 8 0)) (const? 1 0) ⊑ const? 1 0 := by
+  select (icmp IntPred.ugt e_1 e) (icmp IntPred.eq e_1 (const? 8 0)) (const? 1 0) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -252,7 +252,7 @@ theorem ugt_and_min_logical_thm (e e_1 : IntW 8) :
 
 
 theorem ugt_and_min_commute_thm (e e_1 : IntW 8) :
-  LLVM.and (icmp IntPredicate.eq e_1 (const? 8 0)) (icmp IntPredicate.ugt e_1 e) ⊑ const? 1 0 := by
+  LLVM.and (icmp IntPred.eq e_1 (const? 8 0)) (icmp IntPred.ugt e_1 e) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -262,7 +262,7 @@ theorem ugt_and_min_commute_thm (e e_1 : IntW 8) :
 
 
 theorem ugt_and_min_commute_logical_thm (e e_1 : IntW 8) :
-  select (icmp IntPredicate.eq e_1 (const? 8 0)) (icmp IntPredicate.ugt e_1 e) (const? 1 0) ⊑ const? 1 0 := by
+  select (icmp IntPred.eq e_1 (const? 8 0)) (icmp IntPred.ugt e_1 e) (const? 1 0) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -272,7 +272,7 @@ theorem ugt_and_min_commute_logical_thm (e e_1 : IntW 8) :
 
 
 theorem ugt_swap_and_min_thm (e e_1 : IntW 8) :
-  LLVM.and (icmp IntPredicate.ult e_1 e) (icmp IntPredicate.eq e (const? 8 0)) ⊑ const? 1 0 := by
+  LLVM.and (icmp IntPred.ult e_1 e) (icmp IntPred.eq e (const? 8 0)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -282,7 +282,7 @@ theorem ugt_swap_and_min_thm (e e_1 : IntW 8) :
 
 
 theorem ugt_swap_and_min_logical_thm (e e_1 : IntW 8) :
-  select (icmp IntPredicate.ult e_1 e) (icmp IntPredicate.eq e (const? 8 0)) (const? 1 0) ⊑ const? 1 0 := by
+  select (icmp IntPred.ult e_1 e) (icmp IntPred.eq e (const? 8 0)) (const? 1 0) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -292,7 +292,7 @@ theorem ugt_swap_and_min_logical_thm (e e_1 : IntW 8) :
 
 
 theorem ugt_swap_and_min_commute_thm (e e_1 : IntW 8) :
-  LLVM.and (icmp IntPredicate.eq e_1 (const? 8 0)) (icmp IntPredicate.ult e e_1) ⊑ const? 1 0 := by
+  LLVM.and (icmp IntPred.eq e_1 (const? 8 0)) (icmp IntPred.ult e e_1) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -302,7 +302,7 @@ theorem ugt_swap_and_min_commute_thm (e e_1 : IntW 8) :
 
 
 theorem ugt_swap_and_min_commute_logical_thm (e e_1 : IntW 8) :
-  select (icmp IntPredicate.eq e_1 (const? 8 0)) (icmp IntPredicate.ult e e_1) (const? 1 0) ⊑ const? 1 0 := by
+  select (icmp IntPred.eq e_1 (const? 8 0)) (icmp IntPred.ult e e_1) (const? 1 0) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -312,7 +312,7 @@ theorem ugt_swap_and_min_commute_logical_thm (e e_1 : IntW 8) :
 
 
 theorem sge_or_not_max_thm (e e_1 : IntW 8) :
-  LLVM.or (icmp IntPredicate.sge e_1 e) (icmp IntPredicate.ne e_1 (const? 8 127)) ⊑ const? 1 1 := by
+  LLVM.or (icmp IntPred.sge e_1 e) (icmp IntPred.ne e_1 (const? 8 127)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -322,7 +322,7 @@ theorem sge_or_not_max_thm (e e_1 : IntW 8) :
 
 
 theorem sge_or_not_max_logical_thm (e e_1 : IntW 8) :
-  select (icmp IntPredicate.sge e_1 e) (const? 1 1) (icmp IntPredicate.ne e_1 (const? 8 127)) ⊑ const? 1 1 := by
+  select (icmp IntPred.sge e_1 e) (const? 1 1) (icmp IntPred.ne e_1 (const? 8 127)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -332,7 +332,7 @@ theorem sge_or_not_max_logical_thm (e e_1 : IntW 8) :
 
 
 theorem sge_or_not_max_commute_thm (e e_1 : IntW 8) :
-  LLVM.or (icmp IntPredicate.ne e_1 (const? 8 127)) (icmp IntPredicate.sge e_1 e) ⊑ const? 1 1 := by
+  LLVM.or (icmp IntPred.ne e_1 (const? 8 127)) (icmp IntPred.sge e_1 e) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -342,7 +342,7 @@ theorem sge_or_not_max_commute_thm (e e_1 : IntW 8) :
 
 
 theorem sge_or_not_max_commute_logical_thm (e e_1 : IntW 8) :
-  select (icmp IntPredicate.ne e_1 (const? 8 127)) (const? 1 1) (icmp IntPredicate.sge e_1 e) ⊑ const? 1 1 := by
+  select (icmp IntPred.ne e_1 (const? 8 127)) (const? 1 1) (icmp IntPred.sge e_1 e) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -352,7 +352,7 @@ theorem sge_or_not_max_commute_logical_thm (e e_1 : IntW 8) :
 
 
 theorem sge_swap_or_not_max_thm (e e_1 : IntW 8) :
-  LLVM.or (icmp IntPredicate.sle e_1 e) (icmp IntPredicate.ne e (const? 8 127)) ⊑ const? 1 1 := by
+  LLVM.or (icmp IntPred.sle e_1 e) (icmp IntPred.ne e (const? 8 127)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -362,7 +362,7 @@ theorem sge_swap_or_not_max_thm (e e_1 : IntW 8) :
 
 
 theorem sge_swap_or_not_max_logical_thm (e e_1 : IntW 8) :
-  select (icmp IntPredicate.sle e_1 e) (const? 1 1) (icmp IntPredicate.ne e (const? 8 127)) ⊑ const? 1 1 := by
+  select (icmp IntPred.sle e_1 e) (const? 1 1) (icmp IntPred.ne e (const? 8 127)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -372,7 +372,7 @@ theorem sge_swap_or_not_max_logical_thm (e e_1 : IntW 8) :
 
 
 theorem sge_swap_or_not_max_commute_thm (e e_1 : IntW 8) :
-  LLVM.or (icmp IntPredicate.ne e_1 (const? 8 127)) (icmp IntPredicate.sle e e_1) ⊑ const? 1 1 := by
+  LLVM.or (icmp IntPred.ne e_1 (const? 8 127)) (icmp IntPred.sle e e_1) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -382,7 +382,7 @@ theorem sge_swap_or_not_max_commute_thm (e e_1 : IntW 8) :
 
 
 theorem sge_swap_or_not_max_commute_logical_thm (e e_1 : IntW 8) :
-  select (icmp IntPredicate.ne e_1 (const? 8 127)) (const? 1 1) (icmp IntPredicate.sle e e_1) ⊑ const? 1 1 := by
+  select (icmp IntPred.ne e_1 (const? 8 127)) (const? 1 1) (icmp IntPred.sle e e_1) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -392,7 +392,7 @@ theorem sge_swap_or_not_max_commute_logical_thm (e e_1 : IntW 8) :
 
 
 theorem uge_or_not_max_thm (e e_1 : IntW 8) :
-  LLVM.or (icmp IntPredicate.uge e_1 e) (icmp IntPredicate.ne e_1 (const? 8 (-1))) ⊑ const? 1 1 := by
+  LLVM.or (icmp IntPred.uge e_1 e) (icmp IntPred.ne e_1 (const? 8 (-1))) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -402,7 +402,7 @@ theorem uge_or_not_max_thm (e e_1 : IntW 8) :
 
 
 theorem uge_or_not_max_logical_thm (e e_1 : IntW 8) :
-  select (icmp IntPredicate.uge e_1 e) (const? 1 1) (icmp IntPredicate.ne e_1 (const? 8 (-1))) ⊑ const? 1 1 := by
+  select (icmp IntPred.uge e_1 e) (const? 1 1) (icmp IntPred.ne e_1 (const? 8 (-1))) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -412,7 +412,7 @@ theorem uge_or_not_max_logical_thm (e e_1 : IntW 8) :
 
 
 theorem uge_or_not_max_commute_thm (e e_1 : IntW 8) :
-  LLVM.or (icmp IntPredicate.ne e_1 (const? 8 (-1))) (icmp IntPredicate.uge e_1 e) ⊑ const? 1 1 := by
+  LLVM.or (icmp IntPred.ne e_1 (const? 8 (-1))) (icmp IntPred.uge e_1 e) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -422,7 +422,7 @@ theorem uge_or_not_max_commute_thm (e e_1 : IntW 8) :
 
 
 theorem uge_or_not_max_commute_logical_thm (e e_1 : IntW 8) :
-  select (icmp IntPredicate.ne e_1 (const? 8 (-1))) (const? 1 1) (icmp IntPredicate.uge e_1 e) ⊑ const? 1 1 := by
+  select (icmp IntPred.ne e_1 (const? 8 (-1))) (const? 1 1) (icmp IntPred.uge e_1 e) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -432,7 +432,7 @@ theorem uge_or_not_max_commute_logical_thm (e e_1 : IntW 8) :
 
 
 theorem uge_swap_or_not_max_thm (e e_1 : IntW 8) :
-  LLVM.or (icmp IntPredicate.ule e_1 e) (icmp IntPredicate.ne e (const? 8 (-1))) ⊑ const? 1 1 := by
+  LLVM.or (icmp IntPred.ule e_1 e) (icmp IntPred.ne e (const? 8 (-1))) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -442,7 +442,7 @@ theorem uge_swap_or_not_max_thm (e e_1 : IntW 8) :
 
 
 theorem uge_swap_or_not_max_logical_thm (e e_1 : IntW 8) :
-  select (icmp IntPredicate.ule e_1 e) (const? 1 1) (icmp IntPredicate.ne e (const? 8 (-1))) ⊑ const? 1 1 := by
+  select (icmp IntPred.ule e_1 e) (const? 1 1) (icmp IntPred.ne e (const? 8 (-1))) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -452,7 +452,7 @@ theorem uge_swap_or_not_max_logical_thm (e e_1 : IntW 8) :
 
 
 theorem uge_swap_or_not_max_commute_thm (e e_1 : IntW 8) :
-  LLVM.or (icmp IntPredicate.ne e_1 (const? 8 (-1))) (icmp IntPredicate.ule e e_1) ⊑ const? 1 1 := by
+  LLVM.or (icmp IntPred.ne e_1 (const? 8 (-1))) (icmp IntPred.ule e e_1) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -462,7 +462,7 @@ theorem uge_swap_or_not_max_commute_thm (e e_1 : IntW 8) :
 
 
 theorem uge_swap_or_not_max_commute_logical_thm (e e_1 : IntW 8) :
-  select (icmp IntPredicate.ne e_1 (const? 8 (-1))) (const? 1 1) (icmp IntPredicate.ule e e_1) ⊑ const? 1 1 := by
+  select (icmp IntPred.ne e_1 (const? 8 (-1))) (const? 1 1) (icmp IntPred.ule e e_1) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -472,7 +472,7 @@ theorem uge_swap_or_not_max_commute_logical_thm (e e_1 : IntW 8) :
 
 
 theorem sle_or_not_min_thm (e e_1 : IntW 8) :
-  LLVM.or (icmp IntPredicate.sle e_1 e) (icmp IntPredicate.ne e_1 (const? 8 (-128))) ⊑ const? 1 1 := by
+  LLVM.or (icmp IntPred.sle e_1 e) (icmp IntPred.ne e_1 (const? 8 (-128))) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -482,7 +482,7 @@ theorem sle_or_not_min_thm (e e_1 : IntW 8) :
 
 
 theorem sle_or_not_min_logical_thm (e e_1 : IntW 8) :
-  select (icmp IntPredicate.sle e_1 e) (const? 1 1) (icmp IntPredicate.ne e_1 (const? 8 (-128))) ⊑ const? 1 1 := by
+  select (icmp IntPred.sle e_1 e) (const? 1 1) (icmp IntPred.ne e_1 (const? 8 (-128))) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -492,7 +492,7 @@ theorem sle_or_not_min_logical_thm (e e_1 : IntW 8) :
 
 
 theorem sle_or_not_min_commute_thm (e e_1 : IntW 8) :
-  LLVM.or (icmp IntPredicate.ne e_1 (const? 8 (-128))) (icmp IntPredicate.sle e_1 e) ⊑ const? 1 1 := by
+  LLVM.or (icmp IntPred.ne e_1 (const? 8 (-128))) (icmp IntPred.sle e_1 e) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -502,7 +502,7 @@ theorem sle_or_not_min_commute_thm (e e_1 : IntW 8) :
 
 
 theorem sle_or_not_min_commute_logical_thm (e e_1 : IntW 8) :
-  select (icmp IntPredicate.ne e_1 (const? 8 (-128))) (const? 1 1) (icmp IntPredicate.sle e_1 e) ⊑ const? 1 1 := by
+  select (icmp IntPred.ne e_1 (const? 8 (-128))) (const? 1 1) (icmp IntPred.sle e_1 e) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -512,7 +512,7 @@ theorem sle_or_not_min_commute_logical_thm (e e_1 : IntW 8) :
 
 
 theorem sle_swap_or_not_min_thm (e e_1 : IntW 8) :
-  LLVM.or (icmp IntPredicate.sge e_1 e) (icmp IntPredicate.ne e (const? 8 (-128))) ⊑ const? 1 1 := by
+  LLVM.or (icmp IntPred.sge e_1 e) (icmp IntPred.ne e (const? 8 (-128))) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -522,7 +522,7 @@ theorem sle_swap_or_not_min_thm (e e_1 : IntW 8) :
 
 
 theorem sle_swap_or_not_min_logical_thm (e e_1 : IntW 8) :
-  select (icmp IntPredicate.sge e_1 e) (const? 1 1) (icmp IntPredicate.ne e (const? 8 (-128))) ⊑ const? 1 1 := by
+  select (icmp IntPred.sge e_1 e) (const? 1 1) (icmp IntPred.ne e (const? 8 (-128))) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -532,7 +532,7 @@ theorem sle_swap_or_not_min_logical_thm (e e_1 : IntW 8) :
 
 
 theorem sle_swap_or_not_min_commute_thm (e e_1 : IntW 8) :
-  LLVM.or (icmp IntPredicate.ne e_1 (const? 8 (-128))) (icmp IntPredicate.sge e e_1) ⊑ const? 1 1 := by
+  LLVM.or (icmp IntPred.ne e_1 (const? 8 (-128))) (icmp IntPred.sge e e_1) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -542,7 +542,7 @@ theorem sle_swap_or_not_min_commute_thm (e e_1 : IntW 8) :
 
 
 theorem sle_swap_or_not_min_commute_logical_thm (e e_1 : IntW 8) :
-  select (icmp IntPredicate.ne e_1 (const? 8 (-128))) (const? 1 1) (icmp IntPredicate.sge e e_1) ⊑ const? 1 1 := by
+  select (icmp IntPred.ne e_1 (const? 8 (-128))) (const? 1 1) (icmp IntPred.sge e e_1) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -552,7 +552,7 @@ theorem sle_swap_or_not_min_commute_logical_thm (e e_1 : IntW 8) :
 
 
 theorem ule_or_not_min_thm (e e_1 : IntW 427) :
-  LLVM.or (icmp IntPredicate.ule e_1 e) (icmp IntPredicate.ne e_1 (const? 427 0)) ⊑ const? 1 1 := by
+  LLVM.or (icmp IntPred.ule e_1 e) (icmp IntPred.ne e_1 (const? 427 0)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -562,7 +562,7 @@ theorem ule_or_not_min_thm (e e_1 : IntW 427) :
 
 
 theorem ule_or_not_min_logical_thm (e e_1 : IntW 427) :
-  select (icmp IntPredicate.ule e_1 e) (const? 1 1) (icmp IntPredicate.ne e_1 (const? 427 0)) ⊑ const? 1 1 := by
+  select (icmp IntPred.ule e_1 e) (const? 1 1) (icmp IntPred.ne e_1 (const? 427 0)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -572,7 +572,7 @@ theorem ule_or_not_min_logical_thm (e e_1 : IntW 427) :
 
 
 theorem ule_or_not_min_commute_thm (e e_1 : IntW 8) :
-  LLVM.or (icmp IntPredicate.ne e_1 (const? 8 0)) (icmp IntPredicate.ule e_1 e) ⊑ const? 1 1 := by
+  LLVM.or (icmp IntPred.ne e_1 (const? 8 0)) (icmp IntPred.ule e_1 e) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -582,7 +582,7 @@ theorem ule_or_not_min_commute_thm (e e_1 : IntW 8) :
 
 
 theorem ule_or_not_min_commute_logical_thm (e e_1 : IntW 8) :
-  select (icmp IntPredicate.ne e_1 (const? 8 0)) (const? 1 1) (icmp IntPredicate.ule e_1 e) ⊑ const? 1 1 := by
+  select (icmp IntPred.ne e_1 (const? 8 0)) (const? 1 1) (icmp IntPred.ule e_1 e) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -592,7 +592,7 @@ theorem ule_or_not_min_commute_logical_thm (e e_1 : IntW 8) :
 
 
 theorem ule_swap_or_not_min_thm (e e_1 : IntW 8) :
-  LLVM.or (icmp IntPredicate.uge e_1 e) (icmp IntPredicate.ne e (const? 8 0)) ⊑ const? 1 1 := by
+  LLVM.or (icmp IntPred.uge e_1 e) (icmp IntPred.ne e (const? 8 0)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -602,7 +602,7 @@ theorem ule_swap_or_not_min_thm (e e_1 : IntW 8) :
 
 
 theorem ule_swap_or_not_min_logical_thm (e e_1 : IntW 8) :
-  select (icmp IntPredicate.uge e_1 e) (const? 1 1) (icmp IntPredicate.ne e (const? 8 0)) ⊑ const? 1 1 := by
+  select (icmp IntPred.uge e_1 e) (const? 1 1) (icmp IntPred.ne e (const? 8 0)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -612,7 +612,7 @@ theorem ule_swap_or_not_min_logical_thm (e e_1 : IntW 8) :
 
 
 theorem ule_swap_or_not_min_commute_thm (e e_1 : IntW 8) :
-  LLVM.or (icmp IntPredicate.ne e_1 (const? 8 0)) (icmp IntPredicate.uge e e_1) ⊑ const? 1 1 := by
+  LLVM.or (icmp IntPred.ne e_1 (const? 8 0)) (icmp IntPred.uge e e_1) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -622,7 +622,7 @@ theorem ule_swap_or_not_min_commute_thm (e e_1 : IntW 8) :
 
 
 theorem ule_swap_or_not_min_commute_logical_thm (e e_1 : IntW 8) :
-  select (icmp IntPredicate.ne e_1 (const? 8 0)) (const? 1 1) (icmp IntPredicate.uge e e_1) ⊑ const? 1 1 := by
+  select (icmp IntPred.ne e_1 (const? 8 0)) (const? 1 1) (icmp IntPred.uge e e_1) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -632,8 +632,8 @@ theorem ule_swap_or_not_min_commute_logical_thm (e e_1 : IntW 8) :
 
 
 theorem sge_and_max_thm (e e_1 : IntW 8) :
-  LLVM.and (icmp IntPredicate.sge e_1 e) (icmp IntPredicate.eq e_1 (const? 8 127)) ⊑
-    icmp IntPredicate.eq e_1 (const? 8 127) := by
+  LLVM.and (icmp IntPred.sge e_1 e) (icmp IntPred.eq e_1 (const? 8 127)) ⊑
+    icmp IntPred.eq e_1 (const? 8 127) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -643,8 +643,8 @@ theorem sge_and_max_thm (e e_1 : IntW 8) :
 
 
 theorem sge_and_max_logical_thm (e e_1 : IntW 8) :
-  select (icmp IntPredicate.sge e_1 e) (icmp IntPredicate.eq e_1 (const? 8 127)) (const? 1 0) ⊑
-    icmp IntPredicate.eq e_1 (const? 8 127) := by
+  select (icmp IntPred.sge e_1 e) (icmp IntPred.eq e_1 (const? 8 127)) (const? 1 0) ⊑
+    icmp IntPred.eq e_1 (const? 8 127) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -654,8 +654,8 @@ theorem sge_and_max_logical_thm (e e_1 : IntW 8) :
 
 
 theorem sge_and_max_logical_samesign_thm (e e_1 : IntW 8) :
-  select (icmp IntPredicate.sge e_1 e) (icmp IntPredicate.eq e_1 (const? 8 127)) (const? 1 0) ⊑
-    icmp IntPredicate.eq e_1 (const? 8 127) := by
+  select (icmp IntPred.sge e_1 e) (icmp IntPred.eq e_1 (const? 8 127)) (const? 1 0) ⊑
+    icmp IntPred.eq e_1 (const? 8 127) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -665,8 +665,8 @@ theorem sge_and_max_logical_samesign_thm (e e_1 : IntW 8) :
 
 
 theorem sge_and_max_commute_thm (e e_1 : IntW 8) :
-  LLVM.and (icmp IntPredicate.eq e_1 (const? 8 127)) (icmp IntPredicate.sge e_1 e) ⊑
-    icmp IntPredicate.eq e_1 (const? 8 127) := by
+  LLVM.and (icmp IntPred.eq e_1 (const? 8 127)) (icmp IntPred.sge e_1 e) ⊑
+    icmp IntPred.eq e_1 (const? 8 127) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -676,8 +676,8 @@ theorem sge_and_max_commute_thm (e e_1 : IntW 8) :
 
 
 theorem sge_and_max_commute_logical_thm (e e_1 : IntW 8) :
-  select (icmp IntPredicate.eq e_1 (const? 8 127)) (icmp IntPredicate.sge e_1 e) (const? 1 0) ⊑
-    icmp IntPredicate.eq e_1 (const? 8 127) := by
+  select (icmp IntPred.eq e_1 (const? 8 127)) (icmp IntPred.sge e_1 e) (const? 1 0) ⊑
+    icmp IntPred.eq e_1 (const? 8 127) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -687,8 +687,8 @@ theorem sge_and_max_commute_logical_thm (e e_1 : IntW 8) :
 
 
 theorem sge_swap_and_max_thm (e e_1 : IntW 8) :
-  LLVM.and (icmp IntPredicate.sle e_1 e) (icmp IntPredicate.eq e (const? 8 127)) ⊑
-    icmp IntPredicate.eq e (const? 8 127) := by
+  LLVM.and (icmp IntPred.sle e_1 e) (icmp IntPred.eq e (const? 8 127)) ⊑
+    icmp IntPred.eq e (const? 8 127) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -698,8 +698,8 @@ theorem sge_swap_and_max_thm (e e_1 : IntW 8) :
 
 
 theorem sge_swap_and_max_logical_thm (e e_1 : IntW 8) :
-  select (icmp IntPredicate.sle e_1 e) (icmp IntPredicate.eq e (const? 8 127)) (const? 1 0) ⊑
-    icmp IntPredicate.eq e (const? 8 127) := by
+  select (icmp IntPred.sle e_1 e) (icmp IntPred.eq e (const? 8 127)) (const? 1 0) ⊑
+    icmp IntPred.eq e (const? 8 127) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -709,8 +709,8 @@ theorem sge_swap_and_max_logical_thm (e e_1 : IntW 8) :
 
 
 theorem sge_swap_and_max_commute_thm (e e_1 : IntW 8) :
-  LLVM.and (icmp IntPredicate.eq e_1 (const? 8 127)) (icmp IntPredicate.sle e e_1) ⊑
-    icmp IntPredicate.eq e_1 (const? 8 127) := by
+  LLVM.and (icmp IntPred.eq e_1 (const? 8 127)) (icmp IntPred.sle e e_1) ⊑
+    icmp IntPred.eq e_1 (const? 8 127) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -720,8 +720,8 @@ theorem sge_swap_and_max_commute_thm (e e_1 : IntW 8) :
 
 
 theorem sge_swap_and_max_commute_logical_thm (e e_1 : IntW 8) :
-  select (icmp IntPredicate.eq e_1 (const? 8 127)) (icmp IntPredicate.sle e e_1) (const? 1 0) ⊑
-    icmp IntPredicate.eq e_1 (const? 8 127) := by
+  select (icmp IntPred.eq e_1 (const? 8 127)) (icmp IntPred.sle e e_1) (const? 1 0) ⊑
+    icmp IntPred.eq e_1 (const? 8 127) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -731,8 +731,8 @@ theorem sge_swap_and_max_commute_logical_thm (e e_1 : IntW 8) :
 
 
 theorem uge_and_max_thm (e e_1 : IntW 8) :
-  LLVM.and (icmp IntPredicate.uge e_1 e) (icmp IntPredicate.eq e_1 (const? 8 (-1))) ⊑
-    icmp IntPredicate.eq e_1 (const? 8 (-1)) := by
+  LLVM.and (icmp IntPred.uge e_1 e) (icmp IntPred.eq e_1 (const? 8 (-1))) ⊑
+    icmp IntPred.eq e_1 (const? 8 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -742,8 +742,8 @@ theorem uge_and_max_thm (e e_1 : IntW 8) :
 
 
 theorem uge_and_max_logical_thm (e e_1 : IntW 8) :
-  select (icmp IntPredicate.uge e_1 e) (icmp IntPredicate.eq e_1 (const? 8 (-1))) (const? 1 0) ⊑
-    icmp IntPredicate.eq e_1 (const? 8 (-1)) := by
+  select (icmp IntPred.uge e_1 e) (icmp IntPred.eq e_1 (const? 8 (-1))) (const? 1 0) ⊑
+    icmp IntPred.eq e_1 (const? 8 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -753,8 +753,8 @@ theorem uge_and_max_logical_thm (e e_1 : IntW 8) :
 
 
 theorem uge_and_max_commute_thm (e e_1 : IntW 8) :
-  LLVM.and (icmp IntPredicate.eq e_1 (const? 8 (-1))) (icmp IntPredicate.uge e_1 e) ⊑
-    icmp IntPredicate.eq e_1 (const? 8 (-1)) := by
+  LLVM.and (icmp IntPred.eq e_1 (const? 8 (-1))) (icmp IntPred.uge e_1 e) ⊑
+    icmp IntPred.eq e_1 (const? 8 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -764,8 +764,8 @@ theorem uge_and_max_commute_thm (e e_1 : IntW 8) :
 
 
 theorem uge_and_max_commute_logical_thm (e e_1 : IntW 8) :
-  select (icmp IntPredicate.eq e_1 (const? 8 (-1))) (icmp IntPredicate.uge e_1 e) (const? 1 0) ⊑
-    icmp IntPredicate.eq e_1 (const? 8 (-1)) := by
+  select (icmp IntPred.eq e_1 (const? 8 (-1))) (icmp IntPred.uge e_1 e) (const? 1 0) ⊑
+    icmp IntPred.eq e_1 (const? 8 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -775,8 +775,8 @@ theorem uge_and_max_commute_logical_thm (e e_1 : IntW 8) :
 
 
 theorem uge_swap_and_max_thm (e e_1 : IntW 8) :
-  LLVM.and (icmp IntPredicate.ule e_1 e) (icmp IntPredicate.eq e (const? 8 (-1))) ⊑
-    icmp IntPredicate.eq e (const? 8 (-1)) := by
+  LLVM.and (icmp IntPred.ule e_1 e) (icmp IntPred.eq e (const? 8 (-1))) ⊑
+    icmp IntPred.eq e (const? 8 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -786,8 +786,8 @@ theorem uge_swap_and_max_thm (e e_1 : IntW 8) :
 
 
 theorem uge_swap_and_max_logical_thm (e e_1 : IntW 8) :
-  select (icmp IntPredicate.ule e_1 e) (icmp IntPredicate.eq e (const? 8 (-1))) (const? 1 0) ⊑
-    icmp IntPredicate.eq e (const? 8 (-1)) := by
+  select (icmp IntPred.ule e_1 e) (icmp IntPred.eq e (const? 8 (-1))) (const? 1 0) ⊑
+    icmp IntPred.eq e (const? 8 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -797,8 +797,8 @@ theorem uge_swap_and_max_logical_thm (e e_1 : IntW 8) :
 
 
 theorem uge_swap_and_max_commute_thm (e e_1 : IntW 8) :
-  LLVM.and (icmp IntPredicate.eq e_1 (const? 8 (-1))) (icmp IntPredicate.ule e e_1) ⊑
-    icmp IntPredicate.eq e_1 (const? 8 (-1)) := by
+  LLVM.and (icmp IntPred.eq e_1 (const? 8 (-1))) (icmp IntPred.ule e e_1) ⊑
+    icmp IntPred.eq e_1 (const? 8 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -808,8 +808,8 @@ theorem uge_swap_and_max_commute_thm (e e_1 : IntW 8) :
 
 
 theorem uge_swap_and_max_commute_logical_thm (e e_1 : IntW 8) :
-  select (icmp IntPredicate.eq e_1 (const? 8 (-1))) (icmp IntPredicate.ule e e_1) (const? 1 0) ⊑
-    icmp IntPredicate.eq e_1 (const? 8 (-1)) := by
+  select (icmp IntPred.eq e_1 (const? 8 (-1))) (icmp IntPred.ule e e_1) (const? 1 0) ⊑
+    icmp IntPred.eq e_1 (const? 8 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -819,8 +819,8 @@ theorem uge_swap_and_max_commute_logical_thm (e e_1 : IntW 8) :
 
 
 theorem sle_and_min_thm (e e_1 : IntW 8) :
-  LLVM.and (icmp IntPredicate.sle e_1 e) (icmp IntPredicate.eq e_1 (const? 8 (-128))) ⊑
-    icmp IntPredicate.eq e_1 (const? 8 (-128)) := by
+  LLVM.and (icmp IntPred.sle e_1 e) (icmp IntPred.eq e_1 (const? 8 (-128))) ⊑
+    icmp IntPred.eq e_1 (const? 8 (-128)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -830,8 +830,8 @@ theorem sle_and_min_thm (e e_1 : IntW 8) :
 
 
 theorem sle_and_min_logical_thm (e e_1 : IntW 8) :
-  select (icmp IntPredicate.sle e_1 e) (icmp IntPredicate.eq e_1 (const? 8 (-128))) (const? 1 0) ⊑
-    icmp IntPredicate.eq e_1 (const? 8 (-128)) := by
+  select (icmp IntPred.sle e_1 e) (icmp IntPred.eq e_1 (const? 8 (-128))) (const? 1 0) ⊑
+    icmp IntPred.eq e_1 (const? 8 (-128)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -841,8 +841,8 @@ theorem sle_and_min_logical_thm (e e_1 : IntW 8) :
 
 
 theorem sle_and_min_commute_thm (e e_1 : IntW 8) :
-  LLVM.and (icmp IntPredicate.eq e_1 (const? 8 (-128))) (icmp IntPredicate.sle e_1 e) ⊑
-    icmp IntPredicate.eq e_1 (const? 8 (-128)) := by
+  LLVM.and (icmp IntPred.eq e_1 (const? 8 (-128))) (icmp IntPred.sle e_1 e) ⊑
+    icmp IntPred.eq e_1 (const? 8 (-128)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -852,8 +852,8 @@ theorem sle_and_min_commute_thm (e e_1 : IntW 8) :
 
 
 theorem sle_and_min_commute_logical_thm (e e_1 : IntW 8) :
-  select (icmp IntPredicate.eq e_1 (const? 8 (-128))) (icmp IntPredicate.sle e_1 e) (const? 1 0) ⊑
-    icmp IntPredicate.eq e_1 (const? 8 (-128)) := by
+  select (icmp IntPred.eq e_1 (const? 8 (-128))) (icmp IntPred.sle e_1 e) (const? 1 0) ⊑
+    icmp IntPred.eq e_1 (const? 8 (-128)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -863,8 +863,8 @@ theorem sle_and_min_commute_logical_thm (e e_1 : IntW 8) :
 
 
 theorem sle_swap_and_min_thm (e e_1 : IntW 8) :
-  LLVM.and (icmp IntPredicate.sge e_1 e) (icmp IntPredicate.eq e (const? 8 (-128))) ⊑
-    icmp IntPredicate.eq e (const? 8 (-128)) := by
+  LLVM.and (icmp IntPred.sge e_1 e) (icmp IntPred.eq e (const? 8 (-128))) ⊑
+    icmp IntPred.eq e (const? 8 (-128)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -874,8 +874,8 @@ theorem sle_swap_and_min_thm (e e_1 : IntW 8) :
 
 
 theorem sle_swap_and_min_logical_thm (e e_1 : IntW 8) :
-  select (icmp IntPredicate.sge e_1 e) (icmp IntPredicate.eq e (const? 8 (-128))) (const? 1 0) ⊑
-    icmp IntPredicate.eq e (const? 8 (-128)) := by
+  select (icmp IntPred.sge e_1 e) (icmp IntPred.eq e (const? 8 (-128))) (const? 1 0) ⊑
+    icmp IntPred.eq e (const? 8 (-128)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -885,8 +885,8 @@ theorem sle_swap_and_min_logical_thm (e e_1 : IntW 8) :
 
 
 theorem sle_swap_and_min_commute_thm (e e_1 : IntW 8) :
-  LLVM.and (icmp IntPredicate.eq e_1 (const? 8 (-128))) (icmp IntPredicate.sge e e_1) ⊑
-    icmp IntPredicate.eq e_1 (const? 8 (-128)) := by
+  LLVM.and (icmp IntPred.eq e_1 (const? 8 (-128))) (icmp IntPred.sge e e_1) ⊑
+    icmp IntPred.eq e_1 (const? 8 (-128)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -896,8 +896,8 @@ theorem sle_swap_and_min_commute_thm (e e_1 : IntW 8) :
 
 
 theorem sle_swap_and_min_commute_logical_thm (e e_1 : IntW 8) :
-  select (icmp IntPredicate.eq e_1 (const? 8 (-128))) (icmp IntPredicate.sge e e_1) (const? 1 0) ⊑
-    icmp IntPredicate.eq e_1 (const? 8 (-128)) := by
+  select (icmp IntPred.eq e_1 (const? 8 (-128))) (icmp IntPred.sge e e_1) (const? 1 0) ⊑
+    icmp IntPred.eq e_1 (const? 8 (-128)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -907,8 +907,8 @@ theorem sle_swap_and_min_commute_logical_thm (e e_1 : IntW 8) :
 
 
 theorem ule_and_min_thm (e e_1 : IntW 8) :
-  LLVM.and (icmp IntPredicate.ule e_1 e) (icmp IntPredicate.eq e_1 (const? 8 0)) ⊑
-    icmp IntPredicate.eq e_1 (const? 8 0) := by
+  LLVM.and (icmp IntPred.ule e_1 e) (icmp IntPred.eq e_1 (const? 8 0)) ⊑
+    icmp IntPred.eq e_1 (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -918,8 +918,8 @@ theorem ule_and_min_thm (e e_1 : IntW 8) :
 
 
 theorem ule_and_min_logical_thm (e e_1 : IntW 8) :
-  select (icmp IntPredicate.ule e_1 e) (icmp IntPredicate.eq e_1 (const? 8 0)) (const? 1 0) ⊑
-    icmp IntPredicate.eq e_1 (const? 8 0) := by
+  select (icmp IntPred.ule e_1 e) (icmp IntPred.eq e_1 (const? 8 0)) (const? 1 0) ⊑
+    icmp IntPred.eq e_1 (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -929,8 +929,8 @@ theorem ule_and_min_logical_thm (e e_1 : IntW 8) :
 
 
 theorem ule_and_min_commute_thm (e e_1 : IntW 8) :
-  LLVM.and (icmp IntPredicate.eq e_1 (const? 8 0)) (icmp IntPredicate.ule e_1 e) ⊑
-    icmp IntPredicate.eq e_1 (const? 8 0) := by
+  LLVM.and (icmp IntPred.eq e_1 (const? 8 0)) (icmp IntPred.ule e_1 e) ⊑
+    icmp IntPred.eq e_1 (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -940,8 +940,8 @@ theorem ule_and_min_commute_thm (e e_1 : IntW 8) :
 
 
 theorem ule_and_min_commute_logical_thm (e e_1 : IntW 8) :
-  select (icmp IntPredicate.eq e_1 (const? 8 0)) (icmp IntPredicate.ule e_1 e) (const? 1 0) ⊑
-    icmp IntPredicate.eq e_1 (const? 8 0) := by
+  select (icmp IntPred.eq e_1 (const? 8 0)) (icmp IntPred.ule e_1 e) (const? 1 0) ⊑
+    icmp IntPred.eq e_1 (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -951,8 +951,8 @@ theorem ule_and_min_commute_logical_thm (e e_1 : IntW 8) :
 
 
 theorem ule_swap_and_min_thm (e e_1 : IntW 8) :
-  LLVM.and (icmp IntPredicate.uge e_1 e) (icmp IntPredicate.eq e (const? 8 0)) ⊑
-    icmp IntPredicate.eq e (const? 8 0) := by
+  LLVM.and (icmp IntPred.uge e_1 e) (icmp IntPred.eq e (const? 8 0)) ⊑
+    icmp IntPred.eq e (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -962,8 +962,8 @@ theorem ule_swap_and_min_thm (e e_1 : IntW 8) :
 
 
 theorem ule_swap_and_min_logical_thm (e e_1 : IntW 8) :
-  select (icmp IntPredicate.uge e_1 e) (icmp IntPredicate.eq e (const? 8 0)) (const? 1 0) ⊑
-    icmp IntPredicate.eq e (const? 8 0) := by
+  select (icmp IntPred.uge e_1 e) (icmp IntPred.eq e (const? 8 0)) (const? 1 0) ⊑
+    icmp IntPred.eq e (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -973,8 +973,8 @@ theorem ule_swap_and_min_logical_thm (e e_1 : IntW 8) :
 
 
 theorem ule_swap_and_min_commute_thm (e e_1 : IntW 8) :
-  LLVM.and (icmp IntPredicate.eq e_1 (const? 8 0)) (icmp IntPredicate.uge e e_1) ⊑
-    icmp IntPredicate.eq e_1 (const? 8 0) := by
+  LLVM.and (icmp IntPred.eq e_1 (const? 8 0)) (icmp IntPred.uge e e_1) ⊑
+    icmp IntPred.eq e_1 (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -984,8 +984,8 @@ theorem ule_swap_and_min_commute_thm (e e_1 : IntW 8) :
 
 
 theorem ule_swap_and_min_commute_logical_thm (e e_1 : IntW 8) :
-  select (icmp IntPredicate.eq e_1 (const? 8 0)) (icmp IntPredicate.uge e e_1) (const? 1 0) ⊑
-    icmp IntPredicate.eq e_1 (const? 8 0) := by
+  select (icmp IntPred.eq e_1 (const? 8 0)) (icmp IntPred.uge e e_1) (const? 1 0) ⊑
+    icmp IntPred.eq e_1 (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -995,7 +995,7 @@ theorem ule_swap_and_min_commute_logical_thm (e e_1 : IntW 8) :
 
 
 theorem sge_or_max_thm (e e_1 : IntW 8) :
-  LLVM.or (icmp IntPredicate.sge e_1 e) (icmp IntPredicate.eq e_1 (const? 8 127)) ⊑ icmp IntPredicate.sge e_1 e := by
+  LLVM.or (icmp IntPred.sge e_1 e) (icmp IntPred.eq e_1 (const? 8 127)) ⊑ icmp IntPred.sge e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1005,8 +1005,8 @@ theorem sge_or_max_thm (e e_1 : IntW 8) :
 
 
 theorem sge_or_max_logical_thm (e e_1 : IntW 8) :
-  select (icmp IntPredicate.sge e_1 e) (const? 1 1) (icmp IntPredicate.eq e_1 (const? 8 127)) ⊑
-    icmp IntPredicate.sge e_1 e := by
+  select (icmp IntPred.sge e_1 e) (const? 1 1) (icmp IntPred.eq e_1 (const? 8 127)) ⊑
+    icmp IntPred.sge e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1016,7 +1016,7 @@ theorem sge_or_max_logical_thm (e e_1 : IntW 8) :
 
 
 theorem sge_or_max_commute_thm (e e_1 : IntW 8) :
-  LLVM.or (icmp IntPredicate.eq e_1 (const? 8 127)) (icmp IntPredicate.sge e_1 e) ⊑ icmp IntPredicate.sge e_1 e := by
+  LLVM.or (icmp IntPred.eq e_1 (const? 8 127)) (icmp IntPred.sge e_1 e) ⊑ icmp IntPred.sge e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1026,7 +1026,7 @@ theorem sge_or_max_commute_thm (e e_1 : IntW 8) :
 
 
 theorem sge_swap_or_max_thm (e e_1 : IntW 8) :
-  LLVM.or (icmp IntPredicate.sle e_1 e) (icmp IntPredicate.eq e (const? 8 127)) ⊑ icmp IntPredicate.sle e_1 e := by
+  LLVM.or (icmp IntPred.sle e_1 e) (icmp IntPred.eq e (const? 8 127)) ⊑ icmp IntPred.sle e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1036,8 +1036,8 @@ theorem sge_swap_or_max_thm (e e_1 : IntW 8) :
 
 
 theorem sge_swap_or_max_logical_thm (e e_1 : IntW 8) :
-  select (icmp IntPredicate.sle e_1 e) (const? 1 1) (icmp IntPredicate.eq e (const? 8 127)) ⊑
-    icmp IntPredicate.sle e_1 e := by
+  select (icmp IntPred.sle e_1 e) (const? 1 1) (icmp IntPred.eq e (const? 8 127)) ⊑
+    icmp IntPred.sle e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1047,7 +1047,7 @@ theorem sge_swap_or_max_logical_thm (e e_1 : IntW 8) :
 
 
 theorem sge_swap_or_max_commute_thm (e e_1 : IntW 8) :
-  LLVM.or (icmp IntPredicate.eq e_1 (const? 8 127)) (icmp IntPredicate.sle e e_1) ⊑ icmp IntPredicate.sle e e_1 := by
+  LLVM.or (icmp IntPred.eq e_1 (const? 8 127)) (icmp IntPred.sle e e_1) ⊑ icmp IntPred.sle e e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1057,8 +1057,8 @@ theorem sge_swap_or_max_commute_thm (e e_1 : IntW 8) :
 
 
 theorem uge_or_max_thm (e e_1 : IntW 8) :
-  LLVM.or (icmp IntPredicate.uge e_1 e) (icmp IntPredicate.eq e_1 (const? 8 (-1))) ⊑
-    icmp IntPredicate.uge e_1 e := by
+  LLVM.or (icmp IntPred.uge e_1 e) (icmp IntPred.eq e_1 (const? 8 (-1))) ⊑
+    icmp IntPred.uge e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1068,8 +1068,8 @@ theorem uge_or_max_thm (e e_1 : IntW 8) :
 
 
 theorem uge_or_max_logical_thm (e e_1 : IntW 8) :
-  select (icmp IntPredicate.uge e_1 e) (const? 1 1) (icmp IntPredicate.eq e_1 (const? 8 (-1))) ⊑
-    icmp IntPredicate.uge e_1 e := by
+  select (icmp IntPred.uge e_1 e) (const? 1 1) (icmp IntPred.eq e_1 (const? 8 (-1))) ⊑
+    icmp IntPred.uge e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1079,8 +1079,8 @@ theorem uge_or_max_logical_thm (e e_1 : IntW 8) :
 
 
 theorem uge_or_max_commute_thm (e e_1 : IntW 8) :
-  LLVM.or (icmp IntPredicate.eq e_1 (const? 8 (-1))) (icmp IntPredicate.uge e_1 e) ⊑
-    icmp IntPredicate.uge e_1 e := by
+  LLVM.or (icmp IntPred.eq e_1 (const? 8 (-1))) (icmp IntPred.uge e_1 e) ⊑
+    icmp IntPred.uge e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1090,7 +1090,7 @@ theorem uge_or_max_commute_thm (e e_1 : IntW 8) :
 
 
 theorem uge_swap_or_max_thm (e e_1 : IntW 8) :
-  LLVM.or (icmp IntPredicate.ule e_1 e) (icmp IntPredicate.eq e (const? 8 (-1))) ⊑ icmp IntPredicate.ule e_1 e := by
+  LLVM.or (icmp IntPred.ule e_1 e) (icmp IntPred.eq e (const? 8 (-1))) ⊑ icmp IntPred.ule e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1100,8 +1100,8 @@ theorem uge_swap_or_max_thm (e e_1 : IntW 8) :
 
 
 theorem uge_swap_or_max_logical_thm (e e_1 : IntW 8) :
-  select (icmp IntPredicate.ule e_1 e) (const? 1 1) (icmp IntPredicate.eq e (const? 8 (-1))) ⊑
-    icmp IntPredicate.ule e_1 e := by
+  select (icmp IntPred.ule e_1 e) (const? 1 1) (icmp IntPred.eq e (const? 8 (-1))) ⊑
+    icmp IntPred.ule e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1111,8 +1111,8 @@ theorem uge_swap_or_max_logical_thm (e e_1 : IntW 8) :
 
 
 theorem uge_swap_or_max_commute_thm (e e_1 : IntW 8) :
-  LLVM.or (icmp IntPredicate.eq e_1 (const? 8 (-1))) (icmp IntPredicate.ule e e_1) ⊑
-    icmp IntPredicate.ule e e_1 := by
+  LLVM.or (icmp IntPred.eq e_1 (const? 8 (-1))) (icmp IntPred.ule e e_1) ⊑
+    icmp IntPred.ule e e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1122,8 +1122,8 @@ theorem uge_swap_or_max_commute_thm (e e_1 : IntW 8) :
 
 
 theorem sle_or_min_thm (e e_1 : IntW 8) :
-  LLVM.or (icmp IntPredicate.sle e_1 e) (icmp IntPredicate.eq e_1 (const? 8 (-128))) ⊑
-    icmp IntPredicate.sle e_1 e := by
+  LLVM.or (icmp IntPred.sle e_1 e) (icmp IntPred.eq e_1 (const? 8 (-128))) ⊑
+    icmp IntPred.sle e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1133,8 +1133,8 @@ theorem sle_or_min_thm (e e_1 : IntW 8) :
 
 
 theorem sle_or_min_logical_thm (e e_1 : IntW 8) :
-  select (icmp IntPredicate.sle e_1 e) (const? 1 1) (icmp IntPredicate.eq e_1 (const? 8 (-128))) ⊑
-    icmp IntPredicate.sle e_1 e := by
+  select (icmp IntPred.sle e_1 e) (const? 1 1) (icmp IntPred.eq e_1 (const? 8 (-128))) ⊑
+    icmp IntPred.sle e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1144,8 +1144,8 @@ theorem sle_or_min_logical_thm (e e_1 : IntW 8) :
 
 
 theorem sle_or_min_commute_thm (e e_1 : IntW 8) :
-  LLVM.or (icmp IntPredicate.eq e_1 (const? 8 (-128))) (icmp IntPredicate.sle e_1 e) ⊑
-    icmp IntPredicate.sle e_1 e := by
+  LLVM.or (icmp IntPred.eq e_1 (const? 8 (-128))) (icmp IntPred.sle e_1 e) ⊑
+    icmp IntPred.sle e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1155,8 +1155,8 @@ theorem sle_or_min_commute_thm (e e_1 : IntW 8) :
 
 
 theorem sle_swap_or_min_thm (e e_1 : IntW 8) :
-  LLVM.or (icmp IntPredicate.sge e_1 e) (icmp IntPredicate.eq e (const? 8 (-128))) ⊑
-    icmp IntPredicate.sge e_1 e := by
+  LLVM.or (icmp IntPred.sge e_1 e) (icmp IntPred.eq e (const? 8 (-128))) ⊑
+    icmp IntPred.sge e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1166,8 +1166,8 @@ theorem sle_swap_or_min_thm (e e_1 : IntW 8) :
 
 
 theorem sle_swap_or_min_logical_thm (e e_1 : IntW 8) :
-  select (icmp IntPredicate.sge e_1 e) (const? 1 1) (icmp IntPredicate.eq e (const? 8 (-128))) ⊑
-    icmp IntPredicate.sge e_1 e := by
+  select (icmp IntPred.sge e_1 e) (const? 1 1) (icmp IntPred.eq e (const? 8 (-128))) ⊑
+    icmp IntPred.sge e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1177,8 +1177,8 @@ theorem sle_swap_or_min_logical_thm (e e_1 : IntW 8) :
 
 
 theorem sle_swap_or_min_commute_thm (e e_1 : IntW 8) :
-  LLVM.or (icmp IntPredicate.eq e_1 (const? 8 (-128))) (icmp IntPredicate.sge e e_1) ⊑
-    icmp IntPredicate.sge e e_1 := by
+  LLVM.or (icmp IntPred.eq e_1 (const? 8 (-128))) (icmp IntPred.sge e e_1) ⊑
+    icmp IntPred.sge e e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1188,7 +1188,7 @@ theorem sle_swap_or_min_commute_thm (e e_1 : IntW 8) :
 
 
 theorem ule_or_min_thm (e e_1 : IntW 8) :
-  LLVM.or (icmp IntPredicate.ule e_1 e) (icmp IntPredicate.eq e_1 (const? 8 0)) ⊑ icmp IntPredicate.ule e_1 e := by
+  LLVM.or (icmp IntPred.ule e_1 e) (icmp IntPred.eq e_1 (const? 8 0)) ⊑ icmp IntPred.ule e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1198,8 +1198,8 @@ theorem ule_or_min_thm (e e_1 : IntW 8) :
 
 
 theorem ule_or_min_logical_thm (e e_1 : IntW 8) :
-  select (icmp IntPredicate.ule e_1 e) (const? 1 1) (icmp IntPredicate.eq e_1 (const? 8 0)) ⊑
-    icmp IntPredicate.ule e_1 e := by
+  select (icmp IntPred.ule e_1 e) (const? 1 1) (icmp IntPred.eq e_1 (const? 8 0)) ⊑
+    icmp IntPred.ule e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1209,7 +1209,7 @@ theorem ule_or_min_logical_thm (e e_1 : IntW 8) :
 
 
 theorem ule_or_min_commute_thm (e e_1 : IntW 8) :
-  LLVM.or (icmp IntPredicate.eq e_1 (const? 8 0)) (icmp IntPredicate.ule e_1 e) ⊑ icmp IntPredicate.ule e_1 e := by
+  LLVM.or (icmp IntPred.eq e_1 (const? 8 0)) (icmp IntPred.ule e_1 e) ⊑ icmp IntPred.ule e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1219,7 +1219,7 @@ theorem ule_or_min_commute_thm (e e_1 : IntW 8) :
 
 
 theorem ule_swap_or_min_thm (e e_1 : IntW 8) :
-  LLVM.or (icmp IntPredicate.uge e_1 e) (icmp IntPredicate.eq e (const? 8 0)) ⊑ icmp IntPredicate.uge e_1 e := by
+  LLVM.or (icmp IntPred.uge e_1 e) (icmp IntPred.eq e (const? 8 0)) ⊑ icmp IntPred.uge e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1229,8 +1229,8 @@ theorem ule_swap_or_min_thm (e e_1 : IntW 8) :
 
 
 theorem ule_swap_or_min_logical_thm (e e_1 : IntW 8) :
-  select (icmp IntPredicate.uge e_1 e) (const? 1 1) (icmp IntPredicate.eq e (const? 8 0)) ⊑
-    icmp IntPredicate.uge e_1 e := by
+  select (icmp IntPred.uge e_1 e) (const? 1 1) (icmp IntPred.eq e (const? 8 0)) ⊑
+    icmp IntPred.uge e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1240,7 +1240,7 @@ theorem ule_swap_or_min_logical_thm (e e_1 : IntW 8) :
 
 
 theorem ule_swap_or_min_commute_thm (e e_1 : IntW 8) :
-  LLVM.or (icmp IntPredicate.eq e_1 (const? 8 0)) (icmp IntPredicate.uge e e_1) ⊑ icmp IntPredicate.uge e e_1 := by
+  LLVM.or (icmp IntPred.eq e_1 (const? 8 0)) (icmp IntPred.uge e e_1) ⊑ icmp IntPred.uge e e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1250,8 +1250,8 @@ theorem ule_swap_or_min_commute_thm (e e_1 : IntW 8) :
 
 
 theorem slt_and_not_max_thm (e e_1 : IntW 8) :
-  LLVM.and (icmp IntPredicate.slt e_1 e) (icmp IntPredicate.ne e_1 (const? 8 127)) ⊑
-    icmp IntPredicate.slt e_1 e := by
+  LLVM.and (icmp IntPred.slt e_1 e) (icmp IntPred.ne e_1 (const? 8 127)) ⊑
+    icmp IntPred.slt e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1261,8 +1261,8 @@ theorem slt_and_not_max_thm (e e_1 : IntW 8) :
 
 
 theorem slt_and_not_max_logical_thm (e e_1 : IntW 8) :
-  select (icmp IntPredicate.slt e_1 e) (icmp IntPredicate.ne e_1 (const? 8 127)) (const? 1 0) ⊑
-    icmp IntPredicate.slt e_1 e := by
+  select (icmp IntPred.slt e_1 e) (icmp IntPred.ne e_1 (const? 8 127)) (const? 1 0) ⊑
+    icmp IntPred.slt e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1272,8 +1272,8 @@ theorem slt_and_not_max_logical_thm (e e_1 : IntW 8) :
 
 
 theorem slt_and_not_max_commute_thm (e e_1 : IntW 8) :
-  LLVM.and (icmp IntPredicate.ne e_1 (const? 8 127)) (icmp IntPredicate.slt e_1 e) ⊑
-    icmp IntPredicate.slt e_1 e := by
+  LLVM.and (icmp IntPred.ne e_1 (const? 8 127)) (icmp IntPred.slt e_1 e) ⊑
+    icmp IntPred.slt e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1283,7 +1283,7 @@ theorem slt_and_not_max_commute_thm (e e_1 : IntW 8) :
 
 
 theorem slt_swap_and_not_max_thm (e e_1 : IntW 8) :
-  LLVM.and (icmp IntPredicate.sgt e_1 e) (icmp IntPredicate.ne e (const? 8 127)) ⊑ icmp IntPredicate.sgt e_1 e := by
+  LLVM.and (icmp IntPred.sgt e_1 e) (icmp IntPred.ne e (const? 8 127)) ⊑ icmp IntPred.sgt e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1293,8 +1293,8 @@ theorem slt_swap_and_not_max_thm (e e_1 : IntW 8) :
 
 
 theorem slt_swap_and_not_max_logical_thm (e e_1 : IntW 8) :
-  select (icmp IntPredicate.sgt e_1 e) (icmp IntPredicate.ne e (const? 8 127)) (const? 1 0) ⊑
-    icmp IntPredicate.sgt e_1 e := by
+  select (icmp IntPred.sgt e_1 e) (icmp IntPred.ne e (const? 8 127)) (const? 1 0) ⊑
+    icmp IntPred.sgt e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1304,8 +1304,8 @@ theorem slt_swap_and_not_max_logical_thm (e e_1 : IntW 8) :
 
 
 theorem slt_swap_and_not_max_commute_thm (e e_1 : IntW 8) :
-  LLVM.and (icmp IntPredicate.ne e_1 (const? 8 127)) (icmp IntPredicate.sgt e e_1) ⊑
-    icmp IntPredicate.sgt e e_1 := by
+  LLVM.and (icmp IntPred.ne e_1 (const? 8 127)) (icmp IntPred.sgt e e_1) ⊑
+    icmp IntPred.sgt e e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1315,8 +1315,8 @@ theorem slt_swap_and_not_max_commute_thm (e e_1 : IntW 8) :
 
 
 theorem ult_and_not_max_thm (e e_1 : IntW 8) :
-  LLVM.and (icmp IntPredicate.ult e_1 e) (icmp IntPredicate.ne e_1 (const? 8 (-1))) ⊑
-    icmp IntPredicate.ult e_1 e := by
+  LLVM.and (icmp IntPred.ult e_1 e) (icmp IntPred.ne e_1 (const? 8 (-1))) ⊑
+    icmp IntPred.ult e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1326,8 +1326,8 @@ theorem ult_and_not_max_thm (e e_1 : IntW 8) :
 
 
 theorem ult_and_not_max_logical_thm (e e_1 : IntW 8) :
-  select (icmp IntPredicate.ult e_1 e) (icmp IntPredicate.ne e_1 (const? 8 (-1))) (const? 1 0) ⊑
-    icmp IntPredicate.ult e_1 e := by
+  select (icmp IntPred.ult e_1 e) (icmp IntPred.ne e_1 (const? 8 (-1))) (const? 1 0) ⊑
+    icmp IntPred.ult e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1337,8 +1337,8 @@ theorem ult_and_not_max_logical_thm (e e_1 : IntW 8) :
 
 
 theorem ult_and_not_max_commute_thm (e e_1 : IntW 8) :
-  LLVM.and (icmp IntPredicate.ne e_1 (const? 8 (-1))) (icmp IntPredicate.ult e_1 e) ⊑
-    icmp IntPredicate.ult e_1 e := by
+  LLVM.and (icmp IntPred.ne e_1 (const? 8 (-1))) (icmp IntPred.ult e_1 e) ⊑
+    icmp IntPred.ult e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1348,7 +1348,7 @@ theorem ult_and_not_max_commute_thm (e e_1 : IntW 8) :
 
 
 theorem ult_swap_and_not_max_thm (e e_1 : IntW 8) :
-  LLVM.and (icmp IntPredicate.ugt e_1 e) (icmp IntPredicate.ne e (const? 8 (-1))) ⊑ icmp IntPredicate.ugt e_1 e := by
+  LLVM.and (icmp IntPred.ugt e_1 e) (icmp IntPred.ne e (const? 8 (-1))) ⊑ icmp IntPred.ugt e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1358,8 +1358,8 @@ theorem ult_swap_and_not_max_thm (e e_1 : IntW 8) :
 
 
 theorem ult_swap_and_not_max_logical_thm (e e_1 : IntW 8) :
-  select (icmp IntPredicate.ugt e_1 e) (icmp IntPredicate.ne e (const? 8 (-1))) (const? 1 0) ⊑
-    icmp IntPredicate.ugt e_1 e := by
+  select (icmp IntPred.ugt e_1 e) (icmp IntPred.ne e (const? 8 (-1))) (const? 1 0) ⊑
+    icmp IntPred.ugt e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1369,8 +1369,8 @@ theorem ult_swap_and_not_max_logical_thm (e e_1 : IntW 8) :
 
 
 theorem ult_swap_and_not_max_commute_thm (e e_1 : IntW 8) :
-  LLVM.and (icmp IntPredicate.ne e_1 (const? 8 (-1))) (icmp IntPredicate.ugt e e_1) ⊑
-    icmp IntPredicate.ugt e e_1 := by
+  LLVM.and (icmp IntPred.ne e_1 (const? 8 (-1))) (icmp IntPred.ugt e e_1) ⊑
+    icmp IntPred.ugt e e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1380,8 +1380,8 @@ theorem ult_swap_and_not_max_commute_thm (e e_1 : IntW 8) :
 
 
 theorem sgt_and_not_min_thm (e e_1 : IntW 8) :
-  LLVM.and (icmp IntPredicate.sgt e_1 e) (icmp IntPredicate.ne e_1 (const? 8 (-128))) ⊑
-    icmp IntPredicate.sgt e_1 e := by
+  LLVM.and (icmp IntPred.sgt e_1 e) (icmp IntPred.ne e_1 (const? 8 (-128))) ⊑
+    icmp IntPred.sgt e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1391,8 +1391,8 @@ theorem sgt_and_not_min_thm (e e_1 : IntW 8) :
 
 
 theorem sgt_and_not_min_logical_thm (e e_1 : IntW 8) :
-  select (icmp IntPredicate.sgt e_1 e) (icmp IntPredicate.ne e_1 (const? 8 (-128))) (const? 1 0) ⊑
-    icmp IntPredicate.sgt e_1 e := by
+  select (icmp IntPred.sgt e_1 e) (icmp IntPred.ne e_1 (const? 8 (-128))) (const? 1 0) ⊑
+    icmp IntPred.sgt e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1402,8 +1402,8 @@ theorem sgt_and_not_min_logical_thm (e e_1 : IntW 8) :
 
 
 theorem sgt_and_not_min_commute_thm (e e_1 : IntW 8) :
-  LLVM.and (icmp IntPredicate.ne e_1 (const? 8 (-128))) (icmp IntPredicate.sgt e_1 e) ⊑
-    icmp IntPredicate.sgt e_1 e := by
+  LLVM.and (icmp IntPred.ne e_1 (const? 8 (-128))) (icmp IntPred.sgt e_1 e) ⊑
+    icmp IntPred.sgt e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1413,8 +1413,8 @@ theorem sgt_and_not_min_commute_thm (e e_1 : IntW 8) :
 
 
 theorem sgt_swap_and_not_min_thm (e e_1 : IntW 8) :
-  LLVM.and (icmp IntPredicate.slt e_1 e) (icmp IntPredicate.ne e (const? 8 (-128))) ⊑
-    icmp IntPredicate.slt e_1 e := by
+  LLVM.and (icmp IntPred.slt e_1 e) (icmp IntPred.ne e (const? 8 (-128))) ⊑
+    icmp IntPred.slt e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1424,8 +1424,8 @@ theorem sgt_swap_and_not_min_thm (e e_1 : IntW 8) :
 
 
 theorem sgt_swap_and_not_min_logical_thm (e e_1 : IntW 8) :
-  select (icmp IntPredicate.slt e_1 e) (icmp IntPredicate.ne e (const? 8 (-128))) (const? 1 0) ⊑
-    icmp IntPredicate.slt e_1 e := by
+  select (icmp IntPred.slt e_1 e) (icmp IntPred.ne e (const? 8 (-128))) (const? 1 0) ⊑
+    icmp IntPred.slt e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1435,8 +1435,8 @@ theorem sgt_swap_and_not_min_logical_thm (e e_1 : IntW 8) :
 
 
 theorem sgt_swap_and_not_min_commute_thm (e e_1 : IntW 8) :
-  LLVM.and (icmp IntPredicate.ne e_1 (const? 8 (-128))) (icmp IntPredicate.slt e e_1) ⊑
-    icmp IntPredicate.slt e e_1 := by
+  LLVM.and (icmp IntPred.ne e_1 (const? 8 (-128))) (icmp IntPred.slt e e_1) ⊑
+    icmp IntPred.slt e e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1446,7 +1446,7 @@ theorem sgt_swap_and_not_min_commute_thm (e e_1 : IntW 8) :
 
 
 theorem ugt_and_not_min_thm (e e_1 : IntW 8) :
-  LLVM.and (icmp IntPredicate.ugt e_1 e) (icmp IntPredicate.ne e_1 (const? 8 0)) ⊑ icmp IntPredicate.ugt e_1 e := by
+  LLVM.and (icmp IntPred.ugt e_1 e) (icmp IntPred.ne e_1 (const? 8 0)) ⊑ icmp IntPred.ugt e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1456,8 +1456,8 @@ theorem ugt_and_not_min_thm (e e_1 : IntW 8) :
 
 
 theorem ugt_and_not_min_logical_thm (e e_1 : IntW 8) :
-  select (icmp IntPredicate.ugt e_1 e) (icmp IntPredicate.ne e_1 (const? 8 0)) (const? 1 0) ⊑
-    icmp IntPredicate.ugt e_1 e := by
+  select (icmp IntPred.ugt e_1 e) (icmp IntPred.ne e_1 (const? 8 0)) (const? 1 0) ⊑
+    icmp IntPred.ugt e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1467,7 +1467,7 @@ theorem ugt_and_not_min_logical_thm (e e_1 : IntW 8) :
 
 
 theorem ugt_and_not_min_commute_thm (e e_1 : IntW 8) :
-  LLVM.and (icmp IntPredicate.ne e_1 (const? 8 0)) (icmp IntPredicate.ugt e_1 e) ⊑ icmp IntPredicate.ugt e_1 e := by
+  LLVM.and (icmp IntPred.ne e_1 (const? 8 0)) (icmp IntPred.ugt e_1 e) ⊑ icmp IntPred.ugt e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1477,7 +1477,7 @@ theorem ugt_and_not_min_commute_thm (e e_1 : IntW 8) :
 
 
 theorem ugt_swap_and_not_min_thm (e e_1 : IntW 8) :
-  LLVM.and (icmp IntPredicate.ult e_1 e) (icmp IntPredicate.ne e (const? 8 0)) ⊑ icmp IntPredicate.ult e_1 e := by
+  LLVM.and (icmp IntPred.ult e_1 e) (icmp IntPred.ne e (const? 8 0)) ⊑ icmp IntPred.ult e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1487,8 +1487,8 @@ theorem ugt_swap_and_not_min_thm (e e_1 : IntW 8) :
 
 
 theorem ugt_swap_and_not_min_logical_thm (e e_1 : IntW 8) :
-  select (icmp IntPredicate.ult e_1 e) (icmp IntPredicate.ne e (const? 8 0)) (const? 1 0) ⊑
-    icmp IntPredicate.ult e_1 e := by
+  select (icmp IntPred.ult e_1 e) (icmp IntPred.ne e (const? 8 0)) (const? 1 0) ⊑
+    icmp IntPred.ult e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1498,7 +1498,7 @@ theorem ugt_swap_and_not_min_logical_thm (e e_1 : IntW 8) :
 
 
 theorem ugt_swap_and_not_min_commute_thm (e e_1 : IntW 8) :
-  LLVM.and (icmp IntPredicate.ne e_1 (const? 8 0)) (icmp IntPredicate.ult e e_1) ⊑ icmp IntPredicate.ult e e_1 := by
+  LLVM.and (icmp IntPred.ne e_1 (const? 8 0)) (icmp IntPred.ult e e_1) ⊑ icmp IntPred.ult e e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1508,8 +1508,8 @@ theorem ugt_swap_and_not_min_commute_thm (e e_1 : IntW 8) :
 
 
 theorem slt_or_not_max_thm (e e_1 : IntW 8) :
-  LLVM.or (icmp IntPredicate.slt e_1 e) (icmp IntPredicate.ne e_1 (const? 8 127)) ⊑
-    icmp IntPredicate.ne e_1 (const? 8 127) := by
+  LLVM.or (icmp IntPred.slt e_1 e) (icmp IntPred.ne e_1 (const? 8 127)) ⊑
+    icmp IntPred.ne e_1 (const? 8 127) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1519,8 +1519,8 @@ theorem slt_or_not_max_thm (e e_1 : IntW 8) :
 
 
 theorem slt_or_not_max_logical_thm (e e_1 : IntW 8) :
-  select (icmp IntPredicate.slt e_1 e) (const? 1 1) (icmp IntPredicate.ne e_1 (const? 8 127)) ⊑
-    icmp IntPredicate.ne e_1 (const? 8 127) := by
+  select (icmp IntPred.slt e_1 e) (const? 1 1) (icmp IntPred.ne e_1 (const? 8 127)) ⊑
+    icmp IntPred.ne e_1 (const? 8 127) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1530,8 +1530,8 @@ theorem slt_or_not_max_logical_thm (e e_1 : IntW 8) :
 
 
 theorem slt_or_not_max_commute_thm (e e_1 : IntW 8) :
-  LLVM.or (icmp IntPredicate.ne e_1 (const? 8 127)) (icmp IntPredicate.slt e_1 e) ⊑
-    icmp IntPredicate.ne e_1 (const? 8 127) := by
+  LLVM.or (icmp IntPred.ne e_1 (const? 8 127)) (icmp IntPred.slt e_1 e) ⊑
+    icmp IntPred.ne e_1 (const? 8 127) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1541,8 +1541,8 @@ theorem slt_or_not_max_commute_thm (e e_1 : IntW 8) :
 
 
 theorem slt_or_not_max_commute_logical_thm (e e_1 : IntW 8) :
-  select (icmp IntPredicate.ne e_1 (const? 8 127)) (const? 1 1) (icmp IntPredicate.slt e_1 e) ⊑
-    icmp IntPredicate.ne e_1 (const? 8 127) := by
+  select (icmp IntPred.ne e_1 (const? 8 127)) (const? 1 1) (icmp IntPred.slt e_1 e) ⊑
+    icmp IntPred.ne e_1 (const? 8 127) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1552,8 +1552,8 @@ theorem slt_or_not_max_commute_logical_thm (e e_1 : IntW 8) :
 
 
 theorem slt_swap_or_not_max_thm (e e_1 : IntW 8) :
-  LLVM.or (icmp IntPredicate.sgt e_1 e) (icmp IntPredicate.ne e (const? 8 127)) ⊑
-    icmp IntPredicate.ne e (const? 8 127) := by
+  LLVM.or (icmp IntPred.sgt e_1 e) (icmp IntPred.ne e (const? 8 127)) ⊑
+    icmp IntPred.ne e (const? 8 127) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1563,8 +1563,8 @@ theorem slt_swap_or_not_max_thm (e e_1 : IntW 8) :
 
 
 theorem slt_swap_or_not_max_logical_thm (e e_1 : IntW 8) :
-  select (icmp IntPredicate.sgt e_1 e) (const? 1 1) (icmp IntPredicate.ne e (const? 8 127)) ⊑
-    icmp IntPredicate.ne e (const? 8 127) := by
+  select (icmp IntPred.sgt e_1 e) (const? 1 1) (icmp IntPred.ne e (const? 8 127)) ⊑
+    icmp IntPred.ne e (const? 8 127) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1574,8 +1574,8 @@ theorem slt_swap_or_not_max_logical_thm (e e_1 : IntW 8) :
 
 
 theorem slt_swap_or_not_max_commute_thm (e e_1 : IntW 8) :
-  LLVM.or (icmp IntPredicate.ne e_1 (const? 8 127)) (icmp IntPredicate.sgt e e_1) ⊑
-    icmp IntPredicate.ne e_1 (const? 8 127) := by
+  LLVM.or (icmp IntPred.ne e_1 (const? 8 127)) (icmp IntPred.sgt e e_1) ⊑
+    icmp IntPred.ne e_1 (const? 8 127) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1585,8 +1585,8 @@ theorem slt_swap_or_not_max_commute_thm (e e_1 : IntW 8) :
 
 
 theorem slt_swap_or_not_max_commute_logical_thm (e e_1 : IntW 8) :
-  select (icmp IntPredicate.ne e_1 (const? 8 127)) (const? 1 1) (icmp IntPredicate.sgt e e_1) ⊑
-    icmp IntPredicate.ne e_1 (const? 8 127) := by
+  select (icmp IntPred.ne e_1 (const? 8 127)) (const? 1 1) (icmp IntPred.sgt e e_1) ⊑
+    icmp IntPred.ne e_1 (const? 8 127) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1596,8 +1596,8 @@ theorem slt_swap_or_not_max_commute_logical_thm (e e_1 : IntW 8) :
 
 
 theorem ult_or_not_max_thm (e e_1 : IntW 8) :
-  LLVM.or (icmp IntPredicate.ult e_1 e) (icmp IntPredicate.ne e_1 (const? 8 (-1))) ⊑
-    icmp IntPredicate.ne e_1 (const? 8 (-1)) := by
+  LLVM.or (icmp IntPred.ult e_1 e) (icmp IntPred.ne e_1 (const? 8 (-1))) ⊑
+    icmp IntPred.ne e_1 (const? 8 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1607,8 +1607,8 @@ theorem ult_or_not_max_thm (e e_1 : IntW 8) :
 
 
 theorem ult_or_not_max_logical_thm (e e_1 : IntW 8) :
-  select (icmp IntPredicate.ult e_1 e) (const? 1 1) (icmp IntPredicate.ne e_1 (const? 8 (-1))) ⊑
-    icmp IntPredicate.ne e_1 (const? 8 (-1)) := by
+  select (icmp IntPred.ult e_1 e) (const? 1 1) (icmp IntPred.ne e_1 (const? 8 (-1))) ⊑
+    icmp IntPred.ne e_1 (const? 8 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1618,8 +1618,8 @@ theorem ult_or_not_max_logical_thm (e e_1 : IntW 8) :
 
 
 theorem ult_or_not_max_commute_thm (e e_1 : IntW 8) :
-  LLVM.or (icmp IntPredicate.ne e_1 (const? 8 (-1))) (icmp IntPredicate.ult e_1 e) ⊑
-    icmp IntPredicate.ne e_1 (const? 8 (-1)) := by
+  LLVM.or (icmp IntPred.ne e_1 (const? 8 (-1))) (icmp IntPred.ult e_1 e) ⊑
+    icmp IntPred.ne e_1 (const? 8 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1629,8 +1629,8 @@ theorem ult_or_not_max_commute_thm (e e_1 : IntW 8) :
 
 
 theorem ult_or_not_max_commute_logical_thm (e e_1 : IntW 8) :
-  select (icmp IntPredicate.ne e_1 (const? 8 (-1))) (const? 1 1) (icmp IntPredicate.ult e_1 e) ⊑
-    icmp IntPredicate.ne e_1 (const? 8 (-1)) := by
+  select (icmp IntPred.ne e_1 (const? 8 (-1))) (const? 1 1) (icmp IntPred.ult e_1 e) ⊑
+    icmp IntPred.ne e_1 (const? 8 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1640,8 +1640,8 @@ theorem ult_or_not_max_commute_logical_thm (e e_1 : IntW 8) :
 
 
 theorem ult_swap_or_not_max_thm (e e_1 : IntW 8) :
-  LLVM.or (icmp IntPredicate.ugt e_1 e) (icmp IntPredicate.ne e (const? 8 (-1))) ⊑
-    icmp IntPredicate.ne e (const? 8 (-1)) := by
+  LLVM.or (icmp IntPred.ugt e_1 e) (icmp IntPred.ne e (const? 8 (-1))) ⊑
+    icmp IntPred.ne e (const? 8 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1651,8 +1651,8 @@ theorem ult_swap_or_not_max_thm (e e_1 : IntW 8) :
 
 
 theorem ult_swap_or_not_max_logical_thm (e e_1 : IntW 8) :
-  select (icmp IntPredicate.ugt e_1 e) (const? 1 1) (icmp IntPredicate.ne e (const? 8 (-1))) ⊑
-    icmp IntPredicate.ne e (const? 8 (-1)) := by
+  select (icmp IntPred.ugt e_1 e) (const? 1 1) (icmp IntPred.ne e (const? 8 (-1))) ⊑
+    icmp IntPred.ne e (const? 8 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1662,8 +1662,8 @@ theorem ult_swap_or_not_max_logical_thm (e e_1 : IntW 8) :
 
 
 theorem ult_swap_or_not_max_commute_thm (e e_1 : IntW 8) :
-  LLVM.or (icmp IntPredicate.ne e_1 (const? 8 (-1))) (icmp IntPredicate.ugt e e_1) ⊑
-    icmp IntPredicate.ne e_1 (const? 8 (-1)) := by
+  LLVM.or (icmp IntPred.ne e_1 (const? 8 (-1))) (icmp IntPred.ugt e e_1) ⊑
+    icmp IntPred.ne e_1 (const? 8 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1673,8 +1673,8 @@ theorem ult_swap_or_not_max_commute_thm (e e_1 : IntW 8) :
 
 
 theorem ult_swap_or_not_max_commute_logical_thm (e e_1 : IntW 8) :
-  select (icmp IntPredicate.ne e_1 (const? 8 (-1))) (const? 1 1) (icmp IntPredicate.ugt e e_1) ⊑
-    icmp IntPredicate.ne e_1 (const? 8 (-1)) := by
+  select (icmp IntPred.ne e_1 (const? 8 (-1))) (const? 1 1) (icmp IntPred.ugt e e_1) ⊑
+    icmp IntPred.ne e_1 (const? 8 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1684,8 +1684,8 @@ theorem ult_swap_or_not_max_commute_logical_thm (e e_1 : IntW 8) :
 
 
 theorem sgt_or_not_min_thm (e e_1 : IntW 8) :
-  LLVM.or (icmp IntPredicate.sgt e_1 e) (icmp IntPredicate.ne e_1 (const? 8 (-128))) ⊑
-    icmp IntPredicate.ne e_1 (const? 8 (-128)) := by
+  LLVM.or (icmp IntPred.sgt e_1 e) (icmp IntPred.ne e_1 (const? 8 (-128))) ⊑
+    icmp IntPred.ne e_1 (const? 8 (-128)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1695,8 +1695,8 @@ theorem sgt_or_not_min_thm (e e_1 : IntW 8) :
 
 
 theorem sgt_or_not_min_logical_thm (e e_1 : IntW 8) :
-  select (icmp IntPredicate.sgt e_1 e) (const? 1 1) (icmp IntPredicate.ne e_1 (const? 8 (-128))) ⊑
-    icmp IntPredicate.ne e_1 (const? 8 (-128)) := by
+  select (icmp IntPred.sgt e_1 e) (const? 1 1) (icmp IntPred.ne e_1 (const? 8 (-128))) ⊑
+    icmp IntPred.ne e_1 (const? 8 (-128)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1706,8 +1706,8 @@ theorem sgt_or_not_min_logical_thm (e e_1 : IntW 8) :
 
 
 theorem sgt_or_not_min_commute_thm (e e_1 : IntW 8) :
-  LLVM.or (icmp IntPredicate.ne e_1 (const? 8 (-128))) (icmp IntPredicate.sgt e_1 e) ⊑
-    icmp IntPredicate.ne e_1 (const? 8 (-128)) := by
+  LLVM.or (icmp IntPred.ne e_1 (const? 8 (-128))) (icmp IntPred.sgt e_1 e) ⊑
+    icmp IntPred.ne e_1 (const? 8 (-128)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1717,8 +1717,8 @@ theorem sgt_or_not_min_commute_thm (e e_1 : IntW 8) :
 
 
 theorem sgt_or_not_min_commute_logical_thm (e e_1 : IntW 8) :
-  select (icmp IntPredicate.ne e_1 (const? 8 (-128))) (const? 1 1) (icmp IntPredicate.sgt e_1 e) ⊑
-    icmp IntPredicate.ne e_1 (const? 8 (-128)) := by
+  select (icmp IntPred.ne e_1 (const? 8 (-128))) (const? 1 1) (icmp IntPred.sgt e_1 e) ⊑
+    icmp IntPred.ne e_1 (const? 8 (-128)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1728,8 +1728,8 @@ theorem sgt_or_not_min_commute_logical_thm (e e_1 : IntW 8) :
 
 
 theorem sgt_swap_or_not_min_thm (e e_1 : IntW 8) :
-  LLVM.or (icmp IntPredicate.slt e_1 e) (icmp IntPredicate.ne e (const? 8 (-128))) ⊑
-    icmp IntPredicate.ne e (const? 8 (-128)) := by
+  LLVM.or (icmp IntPred.slt e_1 e) (icmp IntPred.ne e (const? 8 (-128))) ⊑
+    icmp IntPred.ne e (const? 8 (-128)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1739,8 +1739,8 @@ theorem sgt_swap_or_not_min_thm (e e_1 : IntW 8) :
 
 
 theorem sgt_swap_or_not_min_logical_thm (e e_1 : IntW 8) :
-  select (icmp IntPredicate.slt e_1 e) (const? 1 1) (icmp IntPredicate.ne e (const? 8 (-128))) ⊑
-    icmp IntPredicate.ne e (const? 8 (-128)) := by
+  select (icmp IntPred.slt e_1 e) (const? 1 1) (icmp IntPred.ne e (const? 8 (-128))) ⊑
+    icmp IntPred.ne e (const? 8 (-128)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1750,8 +1750,8 @@ theorem sgt_swap_or_not_min_logical_thm (e e_1 : IntW 8) :
 
 
 theorem sgt_swap_or_not_min_commute_thm (e e_1 : IntW 8) :
-  LLVM.or (icmp IntPredicate.ne e_1 (const? 8 (-128))) (icmp IntPredicate.slt e e_1) ⊑
-    icmp IntPredicate.ne e_1 (const? 8 (-128)) := by
+  LLVM.or (icmp IntPred.ne e_1 (const? 8 (-128))) (icmp IntPred.slt e e_1) ⊑
+    icmp IntPred.ne e_1 (const? 8 (-128)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1761,8 +1761,8 @@ theorem sgt_swap_or_not_min_commute_thm (e e_1 : IntW 8) :
 
 
 theorem sgt_swap_or_not_min_commute_logical_thm (e e_1 : IntW 8) :
-  select (icmp IntPredicate.ne e_1 (const? 8 (-128))) (const? 1 1) (icmp IntPredicate.slt e e_1) ⊑
-    icmp IntPredicate.ne e_1 (const? 8 (-128)) := by
+  select (icmp IntPred.ne e_1 (const? 8 (-128))) (const? 1 1) (icmp IntPred.slt e e_1) ⊑
+    icmp IntPred.ne e_1 (const? 8 (-128)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1772,8 +1772,8 @@ theorem sgt_swap_or_not_min_commute_logical_thm (e e_1 : IntW 8) :
 
 
 theorem ugt_or_not_min_thm (e e_1 : IntW 8) :
-  LLVM.or (icmp IntPredicate.ugt e_1 e) (icmp IntPredicate.ne e_1 (const? 8 0)) ⊑
-    icmp IntPredicate.ne e_1 (const? 8 0) := by
+  LLVM.or (icmp IntPred.ugt e_1 e) (icmp IntPred.ne e_1 (const? 8 0)) ⊑
+    icmp IntPred.ne e_1 (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1783,8 +1783,8 @@ theorem ugt_or_not_min_thm (e e_1 : IntW 8) :
 
 
 theorem ugt_or_not_min_logical_thm (e e_1 : IntW 8) :
-  select (icmp IntPredicate.ugt e_1 e) (const? 1 1) (icmp IntPredicate.ne e_1 (const? 8 0)) ⊑
-    icmp IntPredicate.ne e_1 (const? 8 0) := by
+  select (icmp IntPred.ugt e_1 e) (const? 1 1) (icmp IntPred.ne e_1 (const? 8 0)) ⊑
+    icmp IntPred.ne e_1 (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1794,8 +1794,8 @@ theorem ugt_or_not_min_logical_thm (e e_1 : IntW 8) :
 
 
 theorem ugt_or_not_min_commute_thm (e e_1 : IntW 8) :
-  LLVM.or (icmp IntPredicate.ne e_1 (const? 8 0)) (icmp IntPredicate.ugt e_1 e) ⊑
-    icmp IntPredicate.ne e_1 (const? 8 0) := by
+  LLVM.or (icmp IntPred.ne e_1 (const? 8 0)) (icmp IntPred.ugt e_1 e) ⊑
+    icmp IntPred.ne e_1 (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1805,8 +1805,8 @@ theorem ugt_or_not_min_commute_thm (e e_1 : IntW 8) :
 
 
 theorem ugt_or_not_min_commute_logical_thm (e e_1 : IntW 8) :
-  select (icmp IntPredicate.ne e_1 (const? 8 0)) (const? 1 1) (icmp IntPredicate.ugt e_1 e) ⊑
-    icmp IntPredicate.ne e_1 (const? 8 0) := by
+  select (icmp IntPred.ne e_1 (const? 8 0)) (const? 1 1) (icmp IntPred.ugt e_1 e) ⊑
+    icmp IntPred.ne e_1 (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1816,8 +1816,8 @@ theorem ugt_or_not_min_commute_logical_thm (e e_1 : IntW 8) :
 
 
 theorem ugt_swap_or_not_min_thm (e e_1 : IntW 8) :
-  LLVM.or (icmp IntPredicate.ult e_1 e) (icmp IntPredicate.ne e (const? 8 0)) ⊑
-    icmp IntPredicate.ne e (const? 8 0) := by
+  LLVM.or (icmp IntPred.ult e_1 e) (icmp IntPred.ne e (const? 8 0)) ⊑
+    icmp IntPred.ne e (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1827,8 +1827,8 @@ theorem ugt_swap_or_not_min_thm (e e_1 : IntW 8) :
 
 
 theorem ugt_swap_or_not_min_logical_thm (e e_1 : IntW 8) :
-  select (icmp IntPredicate.ult e_1 e) (const? 1 1) (icmp IntPredicate.ne e (const? 8 0)) ⊑
-    icmp IntPredicate.ne e (const? 8 0) := by
+  select (icmp IntPred.ult e_1 e) (const? 1 1) (icmp IntPred.ne e (const? 8 0)) ⊑
+    icmp IntPred.ne e (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1838,8 +1838,8 @@ theorem ugt_swap_or_not_min_logical_thm (e e_1 : IntW 8) :
 
 
 theorem ugt_swap_or_not_min_commute_thm (e e_1 : IntW 823) :
-  LLVM.or (icmp IntPredicate.ne e_1 (const? 823 0)) (icmp IntPredicate.ult e e_1) ⊑
-    icmp IntPredicate.ne e_1 (const? 823 0) := by
+  LLVM.or (icmp IntPred.ne e_1 (const? 823 0)) (icmp IntPred.ult e e_1) ⊑
+    icmp IntPred.ne e_1 (const? 823 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1849,8 +1849,8 @@ theorem ugt_swap_or_not_min_commute_thm (e e_1 : IntW 823) :
 
 
 theorem ugt_swap_or_not_min_commute_logical_thm (e e_1 : IntW 823) :
-  select (icmp IntPredicate.ne e_1 (const? 823 0)) (const? 1 1) (icmp IntPredicate.ult e e_1) ⊑
-    icmp IntPredicate.ne e_1 (const? 823 0) := by
+  select (icmp IntPred.ne e_1 (const? 823 0)) (const? 1 1) (icmp IntPred.ult e e_1) ⊑
+    icmp IntPred.ne e_1 (const? 823 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gandhorhicmps_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gandhorhicmps_proof.lean
@@ -12,8 +12,8 @@ set_option Elab.async false
 
 section gandhorhicmps_proof
 theorem PR1817_1_thm (e : IntW 32) :
-  LLVM.and (icmp IntPredicate.slt e (const? 32 10)) (icmp IntPredicate.ult e (const? 32 10)) ⊑
-    icmp IntPredicate.ult e (const? 32 10) := by
+  LLVM.and (icmp IntPred.slt e (const? 32 10)) (icmp IntPred.ult e (const? 32 10)) ⊑
+    icmp IntPred.ult e (const? 32 10) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -23,8 +23,8 @@ theorem PR1817_1_thm (e : IntW 32) :
 
 
 theorem PR1817_1_logical_thm (e : IntW 32) :
-  select (icmp IntPredicate.slt e (const? 32 10)) (icmp IntPredicate.ult e (const? 32 10)) (const? 1 0) ⊑
-    icmp IntPredicate.ult e (const? 32 10) := by
+  select (icmp IntPred.slt e (const? 32 10)) (icmp IntPred.ult e (const? 32 10)) (const? 1 0) ⊑
+    icmp IntPred.ult e (const? 32 10) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -34,8 +34,8 @@ theorem PR1817_1_logical_thm (e : IntW 32) :
 
 
 theorem PR1817_2_thm (e : IntW 32) :
-  LLVM.or (icmp IntPredicate.slt e (const? 32 10)) (icmp IntPredicate.ult e (const? 32 10)) ⊑
-    icmp IntPredicate.slt e (const? 32 10) := by
+  LLVM.or (icmp IntPred.slt e (const? 32 10)) (icmp IntPred.ult e (const? 32 10)) ⊑
+    icmp IntPred.slt e (const? 32 10) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -45,8 +45,8 @@ theorem PR1817_2_thm (e : IntW 32) :
 
 
 theorem PR1817_2_logical_thm (e : IntW 32) :
-  select (icmp IntPredicate.slt e (const? 32 10)) (const? 1 1) (icmp IntPredicate.ult e (const? 32 10)) ⊑
-    icmp IntPredicate.slt e (const? 32 10) := by
+  select (icmp IntPred.slt e (const? 32 10)) (const? 1 1) (icmp IntPred.ult e (const? 32 10)) ⊑
+    icmp IntPred.slt e (const? 32 10) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -56,8 +56,8 @@ theorem PR1817_2_logical_thm (e : IntW 32) :
 
 
 theorem PR2330_thm (e e_1 : IntW 32) :
-  LLVM.and (icmp IntPredicate.ult e_1 (const? 32 8)) (icmp IntPredicate.ult e (const? 32 8)) ⊑
-    icmp IntPredicate.ult (LLVM.or e_1 e) (const? 32 8) := by
+  LLVM.and (icmp IntPred.ult e_1 (const? 32 8)) (icmp IntPred.ult e (const? 32 8)) ⊑
+    icmp IntPred.ult (LLVM.or e_1 e) (const? 32 8) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -67,8 +67,8 @@ theorem PR2330_thm (e e_1 : IntW 32) :
 
 
 theorem or_eq_with_one_bit_diff_constants1_thm (e : IntW 32) :
-  LLVM.or (icmp IntPredicate.eq e (const? 32 50)) (icmp IntPredicate.eq e (const? 32 51)) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 32 (-2))) (const? 32 50) := by
+  LLVM.or (icmp IntPred.eq e (const? 32 50)) (icmp IntPred.eq e (const? 32 51)) ⊑
+    icmp IntPred.eq (LLVM.and e (const? 32 (-2))) (const? 32 50) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -78,8 +78,8 @@ theorem or_eq_with_one_bit_diff_constants1_thm (e : IntW 32) :
 
 
 theorem or_eq_with_one_bit_diff_constants1_logical_thm (e : IntW 32) :
-  select (icmp IntPredicate.eq e (const? 32 50)) (const? 1 1) (icmp IntPredicate.eq e (const? 32 51)) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 32 (-2))) (const? 32 50) := by
+  select (icmp IntPred.eq e (const? 32 50)) (const? 1 1) (icmp IntPred.eq e (const? 32 51)) ⊑
+    icmp IntPred.eq (LLVM.and e (const? 32 (-2))) (const? 32 50) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -89,8 +89,8 @@ theorem or_eq_with_one_bit_diff_constants1_logical_thm (e : IntW 32) :
 
 
 theorem and_ne_with_one_bit_diff_constants1_thm (e : IntW 32) :
-  LLVM.and (icmp IntPredicate.ne e (const? 32 51)) (icmp IntPredicate.ne e (const? 32 50)) ⊑
-    icmp IntPredicate.ult (add e (const? 32 (-52))) (const? 32 (-2)) := by
+  LLVM.and (icmp IntPred.ne e (const? 32 51)) (icmp IntPred.ne e (const? 32 50)) ⊑
+    icmp IntPred.ult (add e (const? 32 (-52))) (const? 32 (-2)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -100,8 +100,8 @@ theorem and_ne_with_one_bit_diff_constants1_thm (e : IntW 32) :
 
 
 theorem and_ne_with_one_bit_diff_constants1_logical_thm (e : IntW 32) :
-  select (icmp IntPredicate.ne e (const? 32 51)) (icmp IntPredicate.ne e (const? 32 50)) (const? 1 0) ⊑
-    icmp IntPredicate.ult (add e (const? 32 (-52))) (const? 32 (-2)) := by
+  select (icmp IntPred.ne e (const? 32 51)) (icmp IntPred.ne e (const? 32 50)) (const? 1 0) ⊑
+    icmp IntPred.ult (add e (const? 32 (-52))) (const? 32 (-2)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -111,8 +111,8 @@ theorem and_ne_with_one_bit_diff_constants1_logical_thm (e : IntW 32) :
 
 
 theorem or_eq_with_one_bit_diff_constants2_thm (e : IntW 32) :
-  LLVM.or (icmp IntPredicate.eq e (const? 32 97)) (icmp IntPredicate.eq e (const? 32 65)) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 32 (-33))) (const? 32 65) := by
+  LLVM.or (icmp IntPred.eq e (const? 32 97)) (icmp IntPred.eq e (const? 32 65)) ⊑
+    icmp IntPred.eq (LLVM.and e (const? 32 (-33))) (const? 32 65) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -122,8 +122,8 @@ theorem or_eq_with_one_bit_diff_constants2_thm (e : IntW 32) :
 
 
 theorem or_eq_with_one_bit_diff_constants2_logical_thm (e : IntW 32) :
-  select (icmp IntPredicate.eq e (const? 32 97)) (const? 1 1) (icmp IntPredicate.eq e (const? 32 65)) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 32 (-33))) (const? 32 65) := by
+  select (icmp IntPred.eq e (const? 32 97)) (const? 1 1) (icmp IntPred.eq e (const? 32 65)) ⊑
+    icmp IntPred.eq (LLVM.and e (const? 32 (-33))) (const? 32 65) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -133,8 +133,8 @@ theorem or_eq_with_one_bit_diff_constants2_logical_thm (e : IntW 32) :
 
 
 theorem and_ne_with_one_bit_diff_constants2_thm (e : IntW 19) :
-  LLVM.and (icmp IntPredicate.ne e (const? 19 65)) (icmp IntPredicate.ne e (const? 19 193)) ⊑
-    icmp IntPredicate.ne (LLVM.and e (const? 19 (-129))) (const? 19 65) := by
+  LLVM.and (icmp IntPred.ne e (const? 19 65)) (icmp IntPred.ne e (const? 19 193)) ⊑
+    icmp IntPred.ne (LLVM.and e (const? 19 (-129))) (const? 19 65) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -144,8 +144,8 @@ theorem and_ne_with_one_bit_diff_constants2_thm (e : IntW 19) :
 
 
 theorem and_ne_with_one_bit_diff_constants2_logical_thm (e : IntW 19) :
-  select (icmp IntPredicate.ne e (const? 19 65)) (icmp IntPredicate.ne e (const? 19 193)) (const? 1 0) ⊑
-    icmp IntPredicate.ne (LLVM.and e (const? 19 (-129))) (const? 19 65) := by
+  select (icmp IntPred.ne e (const? 19 65)) (icmp IntPred.ne e (const? 19 193)) (const? 1 0) ⊑
+    icmp IntPred.ne (LLVM.and e (const? 19 (-129))) (const? 19 65) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -155,8 +155,8 @@ theorem and_ne_with_one_bit_diff_constants2_logical_thm (e : IntW 19) :
 
 
 theorem or_eq_with_one_bit_diff_constants3_thm (e : IntW 8) :
-  LLVM.or (icmp IntPredicate.eq e (const? 8 (-2))) (icmp IntPredicate.eq e (const? 8 126)) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 8 127)) (const? 8 126) := by
+  LLVM.or (icmp IntPred.eq e (const? 8 (-2))) (icmp IntPred.eq e (const? 8 126)) ⊑
+    icmp IntPred.eq (LLVM.and e (const? 8 127)) (const? 8 126) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -166,8 +166,8 @@ theorem or_eq_with_one_bit_diff_constants3_thm (e : IntW 8) :
 
 
 theorem or_eq_with_one_bit_diff_constants3_logical_thm (e : IntW 8) :
-  select (icmp IntPredicate.eq e (const? 8 (-2))) (const? 1 1) (icmp IntPredicate.eq e (const? 8 126)) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 8 127)) (const? 8 126) := by
+  select (icmp IntPred.eq e (const? 8 (-2))) (const? 1 1) (icmp IntPred.eq e (const? 8 126)) ⊑
+    icmp IntPred.eq (LLVM.and e (const? 8 127)) (const? 8 126) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -177,8 +177,8 @@ theorem or_eq_with_one_bit_diff_constants3_logical_thm (e : IntW 8) :
 
 
 theorem and_ne_with_one_bit_diff_constants3_thm (e : IntW 8) :
-  LLVM.and (icmp IntPredicate.ne e (const? 8 65)) (icmp IntPredicate.ne e (const? 8 (-63))) ⊑
-    icmp IntPredicate.ne (LLVM.and e (const? 8 127)) (const? 8 65) := by
+  LLVM.and (icmp IntPred.ne e (const? 8 65)) (icmp IntPred.ne e (const? 8 (-63))) ⊑
+    icmp IntPred.ne (LLVM.and e (const? 8 127)) (const? 8 65) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -188,8 +188,8 @@ theorem and_ne_with_one_bit_diff_constants3_thm (e : IntW 8) :
 
 
 theorem and_ne_with_one_bit_diff_constants3_logical_thm (e : IntW 8) :
-  select (icmp IntPredicate.ne e (const? 8 65)) (icmp IntPredicate.ne e (const? 8 (-63))) (const? 1 0) ⊑
-    icmp IntPredicate.ne (LLVM.and e (const? 8 127)) (const? 8 65) := by
+  select (icmp IntPred.ne e (const? 8 65)) (icmp IntPred.ne e (const? 8 (-63))) (const? 1 0) ⊑
+    icmp IntPred.ne (LLVM.and e (const? 8 127)) (const? 8 65) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -199,8 +199,8 @@ theorem and_ne_with_one_bit_diff_constants3_logical_thm (e : IntW 8) :
 
 
 theorem or_eq_with_diff_one_thm (e : IntW 8) :
-  LLVM.or (icmp IntPredicate.eq e (const? 8 13)) (icmp IntPredicate.eq e (const? 8 14)) ⊑
-    icmp IntPredicate.ult (add e (const? 8 (-13))) (const? 8 2) := by
+  LLVM.or (icmp IntPred.eq e (const? 8 13)) (icmp IntPred.eq e (const? 8 14)) ⊑
+    icmp IntPred.ult (add e (const? 8 (-13))) (const? 8 2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -210,8 +210,8 @@ theorem or_eq_with_diff_one_thm (e : IntW 8) :
 
 
 theorem or_eq_with_diff_one_logical_thm (e : IntW 8) :
-  select (icmp IntPredicate.eq e (const? 8 13)) (const? 1 1) (icmp IntPredicate.eq e (const? 8 14)) ⊑
-    icmp IntPredicate.ult (add e (const? 8 (-13))) (const? 8 2) := by
+  select (icmp IntPred.eq e (const? 8 13)) (const? 1 1) (icmp IntPred.eq e (const? 8 14)) ⊑
+    icmp IntPred.ult (add e (const? 8 (-13))) (const? 8 2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -221,8 +221,8 @@ theorem or_eq_with_diff_one_logical_thm (e : IntW 8) :
 
 
 theorem and_ne_with_diff_one_thm (e : IntW 32) :
-  LLVM.and (icmp IntPredicate.ne e (const? 32 40)) (icmp IntPredicate.ne e (const? 32 39)) ⊑
-    icmp IntPredicate.ult (add e (const? 32 (-41))) (const? 32 (-2)) := by
+  LLVM.and (icmp IntPred.ne e (const? 32 40)) (icmp IntPred.ne e (const? 32 39)) ⊑
+    icmp IntPred.ult (add e (const? 32 (-41))) (const? 32 (-2)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -232,8 +232,8 @@ theorem and_ne_with_diff_one_thm (e : IntW 32) :
 
 
 theorem and_ne_with_diff_one_logical_thm (e : IntW 32) :
-  select (icmp IntPredicate.ne e (const? 32 40)) (icmp IntPredicate.ne e (const? 32 39)) (const? 1 0) ⊑
-    icmp IntPredicate.ult (add e (const? 32 (-41))) (const? 32 (-2)) := by
+  select (icmp IntPred.ne e (const? 32 40)) (icmp IntPred.ne e (const? 32 39)) (const? 1 0) ⊑
+    icmp IntPred.ult (add e (const? 32 (-41))) (const? 32 (-2)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -243,8 +243,8 @@ theorem and_ne_with_diff_one_logical_thm (e : IntW 32) :
 
 
 theorem or_eq_with_diff_one_signed_thm (e : IntW 32) :
-  LLVM.or (icmp IntPredicate.eq e (const? 32 0)) (icmp IntPredicate.eq e (const? 32 (-1))) ⊑
-    icmp IntPredicate.ult (add e (const? 32 1)) (const? 32 2) := by
+  LLVM.or (icmp IntPred.eq e (const? 32 0)) (icmp IntPred.eq e (const? 32 (-1))) ⊑
+    icmp IntPred.ult (add e (const? 32 1)) (const? 32 2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -254,8 +254,8 @@ theorem or_eq_with_diff_one_signed_thm (e : IntW 32) :
 
 
 theorem or_eq_with_diff_one_signed_logical_thm (e : IntW 32) :
-  select (icmp IntPredicate.eq e (const? 32 0)) (const? 1 1) (icmp IntPredicate.eq e (const? 32 (-1))) ⊑
-    icmp IntPredicate.ult (add e (const? 32 1)) (const? 32 2) := by
+  select (icmp IntPred.eq e (const? 32 0)) (const? 1 1) (icmp IntPred.eq e (const? 32 (-1))) ⊑
+    icmp IntPred.ult (add e (const? 32 1)) (const? 32 2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -265,8 +265,8 @@ theorem or_eq_with_diff_one_signed_logical_thm (e : IntW 32) :
 
 
 theorem and_ne_with_diff_one_signed_thm (e : IntW 64) :
-  LLVM.and (icmp IntPredicate.ne e (const? 64 (-1))) (icmp IntPredicate.ne e (const? 64 0)) ⊑
-    icmp IntPredicate.ult (add e (const? 64 (-1))) (const? 64 (-2)) := by
+  LLVM.and (icmp IntPred.ne e (const? 64 (-1))) (icmp IntPred.ne e (const? 64 0)) ⊑
+    icmp IntPred.ult (add e (const? 64 (-1))) (const? 64 (-2)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -276,8 +276,8 @@ theorem and_ne_with_diff_one_signed_thm (e : IntW 64) :
 
 
 theorem and_ne_with_diff_one_signed_logical_thm (e : IntW 64) :
-  select (icmp IntPredicate.ne e (const? 64 (-1))) (icmp IntPredicate.ne e (const? 64 0)) (const? 1 0) ⊑
-    icmp IntPredicate.ult (add e (const? 64 (-1))) (const? 64 (-2)) := by
+  select (icmp IntPred.ne e (const? 64 (-1))) (icmp IntPred.ne e (const? 64 0)) (const? 1 0) ⊑
+    icmp IntPred.ult (add e (const? 64 (-1))) (const? 64 (-2)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -287,8 +287,8 @@ theorem and_ne_with_diff_one_signed_logical_thm (e : IntW 64) :
 
 
 theorem PR42691_1_thm (e : IntW 32) :
-  LLVM.or (icmp IntPredicate.slt e (const? 32 0)) (icmp IntPredicate.eq e (const? 32 2147483647)) ⊑
-    icmp IntPredicate.ugt e (const? 32 2147483646) := by
+  LLVM.or (icmp IntPred.slt e (const? 32 0)) (icmp IntPred.eq e (const? 32 2147483647)) ⊑
+    icmp IntPred.ugt e (const? 32 2147483646) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -298,8 +298,8 @@ theorem PR42691_1_thm (e : IntW 32) :
 
 
 theorem PR42691_1_logical_thm (e : IntW 32) :
-  select (icmp IntPredicate.slt e (const? 32 0)) (const? 1 1) (icmp IntPredicate.eq e (const? 32 2147483647)) ⊑
-    icmp IntPredicate.ugt e (const? 32 2147483646) := by
+  select (icmp IntPred.slt e (const? 32 0)) (const? 1 1) (icmp IntPred.eq e (const? 32 2147483647)) ⊑
+    icmp IntPred.ugt e (const? 32 2147483646) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -309,8 +309,8 @@ theorem PR42691_1_logical_thm (e : IntW 32) :
 
 
 theorem PR42691_2_thm (e : IntW 32) :
-  LLVM.or (icmp IntPredicate.ult e (const? 32 (-2147483648))) (icmp IntPredicate.eq e (const? 32 (-1))) ⊑
-    icmp IntPredicate.sgt e (const? 32 (-2)) := by
+  LLVM.or (icmp IntPred.ult e (const? 32 (-2147483648))) (icmp IntPred.eq e (const? 32 (-1))) ⊑
+    icmp IntPred.sgt e (const? 32 (-2)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -320,8 +320,8 @@ theorem PR42691_2_thm (e : IntW 32) :
 
 
 theorem PR42691_2_logical_thm (e : IntW 32) :
-  select (icmp IntPredicate.ult e (const? 32 (-2147483648))) (const? 1 1) (icmp IntPredicate.eq e (const? 32 (-1))) ⊑
-    icmp IntPredicate.sgt e (const? 32 (-2)) := by
+  select (icmp IntPred.ult e (const? 32 (-2147483648))) (const? 1 1) (icmp IntPred.eq e (const? 32 (-1))) ⊑
+    icmp IntPred.sgt e (const? 32 (-2)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -331,8 +331,8 @@ theorem PR42691_2_logical_thm (e : IntW 32) :
 
 
 theorem PR42691_3_thm (e : IntW 32) :
-  LLVM.or (icmp IntPredicate.sge e (const? 32 0)) (icmp IntPredicate.eq e (const? 32 (-2147483648))) ⊑
-    icmp IntPredicate.ult e (const? 32 (-2147483647)) := by
+  LLVM.or (icmp IntPred.sge e (const? 32 0)) (icmp IntPred.eq e (const? 32 (-2147483648))) ⊑
+    icmp IntPred.ult e (const? 32 (-2147483647)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -342,8 +342,8 @@ theorem PR42691_3_thm (e : IntW 32) :
 
 
 theorem PR42691_3_logical_thm (e : IntW 32) :
-  select (icmp IntPredicate.sge e (const? 32 0)) (const? 1 1) (icmp IntPredicate.eq e (const? 32 (-2147483648))) ⊑
-    icmp IntPredicate.ult e (const? 32 (-2147483647)) := by
+  select (icmp IntPred.sge e (const? 32 0)) (const? 1 1) (icmp IntPred.eq e (const? 32 (-2147483648))) ⊑
+    icmp IntPred.ult e (const? 32 (-2147483647)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -353,8 +353,8 @@ theorem PR42691_3_logical_thm (e : IntW 32) :
 
 
 theorem PR42691_4_thm (e : IntW 32) :
-  LLVM.or (icmp IntPredicate.uge e (const? 32 (-2147483648))) (icmp IntPredicate.eq e (const? 32 0)) ⊑
-    icmp IntPredicate.slt e (const? 32 1) := by
+  LLVM.or (icmp IntPred.uge e (const? 32 (-2147483648))) (icmp IntPred.eq e (const? 32 0)) ⊑
+    icmp IntPred.slt e (const? 32 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -364,8 +364,8 @@ theorem PR42691_4_thm (e : IntW 32) :
 
 
 theorem PR42691_4_logical_thm (e : IntW 32) :
-  select (icmp IntPredicate.uge e (const? 32 (-2147483648))) (const? 1 1) (icmp IntPredicate.eq e (const? 32 0)) ⊑
-    icmp IntPredicate.slt e (const? 32 1) := by
+  select (icmp IntPred.uge e (const? 32 (-2147483648))) (const? 1 1) (icmp IntPred.eq e (const? 32 0)) ⊑
+    icmp IntPred.slt e (const? 32 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -375,8 +375,8 @@ theorem PR42691_4_logical_thm (e : IntW 32) :
 
 
 theorem PR42691_5_thm (e : IntW 32) :
-  LLVM.or (icmp IntPredicate.slt e (const? 32 1)) (icmp IntPredicate.eq e (const? 32 2147483647)) ⊑
-    icmp IntPredicate.ult (add e (const? 32 (-2147483647))) (const? 32 (-2147483646)) := by
+  LLVM.or (icmp IntPred.slt e (const? 32 1)) (icmp IntPred.eq e (const? 32 2147483647)) ⊑
+    icmp IntPred.ult (add e (const? 32 (-2147483647))) (const? 32 (-2147483646)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -386,8 +386,8 @@ theorem PR42691_5_thm (e : IntW 32) :
 
 
 theorem PR42691_5_logical_thm (e : IntW 32) :
-  select (icmp IntPredicate.slt e (const? 32 1)) (const? 1 1) (icmp IntPredicate.eq e (const? 32 2147483647)) ⊑
-    icmp IntPredicate.ult (add e (const? 32 (-2147483647))) (const? 32 (-2147483646)) := by
+  select (icmp IntPred.slt e (const? 32 1)) (const? 1 1) (icmp IntPred.eq e (const? 32 2147483647)) ⊑
+    icmp IntPred.ult (add e (const? 32 (-2147483647))) (const? 32 (-2147483646)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -397,8 +397,8 @@ theorem PR42691_5_logical_thm (e : IntW 32) :
 
 
 theorem PR42691_6_thm (e : IntW 32) :
-  LLVM.or (icmp IntPredicate.ult e (const? 32 (-2147483647))) (icmp IntPredicate.eq e (const? 32 (-1))) ⊑
-    icmp IntPredicate.ult (add e (const? 32 1)) (const? 32 (-2147483646)) := by
+  LLVM.or (icmp IntPred.ult e (const? 32 (-2147483647))) (icmp IntPred.eq e (const? 32 (-1))) ⊑
+    icmp IntPred.ult (add e (const? 32 1)) (const? 32 (-2147483646)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -408,8 +408,8 @@ theorem PR42691_6_thm (e : IntW 32) :
 
 
 theorem PR42691_6_logical_thm (e : IntW 32) :
-  select (icmp IntPredicate.ult e (const? 32 (-2147483647))) (const? 1 1) (icmp IntPredicate.eq e (const? 32 (-1))) ⊑
-    icmp IntPredicate.ult (add e (const? 32 1)) (const? 32 (-2147483646)) := by
+  select (icmp IntPred.ult e (const? 32 (-2147483647))) (const? 1 1) (icmp IntPred.eq e (const? 32 (-1))) ⊑
+    icmp IntPred.ult (add e (const? 32 1)) (const? 32 (-2147483646)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -419,8 +419,8 @@ theorem PR42691_6_logical_thm (e : IntW 32) :
 
 
 theorem PR42691_7_thm (e : IntW 32) :
-  LLVM.or (icmp IntPredicate.uge e (const? 32 (-2147483647))) (icmp IntPredicate.eq e (const? 32 0)) ⊑
-    icmp IntPredicate.slt (add e (const? 32 (-1))) (const? 32 0) := by
+  LLVM.or (icmp IntPred.uge e (const? 32 (-2147483647))) (icmp IntPred.eq e (const? 32 0)) ⊑
+    icmp IntPred.slt (add e (const? 32 (-1))) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -430,8 +430,8 @@ theorem PR42691_7_thm (e : IntW 32) :
 
 
 theorem PR42691_7_logical_thm (e : IntW 32) :
-  select (icmp IntPredicate.uge e (const? 32 (-2147483647))) (const? 1 1) (icmp IntPredicate.eq e (const? 32 0)) ⊑
-    icmp IntPredicate.slt (add e (const? 32 (-1))) (const? 32 0) := by
+  select (icmp IntPred.uge e (const? 32 (-2147483647))) (const? 1 1) (icmp IntPred.eq e (const? 32 0)) ⊑
+    icmp IntPred.slt (add e (const? 32 (-1))) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -441,8 +441,8 @@ theorem PR42691_7_logical_thm (e : IntW 32) :
 
 
 theorem PR42691_8_thm (e : IntW 32) :
-  LLVM.and (icmp IntPredicate.slt e (const? 32 14)) (icmp IntPredicate.ne e (const? 32 (-2147483648))) ⊑
-    icmp IntPredicate.ult (add e (const? 32 2147483647)) (const? 32 (-2147483635)) := by
+  LLVM.and (icmp IntPred.slt e (const? 32 14)) (icmp IntPred.ne e (const? 32 (-2147483648))) ⊑
+    icmp IntPred.ult (add e (const? 32 2147483647)) (const? 32 (-2147483635)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -452,8 +452,8 @@ theorem PR42691_8_thm (e : IntW 32) :
 
 
 theorem PR42691_8_logical_thm (e : IntW 32) :
-  select (icmp IntPredicate.slt e (const? 32 14)) (icmp IntPredicate.ne e (const? 32 (-2147483648))) (const? 1 0) ⊑
-    icmp IntPredicate.ult (add e (const? 32 2147483647)) (const? 32 (-2147483635)) := by
+  select (icmp IntPred.slt e (const? 32 14)) (icmp IntPred.ne e (const? 32 (-2147483648))) (const? 1 0) ⊑
+    icmp IntPred.ult (add e (const? 32 2147483647)) (const? 32 (-2147483635)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -463,8 +463,8 @@ theorem PR42691_8_logical_thm (e : IntW 32) :
 
 
 theorem PR42691_9_thm (e : IntW 32) :
-  LLVM.and (icmp IntPredicate.sgt e (const? 32 13)) (icmp IntPredicate.ne e (const? 32 2147483647)) ⊑
-    icmp IntPredicate.ult (add e (const? 32 (-14))) (const? 32 2147483633) := by
+  LLVM.and (icmp IntPred.sgt e (const? 32 13)) (icmp IntPred.ne e (const? 32 2147483647)) ⊑
+    icmp IntPred.ult (add e (const? 32 (-14))) (const? 32 2147483633) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -474,8 +474,8 @@ theorem PR42691_9_thm (e : IntW 32) :
 
 
 theorem PR42691_9_logical_thm (e : IntW 32) :
-  select (icmp IntPredicate.sgt e (const? 32 13)) (icmp IntPredicate.ne e (const? 32 2147483647)) (const? 1 0) ⊑
-    icmp IntPredicate.ult (add e (const? 32 (-14))) (const? 32 2147483633) := by
+  select (icmp IntPred.sgt e (const? 32 13)) (icmp IntPred.ne e (const? 32 2147483647)) (const? 1 0) ⊑
+    icmp IntPred.ult (add e (const? 32 (-14))) (const? 32 2147483633) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -485,8 +485,8 @@ theorem PR42691_9_logical_thm (e : IntW 32) :
 
 
 theorem PR42691_10_thm (e : IntW 32) :
-  LLVM.and (icmp IntPredicate.ugt e (const? 32 13)) (icmp IntPredicate.ne e (const? 32 (-1))) ⊑
-    icmp IntPredicate.ult (add e (const? 32 (-14))) (const? 32 (-15)) := by
+  LLVM.and (icmp IntPred.ugt e (const? 32 13)) (icmp IntPred.ne e (const? 32 (-1))) ⊑
+    icmp IntPred.ult (add e (const? 32 (-14))) (const? 32 (-15)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -496,8 +496,8 @@ theorem PR42691_10_thm (e : IntW 32) :
 
 
 theorem PR42691_10_logical_thm (e : IntW 32) :
-  select (icmp IntPredicate.ugt e (const? 32 13)) (icmp IntPredicate.ne e (const? 32 (-1))) (const? 1 0) ⊑
-    icmp IntPredicate.ult (add e (const? 32 (-14))) (const? 32 (-15)) := by
+  select (icmp IntPred.ugt e (const? 32 13)) (icmp IntPred.ne e (const? 32 (-1))) (const? 1 0) ⊑
+    icmp IntPred.ult (add e (const? 32 (-14))) (const? 32 (-15)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -507,8 +507,8 @@ theorem PR42691_10_logical_thm (e : IntW 32) :
 
 
 theorem substitute_constant_and_eq_eq_thm (e e_1 : IntW 8) :
-  LLVM.and (icmp IntPredicate.eq e_1 (const? 8 42)) (icmp IntPredicate.eq e_1 e) ⊑
-    LLVM.and (icmp IntPredicate.eq e_1 (const? 8 42)) (icmp IntPredicate.eq e (const? 8 42)) := by
+  LLVM.and (icmp IntPred.eq e_1 (const? 8 42)) (icmp IntPred.eq e_1 e) ⊑
+    LLVM.and (icmp IntPred.eq e_1 (const? 8 42)) (icmp IntPred.eq e (const? 8 42)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -518,8 +518,8 @@ theorem substitute_constant_and_eq_eq_thm (e e_1 : IntW 8) :
 
 
 theorem substitute_constant_and_eq_eq_logical_thm (e e_1 : IntW 8) :
-  select (icmp IntPredicate.eq e_1 (const? 8 42)) (icmp IntPredicate.eq e_1 e) (const? 1 0) ⊑
-    select (icmp IntPredicate.eq e_1 (const? 8 42)) (icmp IntPredicate.eq e (const? 8 42)) (const? 1 0) := by
+  select (icmp IntPred.eq e_1 (const? 8 42)) (icmp IntPred.eq e_1 e) (const? 1 0) ⊑
+    select (icmp IntPred.eq e_1 (const? 8 42)) (icmp IntPred.eq e (const? 8 42)) (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -529,8 +529,8 @@ theorem substitute_constant_and_eq_eq_logical_thm (e e_1 : IntW 8) :
 
 
 theorem substitute_constant_and_eq_eq_commute_thm (e e_1 : IntW 8) :
-  LLVM.and (icmp IntPredicate.eq e_1 e) (icmp IntPredicate.eq e_1 (const? 8 42)) ⊑
-    LLVM.and (icmp IntPredicate.eq e_1 (const? 8 42)) (icmp IntPredicate.eq e (const? 8 42)) := by
+  LLVM.and (icmp IntPred.eq e_1 e) (icmp IntPred.eq e_1 (const? 8 42)) ⊑
+    LLVM.and (icmp IntPred.eq e_1 (const? 8 42)) (icmp IntPred.eq e (const? 8 42)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -540,8 +540,8 @@ theorem substitute_constant_and_eq_eq_commute_thm (e e_1 : IntW 8) :
 
 
 theorem substitute_constant_and_eq_eq_commute_logical_thm (e e_1 : IntW 8) :
-  select (icmp IntPredicate.eq e_1 e) (icmp IntPredicate.eq e_1 (const? 8 42)) (const? 1 0) ⊑
-    LLVM.and (icmp IntPredicate.eq e_1 (const? 8 42)) (icmp IntPredicate.eq e (const? 8 42)) := by
+  select (icmp IntPred.eq e_1 e) (icmp IntPred.eq e_1 (const? 8 42)) (const? 1 0) ⊑
+    LLVM.and (icmp IntPred.eq e_1 (const? 8 42)) (icmp IntPred.eq e (const? 8 42)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -551,8 +551,8 @@ theorem substitute_constant_and_eq_eq_commute_logical_thm (e e_1 : IntW 8) :
 
 
 theorem substitute_constant_and_eq_ugt_swap_thm (e e_1 : IntW 8) :
-  LLVM.and (icmp IntPredicate.ugt e_1 e) (icmp IntPredicate.eq e (const? 8 42)) ⊑
-    LLVM.and (icmp IntPredicate.eq e (const? 8 42)) (icmp IntPredicate.ugt e_1 (const? 8 42)) := by
+  LLVM.and (icmp IntPred.ugt e_1 e) (icmp IntPred.eq e (const? 8 42)) ⊑
+    LLVM.and (icmp IntPred.eq e (const? 8 42)) (icmp IntPred.ugt e_1 (const? 8 42)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -562,8 +562,8 @@ theorem substitute_constant_and_eq_ugt_swap_thm (e e_1 : IntW 8) :
 
 
 theorem substitute_constant_and_eq_ugt_swap_logical_thm (e e_1 : IntW 8) :
-  select (icmp IntPredicate.ugt e_1 e) (icmp IntPredicate.eq e (const? 8 42)) (const? 1 0) ⊑
-    LLVM.and (icmp IntPredicate.eq e (const? 8 42)) (icmp IntPredicate.ugt e_1 (const? 8 42)) := by
+  select (icmp IntPred.ugt e_1 e) (icmp IntPred.eq e (const? 8 42)) (const? 1 0) ⊑
+    LLVM.and (icmp IntPred.eq e (const? 8 42)) (icmp IntPred.ugt e_1 (const? 8 42)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -573,8 +573,8 @@ theorem substitute_constant_and_eq_ugt_swap_logical_thm (e e_1 : IntW 8) :
 
 
 theorem substitute_constant_and_ne_ugt_swap_logical_thm (e e_1 : IntW 8) :
-  select (icmp IntPredicate.ugt e_1 e) (icmp IntPredicate.ne e (const? 8 42)) (const? 1 0) ⊑
-    LLVM.and (icmp IntPredicate.ugt e_1 e) (icmp IntPredicate.ne e (const? 8 42)) := by
+  select (icmp IntPred.ugt e_1 e) (icmp IntPred.ne e (const? 8 42)) (const? 1 0) ⊑
+    LLVM.and (icmp IntPred.ugt e_1 e) (icmp IntPred.ne e (const? 8 42)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -584,8 +584,8 @@ theorem substitute_constant_and_ne_ugt_swap_logical_thm (e e_1 : IntW 8) :
 
 
 theorem substitute_constant_or_ne_swap_sle_thm (e e_1 : IntW 8) :
-  LLVM.or (icmp IntPredicate.ne e_1 (const? 8 42)) (icmp IntPredicate.sle e e_1) ⊑
-    LLVM.or (icmp IntPredicate.ne e_1 (const? 8 42)) (icmp IntPredicate.slt e (const? 8 43)) := by
+  LLVM.or (icmp IntPred.ne e_1 (const? 8 42)) (icmp IntPred.sle e e_1) ⊑
+    LLVM.or (icmp IntPred.ne e_1 (const? 8 42)) (icmp IntPred.slt e (const? 8 43)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -595,8 +595,8 @@ theorem substitute_constant_or_ne_swap_sle_thm (e e_1 : IntW 8) :
 
 
 theorem substitute_constant_or_ne_swap_sle_logical_thm (e e_1 : IntW 8) :
-  select (icmp IntPredicate.ne e_1 (const? 8 42)) (const? 1 1) (icmp IntPredicate.sle e e_1) ⊑
-    select (icmp IntPredicate.ne e_1 (const? 8 42)) (const? 1 1) (icmp IntPredicate.slt e (const? 8 43)) := by
+  select (icmp IntPred.ne e_1 (const? 8 42)) (const? 1 1) (icmp IntPred.sle e e_1) ⊑
+    select (icmp IntPred.ne e_1 (const? 8 42)) (const? 1 1) (icmp IntPred.slt e (const? 8 43)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -606,8 +606,8 @@ theorem substitute_constant_or_ne_swap_sle_logical_thm (e e_1 : IntW 8) :
 
 
 theorem substitute_constant_or_ne_uge_commute_thm (e e_1 : IntW 8) :
-  LLVM.or (icmp IntPredicate.uge e_1 e) (icmp IntPredicate.ne e_1 (const? 8 42)) ⊑
-    LLVM.or (icmp IntPredicate.ne e_1 (const? 8 42)) (icmp IntPredicate.ult e (const? 8 43)) := by
+  LLVM.or (icmp IntPred.uge e_1 e) (icmp IntPred.ne e_1 (const? 8 42)) ⊑
+    LLVM.or (icmp IntPred.ne e_1 (const? 8 42)) (icmp IntPred.ult e (const? 8 43)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -617,8 +617,8 @@ theorem substitute_constant_or_ne_uge_commute_thm (e e_1 : IntW 8) :
 
 
 theorem substitute_constant_or_ne_uge_commute_logical_thm (e e_1 : IntW 8) :
-  select (icmp IntPredicate.uge e_1 e) (const? 1 1) (icmp IntPredicate.ne e_1 (const? 8 42)) ⊑
-    LLVM.or (icmp IntPredicate.ne e_1 (const? 8 42)) (icmp IntPredicate.ult e (const? 8 43)) := by
+  select (icmp IntPred.uge e_1 e) (const? 1 1) (icmp IntPred.ne e_1 (const? 8 42)) ⊑
+    LLVM.or (icmp IntPred.ne e_1 (const? 8 42)) (icmp IntPred.ult e (const? 8 43)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -628,9 +628,9 @@ theorem substitute_constant_or_ne_uge_commute_logical_thm (e e_1 : IntW 8) :
 
 
 theorem or_ranges_overlap_thm (e : IntW 8) :
-  LLVM.or (LLVM.and (icmp IntPredicate.uge e (const? 8 5)) (icmp IntPredicate.ule e (const? 8 10)))
-      (LLVM.and (icmp IntPredicate.uge e (const? 8 10)) (icmp IntPredicate.ule e (const? 8 20))) ⊑
-    icmp IntPredicate.ult (add e (const? 8 (-5))) (const? 8 16) := by
+  LLVM.or (LLVM.and (icmp IntPred.uge e (const? 8 5)) (icmp IntPred.ule e (const? 8 10)))
+      (LLVM.and (icmp IntPred.uge e (const? 8 10)) (icmp IntPred.ule e (const? 8 20))) ⊑
+    icmp IntPred.ult (add e (const? 8 (-5))) (const? 8 16) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -640,9 +640,9 @@ theorem or_ranges_overlap_thm (e : IntW 8) :
 
 
 theorem or_ranges_adjacent_thm (e : IntW 8) :
-  LLVM.or (LLVM.and (icmp IntPredicate.uge e (const? 8 5)) (icmp IntPredicate.ule e (const? 8 10)))
-      (LLVM.and (icmp IntPredicate.uge e (const? 8 11)) (icmp IntPredicate.ule e (const? 8 20))) ⊑
-    icmp IntPredicate.ult (add e (const? 8 (-5))) (const? 8 16) := by
+  LLVM.or (LLVM.and (icmp IntPred.uge e (const? 8 5)) (icmp IntPred.ule e (const? 8 10)))
+      (LLVM.and (icmp IntPred.uge e (const? 8 11)) (icmp IntPred.ule e (const? 8 20))) ⊑
+    icmp IntPred.ult (add e (const? 8 (-5))) (const? 8 16) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -652,10 +652,10 @@ theorem or_ranges_adjacent_thm (e : IntW 8) :
 
 
 theorem or_ranges_separated_thm (e : IntW 8) :
-  LLVM.or (LLVM.and (icmp IntPredicate.uge e (const? 8 5)) (icmp IntPredicate.ule e (const? 8 10)))
-      (LLVM.and (icmp IntPredicate.uge e (const? 8 12)) (icmp IntPredicate.ule e (const? 8 20))) ⊑
-    LLVM.or (icmp IntPredicate.ult (add e (const? 8 (-5))) (const? 8 6))
-      (icmp IntPredicate.ult (add e (const? 8 (-12))) (const? 8 9)) := by
+  LLVM.or (LLVM.and (icmp IntPred.uge e (const? 8 5)) (icmp IntPred.ule e (const? 8 10)))
+      (LLVM.and (icmp IntPred.uge e (const? 8 12)) (icmp IntPred.ule e (const? 8 20))) ⊑
+    LLVM.or (icmp IntPred.ult (add e (const? 8 (-5))) (const? 8 6))
+      (icmp IntPred.ult (add e (const? 8 (-12))) (const? 8 9)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -665,9 +665,9 @@ theorem or_ranges_separated_thm (e : IntW 8) :
 
 
 theorem or_ranges_single_elem_right_thm (e : IntW 8) :
-  LLVM.or (LLVM.and (icmp IntPredicate.uge e (const? 8 5)) (icmp IntPredicate.ule e (const? 8 10)))
-      (icmp IntPredicate.eq e (const? 8 11)) ⊑
-    icmp IntPredicate.ult (add e (const? 8 (-5))) (const? 8 7) := by
+  LLVM.or (LLVM.and (icmp IntPred.uge e (const? 8 5)) (icmp IntPred.ule e (const? 8 10)))
+      (icmp IntPred.eq e (const? 8 11)) ⊑
+    icmp IntPred.ult (add e (const? 8 (-5))) (const? 8 7) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -677,9 +677,9 @@ theorem or_ranges_single_elem_right_thm (e : IntW 8) :
 
 
 theorem or_ranges_single_elem_left_thm (e : IntW 8) :
-  LLVM.or (LLVM.and (icmp IntPredicate.uge e (const? 8 5)) (icmp IntPredicate.ule e (const? 8 10)))
-      (icmp IntPredicate.eq e (const? 8 4)) ⊑
-    icmp IntPredicate.ult (add e (const? 8 (-4))) (const? 8 7) := by
+  LLVM.or (LLVM.and (icmp IntPred.uge e (const? 8 5)) (icmp IntPred.ule e (const? 8 10)))
+      (icmp IntPred.eq e (const? 8 4)) ⊑
+    icmp IntPred.ult (add e (const? 8 (-4))) (const? 8 7) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -689,9 +689,9 @@ theorem or_ranges_single_elem_left_thm (e : IntW 8) :
 
 
 theorem and_ranges_overlap_thm (e : IntW 8) :
-  LLVM.and (LLVM.and (icmp IntPredicate.uge e (const? 8 5)) (icmp IntPredicate.ule e (const? 8 10)))
-      (LLVM.and (icmp IntPredicate.uge e (const? 8 7)) (icmp IntPredicate.ule e (const? 8 20))) ⊑
-    icmp IntPredicate.ult (add e (const? 8 (-7))) (const? 8 4) := by
+  LLVM.and (LLVM.and (icmp IntPred.uge e (const? 8 5)) (icmp IntPred.ule e (const? 8 10)))
+      (LLVM.and (icmp IntPred.uge e (const? 8 7)) (icmp IntPred.ule e (const? 8 20))) ⊑
+    icmp IntPred.ult (add e (const? 8 (-7))) (const? 8 4) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -701,9 +701,9 @@ theorem and_ranges_overlap_thm (e : IntW 8) :
 
 
 theorem and_ranges_overlap_single_thm (e : IntW 8) :
-  LLVM.and (LLVM.and (icmp IntPredicate.uge e (const? 8 5)) (icmp IntPredicate.ule e (const? 8 10)))
-      (LLVM.and (icmp IntPredicate.uge e (const? 8 10)) (icmp IntPredicate.ule e (const? 8 20))) ⊑
-    icmp IntPredicate.eq e (const? 8 10) := by
+  LLVM.and (LLVM.and (icmp IntPred.uge e (const? 8 5)) (icmp IntPred.ule e (const? 8 10)))
+      (LLVM.and (icmp IntPred.uge e (const? 8 10)) (icmp IntPred.ule e (const? 8 20))) ⊑
+    icmp IntPred.eq e (const? 8 10) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -713,8 +713,8 @@ theorem and_ranges_overlap_single_thm (e : IntW 8) :
 
 
 theorem and_ranges_no_overlap_thm (e : IntW 8) :
-  LLVM.and (LLVM.and (icmp IntPredicate.uge e (const? 8 5)) (icmp IntPredicate.ule e (const? 8 10)))
-      (LLVM.and (icmp IntPredicate.uge e (const? 8 11)) (icmp IntPredicate.ule e (const? 8 20))) ⊑
+  LLVM.and (LLVM.and (icmp IntPred.uge e (const? 8 5)) (icmp IntPred.ule e (const? 8 10)))
+      (LLVM.and (icmp IntPred.uge e (const? 8 11)) (icmp IntPred.ule e (const? 8 20))) ⊑
     const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
@@ -725,9 +725,9 @@ theorem and_ranges_no_overlap_thm (e : IntW 8) :
 
 
 theorem and_ranges_signed_pred_thm (e : IntW 64) :
-  LLVM.and (icmp IntPredicate.slt (add e (const? 64 127)) (const? 64 1024))
-      (icmp IntPredicate.slt (add e (const? 64 128)) (const? 64 256)) ⊑
-    icmp IntPredicate.ult (add e (const? 64 (-9223372036854775681))) (const? 64 (-9223372036854775553)) := by
+  LLVM.and (icmp IntPred.slt (add e (const? 64 127)) (const? 64 1024))
+      (icmp IntPred.slt (add e (const? 64 128)) (const? 64 256)) ⊑
+    icmp IntPred.ult (add e (const? 64 (-9223372036854775681))) (const? 64 (-9223372036854775553)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -737,9 +737,9 @@ theorem and_ranges_signed_pred_thm (e : IntW 64) :
 
 
 theorem and_two_ranges_to_mask_and_range_thm (e : IntW 8) :
-  LLVM.and (icmp IntPredicate.ugt (add e (const? 8 (-97))) (const? 8 25))
-      (icmp IntPredicate.ugt (add e (const? 8 (-65))) (const? 8 25)) ⊑
-    icmp IntPredicate.ult (add (LLVM.and e (const? 8 (-33))) (const? 8 (-91))) (const? 8 (-26)) := by
+  LLVM.and (icmp IntPred.ugt (add e (const? 8 (-97))) (const? 8 25))
+      (icmp IntPred.ugt (add e (const? 8 (-65))) (const? 8 25)) ⊑
+    icmp IntPred.ult (add (LLVM.and e (const? 8 (-33))) (const? 8 (-91))) (const? 8 (-26)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -749,10 +749,10 @@ theorem and_two_ranges_to_mask_and_range_thm (e : IntW 8) :
 
 
 theorem and_two_ranges_to_mask_and_range_not_pow2_diff_thm (e : IntW 8) :
-  LLVM.and (icmp IntPredicate.ugt (add e (const? 8 (-97))) (const? 8 25))
-      (icmp IntPredicate.ugt (add e (const? 8 (-64))) (const? 8 25)) ⊑
-    LLVM.and (icmp IntPredicate.ult (add e (const? 8 (-123))) (const? 8 (-26)))
-      (icmp IntPredicate.ult (add e (const? 8 (-90))) (const? 8 (-26))) := by
+  LLVM.and (icmp IntPred.ugt (add e (const? 8 (-97))) (const? 8 25))
+      (icmp IntPred.ugt (add e (const? 8 (-64))) (const? 8 25)) ⊑
+    LLVM.and (icmp IntPred.ult (add e (const? 8 (-123))) (const? 8 (-26)))
+      (icmp IntPred.ult (add e (const? 8 (-90))) (const? 8 (-26))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -762,10 +762,10 @@ theorem and_two_ranges_to_mask_and_range_not_pow2_diff_thm (e : IntW 8) :
 
 
 theorem and_two_ranges_to_mask_and_range_different_sizes_thm (e : IntW 8) :
-  LLVM.and (icmp IntPredicate.ugt (add e (const? 8 (-97))) (const? 8 25))
-      (icmp IntPredicate.ugt (add e (const? 8 (-65))) (const? 8 24)) ⊑
-    LLVM.and (icmp IntPredicate.ult (add e (const? 8 (-123))) (const? 8 (-26)))
-      (icmp IntPredicate.ult (add e (const? 8 (-90))) (const? 8 (-25))) := by
+  LLVM.and (icmp IntPred.ugt (add e (const? 8 (-97))) (const? 8 25))
+      (icmp IntPred.ugt (add e (const? 8 (-65))) (const? 8 24)) ⊑
+    LLVM.and (icmp IntPred.ult (add e (const? 8 (-123))) (const? 8 (-26)))
+      (icmp IntPred.ult (add e (const? 8 (-90))) (const? 8 (-25))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -775,9 +775,9 @@ theorem and_two_ranges_to_mask_and_range_different_sizes_thm (e : IntW 8) :
 
 
 theorem and_two_ranges_to_mask_and_range_no_add_on_one_range_thm (e : IntW 16) :
-  LLVM.and (icmp IntPredicate.uge e (const? 16 12))
-      (LLVM.or (icmp IntPredicate.ult e (const? 16 16)) (icmp IntPredicate.uge e (const? 16 28))) ⊑
-    icmp IntPredicate.ugt (LLVM.and e (const? 16 (-20))) (const? 16 11) := by
+  LLVM.and (icmp IntPred.uge e (const? 16 12))
+      (LLVM.or (icmp IntPred.ult e (const? 16 16)) (icmp IntPred.uge e (const? 16 28))) ⊑
+    icmp IntPred.ugt (LLVM.and e (const? 16 (-20))) (const? 16 11) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -787,9 +787,9 @@ theorem and_two_ranges_to_mask_and_range_no_add_on_one_range_thm (e : IntW 16) :
 
 
 theorem is_ascii_alphabetic_thm (e : IntW 32) :
-  select (icmp IntPredicate.ult (add e (const? 32 (-65)) { «nsw» := true, «nuw» := false }) (const? 32 26)) (const? 1 1)
-      (icmp IntPredicate.ult (add e (const? 32 (-97)) { «nsw» := true, «nuw» := false }) (const? 32 26)) ⊑
-    icmp IntPredicate.ult (add (LLVM.and e (const? 32 (-33))) (const? 32 (-65))) (const? 32 26) := by
+  select (icmp IntPred.ult (add e (const? 32 (-65)) { «nsw» := true, «nuw» := false }) (const? 32 26)) (const? 1 1)
+      (icmp IntPred.ult (add e (const? 32 (-97)) { «nsw» := true, «nuw» := false }) (const? 32 26)) ⊑
+    icmp IntPred.ult (add (LLVM.and e (const? 32 (-33))) (const? 32 (-65))) (const? 32 26) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -799,10 +799,10 @@ theorem is_ascii_alphabetic_thm (e : IntW 32) :
 
 
 theorem is_ascii_alphabetic_inverted_thm (e : IntW 32) :
-  select (icmp IntPredicate.ult (add e (const? 32 (-91)) { «nsw» := true, «nuw» := false }) (const? 32 (-26)))
-      (icmp IntPredicate.ult (add e (const? 32 (-123)) { «nsw» := true, «nuw» := false }) (const? 32 (-26)))
+  select (icmp IntPred.ult (add e (const? 32 (-91)) { «nsw» := true, «nuw» := false }) (const? 32 (-26)))
+      (icmp IntPred.ult (add e (const? 32 (-123)) { «nsw» := true, «nuw» := false }) (const? 32 (-26)))
       (const? 1 0) ⊑
-    icmp IntPredicate.ult (add (LLVM.and e (const? 32 (-33))) (const? 32 (-91))) (const? 32 (-26)) := by
+    icmp IntPred.ult (add (LLVM.and e (const? 32 (-33))) (const? 32 (-91))) (const? 32 (-26)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -813,11 +813,11 @@ theorem is_ascii_alphabetic_inverted_thm (e : IntW 32) :
 
 theorem bitwise_and_bitwise_and_icmps_thm (e e_1 e_2 : IntW 8) :
   LLVM.and
-      (LLVM.and (icmp IntPredicate.eq e_2 (const? 8 42))
-        (icmp IntPredicate.ne (LLVM.and e_1 (const? 8 1)) (const? 8 0)))
-      (icmp IntPredicate.ne (LLVM.and e_1 (shl (const? 8 1) e)) (const? 8 0)) ⊑
-    LLVM.and (icmp IntPredicate.eq e_2 (const? 8 42))
-      (icmp IntPredicate.eq (LLVM.and e_1 (LLVM.or (shl (const? 8 1) e { «nsw» := false, «nuw» := true }) (const? 8 1)))
+      (LLVM.and (icmp IntPred.eq e_2 (const? 8 42))
+        (icmp IntPred.ne (LLVM.and e_1 (const? 8 1)) (const? 8 0)))
+      (icmp IntPred.ne (LLVM.and e_1 (shl (const? 8 1) e)) (const? 8 0)) ⊑
+    LLVM.and (icmp IntPred.eq e_2 (const? 8 42))
+      (icmp IntPred.eq (LLVM.and e_1 (LLVM.or (shl (const? 8 1) e { «nsw» := false, «nuw» := true }) (const? 8 1)))
         (LLVM.or (shl (const? 8 1) e { «nsw» := false, «nuw» := true }) (const? 8 1))) := by
     simp_alive_undef
     simp_alive_ops
@@ -828,11 +828,11 @@ theorem bitwise_and_bitwise_and_icmps_thm (e e_1 e_2 : IntW 8) :
 
 
 theorem bitwise_and_bitwise_and_icmps_comm1_thm (e e_1 e_2 : IntW 8) :
-  LLVM.and (icmp IntPredicate.ne (LLVM.and e_2 (shl (const? 8 1) e_1)) (const? 8 0))
-      (LLVM.and (icmp IntPredicate.eq e (const? 8 42))
-        (icmp IntPredicate.ne (LLVM.and e_2 (const? 8 1)) (const? 8 0))) ⊑
-    LLVM.and (icmp IntPredicate.eq e (const? 8 42))
-      (icmp IntPredicate.eq
+  LLVM.and (icmp IntPred.ne (LLVM.and e_2 (shl (const? 8 1) e_1)) (const? 8 0))
+      (LLVM.and (icmp IntPred.eq e (const? 8 42))
+        (icmp IntPred.ne (LLVM.and e_2 (const? 8 1)) (const? 8 0))) ⊑
+    LLVM.and (icmp IntPred.eq e (const? 8 42))
+      (icmp IntPred.eq
         (LLVM.and e_2 (LLVM.or (shl (const? 8 1) e_1 { «nsw» := false, «nuw» := true }) (const? 8 1)))
         (LLVM.or (shl (const? 8 1) e_1 { «nsw» := false, «nuw» := true }) (const? 8 1))) := by
     simp_alive_undef
@@ -845,13 +845,13 @@ theorem bitwise_and_bitwise_and_icmps_comm1_thm (e e_1 e_2 : IntW 8) :
 
 theorem bitwise_and_bitwise_and_icmps_comm2_thm (e e_1 e_2 : IntW 8) :
   LLVM.and
-      (LLVM.and (icmp IntPredicate.ne (LLVM.and e_2 (const? 8 1)) (const? 8 0))
-        (icmp IntPredicate.eq e_1 (const? 8 42)))
-      (icmp IntPredicate.ne (LLVM.and e_2 (shl (const? 8 1) e)) (const? 8 0)) ⊑
+      (LLVM.and (icmp IntPred.ne (LLVM.and e_2 (const? 8 1)) (const? 8 0))
+        (icmp IntPred.eq e_1 (const? 8 42)))
+      (icmp IntPred.ne (LLVM.and e_2 (shl (const? 8 1) e)) (const? 8 0)) ⊑
     LLVM.and
-      (icmp IntPredicate.eq (LLVM.and e_2 (LLVM.or (shl (const? 8 1) e { «nsw» := false, «nuw» := true }) (const? 8 1)))
+      (icmp IntPred.eq (LLVM.and e_2 (LLVM.or (shl (const? 8 1) e { «nsw» := false, «nuw» := true }) (const? 8 1)))
         (LLVM.or (shl (const? 8 1) e { «nsw» := false, «nuw» := true }) (const? 8 1)))
-      (icmp IntPredicate.eq e_1 (const? 8 42)) := by
+      (icmp IntPred.eq e_1 (const? 8 42)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -861,14 +861,14 @@ theorem bitwise_and_bitwise_and_icmps_comm2_thm (e e_1 e_2 : IntW 8) :
 
 
 theorem bitwise_and_bitwise_and_icmps_comm3_thm (e e_1 e_2 : IntW 8) :
-  LLVM.and (icmp IntPredicate.ne (LLVM.and e_2 (shl (const? 8 1) e_1)) (const? 8 0))
-      (LLVM.and (icmp IntPredicate.ne (LLVM.and e_2 (const? 8 1)) (const? 8 0))
-        (icmp IntPredicate.eq e (const? 8 42))) ⊑
+  LLVM.and (icmp IntPred.ne (LLVM.and e_2 (shl (const? 8 1) e_1)) (const? 8 0))
+      (LLVM.and (icmp IntPred.ne (LLVM.and e_2 (const? 8 1)) (const? 8 0))
+        (icmp IntPred.eq e (const? 8 42))) ⊑
     LLVM.and
-      (icmp IntPredicate.eq
+      (icmp IntPred.eq
         (LLVM.and e_2 (LLVM.or (shl (const? 8 1) e_1 { «nsw» := false, «nuw» := true }) (const? 8 1)))
         (LLVM.or (shl (const? 8 1) e_1 { «nsw» := false, «nuw» := true }) (const? 8 1)))
-      (icmp IntPredicate.eq e (const? 8 42)) := by
+      (icmp IntPred.eq e (const? 8 42)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -879,11 +879,11 @@ theorem bitwise_and_bitwise_and_icmps_comm3_thm (e e_1 e_2 : IntW 8) :
 
 theorem bitwise_and_logical_and_icmps_thm (e e_1 e_2 : IntW 8) :
   LLVM.and
-      (select (icmp IntPredicate.eq e_2 (const? 8 42)) (icmp IntPredicate.ne (LLVM.and e_1 (const? 8 1)) (const? 8 0))
+      (select (icmp IntPred.eq e_2 (const? 8 42)) (icmp IntPred.ne (LLVM.and e_1 (const? 8 1)) (const? 8 0))
         (const? 1 0))
-      (icmp IntPredicate.ne (LLVM.and e_1 (shl (const? 8 1) e)) (const? 8 0)) ⊑
-    select (icmp IntPredicate.eq e_2 (const? 8 42))
-      (icmp IntPredicate.eq (LLVM.and e_1 (LLVM.or (shl (const? 8 1) e { «nsw» := false, «nuw» := true }) (const? 8 1)))
+      (icmp IntPred.ne (LLVM.and e_1 (shl (const? 8 1) e)) (const? 8 0)) ⊑
+    select (icmp IntPred.eq e_2 (const? 8 42))
+      (icmp IntPred.eq (LLVM.and e_1 (LLVM.or (shl (const? 8 1) e { «nsw» := false, «nuw» := true }) (const? 8 1)))
         (LLVM.or (shl (const? 8 1) e { «nsw» := false, «nuw» := true }) (const? 8 1)))
       (const? 1 0) := by
     simp_alive_undef
@@ -895,11 +895,11 @@ theorem bitwise_and_logical_and_icmps_thm (e e_1 e_2 : IntW 8) :
 
 
 theorem bitwise_and_logical_and_icmps_comm1_thm (e e_1 e_2 : IntW 8) :
-  LLVM.and (icmp IntPredicate.ne (LLVM.and e_2 (shl (const? 8 1) e_1)) (const? 8 0))
-      (select (icmp IntPredicate.eq e (const? 8 42)) (icmp IntPredicate.ne (LLVM.and e_2 (const? 8 1)) (const? 8 0))
+  LLVM.and (icmp IntPred.ne (LLVM.and e_2 (shl (const? 8 1) e_1)) (const? 8 0))
+      (select (icmp IntPred.eq e (const? 8 42)) (icmp IntPred.ne (LLVM.and e_2 (const? 8 1)) (const? 8 0))
         (const? 1 0)) ⊑
-    select (icmp IntPredicate.eq e (const? 8 42))
-      (icmp IntPredicate.eq
+    select (icmp IntPred.eq e (const? 8 42))
+      (icmp IntPred.eq
         (LLVM.and e_2 (LLVM.or (shl (const? 8 1) e_1 { «nsw» := false, «nuw» := true }) (const? 8 1)))
         (LLVM.or (shl (const? 8 1) e_1 { «nsw» := false, «nuw» := true }) (const? 8 1)))
       (const? 1 0) := by
@@ -912,14 +912,14 @@ theorem bitwise_and_logical_and_icmps_comm1_thm (e e_1 e_2 : IntW 8) :
 
 
 theorem bitwise_and_logical_and_icmps_comm3_thm (e e_1 e_2 : IntW 8) :
-  LLVM.and (icmp IntPredicate.ne (LLVM.and e_2 (shl (const? 8 1) e_1)) (const? 8 0))
-      (select (icmp IntPredicate.ne (LLVM.and e_2 (const? 8 1)) (const? 8 0)) (icmp IntPredicate.eq e (const? 8 42))
+  LLVM.and (icmp IntPred.ne (LLVM.and e_2 (shl (const? 8 1) e_1)) (const? 8 0))
+      (select (icmp IntPred.ne (LLVM.and e_2 (const? 8 1)) (const? 8 0)) (icmp IntPred.eq e (const? 8 42))
         (const? 1 0)) ⊑
     select
-      (icmp IntPredicate.eq
+      (icmp IntPred.eq
         (LLVM.and e_2 (LLVM.or (shl (const? 8 1) e_1 { «nsw» := false, «nuw» := true }) (const? 8 1)))
         (LLVM.or (shl (const? 8 1) e_1 { «nsw» := false, «nuw» := true }) (const? 8 1)))
-      (icmp IntPredicate.eq e (const? 8 42)) (const? 1 0) := by
+      (icmp IntPred.eq e (const? 8 42)) (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -930,13 +930,13 @@ theorem bitwise_and_logical_and_icmps_comm3_thm (e e_1 e_2 : IntW 8) :
 
 theorem logical_and_bitwise_and_icmps_thm (e e_1 e_2 : IntW 8) :
   select
-      (LLVM.and (icmp IntPredicate.eq e_2 (const? 8 42))
-        (icmp IntPredicate.ne (LLVM.and e_1 (const? 8 1)) (const? 8 0)))
-      (icmp IntPredicate.ne (LLVM.and e_1 (shl (const? 8 1) e)) (const? 8 0)) (const? 1 0) ⊑
+      (LLVM.and (icmp IntPred.eq e_2 (const? 8 42))
+        (icmp IntPred.ne (LLVM.and e_1 (const? 8 1)) (const? 8 0)))
+      (icmp IntPred.ne (LLVM.and e_1 (shl (const? 8 1) e)) (const? 8 0)) (const? 1 0) ⊑
     select
-      (LLVM.and (icmp IntPredicate.eq e_2 (const? 8 42))
-        (icmp IntPredicate.ne (LLVM.and e_1 (const? 8 1)) (const? 8 0)))
-      (icmp IntPredicate.ne (LLVM.and e_1 (shl (const? 8 1) e { «nsw» := false, «nuw» := true })) (const? 8 0))
+      (LLVM.and (icmp IntPred.eq e_2 (const? 8 42))
+        (icmp IntPred.ne (LLVM.and e_1 (const? 8 1)) (const? 8 0)))
+      (icmp IntPred.ne (LLVM.and e_1 (shl (const? 8 1) e { «nsw» := false, «nuw» := true })) (const? 8 0))
       (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
@@ -947,11 +947,11 @@ theorem logical_and_bitwise_and_icmps_thm (e e_1 e_2 : IntW 8) :
 
 
 theorem logical_and_bitwise_and_icmps_comm1_thm (e e_1 e_2 : IntW 8) :
-  select (icmp IntPredicate.ne (LLVM.and e_2 (shl (const? 8 1) e_1)) (const? 8 0))
-      (LLVM.and (icmp IntPredicate.eq e (const? 8 42)) (icmp IntPredicate.ne (LLVM.and e_2 (const? 8 1)) (const? 8 0)))
+  select (icmp IntPred.ne (LLVM.and e_2 (shl (const? 8 1) e_1)) (const? 8 0))
+      (LLVM.and (icmp IntPred.eq e (const? 8 42)) (icmp IntPred.ne (LLVM.and e_2 (const? 8 1)) (const? 8 0)))
       (const? 1 0) ⊑
-    select (icmp IntPredicate.ne (LLVM.and e_2 (shl (const? 8 1) e_1 { «nsw» := false, «nuw» := true })) (const? 8 0))
-      (LLVM.and (icmp IntPredicate.eq e (const? 8 42)) (icmp IntPredicate.ne (LLVM.and e_2 (const? 8 1)) (const? 8 0)))
+    select (icmp IntPred.ne (LLVM.and e_2 (shl (const? 8 1) e_1 { «nsw» := false, «nuw» := true })) (const? 8 0))
+      (LLVM.and (icmp IntPred.eq e (const? 8 42)) (icmp IntPred.ne (LLVM.and e_2 (const? 8 1)) (const? 8 0)))
       (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
@@ -963,13 +963,13 @@ theorem logical_and_bitwise_and_icmps_comm1_thm (e e_1 e_2 : IntW 8) :
 
 theorem logical_and_bitwise_and_icmps_comm2_thm (e e_1 e_2 : IntW 8) :
   select
-      (LLVM.and (icmp IntPredicate.ne (LLVM.and e_2 (const? 8 1)) (const? 8 0))
-        (icmp IntPredicate.eq e_1 (const? 8 42)))
-      (icmp IntPredicate.ne (LLVM.and e_2 (shl (const? 8 1) e)) (const? 8 0)) (const? 1 0) ⊑
+      (LLVM.and (icmp IntPred.ne (LLVM.and e_2 (const? 8 1)) (const? 8 0))
+        (icmp IntPred.eq e_1 (const? 8 42)))
+      (icmp IntPred.ne (LLVM.and e_2 (shl (const? 8 1) e)) (const? 8 0)) (const? 1 0) ⊑
     select
-      (LLVM.and (icmp IntPredicate.ne (LLVM.and e_2 (const? 8 1)) (const? 8 0))
-        (icmp IntPredicate.eq e_1 (const? 8 42)))
-      (icmp IntPredicate.ne (LLVM.and e_2 (shl (const? 8 1) e { «nsw» := false, «nuw» := true })) (const? 8 0))
+      (LLVM.and (icmp IntPred.ne (LLVM.and e_2 (const? 8 1)) (const? 8 0))
+        (icmp IntPred.eq e_1 (const? 8 42)))
+      (icmp IntPred.ne (LLVM.and e_2 (shl (const? 8 1) e { «nsw» := false, «nuw» := true })) (const? 8 0))
       (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
@@ -980,11 +980,11 @@ theorem logical_and_bitwise_and_icmps_comm2_thm (e e_1 e_2 : IntW 8) :
 
 
 theorem logical_and_bitwise_and_icmps_comm3_thm (e e_1 e_2 : IntW 8) :
-  select (icmp IntPredicate.ne (LLVM.and e_2 (shl (const? 8 1) e_1)) (const? 8 0))
-      (LLVM.and (icmp IntPredicate.ne (LLVM.and e_2 (const? 8 1)) (const? 8 0)) (icmp IntPredicate.eq e (const? 8 42)))
+  select (icmp IntPred.ne (LLVM.and e_2 (shl (const? 8 1) e_1)) (const? 8 0))
+      (LLVM.and (icmp IntPred.ne (LLVM.and e_2 (const? 8 1)) (const? 8 0)) (icmp IntPred.eq e (const? 8 42)))
       (const? 1 0) ⊑
-    select (icmp IntPredicate.ne (LLVM.and e_2 (shl (const? 8 1) e_1 { «nsw» := false, «nuw» := true })) (const? 8 0))
-      (LLVM.and (icmp IntPredicate.ne (LLVM.and e_2 (const? 8 1)) (const? 8 0)) (icmp IntPredicate.eq e (const? 8 42)))
+    select (icmp IntPred.ne (LLVM.and e_2 (shl (const? 8 1) e_1 { «nsw» := false, «nuw» := true })) (const? 8 0))
+      (LLVM.and (icmp IntPred.ne (LLVM.and e_2 (const? 8 1)) (const? 8 0)) (icmp IntPred.eq e (const? 8 42)))
       (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
@@ -996,13 +996,13 @@ theorem logical_and_bitwise_and_icmps_comm3_thm (e e_1 e_2 : IntW 8) :
 
 theorem logical_and_logical_and_icmps_thm (e e_1 e_2 : IntW 8) :
   select
-      (select (icmp IntPredicate.eq e_2 (const? 8 42)) (icmp IntPredicate.ne (LLVM.and e_1 (const? 8 1)) (const? 8 0))
+      (select (icmp IntPred.eq e_2 (const? 8 42)) (icmp IntPred.ne (LLVM.and e_1 (const? 8 1)) (const? 8 0))
         (const? 1 0))
-      (icmp IntPredicate.ne (LLVM.and e_1 (shl (const? 8 1) e)) (const? 8 0)) (const? 1 0) ⊑
+      (icmp IntPred.ne (LLVM.and e_1 (shl (const? 8 1) e)) (const? 8 0)) (const? 1 0) ⊑
     select
-      (select (icmp IntPredicate.eq e_2 (const? 8 42)) (icmp IntPredicate.ne (LLVM.and e_1 (const? 8 1)) (const? 8 0))
+      (select (icmp IntPred.eq e_2 (const? 8 42)) (icmp IntPred.ne (LLVM.and e_1 (const? 8 1)) (const? 8 0))
         (const? 1 0))
-      (icmp IntPredicate.ne (LLVM.and e_1 (shl (const? 8 1) e { «nsw» := false, «nuw» := true })) (const? 8 0))
+      (icmp IntPred.ne (LLVM.and e_1 (shl (const? 8 1) e { «nsw» := false, «nuw» := true })) (const? 8 0))
       (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
@@ -1013,15 +1013,15 @@ theorem logical_and_logical_and_icmps_thm (e e_1 e_2 : IntW 8) :
 
 
 theorem logical_and_logical_and_icmps_comm1_thm (e e_1 e_2 : IntW 8) :
-  select (icmp IntPredicate.ne (LLVM.and e_2 (shl (const? 8 1) e_1)) (const? 8 0))
-      (select (icmp IntPredicate.eq e (const? 8 42)) (icmp IntPredicate.ne (LLVM.and e_2 (const? 8 1)) (const? 8 0))
+  select (icmp IntPred.ne (LLVM.and e_2 (shl (const? 8 1) e_1)) (const? 8 0))
+      (select (icmp IntPred.eq e (const? 8 42)) (icmp IntPred.ne (LLVM.and e_2 (const? 8 1)) (const? 8 0))
         (const? 1 0))
       (const? 1 0) ⊑
     select
       (select
-        (icmp IntPredicate.ne (LLVM.and e_2 (shl (const? 8 1) e_1 { «nsw» := false, «nuw» := true })) (const? 8 0))
-        (icmp IntPredicate.eq e (const? 8 42)) (const? 1 0))
-      (icmp IntPredicate.ne (LLVM.and e_2 (const? 8 1)) (const? 8 0)) (const? 1 0) := by
+        (icmp IntPred.ne (LLVM.and e_2 (shl (const? 8 1) e_1 { «nsw» := false, «nuw» := true })) (const? 8 0))
+        (icmp IntPred.eq e (const? 8 42)) (const? 1 0))
+      (icmp IntPred.ne (LLVM.and e_2 (const? 8 1)) (const? 8 0)) (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1032,13 +1032,13 @@ theorem logical_and_logical_and_icmps_comm1_thm (e e_1 e_2 : IntW 8) :
 
 theorem logical_and_logical_and_icmps_comm2_thm (e e_1 e_2 : IntW 8) :
   select
-      (select (icmp IntPredicate.ne (LLVM.and e_2 (const? 8 1)) (const? 8 0)) (icmp IntPredicate.eq e_1 (const? 8 42))
+      (select (icmp IntPred.ne (LLVM.and e_2 (const? 8 1)) (const? 8 0)) (icmp IntPred.eq e_1 (const? 8 42))
         (const? 1 0))
-      (icmp IntPredicate.ne (LLVM.and e_2 (shl (const? 8 1) e)) (const? 8 0)) (const? 1 0) ⊑
+      (icmp IntPred.ne (LLVM.and e_2 (shl (const? 8 1) e)) (const? 8 0)) (const? 1 0) ⊑
     select
-      (select (icmp IntPredicate.ne (LLVM.and e_2 (const? 8 1)) (const? 8 0)) (icmp IntPredicate.eq e_1 (const? 8 42))
+      (select (icmp IntPred.ne (LLVM.and e_2 (const? 8 1)) (const? 8 0)) (icmp IntPred.eq e_1 (const? 8 42))
         (const? 1 0))
-      (icmp IntPredicate.ne (LLVM.and e_2 (shl (const? 8 1) e { «nsw» := false, «nuw» := true })) (const? 8 0))
+      (icmp IntPred.ne (LLVM.and e_2 (shl (const? 8 1) e { «nsw» := false, «nuw» := true })) (const? 8 0))
       (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
@@ -1049,15 +1049,15 @@ theorem logical_and_logical_and_icmps_comm2_thm (e e_1 e_2 : IntW 8) :
 
 
 theorem logical_and_logical_and_icmps_comm3_thm (e e_1 e_2 : IntW 8) :
-  select (icmp IntPredicate.ne (LLVM.and e_2 (shl (const? 8 1) e_1)) (const? 8 0))
-      (select (icmp IntPredicate.ne (LLVM.and e_2 (const? 8 1)) (const? 8 0)) (icmp IntPredicate.eq e (const? 8 42))
+  select (icmp IntPred.ne (LLVM.and e_2 (shl (const? 8 1) e_1)) (const? 8 0))
+      (select (icmp IntPred.ne (LLVM.and e_2 (const? 8 1)) (const? 8 0)) (icmp IntPred.eq e (const? 8 42))
         (const? 1 0))
       (const? 1 0) ⊑
     select
-      (icmp IntPredicate.eq
+      (icmp IntPred.eq
         (LLVM.and e_2 (LLVM.or (shl (const? 8 1) e_1 { «nsw» := false, «nuw» := true }) (const? 8 1)))
         (LLVM.or (shl (const? 8 1) e_1 { «nsw» := false, «nuw» := true }) (const? 8 1)))
-      (icmp IntPredicate.eq e (const? 8 42)) (const? 1 0) := by
+      (icmp IntPred.eq e (const? 8 42)) (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1068,10 +1068,10 @@ theorem logical_and_logical_and_icmps_comm3_thm (e e_1 e_2 : IntW 8) :
 
 theorem bitwise_or_bitwise_or_icmps_thm (e e_1 e_2 : IntW 8) :
   LLVM.or
-      (LLVM.or (icmp IntPredicate.eq e_2 (const? 8 42)) (icmp IntPredicate.eq (LLVM.and e_1 (const? 8 1)) (const? 8 0)))
-      (icmp IntPredicate.eq (LLVM.and e_1 (shl (const? 8 1) e)) (const? 8 0)) ⊑
-    LLVM.or (icmp IntPredicate.eq e_2 (const? 8 42))
-      (icmp IntPredicate.ne (LLVM.and e_1 (LLVM.or (shl (const? 8 1) e { «nsw» := false, «nuw» := true }) (const? 8 1)))
+      (LLVM.or (icmp IntPred.eq e_2 (const? 8 42)) (icmp IntPred.eq (LLVM.and e_1 (const? 8 1)) (const? 8 0)))
+      (icmp IntPred.eq (LLVM.and e_1 (shl (const? 8 1) e)) (const? 8 0)) ⊑
+    LLVM.or (icmp IntPred.eq e_2 (const? 8 42))
+      (icmp IntPred.ne (LLVM.and e_1 (LLVM.or (shl (const? 8 1) e { «nsw» := false, «nuw» := true }) (const? 8 1)))
         (LLVM.or (shl (const? 8 1) e { «nsw» := false, «nuw» := true }) (const? 8 1))) := by
     simp_alive_undef
     simp_alive_ops
@@ -1082,10 +1082,10 @@ theorem bitwise_or_bitwise_or_icmps_thm (e e_1 e_2 : IntW 8) :
 
 
 theorem bitwise_or_bitwise_or_icmps_comm1_thm (e e_1 e_2 : IntW 8) :
-  LLVM.or (icmp IntPredicate.eq (LLVM.and e_2 (shl (const? 8 1) e_1)) (const? 8 0))
-      (LLVM.or (icmp IntPredicate.eq e (const? 8 42)) (icmp IntPredicate.eq (LLVM.and e_2 (const? 8 1)) (const? 8 0))) ⊑
-    LLVM.or (icmp IntPredicate.eq e (const? 8 42))
-      (icmp IntPredicate.ne
+  LLVM.or (icmp IntPred.eq (LLVM.and e_2 (shl (const? 8 1) e_1)) (const? 8 0))
+      (LLVM.or (icmp IntPred.eq e (const? 8 42)) (icmp IntPred.eq (LLVM.and e_2 (const? 8 1)) (const? 8 0))) ⊑
+    LLVM.or (icmp IntPred.eq e (const? 8 42))
+      (icmp IntPred.ne
         (LLVM.and e_2 (LLVM.or (shl (const? 8 1) e_1 { «nsw» := false, «nuw» := true }) (const? 8 1)))
         (LLVM.or (shl (const? 8 1) e_1 { «nsw» := false, «nuw» := true }) (const? 8 1))) := by
     simp_alive_undef
@@ -1098,12 +1098,12 @@ theorem bitwise_or_bitwise_or_icmps_comm1_thm (e e_1 e_2 : IntW 8) :
 
 theorem bitwise_or_bitwise_or_icmps_comm2_thm (e e_1 e_2 : IntW 8) :
   LLVM.or
-      (LLVM.or (icmp IntPredicate.eq (LLVM.and e_2 (const? 8 1)) (const? 8 0)) (icmp IntPredicate.eq e_1 (const? 8 42)))
-      (icmp IntPredicate.eq (LLVM.and e_2 (shl (const? 8 1) e)) (const? 8 0)) ⊑
+      (LLVM.or (icmp IntPred.eq (LLVM.and e_2 (const? 8 1)) (const? 8 0)) (icmp IntPred.eq e_1 (const? 8 42)))
+      (icmp IntPred.eq (LLVM.and e_2 (shl (const? 8 1) e)) (const? 8 0)) ⊑
     LLVM.or
-      (icmp IntPredicate.ne (LLVM.and e_2 (LLVM.or (shl (const? 8 1) e { «nsw» := false, «nuw» := true }) (const? 8 1)))
+      (icmp IntPred.ne (LLVM.and e_2 (LLVM.or (shl (const? 8 1) e { «nsw» := false, «nuw» := true }) (const? 8 1)))
         (LLVM.or (shl (const? 8 1) e { «nsw» := false, «nuw» := true }) (const? 8 1)))
-      (icmp IntPredicate.eq e_1 (const? 8 42)) := by
+      (icmp IntPred.eq e_1 (const? 8 42)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1113,13 +1113,13 @@ theorem bitwise_or_bitwise_or_icmps_comm2_thm (e e_1 e_2 : IntW 8) :
 
 
 theorem bitwise_or_bitwise_or_icmps_comm3_thm (e e_1 e_2 : IntW 8) :
-  LLVM.or (icmp IntPredicate.eq (LLVM.and e_2 (shl (const? 8 1) e_1)) (const? 8 0))
-      (LLVM.or (icmp IntPredicate.eq (LLVM.and e_2 (const? 8 1)) (const? 8 0)) (icmp IntPredicate.eq e (const? 8 42))) ⊑
+  LLVM.or (icmp IntPred.eq (LLVM.and e_2 (shl (const? 8 1) e_1)) (const? 8 0))
+      (LLVM.or (icmp IntPred.eq (LLVM.and e_2 (const? 8 1)) (const? 8 0)) (icmp IntPred.eq e (const? 8 42))) ⊑
     LLVM.or
-      (icmp IntPredicate.ne
+      (icmp IntPred.ne
         (LLVM.and e_2 (LLVM.or (shl (const? 8 1) e_1 { «nsw» := false, «nuw» := true }) (const? 8 1)))
         (LLVM.or (shl (const? 8 1) e_1 { «nsw» := false, «nuw» := true }) (const? 8 1)))
-      (icmp IntPredicate.eq e (const? 8 42)) := by
+      (icmp IntPred.eq e (const? 8 42)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1130,11 +1130,11 @@ theorem bitwise_or_bitwise_or_icmps_comm3_thm (e e_1 e_2 : IntW 8) :
 
 theorem bitwise_or_logical_or_icmps_thm (e e_1 e_2 : IntW 8) :
   LLVM.or
-      (select (icmp IntPredicate.eq e_2 (const? 8 42)) (const? 1 1)
-        (icmp IntPredicate.eq (LLVM.and e_1 (const? 8 1)) (const? 8 0)))
-      (icmp IntPredicate.eq (LLVM.and e_1 (shl (const? 8 1) e)) (const? 8 0)) ⊑
-    select (icmp IntPredicate.eq e_2 (const? 8 42)) (const? 1 1)
-      (icmp IntPredicate.ne (LLVM.and e_1 (LLVM.or (shl (const? 8 1) e { «nsw» := false, «nuw» := true }) (const? 8 1)))
+      (select (icmp IntPred.eq e_2 (const? 8 42)) (const? 1 1)
+        (icmp IntPred.eq (LLVM.and e_1 (const? 8 1)) (const? 8 0)))
+      (icmp IntPred.eq (LLVM.and e_1 (shl (const? 8 1) e)) (const? 8 0)) ⊑
+    select (icmp IntPred.eq e_2 (const? 8 42)) (const? 1 1)
+      (icmp IntPred.ne (LLVM.and e_1 (LLVM.or (shl (const? 8 1) e { «nsw» := false, «nuw» := true }) (const? 8 1)))
         (LLVM.or (shl (const? 8 1) e { «nsw» := false, «nuw» := true }) (const? 8 1))) := by
     simp_alive_undef
     simp_alive_ops
@@ -1145,11 +1145,11 @@ theorem bitwise_or_logical_or_icmps_thm (e e_1 e_2 : IntW 8) :
 
 
 theorem bitwise_or_logical_or_icmps_comm1_thm (e e_1 e_2 : IntW 8) :
-  LLVM.or (icmp IntPredicate.eq (LLVM.and e_2 (shl (const? 8 1) e_1)) (const? 8 0))
-      (select (icmp IntPredicate.eq e (const? 8 42)) (const? 1 1)
-        (icmp IntPredicate.eq (LLVM.and e_2 (const? 8 1)) (const? 8 0))) ⊑
-    select (icmp IntPredicate.eq e (const? 8 42)) (const? 1 1)
-      (icmp IntPredicate.ne
+  LLVM.or (icmp IntPred.eq (LLVM.and e_2 (shl (const? 8 1) e_1)) (const? 8 0))
+      (select (icmp IntPred.eq e (const? 8 42)) (const? 1 1)
+        (icmp IntPred.eq (LLVM.and e_2 (const? 8 1)) (const? 8 0))) ⊑
+    select (icmp IntPred.eq e (const? 8 42)) (const? 1 1)
+      (icmp IntPred.ne
         (LLVM.and e_2 (LLVM.or (shl (const? 8 1) e_1 { «nsw» := false, «nuw» := true }) (const? 8 1)))
         (LLVM.or (shl (const? 8 1) e_1 { «nsw» := false, «nuw» := true }) (const? 8 1))) := by
     simp_alive_undef
@@ -1161,14 +1161,14 @@ theorem bitwise_or_logical_or_icmps_comm1_thm (e e_1 e_2 : IntW 8) :
 
 
 theorem bitwise_or_logical_or_icmps_comm3_thm (e e_1 e_2 : IntW 8) :
-  LLVM.or (icmp IntPredicate.eq (LLVM.and e_2 (shl (const? 8 1) e_1)) (const? 8 0))
-      (select (icmp IntPredicate.eq (LLVM.and e_2 (const? 8 1)) (const? 8 0)) (const? 1 1)
-        (icmp IntPredicate.eq e (const? 8 42))) ⊑
+  LLVM.or (icmp IntPred.eq (LLVM.and e_2 (shl (const? 8 1) e_1)) (const? 8 0))
+      (select (icmp IntPred.eq (LLVM.and e_2 (const? 8 1)) (const? 8 0)) (const? 1 1)
+        (icmp IntPred.eq e (const? 8 42))) ⊑
     select
-      (icmp IntPredicate.ne
+      (icmp IntPred.ne
         (LLVM.and e_2 (LLVM.or (shl (const? 8 1) e_1 { «nsw» := false, «nuw» := true }) (const? 8 1)))
         (LLVM.or (shl (const? 8 1) e_1 { «nsw» := false, «nuw» := true }) (const? 8 1)))
-      (const? 1 1) (icmp IntPredicate.eq e (const? 8 42)) := by
+      (const? 1 1) (icmp IntPred.eq e (const? 8 42)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1179,12 +1179,12 @@ theorem bitwise_or_logical_or_icmps_comm3_thm (e e_1 e_2 : IntW 8) :
 
 theorem logical_or_bitwise_or_icmps_thm (e e_1 e_2 : IntW 8) :
   select
-      (LLVM.or (icmp IntPredicate.eq e_2 (const? 8 42)) (icmp IntPredicate.eq (LLVM.and e_1 (const? 8 1)) (const? 8 0)))
-      (const? 1 1) (icmp IntPredicate.eq (LLVM.and e_1 (shl (const? 8 1) e)) (const? 8 0)) ⊑
+      (LLVM.or (icmp IntPred.eq e_2 (const? 8 42)) (icmp IntPred.eq (LLVM.and e_1 (const? 8 1)) (const? 8 0)))
+      (const? 1 1) (icmp IntPred.eq (LLVM.and e_1 (shl (const? 8 1) e)) (const? 8 0)) ⊑
     select
-      (LLVM.or (icmp IntPredicate.eq e_2 (const? 8 42)) (icmp IntPredicate.eq (LLVM.and e_1 (const? 8 1)) (const? 8 0)))
+      (LLVM.or (icmp IntPred.eq e_2 (const? 8 42)) (icmp IntPred.eq (LLVM.and e_1 (const? 8 1)) (const? 8 0)))
       (const? 1 1)
-      (icmp IntPredicate.eq (LLVM.and e_1 (shl (const? 8 1) e { «nsw» := false, «nuw» := true })) (const? 8 0)) := by
+      (icmp IntPred.eq (LLVM.and e_1 (shl (const? 8 1) e { «nsw» := false, «nuw» := true })) (const? 8 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1194,12 +1194,12 @@ theorem logical_or_bitwise_or_icmps_thm (e e_1 e_2 : IntW 8) :
 
 
 theorem logical_or_bitwise_or_icmps_comm1_thm (e e_1 e_2 : IntW 8) :
-  select (icmp IntPredicate.eq (LLVM.and e_2 (shl (const? 8 1) e_1)) (const? 8 0)) (const? 1 1)
-      (LLVM.or (icmp IntPredicate.eq e (const? 8 42)) (icmp IntPredicate.eq (LLVM.and e_2 (const? 8 1)) (const? 8 0))) ⊑
-    select (icmp IntPredicate.eq (LLVM.and e_2 (shl (const? 8 1) e_1 { «nsw» := false, «nuw» := true })) (const? 8 0))
+  select (icmp IntPred.eq (LLVM.and e_2 (shl (const? 8 1) e_1)) (const? 8 0)) (const? 1 1)
+      (LLVM.or (icmp IntPred.eq e (const? 8 42)) (icmp IntPred.eq (LLVM.and e_2 (const? 8 1)) (const? 8 0))) ⊑
+    select (icmp IntPred.eq (LLVM.and e_2 (shl (const? 8 1) e_1 { «nsw» := false, «nuw» := true })) (const? 8 0))
       (const? 1 1)
-      (LLVM.or (icmp IntPredicate.eq e (const? 8 42))
-        (icmp IntPredicate.eq (LLVM.and e_2 (const? 8 1)) (const? 8 0))) := by
+      (LLVM.or (icmp IntPred.eq e (const? 8 42))
+        (icmp IntPred.eq (LLVM.and e_2 (const? 8 1)) (const? 8 0))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1210,12 +1210,12 @@ theorem logical_or_bitwise_or_icmps_comm1_thm (e e_1 e_2 : IntW 8) :
 
 theorem logical_or_bitwise_or_icmps_comm2_thm (e e_1 e_2 : IntW 8) :
   select
-      (LLVM.or (icmp IntPredicate.eq (LLVM.and e_2 (const? 8 1)) (const? 8 0)) (icmp IntPredicate.eq e_1 (const? 8 42)))
-      (const? 1 1) (icmp IntPredicate.eq (LLVM.and e_2 (shl (const? 8 1) e)) (const? 8 0)) ⊑
+      (LLVM.or (icmp IntPred.eq (LLVM.and e_2 (const? 8 1)) (const? 8 0)) (icmp IntPred.eq e_1 (const? 8 42)))
+      (const? 1 1) (icmp IntPred.eq (LLVM.and e_2 (shl (const? 8 1) e)) (const? 8 0)) ⊑
     select
-      (LLVM.or (icmp IntPredicate.eq (LLVM.and e_2 (const? 8 1)) (const? 8 0)) (icmp IntPredicate.eq e_1 (const? 8 42)))
+      (LLVM.or (icmp IntPred.eq (LLVM.and e_2 (const? 8 1)) (const? 8 0)) (icmp IntPred.eq e_1 (const? 8 42)))
       (const? 1 1)
-      (icmp IntPredicate.eq (LLVM.and e_2 (shl (const? 8 1) e { «nsw» := false, «nuw» := true })) (const? 8 0)) := by
+      (icmp IntPred.eq (LLVM.and e_2 (shl (const? 8 1) e { «nsw» := false, «nuw» := true })) (const? 8 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1225,12 +1225,12 @@ theorem logical_or_bitwise_or_icmps_comm2_thm (e e_1 e_2 : IntW 8) :
 
 
 theorem logical_or_bitwise_or_icmps_comm3_thm (e e_1 e_2 : IntW 8) :
-  select (icmp IntPredicate.eq (LLVM.and e_2 (shl (const? 8 1) e_1)) (const? 8 0)) (const? 1 1)
-      (LLVM.or (icmp IntPredicate.eq (LLVM.and e_2 (const? 8 1)) (const? 8 0)) (icmp IntPredicate.eq e (const? 8 42))) ⊑
-    select (icmp IntPredicate.eq (LLVM.and e_2 (shl (const? 8 1) e_1 { «nsw» := false, «nuw» := true })) (const? 8 0))
+  select (icmp IntPred.eq (LLVM.and e_2 (shl (const? 8 1) e_1)) (const? 8 0)) (const? 1 1)
+      (LLVM.or (icmp IntPred.eq (LLVM.and e_2 (const? 8 1)) (const? 8 0)) (icmp IntPred.eq e (const? 8 42))) ⊑
+    select (icmp IntPred.eq (LLVM.and e_2 (shl (const? 8 1) e_1 { «nsw» := false, «nuw» := true })) (const? 8 0))
       (const? 1 1)
-      (LLVM.or (icmp IntPredicate.eq (LLVM.and e_2 (const? 8 1)) (const? 8 0))
-        (icmp IntPredicate.eq e (const? 8 42))) := by
+      (LLVM.or (icmp IntPred.eq (LLVM.and e_2 (const? 8 1)) (const? 8 0))
+        (icmp IntPred.eq e (const? 8 42))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1241,14 +1241,14 @@ theorem logical_or_bitwise_or_icmps_comm3_thm (e e_1 e_2 : IntW 8) :
 
 theorem logical_or_logical_or_icmps_thm (e e_1 e_2 : IntW 8) :
   select
-      (select (icmp IntPredicate.eq e_2 (const? 8 42)) (const? 1 1)
-        (icmp IntPredicate.eq (LLVM.and e_1 (const? 8 1)) (const? 8 0)))
-      (const? 1 1) (icmp IntPredicate.eq (LLVM.and e_1 (shl (const? 8 1) e)) (const? 8 0)) ⊑
+      (select (icmp IntPred.eq e_2 (const? 8 42)) (const? 1 1)
+        (icmp IntPred.eq (LLVM.and e_1 (const? 8 1)) (const? 8 0)))
+      (const? 1 1) (icmp IntPred.eq (LLVM.and e_1 (shl (const? 8 1) e)) (const? 8 0)) ⊑
     select
-      (select (icmp IntPredicate.eq e_2 (const? 8 42)) (const? 1 1)
-        (icmp IntPredicate.eq (LLVM.and e_1 (const? 8 1)) (const? 8 0)))
+      (select (icmp IntPred.eq e_2 (const? 8 42)) (const? 1 1)
+        (icmp IntPred.eq (LLVM.and e_1 (const? 8 1)) (const? 8 0)))
       (const? 1 1)
-      (icmp IntPredicate.eq (LLVM.and e_1 (shl (const? 8 1) e { «nsw» := false, «nuw» := true })) (const? 8 0)) := by
+      (icmp IntPred.eq (LLVM.and e_1 (shl (const? 8 1) e { «nsw» := false, «nuw» := true })) (const? 8 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1258,14 +1258,14 @@ theorem logical_or_logical_or_icmps_thm (e e_1 e_2 : IntW 8) :
 
 
 theorem logical_or_logical_or_icmps_comm1_thm (e e_1 e_2 : IntW 8) :
-  select (icmp IntPredicate.eq (LLVM.and e_2 (shl (const? 8 1) e_1)) (const? 8 0)) (const? 1 1)
-      (select (icmp IntPredicate.eq e (const? 8 42)) (const? 1 1)
-        (icmp IntPredicate.eq (LLVM.and e_2 (const? 8 1)) (const? 8 0))) ⊑
+  select (icmp IntPred.eq (LLVM.and e_2 (shl (const? 8 1) e_1)) (const? 8 0)) (const? 1 1)
+      (select (icmp IntPred.eq e (const? 8 42)) (const? 1 1)
+        (icmp IntPred.eq (LLVM.and e_2 (const? 8 1)) (const? 8 0))) ⊑
     select
       (select
-        (icmp IntPredicate.eq (LLVM.and e_2 (shl (const? 8 1) e_1 { «nsw» := false, «nuw» := true })) (const? 8 0))
-        (const? 1 1) (icmp IntPredicate.eq e (const? 8 42)))
-      (const? 1 1) (icmp IntPredicate.eq (LLVM.and e_2 (const? 8 1)) (const? 8 0)) := by
+        (icmp IntPred.eq (LLVM.and e_2 (shl (const? 8 1) e_1 { «nsw» := false, «nuw» := true })) (const? 8 0))
+        (const? 1 1) (icmp IntPred.eq e (const? 8 42)))
+      (const? 1 1) (icmp IntPred.eq (LLVM.and e_2 (const? 8 1)) (const? 8 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1276,14 +1276,14 @@ theorem logical_or_logical_or_icmps_comm1_thm (e e_1 e_2 : IntW 8) :
 
 theorem logical_or_logical_or_icmps_comm2_thm (e e_1 e_2 : IntW 8) :
   select
-      (select (icmp IntPredicate.eq (LLVM.and e_2 (const? 8 1)) (const? 8 0)) (const? 1 1)
-        (icmp IntPredicate.eq e_1 (const? 8 42)))
-      (const? 1 1) (icmp IntPredicate.eq (LLVM.and e_2 (shl (const? 8 1) e)) (const? 8 0)) ⊑
+      (select (icmp IntPred.eq (LLVM.and e_2 (const? 8 1)) (const? 8 0)) (const? 1 1)
+        (icmp IntPred.eq e_1 (const? 8 42)))
+      (const? 1 1) (icmp IntPred.eq (LLVM.and e_2 (shl (const? 8 1) e)) (const? 8 0)) ⊑
     select
-      (select (icmp IntPredicate.eq (LLVM.and e_2 (const? 8 1)) (const? 8 0)) (const? 1 1)
-        (icmp IntPredicate.eq e_1 (const? 8 42)))
+      (select (icmp IntPred.eq (LLVM.and e_2 (const? 8 1)) (const? 8 0)) (const? 1 1)
+        (icmp IntPred.eq e_1 (const? 8 42)))
       (const? 1 1)
-      (icmp IntPredicate.eq (LLVM.and e_2 (shl (const? 8 1) e { «nsw» := false, «nuw» := true })) (const? 8 0)) := by
+      (icmp IntPred.eq (LLVM.and e_2 (shl (const? 8 1) e { «nsw» := false, «nuw» := true })) (const? 8 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1293,14 +1293,14 @@ theorem logical_or_logical_or_icmps_comm2_thm (e e_1 e_2 : IntW 8) :
 
 
 theorem logical_or_logical_or_icmps_comm3_thm (e e_1 e_2 : IntW 8) :
-  select (icmp IntPredicate.eq (LLVM.and e_2 (shl (const? 8 1) e_1)) (const? 8 0)) (const? 1 1)
-      (select (icmp IntPredicate.eq (LLVM.and e_2 (const? 8 1)) (const? 8 0)) (const? 1 1)
-        (icmp IntPredicate.eq e (const? 8 42))) ⊑
+  select (icmp IntPred.eq (LLVM.and e_2 (shl (const? 8 1) e_1)) (const? 8 0)) (const? 1 1)
+      (select (icmp IntPred.eq (LLVM.and e_2 (const? 8 1)) (const? 8 0)) (const? 1 1)
+        (icmp IntPred.eq e (const? 8 42))) ⊑
     select
-      (icmp IntPredicate.ne
+      (icmp IntPred.ne
         (LLVM.and e_2 (LLVM.or (shl (const? 8 1) e_1 { «nsw» := false, «nuw» := true }) (const? 8 1)))
         (LLVM.or (shl (const? 8 1) e_1 { «nsw» := false, «nuw» := true }) (const? 8 1)))
-      (const? 1 1) (icmp IntPredicate.eq e (const? 8 42)) := by
+      (const? 1 1) (icmp IntPred.eq e (const? 8 42)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1310,9 +1310,9 @@ theorem logical_or_logical_or_icmps_comm3_thm (e e_1 e_2 : IntW 8) :
 
 
 theorem bitwise_and_logical_and_masked_icmp_asymmetric_thm (e : IntW 1) (e_1 : IntW 32) :
-  LLVM.and (select (icmp IntPredicate.ne (LLVM.and e_1 (const? 32 255)) (const? 32 0)) e (const? 1 0))
-      (icmp IntPredicate.eq (LLVM.and e_1 (const? 32 11)) (const? 32 11)) ⊑
-    select (icmp IntPredicate.eq (LLVM.and e_1 (const? 32 11)) (const? 32 11)) e (const? 1 0) := by
+  LLVM.and (select (icmp IntPred.ne (LLVM.and e_1 (const? 32 255)) (const? 32 0)) e (const? 1 0))
+      (icmp IntPred.eq (LLVM.and e_1 (const? 32 11)) (const? 32 11)) ⊑
+    select (icmp IntPred.eq (LLVM.and e_1 (const? 32 11)) (const? 32 11)) e (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1322,9 +1322,9 @@ theorem bitwise_and_logical_and_masked_icmp_asymmetric_thm (e : IntW 1) (e_1 : I
 
 
 theorem bitwise_and_logical_and_masked_icmp_allzeros_thm (e : IntW 1) (e_1 : IntW 32) :
-  LLVM.and (select (icmp IntPredicate.eq (LLVM.and e_1 (const? 32 8)) (const? 32 0)) e (const? 1 0))
-      (icmp IntPredicate.eq (LLVM.and e_1 (const? 32 7)) (const? 32 0)) ⊑
-    select (icmp IntPredicate.eq (LLVM.and e_1 (const? 32 15)) (const? 32 0)) e (const? 1 0) := by
+  LLVM.and (select (icmp IntPred.eq (LLVM.and e_1 (const? 32 8)) (const? 32 0)) e (const? 1 0))
+      (icmp IntPred.eq (LLVM.and e_1 (const? 32 7)) (const? 32 0)) ⊑
+    select (icmp IntPred.eq (LLVM.and e_1 (const? 32 15)) (const? 32 0)) e (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1334,9 +1334,9 @@ theorem bitwise_and_logical_and_masked_icmp_allzeros_thm (e : IntW 1) (e_1 : Int
 
 
 theorem bitwise_and_logical_and_masked_icmp_allzeros_poison1_thm (e : IntW 1) (e_1 e_2 : IntW 32) :
-  LLVM.and (select (icmp IntPredicate.eq (LLVM.and e_2 e_1) (const? 32 0)) e (const? 1 0))
-      (icmp IntPredicate.eq (LLVM.and e_2 (const? 32 7)) (const? 32 0)) ⊑
-    select (icmp IntPredicate.eq (LLVM.and e_2 (LLVM.or e_1 (const? 32 7))) (const? 32 0)) e (const? 1 0) := by
+  LLVM.and (select (icmp IntPred.eq (LLVM.and e_2 e_1) (const? 32 0)) e (const? 1 0))
+      (icmp IntPred.eq (LLVM.and e_2 (const? 32 7)) (const? 32 0)) ⊑
+    select (icmp IntPred.eq (LLVM.and e_2 (LLVM.or e_1 (const? 32 7))) (const? 32 0)) e (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1346,9 +1346,9 @@ theorem bitwise_and_logical_and_masked_icmp_allzeros_poison1_thm (e : IntW 1) (e
 
 
 theorem bitwise_and_logical_and_masked_icmp_allones_thm (e : IntW 1) (e_1 : IntW 32) :
-  LLVM.and (select (icmp IntPredicate.eq (LLVM.and e_1 (const? 32 8)) (const? 32 8)) e (const? 1 0))
-      (icmp IntPredicate.eq (LLVM.and e_1 (const? 32 7)) (const? 32 7)) ⊑
-    select (icmp IntPredicate.eq (LLVM.and e_1 (const? 32 15)) (const? 32 15)) e (const? 1 0) := by
+  LLVM.and (select (icmp IntPred.eq (LLVM.and e_1 (const? 32 8)) (const? 32 8)) e (const? 1 0))
+      (icmp IntPred.eq (LLVM.and e_1 (const? 32 7)) (const? 32 7)) ⊑
+    select (icmp IntPred.eq (LLVM.and e_1 (const? 32 15)) (const? 32 15)) e (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1358,9 +1358,9 @@ theorem bitwise_and_logical_and_masked_icmp_allones_thm (e : IntW 1) (e_1 : IntW
 
 
 theorem bitwise_and_logical_and_masked_icmp_allones_poison1_thm (e : IntW 1) (e_1 e_2 : IntW 32) :
-  LLVM.and (select (icmp IntPredicate.eq (LLVM.and e_2 e_1) e_1) e (const? 1 0))
-      (icmp IntPredicate.eq (LLVM.and e_2 (const? 32 7)) (const? 32 7)) ⊑
-    select (icmp IntPredicate.eq (LLVM.and e_2 (LLVM.or e_1 (const? 32 7))) (LLVM.or e_1 (const? 32 7))) e
+  LLVM.and (select (icmp IntPred.eq (LLVM.and e_2 e_1) e_1) e (const? 1 0))
+      (icmp IntPred.eq (LLVM.and e_2 (const? 32 7)) (const? 32 7)) ⊑
+    select (icmp IntPred.eq (LLVM.and e_2 (LLVM.or e_1 (const? 32 7))) (LLVM.or e_1 (const? 32 7))) e
       (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
@@ -1371,10 +1371,10 @@ theorem bitwise_and_logical_and_masked_icmp_allones_poison1_thm (e : IntW 1) (e_
 
 
 theorem bitwise_and_logical_and_masked_icmp_allones_poison2_thm (e : IntW 32) (e_1 : IntW 1) (e_2 : IntW 32) :
-  LLVM.and (select (icmp IntPredicate.eq (LLVM.and e_2 (const? 32 8)) (const? 32 8)) e_1 (const? 1 0))
-      (icmp IntPredicate.eq (LLVM.and e_2 e) e) ⊑
-    LLVM.and (select (icmp IntPredicate.ne (LLVM.and e_2 (const? 32 8)) (const? 32 0)) e_1 (const? 1 0))
-      (icmp IntPredicate.eq (LLVM.and e_2 e) e) := by
+  LLVM.and (select (icmp IntPred.eq (LLVM.and e_2 (const? 32 8)) (const? 32 8)) e_1 (const? 1 0))
+      (icmp IntPred.eq (LLVM.and e_2 e) e) ⊑
+    LLVM.and (select (icmp IntPred.ne (LLVM.and e_2 (const? 32 8)) (const? 32 0)) e_1 (const? 1 0))
+      (icmp IntPred.eq (LLVM.and e_2 e) e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1384,9 +1384,9 @@ theorem bitwise_and_logical_and_masked_icmp_allones_poison2_thm (e : IntW 32) (e
 
 
 theorem samesign_thm (e e_1 : IntW 32) :
-  LLVM.or (icmp IntPredicate.slt (LLVM.and e_1 e) (const? 32 0))
-      (icmp IntPredicate.sgt (LLVM.or e_1 e) (const? 32 (-1))) ⊑
-    icmp IntPredicate.sgt (LLVM.xor e_1 e) (const? 32 (-1)) := by
+  LLVM.or (icmp IntPred.slt (LLVM.and e_1 e) (const? 32 0))
+      (icmp IntPred.sgt (LLVM.or e_1 e) (const? 32 (-1))) ⊑
+    icmp IntPred.sgt (LLVM.xor e_1 e) (const? 32 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1396,8 +1396,8 @@ theorem samesign_thm (e e_1 : IntW 32) :
 
 
 theorem samesign_different_sign_bittest2_thm (e e_1 : IntW 32) :
-  LLVM.or (icmp IntPredicate.slt (LLVM.and e_1 e) (const? 32 0)) (icmp IntPredicate.sge (LLVM.or e_1 e) (const? 32 0)) ⊑
-    icmp IntPredicate.sgt (LLVM.xor e_1 e) (const? 32 (-1)) := by
+  LLVM.or (icmp IntPred.slt (LLVM.and e_1 e) (const? 32 0)) (icmp IntPred.sge (LLVM.or e_1 e) (const? 32 0)) ⊑
+    icmp IntPred.sgt (LLVM.xor e_1 e) (const? 32 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1407,9 +1407,9 @@ theorem samesign_different_sign_bittest2_thm (e e_1 : IntW 32) :
 
 
 theorem samesign_commute1_thm (e e_1 : IntW 32) :
-  LLVM.or (icmp IntPredicate.sgt (LLVM.or e_1 e) (const? 32 (-1)))
-      (icmp IntPredicate.slt (LLVM.and e_1 e) (const? 32 0)) ⊑
-    icmp IntPredicate.sgt (LLVM.xor e_1 e) (const? 32 (-1)) := by
+  LLVM.or (icmp IntPred.sgt (LLVM.or e_1 e) (const? 32 (-1)))
+      (icmp IntPred.slt (LLVM.and e_1 e) (const? 32 0)) ⊑
+    icmp IntPred.sgt (LLVM.xor e_1 e) (const? 32 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1419,9 +1419,9 @@ theorem samesign_commute1_thm (e e_1 : IntW 32) :
 
 
 theorem samesign_commute2_thm (e e_1 : IntW 32) :
-  LLVM.or (icmp IntPredicate.slt (LLVM.and e_1 e) (const? 32 0))
-      (icmp IntPredicate.sgt (LLVM.or e e_1) (const? 32 (-1))) ⊑
-    icmp IntPredicate.sgt (LLVM.xor e_1 e) (const? 32 (-1)) := by
+  LLVM.or (icmp IntPred.slt (LLVM.and e_1 e) (const? 32 0))
+      (icmp IntPred.sgt (LLVM.or e e_1) (const? 32 (-1))) ⊑
+    icmp IntPred.sgt (LLVM.xor e_1 e) (const? 32 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1431,9 +1431,9 @@ theorem samesign_commute2_thm (e e_1 : IntW 32) :
 
 
 theorem samesign_commute3_thm (e e_1 : IntW 32) :
-  LLVM.or (icmp IntPredicate.sgt (LLVM.or e_1 e) (const? 32 (-1)))
-      (icmp IntPredicate.slt (LLVM.and e e_1) (const? 32 0)) ⊑
-    icmp IntPredicate.sgt (LLVM.xor e_1 e) (const? 32 (-1)) := by
+  LLVM.or (icmp IntPred.sgt (LLVM.or e_1 e) (const? 32 (-1)))
+      (icmp IntPred.slt (LLVM.and e e_1) (const? 32 0)) ⊑
+    icmp IntPred.sgt (LLVM.xor e_1 e) (const? 32 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1443,9 +1443,9 @@ theorem samesign_commute3_thm (e e_1 : IntW 32) :
 
 
 theorem samesign_inverted_thm (e e_1 : IntW 32) :
-  LLVM.and (icmp IntPredicate.sgt (LLVM.and e_1 e) (const? 32 (-1)))
-      (icmp IntPredicate.slt (LLVM.or e_1 e) (const? 32 0)) ⊑
-    icmp IntPredicate.slt (LLVM.xor e_1 e) (const? 32 0) := by
+  LLVM.and (icmp IntPred.sgt (LLVM.and e_1 e) (const? 32 (-1)))
+      (icmp IntPred.slt (LLVM.or e_1 e) (const? 32 0)) ⊑
+    icmp IntPred.slt (LLVM.xor e_1 e) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1455,9 +1455,9 @@ theorem samesign_inverted_thm (e e_1 : IntW 32) :
 
 
 theorem samesign_inverted_different_sign_bittest1_thm (e e_1 : IntW 32) :
-  LLVM.and (icmp IntPredicate.sge (LLVM.and e_1 e) (const? 32 0))
-      (icmp IntPredicate.slt (LLVM.or e_1 e) (const? 32 0)) ⊑
-    icmp IntPredicate.slt (LLVM.xor e_1 e) (const? 32 0) := by
+  LLVM.and (icmp IntPred.sge (LLVM.and e_1 e) (const? 32 0))
+      (icmp IntPred.slt (LLVM.or e_1 e) (const? 32 0)) ⊑
+    icmp IntPred.slt (LLVM.xor e_1 e) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1467,9 +1467,9 @@ theorem samesign_inverted_different_sign_bittest1_thm (e e_1 : IntW 32) :
 
 
 theorem samesign_inverted_different_sign_bittest2_thm (e e_1 : IntW 32) :
-  LLVM.and (icmp IntPredicate.sgt (LLVM.and e_1 e) (const? 32 (-1)))
-      (icmp IntPredicate.sle (LLVM.or e_1 e) (const? 32 (-1))) ⊑
-    icmp IntPredicate.slt (LLVM.xor e_1 e) (const? 32 0) := by
+  LLVM.and (icmp IntPred.sgt (LLVM.and e_1 e) (const? 32 (-1)))
+      (icmp IntPred.sle (LLVM.or e_1 e) (const? 32 (-1))) ⊑
+    icmp IntPred.slt (LLVM.xor e_1 e) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1479,9 +1479,9 @@ theorem samesign_inverted_different_sign_bittest2_thm (e e_1 : IntW 32) :
 
 
 theorem samesign_inverted_commute1_thm (e e_1 : IntW 32) :
-  LLVM.and (icmp IntPredicate.slt (LLVM.or e_1 e) (const? 32 0))
-      (icmp IntPredicate.sgt (LLVM.and e_1 e) (const? 32 (-1))) ⊑
-    icmp IntPredicate.slt (LLVM.xor e_1 e) (const? 32 0) := by
+  LLVM.and (icmp IntPred.slt (LLVM.or e_1 e) (const? 32 0))
+      (icmp IntPred.sgt (LLVM.and e_1 e) (const? 32 (-1))) ⊑
+    icmp IntPred.slt (LLVM.xor e_1 e) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1491,9 +1491,9 @@ theorem samesign_inverted_commute1_thm (e e_1 : IntW 32) :
 
 
 theorem samesign_inverted_commute2_thm (e e_1 : IntW 32) :
-  LLVM.and (icmp IntPredicate.sgt (LLVM.and e_1 e) (const? 32 (-1)))
-      (icmp IntPredicate.slt (LLVM.or e e_1) (const? 32 0)) ⊑
-    icmp IntPredicate.slt (LLVM.xor e_1 e) (const? 32 0) := by
+  LLVM.and (icmp IntPred.sgt (LLVM.and e_1 e) (const? 32 (-1)))
+      (icmp IntPred.slt (LLVM.or e e_1) (const? 32 0)) ⊑
+    icmp IntPred.slt (LLVM.xor e_1 e) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1503,9 +1503,9 @@ theorem samesign_inverted_commute2_thm (e e_1 : IntW 32) :
 
 
 theorem samesign_inverted_commute3_thm (e e_1 : IntW 32) :
-  LLVM.and (icmp IntPredicate.slt (LLVM.or e_1 e) (const? 32 0))
-      (icmp IntPredicate.sgt (LLVM.and e e_1) (const? 32 (-1))) ⊑
-    icmp IntPredicate.slt (LLVM.xor e_1 e) (const? 32 0) := by
+  LLVM.and (icmp IntPred.slt (LLVM.or e_1 e) (const? 32 0))
+      (icmp IntPred.sgt (LLVM.and e e_1) (const? 32 (-1))) ⊑
+    icmp IntPred.slt (LLVM.xor e_1 e) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1515,8 +1515,8 @@ theorem samesign_inverted_commute3_thm (e e_1 : IntW 32) :
 
 
 theorem icmp_slt_0_or_icmp_sgt_0_i32_thm (e : IntW 32) :
-  LLVM.or (zext 32 (icmp IntPredicate.slt e (const? 32 0))) (zext 32 (icmp IntPredicate.sgt e (const? 32 0))) ⊑
-    zext 32 (icmp IntPredicate.ne e (const? 32 0)) := by
+  LLVM.or (zext 32 (icmp IntPred.slt e (const? 32 0))) (zext 32 (icmp IntPred.sgt e (const? 32 0))) ⊑
+    zext 32 (icmp IntPred.ne e (const? 32 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1526,8 +1526,8 @@ theorem icmp_slt_0_or_icmp_sgt_0_i32_thm (e : IntW 32) :
 
 
 theorem icmp_slt_0_or_icmp_sgt_0_i64_thm (e : IntW 64) :
-  LLVM.or (zext 64 (icmp IntPredicate.slt e (const? 64 0))) (zext 64 (icmp IntPredicate.sgt e (const? 64 0))) ⊑
-    zext 64 (icmp IntPredicate.ne e (const? 64 0)) := by
+  LLVM.or (zext 64 (icmp IntPred.slt e (const? 64 0))) (zext 64 (icmp IntPred.sgt e (const? 64 0))) ⊑
+    zext 64 (icmp IntPred.ne e (const? 64 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1537,7 +1537,7 @@ theorem icmp_slt_0_or_icmp_sgt_0_i64_thm (e : IntW 64) :
 
 
 theorem icmp_slt_0_or_icmp_sgt_0_i64_fail0_thm (e : IntW 64) :
-  LLVM.or (lshr e (const? 64 63)) (zext 64 (icmp IntPredicate.slt e (const? 64 0))) ⊑ lshr e (const? 64 63) := by
+  LLVM.or (lshr e (const? 64 63)) (zext 64 (icmp IntPred.slt e (const? 64 0))) ⊑ lshr e (const? 64 63) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1547,7 +1547,7 @@ theorem icmp_slt_0_or_icmp_sgt_0_i64_fail0_thm (e : IntW 64) :
 
 
 theorem icmp_slt_0_or_icmp_sgt_0_i64_fail3_thm (e : IntW 64) :
-  LLVM.or (ashr e (const? 64 62)) (zext 64 (icmp IntPredicate.slt e (const? 64 0))) ⊑
+  LLVM.or (ashr e (const? 64 62)) (zext 64 (icmp IntPred.slt e (const? 64 0))) ⊑
     LLVM.or (ashr e (const? 64 62)) (lshr e (const? 64 63)) := by
     simp_alive_undef
     simp_alive_ops
@@ -1558,7 +1558,7 @@ theorem icmp_slt_0_or_icmp_sgt_0_i64_fail3_thm (e : IntW 64) :
 
 
 theorem icmp_slt_0_and_icmp_sge_neg1_i32_thm (e : IntW 32) :
-  LLVM.and (lshr e (const? 32 31)) (zext 32 (icmp IntPredicate.sgt e (const? 32 (-1)))) ⊑ const? 32 0 := by
+  LLVM.and (lshr e (const? 32 31)) (zext 32 (icmp IntPred.sgt e (const? 32 (-1)))) ⊑ const? 32 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1568,7 +1568,7 @@ theorem icmp_slt_0_and_icmp_sge_neg1_i32_thm (e : IntW 32) :
 
 
 theorem icmp_slt_0_or_icmp_sge_neg1_i32_thm (e : IntW 32) :
-  LLVM.or (lshr e (const? 32 31)) (zext 32 (icmp IntPredicate.sge e (const? 32 (-1)))) ⊑ const? 32 1 := by
+  LLVM.or (lshr e (const? 32 31)) (zext 32 (icmp IntPred.sge e (const? 32 (-1)))) ⊑ const? 32 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1578,8 +1578,8 @@ theorem icmp_slt_0_or_icmp_sge_neg1_i32_thm (e : IntW 32) :
 
 
 theorem icmp_slt_0_or_icmp_sge_100_i32_thm (e : IntW 32) :
-  LLVM.or (lshr e (const? 32 31)) (zext 32 (icmp IntPredicate.sge e (const? 32 100))) ⊑
-    zext 32 (icmp IntPredicate.ugt e (const? 32 99)) := by
+  LLVM.or (lshr e (const? 32 31)) (zext 32 (icmp IntPred.sge e (const? 32 100))) ⊑
+    zext 32 (icmp IntPred.ugt e (const? 32 99)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1589,8 +1589,8 @@ theorem icmp_slt_0_or_icmp_sge_100_i32_thm (e : IntW 32) :
 
 
 theorem icmp_slt_0_and_icmp_sge_neg1_i64_thm (e : IntW 64) :
-  LLVM.and (lshr e (const? 64 63)) (zext 64 (icmp IntPredicate.sge e (const? 64 (-1)))) ⊑
-    zext 64 (icmp IntPredicate.eq e (const? 64 (-1))) := by
+  LLVM.and (lshr e (const? 64 63)) (zext 64 (icmp IntPred.sge e (const? 64 (-1)))) ⊑
+    zext 64 (icmp IntPred.eq e (const? 64 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1600,8 +1600,8 @@ theorem icmp_slt_0_and_icmp_sge_neg1_i64_thm (e : IntW 64) :
 
 
 theorem icmp_slt_0_and_icmp_sge_neg2_i64_thm (e : IntW 64) :
-  LLVM.and (lshr e (const? 64 63)) (zext 64 (icmp IntPredicate.sge e (const? 64 (-2)))) ⊑
-    zext 64 (icmp IntPredicate.ugt e (const? 64 (-3))) := by
+  LLVM.and (lshr e (const? 64 63)) (zext 64 (icmp IntPred.sge e (const? 64 (-2)))) ⊑
+    zext 64 (icmp IntPred.ugt e (const? 64 (-3))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1611,8 +1611,8 @@ theorem icmp_slt_0_and_icmp_sge_neg2_i64_thm (e : IntW 64) :
 
 
 theorem ashr_and_icmp_sge_neg1_i64_thm (e : IntW 64) :
-  LLVM.and (ashr e (const? 64 63)) (zext 64 (icmp IntPredicate.sge e (const? 64 (-1)))) ⊑
-    zext 64 (icmp IntPredicate.eq e (const? 64 (-1))) := by
+  LLVM.and (ashr e (const? 64 63)) (zext 64 (icmp IntPred.sge e (const? 64 (-1)))) ⊑
+    zext 64 (icmp IntPred.eq e (const? 64 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1622,7 +1622,7 @@ theorem ashr_and_icmp_sge_neg1_i64_thm (e : IntW 64) :
 
 
 theorem icmp_slt_0_and_icmp_sgt_neg1_i64_thm (e : IntW 64) :
-  LLVM.and (lshr e (const? 64 63)) (zext 64 (icmp IntPredicate.sgt e (const? 64 (-1)))) ⊑ const? 64 0 := by
+  LLVM.and (lshr e (const? 64 63)) (zext 64 (icmp IntPred.sgt e (const? 64 (-1)))) ⊑ const? 64 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1632,8 +1632,8 @@ theorem icmp_slt_0_and_icmp_sgt_neg1_i64_thm (e : IntW 64) :
 
 
 theorem icmp_slt_0_and_icmp_sge_neg1_i64_fail_thm (e : IntW 64) :
-  LLVM.and (lshr e (const? 64 62)) (zext 64 (icmp IntPredicate.sge e (const? 64 (-1)))) ⊑
-    select (icmp IntPredicate.sgt e (const? 64 (-2))) (LLVM.and (lshr e (const? 64 62)) (const? 64 1))
+  LLVM.and (lshr e (const? 64 62)) (zext 64 (icmp IntPred.sge e (const? 64 (-1)))) ⊑
+    select (icmp IntPred.sgt e (const? 64 (-2))) (LLVM.and (lshr e (const? 64 62)) (const? 64 1))
       (const? 64 0) := by
     simp_alive_undef
     simp_alive_ops
@@ -1644,8 +1644,8 @@ theorem icmp_slt_0_and_icmp_sge_neg1_i64_fail_thm (e : IntW 64) :
 
 
 theorem icmp_x_slt_0_xor_icmp_y_sgt_neg1_i32_thm (e e_1 : IntW 32) :
-  LLVM.xor (lshr e_1 (const? 32 31)) (zext 32 (icmp IntPredicate.sgt e (const? 32 (-1)))) ⊑
-    zext 32 (icmp IntPredicate.sgt (LLVM.xor e_1 e) (const? 32 (-1))) := by
+  LLVM.xor (lshr e_1 (const? 32 31)) (zext 32 (icmp IntPred.sgt e (const? 32 (-1)))) ⊑
+    zext 32 (icmp IntPred.sgt (LLVM.xor e_1 e) (const? 32 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1655,8 +1655,8 @@ theorem icmp_x_slt_0_xor_icmp_y_sgt_neg1_i32_thm (e e_1 : IntW 32) :
 
 
 theorem icmp_slt_0_xor_icmp_sgt_neg2_i32_thm (e : IntW 32) :
-  LLVM.xor (lshr e (const? 32 31)) (zext 32 (icmp IntPredicate.sgt e (const? 32 (-2)))) ⊑
-    zext 32 (icmp IntPredicate.ne e (const? 32 (-1))) := by
+  LLVM.xor (lshr e (const? 32 31)) (zext 32 (icmp IntPred.sgt e (const? 32 (-2)))) ⊑
+    zext 32 (icmp IntPred.ne e (const? 32 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1666,8 +1666,8 @@ theorem icmp_slt_0_xor_icmp_sgt_neg2_i32_thm (e : IntW 32) :
 
 
 theorem icmp_slt_0_or_icmp_eq_100_i32_fail_thm (e : IntW 32) :
-  LLVM.or (lshr e (const? 32 31)) (zext 32 (icmp IntPredicate.eq e (const? 32 100))) ⊑
-    zext 32 (LLVM.or (icmp IntPredicate.slt e (const? 32 0)) (icmp IntPredicate.eq e (const? 32 100))) := by
+  LLVM.or (lshr e (const? 32 31)) (zext 32 (icmp IntPred.eq e (const? 32 100))) ⊑
+    zext 32 (LLVM.or (icmp IntPred.slt e (const? 32 0)) (icmp IntPred.eq e (const? 32 100))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1677,8 +1677,8 @@ theorem icmp_slt_0_or_icmp_eq_100_i32_fail_thm (e : IntW 32) :
 
 
 theorem icmp_slt_0_and_icmp_ne_neg2_i32_fail_thm (e : IntW 32) :
-  LLVM.and (lshr e (const? 32 31)) (zext 32 (icmp IntPredicate.ne e (const? 32 (-2)))) ⊑
-    zext 32 (LLVM.and (icmp IntPredicate.slt e (const? 32 0)) (icmp IntPredicate.ne e (const? 32 (-2)))) := by
+  LLVM.and (lshr e (const? 32 31)) (zext 32 (icmp IntPred.ne e (const? 32 (-2)))) ⊑
+    zext 32 (LLVM.and (icmp IntPred.slt e (const? 32 0)) (icmp IntPred.ne e (const? 32 (-2)))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1688,8 +1688,8 @@ theorem icmp_slt_0_and_icmp_ne_neg2_i32_fail_thm (e : IntW 32) :
 
 
 theorem icmp_x_slt_0_and_icmp_y_ne_neg2_i32_fail_thm (e e_1 : IntW 32) :
-  LLVM.and (lshr e_1 (const? 32 31)) (zext 32 (icmp IntPredicate.ne e (const? 32 (-2)))) ⊑
-    zext 32 (LLVM.and (icmp IntPredicate.slt e_1 (const? 32 0)) (icmp IntPredicate.ne e (const? 32 (-2)))) := by
+  LLVM.and (lshr e_1 (const? 32 31)) (zext 32 (icmp IntPred.ne e (const? 32 (-2)))) ⊑
+    zext 32 (LLVM.and (icmp IntPred.slt e_1 (const? 32 0)) (icmp IntPred.ne e (const? 32 (-2)))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1699,8 +1699,8 @@ theorem icmp_x_slt_0_and_icmp_y_ne_neg2_i32_fail_thm (e e_1 : IntW 32) :
 
 
 theorem icmp_x_slt_0_and_icmp_y_sgt_neg1_i32_fail_thm (e e_1 : IntW 32) :
-  LLVM.and (lshr e_1 (const? 32 31)) (zext 32 (icmp IntPredicate.sgt e (const? 32 (-1)))) ⊑
-    zext 32 (LLVM.and (icmp IntPredicate.slt e_1 (const? 32 0)) (icmp IntPredicate.sgt e (const? 32 (-1)))) := by
+  LLVM.and (lshr e_1 (const? 32 31)) (zext 32 (icmp IntPred.sgt e (const? 32 (-1)))) ⊑
+    zext 32 (LLVM.and (icmp IntPred.slt e_1 (const? 32 0)) (icmp IntPred.sgt e (const? 32 (-1)))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1710,8 +1710,8 @@ theorem icmp_x_slt_0_and_icmp_y_sgt_neg1_i32_fail_thm (e e_1 : IntW 32) :
 
 
 theorem icmp_slt_0_xor_icmp_sge_neg2_i32_fail_thm (e : IntW 32) :
-  LLVM.xor (lshr e (const? 32 31)) (zext 32 (icmp IntPredicate.sge e (const? 32 (-2)))) ⊑
-    zext 32 (icmp IntPredicate.ult e (const? 32 (-2))) := by
+  LLVM.xor (lshr e (const? 32 31)) (zext 32 (icmp IntPred.sge e (const? 32 (-2)))) ⊑
+    zext 32 (icmp IntPred.ult e (const? 32 (-2))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1721,10 +1721,10 @@ theorem icmp_slt_0_xor_icmp_sge_neg2_i32_fail_thm (e : IntW 32) :
 
 
 theorem icmp_slt_0_or_icmp_add_1_sge_100_i32_fail_thm (e : IntW 32) :
-  LLVM.or (lshr e (const? 32 31)) (zext 32 (icmp IntPredicate.sge (add e (const? 32 1)) (const? 32 100))) ⊑
+  LLVM.or (lshr e (const? 32 31)) (zext 32 (icmp IntPred.sge (add e (const? 32 1)) (const? 32 100))) ⊑
     zext 32
-      (LLVM.or (icmp IntPredicate.slt e (const? 32 0))
-        (icmp IntPredicate.sgt (add e (const? 32 1)) (const? 32 99))) := by
+      (LLVM.or (icmp IntPred.slt e (const? 32 0))
+        (icmp IntPred.sgt (add e (const? 32 1)) (const? 32 99))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1734,9 +1734,9 @@ theorem icmp_slt_0_or_icmp_add_1_sge_100_i32_fail_thm (e : IntW 32) :
 
 
 theorem logical_and_icmps1_thm (e : IntW 32) (e_1 : IntW 1) :
-  select (select e_1 (icmp IntPredicate.sgt e (const? 32 (-1))) (const? 1 0))
-      (icmp IntPredicate.slt e (const? 32 10086)) (const? 1 0) ⊑
-    select e_1 (icmp IntPredicate.ult e (const? 32 10086)) (const? 1 0) := by
+  select (select e_1 (icmp IntPred.sgt e (const? 32 (-1))) (const? 1 0))
+      (icmp IntPred.slt e (const? 32 10086)) (const? 1 0) ⊑
+    select e_1 (icmp IntPred.ult e (const? 32 10086)) (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1746,7 +1746,7 @@ theorem logical_and_icmps1_thm (e : IntW 32) (e_1 : IntW 1) :
 
 
 theorem logical_and_icmps2_thm (e : IntW 32) (e_1 : IntW 1) :
-  select (select e_1 (icmp IntPredicate.slt e (const? 32 (-1))) (const? 1 0)) (icmp IntPredicate.eq e (const? 32 10086))
+  select (select e_1 (icmp IntPred.slt e (const? 32 (-1))) (const? 1 0)) (icmp IntPred.eq e (const? 32 10086))
       (const? 1 0) ⊑
     const? 1 0 := by
     simp_alive_undef
@@ -1758,8 +1758,8 @@ theorem logical_and_icmps2_thm (e : IntW 32) (e_1 : IntW 1) :
 
 
 theorem icmp_eq_or_z_or_pow2orz_thm (e e_1 : IntW 8) :
-  LLVM.or (icmp IntPredicate.eq e_1 (LLVM.and (sub (const? 8 0) e) e)) (icmp IntPredicate.eq e_1 (const? 8 0)) ⊑
-    icmp IntPredicate.eq (LLVM.and e_1 (LLVM.and e (sub (const? 8 0) e))) e_1 := by
+  LLVM.or (icmp IntPred.eq e_1 (LLVM.and (sub (const? 8 0) e) e)) (icmp IntPred.eq e_1 (const? 8 0)) ⊑
+    icmp IntPred.eq (LLVM.and e_1 (LLVM.and e (sub (const? 8 0) e))) e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1769,9 +1769,9 @@ theorem icmp_eq_or_z_or_pow2orz_thm (e e_1 : IntW 8) :
 
 
 theorem icmp_eq_or_z_or_pow2orz_logical_thm (e e_1 : IntW 8) :
-  select (icmp IntPredicate.eq e_1 (LLVM.and (sub (const? 8 0) e) e)) (const? 1 1)
-      (icmp IntPredicate.eq e_1 (const? 8 0)) ⊑
-    icmp IntPredicate.eq (LLVM.and e_1 (LLVM.and e (sub (const? 8 0) e))) e_1 := by
+  select (icmp IntPred.eq e_1 (LLVM.and (sub (const? 8 0) e) e)) (const? 1 1)
+      (icmp IntPred.eq e_1 (const? 8 0)) ⊑
+    icmp IntPred.eq (LLVM.and e_1 (LLVM.and e (sub (const? 8 0) e))) e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1781,10 +1781,10 @@ theorem icmp_eq_or_z_or_pow2orz_logical_thm (e e_1 : IntW 8) :
 
 
 theorem icmp_eq_or_z_or_pow2orz_fail_logic_or_thm (e e_1 : IntW 8) :
-  select (icmp IntPredicate.eq e_1 (const? 8 0)) (const? 1 1)
-      (icmp IntPredicate.eq e_1 (LLVM.and (sub (const? 8 0) e) e)) ⊑
-    select (icmp IntPredicate.eq e_1 (const? 8 0)) (const? 1 1)
-      (icmp IntPredicate.eq e_1 (LLVM.and e (sub (const? 8 0) e))) := by
+  select (icmp IntPred.eq e_1 (const? 8 0)) (const? 1 1)
+      (icmp IntPred.eq e_1 (LLVM.and (sub (const? 8 0) e) e)) ⊑
+    select (icmp IntPred.eq e_1 (const? 8 0)) (const? 1 1)
+      (icmp IntPred.eq e_1 (LLVM.and e (sub (const? 8 0) e))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1794,9 +1794,9 @@ theorem icmp_eq_or_z_or_pow2orz_fail_logic_or_thm (e e_1 : IntW 8) :
 
 
 theorem icmp_ne_and_z_and_onefail_thm (e : IntW 8) :
-  LLVM.and (LLVM.and (icmp IntPredicate.ne e (const? 8 0)) (icmp IntPredicate.ne e (const? 8 1)))
-      (icmp IntPredicate.ne e (const? 8 2)) ⊑
-    icmp IntPredicate.ugt e (const? 8 2) := by
+  LLVM.and (LLVM.and (icmp IntPred.ne e (const? 8 0)) (icmp IntPred.ne e (const? 8 1)))
+      (icmp IntPred.ne e (const? 8 2)) ⊑
+    icmp IntPred.ugt e (const? 8 2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1806,9 +1806,9 @@ theorem icmp_ne_and_z_and_onefail_thm (e : IntW 8) :
 
 
 theorem icmp_eq_or_z_or_pow2orz_fail_nonzero_const_thm (e e_1 : IntW 8) :
-  LLVM.or (icmp IntPredicate.eq e_1 (const? 8 1)) (icmp IntPredicate.eq e_1 (LLVM.and (sub (const? 8 0) e) e)) ⊑
-    LLVM.or (icmp IntPredicate.eq e_1 (const? 8 1))
-      (icmp IntPredicate.eq e_1 (LLVM.and e (sub (const? 8 0) e))) := by
+  LLVM.or (icmp IntPred.eq e_1 (const? 8 1)) (icmp IntPred.eq e_1 (LLVM.and (sub (const? 8 0) e) e)) ⊑
+    LLVM.or (icmp IntPred.eq e_1 (const? 8 1))
+      (icmp IntPred.eq e_1 (LLVM.and e (sub (const? 8 0) e))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1818,9 +1818,9 @@ theorem icmp_eq_or_z_or_pow2orz_fail_nonzero_const_thm (e e_1 : IntW 8) :
 
 
 theorem icmp_eq_or_z_or_pow2orz_fail_bad_pred2_thm (e e_1 : IntW 8) :
-  LLVM.or (icmp IntPredicate.sle e_1 (const? 8 0)) (icmp IntPredicate.sle e_1 (LLVM.and (sub (const? 8 0) e) e)) ⊑
-    LLVM.or (icmp IntPredicate.slt e_1 (const? 8 1))
-      (icmp IntPredicate.sle e_1 (LLVM.and e (sub (const? 8 0) e))) := by
+  LLVM.or (icmp IntPred.sle e_1 (const? 8 0)) (icmp IntPred.sle e_1 (LLVM.and (sub (const? 8 0) e) e)) ⊑
+    LLVM.or (icmp IntPred.slt e_1 (const? 8 1))
+      (icmp IntPred.sle e_1 (LLVM.and e (sub (const? 8 0) e))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1830,8 +1830,8 @@ theorem icmp_eq_or_z_or_pow2orz_fail_bad_pred2_thm (e e_1 : IntW 8) :
 
 
 theorem and_slt_to_mask_thm (e : IntW 8) :
-  LLVM.and (icmp IntPredicate.slt e (const? 8 (-124))) (icmp IntPredicate.eq (LLVM.and e (const? 8 2)) (const? 8 0)) ⊑
-    icmp IntPredicate.slt e (const? 8 (-126)) := by
+  LLVM.and (icmp IntPred.slt e (const? 8 (-124))) (icmp IntPred.eq (LLVM.and e (const? 8 2)) (const? 8 0)) ⊑
+    icmp IntPred.slt e (const? 8 (-126)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1841,8 +1841,8 @@ theorem and_slt_to_mask_thm (e : IntW 8) :
 
 
 theorem and_sgt_to_mask_thm (e : IntW 8) :
-  LLVM.and (icmp IntPredicate.sgt e (const? 8 123)) (icmp IntPredicate.eq (LLVM.and e (const? 8 2)) (const? 8 0)) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 8 (-2))) (const? 8 124) := by
+  LLVM.and (icmp IntPred.sgt e (const? 8 123)) (icmp IntPred.eq (LLVM.and e (const? 8 2)) (const? 8 0)) ⊑
+    icmp IntPred.eq (LLVM.and e (const? 8 (-2))) (const? 8 124) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1852,8 +1852,8 @@ theorem and_sgt_to_mask_thm (e : IntW 8) :
 
 
 theorem and_ugt_to_mask_thm (e : IntW 8) :
-  LLVM.and (icmp IntPredicate.ugt e (const? 8 (-5))) (icmp IntPredicate.eq (LLVM.and e (const? 8 2)) (const? 8 0)) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 8 (-2))) (const? 8 (-4)) := by
+  LLVM.and (icmp IntPred.ugt e (const? 8 (-5))) (icmp IntPred.eq (LLVM.and e (const? 8 2)) (const? 8 0)) ⊑
+    icmp IntPred.eq (LLVM.and e (const? 8 (-2))) (const? 8 (-4)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gandhorhimpliedhcondhnot_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gandhorhimpliedhcondhnot_proof.lean
@@ -12,9 +12,9 @@ set_option Elab.async false
 
 section gandhorhimpliedhcondhnot_proof
 theorem test_imply_not2_thm (e : IntW 1) (e_1 : IntW 32) :
-  LLVM.or (select (icmp IntPredicate.eq e_1 (const? 32 0)) e (const? 1 0))
-      (LLVM.xor (icmp IntPredicate.eq e_1 (const? 32 0)) (const? 1 1)) ⊑
-    select (icmp IntPredicate.ne e_1 (const? 32 0)) (const? 1 1) e := by
+  LLVM.or (select (icmp IntPred.eq e_1 (const? 32 0)) e (const? 1 0))
+      (LLVM.xor (icmp IntPred.eq e_1 (const? 32 0)) (const? 1 1)) ⊑
+    select (icmp IntPred.ne e_1 (const? 32 0)) (const? 1 1) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gandhxorhmerge_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gandhxorhmerge_proof.lean
@@ -32,7 +32,7 @@ theorem test2_thm (e e_1 : IntW 32) : LLVM.xor (LLVM.and e_1 e) (LLVM.or e_1 e) 
 
 theorem PR38781_thm (e e_1 : IntW 32) :
   LLVM.and (LLVM.xor (lshr e_1 (const? 32 31)) (const? 32 1)) (LLVM.xor (lshr e (const? 32 31)) (const? 32 1)) ⊑
-    zext 32 (icmp IntPredicate.sgt (LLVM.or e_1 e) (const? 32 (-1))) := by
+    zext 32 (icmp IntPred.sgt (LLVM.or e_1 e) (const? 32 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gandhxorhor_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gandhxorhor_proof.lean
@@ -1390,7 +1390,7 @@ theorem xor_sext_sext_thm (e : IntW 4) (e_1 : IntW 8) :
 
 
 theorem PR56294_thm (e : IntW 8) :
-  icmp IntPredicate.ne (LLVM.and (zext 32 (icmp IntPredicate.eq e (const? 8 2))) (zext 32 (LLVM.and e (const? 8 1))))
+  icmp IntPred.ne (LLVM.and (zext 32 (icmp IntPred.eq e (const? 8 2))) (zext 32 (LLVM.and e (const? 8 1))))
       (const? 32 0) ⊑
     const? 1 0 := by
     simp_alive_undef
@@ -1498,7 +1498,7 @@ theorem canonicalize_logic_first_xor_0_nswnuw_thm (e : IntW 8) :
 
 
 theorem test_and_xor_freely_invertable_thm (e : IntW 1) (e_1 e_2 : IntW 32) :
-  LLVM.and (LLVM.xor (icmp IntPredicate.sgt e_2 e_1) e) e ⊑ LLVM.and (icmp IntPredicate.sle e_2 e_1) e := by
+  LLVM.and (LLVM.xor (icmp IntPred.sgt e_2 e_1) e) e ⊑ LLVM.and (icmp IntPred.sle e_2 e_1) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gapinthand_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gapinthand_proof.lean
@@ -39,8 +39,8 @@ theorem test3_thm (e : IntW 23) : LLVM.and (LLVM.and e (const? 23 127)) (const? 
 
 
 theorem test4_thm (e : IntW 37) :
-  icmp IntPredicate.ne (LLVM.and e (const? 37 (-2147483648))) (const? 37 0) ⊑
-    icmp IntPredicate.ugt e (const? 37 2147483647) := by
+  icmp IntPred.ne (LLVM.and e (const? 37 (-2147483648))) (const? 37 0) ⊑
+    icmp IntPred.ugt e (const? 37 2147483647) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -86,8 +86,8 @@ theorem test10_thm (e : IntW 123) : LLVM.and (LLVM.and e (const? 123 127)) (cons
 
 
 theorem test11_thm (e : IntW 737) :
-  icmp IntPredicate.ne (LLVM.and e (const? 737 (-2147483648))) (const? 737 0) ⊑
-    icmp IntPredicate.ugt e (const? 737 2147483647) := by
+  icmp IntPred.ne (LLVM.and e (const? 737 (-2147483648))) (const? 737 0) ⊑
+    icmp IntPred.ugt e (const? 737 2147483647) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gapinthandhcompare_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gapinthandhcompare_proof.lean
@@ -12,8 +12,8 @@ set_option Elab.async false
 
 section gapinthandhcompare_proof
 theorem test1_thm (e e_1 : IntW 33) :
-  icmp IntPredicate.ne (LLVM.and e_1 (const? 33 65280)) (LLVM.and e (const? 33 65280)) ⊑
-    icmp IntPredicate.ne (LLVM.and (LLVM.xor e_1 e) (const? 33 65280)) (const? 33 0) := by
+  icmp IntPred.ne (LLVM.and e_1 (const? 33 65280)) (LLVM.and e (const? 33 65280)) ⊑
+    icmp IntPred.ne (LLVM.and (LLVM.xor e_1 e) (const? 33 65280)) (const? 33 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -23,8 +23,8 @@ theorem test1_thm (e e_1 : IntW 33) :
 
 
 theorem test2_thm (e e_1 : IntW 999) :
-  icmp IntPredicate.ne (LLVM.and e_1 (const? 999 65280)) (LLVM.and e (const? 999 65280)) ⊑
-    icmp IntPredicate.ne (LLVM.and (LLVM.xor e_1 e) (const? 999 65280)) (const? 999 0) := by
+  icmp IntPred.ne (LLVM.and e_1 (const? 999 65280)) (LLVM.and e (const? 999 65280)) ⊑
+    icmp IntPred.ne (LLVM.and (LLVM.xor e_1 e) (const? 999 65280)) (const? 999 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gapinthnot_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gapinthnot_proof.lean
@@ -21,7 +21,7 @@ theorem test1_thm (e : IntW 33) : LLVM.xor (LLVM.xor e (const? 33 (-1))) (const?
 
 
 theorem test2_thm (e e_1 : IntW 52) :
-  LLVM.xor (icmp IntPredicate.ule e_1 e) (const? 1 1) ⊑ icmp IntPredicate.ugt e_1 e := by
+  LLVM.xor (icmp IntPred.ule e_1 e) (const? 1 1) ⊑ icmp IntPred.ugt e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gapinthselect_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gapinthselect_proof.lean
@@ -49,7 +49,7 @@ theorem not_sext_thm (e : IntW 1) :
 
 
 theorem test3_thm (e : IntW 41) :
-  select (icmp IntPredicate.slt e (const? 41 0)) (const? 41 (-1)) (const? 41 0) ⊑ ashr e (const? 41 40) := by
+  select (icmp IntPred.slt e (const? 41 0)) (const? 41 (-1)) (const? 41 0) ⊑ ashr e (const? 41 40) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -59,7 +59,7 @@ theorem test3_thm (e : IntW 41) :
 
 
 theorem test4_thm (e : IntW 1023) :
-  select (icmp IntPredicate.slt e (const? 1023 0)) (const? 1023 (-1)) (const? 1023 0) ⊑
+  select (icmp IntPred.slt e (const? 1023 0)) (const? 1023 (-1)) (const? 1023 0) ⊑
     ashr e (const? 1023 1022) := by
     simp_alive_undef
     simp_alive_ops

--- a/SSA/Projects/InstCombine/tests/proofs/gapinthshift_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gapinthshift_proof.lean
@@ -161,8 +161,8 @@ theorem test15a_thm (e : IntW 1) :
 
 
 theorem test16_thm (e : IntW 84) :
-  icmp IntPredicate.ne (LLVM.and (ashr e (const? 84 4)) (const? 84 1)) (const? 84 0) ⊑
-    icmp IntPredicate.ne (LLVM.and e (const? 84 16)) (const? 84 0) := by
+  icmp IntPred.ne (LLVM.and (ashr e (const? 84 4)) (const? 84 1)) (const? 84 0) ⊑
+    icmp IntPred.ne (LLVM.and e (const? 84 16)) (const? 84 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -172,8 +172,8 @@ theorem test16_thm (e : IntW 84) :
 
 
 theorem test17_thm (e : IntW 106) :
-  icmp IntPredicate.eq (lshr e (const? 106 3)) (const? 106 1234) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 106 (-8))) (const? 106 9872) := by
+  icmp IntPred.eq (lshr e (const? 106 3)) (const? 106 1234) ⊑
+    icmp IntPred.eq (LLVM.and e (const? 106 (-8))) (const? 106 9872) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -182,7 +182,7 @@ theorem test17_thm (e : IntW 106) :
     all_goals sorry
 
 
-theorem test18_thm (e : IntW 11) : icmp IntPredicate.eq (lshr e (const? 11 10)) (const? 11 123) ⊑ const? 1 0 := by
+theorem test18_thm (e : IntW 11) : icmp IntPred.eq (lshr e (const? 11 10)) (const? 11 123) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -192,7 +192,7 @@ theorem test18_thm (e : IntW 11) : icmp IntPredicate.eq (lshr e (const? 11 10)) 
 
 
 theorem test19_thm (e : IntW 37) :
-  icmp IntPredicate.eq (ashr e (const? 37 2)) (const? 37 0) ⊑ icmp IntPredicate.ult e (const? 37 4) := by
+  icmp IntPred.eq (ashr e (const? 37 2)) (const? 37 0) ⊑ icmp IntPred.ult e (const? 37 4) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -202,7 +202,7 @@ theorem test19_thm (e : IntW 37) :
 
 
 theorem test19a_thm (e : IntW 39) :
-  icmp IntPredicate.eq (ashr e (const? 39 2)) (const? 39 (-1)) ⊑ icmp IntPredicate.ugt e (const? 39 (-5)) := by
+  icmp IntPred.eq (ashr e (const? 39 2)) (const? 39 (-1)) ⊑ icmp IntPred.ugt e (const? 39 (-5)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -211,7 +211,7 @@ theorem test19a_thm (e : IntW 39) :
     all_goals sorry
 
 
-theorem test20_thm (e : IntW 13) : icmp IntPredicate.eq (ashr e (const? 13 12)) (const? 13 123) ⊑ const? 1 0 := by
+theorem test20_thm (e : IntW 13) : icmp IntPred.eq (ashr e (const? 13 12)) (const? 13 123) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -221,8 +221,8 @@ theorem test20_thm (e : IntW 13) : icmp IntPredicate.eq (ashr e (const? 13 12)) 
 
 
 theorem test21_thm (e : IntW 12) :
-  icmp IntPredicate.eq (shl e (const? 12 6)) (const? 12 (-128)) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 12 63)) (const? 12 62) := by
+  icmp IntPred.eq (shl e (const? 12 6)) (const? 12 (-128)) ⊑
+    icmp IntPred.eq (LLVM.and e (const? 12 63)) (const? 12 62) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -232,8 +232,8 @@ theorem test21_thm (e : IntW 12) :
 
 
 theorem test22_thm (e : IntW 14) :
-  icmp IntPredicate.eq (shl e (const? 14 7)) (const? 14 0) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 14 127)) (const? 14 0) := by
+  icmp IntPred.eq (shl e (const? 14 7)) (const? 14 0) ⊑
+    icmp IntPred.eq (LLVM.and e (const? 14 127)) (const? 14 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gapinthsub_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gapinthsub_proof.lean
@@ -93,7 +93,7 @@ theorem test9_thm (e : IntW 42) : sub e (mul (const? 42 3) e) ⊑ mul e (const? 
 
 
 theorem test11_thm (e e_1 : IntW 9) :
-  icmp IntPredicate.ne (sub e_1 e) (const? 9 0) ⊑ icmp IntPredicate.ne e_1 e := by
+  icmp IntPred.ne (sub e_1 e) (const? 9 0) ⊑ icmp IntPred.ne e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -149,7 +149,7 @@ theorem test19_thm (e e_1 : IntW 39) : add (sub e_1 e) e ⊑ e_1 := by
 
 
 theorem test20_thm (e e_1 : IntW 33) :
-  icmp IntPredicate.ne (sub e_1 e) e_1 ⊑ icmp IntPredicate.ne e (const? 33 0) := by
+  icmp IntPred.ne (sub e_1 e) e_1 ⊑ icmp IntPred.ne e (const? 33 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -159,7 +159,7 @@ theorem test20_thm (e e_1 : IntW 33) :
 
 
 theorem test21_thm (e e_1 : IntW 256) :
-  icmp IntPredicate.ne (sub e_1 e) e_1 ⊑ icmp IntPredicate.ne e (const? 256 0) := by
+  icmp IntPred.ne (sub e_1 e) e_1 ⊑ icmp IntPred.ne e (const? 256 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gashrhdemand_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gashrhdemand_proof.lean
@@ -24,7 +24,7 @@ theorem srem2_ashr_mask_thm (e : IntW 32) :
 
 theorem srem8_ashr_mask_thm (e : IntW 32) :
   LLVM.and (ashr (LLVM.srem e (const? 32 8)) (const? 32 31)) (const? 32 2) ⊑
-    select (icmp IntPredicate.ugt (LLVM.and e (const? 32 (-2147483641))) (const? 32 (-2147483648))) (const? 32 2)
+    select (icmp IntPred.ugt (LLVM.and e (const? 32 (-2147483641))) (const? 32 (-2147483648))) (const? 32 2)
       (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops

--- a/SSA/Projects/InstCombine/tests/proofs/gashrhlshr_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gashrhlshr_proof.lean
@@ -12,7 +12,7 @@ set_option Elab.async false
 
 section gashrhlshr_proof
 theorem ashr_lshr_exact_ashr_only_thm (e e_1 : IntW 32) :
-  select (icmp IntPredicate.sgt e_1 (const? 32 (-1))) (lshr e_1 e) (ashr e_1 e { «exact» := true }) ⊑
+  select (icmp IntPred.sgt e_1 (const? 32 (-1))) (lshr e_1 e) (ashr e_1 e { «exact» := true }) ⊑
     ashr e_1 e := by
     simp_alive_undef
     simp_alive_ops
@@ -23,7 +23,7 @@ theorem ashr_lshr_exact_ashr_only_thm (e e_1 : IntW 32) :
 
 
 theorem ashr_lshr_no_exact_thm (e e_1 : IntW 32) :
-  select (icmp IntPredicate.sgt e_1 (const? 32 (-1))) (lshr e_1 e) (ashr e_1 e) ⊑ ashr e_1 e := by
+  select (icmp IntPred.sgt e_1 (const? 32 (-1))) (lshr e_1 e) (ashr e_1 e) ⊑ ashr e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -33,7 +33,7 @@ theorem ashr_lshr_no_exact_thm (e e_1 : IntW 32) :
 
 
 theorem ashr_lshr_exact_both_thm (e e_1 : IntW 32) :
-  select (icmp IntPredicate.sgt e_1 (const? 32 (-1))) (lshr e_1 e { «exact» := true })
+  select (icmp IntPred.sgt e_1 (const? 32 (-1))) (lshr e_1 e { «exact» := true })
       (ashr e_1 e { «exact» := true }) ⊑
     ashr e_1 e { «exact» := true } := by
     simp_alive_undef
@@ -45,7 +45,7 @@ theorem ashr_lshr_exact_both_thm (e e_1 : IntW 32) :
 
 
 theorem ashr_lshr_exact_lshr_only_thm (e e_1 : IntW 32) :
-  select (icmp IntPredicate.sgt e_1 (const? 32 (-1))) (lshr e_1 e { «exact» := true }) (ashr e_1 e) ⊑
+  select (icmp IntPred.sgt e_1 (const? 32 (-1))) (lshr e_1 e { «exact» := true }) (ashr e_1 e) ⊑
     ashr e_1 e := by
     simp_alive_undef
     simp_alive_ops
@@ -56,7 +56,7 @@ theorem ashr_lshr_exact_lshr_only_thm (e e_1 : IntW 32) :
 
 
 theorem ashr_lshr2_thm (e e_1 : IntW 32) :
-  select (icmp IntPredicate.sgt e_1 (const? 32 5)) (lshr e_1 e) (ashr e_1 e { «exact» := true }) ⊑ ashr e_1 e := by
+  select (icmp IntPred.sgt e_1 (const? 32 5)) (lshr e_1 e) (ashr e_1 e { «exact» := true }) ⊑ ashr e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -66,7 +66,7 @@ theorem ashr_lshr2_thm (e e_1 : IntW 32) :
 
 
 theorem ashr_lshr2_i128_thm (e e_1 : IntW 128) :
-  select (icmp IntPredicate.sgt e_1 (const? 128 5)) (lshr e_1 e) (ashr e_1 e { «exact» := true }) ⊑ ashr e_1 e := by
+  select (icmp IntPred.sgt e_1 (const? 128 5)) (lshr e_1 e) (ashr e_1 e { «exact» := true }) ⊑ ashr e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -76,7 +76,7 @@ theorem ashr_lshr2_i128_thm (e e_1 : IntW 128) :
 
 
 theorem ashr_lshr_cst_thm (e : IntW 32) :
-  select (icmp IntPredicate.slt e (const? 32 1)) (ashr e (const? 32 8) { «exact» := true }) (lshr e (const? 32 8)) ⊑
+  select (icmp IntPred.slt e (const? 32 1)) (ashr e (const? 32 8) { «exact» := true }) (lshr e (const? 32 8)) ⊑
     ashr e (const? 32 8) := by
     simp_alive_undef
     simp_alive_ops
@@ -87,7 +87,7 @@ theorem ashr_lshr_cst_thm (e : IntW 32) :
 
 
 theorem ashr_lshr_cst2_thm (e : IntW 32) :
-  select (icmp IntPredicate.sgt e (const? 32 (-1))) (lshr e (const? 32 8)) (ashr e (const? 32 8) { «exact» := true }) ⊑
+  select (icmp IntPred.sgt e (const? 32 (-1))) (lshr e (const? 32 8)) (ashr e (const? 32 8) { «exact» := true }) ⊑
     ashr e (const? 32 8) := by
     simp_alive_undef
     simp_alive_ops
@@ -98,7 +98,7 @@ theorem ashr_lshr_cst2_thm (e : IntW 32) :
 
 
 theorem ashr_lshr_inv_thm (e e_1 : IntW 32) :
-  select (icmp IntPredicate.slt e_1 (const? 32 1)) (ashr e_1 e { «exact» := true }) (lshr e_1 e) ⊑ ashr e_1 e := by
+  select (icmp IntPred.slt e_1 (const? 32 1)) (ashr e_1 e { «exact» := true }) (lshr e_1 e) ⊑ ashr e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -108,7 +108,7 @@ theorem ashr_lshr_inv_thm (e e_1 : IntW 32) :
 
 
 theorem ashr_lshr_inv2_thm (e e_1 : IntW 32) :
-  select (icmp IntPredicate.slt e_1 (const? 32 7)) (ashr e_1 e { «exact» := true }) (lshr e_1 e) ⊑ ashr e_1 e := by
+  select (icmp IntPred.slt e_1 (const? 32 7)) (ashr e_1 e { «exact» := true }) (lshr e_1 e) ⊑ ashr e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -118,8 +118,8 @@ theorem ashr_lshr_inv2_thm (e e_1 : IntW 32) :
 
 
 theorem ashr_lshr_wrong_cond_thm (e e_1 : IntW 32) :
-  select (icmp IntPredicate.sge e_1 (const? 32 (-1))) (lshr e_1 e) (ashr e_1 e) ⊑
-    select (icmp IntPredicate.sgt e_1 (const? 32 (-2))) (lshr e_1 e) (ashr e_1 e) := by
+  select (icmp IntPred.sge e_1 (const? 32 (-1))) (lshr e_1 e) (ashr e_1 e) ⊑
+    select (icmp IntPred.sgt e_1 (const? 32 (-2))) (lshr e_1 e) (ashr e_1 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -129,8 +129,8 @@ theorem ashr_lshr_wrong_cond_thm (e e_1 : IntW 32) :
 
 
 theorem ashr_lshr_shift_wrong_pred_thm (e e_1 : IntW 32) :
-  select (icmp IntPredicate.sle e_1 (const? 32 0)) (lshr e_1 e) (ashr e_1 e) ⊑
-    select (icmp IntPredicate.slt e_1 (const? 32 1)) (lshr e_1 e) (ashr e_1 e) := by
+  select (icmp IntPred.sle e_1 (const? 32 0)) (lshr e_1 e) (ashr e_1 e) ⊑
+    select (icmp IntPred.slt e_1 (const? 32 1)) (lshr e_1 e) (ashr e_1 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -140,8 +140,8 @@ theorem ashr_lshr_shift_wrong_pred_thm (e e_1 : IntW 32) :
 
 
 theorem ashr_lshr_shift_wrong_pred2_thm (e e_1 e_2 : IntW 32) :
-  select (icmp IntPredicate.sge e_2 (const? 32 0)) (lshr e_1 e) (ashr e_1 e) ⊑
-    select (icmp IntPredicate.slt e_2 (const? 32 0)) (ashr e_1 e) (lshr e_1 e) := by
+  select (icmp IntPred.sge e_2 (const? 32 0)) (lshr e_1 e) (ashr e_1 e) ⊑
+    select (icmp IntPred.slt e_2 (const? 32 0)) (ashr e_1 e) (lshr e_1 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -151,8 +151,8 @@ theorem ashr_lshr_shift_wrong_pred2_thm (e e_1 e_2 : IntW 32) :
 
 
 theorem ashr_lshr_wrong_operands_thm (e e_1 : IntW 32) :
-  select (icmp IntPredicate.sge e_1 (const? 32 0)) (ashr e_1 e) (lshr e_1 e) ⊑
-    select (icmp IntPredicate.slt e_1 (const? 32 0)) (lshr e_1 e) (ashr e_1 e) := by
+  select (icmp IntPred.sge e_1 (const? 32 0)) (ashr e_1 e) (lshr e_1 e) ⊑
+    select (icmp IntPred.slt e_1 (const? 32 0)) (lshr e_1 e) (ashr e_1 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -162,8 +162,8 @@ theorem ashr_lshr_wrong_operands_thm (e e_1 : IntW 32) :
 
 
 theorem ashr_lshr_no_ashr_thm (e e_1 : IntW 32) :
-  select (icmp IntPredicate.sge e_1 (const? 32 0)) (lshr e_1 e) (LLVM.xor e_1 e) ⊑
-    select (icmp IntPredicate.slt e_1 (const? 32 0)) (LLVM.xor e_1 e) (lshr e_1 e) := by
+  select (icmp IntPred.sge e_1 (const? 32 0)) (lshr e_1 e) (LLVM.xor e_1 e) ⊑
+    select (icmp IntPred.slt e_1 (const? 32 0)) (LLVM.xor e_1 e) (lshr e_1 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -173,8 +173,8 @@ theorem ashr_lshr_no_ashr_thm (e e_1 : IntW 32) :
 
 
 theorem ashr_lshr_shift_amt_mismatch_thm (e e_1 e_2 : IntW 32) :
-  select (icmp IntPredicate.sge e_2 (const? 32 0)) (lshr e_2 e_1) (ashr e_2 e) ⊑
-    select (icmp IntPredicate.slt e_2 (const? 32 0)) (ashr e_2 e) (lshr e_2 e_1) := by
+  select (icmp IntPred.sge e_2 (const? 32 0)) (lshr e_2 e_1) (ashr e_2 e) ⊑
+    select (icmp IntPred.slt e_2 (const? 32 0)) (ashr e_2 e) (lshr e_2 e_1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -184,8 +184,8 @@ theorem ashr_lshr_shift_amt_mismatch_thm (e e_1 e_2 : IntW 32) :
 
 
 theorem ashr_lshr_shift_base_mismatch_thm (e e_1 e_2 : IntW 32) :
-  select (icmp IntPredicate.sge e_2 (const? 32 0)) (lshr e_2 e_1) (ashr e e_1) ⊑
-    select (icmp IntPredicate.slt e_2 (const? 32 0)) (ashr e e_1) (lshr e_2 e_1) := by
+  select (icmp IntPred.sge e_2 (const? 32 0)) (lshr e_2 e_1) (ashr e e_1) ⊑
+    select (icmp IntPred.slt e_2 (const? 32 0)) (ashr e e_1) (lshr e_2 e_1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -195,8 +195,8 @@ theorem ashr_lshr_shift_base_mismatch_thm (e e_1 e_2 : IntW 32) :
 
 
 theorem ashr_lshr_no_lshr_thm (e e_1 : IntW 32) :
-  select (icmp IntPredicate.sge e_1 (const? 32 0)) (add e_1 e) (ashr e_1 e) ⊑
-    select (icmp IntPredicate.slt e_1 (const? 32 0)) (ashr e_1 e) (add e_1 e) := by
+  select (icmp IntPred.sge e_1 (const? 32 0)) (add e_1 e) (ashr e_1 e) ⊑
+    select (icmp IntPred.slt e_1 (const? 32 0)) (ashr e_1 e) (add e_1 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -206,7 +206,7 @@ theorem ashr_lshr_no_lshr_thm (e e_1 : IntW 32) :
 
 
 theorem lshr_sub_nsw_thm (e e_1 : IntW 32) :
-  lshr (sub e_1 e { «nsw» := true, «nuw» := false }) (const? 32 31) ⊑ zext 32 (icmp IntPredicate.slt e_1 e) := by
+  lshr (sub e_1 e { «nsw» := true, «nuw» := false }) (const? 32 31) ⊑ zext 32 (icmp IntPred.slt e_1 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -216,7 +216,7 @@ theorem lshr_sub_nsw_thm (e e_1 : IntW 32) :
 
 
 theorem ashr_sub_nsw_thm (e e_1 : IntW 17) :
-  ashr (sub e_1 e { «nsw» := true, «nuw» := false }) (const? 17 16) ⊑ sext 17 (icmp IntPredicate.slt e_1 e) := by
+  ashr (sub e_1 e { «nsw» := true, «nuw» := false }) (const? 17 16) ⊑ sext 17 (icmp IntPred.slt e_1 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -370,7 +370,7 @@ theorem ashr_mul_times_5_div_4_exact_2_thm (e : IntW 32) :
 
 theorem lsb_mask_sign_zext_thm (e : IntW 32) :
   lshr (LLVM.and (add e (const? 32 (-1))) (LLVM.xor e (const? 32 (-1)))) (const? 32 31) ⊑
-    zext 32 (icmp IntPredicate.eq e (const? 32 0)) := by
+    zext 32 (icmp IntPred.eq e (const? 32 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -381,7 +381,7 @@ theorem lsb_mask_sign_zext_thm (e : IntW 32) :
 
 theorem lsb_mask_sign_zext_commuted_thm (e : IntW 32) :
   lshr (LLVM.and (LLVM.xor e (const? 32 (-1))) (add e (const? 32 (-1)))) (const? 32 31) ⊑
-    zext 32 (icmp IntPredicate.eq e (const? 32 0)) := by
+    zext 32 (icmp IntPred.eq e (const? 32 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -403,7 +403,7 @@ theorem lsb_mask_sign_zext_wrong_cst2_thm (e : IntW 32) :
 
 theorem lsb_mask_sign_sext_thm (e : IntW 32) :
   ashr (LLVM.and (add e (const? 32 (-1))) (LLVM.xor e (const? 32 (-1)))) (const? 32 31) ⊑
-    sext 32 (icmp IntPredicate.eq e (const? 32 0)) := by
+    sext 32 (icmp IntPred.eq e (const? 32 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -414,7 +414,7 @@ theorem lsb_mask_sign_sext_thm (e : IntW 32) :
 
 theorem lsb_mask_sign_sext_commuted_thm (e : IntW 32) :
   ashr (LLVM.and (LLVM.xor e (const? 32 (-1))) (add e (const? 32 (-1)))) (const? 32 31) ⊑
-    sext 32 (icmp IntPredicate.eq e (const? 32 0)) := by
+    sext 32 (icmp IntPred.eq e (const? 32 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gbinophcast_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gbinophcast_proof.lean
@@ -50,7 +50,7 @@ theorem and_add_bool_to_select_thm (e : IntW 32) (e_1 : IntW 1) :
 
 theorem and_add_bool_no_fold_thm (e : IntW 32) :
   LLVM.and (add (const? 32 (-1)) (LLVM.and e (const? 32 1))) e ⊑
-    select (icmp IntPredicate.eq (LLVM.and e (const? 32 1)) (const? 32 0)) e (const? 32 0) := by
+    select (icmp IntPred.eq (LLVM.and e (const? 32 1)) (const? 32 0)) e (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gbithchecks_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gbithchecks_proof.lean
@@ -13,10 +13,10 @@ set_option Elab.async false
 section gbithchecks_proof
 theorem main1_thm (e : IntW 32) :
   select
-      (LLVM.and (icmp IntPredicate.ne (LLVM.and e (const? 32 1)) (const? 32 0))
-        (icmp IntPredicate.ne (LLVM.and e (const? 32 2)) (const? 32 0)))
+      (LLVM.and (icmp IntPred.ne (LLVM.and e (const? 32 1)) (const? 32 0))
+        (icmp IntPred.ne (LLVM.and e (const? 32 2)) (const? 32 0)))
       (const? 32 2) (const? 32 1) ⊑
-    select (icmp IntPredicate.eq (LLVM.and e (const? 32 3)) (const? 32 3)) (const? 32 2) (const? 32 1) := by
+    select (icmp IntPred.eq (LLVM.and e (const? 32 3)) (const? 32 3)) (const? 32 2) (const? 32 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -27,10 +27,10 @@ theorem main1_thm (e : IntW 32) :
 
 theorem main1_logical_thm (e : IntW 32) :
   select
-      (select (icmp IntPredicate.ne (LLVM.and e (const? 32 1)) (const? 32 0))
-        (icmp IntPredicate.ne (LLVM.and e (const? 32 2)) (const? 32 0)) (const? 1 0))
+      (select (icmp IntPred.ne (LLVM.and e (const? 32 1)) (const? 32 0))
+        (icmp IntPred.ne (LLVM.and e (const? 32 2)) (const? 32 0)) (const? 1 0))
       (const? 32 2) (const? 32 1) ⊑
-    select (icmp IntPredicate.eq (LLVM.and e (const? 32 3)) (const? 32 3)) (const? 32 2) (const? 32 1) := by
+    select (icmp IntPred.eq (LLVM.and e (const? 32 3)) (const? 32 3)) (const? 32 2) (const? 32 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -41,10 +41,10 @@ theorem main1_logical_thm (e : IntW 32) :
 
 theorem main2_thm (e : IntW 32) :
   select
-      (LLVM.or (icmp IntPredicate.eq (LLVM.and e (const? 32 1)) (const? 32 0))
-        (icmp IntPredicate.eq (LLVM.and e (const? 32 2)) (const? 32 0)))
+      (LLVM.or (icmp IntPred.eq (LLVM.and e (const? 32 1)) (const? 32 0))
+        (icmp IntPred.eq (LLVM.and e (const? 32 2)) (const? 32 0)))
       (const? 32 0) (const? 32 1) ⊑
-    zext 32 (icmp IntPredicate.eq (LLVM.and e (const? 32 3)) (const? 32 3)) := by
+    zext 32 (icmp IntPred.eq (LLVM.and e (const? 32 3)) (const? 32 3)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -55,10 +55,10 @@ theorem main2_thm (e : IntW 32) :
 
 theorem main2_logical_thm (e : IntW 32) :
   select
-      (select (icmp IntPredicate.eq (LLVM.and e (const? 32 1)) (const? 32 0)) (const? 1 1)
-        (icmp IntPredicate.eq (LLVM.and e (const? 32 2)) (const? 32 0)))
+      (select (icmp IntPred.eq (LLVM.and e (const? 32 1)) (const? 32 0)) (const? 1 1)
+        (icmp IntPred.eq (LLVM.and e (const? 32 2)) (const? 32 0)))
       (const? 32 0) (const? 32 1) ⊑
-    zext 32 (icmp IntPredicate.eq (LLVM.and e (const? 32 3)) (const? 32 3)) := by
+    zext 32 (icmp IntPred.eq (LLVM.and e (const? 32 3)) (const? 32 3)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -69,10 +69,10 @@ theorem main2_logical_thm (e : IntW 32) :
 
 theorem main3_thm (e : IntW 32) :
   select
-      (LLVM.and (icmp IntPredicate.eq (LLVM.and e (const? 32 7)) (const? 32 0))
-        (icmp IntPredicate.eq (LLVM.and e (const? 32 48)) (const? 32 0)))
+      (LLVM.and (icmp IntPred.eq (LLVM.and e (const? 32 7)) (const? 32 0))
+        (icmp IntPred.eq (LLVM.and e (const? 32 48)) (const? 32 0)))
       (const? 32 0) (const? 32 1) ⊑
-    zext 32 (icmp IntPredicate.ne (LLVM.and e (const? 32 55)) (const? 32 0)) := by
+    zext 32 (icmp IntPred.ne (LLVM.and e (const? 32 55)) (const? 32 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -83,10 +83,10 @@ theorem main3_thm (e : IntW 32) :
 
 theorem main3_logical_thm (e : IntW 32) :
   select
-      (select (icmp IntPredicate.eq (LLVM.and e (const? 32 7)) (const? 32 0))
-        (icmp IntPredicate.eq (LLVM.and e (const? 32 48)) (const? 32 0)) (const? 1 0))
+      (select (icmp IntPred.eq (LLVM.and e (const? 32 7)) (const? 32 0))
+        (icmp IntPred.eq (LLVM.and e (const? 32 48)) (const? 32 0)) (const? 1 0))
       (const? 32 0) (const? 32 1) ⊑
-    zext 32 (icmp IntPredicate.ne (LLVM.and e (const? 32 55)) (const? 32 0)) := by
+    zext 32 (icmp IntPred.ne (LLVM.and e (const? 32 55)) (const? 32 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -97,10 +97,10 @@ theorem main3_logical_thm (e : IntW 32) :
 
 theorem main3b_thm (e : IntW 32) :
   select
-      (LLVM.and (icmp IntPredicate.eq (LLVM.and e (const? 32 7)) (const? 32 0))
-        (icmp IntPredicate.ne (LLVM.and e (const? 32 16)) (const? 32 16)))
+      (LLVM.and (icmp IntPred.eq (LLVM.and e (const? 32 7)) (const? 32 0))
+        (icmp IntPred.ne (LLVM.and e (const? 32 16)) (const? 32 16)))
       (const? 32 0) (const? 32 1) ⊑
-    zext 32 (icmp IntPredicate.ne (LLVM.and e (const? 32 23)) (const? 32 0)) := by
+    zext 32 (icmp IntPred.ne (LLVM.and e (const? 32 23)) (const? 32 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -111,10 +111,10 @@ theorem main3b_thm (e : IntW 32) :
 
 theorem main3b_logical_thm (e : IntW 32) :
   select
-      (select (icmp IntPredicate.eq (LLVM.and e (const? 32 7)) (const? 32 0))
-        (icmp IntPredicate.ne (LLVM.and e (const? 32 16)) (const? 32 16)) (const? 1 0))
+      (select (icmp IntPred.eq (LLVM.and e (const? 32 7)) (const? 32 0))
+        (icmp IntPred.ne (LLVM.and e (const? 32 16)) (const? 32 16)) (const? 1 0))
       (const? 32 0) (const? 32 1) ⊑
-    zext 32 (icmp IntPredicate.ne (LLVM.and e (const? 32 23)) (const? 32 0)) := by
+    zext 32 (icmp IntPred.ne (LLVM.and e (const? 32 23)) (const? 32 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -125,10 +125,10 @@ theorem main3b_logical_thm (e : IntW 32) :
 
 theorem main3e_like_thm (e e_1 e_2 : IntW 32) :
   select
-      (LLVM.and (icmp IntPredicate.eq (LLVM.and e_2 e_1) (const? 32 0))
-        (icmp IntPredicate.eq (LLVM.and e_2 e) (const? 32 0)))
+      (LLVM.and (icmp IntPred.eq (LLVM.and e_2 e_1) (const? 32 0))
+        (icmp IntPred.eq (LLVM.and e_2 e) (const? 32 0)))
       (const? 32 0) (const? 32 1) ⊑
-    zext 32 (icmp IntPredicate.ne (LLVM.and e_2 (LLVM.or e_1 e)) (const? 32 0)) := by
+    zext 32 (icmp IntPred.ne (LLVM.and e_2 (LLVM.or e_1 e)) (const? 32 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -139,12 +139,12 @@ theorem main3e_like_thm (e e_1 e_2 : IntW 32) :
 
 theorem main3e_like_logical_thm (e e_1 e_2 : IntW 32) :
   select
-      (select (icmp IntPredicate.eq (LLVM.and e_2 e_1) (const? 32 0))
-        (icmp IntPredicate.eq (LLVM.and e_2 e) (const? 32 0)) (const? 1 0))
+      (select (icmp IntPred.eq (LLVM.and e_2 e_1) (const? 32 0))
+        (icmp IntPred.eq (LLVM.and e_2 e) (const? 32 0)) (const? 1 0))
       (const? 32 0) (const? 32 1) ⊑
     zext 32
-      (select (icmp IntPredicate.ne (LLVM.and e_2 e_1) (const? 32 0)) (const? 1 1)
-        (icmp IntPredicate.ne (LLVM.and e_2 e) (const? 32 0))) := by
+      (select (icmp IntPred.ne (LLVM.and e_2 e_1) (const? 32 0)) (const? 1 1)
+        (icmp IntPred.ne (LLVM.and e_2 e) (const? 32 0))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -155,10 +155,10 @@ theorem main3e_like_logical_thm (e e_1 e_2 : IntW 32) :
 
 theorem main3c_thm (e : IntW 32) :
   select
-      (LLVM.or (icmp IntPredicate.ne (LLVM.and e (const? 32 7)) (const? 32 0))
-        (icmp IntPredicate.ne (LLVM.and e (const? 32 48)) (const? 32 0)))
+      (LLVM.or (icmp IntPred.ne (LLVM.and e (const? 32 7)) (const? 32 0))
+        (icmp IntPred.ne (LLVM.and e (const? 32 48)) (const? 32 0)))
       (const? 32 0) (const? 32 1) ⊑
-    zext 32 (icmp IntPredicate.eq (LLVM.and e (const? 32 55)) (const? 32 0)) := by
+    zext 32 (icmp IntPred.eq (LLVM.and e (const? 32 55)) (const? 32 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -169,10 +169,10 @@ theorem main3c_thm (e : IntW 32) :
 
 theorem main3c_logical_thm (e : IntW 32) :
   select
-      (select (icmp IntPredicate.ne (LLVM.and e (const? 32 7)) (const? 32 0)) (const? 1 1)
-        (icmp IntPredicate.ne (LLVM.and e (const? 32 48)) (const? 32 0)))
+      (select (icmp IntPred.ne (LLVM.and e (const? 32 7)) (const? 32 0)) (const? 1 1)
+        (icmp IntPred.ne (LLVM.and e (const? 32 48)) (const? 32 0)))
       (const? 32 0) (const? 32 1) ⊑
-    zext 32 (icmp IntPredicate.eq (LLVM.and e (const? 32 55)) (const? 32 0)) := by
+    zext 32 (icmp IntPred.eq (LLVM.and e (const? 32 55)) (const? 32 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -183,10 +183,10 @@ theorem main3c_logical_thm (e : IntW 32) :
 
 theorem main3d_thm (e : IntW 32) :
   select
-      (LLVM.or (icmp IntPredicate.ne (LLVM.and e (const? 32 7)) (const? 32 0))
-        (icmp IntPredicate.eq (LLVM.and e (const? 32 16)) (const? 32 16)))
+      (LLVM.or (icmp IntPred.ne (LLVM.and e (const? 32 7)) (const? 32 0))
+        (icmp IntPred.eq (LLVM.and e (const? 32 16)) (const? 32 16)))
       (const? 32 0) (const? 32 1) ⊑
-    zext 32 (icmp IntPredicate.eq (LLVM.and e (const? 32 23)) (const? 32 0)) := by
+    zext 32 (icmp IntPred.eq (LLVM.and e (const? 32 23)) (const? 32 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -197,10 +197,10 @@ theorem main3d_thm (e : IntW 32) :
 
 theorem main3d_logical_thm (e : IntW 32) :
   select
-      (select (icmp IntPredicate.ne (LLVM.and e (const? 32 7)) (const? 32 0)) (const? 1 1)
-        (icmp IntPredicate.eq (LLVM.and e (const? 32 16)) (const? 32 16)))
+      (select (icmp IntPred.ne (LLVM.and e (const? 32 7)) (const? 32 0)) (const? 1 1)
+        (icmp IntPred.eq (LLVM.and e (const? 32 16)) (const? 32 16)))
       (const? 32 0) (const? 32 1) ⊑
-    zext 32 (icmp IntPredicate.eq (LLVM.and e (const? 32 23)) (const? 32 0)) := by
+    zext 32 (icmp IntPred.eq (LLVM.and e (const? 32 23)) (const? 32 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -211,10 +211,10 @@ theorem main3d_logical_thm (e : IntW 32) :
 
 theorem main3f_like_thm (e e_1 e_2 : IntW 32) :
   select
-      (LLVM.or (icmp IntPredicate.ne (LLVM.and e_2 e_1) (const? 32 0))
-        (icmp IntPredicate.ne (LLVM.and e_2 e) (const? 32 0)))
+      (LLVM.or (icmp IntPred.ne (LLVM.and e_2 e_1) (const? 32 0))
+        (icmp IntPred.ne (LLVM.and e_2 e) (const? 32 0)))
       (const? 32 0) (const? 32 1) ⊑
-    zext 32 (icmp IntPredicate.eq (LLVM.and e_2 (LLVM.or e_1 e)) (const? 32 0)) := by
+    zext 32 (icmp IntPred.eq (LLVM.and e_2 (LLVM.or e_1 e)) (const? 32 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -225,12 +225,12 @@ theorem main3f_like_thm (e e_1 e_2 : IntW 32) :
 
 theorem main3f_like_logical_thm (e e_1 e_2 : IntW 32) :
   select
-      (select (icmp IntPredicate.ne (LLVM.and e_2 e_1) (const? 32 0)) (const? 1 1)
-        (icmp IntPredicate.ne (LLVM.and e_2 e) (const? 32 0)))
+      (select (icmp IntPred.ne (LLVM.and e_2 e_1) (const? 32 0)) (const? 1 1)
+        (icmp IntPred.ne (LLVM.and e_2 e) (const? 32 0)))
       (const? 32 0) (const? 32 1) ⊑
     zext 32
-      (select (icmp IntPredicate.eq (LLVM.and e_2 e_1) (const? 32 0))
-        (icmp IntPredicate.eq (LLVM.and e_2 e) (const? 32 0)) (const? 1 0)) := by
+      (select (icmp IntPred.eq (LLVM.and e_2 e_1) (const? 32 0))
+        (icmp IntPred.eq (LLVM.and e_2 e) (const? 32 0)) (const? 1 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -241,10 +241,10 @@ theorem main3f_like_logical_thm (e e_1 e_2 : IntW 32) :
 
 theorem main4_thm (e : IntW 32) :
   select
-      (LLVM.and (icmp IntPredicate.eq (LLVM.and e (const? 32 7)) (const? 32 7))
-        (icmp IntPredicate.eq (LLVM.and e (const? 32 48)) (const? 32 48)))
+      (LLVM.and (icmp IntPred.eq (LLVM.and e (const? 32 7)) (const? 32 7))
+        (icmp IntPred.eq (LLVM.and e (const? 32 48)) (const? 32 48)))
       (const? 32 0) (const? 32 1) ⊑
-    zext 32 (icmp IntPredicate.ne (LLVM.and e (const? 32 55)) (const? 32 55)) := by
+    zext 32 (icmp IntPred.ne (LLVM.and e (const? 32 55)) (const? 32 55)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -255,10 +255,10 @@ theorem main4_thm (e : IntW 32) :
 
 theorem main4_logical_thm (e : IntW 32) :
   select
-      (select (icmp IntPredicate.eq (LLVM.and e (const? 32 7)) (const? 32 7))
-        (icmp IntPredicate.eq (LLVM.and e (const? 32 48)) (const? 32 48)) (const? 1 0))
+      (select (icmp IntPred.eq (LLVM.and e (const? 32 7)) (const? 32 7))
+        (icmp IntPred.eq (LLVM.and e (const? 32 48)) (const? 32 48)) (const? 1 0))
       (const? 32 0) (const? 32 1) ⊑
-    zext 32 (icmp IntPredicate.ne (LLVM.and e (const? 32 55)) (const? 32 55)) := by
+    zext 32 (icmp IntPred.ne (LLVM.and e (const? 32 55)) (const? 32 55)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -269,10 +269,10 @@ theorem main4_logical_thm (e : IntW 32) :
 
 theorem main4b_thm (e : IntW 32) :
   select
-      (LLVM.and (icmp IntPredicate.eq (LLVM.and e (const? 32 7)) (const? 32 7))
-        (icmp IntPredicate.ne (LLVM.and e (const? 32 16)) (const? 32 0)))
+      (LLVM.and (icmp IntPred.eq (LLVM.and e (const? 32 7)) (const? 32 7))
+        (icmp IntPred.ne (LLVM.and e (const? 32 16)) (const? 32 0)))
       (const? 32 0) (const? 32 1) ⊑
-    zext 32 (icmp IntPredicate.ne (LLVM.and e (const? 32 23)) (const? 32 23)) := by
+    zext 32 (icmp IntPred.ne (LLVM.and e (const? 32 23)) (const? 32 23)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -283,10 +283,10 @@ theorem main4b_thm (e : IntW 32) :
 
 theorem main4b_logical_thm (e : IntW 32) :
   select
-      (select (icmp IntPredicate.eq (LLVM.and e (const? 32 7)) (const? 32 7))
-        (icmp IntPredicate.ne (LLVM.and e (const? 32 16)) (const? 32 0)) (const? 1 0))
+      (select (icmp IntPred.eq (LLVM.and e (const? 32 7)) (const? 32 7))
+        (icmp IntPred.ne (LLVM.and e (const? 32 16)) (const? 32 0)) (const? 1 0))
       (const? 32 0) (const? 32 1) ⊑
-    zext 32 (icmp IntPredicate.ne (LLVM.and e (const? 32 23)) (const? 32 23)) := by
+    zext 32 (icmp IntPred.ne (LLVM.and e (const? 32 23)) (const? 32 23)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -296,9 +296,9 @@ theorem main4b_logical_thm (e : IntW 32) :
 
 
 theorem main4e_like_thm (e e_1 e_2 : IntW 32) :
-  select (LLVM.and (icmp IntPredicate.eq (LLVM.and e_2 e_1) e_1) (icmp IntPredicate.eq (LLVM.and e_2 e) e))
+  select (LLVM.and (icmp IntPred.eq (LLVM.and e_2 e_1) e_1) (icmp IntPred.eq (LLVM.and e_2 e) e))
       (const? 32 0) (const? 32 1) ⊑
-    zext 32 (icmp IntPredicate.ne (LLVM.and e_2 (LLVM.or e_1 e)) (LLVM.or e_1 e)) := by
+    zext 32 (icmp IntPred.ne (LLVM.and e_2 (LLVM.or e_1 e)) (LLVM.or e_1 e)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -308,11 +308,11 @@ theorem main4e_like_thm (e e_1 e_2 : IntW 32) :
 
 
 theorem main4e_like_logical_thm (e e_1 e_2 : IntW 32) :
-  select (select (icmp IntPredicate.eq (LLVM.and e_2 e_1) e_1) (icmp IntPredicate.eq (LLVM.and e_2 e) e) (const? 1 0))
+  select (select (icmp IntPred.eq (LLVM.and e_2 e_1) e_1) (icmp IntPred.eq (LLVM.and e_2 e) e) (const? 1 0))
       (const? 32 0) (const? 32 1) ⊑
     zext 32
-      (select (icmp IntPredicate.ne (LLVM.and e_2 e_1) e_1) (const? 1 1)
-        (icmp IntPredicate.ne (LLVM.and e_2 e) e)) := by
+      (select (icmp IntPred.ne (LLVM.and e_2 e_1) e_1) (const? 1 1)
+        (icmp IntPred.ne (LLVM.and e_2 e) e)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -323,10 +323,10 @@ theorem main4e_like_logical_thm (e e_1 e_2 : IntW 32) :
 
 theorem main4c_thm (e : IntW 32) :
   select
-      (LLVM.or (icmp IntPredicate.ne (LLVM.and e (const? 32 7)) (const? 32 7))
-        (icmp IntPredicate.ne (LLVM.and e (const? 32 48)) (const? 32 48)))
+      (LLVM.or (icmp IntPred.ne (LLVM.and e (const? 32 7)) (const? 32 7))
+        (icmp IntPred.ne (LLVM.and e (const? 32 48)) (const? 32 48)))
       (const? 32 0) (const? 32 1) ⊑
-    zext 32 (icmp IntPredicate.eq (LLVM.and e (const? 32 55)) (const? 32 55)) := by
+    zext 32 (icmp IntPred.eq (LLVM.and e (const? 32 55)) (const? 32 55)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -337,10 +337,10 @@ theorem main4c_thm (e : IntW 32) :
 
 theorem main4c_logical_thm (e : IntW 32) :
   select
-      (select (icmp IntPredicate.ne (LLVM.and e (const? 32 7)) (const? 32 7)) (const? 1 1)
-        (icmp IntPredicate.ne (LLVM.and e (const? 32 48)) (const? 32 48)))
+      (select (icmp IntPred.ne (LLVM.and e (const? 32 7)) (const? 32 7)) (const? 1 1)
+        (icmp IntPred.ne (LLVM.and e (const? 32 48)) (const? 32 48)))
       (const? 32 0) (const? 32 1) ⊑
-    zext 32 (icmp IntPredicate.eq (LLVM.and e (const? 32 55)) (const? 32 55)) := by
+    zext 32 (icmp IntPred.eq (LLVM.and e (const? 32 55)) (const? 32 55)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -351,10 +351,10 @@ theorem main4c_logical_thm (e : IntW 32) :
 
 theorem main4d_thm (e : IntW 32) :
   select
-      (LLVM.or (icmp IntPredicate.ne (LLVM.and e (const? 32 7)) (const? 32 7))
-        (icmp IntPredicate.eq (LLVM.and e (const? 32 16)) (const? 32 0)))
+      (LLVM.or (icmp IntPred.ne (LLVM.and e (const? 32 7)) (const? 32 7))
+        (icmp IntPred.eq (LLVM.and e (const? 32 16)) (const? 32 0)))
       (const? 32 0) (const? 32 1) ⊑
-    zext 32 (icmp IntPredicate.eq (LLVM.and e (const? 32 23)) (const? 32 23)) := by
+    zext 32 (icmp IntPred.eq (LLVM.and e (const? 32 23)) (const? 32 23)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -365,10 +365,10 @@ theorem main4d_thm (e : IntW 32) :
 
 theorem main4d_logical_thm (e : IntW 32) :
   select
-      (select (icmp IntPredicate.ne (LLVM.and e (const? 32 7)) (const? 32 7)) (const? 1 1)
-        (icmp IntPredicate.eq (LLVM.and e (const? 32 16)) (const? 32 0)))
+      (select (icmp IntPred.ne (LLVM.and e (const? 32 7)) (const? 32 7)) (const? 1 1)
+        (icmp IntPred.eq (LLVM.and e (const? 32 16)) (const? 32 0)))
       (const? 32 0) (const? 32 1) ⊑
-    zext 32 (icmp IntPredicate.eq (LLVM.and e (const? 32 23)) (const? 32 23)) := by
+    zext 32 (icmp IntPred.eq (LLVM.and e (const? 32 23)) (const? 32 23)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -378,9 +378,9 @@ theorem main4d_logical_thm (e : IntW 32) :
 
 
 theorem main4f_like_thm (e e_1 e_2 : IntW 32) :
-  select (LLVM.or (icmp IntPredicate.ne (LLVM.and e_2 e_1) e_1) (icmp IntPredicate.ne (LLVM.and e_2 e) e)) (const? 32 0)
+  select (LLVM.or (icmp IntPred.ne (LLVM.and e_2 e_1) e_1) (icmp IntPred.ne (LLVM.and e_2 e) e)) (const? 32 0)
       (const? 32 1) ⊑
-    zext 32 (icmp IntPredicate.eq (LLVM.and e_2 (LLVM.or e_1 e)) (LLVM.or e_1 e)) := by
+    zext 32 (icmp IntPred.eq (LLVM.and e_2 (LLVM.or e_1 e)) (LLVM.or e_1 e)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -390,10 +390,10 @@ theorem main4f_like_thm (e e_1 e_2 : IntW 32) :
 
 
 theorem main4f_like_logical_thm (e e_1 e_2 : IntW 32) :
-  select (select (icmp IntPredicate.ne (LLVM.and e_2 e_1) e_1) (const? 1 1) (icmp IntPredicate.ne (LLVM.and e_2 e) e))
+  select (select (icmp IntPred.ne (LLVM.and e_2 e_1) e_1) (const? 1 1) (icmp IntPred.ne (LLVM.and e_2 e) e))
       (const? 32 0) (const? 32 1) ⊑
     zext 32
-      (select (icmp IntPredicate.eq (LLVM.and e_2 e_1) e_1) (icmp IntPredicate.eq (LLVM.and e_2 e) e)
+      (select (icmp IntPred.eq (LLVM.and e_2 e_1) e_1) (icmp IntPred.eq (LLVM.and e_2 e) e)
         (const? 1 0)) := by
     simp_alive_undef
     simp_alive_ops
@@ -405,10 +405,10 @@ theorem main4f_like_logical_thm (e e_1 e_2 : IntW 32) :
 
 theorem main5_like_thm (e e_1 : IntW 32) :
   select
-      (LLVM.and (icmp IntPredicate.eq (LLVM.and e_1 (const? 32 7)) (const? 32 7))
-        (icmp IntPredicate.eq (LLVM.and e (const? 32 7)) (const? 32 7)))
+      (LLVM.and (icmp IntPred.eq (LLVM.and e_1 (const? 32 7)) (const? 32 7))
+        (icmp IntPred.eq (LLVM.and e (const? 32 7)) (const? 32 7)))
       (const? 32 0) (const? 32 1) ⊑
-    zext 32 (icmp IntPredicate.ne (LLVM.and (LLVM.and e_1 e) (const? 32 7)) (const? 32 7)) := by
+    zext 32 (icmp IntPred.ne (LLVM.and (LLVM.and e_1 e) (const? 32 7)) (const? 32 7)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -419,12 +419,12 @@ theorem main5_like_thm (e e_1 : IntW 32) :
 
 theorem main5_like_logical_thm (e e_1 : IntW 32) :
   select
-      (select (icmp IntPredicate.eq (LLVM.and e_1 (const? 32 7)) (const? 32 7))
-        (icmp IntPredicate.eq (LLVM.and e (const? 32 7)) (const? 32 7)) (const? 1 0))
+      (select (icmp IntPred.eq (LLVM.and e_1 (const? 32 7)) (const? 32 7))
+        (icmp IntPred.eq (LLVM.and e (const? 32 7)) (const? 32 7)) (const? 1 0))
       (const? 32 0) (const? 32 1) ⊑
     zext 32
-      (select (icmp IntPredicate.ne (LLVM.and e_1 (const? 32 7)) (const? 32 7)) (const? 1 1)
-        (icmp IntPredicate.ne (LLVM.and e (const? 32 7)) (const? 32 7))) := by
+      (select (icmp IntPred.ne (LLVM.and e_1 (const? 32 7)) (const? 32 7)) (const? 1 1)
+        (icmp IntPred.ne (LLVM.and e (const? 32 7)) (const? 32 7))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -434,9 +434,9 @@ theorem main5_like_logical_thm (e e_1 : IntW 32) :
 
 
 theorem main5e_like_thm (e e_1 e_2 : IntW 32) :
-  select (LLVM.and (icmp IntPredicate.eq (LLVM.and e_2 e_1) e_2) (icmp IntPredicate.eq (LLVM.and e_2 e) e_2))
+  select (LLVM.and (icmp IntPred.eq (LLVM.and e_2 e_1) e_2) (icmp IntPred.eq (LLVM.and e_2 e) e_2))
       (const? 32 0) (const? 32 1) ⊑
-    zext 32 (icmp IntPredicate.ne (LLVM.and e_2 (LLVM.and e_1 e)) e_2) := by
+    zext 32 (icmp IntPred.ne (LLVM.and e_2 (LLVM.and e_1 e)) e_2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -446,11 +446,11 @@ theorem main5e_like_thm (e e_1 e_2 : IntW 32) :
 
 
 theorem main5e_like_logical_thm (e e_1 e_2 : IntW 32) :
-  select (select (icmp IntPredicate.eq (LLVM.and e_2 e_1) e_2) (icmp IntPredicate.eq (LLVM.and e_2 e) e_2) (const? 1 0))
+  select (select (icmp IntPred.eq (LLVM.and e_2 e_1) e_2) (icmp IntPred.eq (LLVM.and e_2 e) e_2) (const? 1 0))
       (const? 32 0) (const? 32 1) ⊑
     zext 32
-      (select (icmp IntPredicate.ne (LLVM.and e_2 e_1) e_2) (const? 1 1)
-        (icmp IntPredicate.ne (LLVM.and e_2 e) e_2)) := by
+      (select (icmp IntPred.ne (LLVM.and e_2 e_1) e_2) (const? 1 1)
+        (icmp IntPred.ne (LLVM.and e_2 e) e_2)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -461,10 +461,10 @@ theorem main5e_like_logical_thm (e e_1 e_2 : IntW 32) :
 
 theorem main5c_like_thm (e e_1 : IntW 32) :
   select
-      (LLVM.or (icmp IntPredicate.ne (LLVM.and e_1 (const? 32 7)) (const? 32 7))
-        (icmp IntPredicate.ne (LLVM.and e (const? 32 7)) (const? 32 7)))
+      (LLVM.or (icmp IntPred.ne (LLVM.and e_1 (const? 32 7)) (const? 32 7))
+        (icmp IntPred.ne (LLVM.and e (const? 32 7)) (const? 32 7)))
       (const? 32 0) (const? 32 1) ⊑
-    zext 32 (icmp IntPredicate.eq (LLVM.and (LLVM.and e_1 e) (const? 32 7)) (const? 32 7)) := by
+    zext 32 (icmp IntPred.eq (LLVM.and (LLVM.and e_1 e) (const? 32 7)) (const? 32 7)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -475,12 +475,12 @@ theorem main5c_like_thm (e e_1 : IntW 32) :
 
 theorem main5c_like_logical_thm (e e_1 : IntW 32) :
   select
-      (select (icmp IntPredicate.ne (LLVM.and e_1 (const? 32 7)) (const? 32 7)) (const? 1 1)
-        (icmp IntPredicate.ne (LLVM.and e (const? 32 7)) (const? 32 7)))
+      (select (icmp IntPred.ne (LLVM.and e_1 (const? 32 7)) (const? 32 7)) (const? 1 1)
+        (icmp IntPred.ne (LLVM.and e (const? 32 7)) (const? 32 7)))
       (const? 32 0) (const? 32 1) ⊑
     zext 32
-      (select (icmp IntPredicate.eq (LLVM.and e_1 (const? 32 7)) (const? 32 7))
-        (icmp IntPredicate.eq (LLVM.and e (const? 32 7)) (const? 32 7)) (const? 1 0)) := by
+      (select (icmp IntPred.eq (LLVM.and e_1 (const? 32 7)) (const? 32 7))
+        (icmp IntPred.eq (LLVM.and e (const? 32 7)) (const? 32 7)) (const? 1 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -490,9 +490,9 @@ theorem main5c_like_logical_thm (e e_1 : IntW 32) :
 
 
 theorem main5f_like_thm (e e_1 e_2 : IntW 32) :
-  select (LLVM.or (icmp IntPredicate.ne (LLVM.and e_2 e_1) e_2) (icmp IntPredicate.ne (LLVM.and e_2 e) e_2))
+  select (LLVM.or (icmp IntPred.ne (LLVM.and e_2 e_1) e_2) (icmp IntPred.ne (LLVM.and e_2 e) e_2))
       (const? 32 0) (const? 32 1) ⊑
-    zext 32 (icmp IntPredicate.eq (LLVM.and e_2 (LLVM.and e_1 e)) e_2) := by
+    zext 32 (icmp IntPred.eq (LLVM.and e_2 (LLVM.and e_1 e)) e_2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -502,10 +502,10 @@ theorem main5f_like_thm (e e_1 e_2 : IntW 32) :
 
 
 theorem main5f_like_logical_thm (e e_1 e_2 : IntW 32) :
-  select (select (icmp IntPredicate.ne (LLVM.and e_2 e_1) e_2) (const? 1 1) (icmp IntPredicate.ne (LLVM.and e_2 e) e_2))
+  select (select (icmp IntPred.ne (LLVM.and e_2 e_1) e_2) (const? 1 1) (icmp IntPred.ne (LLVM.and e_2 e) e_2))
       (const? 32 0) (const? 32 1) ⊑
     zext 32
-      (select (icmp IntPredicate.eq (LLVM.and e_2 e_1) e_2) (icmp IntPredicate.eq (LLVM.and e_2 e) e_2)
+      (select (icmp IntPred.eq (LLVM.and e_2 e_1) e_2) (icmp IntPred.eq (LLVM.and e_2 e) e_2)
         (const? 1 0)) := by
     simp_alive_undef
     simp_alive_ops
@@ -517,10 +517,10 @@ theorem main5f_like_logical_thm (e e_1 e_2 : IntW 32) :
 
 theorem main6_thm (e : IntW 32) :
   select
-      (LLVM.and (icmp IntPredicate.eq (LLVM.and e (const? 32 7)) (const? 32 3))
-        (icmp IntPredicate.eq (LLVM.and e (const? 32 48)) (const? 32 16)))
+      (LLVM.and (icmp IntPred.eq (LLVM.and e (const? 32 7)) (const? 32 3))
+        (icmp IntPred.eq (LLVM.and e (const? 32 48)) (const? 32 16)))
       (const? 32 0) (const? 32 1) ⊑
-    zext 32 (icmp IntPredicate.ne (LLVM.and e (const? 32 55)) (const? 32 19)) := by
+    zext 32 (icmp IntPred.ne (LLVM.and e (const? 32 55)) (const? 32 19)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -531,10 +531,10 @@ theorem main6_thm (e : IntW 32) :
 
 theorem main6_logical_thm (e : IntW 32) :
   select
-      (select (icmp IntPredicate.eq (LLVM.and e (const? 32 7)) (const? 32 3))
-        (icmp IntPredicate.eq (LLVM.and e (const? 32 48)) (const? 32 16)) (const? 1 0))
+      (select (icmp IntPred.eq (LLVM.and e (const? 32 7)) (const? 32 3))
+        (icmp IntPred.eq (LLVM.and e (const? 32 48)) (const? 32 16)) (const? 1 0))
       (const? 32 0) (const? 32 1) ⊑
-    zext 32 (icmp IntPredicate.ne (LLVM.and e (const? 32 55)) (const? 32 19)) := by
+    zext 32 (icmp IntPred.ne (LLVM.and e (const? 32 55)) (const? 32 19)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -545,10 +545,10 @@ theorem main6_logical_thm (e : IntW 32) :
 
 theorem main6b_thm (e : IntW 32) :
   select
-      (LLVM.and (icmp IntPredicate.eq (LLVM.and e (const? 32 7)) (const? 32 3))
-        (icmp IntPredicate.ne (LLVM.and e (const? 32 16)) (const? 32 0)))
+      (LLVM.and (icmp IntPred.eq (LLVM.and e (const? 32 7)) (const? 32 3))
+        (icmp IntPred.ne (LLVM.and e (const? 32 16)) (const? 32 0)))
       (const? 32 0) (const? 32 1) ⊑
-    zext 32 (icmp IntPredicate.ne (LLVM.and e (const? 32 23)) (const? 32 19)) := by
+    zext 32 (icmp IntPred.ne (LLVM.and e (const? 32 23)) (const? 32 19)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -559,10 +559,10 @@ theorem main6b_thm (e : IntW 32) :
 
 theorem main6b_logical_thm (e : IntW 32) :
   select
-      (select (icmp IntPredicate.eq (LLVM.and e (const? 32 7)) (const? 32 3))
-        (icmp IntPredicate.ne (LLVM.and e (const? 32 16)) (const? 32 0)) (const? 1 0))
+      (select (icmp IntPred.eq (LLVM.and e (const? 32 7)) (const? 32 3))
+        (icmp IntPred.ne (LLVM.and e (const? 32 16)) (const? 32 0)) (const? 1 0))
       (const? 32 0) (const? 32 1) ⊑
-    zext 32 (icmp IntPredicate.ne (LLVM.and e (const? 32 23)) (const? 32 19)) := by
+    zext 32 (icmp IntPred.ne (LLVM.and e (const? 32 23)) (const? 32 19)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -573,10 +573,10 @@ theorem main6b_logical_thm (e : IntW 32) :
 
 theorem main6c_thm (e : IntW 32) :
   select
-      (LLVM.or (icmp IntPredicate.ne (LLVM.and e (const? 32 7)) (const? 32 3))
-        (icmp IntPredicate.ne (LLVM.and e (const? 32 48)) (const? 32 16)))
+      (LLVM.or (icmp IntPred.ne (LLVM.and e (const? 32 7)) (const? 32 3))
+        (icmp IntPred.ne (LLVM.and e (const? 32 48)) (const? 32 16)))
       (const? 32 0) (const? 32 1) ⊑
-    zext 32 (icmp IntPredicate.eq (LLVM.and e (const? 32 55)) (const? 32 19)) := by
+    zext 32 (icmp IntPred.eq (LLVM.and e (const? 32 55)) (const? 32 19)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -587,10 +587,10 @@ theorem main6c_thm (e : IntW 32) :
 
 theorem main6c_logical_thm (e : IntW 32) :
   select
-      (select (icmp IntPredicate.ne (LLVM.and e (const? 32 7)) (const? 32 3)) (const? 1 1)
-        (icmp IntPredicate.ne (LLVM.and e (const? 32 48)) (const? 32 16)))
+      (select (icmp IntPred.ne (LLVM.and e (const? 32 7)) (const? 32 3)) (const? 1 1)
+        (icmp IntPred.ne (LLVM.and e (const? 32 48)) (const? 32 16)))
       (const? 32 0) (const? 32 1) ⊑
-    zext 32 (icmp IntPredicate.eq (LLVM.and e (const? 32 55)) (const? 32 19)) := by
+    zext 32 (icmp IntPred.eq (LLVM.and e (const? 32 55)) (const? 32 19)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -601,10 +601,10 @@ theorem main6c_logical_thm (e : IntW 32) :
 
 theorem main6d_thm (e : IntW 32) :
   select
-      (LLVM.or (icmp IntPredicate.ne (LLVM.and e (const? 32 7)) (const? 32 3))
-        (icmp IntPredicate.eq (LLVM.and e (const? 32 16)) (const? 32 0)))
+      (LLVM.or (icmp IntPred.ne (LLVM.and e (const? 32 7)) (const? 32 3))
+        (icmp IntPred.eq (LLVM.and e (const? 32 16)) (const? 32 0)))
       (const? 32 0) (const? 32 1) ⊑
-    zext 32 (icmp IntPredicate.eq (LLVM.and e (const? 32 23)) (const? 32 19)) := by
+    zext 32 (icmp IntPred.eq (LLVM.and e (const? 32 23)) (const? 32 19)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -615,10 +615,10 @@ theorem main6d_thm (e : IntW 32) :
 
 theorem main6d_logical_thm (e : IntW 32) :
   select
-      (select (icmp IntPredicate.ne (LLVM.and e (const? 32 7)) (const? 32 3)) (const? 1 1)
-        (icmp IntPredicate.eq (LLVM.and e (const? 32 16)) (const? 32 0)))
+      (select (icmp IntPred.ne (LLVM.and e (const? 32 7)) (const? 32 3)) (const? 1 1)
+        (icmp IntPred.eq (LLVM.and e (const? 32 16)) (const? 32 0)))
       (const? 32 0) (const? 32 1) ⊑
-    zext 32 (icmp IntPredicate.eq (LLVM.and e (const? 32 23)) (const? 32 19)) := by
+    zext 32 (icmp IntPred.eq (LLVM.and e (const? 32 23)) (const? 32 19)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -628,9 +628,9 @@ theorem main6d_logical_thm (e : IntW 32) :
 
 
 theorem main7a_thm (e e_1 e_2 : IntW 32) :
-  select (LLVM.and (icmp IntPredicate.eq (LLVM.and e_2 e_1) e_2) (icmp IntPredicate.eq (LLVM.and e e_1) e))
+  select (LLVM.and (icmp IntPred.eq (LLVM.and e_2 e_1) e_2) (icmp IntPred.eq (LLVM.and e e_1) e))
       (const? 32 0) (const? 32 1) ⊑
-    zext 32 (icmp IntPredicate.ne (LLVM.and e_1 (LLVM.or e_2 e)) (LLVM.or e_2 e)) := by
+    zext 32 (icmp IntPred.ne (LLVM.and e_1 (LLVM.or e_2 e)) (LLVM.or e_2 e)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -640,11 +640,11 @@ theorem main7a_thm (e e_1 e_2 : IntW 32) :
 
 
 theorem main7a_logical_thm (e e_1 e_2 : IntW 32) :
-  select (select (icmp IntPredicate.eq (LLVM.and e_2 e_1) e_2) (icmp IntPredicate.eq (LLVM.and e e_1) e) (const? 1 0))
+  select (select (icmp IntPred.eq (LLVM.and e_2 e_1) e_2) (icmp IntPred.eq (LLVM.and e e_1) e) (const? 1 0))
       (const? 32 0) (const? 32 1) ⊑
     zext 32
-      (select (icmp IntPredicate.ne (LLVM.and e_2 e_1) e_2) (const? 1 1)
-        (icmp IntPredicate.ne (LLVM.and e e_1) e)) := by
+      (select (icmp IntPred.ne (LLVM.and e_2 e_1) e_2) (const? 1 1)
+        (icmp IntPred.ne (LLVM.and e e_1) e)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -655,11 +655,11 @@ theorem main7a_logical_thm (e e_1 e_2 : IntW 32) :
 
 theorem main7b_thm (e e_1 e_2 : IntW 32) :
   select
-      (LLVM.and (icmp IntPredicate.eq e_2 (LLVM.and e_1 e_2))
-        (icmp IntPredicate.eq (mul e (const? 32 42)) (LLVM.and e_1 (mul e (const? 32 42)))))
+      (LLVM.and (icmp IntPred.eq e_2 (LLVM.and e_1 e_2))
+        (icmp IntPred.eq (mul e (const? 32 42)) (LLVM.and e_1 (mul e (const? 32 42)))))
       (const? 32 0) (const? 32 1) ⊑
     zext 32
-      (icmp IntPredicate.ne (LLVM.and e_1 (LLVM.or e_2 (mul e (const? 32 42))))
+      (icmp IntPred.ne (LLVM.and e_1 (LLVM.or e_2 (mul e (const? 32 42))))
         (LLVM.or e_2 (mul e (const? 32 42)))) := by
     simp_alive_undef
     simp_alive_ops
@@ -670,11 +670,11 @@ theorem main7b_thm (e e_1 e_2 : IntW 32) :
 
 
 theorem main7b_logical_thm (e e_1 e_2 : IntW 32) :
-  select (select (icmp IntPredicate.eq e_2 (LLVM.and e_1 e_2)) (icmp IntPredicate.eq e (LLVM.and e_1 e)) (const? 1 0))
+  select (select (icmp IntPred.eq e_2 (LLVM.and e_1 e_2)) (icmp IntPred.eq e (LLVM.and e_1 e)) (const? 1 0))
       (const? 32 0) (const? 32 1) ⊑
     zext 32
-      (select (icmp IntPredicate.ne e_2 (LLVM.and e_1 e_2)) (const? 1 1)
-        (icmp IntPredicate.ne e (LLVM.and e_1 e))) := by
+      (select (icmp IntPred.ne e_2 (LLVM.and e_1 e_2)) (const? 1 1)
+        (icmp IntPred.ne e (LLVM.and e_1 e))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -685,11 +685,11 @@ theorem main7b_logical_thm (e e_1 e_2 : IntW 32) :
 
 theorem main7c_thm (e e_1 e_2 : IntW 32) :
   select
-      (LLVM.and (icmp IntPredicate.eq e_2 (LLVM.and e_2 e_1))
-        (icmp IntPredicate.eq (mul e (const? 32 42)) (LLVM.and (mul e (const? 32 42)) e_1)))
+      (LLVM.and (icmp IntPred.eq e_2 (LLVM.and e_2 e_1))
+        (icmp IntPred.eq (mul e (const? 32 42)) (LLVM.and (mul e (const? 32 42)) e_1)))
       (const? 32 0) (const? 32 1) ⊑
     zext 32
-      (icmp IntPredicate.ne (LLVM.and e_1 (LLVM.or e_2 (mul e (const? 32 42))))
+      (icmp IntPred.ne (LLVM.and e_1 (LLVM.or e_2 (mul e (const? 32 42))))
         (LLVM.or e_2 (mul e (const? 32 42)))) := by
     simp_alive_undef
     simp_alive_ops
@@ -700,11 +700,11 @@ theorem main7c_thm (e e_1 e_2 : IntW 32) :
 
 
 theorem main7c_logical_thm (e e_1 e_2 : IntW 32) :
-  select (select (icmp IntPredicate.eq e_2 (LLVM.and e_2 e_1)) (icmp IntPredicate.eq e (LLVM.and e e_1)) (const? 1 0))
+  select (select (icmp IntPred.eq e_2 (LLVM.and e_2 e_1)) (icmp IntPred.eq e (LLVM.and e e_1)) (const? 1 0))
       (const? 32 0) (const? 32 1) ⊑
     zext 32
-      (select (icmp IntPredicate.ne e_2 (LLVM.and e_2 e_1)) (const? 1 1)
-        (icmp IntPredicate.ne e (LLVM.and e e_1))) := by
+      (select (icmp IntPred.ne e_2 (LLVM.and e_2 e_1)) (const? 1 1)
+        (icmp IntPred.ne e (LLVM.and e e_1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -715,11 +715,11 @@ theorem main7c_logical_thm (e e_1 e_2 : IntW 32) :
 
 theorem main7d_thm (e e_1 e_2 e_3 e_4 : IntW 32) :
   select
-      (LLVM.and (icmp IntPredicate.eq (LLVM.and e_4 (LLVM.and e_3 e_2)) (LLVM.and e_3 e_2))
-        (icmp IntPredicate.eq (LLVM.and e_4 (LLVM.and e_1 e)) (LLVM.and e_1 e)))
+      (LLVM.and (icmp IntPred.eq (LLVM.and e_4 (LLVM.and e_3 e_2)) (LLVM.and e_3 e_2))
+        (icmp IntPred.eq (LLVM.and e_4 (LLVM.and e_1 e)) (LLVM.and e_1 e)))
       (const? 32 0) (const? 32 1) ⊑
     zext 32
-      (icmp IntPredicate.ne (LLVM.and e_4 (LLVM.or (LLVM.and e_3 e_2) (LLVM.and e_1 e)))
+      (icmp IntPred.ne (LLVM.and e_4 (LLVM.or (LLVM.and e_3 e_2) (LLVM.and e_1 e)))
         (LLVM.or (LLVM.and e_3 e_2) (LLVM.and e_1 e))) := by
     simp_alive_undef
     simp_alive_ops
@@ -731,12 +731,12 @@ theorem main7d_thm (e e_1 e_2 e_3 e_4 : IntW 32) :
 
 theorem main7d_logical_thm (e e_1 e_2 e_3 e_4 : IntW 32) :
   select
-      (select (icmp IntPredicate.eq (LLVM.and e_4 (LLVM.and e_3 e_2)) (LLVM.and e_3 e_2))
-        (icmp IntPredicate.eq (LLVM.and e_4 (LLVM.and e_1 e)) (LLVM.and e_1 e)) (const? 1 0))
+      (select (icmp IntPred.eq (LLVM.and e_4 (LLVM.and e_3 e_2)) (LLVM.and e_3 e_2))
+        (icmp IntPred.eq (LLVM.and e_4 (LLVM.and e_1 e)) (LLVM.and e_1 e)) (const? 1 0))
       (const? 32 0) (const? 32 1) ⊑
     zext 32
-      (select (icmp IntPredicate.ne (LLVM.and e_4 (LLVM.and e_3 e_2)) (LLVM.and e_3 e_2)) (const? 1 1)
-        (icmp IntPredicate.ne (LLVM.and e_4 (LLVM.and e_1 e)) (LLVM.and e_1 e))) := by
+      (select (icmp IntPred.ne (LLVM.and e_4 (LLVM.and e_3 e_2)) (LLVM.and e_3 e_2)) (const? 1 1)
+        (icmp IntPred.ne (LLVM.and e_4 (LLVM.and e_1 e)) (LLVM.and e_1 e))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -747,11 +747,11 @@ theorem main7d_logical_thm (e e_1 e_2 e_3 e_4 : IntW 32) :
 
 theorem main7e_thm (e e_1 e_2 e_3 e_4 : IntW 32) :
   select
-      (LLVM.and (icmp IntPredicate.eq (LLVM.and (LLVM.and e_4 e_3) e_2) (LLVM.and e_4 e_3))
-        (icmp IntPredicate.eq (LLVM.and (LLVM.and e_1 e) e_2) (LLVM.and e_1 e)))
+      (LLVM.and (icmp IntPred.eq (LLVM.and (LLVM.and e_4 e_3) e_2) (LLVM.and e_4 e_3))
+        (icmp IntPred.eq (LLVM.and (LLVM.and e_1 e) e_2) (LLVM.and e_1 e)))
       (const? 32 0) (const? 32 1) ⊑
     zext 32
-      (icmp IntPredicate.ne (LLVM.and e_2 (LLVM.or (LLVM.and e_4 e_3) (LLVM.and e_1 e)))
+      (icmp IntPred.ne (LLVM.and e_2 (LLVM.or (LLVM.and e_4 e_3) (LLVM.and e_1 e)))
         (LLVM.or (LLVM.and e_4 e_3) (LLVM.and e_1 e))) := by
     simp_alive_undef
     simp_alive_ops
@@ -763,12 +763,12 @@ theorem main7e_thm (e e_1 e_2 e_3 e_4 : IntW 32) :
 
 theorem main7e_logical_thm (e e_1 e_2 e_3 e_4 : IntW 32) :
   select
-      (select (icmp IntPredicate.eq (LLVM.and (LLVM.and e_4 e_3) e_2) (LLVM.and e_4 e_3))
-        (icmp IntPredicate.eq (LLVM.and (LLVM.and e_1 e) e_2) (LLVM.and e_1 e)) (const? 1 0))
+      (select (icmp IntPred.eq (LLVM.and (LLVM.and e_4 e_3) e_2) (LLVM.and e_4 e_3))
+        (icmp IntPred.eq (LLVM.and (LLVM.and e_1 e) e_2) (LLVM.and e_1 e)) (const? 1 0))
       (const? 32 0) (const? 32 1) ⊑
     zext 32
-      (select (icmp IntPredicate.ne (LLVM.and (LLVM.and e_4 e_3) e_2) (LLVM.and e_4 e_3)) (const? 1 1)
-        (icmp IntPredicate.ne (LLVM.and (LLVM.and e_1 e) e_2) (LLVM.and e_1 e))) := by
+      (select (icmp IntPred.ne (LLVM.and (LLVM.and e_4 e_3) e_2) (LLVM.and e_4 e_3)) (const? 1 1)
+        (icmp IntPred.ne (LLVM.and (LLVM.and e_1 e) e_2) (LLVM.and e_1 e))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -779,11 +779,11 @@ theorem main7e_logical_thm (e e_1 e_2 e_3 e_4 : IntW 32) :
 
 theorem main7f_thm (e e_1 e_2 e_3 e_4 : IntW 32) :
   select
-      (LLVM.and (icmp IntPredicate.eq (LLVM.and e_4 e_3) (LLVM.and e_2 (LLVM.and e_4 e_3)))
-        (icmp IntPredicate.eq (LLVM.and e_1 e) (LLVM.and e_2 (LLVM.and e_1 e))))
+      (LLVM.and (icmp IntPred.eq (LLVM.and e_4 e_3) (LLVM.and e_2 (LLVM.and e_4 e_3)))
+        (icmp IntPred.eq (LLVM.and e_1 e) (LLVM.and e_2 (LLVM.and e_1 e))))
       (const? 32 0) (const? 32 1) ⊑
     zext 32
-      (icmp IntPredicate.ne (LLVM.and e_2 (LLVM.or (LLVM.and e_4 e_3) (LLVM.and e_1 e)))
+      (icmp IntPred.ne (LLVM.and e_2 (LLVM.or (LLVM.and e_4 e_3) (LLVM.and e_1 e)))
         (LLVM.or (LLVM.and e_4 e_3) (LLVM.and e_1 e))) := by
     simp_alive_undef
     simp_alive_ops
@@ -795,12 +795,12 @@ theorem main7f_thm (e e_1 e_2 e_3 e_4 : IntW 32) :
 
 theorem main7f_logical_thm (e e_1 e_2 e_3 e_4 : IntW 32) :
   select
-      (select (icmp IntPredicate.eq (LLVM.and e_4 e_3) (LLVM.and e_2 (LLVM.and e_4 e_3)))
-        (icmp IntPredicate.eq (LLVM.and e_1 e) (LLVM.and e_2 (LLVM.and e_1 e))) (const? 1 0))
+      (select (icmp IntPred.eq (LLVM.and e_4 e_3) (LLVM.and e_2 (LLVM.and e_4 e_3)))
+        (icmp IntPred.eq (LLVM.and e_1 e) (LLVM.and e_2 (LLVM.and e_1 e))) (const? 1 0))
       (const? 32 0) (const? 32 1) ⊑
     zext 32
-      (select (icmp IntPredicate.ne (LLVM.and e_4 e_3) (LLVM.and e_2 (LLVM.and e_4 e_3))) (const? 1 1)
-        (icmp IntPredicate.ne (LLVM.and e_1 e) (LLVM.and e_2 (LLVM.and e_1 e)))) := by
+      (select (icmp IntPred.ne (LLVM.and e_4 e_3) (LLVM.and e_2 (LLVM.and e_4 e_3))) (const? 1 1)
+        (icmp IntPred.ne (LLVM.and e_1 e) (LLVM.and e_2 (LLVM.and e_1 e)))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -811,11 +811,11 @@ theorem main7f_logical_thm (e e_1 e_2 e_3 e_4 : IntW 32) :
 
 theorem main7g_thm (e e_1 e_2 e_3 e_4 : IntW 32) :
   select
-      (LLVM.and (icmp IntPredicate.eq (LLVM.and e_4 e_3) (LLVM.and (LLVM.and e_4 e_3) e_2))
-        (icmp IntPredicate.eq (LLVM.and e_1 e) (LLVM.and (LLVM.and e_1 e) e_2)))
+      (LLVM.and (icmp IntPred.eq (LLVM.and e_4 e_3) (LLVM.and (LLVM.and e_4 e_3) e_2))
+        (icmp IntPred.eq (LLVM.and e_1 e) (LLVM.and (LLVM.and e_1 e) e_2)))
       (const? 32 0) (const? 32 1) ⊑
     zext 32
-      (icmp IntPredicate.ne (LLVM.and e_2 (LLVM.or (LLVM.and e_4 e_3) (LLVM.and e_1 e)))
+      (icmp IntPred.ne (LLVM.and e_2 (LLVM.or (LLVM.and e_4 e_3) (LLVM.and e_1 e)))
         (LLVM.or (LLVM.and e_4 e_3) (LLVM.and e_1 e))) := by
     simp_alive_undef
     simp_alive_ops
@@ -827,12 +827,12 @@ theorem main7g_thm (e e_1 e_2 e_3 e_4 : IntW 32) :
 
 theorem main7g_logical_thm (e e_1 e_2 e_3 e_4 : IntW 32) :
   select
-      (select (icmp IntPredicate.eq (LLVM.and e_4 e_3) (LLVM.and (LLVM.and e_4 e_3) e_2))
-        (icmp IntPredicate.eq (LLVM.and e_1 e) (LLVM.and (LLVM.and e_1 e) e_2)) (const? 1 0))
+      (select (icmp IntPred.eq (LLVM.and e_4 e_3) (LLVM.and (LLVM.and e_4 e_3) e_2))
+        (icmp IntPred.eq (LLVM.and e_1 e) (LLVM.and (LLVM.and e_1 e) e_2)) (const? 1 0))
       (const? 32 0) (const? 32 1) ⊑
     zext 32
-      (select (icmp IntPredicate.ne (LLVM.and e_4 e_3) (LLVM.and (LLVM.and e_4 e_3) e_2)) (const? 1 1)
-        (icmp IntPredicate.ne (LLVM.and e_1 e) (LLVM.and (LLVM.and e_1 e) e_2))) := by
+      (select (icmp IntPred.ne (LLVM.and e_4 e_3) (LLVM.and (LLVM.and e_4 e_3) e_2)) (const? 1 1)
+        (icmp IntPred.ne (LLVM.and e_1 e) (LLVM.and (LLVM.and e_1 e) e_2))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -843,10 +843,10 @@ theorem main7g_logical_thm (e e_1 e_2 e_3 e_4 : IntW 32) :
 
 theorem main8_thm (e : IntW 32) :
   select
-      (LLVM.or (icmp IntPredicate.ne (LLVM.and e (const? 32 64)) (const? 32 0))
-        (icmp IntPredicate.slt (trunc 8 e) (const? 8 0)))
+      (LLVM.or (icmp IntPred.ne (LLVM.and e (const? 32 64)) (const? 32 0))
+        (icmp IntPred.slt (trunc 8 e) (const? 8 0)))
       (const? 32 2) (const? 32 1) ⊑
-    select (icmp IntPredicate.eq (LLVM.and e (const? 32 192)) (const? 32 0)) (const? 32 1) (const? 32 2) := by
+    select (icmp IntPred.eq (LLVM.and e (const? 32 192)) (const? 32 0)) (const? 32 1) (const? 32 2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -857,10 +857,10 @@ theorem main8_thm (e : IntW 32) :
 
 theorem main8_logical_thm (e : IntW 32) :
   select
-      (select (icmp IntPredicate.ne (LLVM.and e (const? 32 64)) (const? 32 0)) (const? 1 1)
-        (icmp IntPredicate.slt (trunc 8 e) (const? 8 0)))
+      (select (icmp IntPred.ne (LLVM.and e (const? 32 64)) (const? 32 0)) (const? 1 1)
+        (icmp IntPred.slt (trunc 8 e) (const? 8 0)))
       (const? 32 2) (const? 32 1) ⊑
-    select (icmp IntPredicate.eq (LLVM.and e (const? 32 192)) (const? 32 0)) (const? 32 1) (const? 32 2) := by
+    select (icmp IntPred.eq (LLVM.and e (const? 32 192)) (const? 32 0)) (const? 32 1) (const? 32 2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -871,10 +871,10 @@ theorem main8_logical_thm (e : IntW 32) :
 
 theorem main9_thm (e : IntW 32) :
   select
-      (LLVM.and (icmp IntPredicate.ne (LLVM.and e (const? 32 64)) (const? 32 0))
-        (icmp IntPredicate.slt (trunc 8 e) (const? 8 0)))
+      (LLVM.and (icmp IntPred.ne (LLVM.and e (const? 32 64)) (const? 32 0))
+        (icmp IntPred.slt (trunc 8 e) (const? 8 0)))
       (const? 32 2) (const? 32 1) ⊑
-    select (icmp IntPredicate.eq (LLVM.and e (const? 32 192)) (const? 32 192)) (const? 32 2) (const? 32 1) := by
+    select (icmp IntPred.eq (LLVM.and e (const? 32 192)) (const? 32 192)) (const? 32 2) (const? 32 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -885,10 +885,10 @@ theorem main9_thm (e : IntW 32) :
 
 theorem main9_logical_thm (e : IntW 32) :
   select
-      (select (icmp IntPredicate.ne (LLVM.and e (const? 32 64)) (const? 32 0))
-        (icmp IntPredicate.slt (trunc 8 e) (const? 8 0)) (const? 1 0))
+      (select (icmp IntPred.ne (LLVM.and e (const? 32 64)) (const? 32 0))
+        (icmp IntPred.slt (trunc 8 e) (const? 8 0)) (const? 1 0))
       (const? 32 2) (const? 32 1) ⊑
-    select (icmp IntPredicate.eq (LLVM.and e (const? 32 192)) (const? 32 192)) (const? 32 2) (const? 32 1) := by
+    select (icmp IntPred.eq (LLVM.and e (const? 32 192)) (const? 32 192)) (const? 32 2) (const? 32 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -899,10 +899,10 @@ theorem main9_logical_thm (e : IntW 32) :
 
 theorem main10_thm (e : IntW 32) :
   select
-      (LLVM.and (icmp IntPredicate.eq (LLVM.and e (const? 32 64)) (const? 32 0))
-        (icmp IntPredicate.sge (trunc 8 e) (const? 8 0)))
+      (LLVM.and (icmp IntPred.eq (LLVM.and e (const? 32 64)) (const? 32 0))
+        (icmp IntPred.sge (trunc 8 e) (const? 8 0)))
       (const? 32 2) (const? 32 1) ⊑
-    select (icmp IntPredicate.eq (LLVM.and e (const? 32 192)) (const? 32 0)) (const? 32 2) (const? 32 1) := by
+    select (icmp IntPred.eq (LLVM.and e (const? 32 192)) (const? 32 0)) (const? 32 2) (const? 32 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -913,10 +913,10 @@ theorem main10_thm (e : IntW 32) :
 
 theorem main10_logical_thm (e : IntW 32) :
   select
-      (select (icmp IntPredicate.eq (LLVM.and e (const? 32 64)) (const? 32 0))
-        (icmp IntPredicate.sge (trunc 8 e) (const? 8 0)) (const? 1 0))
+      (select (icmp IntPred.eq (LLVM.and e (const? 32 64)) (const? 32 0))
+        (icmp IntPred.sge (trunc 8 e) (const? 8 0)) (const? 1 0))
       (const? 32 2) (const? 32 1) ⊑
-    select (icmp IntPredicate.eq (LLVM.and e (const? 32 192)) (const? 32 0)) (const? 32 2) (const? 32 1) := by
+    select (icmp IntPred.eq (LLVM.and e (const? 32 192)) (const? 32 0)) (const? 32 2) (const? 32 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -927,10 +927,10 @@ theorem main10_logical_thm (e : IntW 32) :
 
 theorem main11_thm (e : IntW 32) :
   select
-      (LLVM.or (icmp IntPredicate.eq (LLVM.and e (const? 32 64)) (const? 32 0))
-        (icmp IntPredicate.sge (trunc 8 e) (const? 8 0)))
+      (LLVM.or (icmp IntPred.eq (LLVM.and e (const? 32 64)) (const? 32 0))
+        (icmp IntPred.sge (trunc 8 e) (const? 8 0)))
       (const? 32 2) (const? 32 1) ⊑
-    select (icmp IntPredicate.eq (LLVM.and e (const? 32 192)) (const? 32 192)) (const? 32 1) (const? 32 2) := by
+    select (icmp IntPred.eq (LLVM.and e (const? 32 192)) (const? 32 192)) (const? 32 1) (const? 32 2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -941,10 +941,10 @@ theorem main11_thm (e : IntW 32) :
 
 theorem main11_logical_thm (e : IntW 32) :
   select
-      (select (icmp IntPredicate.eq (LLVM.and e (const? 32 64)) (const? 32 0)) (const? 1 1)
-        (icmp IntPredicate.sge (trunc 8 e) (const? 8 0)))
+      (select (icmp IntPred.eq (LLVM.and e (const? 32 64)) (const? 32 0)) (const? 1 1)
+        (icmp IntPred.sge (trunc 8 e) (const? 8 0)))
       (const? 32 2) (const? 32 1) ⊑
-    select (icmp IntPredicate.eq (LLVM.and e (const? 32 192)) (const? 32 192)) (const? 32 1) (const? 32 2) := by
+    select (icmp IntPred.eq (LLVM.and e (const? 32 192)) (const? 32 192)) (const? 32 1) (const? 32 2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -954,9 +954,9 @@ theorem main11_logical_thm (e : IntW 32) :
 
 
 theorem main12_thm (e : IntW 32) :
-  select (LLVM.or (icmp IntPredicate.slt (trunc 16 e) (const? 16 0)) (icmp IntPredicate.slt (trunc 8 e) (const? 8 0)))
+  select (LLVM.or (icmp IntPred.slt (trunc 16 e) (const? 16 0)) (icmp IntPred.slt (trunc 8 e) (const? 8 0)))
       (const? 32 2) (const? 32 1) ⊑
-    select (icmp IntPredicate.eq (LLVM.and e (const? 32 32896)) (const? 32 0)) (const? 32 1) (const? 32 2) := by
+    select (icmp IntPred.eq (LLVM.and e (const? 32 32896)) (const? 32 0)) (const? 32 1) (const? 32 2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -967,10 +967,10 @@ theorem main12_thm (e : IntW 32) :
 
 theorem main12_logical_thm (e : IntW 32) :
   select
-      (select (icmp IntPredicate.slt (trunc 16 e) (const? 16 0)) (const? 1 1)
-        (icmp IntPredicate.slt (trunc 8 e) (const? 8 0)))
+      (select (icmp IntPred.slt (trunc 16 e) (const? 16 0)) (const? 1 1)
+        (icmp IntPred.slt (trunc 8 e) (const? 8 0)))
       (const? 32 2) (const? 32 1) ⊑
-    select (icmp IntPredicate.eq (LLVM.and e (const? 32 32896)) (const? 32 0)) (const? 32 1) (const? 32 2) := by
+    select (icmp IntPred.eq (LLVM.and e (const? 32 32896)) (const? 32 0)) (const? 32 1) (const? 32 2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -980,9 +980,9 @@ theorem main12_logical_thm (e : IntW 32) :
 
 
 theorem main13_thm (e : IntW 32) :
-  select (LLVM.and (icmp IntPredicate.slt (trunc 16 e) (const? 16 0)) (icmp IntPredicate.slt (trunc 8 e) (const? 8 0)))
+  select (LLVM.and (icmp IntPred.slt (trunc 16 e) (const? 16 0)) (icmp IntPred.slt (trunc 8 e) (const? 8 0)))
       (const? 32 2) (const? 32 1) ⊑
-    select (icmp IntPredicate.eq (LLVM.and e (const? 32 32896)) (const? 32 32896)) (const? 32 2) (const? 32 1) := by
+    select (icmp IntPred.eq (LLVM.and e (const? 32 32896)) (const? 32 32896)) (const? 32 2) (const? 32 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -993,10 +993,10 @@ theorem main13_thm (e : IntW 32) :
 
 theorem main13_logical_thm (e : IntW 32) :
   select
-      (select (icmp IntPredicate.slt (trunc 16 e) (const? 16 0)) (icmp IntPredicate.slt (trunc 8 e) (const? 8 0))
+      (select (icmp IntPred.slt (trunc 16 e) (const? 16 0)) (icmp IntPred.slt (trunc 8 e) (const? 8 0))
         (const? 1 0))
       (const? 32 2) (const? 32 1) ⊑
-    select (icmp IntPredicate.eq (LLVM.and e (const? 32 32896)) (const? 32 32896)) (const? 32 2) (const? 32 1) := by
+    select (icmp IntPred.eq (LLVM.and e (const? 32 32896)) (const? 32 32896)) (const? 32 2) (const? 32 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1006,9 +1006,9 @@ theorem main13_logical_thm (e : IntW 32) :
 
 
 theorem main14_thm (e : IntW 32) :
-  select (LLVM.and (icmp IntPredicate.sge (trunc 16 e) (const? 16 0)) (icmp IntPredicate.sge (trunc 8 e) (const? 8 0)))
+  select (LLVM.and (icmp IntPred.sge (trunc 16 e) (const? 16 0)) (icmp IntPred.sge (trunc 8 e) (const? 8 0)))
       (const? 32 2) (const? 32 1) ⊑
-    select (icmp IntPredicate.eq (LLVM.and e (const? 32 32896)) (const? 32 0)) (const? 32 2) (const? 32 1) := by
+    select (icmp IntPred.eq (LLVM.and e (const? 32 32896)) (const? 32 0)) (const? 32 2) (const? 32 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1019,10 +1019,10 @@ theorem main14_thm (e : IntW 32) :
 
 theorem main14_logical_thm (e : IntW 32) :
   select
-      (select (icmp IntPredicate.sge (trunc 16 e) (const? 16 0)) (icmp IntPredicate.sge (trunc 8 e) (const? 8 0))
+      (select (icmp IntPred.sge (trunc 16 e) (const? 16 0)) (icmp IntPred.sge (trunc 8 e) (const? 8 0))
         (const? 1 0))
       (const? 32 2) (const? 32 1) ⊑
-    select (icmp IntPredicate.eq (LLVM.and e (const? 32 32896)) (const? 32 0)) (const? 32 2) (const? 32 1) := by
+    select (icmp IntPred.eq (LLVM.and e (const? 32 32896)) (const? 32 0)) (const? 32 2) (const? 32 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1032,9 +1032,9 @@ theorem main14_logical_thm (e : IntW 32) :
 
 
 theorem main15_thm (e : IntW 32) :
-  select (LLVM.or (icmp IntPredicate.sge (trunc 16 e) (const? 16 0)) (icmp IntPredicate.sge (trunc 8 e) (const? 8 0)))
+  select (LLVM.or (icmp IntPred.sge (trunc 16 e) (const? 16 0)) (icmp IntPred.sge (trunc 8 e) (const? 8 0)))
       (const? 32 2) (const? 32 1) ⊑
-    select (icmp IntPredicate.eq (LLVM.and e (const? 32 32896)) (const? 32 32896)) (const? 32 1) (const? 32 2) := by
+    select (icmp IntPred.eq (LLVM.and e (const? 32 32896)) (const? 32 32896)) (const? 32 1) (const? 32 2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1045,10 +1045,10 @@ theorem main15_thm (e : IntW 32) :
 
 theorem main15_logical_thm (e : IntW 32) :
   select
-      (select (icmp IntPredicate.sge (trunc 16 e) (const? 16 0)) (const? 1 1)
-        (icmp IntPredicate.sge (trunc 8 e) (const? 8 0)))
+      (select (icmp IntPred.sge (trunc 16 e) (const? 16 0)) (const? 1 1)
+        (icmp IntPred.sge (trunc 8 e) (const? 8 0)))
       (const? 32 2) (const? 32 1) ⊑
-    select (icmp IntPredicate.eq (LLVM.and e (const? 32 32896)) (const? 32 32896)) (const? 32 1) (const? 32 2) := by
+    select (icmp IntPred.eq (LLVM.and e (const? 32 32896)) (const? 32 32896)) (const? 32 1) (const? 32 2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1058,10 +1058,10 @@ theorem main15_logical_thm (e : IntW 32) :
 
 
 theorem no_masks_with_logical_or_thm (e e_1 e_2 : IntW 32) :
-  LLVM.or (select (icmp IntPredicate.ne e_2 (const? 32 0)) (const? 1 1) (icmp IntPredicate.ne e_1 (const? 32 63)))
-      (icmp IntPredicate.ne e (const? 32 0)) ⊑
-    select (icmp IntPredicate.ne (LLVM.or e_2 e) (const? 32 0)) (const? 1 1)
-      (icmp IntPredicate.ne e_1 (const? 32 63)) := by
+  LLVM.or (select (icmp IntPred.ne e_2 (const? 32 0)) (const? 1 1) (icmp IntPred.ne e_1 (const? 32 63)))
+      (icmp IntPred.ne e (const? 32 0)) ⊑
+    select (icmp IntPred.ne (LLVM.or e_2 e) (const? 32 0)) (const? 1 1)
+      (icmp IntPred.ne e_1 (const? 32 63)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1071,10 +1071,10 @@ theorem no_masks_with_logical_or_thm (e e_1 e_2 : IntW 32) :
 
 
 theorem no_masks_with_logical_or2_thm (e e_1 e_2 : IntW 32) :
-  LLVM.or (select (icmp IntPredicate.ne e_2 (const? 32 (-1))) (const? 1 1) (icmp IntPredicate.ne e_1 (const? 32 63)))
-      (icmp IntPredicate.ne e (const? 32 (-1))) ⊑
-    select (icmp IntPredicate.ne (LLVM.and e_2 e) (const? 32 (-1))) (const? 1 1)
-      (icmp IntPredicate.ne e_1 (const? 32 63)) := by
+  LLVM.or (select (icmp IntPred.ne e_2 (const? 32 (-1))) (const? 1 1) (icmp IntPred.ne e_1 (const? 32 63)))
+      (icmp IntPred.ne e (const? 32 (-1))) ⊑
+    select (icmp IntPred.ne (LLVM.and e_2 e) (const? 32 (-1))) (const? 1 1)
+      (icmp IntPred.ne e_1 (const? 32 63)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1084,9 +1084,9 @@ theorem no_masks_with_logical_or2_thm (e e_1 e_2 : IntW 32) :
 
 
 theorem only_one_masked_thm (e : IntW 64) :
-  LLVM.and (icmp IntPredicate.ne e (const? 64 0))
-      (icmp IntPredicate.eq (LLVM.and e (const? 64 9223372036854775807)) (const? 64 0)) ⊑
-    icmp IntPredicate.eq e (const? 64 (-9223372036854775808)) := by
+  LLVM.and (icmp IntPred.ne e (const? 64 0))
+      (icmp IntPred.eq (LLVM.and e (const? 64 9223372036854775807)) (const? 64 0)) ⊑
+    icmp IntPred.eq e (const? 64 (-9223372036854775808)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gcanonicalizehclamphlikehpatternhbetweenhnegativehandhpositivehthresholds_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gcanonicalizehclamphlikehpatternhbetweenhnegativehandhpositivehthresholds_proof.lean
@@ -12,10 +12,10 @@ set_option Elab.async false
 
 section gcanonicalizehclamphlikehpatternhbetweenhnegativehandhpositivehthresholds_proof
 theorem t0_ult_slt_128_thm (e e_1 e_2 : IntW 32) :
-  select (icmp IntPredicate.ult (add e_2 (const? 32 16)) (const? 32 144)) e_2
-      (select (icmp IntPredicate.slt e_2 (const? 32 128)) e_1 e) ⊑
-    select (icmp IntPredicate.sgt e_2 (const? 32 127)) e
-      (select (icmp IntPredicate.slt e_2 (const? 32 (-16))) e_1 e_2) := by
+  select (icmp IntPred.ult (add e_2 (const? 32 16)) (const? 32 144)) e_2
+      (select (icmp IntPred.slt e_2 (const? 32 128)) e_1 e) ⊑
+    select (icmp IntPred.sgt e_2 (const? 32 127)) e
+      (select (icmp IntPred.slt e_2 (const? 32 (-16))) e_1 e_2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -25,10 +25,10 @@ theorem t0_ult_slt_128_thm (e e_1 e_2 : IntW 32) :
 
 
 theorem t1_ult_slt_0_thm (e e_1 e_2 : IntW 32) :
-  select (icmp IntPredicate.ult (add e_2 (const? 32 16)) (const? 32 144)) e_2
-      (select (icmp IntPredicate.slt e_2 (const? 32 (-16))) e_1 e) ⊑
-    select (icmp IntPredicate.sgt e_2 (const? 32 127)) e
-      (select (icmp IntPredicate.slt e_2 (const? 32 (-16))) e_1 e_2) := by
+  select (icmp IntPred.ult (add e_2 (const? 32 16)) (const? 32 144)) e_2
+      (select (icmp IntPred.slt e_2 (const? 32 (-16))) e_1 e) ⊑
+    select (icmp IntPred.sgt e_2 (const? 32 127)) e
+      (select (icmp IntPred.slt e_2 (const? 32 (-16))) e_1 e_2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -38,10 +38,10 @@ theorem t1_ult_slt_0_thm (e e_1 e_2 : IntW 32) :
 
 
 theorem t2_ult_sgt_128_thm (e e_1 e_2 : IntW 32) :
-  select (icmp IntPredicate.ult (add e_2 (const? 32 16)) (const? 32 144)) e_2
-      (select (icmp IntPredicate.sgt e_2 (const? 32 127)) e_1 e) ⊑
-    select (icmp IntPredicate.sgt e_2 (const? 32 127)) e_1
-      (select (icmp IntPredicate.slt e_2 (const? 32 (-16))) e e_2) := by
+  select (icmp IntPred.ult (add e_2 (const? 32 16)) (const? 32 144)) e_2
+      (select (icmp IntPred.sgt e_2 (const? 32 127)) e_1 e) ⊑
+    select (icmp IntPred.sgt e_2 (const? 32 127)) e_1
+      (select (icmp IntPred.slt e_2 (const? 32 (-16))) e e_2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -51,10 +51,10 @@ theorem t2_ult_sgt_128_thm (e e_1 e_2 : IntW 32) :
 
 
 theorem t3_ult_sgt_neg1_thm (e e_1 e_2 : IntW 32) :
-  select (icmp IntPredicate.ult (add e_2 (const? 32 16)) (const? 32 144)) e_2
-      (select (icmp IntPredicate.sgt e_2 (const? 32 (-17))) e_1 e) ⊑
-    select (icmp IntPredicate.sgt e_2 (const? 32 127)) e_1
-      (select (icmp IntPredicate.slt e_2 (const? 32 (-16))) e e_2) := by
+  select (icmp IntPred.ult (add e_2 (const? 32 16)) (const? 32 144)) e_2
+      (select (icmp IntPred.sgt e_2 (const? 32 (-17))) e_1 e) ⊑
+    select (icmp IntPred.sgt e_2 (const? 32 127)) e_1
+      (select (icmp IntPred.slt e_2 (const? 32 (-16))) e e_2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -64,10 +64,10 @@ theorem t3_ult_sgt_neg1_thm (e e_1 e_2 : IntW 32) :
 
 
 theorem t4_ugt_slt_128_thm (e e_1 e_2 : IntW 32) :
-  select (icmp IntPredicate.ugt (add e_2 (const? 32 16)) (const? 32 143))
-      (select (icmp IntPredicate.slt e_2 (const? 32 128)) e_1 e) e_2 ⊑
-    select (icmp IntPredicate.sgt e_2 (const? 32 127)) e
-      (select (icmp IntPredicate.slt e_2 (const? 32 (-16))) e_1 e_2) := by
+  select (icmp IntPred.ugt (add e_2 (const? 32 16)) (const? 32 143))
+      (select (icmp IntPred.slt e_2 (const? 32 128)) e_1 e) e_2 ⊑
+    select (icmp IntPred.sgt e_2 (const? 32 127)) e
+      (select (icmp IntPred.slt e_2 (const? 32 (-16))) e_1 e_2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -77,10 +77,10 @@ theorem t4_ugt_slt_128_thm (e e_1 e_2 : IntW 32) :
 
 
 theorem t5_ugt_slt_0_thm (e e_1 e_2 : IntW 32) :
-  select (icmp IntPredicate.ugt (add e_2 (const? 32 16)) (const? 32 143))
-      (select (icmp IntPredicate.slt e_2 (const? 32 (-16))) e_1 e) e_2 ⊑
-    select (icmp IntPredicate.sgt e_2 (const? 32 127)) e
-      (select (icmp IntPredicate.slt e_2 (const? 32 (-16))) e_1 e_2) := by
+  select (icmp IntPred.ugt (add e_2 (const? 32 16)) (const? 32 143))
+      (select (icmp IntPred.slt e_2 (const? 32 (-16))) e_1 e) e_2 ⊑
+    select (icmp IntPred.sgt e_2 (const? 32 127)) e
+      (select (icmp IntPred.slt e_2 (const? 32 (-16))) e_1 e_2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -90,10 +90,10 @@ theorem t5_ugt_slt_0_thm (e e_1 e_2 : IntW 32) :
 
 
 theorem t6_ugt_sgt_128_thm (e e_1 e_2 : IntW 32) :
-  select (icmp IntPredicate.ugt (add e_2 (const? 32 16)) (const? 32 143))
-      (select (icmp IntPredicate.sgt e_2 (const? 32 127)) e_1 e) e_2 ⊑
-    select (icmp IntPredicate.sgt e_2 (const? 32 127)) e_1
-      (select (icmp IntPredicate.slt e_2 (const? 32 (-16))) e e_2) := by
+  select (icmp IntPred.ugt (add e_2 (const? 32 16)) (const? 32 143))
+      (select (icmp IntPred.sgt e_2 (const? 32 127)) e_1 e) e_2 ⊑
+    select (icmp IntPred.sgt e_2 (const? 32 127)) e_1
+      (select (icmp IntPred.slt e_2 (const? 32 (-16))) e e_2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -103,10 +103,10 @@ theorem t6_ugt_sgt_128_thm (e e_1 e_2 : IntW 32) :
 
 
 theorem t7_ugt_sgt_neg1_thm (e e_1 e_2 : IntW 32) :
-  select (icmp IntPredicate.ugt (add e_2 (const? 32 16)) (const? 32 143))
-      (select (icmp IntPredicate.sgt e_2 (const? 32 (-17))) e_1 e) e_2 ⊑
-    select (icmp IntPredicate.sgt e_2 (const? 32 127)) e_1
-      (select (icmp IntPredicate.slt e_2 (const? 32 (-16))) e e_2) := by
+  select (icmp IntPred.ugt (add e_2 (const? 32 16)) (const? 32 143))
+      (select (icmp IntPred.sgt e_2 (const? 32 (-17))) e_1 e) e_2 ⊑
+    select (icmp IntPred.sgt e_2 (const? 32 127)) e_1
+      (select (icmp IntPred.slt e_2 (const? 32 (-16))) e e_2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -116,8 +116,8 @@ theorem t7_ugt_sgt_neg1_thm (e e_1 e_2 : IntW 32) :
 
 
 theorem n10_ugt_slt_thm (e e_1 e_2 : IntW 32) :
-  select (icmp IntPredicate.ugt e_2 (const? 32 128)) e_2 (select (icmp IntPredicate.slt e_2 (const? 32 0)) e_1 e) ⊑
-    select (icmp IntPredicate.ugt e_2 (const? 32 128)) e_2 e := by
+  select (icmp IntPred.ugt e_2 (const? 32 128)) e_2 (select (icmp IntPred.slt e_2 (const? 32 0)) e_1 e) ⊑
+    select (icmp IntPred.ugt e_2 (const? 32 128)) e_2 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -127,8 +127,8 @@ theorem n10_ugt_slt_thm (e e_1 e_2 : IntW 32) :
 
 
 theorem n11_uge_slt_thm (e e_1 e_2 : IntW 32) :
-  select (icmp IntPredicate.ult e_2 (const? 32 129)) (select (icmp IntPredicate.slt e_2 (const? 32 0)) e_1 e) e_2 ⊑
-    select (icmp IntPredicate.ult e_2 (const? 32 129)) e e_2 := by
+  select (icmp IntPred.ult e_2 (const? 32 129)) (select (icmp IntPred.slt e_2 (const? 32 0)) e_1 e) e_2 ⊑
+    select (icmp IntPred.ult e_2 (const? 32 129)) e e_2 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gcanonicalizehclamphlikehpatternhbetweenhzerohandhpositivehthreshold_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gcanonicalizehclamphlikehpatternhbetweenhzerohandhpositivehthreshold_proof.lean
@@ -12,10 +12,10 @@ set_option Elab.async false
 
 section gcanonicalizehclamphlikehpatternhbetweenhzerohandhpositivehthreshold_proof
 theorem t0_ult_slt_65536_thm (e e_1 e_2 : IntW 32) :
-  select (icmp IntPredicate.ult e_2 (const? 32 65536)) e_2
-      (select (icmp IntPredicate.slt e_2 (const? 32 65536)) e_1 e) ⊑
-    select (icmp IntPredicate.sgt e_2 (const? 32 65535)) e
-      (select (icmp IntPredicate.slt e_2 (const? 32 0)) e_1 e_2) := by
+  select (icmp IntPred.ult e_2 (const? 32 65536)) e_2
+      (select (icmp IntPred.slt e_2 (const? 32 65536)) e_1 e) ⊑
+    select (icmp IntPred.sgt e_2 (const? 32 65535)) e
+      (select (icmp IntPred.slt e_2 (const? 32 0)) e_1 e_2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -25,9 +25,9 @@ theorem t0_ult_slt_65536_thm (e e_1 e_2 : IntW 32) :
 
 
 theorem t1_ult_slt_0_thm (e e_1 e_2 : IntW 32) :
-  select (icmp IntPredicate.ult e_2 (const? 32 65536)) e_2 (select (icmp IntPredicate.slt e_2 (const? 32 0)) e_1 e) ⊑
-    select (icmp IntPredicate.sgt e_2 (const? 32 65535)) e
-      (select (icmp IntPredicate.slt e_2 (const? 32 0)) e_1 e_2) := by
+  select (icmp IntPred.ult e_2 (const? 32 65536)) e_2 (select (icmp IntPred.slt e_2 (const? 32 0)) e_1 e) ⊑
+    select (icmp IntPred.sgt e_2 (const? 32 65535)) e
+      (select (icmp IntPred.slt e_2 (const? 32 0)) e_1 e_2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -37,10 +37,10 @@ theorem t1_ult_slt_0_thm (e e_1 e_2 : IntW 32) :
 
 
 theorem t2_ult_sgt_65536_thm (e e_1 e_2 : IntW 32) :
-  select (icmp IntPredicate.ult e_2 (const? 32 65536)) e_2
-      (select (icmp IntPredicate.sgt e_2 (const? 32 65535)) e_1 e) ⊑
-    select (icmp IntPredicate.sgt e_2 (const? 32 65535)) e_1
-      (select (icmp IntPredicate.slt e_2 (const? 32 0)) e e_2) := by
+  select (icmp IntPred.ult e_2 (const? 32 65536)) e_2
+      (select (icmp IntPred.sgt e_2 (const? 32 65535)) e_1 e) ⊑
+    select (icmp IntPred.sgt e_2 (const? 32 65535)) e_1
+      (select (icmp IntPred.slt e_2 (const? 32 0)) e e_2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -50,9 +50,9 @@ theorem t2_ult_sgt_65536_thm (e e_1 e_2 : IntW 32) :
 
 
 theorem t3_ult_sgt_neg1_thm (e e_1 e_2 : IntW 32) :
-  select (icmp IntPredicate.ult e_2 (const? 32 65536)) e_2 (select (icmp IntPredicate.sgt e_2 (const? 32 (-1))) e_1 e) ⊑
-    select (icmp IntPredicate.sgt e_2 (const? 32 65535)) e_1
-      (select (icmp IntPredicate.slt e_2 (const? 32 0)) e e_2) := by
+  select (icmp IntPred.ult e_2 (const? 32 65536)) e_2 (select (icmp IntPred.sgt e_2 (const? 32 (-1))) e_1 e) ⊑
+    select (icmp IntPred.sgt e_2 (const? 32 65535)) e_1
+      (select (icmp IntPred.slt e_2 (const? 32 0)) e e_2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -62,10 +62,10 @@ theorem t3_ult_sgt_neg1_thm (e e_1 e_2 : IntW 32) :
 
 
 theorem t4_ugt_slt_65536_thm (e e_1 e_2 : IntW 32) :
-  select (icmp IntPredicate.ugt e_2 (const? 32 65535)) (select (icmp IntPredicate.slt e_2 (const? 32 65536)) e_1 e)
+  select (icmp IntPred.ugt e_2 (const? 32 65535)) (select (icmp IntPred.slt e_2 (const? 32 65536)) e_1 e)
       e_2 ⊑
-    select (icmp IntPredicate.sgt e_2 (const? 32 65535)) e
-      (select (icmp IntPredicate.slt e_2 (const? 32 0)) e_1 e_2) := by
+    select (icmp IntPred.sgt e_2 (const? 32 65535)) e
+      (select (icmp IntPred.slt e_2 (const? 32 0)) e_1 e_2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -75,9 +75,9 @@ theorem t4_ugt_slt_65536_thm (e e_1 e_2 : IntW 32) :
 
 
 theorem t5_ugt_slt_0_thm (e e_1 e_2 : IntW 32) :
-  select (icmp IntPredicate.ugt e_2 (const? 32 65535)) (select (icmp IntPredicate.slt e_2 (const? 32 0)) e_1 e) e_2 ⊑
-    select (icmp IntPredicate.sgt e_2 (const? 32 65535)) e
-      (select (icmp IntPredicate.slt e_2 (const? 32 0)) e_1 e_2) := by
+  select (icmp IntPred.ugt e_2 (const? 32 65535)) (select (icmp IntPred.slt e_2 (const? 32 0)) e_1 e) e_2 ⊑
+    select (icmp IntPred.sgt e_2 (const? 32 65535)) e
+      (select (icmp IntPred.slt e_2 (const? 32 0)) e_1 e_2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -87,10 +87,10 @@ theorem t5_ugt_slt_0_thm (e e_1 e_2 : IntW 32) :
 
 
 theorem t6_ugt_sgt_65536_thm (e e_1 e_2 : IntW 32) :
-  select (icmp IntPredicate.ugt e_2 (const? 32 65535)) (select (icmp IntPredicate.sgt e_2 (const? 32 65535)) e_1 e)
+  select (icmp IntPred.ugt e_2 (const? 32 65535)) (select (icmp IntPred.sgt e_2 (const? 32 65535)) e_1 e)
       e_2 ⊑
-    select (icmp IntPredicate.sgt e_2 (const? 32 65535)) e_1
-      (select (icmp IntPredicate.slt e_2 (const? 32 0)) e e_2) := by
+    select (icmp IntPred.sgt e_2 (const? 32 65535)) e_1
+      (select (icmp IntPred.slt e_2 (const? 32 0)) e e_2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -100,9 +100,9 @@ theorem t6_ugt_sgt_65536_thm (e e_1 e_2 : IntW 32) :
 
 
 theorem t7_ugt_sgt_neg1_thm (e e_1 e_2 : IntW 32) :
-  select (icmp IntPredicate.ugt e_2 (const? 32 65535)) (select (icmp IntPredicate.sgt e_2 (const? 32 (-1))) e_1 e) e_2 ⊑
-    select (icmp IntPredicate.sgt e_2 (const? 32 65535)) e_1
-      (select (icmp IntPredicate.slt e_2 (const? 32 0)) e e_2) := by
+  select (icmp IntPred.ugt e_2 (const? 32 65535)) (select (icmp IntPred.sgt e_2 (const? 32 (-1))) e_1 e) e_2 ⊑
+    select (icmp IntPred.sgt e_2 (const? 32 65535)) e_1
+      (select (icmp IntPred.slt e_2 (const? 32 0)) e e_2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gcanonicalizehconstanthlowhbithmaskhandhicmpheqhtohicmphule_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gcanonicalizehconstanthlowhbithmaskhandhicmpheqhtohicmphule_proof.lean
@@ -12,7 +12,7 @@ set_option Elab.async false
 
 section gcanonicalizehconstanthlowhbithmaskhandhicmpheqhtohicmphule_proof
 theorem p0_thm (e : IntW 8) :
-  icmp IntPredicate.eq (LLVM.and e (const? 8 3)) e ⊑ icmp IntPredicate.ult e (const? 8 4) := by
+  icmp IntPred.eq (LLVM.and e (const? 8 3)) e ⊑ icmp IntPred.ult e (const? 8 4) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -22,8 +22,8 @@ theorem p0_thm (e : IntW 8) :
 
 
 theorem pv_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.eq (LLVM.and (lshr (const? 8 (-1)) e_1) e) e ⊑
-    icmp IntPredicate.ule e (lshr (const? 8 (-1)) e_1) := by
+  icmp IntPred.eq (LLVM.and (lshr (const? 8 (-1)) e_1) e) e ⊑
+    icmp IntPred.ule e (lshr (const? 8 (-1)) e_1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -33,8 +33,8 @@ theorem pv_thm (e e_1 : IntW 8) :
 
 
 theorem n0_thm (e : IntW 8) :
-  icmp IntPredicate.eq (LLVM.and e (const? 8 4)) e ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 8 (-5))) (const? 8 0) := by
+  icmp IntPred.eq (LLVM.and e (const? 8 4)) e ⊑
+    icmp IntPred.eq (LLVM.and e (const? 8 (-5))) (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gcanonicalizehconstanthlowhbithmaskhandhicmphnehtohicmphugt_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gcanonicalizehconstanthlowhbithmaskhandhicmphnehtohicmphugt_proof.lean
@@ -12,7 +12,7 @@ set_option Elab.async false
 
 section gcanonicalizehconstanthlowhbithmaskhandhicmphnehtohicmphugt_proof
 theorem p0_thm (e : IntW 8) :
-  icmp IntPredicate.ne (LLVM.and e (const? 8 3)) e ⊑ icmp IntPredicate.ugt e (const? 8 3) := by
+  icmp IntPred.ne (LLVM.and e (const? 8 3)) e ⊑ icmp IntPred.ugt e (const? 8 3) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -22,8 +22,8 @@ theorem p0_thm (e : IntW 8) :
 
 
 theorem pv_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.ne (LLVM.and (lshr (const? 8 (-1)) e_1) e) e ⊑
-    icmp IntPredicate.ugt e (lshr (const? 8 (-1)) e_1) := by
+  icmp IntPred.ne (LLVM.and (lshr (const? 8 (-1)) e_1) e) e ⊑
+    icmp IntPred.ugt e (lshr (const? 8 (-1)) e_1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -33,8 +33,8 @@ theorem pv_thm (e e_1 : IntW 8) :
 
 
 theorem n0_thm (e : IntW 8) :
-  icmp IntPredicate.ne (LLVM.and e (const? 8 4)) e ⊑
-    icmp IntPredicate.ne (LLVM.and e (const? 8 (-5))) (const? 8 0) := by
+  icmp IntPred.ne (LLVM.and e (const? 8 4)) e ⊑
+    icmp IntPred.ne (LLVM.and e (const? 8 (-5))) (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gcanonicalizehconstanthlowhbithmaskhandhicmphsgehtohicmphsle_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gcanonicalizehconstanthlowhbithmaskhandhicmphsgehtohicmphsle_proof.lean
@@ -12,7 +12,7 @@ set_option Elab.async false
 
 section gcanonicalizehconstanthlowhbithmaskhandhicmphsgehtohicmphsle_proof
 theorem p0_thm (e : IntW 8) :
-  icmp IntPredicate.sge (LLVM.and e (const? 8 3)) e ⊑ icmp IntPredicate.slt e (const? 8 4) := by
+  icmp IntPred.sge (LLVM.and e (const? 8 3)) e ⊑ icmp IntPred.slt e (const? 8 4) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gcanonicalizehconstanthlowhbithmaskhandhicmphsgthtohicmphsgt_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gcanonicalizehconstanthlowhbithmaskhandhicmphsgthtohicmphsgt_proof.lean
@@ -12,7 +12,7 @@ set_option Elab.async false
 
 section gcanonicalizehconstanthlowhbithmaskhandhicmphsgthtohicmphsgt_proof
 theorem c0_thm (e : IntW 8) :
-  icmp IntPredicate.sgt (LLVM.and e (const? 8 3)) e ⊑ icmp IntPredicate.slt e (const? 8 0) := by
+  icmp IntPred.sgt (LLVM.and e (const? 8 3)) e ⊑ icmp IntPred.slt e (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gcanonicalizehconstanthlowhbithmaskhandhicmphslehtohicmphsle_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gcanonicalizehconstanthlowhbithmaskhandhicmphslehtohicmphsle_proof.lean
@@ -12,7 +12,7 @@ set_option Elab.async false
 
 section gcanonicalizehconstanthlowhbithmaskhandhicmphslehtohicmphsle_proof
 theorem c0_thm (e : IntW 8) :
-  icmp IntPredicate.sle (LLVM.and e (const? 8 3)) e ⊑ icmp IntPredicate.sgt e (const? 8 (-1)) := by
+  icmp IntPred.sle (LLVM.and e (const? 8 3)) e ⊑ icmp IntPred.sgt e (const? 8 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gcanonicalizehconstanthlowhbithmaskhandhicmphslthtohicmphsgt_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gcanonicalizehconstanthlowhbithmaskhandhicmphslthtohicmphsgt_proof.lean
@@ -12,7 +12,7 @@ set_option Elab.async false
 
 section gcanonicalizehconstanthlowhbithmaskhandhicmphslthtohicmphsgt_proof
 theorem p0_thm (e : IntW 8) :
-  icmp IntPredicate.slt (LLVM.and e (const? 8 3)) e ⊑ icmp IntPredicate.sgt e (const? 8 3) := by
+  icmp IntPred.slt (LLVM.and e (const? 8 3)) e ⊑ icmp IntPred.sgt e (const? 8 3) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gcanonicalizehconstanthlowhbithmaskhandhicmphugehtohicmphule_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gcanonicalizehconstanthlowhbithmaskhandhicmphugehtohicmphule_proof.lean
@@ -12,7 +12,7 @@ set_option Elab.async false
 
 section gcanonicalizehconstanthlowhbithmaskhandhicmphugehtohicmphule_proof
 theorem p0_thm (e : IntW 8) :
-  icmp IntPredicate.uge (LLVM.and e (const? 8 3)) e ⊑ icmp IntPredicate.ult e (const? 8 4) := by
+  icmp IntPred.uge (LLVM.and e (const? 8 3)) e ⊑ icmp IntPred.ult e (const? 8 4) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -22,8 +22,8 @@ theorem p0_thm (e : IntW 8) :
 
 
 theorem pv_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.uge (LLVM.and (lshr (const? 8 (-1)) e_1) e) e ⊑
-    icmp IntPredicate.ule e (lshr (const? 8 (-1)) e_1) := by
+  icmp IntPred.uge (LLVM.and (lshr (const? 8 (-1)) e_1) e) e ⊑
+    icmp IntPred.ule e (lshr (const? 8 (-1)) e_1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -33,8 +33,8 @@ theorem pv_thm (e e_1 : IntW 8) :
 
 
 theorem n0_thm (e : IntW 8) :
-  icmp IntPredicate.uge (LLVM.and e (const? 8 4)) e ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 8 (-5))) (const? 8 0) := by
+  icmp IntPred.uge (LLVM.and e (const? 8 4)) e ⊑
+    icmp IntPred.eq (LLVM.and e (const? 8 (-5))) (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gcanonicalizehconstanthlowhbithmaskhandhicmphugthtohicmphugt_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gcanonicalizehconstanthlowhbithmaskhandhicmphugthtohicmphugt_proof.lean
@@ -11,7 +11,7 @@ set_option maxRecDepth 1000000
 set_option Elab.async false
 
 section gcanonicalizehconstanthlowhbithmaskhandhicmphugthtohicmphugt_proof
-theorem c0_thm (e : IntW 8) : icmp IntPredicate.ugt (LLVM.and e (const? 8 3)) e ⊑ const? 1 0 := by
+theorem c0_thm (e : IntW 8) : icmp IntPred.ugt (LLVM.and e (const? 8 3)) e ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -21,7 +21,7 @@ theorem c0_thm (e : IntW 8) : icmp IntPredicate.ugt (LLVM.and e (const? 8 3)) e 
 
 
 theorem cv2_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.ugt (LLVM.and (lshr (const? 8 (-1)) e_1) e) e ⊑ const? 1 0 := by
+  icmp IntPred.ugt (LLVM.and (lshr (const? 8 (-1)) e_1) e) e ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gcanonicalizehconstanthlowhbithmaskhandhicmphulehtohicmphule_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gcanonicalizehconstanthlowhbithmaskhandhicmphulehtohicmphule_proof.lean
@@ -11,7 +11,7 @@ set_option maxRecDepth 1000000
 set_option Elab.async false
 
 section gcanonicalizehconstanthlowhbithmaskhandhicmphulehtohicmphule_proof
-theorem c0_thm (e : IntW 8) : icmp IntPredicate.ule (LLVM.and e (const? 8 3)) e ⊑ const? 1 1 := by
+theorem c0_thm (e : IntW 8) : icmp IntPred.ule (LLVM.and e (const? 8 3)) e ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -21,7 +21,7 @@ theorem c0_thm (e : IntW 8) : icmp IntPredicate.ule (LLVM.and e (const? 8 3)) e 
 
 
 theorem cv2_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.ule (LLVM.and (lshr (const? 8 (-1)) e_1) e) e ⊑ const? 1 1 := by
+  icmp IntPred.ule (LLVM.and (lshr (const? 8 (-1)) e_1) e) e ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gcanonicalizehconstanthlowhbithmaskhandhicmphulthtohicmphugt_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gcanonicalizehconstanthlowhbithmaskhandhicmphulthtohicmphugt_proof.lean
@@ -12,7 +12,7 @@ set_option Elab.async false
 
 section gcanonicalizehconstanthlowhbithmaskhandhicmphulthtohicmphugt_proof
 theorem p0_thm (e : IntW 8) :
-  icmp IntPredicate.ult (LLVM.and e (const? 8 3)) e ⊑ icmp IntPredicate.ugt e (const? 8 3) := by
+  icmp IntPred.ult (LLVM.and e (const? 8 3)) e ⊑ icmp IntPred.ugt e (const? 8 3) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -22,8 +22,8 @@ theorem p0_thm (e : IntW 8) :
 
 
 theorem pv_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.ult (LLVM.and (lshr (const? 8 (-1)) e_1) e) e ⊑
-    icmp IntPredicate.ugt e (lshr (const? 8 (-1)) e_1) := by
+  icmp IntPred.ult (LLVM.and (lshr (const? 8 (-1)) e_1) e) e ⊑
+    icmp IntPred.ugt e (lshr (const? 8 (-1)) e_1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -33,8 +33,8 @@ theorem pv_thm (e e_1 : IntW 8) :
 
 
 theorem n0_thm (e : IntW 8) :
-  icmp IntPredicate.ult (LLVM.and e (const? 8 4)) e ⊑
-    icmp IntPredicate.ne (LLVM.and e (const? 8 (-5))) (const? 8 0) := by
+  icmp IntPred.ult (LLVM.and e (const? 8 4)) e ⊑
+    icmp IntPred.ne (LLVM.and e (const? 8 (-5))) (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gcanonicalizehlackhofhsignedhtruncationhcheck_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gcanonicalizehlackhofhsignedhtruncationhcheck_proof.lean
@@ -12,8 +12,8 @@ set_option Elab.async false
 
 section gcanonicalizehlackhofhsignedhtruncationhcheck_proof
 theorem p0_thm (e : IntW 8) :
-  icmp IntPredicate.eq (ashr (shl e (const? 8 5)) (const? 8 5) { «exact» := true }) e ⊑
-    icmp IntPredicate.ult (add e (const? 8 4)) (const? 8 8) := by
+  icmp IntPred.eq (ashr (shl e (const? 8 5)) (const? 8 5) { «exact» := true }) e ⊑
+    icmp IntPred.ult (add e (const? 8 4)) (const? 8 8) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -23,8 +23,8 @@ theorem p0_thm (e : IntW 8) :
 
 
 theorem pb_thm (e : IntW 65) :
-  icmp IntPredicate.eq e (ashr (shl e (const? 65 1)) (const? 65 1) { «exact» := true }) ⊑
-    icmp IntPredicate.sgt (add e (const? 65 9223372036854775808)) (const? 65 (-1)) := by
+  icmp IntPred.eq e (ashr (shl e (const? 65 1)) (const? 65 1) { «exact» := true }) ⊑
+    icmp IntPred.sgt (add e (const? 65 9223372036854775808)) (const? 65 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -34,8 +34,8 @@ theorem pb_thm (e : IntW 65) :
 
 
 theorem n1_thm (e : IntW 8) :
-  icmp IntPredicate.eq (lshr (shl e (const? 8 5)) (const? 8 5) { «exact» := true }) e ⊑
-    icmp IntPredicate.ult e (const? 8 8) := by
+  icmp IntPred.eq (lshr (shl e (const? 8 5)) (const? 8 5) { «exact» := true }) e ⊑
+    icmp IntPred.ult e (const? 8 8) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gcanonicalizehlowhbithmaskhandhicmpheqhtohicmphule_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gcanonicalizehlowhbithmaskhandhicmpheqhtohicmphule_proof.lean
@@ -12,8 +12,8 @@ set_option Elab.async false
 
 section gcanonicalizehlowhbithmaskhandhicmpheqhtohicmphule_proof
 theorem p0_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.eq (LLVM.and (lshr (const? 8 (-1)) e_1) e) e ⊑
-    icmp IntPredicate.ule e (lshr (const? 8 (-1)) e_1) := by
+  icmp IntPred.eq (LLVM.and (lshr (const? 8 (-1)) e_1) e) e ⊑
+    icmp IntPred.ule e (lshr (const? 8 (-1)) e_1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gcanonicalizehlowhbithmaskhandhicmphnehtohicmphugt_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gcanonicalizehlowhbithmaskhandhicmphnehtohicmphugt_proof.lean
@@ -12,8 +12,8 @@ set_option Elab.async false
 
 section gcanonicalizehlowhbithmaskhandhicmphnehtohicmphugt_proof
 theorem p0_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.ne (LLVM.and (lshr (const? 8 (-1)) e_1) e) e ⊑
-    icmp IntPredicate.ugt e (lshr (const? 8 (-1)) e_1) := by
+  icmp IntPred.ne (LLVM.and (lshr (const? 8 (-1)) e_1) e) e ⊑
+    icmp IntPred.ugt e (lshr (const? 8 (-1)) e_1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gcanonicalizehlowhbithmaskhv2handhicmpheqhtohicmphule_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gcanonicalizehlowhbithmaskhv2handhicmpheqhtohicmphule_proof.lean
@@ -12,8 +12,8 @@ set_option Elab.async false
 
 section gcanonicalizehlowhbithmaskhv2handhicmpheqhtohicmphule_proof
 theorem p0_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.eq (LLVM.and (LLVM.xor (shl (const? 8 (-1)) e_1) (const? 8 (-1))) e) e ⊑
-    icmp IntPredicate.eq (lshr e e_1) (const? 8 0) := by
+  icmp IntPred.eq (LLVM.and (LLVM.xor (shl (const? 8 (-1)) e_1) (const? 8 (-1))) e) e ⊑
+    icmp IntPred.eq (lshr e e_1) (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -23,8 +23,8 @@ theorem p0_thm (e e_1 : IntW 8) :
 
 
 theorem n0_thm (e e_1 e_2 : IntW 8) :
-  icmp IntPredicate.eq (LLVM.and (LLVM.xor (shl (const? 8 (-1)) e_2) (const? 8 (-1))) e_1) e ⊑
-    icmp IntPredicate.eq
+  icmp IntPred.eq (LLVM.and (LLVM.xor (shl (const? 8 (-1)) e_2) (const? 8 (-1))) e_1) e ⊑
+    icmp IntPred.eq
       (LLVM.and e_1 (LLVM.xor (shl (const? 8 (-1)) e_2 { «nsw» := true, «nuw» := false }) (const? 8 (-1)))) e := by
     simp_alive_undef
     simp_alive_ops
@@ -35,8 +35,8 @@ theorem n0_thm (e e_1 e_2 : IntW 8) :
 
 
 theorem n1_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.eq (LLVM.and (LLVM.xor (shl (const? 8 1) e_1) (const? 8 (-1))) e) e ⊑
-    icmp IntPredicate.eq (LLVM.and e (shl (const? 8 1) e_1 { «nsw» := false, «nuw» := true })) (const? 8 0) := by
+  icmp IntPred.eq (LLVM.and (LLVM.xor (shl (const? 8 1) e_1) (const? 8 (-1))) e) e ⊑
+    icmp IntPred.eq (LLVM.and e (shl (const? 8 1) e_1 { «nsw» := false, «nuw» := true })) (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -46,8 +46,8 @@ theorem n1_thm (e e_1 : IntW 8) :
 
 
 theorem n2_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.eq (LLVM.and (LLVM.xor (shl (const? 8 (-1)) e_1) (const? 8 1)) e) e ⊑
-    icmp IntPredicate.eq
+  icmp IntPred.eq (LLVM.and (LLVM.xor (shl (const? 8 (-1)) e_1) (const? 8 1)) e) e ⊑
+    icmp IntPred.eq
       (LLVM.and e (LLVM.xor (shl (const? 8 (-1)) e_1 { «nsw» := true, «nuw» := false }) (const? 8 (-2))))
       (const? 8 0) := by
     simp_alive_undef

--- a/SSA/Projects/InstCombine/tests/proofs/gcanonicalizehlowhbithmaskhv2handhicmphnehtohicmphugt_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gcanonicalizehlowhbithmaskhv2handhicmphnehtohicmphugt_proof.lean
@@ -12,8 +12,8 @@ set_option Elab.async false
 
 section gcanonicalizehlowhbithmaskhv2handhicmphnehtohicmphugt_proof
 theorem p0_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.ne (LLVM.and (LLVM.xor (shl (const? 8 (-1)) e_1) (const? 8 (-1))) e) e ⊑
-    icmp IntPredicate.ne (lshr e e_1) (const? 8 0) := by
+  icmp IntPred.ne (LLVM.and (LLVM.xor (shl (const? 8 (-1)) e_1) (const? 8 (-1))) e) e ⊑
+    icmp IntPred.ne (lshr e e_1) (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -23,8 +23,8 @@ theorem p0_thm (e e_1 : IntW 8) :
 
 
 theorem n0_thm (e e_1 e_2 : IntW 8) :
-  icmp IntPredicate.ne (LLVM.and (LLVM.xor (shl (const? 8 (-1)) e_2) (const? 8 (-1))) e_1) e ⊑
-    icmp IntPredicate.ne
+  icmp IntPred.ne (LLVM.and (LLVM.xor (shl (const? 8 (-1)) e_2) (const? 8 (-1))) e_1) e ⊑
+    icmp IntPred.ne
       (LLVM.and e_1 (LLVM.xor (shl (const? 8 (-1)) e_2 { «nsw» := true, «nuw» := false }) (const? 8 (-1)))) e := by
     simp_alive_undef
     simp_alive_ops
@@ -35,8 +35,8 @@ theorem n0_thm (e e_1 e_2 : IntW 8) :
 
 
 theorem n1_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.ne (LLVM.and (LLVM.xor (shl (const? 8 1) e_1) (const? 8 (-1))) e) e ⊑
-    icmp IntPredicate.ne (LLVM.and e (shl (const? 8 1) e_1 { «nsw» := false, «nuw» := true })) (const? 8 0) := by
+  icmp IntPred.ne (LLVM.and (LLVM.xor (shl (const? 8 1) e_1) (const? 8 (-1))) e) e ⊑
+    icmp IntPred.ne (LLVM.and e (shl (const? 8 1) e_1 { «nsw» := false, «nuw» := true })) (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -46,8 +46,8 @@ theorem n1_thm (e e_1 : IntW 8) :
 
 
 theorem n2_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.ne (LLVM.and (LLVM.xor (shl (const? 8 (-1)) e_1) (const? 8 1)) e) e ⊑
-    icmp IntPredicate.ne
+  icmp IntPred.ne (LLVM.and (LLVM.xor (shl (const? 8 (-1)) e_1) (const? 8 1)) e) e ⊑
+    icmp IntPred.ne
       (LLVM.and e (LLVM.xor (shl (const? 8 (-1)) e_1 { «nsw» := true, «nuw» := false }) (const? 8 (-2))))
       (const? 8 0) := by
     simp_alive_undef

--- a/SSA/Projects/InstCombine/tests/proofs/gcanonicalizehselectshicmphconditionhbittest_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gcanonicalizehselectshicmphconditionhbittest_proof.lean
@@ -12,8 +12,8 @@ set_option Elab.async false
 
 section gcanonicalizehselectshicmphconditionhbittest_proof
 theorem p0_thm (e e_1 e_2 : IntW 8) :
-  select (icmp IntPredicate.eq (LLVM.and e_2 (const? 8 1)) (const? 8 1)) e_1 e ⊑
-    select (icmp IntPredicate.eq (LLVM.and e_2 (const? 8 1)) (const? 8 0)) e e_1 := by
+  select (icmp IntPred.eq (LLVM.and e_2 (const? 8 1)) (const? 8 1)) e_1 e ⊑
+    select (icmp IntPred.eq (LLVM.and e_2 (const? 8 1)) (const? 8 0)) e e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -23,8 +23,8 @@ theorem p0_thm (e e_1 e_2 : IntW 8) :
 
 
 theorem p1_thm (e e_1 e_2 : IntW 8) :
-  select (icmp IntPredicate.ne (LLVM.and e_2 (const? 8 1)) (const? 8 0)) e_1 e ⊑
-    select (icmp IntPredicate.eq (LLVM.and e_2 (const? 8 1)) (const? 8 0)) e e_1 := by
+  select (icmp IntPred.ne (LLVM.and e_2 (const? 8 1)) (const? 8 0)) e_1 e ⊑
+    select (icmp IntPred.eq (LLVM.and e_2 (const? 8 1)) (const? 8 0)) e e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -34,7 +34,7 @@ theorem p1_thm (e e_1 e_2 : IntW 8) :
 
 
 theorem n5_thm (e e_1 e_2 : IntW 8) :
-  select (icmp IntPredicate.eq (LLVM.and e_2 (const? 8 1)) (const? 8 2)) e_1 e ⊑ e := by
+  select (icmp IntPred.eq (LLVM.and e_2 (const? 8 1)) (const? 8 2)) e_1 e ⊑ e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -44,7 +44,7 @@ theorem n5_thm (e e_1 e_2 : IntW 8) :
 
 
 theorem n6_thm (e e_1 e_2 : IntW 8) :
-  select (icmp IntPredicate.eq (LLVM.and e_2 (const? 8 1)) (const? 8 3)) e_1 e ⊑ e := by
+  select (icmp IntPred.eq (LLVM.and e_2 (const? 8 1)) (const? 8 3)) e_1 e ⊑ e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -54,8 +54,8 @@ theorem n6_thm (e e_1 e_2 : IntW 8) :
 
 
 theorem n7_thm (e e_1 e_2 : IntW 8) :
-  select (icmp IntPredicate.ne (LLVM.and e_2 (const? 8 1)) (const? 8 1)) e_1 e ⊑
-    select (icmp IntPredicate.eq (LLVM.and e_2 (const? 8 1)) (const? 8 0)) e_1 e := by
+  select (icmp IntPred.ne (LLVM.and e_2 (const? 8 1)) (const? 8 1)) e_1 e ⊑
+    select (icmp IntPred.eq (LLVM.and e_2 (const? 8 1)) (const? 8 0)) e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gcanonicalizehsignedhtruncationhcheck_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gcanonicalizehsignedhtruncationhcheck_proof.lean
@@ -12,8 +12,8 @@ set_option Elab.async false
 
 section gcanonicalizehsignedhtruncationhcheck_proof
 theorem p0_thm (e : IntW 8) :
-  icmp IntPredicate.ne (ashr (shl e (const? 8 5)) (const? 8 5) { «exact» := true }) e ⊑
-    icmp IntPredicate.ult (add e (const? 8 (-4))) (const? 8 (-8)) := by
+  icmp IntPred.ne (ashr (shl e (const? 8 5)) (const? 8 5) { «exact» := true }) e ⊑
+    icmp IntPred.ult (add e (const? 8 (-4))) (const? 8 (-8)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -23,8 +23,8 @@ theorem p0_thm (e : IntW 8) :
 
 
 theorem pb_thm (e : IntW 65) :
-  icmp IntPredicate.ne e (ashr (shl e (const? 65 1)) (const? 65 1) { «exact» := true }) ⊑
-    icmp IntPredicate.slt (add e (const? 65 9223372036854775808)) (const? 65 0) := by
+  icmp IntPred.ne e (ashr (shl e (const? 65 1)) (const? 65 1) { «exact» := true }) ⊑
+    icmp IntPred.slt (add e (const? 65 9223372036854775808)) (const? 65 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -34,8 +34,8 @@ theorem pb_thm (e : IntW 65) :
 
 
 theorem n1_thm (e : IntW 8) :
-  icmp IntPredicate.ne (lshr (shl e (const? 8 5)) (const? 8 5) { «exact» := true }) e ⊑
-    icmp IntPredicate.ugt e (const? 8 7) := by
+  icmp IntPred.ne (lshr (shl e (const? 8 5)) (const? 8 5) { «exact» := true }) e ⊑
+    icmp IntPred.ugt e (const? 8 7) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gcast_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gcast_proof.lean
@@ -30,7 +30,7 @@ theorem test3_thm (e : IntW 64) : zext 64 (trunc 8 e) ⊑ LLVM.and e (const? 64 
 
 
 theorem test4_thm (e e_1 : IntW 32) :
-  zext 32 (zext 8 (icmp IntPredicate.slt e_1 e)) ⊑ zext 32 (icmp IntPredicate.slt e_1 e) := by
+  zext 32 (zext 8 (icmp IntPred.slt e_1 e)) ⊑ zext 32 (icmp IntPred.slt e_1 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -94,7 +94,7 @@ theorem test18_thm (e : IntW 8) : trunc 16 (sext 32 e) ⊑ sext 16 e := by
 
 
 theorem test19_thm (e : IntW 32) :
-  icmp IntPredicate.slt (sext 64 e) (const? 64 12345) ⊑ icmp IntPredicate.slt e (const? 32 12345) := by
+  icmp IntPred.slt (sext 64 e) (const? 64 12345) ⊑ icmp IntPred.slt e (const? 32 12345) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -103,7 +103,7 @@ theorem test19_thm (e : IntW 32) :
     all_goals sorry
 
 
-theorem test20_thm (e : IntW 1) : icmp IntPredicate.slt (zext 32 e) (const? 32 (-1)) ⊑ const? 1 0 := by
+theorem test20_thm (e : IntW 1) : icmp IntPred.slt (zext 32 e) (const? 32 (-1)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -140,7 +140,7 @@ theorem test23_thm (e : IntW 32) : zext 32 (trunc 16 e) ⊑ LLVM.and e (const? 3
 
 
 theorem test24_thm (e : IntW 1) :
-  icmp IntPredicate.ne (select e (const? 32 14) (const? 32 1234)) (const? 32 0) ⊑ const? 1 1 := by
+  icmp IntPred.ne (select e (const? 32 14) (const? 32 1234)) (const? 32 0) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -160,8 +160,8 @@ theorem test29_thm (e e_1 : IntW 32) :
 
 
 theorem test31_thm (e : IntW 64) :
-  icmp IntPredicate.eq (LLVM.and (trunc 32 e) (const? 32 42)) (const? 32 10) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 64 42)) (const? 64 10) := by
+  icmp IntPred.eq (LLVM.and (trunc 32 e) (const? 32 42)) (const? 32 10) ⊑
+    icmp IntPred.eq (LLVM.and e (const? 64 42)) (const? 64 10) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -180,8 +180,8 @@ theorem test34_thm (e : IntW 16) : trunc 16 (lshr (zext 32 e) (const? 32 8)) ⊑
 
 
 theorem test36_thm (e : IntW 32) :
-  icmp IntPredicate.eq (trunc 8 (lshr e (const? 32 31))) (const? 8 0) ⊑
-    icmp IntPredicate.sgt e (const? 32 (-1)) := by
+  icmp IntPred.eq (trunc 8 (lshr e (const? 32 31))) (const? 8 0) ⊑
+    icmp IntPred.sgt e (const? 32 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -191,7 +191,7 @@ theorem test36_thm (e : IntW 32) :
 
 
 theorem test37_thm (e : IntW 32) :
-  icmp IntPredicate.eq (trunc 8 (LLVM.or (lshr e (const? 32 31)) (const? 32 512))) (const? 8 11) ⊑ const? 1 0 := by
+  icmp IntPred.eq (trunc 8 (LLVM.or (lshr e (const? 32 31)) (const? 32 512))) (const? 8 11) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -201,8 +201,8 @@ theorem test37_thm (e : IntW 32) :
 
 
 theorem test38_thm (e : IntW 32) :
-  zext 64 (LLVM.xor (zext 8 (icmp IntPredicate.eq e (const? 32 (-2)))) (const? 8 1)) ⊑
-    zext 64 (icmp IntPredicate.ne e (const? 32 (-2))) := by
+  zext 64 (LLVM.xor (zext 8 (icmp IntPred.eq e (const? 32 (-2)))) (const? 8 1)) ⊑
+    zext 64 (icmp IntPred.ne e (const? 32 (-2))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -390,7 +390,7 @@ theorem test59_thm (e e_1 : IntW 8) :
 
 
 theorem test67_thm (e : IntW 1) (e_1 : IntW 32) :
-  icmp IntPredicate.eq
+  icmp IntPred.eq
       (trunc 8
         (ashr
           (LLVM.xor
@@ -647,8 +647,8 @@ theorem pr33078_4_thm (e : IntW 3) :
 
 
 theorem test94_thm (e : IntW 32) :
-  sext 64 (LLVM.xor (sext 8 (icmp IntPredicate.eq e (const? 32 (-2)))) (const? 8 (-1))) ⊑
-    sext 64 (icmp IntPredicate.ne e (const? 32 (-2))) := by
+  sext 64 (LLVM.xor (sext 8 (icmp IntPred.eq e (const? 32 (-2)))) (const? 8 (-1))) ⊑
+    sext 64 (icmp IntPred.ne e (const? 32 (-2))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gcasthselect_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gcasthselect_proof.lean
@@ -12,8 +12,8 @@ set_option Elab.async false
 
 section gcasthselect_proof
 theorem trunc_thm (e e_1 e_2 : IntW 32) :
-  trunc 16 (select (icmp IntPredicate.ult e_2 e_1) (const? 32 42) e) ⊑
-    select (icmp IntPredicate.ult e_2 e_1) (const? 16 42) (trunc 16 e) := by
+  trunc 16 (select (icmp IntPred.ult e_2 e_1) (const? 32 42) e) ⊑
+    select (icmp IntPred.ult e_2 e_1) (const? 16 42) (trunc 16 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gcasthset_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gcasthset_proof.lean
@@ -20,7 +20,7 @@ theorem test5_thm (e : IntW 16) : trunc 16 (LLVM.and (sext 32 e) (const? 32 15))
     all_goals sorry
 
 
-theorem test6_thm (e : IntW 1) : icmp IntPredicate.ne (zext 32 e) (const? 32 0) ⊑ e := by
+theorem test6_thm (e : IntW 1) : icmp IntPred.ne (zext 32 e) (const? 32 0) ⊑ e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -29,7 +29,7 @@ theorem test6_thm (e : IntW 1) : icmp IntPredicate.ne (zext 32 e) (const? 32 0) 
     all_goals sorry
 
 
-theorem test6a_thm (e : IntW 1) : icmp IntPredicate.ne (zext 32 e) (const? 32 (-1)) ⊑ const? 1 1 := by
+theorem test6a_thm (e : IntW 1) : icmp IntPred.ne (zext 32 e) (const? 32 (-1)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gcmphxhvshneghx_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gcmphxhvshneghx_proof.lean
@@ -12,8 +12,8 @@ set_option Elab.async false
 
 section gcmphxhvshneghx_proof
 theorem t0_thm (e : IntW 8) :
-  icmp IntPredicate.sgt (sub (const? 8 0) e { «nsw» := true, «nuw» := false }) e ⊑
-    icmp IntPredicate.slt e (const? 8 0) := by
+  icmp IntPred.sgt (sub (const? 8 0) e { «nsw» := true, «nuw» := false }) e ⊑
+    icmp IntPred.slt e (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -23,8 +23,8 @@ theorem t0_thm (e : IntW 8) :
 
 
 theorem t1_thm (e : IntW 8) :
-  icmp IntPredicate.sge (sub (const? 8 0) e { «nsw» := true, «nuw» := false }) e ⊑
-    icmp IntPredicate.slt e (const? 8 1) := by
+  icmp IntPred.sge (sub (const? 8 0) e { «nsw» := true, «nuw» := false }) e ⊑
+    icmp IntPred.slt e (const? 8 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -34,8 +34,8 @@ theorem t1_thm (e : IntW 8) :
 
 
 theorem t2_thm (e : IntW 8) :
-  icmp IntPredicate.slt (sub (const? 8 0) e { «nsw» := true, «nuw» := false }) e ⊑
-    icmp IntPredicate.sgt e (const? 8 0) := by
+  icmp IntPred.slt (sub (const? 8 0) e { «nsw» := true, «nuw» := false }) e ⊑
+    icmp IntPred.sgt e (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -45,8 +45,8 @@ theorem t2_thm (e : IntW 8) :
 
 
 theorem t3_thm (e : IntW 8) :
-  icmp IntPredicate.sle (sub (const? 8 0) e { «nsw» := true, «nuw» := false }) e ⊑
-    icmp IntPredicate.sgt e (const? 8 (-1)) := by
+  icmp IntPred.sle (sub (const? 8 0) e { «nsw» := true, «nuw» := false }) e ⊑
+    icmp IntPred.sgt e (const? 8 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -56,8 +56,8 @@ theorem t3_thm (e : IntW 8) :
 
 
 theorem t4_thm (e : IntW 8) :
-  icmp IntPredicate.ugt (sub (const? 8 0) e { «nsw» := true, «nuw» := false }) e ⊑
-    icmp IntPredicate.sgt e (const? 8 0) := by
+  icmp IntPred.ugt (sub (const? 8 0) e { «nsw» := true, «nuw» := false }) e ⊑
+    icmp IntPred.sgt e (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -67,8 +67,8 @@ theorem t4_thm (e : IntW 8) :
 
 
 theorem t5_thm (e : IntW 8) :
-  icmp IntPredicate.uge (sub (const? 8 0) e { «nsw» := true, «nuw» := false }) e ⊑
-    icmp IntPredicate.sgt e (const? 8 (-1)) := by
+  icmp IntPred.uge (sub (const? 8 0) e { «nsw» := true, «nuw» := false }) e ⊑
+    icmp IntPred.sgt e (const? 8 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -78,8 +78,8 @@ theorem t5_thm (e : IntW 8) :
 
 
 theorem t6_thm (e : IntW 8) :
-  icmp IntPredicate.ult (sub (const? 8 0) e { «nsw» := true, «nuw» := false }) e ⊑
-    icmp IntPredicate.slt e (const? 8 0) := by
+  icmp IntPred.ult (sub (const? 8 0) e { «nsw» := true, «nuw» := false }) e ⊑
+    icmp IntPred.slt e (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -89,8 +89,8 @@ theorem t6_thm (e : IntW 8) :
 
 
 theorem t7_thm (e : IntW 8) :
-  icmp IntPredicate.ule (sub (const? 8 0) e { «nsw» := true, «nuw» := false }) e ⊑
-    icmp IntPredicate.slt e (const? 8 1) := by
+  icmp IntPred.ule (sub (const? 8 0) e { «nsw» := true, «nuw» := false }) e ⊑
+    icmp IntPred.slt e (const? 8 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -100,8 +100,8 @@ theorem t7_thm (e : IntW 8) :
 
 
 theorem t8_thm (e : IntW 8) :
-  icmp IntPredicate.eq (sub (const? 8 0) e { «nsw» := true, «nuw» := false }) e ⊑
-    icmp IntPredicate.eq e (const? 8 0) := by
+  icmp IntPred.eq (sub (const? 8 0) e { «nsw» := true, «nuw» := false }) e ⊑
+    icmp IntPred.eq e (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -111,8 +111,8 @@ theorem t8_thm (e : IntW 8) :
 
 
 theorem t9_thm (e : IntW 8) :
-  icmp IntPredicate.ne (sub (const? 8 0) e { «nsw» := true, «nuw» := false }) e ⊑
-    icmp IntPredicate.ne e (const? 8 0) := by
+  icmp IntPred.ne (sub (const? 8 0) e { «nsw» := true, «nuw» := false }) e ⊑
+    icmp IntPred.ne e (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -122,7 +122,7 @@ theorem t9_thm (e : IntW 8) :
 
 
 theorem n10_thm (e : IntW 8) :
-  icmp IntPredicate.sgt (sub (const? 8 0) e) e ⊑ icmp IntPredicate.slt e (sub (const? 8 0) e) := by
+  icmp IntPred.sgt (sub (const? 8 0) e) e ⊑ icmp IntPred.slt e (sub (const? 8 0) e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -132,8 +132,8 @@ theorem n10_thm (e : IntW 8) :
 
 
 theorem n12_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.sgt (sub (const? 8 0) e_1 { «nsw» := true, «nuw» := false }) e ⊑
-    icmp IntPredicate.slt e (sub (const? 8 0) e_1 { «nsw» := true, «nuw» := false }) := by
+  icmp IntPred.sgt (sub (const? 8 0) e_1 { «nsw» := true, «nuw» := false }) e ⊑
+    icmp IntPred.slt e (sub (const? 8 0) e_1 { «nsw» := true, «nuw» := false }) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gcomparehsigns_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gcomparehsigns_proof.lean
@@ -12,8 +12,8 @@ set_option Elab.async false
 
 section gcomparehsigns_proof
 theorem test1_thm (e e_1 : IntW 32) :
-  zext 32 (LLVM.xor (icmp IntPredicate.slt e_1 (const? 32 0)) (icmp IntPredicate.sgt e (const? 32 (-1)))) ⊑
-    zext 32 (icmp IntPredicate.sgt (LLVM.xor e_1 e) (const? 32 (-1))) := by
+  zext 32 (LLVM.xor (icmp IntPred.slt e_1 (const? 32 0)) (icmp IntPred.sgt e (const? 32 (-1)))) ⊑
+    zext 32 (icmp IntPred.sgt (LLVM.xor e_1 e) (const? 32 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -23,7 +23,7 @@ theorem test1_thm (e e_1 : IntW 32) :
 
 
 theorem test2_thm (e e_1 : IntW 32) :
-  zext 32 (icmp IntPredicate.eq (LLVM.and e_1 (const? 32 8)) (LLVM.and e (const? 32 8))) ⊑
+  zext 32 (icmp IntPred.eq (LLVM.and e_1 (const? 32 8)) (LLVM.and e (const? 32 8))) ⊑
     LLVM.xor (LLVM.and (lshr (LLVM.xor e_1 e) (const? 32 3)) (const? 32 1)) (const? 32 1) := by
     simp_alive_undef
     simp_alive_ops
@@ -34,8 +34,8 @@ theorem test2_thm (e e_1 : IntW 32) :
 
 
 theorem test3_thm (e e_1 : IntW 32) :
-  zext 32 (icmp IntPredicate.eq (lshr e_1 (const? 32 31)) (lshr e (const? 32 31))) ⊑
-    zext 32 (icmp IntPredicate.sgt (LLVM.xor e_1 e) (const? 32 (-1))) := by
+  zext 32 (icmp IntPred.eq (lshr e_1 (const? 32 31)) (lshr e (const? 32 31))) ⊑
+    zext 32 (icmp IntPred.sgt (LLVM.xor e_1 e) (const? 32 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -46,9 +46,9 @@ theorem test3_thm (e e_1 : IntW 32) :
 
 theorem test3i_thm (e e_1 : IntW 32) :
   zext 32
-      (icmp IntPredicate.eq (LLVM.or (lshr e_1 (const? 32 29)) (const? 32 35))
+      (icmp IntPred.eq (LLVM.or (lshr e_1 (const? 32 29)) (const? 32 35))
         (LLVM.or (lshr e (const? 32 29)) (const? 32 35))) ⊑
-    zext 32 (icmp IntPredicate.sgt (LLVM.xor e_1 e) (const? 32 (-1))) := by
+    zext 32 (icmp IntPred.sgt (LLVM.xor e_1 e) (const? 32 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -58,8 +58,8 @@ theorem test3i_thm (e e_1 : IntW 32) :
 
 
 theorem test4a_thm (e : IntW 32) :
-  icmp IntPredicate.slt (LLVM.or (ashr e (const? 32 31)) (lshr (sub (const? 32 0) e) (const? 32 31))) (const? 32 1) ⊑
-    icmp IntPredicate.slt e (const? 32 1) := by
+  icmp IntPred.slt (LLVM.or (ashr e (const? 32 31)) (lshr (sub (const? 32 0) e) (const? 32 31))) (const? 32 1) ⊑
+    icmp IntPred.slt e (const? 32 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -69,8 +69,8 @@ theorem test4a_thm (e : IntW 32) :
 
 
 theorem test4b_thm (e : IntW 64) :
-  icmp IntPredicate.slt (LLVM.or (ashr e (const? 64 63)) (lshr (sub (const? 64 0) e) (const? 64 63))) (const? 64 1) ⊑
-    icmp IntPredicate.slt e (const? 64 1) := by
+  icmp IntPred.slt (LLVM.or (ashr e (const? 64 63)) (lshr (sub (const? 64 0) e) (const? 64 63))) (const? 64 1) ⊑
+    icmp IntPred.slt e (const? 64 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -80,9 +80,9 @@ theorem test4b_thm (e : IntW 64) :
 
 
 theorem test4c_thm (e : IntW 64) :
-  icmp IntPredicate.slt (trunc 32 (LLVM.or (ashr e (const? 64 63)) (lshr (sub (const? 64 0) e) (const? 64 63))))
+  icmp IntPred.slt (trunc 32 (LLVM.or (ashr e (const? 64 63)) (lshr (sub (const? 64 0) e) (const? 64 63))))
       (const? 32 1) ⊑
-    icmp IntPredicate.slt e (const? 64 1) := by
+    icmp IntPred.slt e (const? 64 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -92,7 +92,7 @@ theorem test4c_thm (e : IntW 64) :
 
 
 theorem shift_trunc_signbit_test_thm (e : IntW 32) :
-  icmp IntPredicate.slt (trunc 8 (lshr e (const? 32 24))) (const? 8 0) ⊑ icmp IntPredicate.slt e (const? 32 0) := by
+  icmp IntPred.slt (trunc 8 (lshr e (const? 32 24))) (const? 8 0) ⊑ icmp IntPred.slt e (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -102,8 +102,8 @@ theorem shift_trunc_signbit_test_thm (e : IntW 32) :
 
 
 theorem shift_trunc_wrong_shift_thm (e : IntW 32) :
-  icmp IntPredicate.slt (trunc 8 (lshr e (const? 32 23))) (const? 8 0) ⊑
-    icmp IntPredicate.ne (LLVM.and e (const? 32 1073741824)) (const? 32 0) := by
+  icmp IntPred.slt (trunc 8 (lshr e (const? 32 23))) (const? 8 0) ⊑
+    icmp IntPred.ne (LLVM.and e (const? 32 1073741824)) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -113,8 +113,8 @@ theorem shift_trunc_wrong_shift_thm (e : IntW 32) :
 
 
 theorem shift_trunc_wrong_cmp_thm (e : IntW 32) :
-  icmp IntPredicate.slt (trunc 8 (lshr e (const? 32 24))) (const? 8 1) ⊑
-    icmp IntPredicate.slt (trunc 8 (lshr e (const? 32 24)) { «nsw» := false, «nuw» := true }) (const? 8 1) := by
+  icmp IntPred.slt (trunc 8 (lshr e (const? 32 24))) (const? 8 1) ⊑
+    icmp IntPred.slt (trunc 8 (lshr e (const? 32 24)) { «nsw» := false, «nuw» := true }) (const? 8 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gcomparehudiv_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gcomparehudiv_proof.lean
@@ -12,7 +12,7 @@ set_option Elab.async false
 
 section gcomparehudiv_proof
 theorem test1_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.eq (LLVM.udiv e_1 e) (const? 32 0) ⊑ icmp IntPredicate.ugt e e_1 := by
+  icmp IntPred.eq (LLVM.udiv e_1 e) (const? 32 0) ⊑ icmp IntPred.ugt e e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -22,7 +22,7 @@ theorem test1_thm (e e_1 : IntW 32) :
 
 
 theorem test2_thm (e : IntW 32) :
-  icmp IntPredicate.eq (LLVM.udiv (const? 32 64) e) (const? 32 0) ⊑ icmp IntPredicate.ugt e (const? 32 64) := by
+  icmp IntPred.eq (LLVM.udiv (const? 32 64) e) (const? 32 0) ⊑ icmp IntPred.ugt e (const? 32 64) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -32,7 +32,7 @@ theorem test2_thm (e : IntW 32) :
 
 
 theorem test3_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.ne (LLVM.udiv e_1 e) (const? 32 0) ⊑ icmp IntPredicate.ule e e_1 := by
+  icmp IntPred.ne (LLVM.udiv e_1 e) (const? 32 0) ⊑ icmp IntPred.ule e e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -42,7 +42,7 @@ theorem test3_thm (e e_1 : IntW 32) :
 
 
 theorem test4_thm (e : IntW 32) :
-  icmp IntPredicate.ne (LLVM.udiv (const? 32 64) e) (const? 32 0) ⊑ icmp IntPredicate.ult e (const? 32 65) := by
+  icmp IntPred.ne (LLVM.udiv (const? 32 64) e) (const? 32 0) ⊑ icmp IntPred.ult e (const? 32 65) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -52,7 +52,7 @@ theorem test4_thm (e : IntW 32) :
 
 
 theorem test5_thm (e : IntW 32) :
-  icmp IntPredicate.ne (LLVM.udiv (const? 32 (-1)) e) (const? 32 0) ⊑ const? 1 1 := by
+  icmp IntPred.ne (LLVM.udiv (const? 32 (-1)) e) (const? 32 0) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -62,7 +62,7 @@ theorem test5_thm (e : IntW 32) :
 
 
 theorem test6_thm (e : IntW 32) :
-  icmp IntPredicate.ugt (LLVM.udiv (const? 32 5) e) (const? 32 0) ⊑ icmp IntPredicate.ult e (const? 32 6) := by
+  icmp IntPred.ugt (LLVM.udiv (const? 32 5) e) (const? 32 0) ⊑ icmp IntPred.ult e (const? 32 6) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -72,7 +72,7 @@ theorem test6_thm (e : IntW 32) :
 
 
 theorem test7_thm (e : IntW 32) :
-  icmp IntPredicate.ugt (LLVM.udiv (const? 32 8) e) (const? 32 8) ⊑ const? 1 0 := by
+  icmp IntPred.ugt (LLVM.udiv (const? 32 8) e) (const? 32 8) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -82,7 +82,7 @@ theorem test7_thm (e : IntW 32) :
 
 
 theorem test8_thm (e : IntW 32) :
-  icmp IntPredicate.ugt (LLVM.udiv (const? 32 4) e) (const? 32 3) ⊑ icmp IntPredicate.ult e (const? 32 2) := by
+  icmp IntPred.ugt (LLVM.udiv (const? 32 4) e) (const? 32 3) ⊑ icmp IntPred.ult e (const? 32 2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -92,7 +92,7 @@ theorem test8_thm (e : IntW 32) :
 
 
 theorem test9_thm (e : IntW 32) :
-  icmp IntPredicate.ugt (LLVM.udiv (const? 32 4) e) (const? 32 2) ⊑ icmp IntPredicate.ult e (const? 32 2) := by
+  icmp IntPred.ugt (LLVM.udiv (const? 32 4) e) (const? 32 2) ⊑ icmp IntPred.ult e (const? 32 2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -102,7 +102,7 @@ theorem test9_thm (e : IntW 32) :
 
 
 theorem test10_thm (e : IntW 32) :
-  icmp IntPredicate.ugt (LLVM.udiv (const? 32 4) e) (const? 32 1) ⊑ icmp IntPredicate.ult e (const? 32 3) := by
+  icmp IntPred.ugt (LLVM.udiv (const? 32 4) e) (const? 32 1) ⊑ icmp IntPred.ult e (const? 32 3) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -112,7 +112,7 @@ theorem test10_thm (e : IntW 32) :
 
 
 theorem test11_thm (e : IntW 32) :
-  icmp IntPredicate.ult (LLVM.udiv (const? 32 4) e) (const? 32 1) ⊑ icmp IntPredicate.ugt e (const? 32 4) := by
+  icmp IntPred.ult (LLVM.udiv (const? 32 4) e) (const? 32 1) ⊑ icmp IntPred.ugt e (const? 32 4) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -122,7 +122,7 @@ theorem test11_thm (e : IntW 32) :
 
 
 theorem test12_thm (e : IntW 32) :
-  icmp IntPredicate.ult (LLVM.udiv (const? 32 4) e) (const? 32 2) ⊑ icmp IntPredicate.ugt e (const? 32 2) := by
+  icmp IntPred.ult (LLVM.udiv (const? 32 4) e) (const? 32 2) ⊑ icmp IntPred.ugt e (const? 32 2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -132,7 +132,7 @@ theorem test12_thm (e : IntW 32) :
 
 
 theorem test13_thm (e : IntW 32) :
-  icmp IntPredicate.ult (LLVM.udiv (const? 32 4) e) (const? 32 3) ⊑ icmp IntPredicate.ugt e (const? 32 1) := by
+  icmp IntPred.ult (LLVM.udiv (const? 32 4) e) (const? 32 3) ⊑ icmp IntPred.ugt e (const? 32 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -142,7 +142,7 @@ theorem test13_thm (e : IntW 32) :
 
 
 theorem test14_thm (e : IntW 32) :
-  icmp IntPredicate.ult (LLVM.udiv (const? 32 4) e) (const? 32 4) ⊑ icmp IntPredicate.ugt e (const? 32 1) := by
+  icmp IntPred.ult (LLVM.udiv (const? 32 4) e) (const? 32 4) ⊑ icmp IntPred.ugt e (const? 32 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -152,7 +152,7 @@ theorem test14_thm (e : IntW 32) :
 
 
 theorem test15_thm (e : IntW 32) :
-  icmp IntPredicate.ugt (LLVM.udiv (const? 32 4) e) (const? 32 (-1)) ⊑ const? 1 0 := by
+  icmp IntPred.ugt (LLVM.udiv (const? 32 4) e) (const? 32 (-1)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -162,7 +162,7 @@ theorem test15_thm (e : IntW 32) :
 
 
 theorem test16_thm (e : IntW 32) :
-  icmp IntPredicate.ult (LLVM.udiv (const? 32 4) e) (const? 32 (-1)) ⊑ const? 1 1 := by
+  icmp IntPred.ult (LLVM.udiv (const? 32 4) e) (const? 32 (-1)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gdemorgan_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gdemorgan_proof.lean
@@ -313,9 +313,9 @@ theorem demorgan_and_zext_thm (e e_1 : IntW 1) :
 
 
 theorem PR28476_thm (e e_1 : IntW 32) :
-  LLVM.xor (zext 32 (LLVM.and (icmp IntPredicate.ne e_1 (const? 32 0)) (icmp IntPredicate.ne e (const? 32 0))))
+  LLVM.xor (zext 32 (LLVM.and (icmp IntPred.ne e_1 (const? 32 0)) (icmp IntPred.ne e (const? 32 0))))
       (const? 32 1) ⊑
-    zext 32 (LLVM.or (icmp IntPredicate.eq e_1 (const? 32 0)) (icmp IntPredicate.eq e (const? 32 0))) := by
+    zext 32 (LLVM.or (icmp IntPred.eq e_1 (const? 32 0)) (icmp IntPred.eq e (const? 32 0))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -326,10 +326,10 @@ theorem PR28476_thm (e e_1 : IntW 32) :
 
 theorem PR28476_logical_thm (e e_1 : IntW 32) :
   LLVM.xor
-      (zext 32 (select (icmp IntPredicate.ne e_1 (const? 32 0)) (icmp IntPredicate.ne e (const? 32 0)) (const? 1 0)))
+      (zext 32 (select (icmp IntPred.ne e_1 (const? 32 0)) (icmp IntPred.ne e (const? 32 0)) (const? 1 0)))
       (const? 32 1) ⊑
     zext 32
-      (select (icmp IntPredicate.eq e_1 (const? 32 0)) (const? 1 1) (icmp IntPredicate.eq e (const? 32 0))) := by
+      (select (icmp IntPred.eq e_1 (const? 32 0)) (const? 1 1) (icmp IntPred.eq e (const? 32 0))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gdemorganhsinkhnothintohxor_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gdemorganhsinkhnothintohxor_proof.lean
@@ -12,8 +12,8 @@ set_option Elab.async false
 
 section gdemorganhsinkhnothintohxor_proof
 theorem positive_easyinvert_thm (e : IntW 16) (e_1 : IntW 8) :
-  LLVM.xor (LLVM.xor (icmp IntPredicate.slt e_1 (const? 8 0)) (icmp IntPredicate.slt e (const? 16 0))) (const? 1 1) ⊑
-    LLVM.xor (icmp IntPredicate.slt e_1 (const? 8 0)) (icmp IntPredicate.sgt e (const? 16 (-1))) := by
+  LLVM.xor (LLVM.xor (icmp IntPred.slt e_1 (const? 8 0)) (icmp IntPred.slt e (const? 16 0))) (const? 1 1) ⊑
+    LLVM.xor (icmp IntPred.slt e_1 (const? 8 0)) (icmp IntPred.sgt e (const? 16 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/geqhofhparts_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/geqhofhparts_proof.lean
@@ -12,9 +12,9 @@ set_option Elab.async false
 
 section geqhofhparts_proof
 theorem eq_10_thm (e e_1 : IntW 32) :
-  LLVM.and (icmp IntPredicate.eq (trunc 8 e_1) (trunc 8 e))
-      (icmp IntPredicate.eq (trunc 8 (lshr e_1 (const? 32 8))) (trunc 8 (lshr e (const? 32 8)))) ⊑
-    icmp IntPredicate.eq (trunc 16 e_1) (trunc 16 e) := by
+  LLVM.and (icmp IntPred.eq (trunc 8 e_1) (trunc 8 e))
+      (icmp IntPred.eq (trunc 8 (lshr e_1 (const? 32 8))) (trunc 8 (lshr e (const? 32 8)))) ⊑
+    icmp IntPred.eq (trunc 16 e_1) (trunc 16 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -24,10 +24,10 @@ theorem eq_10_thm (e e_1 : IntW 32) :
 
 
 theorem eq_210_thm (e e_1 : IntW 32) :
-  LLVM.and (icmp IntPredicate.eq (trunc 8 (lshr e_1 (const? 32 16))) (trunc 8 (lshr e (const? 32 16))))
-      (LLVM.and (icmp IntPredicate.eq (trunc 8 e_1) (trunc 8 e))
-        (icmp IntPredicate.eq (trunc 8 (lshr e_1 (const? 32 8))) (trunc 8 (lshr e (const? 32 8))))) ⊑
-    icmp IntPredicate.eq (trunc 24 e_1) (trunc 24 e) := by
+  LLVM.and (icmp IntPred.eq (trunc 8 (lshr e_1 (const? 32 16))) (trunc 8 (lshr e (const? 32 16))))
+      (LLVM.and (icmp IntPred.eq (trunc 8 e_1) (trunc 8 e))
+        (icmp IntPred.eq (trunc 8 (lshr e_1 (const? 32 8))) (trunc 8 (lshr e (const? 32 8))))) ⊑
+    icmp IntPred.eq (trunc 24 e_1) (trunc 24 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -37,11 +37,11 @@ theorem eq_210_thm (e e_1 : IntW 32) :
 
 
 theorem eq_3210_thm (e e_1 : IntW 32) :
-  LLVM.and (icmp IntPredicate.eq (trunc 8 (lshr e_1 (const? 32 24))) (trunc 8 (lshr e (const? 32 24))))
-      (LLVM.and (icmp IntPredicate.eq (trunc 8 (lshr e_1 (const? 32 16))) (trunc 8 (lshr e (const? 32 16))))
-        (LLVM.and (icmp IntPredicate.eq (trunc 8 e_1) (trunc 8 e))
-          (icmp IntPredicate.eq (trunc 8 (lshr e_1 (const? 32 8))) (trunc 8 (lshr e (const? 32 8)))))) ⊑
-    icmp IntPredicate.eq e_1 e := by
+  LLVM.and (icmp IntPred.eq (trunc 8 (lshr e_1 (const? 32 24))) (trunc 8 (lshr e (const? 32 24))))
+      (LLVM.and (icmp IntPred.eq (trunc 8 (lshr e_1 (const? 32 16))) (trunc 8 (lshr e (const? 32 16))))
+        (LLVM.and (icmp IntPred.eq (trunc 8 e_1) (trunc 8 e))
+          (icmp IntPred.eq (trunc 8 (lshr e_1 (const? 32 8))) (trunc 8 (lshr e (const? 32 8)))))) ⊑
+    icmp IntPred.eq e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -51,9 +51,9 @@ theorem eq_3210_thm (e e_1 : IntW 32) :
 
 
 theorem eq_21_thm (e e_1 : IntW 32) :
-  LLVM.and (icmp IntPredicate.eq (trunc 8 (lshr e_1 (const? 32 16))) (trunc 8 (lshr e (const? 32 16))))
-      (icmp IntPredicate.eq (trunc 8 (lshr e_1 (const? 32 8))) (trunc 8 (lshr e (const? 32 8)))) ⊑
-    icmp IntPredicate.eq (trunc 16 (lshr e_1 (const? 32 8))) (trunc 16 (lshr e (const? 32 8))) := by
+  LLVM.and (icmp IntPred.eq (trunc 8 (lshr e_1 (const? 32 16))) (trunc 8 (lshr e (const? 32 16))))
+      (icmp IntPred.eq (trunc 8 (lshr e_1 (const? 32 8))) (trunc 8 (lshr e (const? 32 8)))) ⊑
+    icmp IntPred.eq (trunc 16 (lshr e_1 (const? 32 8))) (trunc 16 (lshr e (const? 32 8))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -63,9 +63,9 @@ theorem eq_21_thm (e e_1 : IntW 32) :
 
 
 theorem eq_21_comm_and_thm (e e_1 : IntW 32) :
-  LLVM.and (icmp IntPredicate.eq (trunc 8 (lshr e_1 (const? 32 8))) (trunc 8 (lshr e (const? 32 8))))
-      (icmp IntPredicate.eq (trunc 8 (lshr e_1 (const? 32 16))) (trunc 8 (lshr e (const? 32 16)))) ⊑
-    icmp IntPredicate.eq (trunc 16 (lshr e_1 (const? 32 8))) (trunc 16 (lshr e (const? 32 8))) := by
+  LLVM.and (icmp IntPred.eq (trunc 8 (lshr e_1 (const? 32 8))) (trunc 8 (lshr e (const? 32 8))))
+      (icmp IntPred.eq (trunc 8 (lshr e_1 (const? 32 16))) (trunc 8 (lshr e (const? 32 16)))) ⊑
+    icmp IntPred.eq (trunc 16 (lshr e_1 (const? 32 8))) (trunc 16 (lshr e (const? 32 8))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -75,9 +75,9 @@ theorem eq_21_comm_and_thm (e e_1 : IntW 32) :
 
 
 theorem eq_21_comm_eq_thm (e e_1 : IntW 32) :
-  LLVM.and (icmp IntPredicate.eq (trunc 8 (lshr e_1 (const? 32 16))) (trunc 8 (lshr e (const? 32 16))))
-      (icmp IntPredicate.eq (trunc 8 (lshr e (const? 32 8))) (trunc 8 (lshr e_1 (const? 32 8)))) ⊑
-    icmp IntPredicate.eq (trunc 16 (lshr e_1 (const? 32 8))) (trunc 16 (lshr e (const? 32 8))) := by
+  LLVM.and (icmp IntPred.eq (trunc 8 (lshr e_1 (const? 32 16))) (trunc 8 (lshr e (const? 32 16))))
+      (icmp IntPred.eq (trunc 8 (lshr e (const? 32 8))) (trunc 8 (lshr e_1 (const? 32 8)))) ⊑
+    icmp IntPred.eq (trunc 16 (lshr e_1 (const? 32 8))) (trunc 16 (lshr e (const? 32 8))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -87,9 +87,9 @@ theorem eq_21_comm_eq_thm (e e_1 : IntW 32) :
 
 
 theorem eq_21_comm_eq2_thm (e e_1 : IntW 32) :
-  LLVM.and (icmp IntPredicate.eq (trunc 8 (lshr e_1 (const? 32 16))) (trunc 8 (lshr e (const? 32 16))))
-      (icmp IntPredicate.eq (trunc 8 (lshr e (const? 32 8))) (trunc 8 (lshr e_1 (const? 32 8)))) ⊑
-    icmp IntPredicate.eq (trunc 16 (lshr e_1 (const? 32 8))) (trunc 16 (lshr e (const? 32 8))) := by
+  LLVM.and (icmp IntPred.eq (trunc 8 (lshr e_1 (const? 32 16))) (trunc 8 (lshr e (const? 32 16))))
+      (icmp IntPred.eq (trunc 8 (lshr e (const? 32 8))) (trunc 8 (lshr e_1 (const? 32 8)))) ⊑
+    icmp IntPred.eq (trunc 16 (lshr e_1 (const? 32 8))) (trunc 16 (lshr e (const? 32 8))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -99,9 +99,9 @@ theorem eq_21_comm_eq2_thm (e e_1 : IntW 32) :
 
 
 theorem eq_irregular_bit_widths_thm (e e_1 : IntW 31) :
-  LLVM.and (icmp IntPredicate.eq (trunc 5 (lshr e_1 (const? 31 13))) (trunc 5 (lshr e (const? 31 13))))
-      (icmp IntPredicate.eq (trunc 6 (lshr e_1 (const? 31 7))) (trunc 6 (lshr e (const? 31 7)))) ⊑
-    icmp IntPredicate.eq (trunc 11 (lshr e_1 (const? 31 7))) (trunc 11 (lshr e (const? 31 7))) := by
+  LLVM.and (icmp IntPred.eq (trunc 5 (lshr e_1 (const? 31 13))) (trunc 5 (lshr e (const? 31 13))))
+      (icmp IntPred.eq (trunc 6 (lshr e_1 (const? 31 7))) (trunc 6 (lshr e (const? 31 7)))) ⊑
+    icmp IntPred.eq (trunc 11 (lshr e_1 (const? 31 7))) (trunc 11 (lshr e (const? 31 7))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -111,9 +111,9 @@ theorem eq_irregular_bit_widths_thm (e e_1 : IntW 31) :
 
 
 theorem eq_21_logical_thm (e e_1 : IntW 32) :
-  select (icmp IntPredicate.eq (trunc 8 (lshr e_1 (const? 32 16))) (trunc 8 (lshr e (const? 32 16))))
-      (icmp IntPredicate.eq (trunc 8 (lshr e_1 (const? 32 8))) (trunc 8 (lshr e (const? 32 8)))) (const? 1 0) ⊑
-    icmp IntPredicate.eq (trunc 16 (lshr e_1 (const? 32 8))) (trunc 16 (lshr e (const? 32 8))) := by
+  select (icmp IntPred.eq (trunc 8 (lshr e_1 (const? 32 16))) (trunc 8 (lshr e (const? 32 16))))
+      (icmp IntPred.eq (trunc 8 (lshr e_1 (const? 32 8))) (trunc 8 (lshr e (const? 32 8)))) (const? 1 0) ⊑
+    icmp IntPred.eq (trunc 16 (lshr e_1 (const? 32 8))) (trunc 16 (lshr e (const? 32 8))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -123,9 +123,9 @@ theorem eq_21_logical_thm (e e_1 : IntW 32) :
 
 
 theorem eq_shift_in_zeros_thm (e e_1 : IntW 32) :
-  LLVM.and (icmp IntPredicate.eq (trunc 24 (lshr e_1 (const? 32 16))) (trunc 24 (lshr e (const? 32 16))))
-      (icmp IntPredicate.eq (trunc 8 (lshr e_1 (const? 32 8))) (trunc 8 (lshr e (const? 32 8)))) ⊑
-    icmp IntPredicate.ult (LLVM.xor e_1 e) (const? 32 256) := by
+  LLVM.and (icmp IntPred.eq (trunc 24 (lshr e_1 (const? 32 16))) (trunc 24 (lshr e (const? 32 16))))
+      (icmp IntPred.eq (trunc 8 (lshr e_1 (const? 32 8))) (trunc 8 (lshr e (const? 32 8)))) ⊑
+    icmp IntPred.ult (LLVM.xor e_1 e) (const? 32 256) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -135,9 +135,9 @@ theorem eq_shift_in_zeros_thm (e e_1 : IntW 32) :
 
 
 theorem ne_10_thm (e e_1 : IntW 32) :
-  LLVM.or (icmp IntPredicate.ne (trunc 8 e_1) (trunc 8 e))
-      (icmp IntPredicate.ne (trunc 8 (lshr e_1 (const? 32 8))) (trunc 8 (lshr e (const? 32 8)))) ⊑
-    icmp IntPredicate.ne (trunc 16 e_1) (trunc 16 e) := by
+  LLVM.or (icmp IntPred.ne (trunc 8 e_1) (trunc 8 e))
+      (icmp IntPred.ne (trunc 8 (lshr e_1 (const? 32 8))) (trunc 8 (lshr e (const? 32 8)))) ⊑
+    icmp IntPred.ne (trunc 16 e_1) (trunc 16 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -147,10 +147,10 @@ theorem ne_10_thm (e e_1 : IntW 32) :
 
 
 theorem ne_210_thm (e e_1 : IntW 32) :
-  LLVM.or (icmp IntPredicate.ne (trunc 8 (lshr e_1 (const? 32 16))) (trunc 8 (lshr e (const? 32 16))))
-      (LLVM.or (icmp IntPredicate.ne (trunc 8 e_1) (trunc 8 e))
-        (icmp IntPredicate.ne (trunc 8 (lshr e_1 (const? 32 8))) (trunc 8 (lshr e (const? 32 8))))) ⊑
-    icmp IntPredicate.ne (trunc 24 e_1) (trunc 24 e) := by
+  LLVM.or (icmp IntPred.ne (trunc 8 (lshr e_1 (const? 32 16))) (trunc 8 (lshr e (const? 32 16))))
+      (LLVM.or (icmp IntPred.ne (trunc 8 e_1) (trunc 8 e))
+        (icmp IntPred.ne (trunc 8 (lshr e_1 (const? 32 8))) (trunc 8 (lshr e (const? 32 8))))) ⊑
+    icmp IntPred.ne (trunc 24 e_1) (trunc 24 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -160,11 +160,11 @@ theorem ne_210_thm (e e_1 : IntW 32) :
 
 
 theorem ne_3210_thm (e e_1 : IntW 32) :
-  LLVM.or (icmp IntPredicate.ne (trunc 8 (lshr e_1 (const? 32 24))) (trunc 8 (lshr e (const? 32 24))))
-      (LLVM.or (icmp IntPredicate.ne (trunc 8 (lshr e_1 (const? 32 16))) (trunc 8 (lshr e (const? 32 16))))
-        (LLVM.or (icmp IntPredicate.ne (trunc 8 e_1) (trunc 8 e))
-          (icmp IntPredicate.ne (trunc 8 (lshr e_1 (const? 32 8))) (trunc 8 (lshr e (const? 32 8)))))) ⊑
-    icmp IntPredicate.ne e_1 e := by
+  LLVM.or (icmp IntPred.ne (trunc 8 (lshr e_1 (const? 32 24))) (trunc 8 (lshr e (const? 32 24))))
+      (LLVM.or (icmp IntPred.ne (trunc 8 (lshr e_1 (const? 32 16))) (trunc 8 (lshr e (const? 32 16))))
+        (LLVM.or (icmp IntPred.ne (trunc 8 e_1) (trunc 8 e))
+          (icmp IntPred.ne (trunc 8 (lshr e_1 (const? 32 8))) (trunc 8 (lshr e (const? 32 8)))))) ⊑
+    icmp IntPred.ne e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -174,9 +174,9 @@ theorem ne_3210_thm (e e_1 : IntW 32) :
 
 
 theorem ne_21_thm (e e_1 : IntW 32) :
-  LLVM.or (icmp IntPredicate.ne (trunc 8 (lshr e_1 (const? 32 16))) (trunc 8 (lshr e (const? 32 16))))
-      (icmp IntPredicate.ne (trunc 8 (lshr e_1 (const? 32 8))) (trunc 8 (lshr e (const? 32 8)))) ⊑
-    icmp IntPredicate.ne (trunc 16 (lshr e_1 (const? 32 8))) (trunc 16 (lshr e (const? 32 8))) := by
+  LLVM.or (icmp IntPred.ne (trunc 8 (lshr e_1 (const? 32 16))) (trunc 8 (lshr e (const? 32 16))))
+      (icmp IntPred.ne (trunc 8 (lshr e_1 (const? 32 8))) (trunc 8 (lshr e (const? 32 8)))) ⊑
+    icmp IntPred.ne (trunc 16 (lshr e_1 (const? 32 8))) (trunc 16 (lshr e (const? 32 8))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -186,9 +186,9 @@ theorem ne_21_thm (e e_1 : IntW 32) :
 
 
 theorem ne_21_comm_or_thm (e e_1 : IntW 32) :
-  LLVM.or (icmp IntPredicate.ne (trunc 8 (lshr e_1 (const? 32 8))) (trunc 8 (lshr e (const? 32 8))))
-      (icmp IntPredicate.ne (trunc 8 (lshr e_1 (const? 32 16))) (trunc 8 (lshr e (const? 32 16)))) ⊑
-    icmp IntPredicate.ne (trunc 16 (lshr e_1 (const? 32 8))) (trunc 16 (lshr e (const? 32 8))) := by
+  LLVM.or (icmp IntPred.ne (trunc 8 (lshr e_1 (const? 32 8))) (trunc 8 (lshr e (const? 32 8))))
+      (icmp IntPred.ne (trunc 8 (lshr e_1 (const? 32 16))) (trunc 8 (lshr e (const? 32 16)))) ⊑
+    icmp IntPred.ne (trunc 16 (lshr e_1 (const? 32 8))) (trunc 16 (lshr e (const? 32 8))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -198,9 +198,9 @@ theorem ne_21_comm_or_thm (e e_1 : IntW 32) :
 
 
 theorem ne_21_comm_ne_thm (e e_1 : IntW 32) :
-  LLVM.or (icmp IntPredicate.ne (trunc 8 (lshr e_1 (const? 32 16))) (trunc 8 (lshr e (const? 32 16))))
-      (icmp IntPredicate.ne (trunc 8 (lshr e (const? 32 8))) (trunc 8 (lshr e_1 (const? 32 8)))) ⊑
-    icmp IntPredicate.ne (trunc 16 (lshr e_1 (const? 32 8))) (trunc 16 (lshr e (const? 32 8))) := by
+  LLVM.or (icmp IntPred.ne (trunc 8 (lshr e_1 (const? 32 16))) (trunc 8 (lshr e (const? 32 16))))
+      (icmp IntPred.ne (trunc 8 (lshr e (const? 32 8))) (trunc 8 (lshr e_1 (const? 32 8)))) ⊑
+    icmp IntPred.ne (trunc 16 (lshr e_1 (const? 32 8))) (trunc 16 (lshr e (const? 32 8))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -210,9 +210,9 @@ theorem ne_21_comm_ne_thm (e e_1 : IntW 32) :
 
 
 theorem ne_21_comm_ne2_thm (e e_1 : IntW 32) :
-  LLVM.or (icmp IntPredicate.ne (trunc 8 (lshr e_1 (const? 32 16))) (trunc 8 (lshr e (const? 32 16))))
-      (icmp IntPredicate.ne (trunc 8 (lshr e (const? 32 8))) (trunc 8 (lshr e_1 (const? 32 8)))) ⊑
-    icmp IntPredicate.ne (trunc 16 (lshr e_1 (const? 32 8))) (trunc 16 (lshr e (const? 32 8))) := by
+  LLVM.or (icmp IntPred.ne (trunc 8 (lshr e_1 (const? 32 16))) (trunc 8 (lshr e (const? 32 16))))
+      (icmp IntPred.ne (trunc 8 (lshr e (const? 32 8))) (trunc 8 (lshr e_1 (const? 32 8)))) ⊑
+    icmp IntPred.ne (trunc 16 (lshr e_1 (const? 32 8))) (trunc 16 (lshr e (const? 32 8))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -222,9 +222,9 @@ theorem ne_21_comm_ne2_thm (e e_1 : IntW 32) :
 
 
 theorem ne_irregular_bit_widths_thm (e e_1 : IntW 31) :
-  LLVM.or (icmp IntPredicate.ne (trunc 5 (lshr e_1 (const? 31 13))) (trunc 5 (lshr e (const? 31 13))))
-      (icmp IntPredicate.ne (trunc 6 (lshr e_1 (const? 31 7))) (trunc 6 (lshr e (const? 31 7)))) ⊑
-    icmp IntPredicate.ne (trunc 11 (lshr e_1 (const? 31 7))) (trunc 11 (lshr e (const? 31 7))) := by
+  LLVM.or (icmp IntPred.ne (trunc 5 (lshr e_1 (const? 31 13))) (trunc 5 (lshr e (const? 31 13))))
+      (icmp IntPred.ne (trunc 6 (lshr e_1 (const? 31 7))) (trunc 6 (lshr e (const? 31 7)))) ⊑
+    icmp IntPred.ne (trunc 11 (lshr e_1 (const? 31 7))) (trunc 11 (lshr e (const? 31 7))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -234,9 +234,9 @@ theorem ne_irregular_bit_widths_thm (e e_1 : IntW 31) :
 
 
 theorem ne_21_logical_thm (e e_1 : IntW 32) :
-  select (icmp IntPredicate.ne (trunc 8 (lshr e_1 (const? 32 16))) (trunc 8 (lshr e (const? 32 16)))) (const? 1 1)
-      (icmp IntPredicate.ne (trunc 8 (lshr e_1 (const? 32 8))) (trunc 8 (lshr e (const? 32 8)))) ⊑
-    icmp IntPredicate.ne (trunc 16 (lshr e_1 (const? 32 8))) (trunc 16 (lshr e (const? 32 8))) := by
+  select (icmp IntPred.ne (trunc 8 (lshr e_1 (const? 32 16))) (trunc 8 (lshr e (const? 32 16)))) (const? 1 1)
+      (icmp IntPred.ne (trunc 8 (lshr e_1 (const? 32 8))) (trunc 8 (lshr e (const? 32 8)))) ⊑
+    icmp IntPred.ne (trunc 16 (lshr e_1 (const? 32 8))) (trunc 16 (lshr e (const? 32 8))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -246,9 +246,9 @@ theorem ne_21_logical_thm (e e_1 : IntW 32) :
 
 
 theorem ne_shift_in_zeros_thm (e e_1 : IntW 32) :
-  LLVM.or (icmp IntPredicate.ne (trunc 24 (lshr e_1 (const? 32 16))) (trunc 24 (lshr e (const? 32 16))))
-      (icmp IntPredicate.ne (trunc 8 (lshr e_1 (const? 32 8))) (trunc 8 (lshr e (const? 32 8)))) ⊑
-    icmp IntPredicate.ugt (LLVM.xor e_1 e) (const? 32 255) := by
+  LLVM.or (icmp IntPred.ne (trunc 24 (lshr e_1 (const? 32 16))) (trunc 24 (lshr e (const? 32 16))))
+      (icmp IntPred.ne (trunc 8 (lshr e_1 (const? 32 8))) (trunc 8 (lshr e (const? 32 8)))) ⊑
+    icmp IntPred.ugt (LLVM.xor e_1 e) (const? 32 255) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -258,9 +258,9 @@ theorem ne_shift_in_zeros_thm (e e_1 : IntW 32) :
 
 
 theorem eq_optimized_highbits_cmp_thm (e e_1 : IntW 32) :
-  LLVM.and (icmp IntPredicate.ult (LLVM.xor e_1 e) (const? 32 33554432))
-      (icmp IntPredicate.eq (trunc 25 e) (trunc 25 e_1)) ⊑
-    icmp IntPredicate.eq e_1 e := by
+  LLVM.and (icmp IntPred.ult (LLVM.xor e_1 e) (const? 32 33554432))
+      (icmp IntPred.eq (trunc 25 e) (trunc 25 e_1)) ⊑
+    icmp IntPred.eq e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -270,9 +270,9 @@ theorem eq_optimized_highbits_cmp_thm (e e_1 : IntW 32) :
 
 
 theorem ne_optimized_highbits_cmp_thm (e e_1 : IntW 32) :
-  LLVM.or (icmp IntPredicate.ugt (LLVM.xor e_1 e) (const? 32 16777215))
-      (icmp IntPredicate.ne (trunc 24 e) (trunc 24 e_1)) ⊑
-    icmp IntPredicate.ne e_1 e := by
+  LLVM.or (icmp IntPred.ugt (LLVM.xor e_1 e) (const? 32 16777215))
+      (icmp IntPred.ne (trunc 24 e) (trunc 24 e_1)) ⊑
+    icmp IntPred.ne e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gexact_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gexact_proof.lean
@@ -70,8 +70,8 @@ theorem ashr1_thm (e : IntW 64) :
 
 
 theorem ashr_icmp1_thm (e : IntW 64) :
-  icmp IntPredicate.eq (ashr e (const? 64 2) { «exact» := true }) (const? 64 0) ⊑
-    icmp IntPredicate.eq e (const? 64 0) := by
+  icmp IntPred.eq (ashr e (const? 64 2) { «exact» := true }) (const? 64 0) ⊑
+    icmp IntPred.eq e (const? 64 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -81,8 +81,8 @@ theorem ashr_icmp1_thm (e : IntW 64) :
 
 
 theorem ashr_icmp2_thm (e : IntW 64) :
-  icmp IntPredicate.slt (ashr e (const? 64 2) { «exact» := true }) (const? 64 4) ⊑
-    icmp IntPredicate.slt e (const? 64 16) := by
+  icmp IntPred.slt (ashr e (const? 64 2) { «exact» := true }) (const? 64 4) ⊑
+    icmp IntPred.slt e (const? 64 16) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -92,9 +92,9 @@ theorem ashr_icmp2_thm (e : IntW 64) :
 
 
 theorem pr9998_thm (e : IntW 32) :
-  icmp IntPredicate.ugt (sext 64 (ashr (shl e (const? 32 31)) (const? 32 31) { «exact» := true }))
+  icmp IntPred.ugt (sext 64 (ashr (shl e (const? 32 31)) (const? 32 31) { «exact» := true }))
       (const? 64 7297771788697658747) ⊑
-    icmp IntPredicate.ne (LLVM.and e (const? 32 1)) (const? 32 0) := by
+    icmp IntPred.ne (LLVM.and e (const? 32 1)) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -104,8 +104,8 @@ theorem pr9998_thm (e : IntW 32) :
 
 
 theorem udiv_icmp1_thm (e : IntW 64) :
-  icmp IntPredicate.ne (LLVM.udiv e (const? 64 5) { «exact» := true }) (const? 64 0) ⊑
-    icmp IntPredicate.ne e (const? 64 0) := by
+  icmp IntPred.ne (LLVM.udiv e (const? 64 5) { «exact» := true }) (const? 64 0) ⊑
+    icmp IntPred.ne e (const? 64 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -115,8 +115,8 @@ theorem udiv_icmp1_thm (e : IntW 64) :
 
 
 theorem udiv_icmp2_thm (e : IntW 64) :
-  icmp IntPredicate.eq (LLVM.udiv e (const? 64 5) { «exact» := true }) (const? 64 0) ⊑
-    icmp IntPredicate.eq e (const? 64 0) := by
+  icmp IntPred.eq (LLVM.udiv e (const? 64 5) { «exact» := true }) (const? 64 0) ⊑
+    icmp IntPred.eq e (const? 64 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -126,8 +126,8 @@ theorem udiv_icmp2_thm (e : IntW 64) :
 
 
 theorem sdiv_icmp1_thm (e : IntW 64) :
-  icmp IntPredicate.eq (LLVM.sdiv e (const? 64 5) { «exact» := true }) (const? 64 0) ⊑
-    icmp IntPredicate.eq e (const? 64 0) := by
+  icmp IntPred.eq (LLVM.sdiv e (const? 64 5) { «exact» := true }) (const? 64 0) ⊑
+    icmp IntPred.eq e (const? 64 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -137,8 +137,8 @@ theorem sdiv_icmp1_thm (e : IntW 64) :
 
 
 theorem sdiv_icmp2_thm (e : IntW 64) :
-  icmp IntPredicate.eq (LLVM.sdiv e (const? 64 5) { «exact» := true }) (const? 64 1) ⊑
-    icmp IntPredicate.eq e (const? 64 5) := by
+  icmp IntPred.eq (LLVM.sdiv e (const? 64 5) { «exact» := true }) (const? 64 1) ⊑
+    icmp IntPred.eq e (const? 64 5) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -148,8 +148,8 @@ theorem sdiv_icmp2_thm (e : IntW 64) :
 
 
 theorem sdiv_icmp3_thm (e : IntW 64) :
-  icmp IntPredicate.eq (LLVM.sdiv e (const? 64 5) { «exact» := true }) (const? 64 (-1)) ⊑
-    icmp IntPredicate.eq e (const? 64 (-5)) := by
+  icmp IntPred.eq (LLVM.sdiv e (const? 64 5) { «exact» := true }) (const? 64 (-1)) ⊑
+    icmp IntPred.eq e (const? 64 (-5)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -159,8 +159,8 @@ theorem sdiv_icmp3_thm (e : IntW 64) :
 
 
 theorem sdiv_icmp4_thm (e : IntW 64) :
-  icmp IntPredicate.eq (LLVM.sdiv e (const? 64 (-5)) { «exact» := true }) (const? 64 0) ⊑
-    icmp IntPredicate.eq e (const? 64 0) := by
+  icmp IntPred.eq (LLVM.sdiv e (const? 64 (-5)) { «exact» := true }) (const? 64 0) ⊑
+    icmp IntPred.eq e (const? 64 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -170,8 +170,8 @@ theorem sdiv_icmp4_thm (e : IntW 64) :
 
 
 theorem sdiv_icmp5_thm (e : IntW 64) :
-  icmp IntPredicate.eq (LLVM.sdiv e (const? 64 (-5)) { «exact» := true }) (const? 64 1) ⊑
-    icmp IntPredicate.eq e (const? 64 (-5)) := by
+  icmp IntPred.eq (LLVM.sdiv e (const? 64 (-5)) { «exact» := true }) (const? 64 1) ⊑
+    icmp IntPred.eq e (const? 64 (-5)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -181,8 +181,8 @@ theorem sdiv_icmp5_thm (e : IntW 64) :
 
 
 theorem sdiv_icmp6_thm (e : IntW 64) :
-  icmp IntPredicate.eq (LLVM.sdiv e (const? 64 (-5)) { «exact» := true }) (const? 64 (-1)) ⊑
-    icmp IntPredicate.eq e (const? 64 5) := by
+  icmp IntPred.eq (LLVM.sdiv e (const? 64 (-5)) { «exact» := true }) (const? 64 (-1)) ⊑
+    icmp IntPred.eq e (const? 64 5) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gfoldhahorhbhzero_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gfoldhahorhbhzero_proof.lean
@@ -12,9 +12,9 @@ set_option Elab.async false
 
 section gfoldhahorhbhzero_proof
 theorem a_or_b_thm (e e_1 : IntW 32) :
-  LLVM.or (LLVM.and (icmp IntPredicate.eq e_1 (const? 32 0)) (icmp IntPredicate.ne e (const? 32 0)))
-      (LLVM.and (icmp IntPredicate.ne e_1 (const? 32 0)) (icmp IntPredicate.eq e (const? 32 0))) ⊑
-    LLVM.xor (icmp IntPredicate.eq e_1 (const? 32 0)) (icmp IntPredicate.eq e (const? 32 0)) := by
+  LLVM.or (LLVM.and (icmp IntPred.eq e_1 (const? 32 0)) (icmp IntPred.ne e (const? 32 0)))
+      (LLVM.and (icmp IntPred.ne e_1 (const? 32 0)) (icmp IntPred.eq e (const? 32 0))) ⊑
+    LLVM.xor (icmp IntPred.eq e_1 (const? 32 0)) (icmp IntPred.eq e (const? 32 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -24,9 +24,9 @@ theorem a_or_b_thm (e e_1 : IntW 32) :
 
 
 theorem a_or_b_const_thm (e e_1 e_2 : IntW 32) :
-  LLVM.or (LLVM.and (icmp IntPredicate.eq e_2 e_1) (icmp IntPredicate.ne e e_1))
-      (LLVM.and (icmp IntPredicate.ne e_2 e_1) (icmp IntPredicate.eq e e_1)) ⊑
-    LLVM.xor (icmp IntPredicate.eq e_2 e_1) (icmp IntPredicate.eq e e_1) := by
+  LLVM.or (LLVM.and (icmp IntPred.eq e_2 e_1) (icmp IntPred.ne e e_1))
+      (LLVM.and (icmp IntPred.ne e_2 e_1) (icmp IntPred.eq e e_1)) ⊑
+    LLVM.xor (icmp IntPred.eq e_2 e_1) (icmp IntPred.eq e e_1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -36,9 +36,9 @@ theorem a_or_b_const_thm (e e_1 e_2 : IntW 32) :
 
 
 theorem a_or_b_const2_thm (e e_1 e_2 e_3 : IntW 32) :
-  LLVM.or (LLVM.and (icmp IntPredicate.eq e_3 e_2) (icmp IntPredicate.ne e_1 e))
-      (LLVM.and (icmp IntPredicate.ne e_3 e_2) (icmp IntPredicate.eq e_1 e)) ⊑
-    LLVM.xor (icmp IntPredicate.eq e_3 e_2) (icmp IntPredicate.eq e_1 e) := by
+  LLVM.or (LLVM.and (icmp IntPred.eq e_3 e_2) (icmp IntPred.ne e_1 e))
+      (LLVM.and (icmp IntPred.ne e_3 e_2) (icmp IntPred.eq e_1 e)) ⊑
+    LLVM.xor (icmp IntPred.eq e_3 e_2) (icmp IntPred.eq e_1 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gfoldhsignbithtesthpower2_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gfoldhsignbithtesthpower2_proof.lean
@@ -12,8 +12,8 @@ set_option Elab.async false
 
 section gfoldhsignbithtesthpower2_proof
 theorem pow2_or_zero_is_negative_commute_thm (e : IntW 8) :
-  icmp IntPredicate.slt (LLVM.and (sub (const? 8 0) (mul (const? 8 42) e)) (mul (const? 8 42) e)) (const? 8 0) ⊑
-    icmp IntPredicate.eq (mul e (const? 8 42)) (const? 8 (-128)) := by
+  icmp IntPred.slt (LLVM.and (sub (const? 8 0) (mul (const? 8 42) e)) (mul (const? 8 42) e)) (const? 8 0) ⊑
+    icmp IntPred.eq (mul e (const? 8 42)) (const? 8 (-128)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -23,8 +23,8 @@ theorem pow2_or_zero_is_negative_commute_thm (e : IntW 8) :
 
 
 theorem pow2_or_zero_is_not_negative_commute_thm (e : IntW 8) :
-  icmp IntPredicate.sgt (LLVM.and (sub (const? 8 0) (mul (const? 8 42) e)) (mul (const? 8 42) e)) (const? 8 (-1)) ⊑
-    icmp IntPredicate.ne (mul e (const? 8 42)) (const? 8 (-128)) := by
+  icmp IntPred.sgt (LLVM.and (sub (const? 8 0) (mul (const? 8 42) e)) (mul (const? 8 42) e)) (const? 8 (-1)) ⊑
+    icmp IntPred.ne (mul e (const? 8 42)) (const? 8 (-128)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/ghighhbithsignmask_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/ghighhbithsignmask_proof.lean
@@ -61,7 +61,7 @@ theorem n9_thm (e : IntW 64) :
 
 
 theorem n10_thm (e : IntW 64) :
-  sub (const? 64 1) (lshr e (const? 64 63)) ⊑ zext 64 (icmp IntPredicate.sgt e (const? 64 (-1))) := by
+  sub (const? 64 1) (lshr e (const? 64 63)) ⊑ zext 64 (icmp IntPred.sgt e (const? 64 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gicmphandhlowbithmask_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gicmphandhlowbithmask_proof.lean
@@ -12,9 +12,9 @@ set_option Elab.async false
 
 section gicmphandhlowbithmask_proof
 theorem src_is_mask_zext_thm (e : IntW 8) (e_1 : IntW 16) :
-  icmp IntPredicate.eq (LLVM.and (LLVM.xor e_1 (const? 16 123)) (zext 16 (lshr (const? 8 (-1)) e)))
+  icmp IntPred.eq (LLVM.and (LLVM.xor e_1 (const? 16 123)) (zext 16 (lshr (const? 8 (-1)) e)))
       (LLVM.xor e_1 (const? 16 123)) ⊑
-    icmp IntPredicate.ule (LLVM.xor e_1 (const? 16 123)) (zext 16 (lshr (const? 8 (-1)) e)) := by
+    icmp IntPred.ule (LLVM.xor e_1 (const? 16 123)) (zext 16 (lshr (const? 8 (-1)) e)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -24,9 +24,9 @@ theorem src_is_mask_zext_thm (e : IntW 8) (e_1 : IntW 16) :
 
 
 theorem src_is_mask_zext_fail_not_mask_thm (e : IntW 8) (e_1 : IntW 16) :
-  icmp IntPredicate.eq (LLVM.and (LLVM.xor e_1 (const? 16 123)) (zext 16 (lshr (const? 8 (-2)) e)))
+  icmp IntPred.eq (LLVM.and (LLVM.xor e_1 (const? 16 123)) (zext 16 (lshr (const? 8 (-2)) e)))
       (LLVM.xor e_1 (const? 16 123)) ⊑
-    icmp IntPredicate.eq (LLVM.or (LLVM.xor e_1 (const? 16 (-124))) (zext 16 (lshr (const? 8 (-2)) e)))
+    icmp IntPred.eq (LLVM.or (LLVM.xor e_1 (const? 16 (-124))) (zext 16 (lshr (const? 8 (-2)) e)))
       (const? 16 (-1)) := by
     simp_alive_undef
     simp_alive_ops
@@ -37,10 +37,10 @@ theorem src_is_mask_zext_fail_not_mask_thm (e : IntW 8) (e_1 : IntW 16) :
 
 
 theorem src_is_mask_sext_thm (e : IntW 16) (e_1 : IntW 8) :
-  icmp IntPredicate.eq
+  icmp IntPred.eq
       (LLVM.and (LLVM.xor (sext 16 (lshr (const? 8 31) e_1)) (const? 16 (-1))) (LLVM.xor e (const? 16 123)))
       (const? 16 0) ⊑
-    icmp IntPredicate.ule (LLVM.xor e (const? 16 123)) (zext 16 (lshr (const? 8 31) e_1) { «nneg» := true }) := by
+    icmp IntPred.ule (LLVM.xor e (const? 16 123)) (zext 16 (lshr (const? 8 31) e_1) { «nneg» := true }) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -50,9 +50,9 @@ theorem src_is_mask_sext_thm (e : IntW 16) (e_1 : IntW 8) :
 
 
 theorem src_is_mask_and_thm (e e_1 e_2 : IntW 8) :
-  icmp IntPredicate.eq (LLVM.xor e_2 (const? 8 123))
+  icmp IntPred.eq (LLVM.xor e_2 (const? 8 123))
       (LLVM.and (LLVM.xor e_2 (const? 8 123)) (LLVM.and (ashr (const? 8 7) e_1) (lshr (const? 8 (-1)) e))) ⊑
-    icmp IntPredicate.ule (LLVM.xor e_2 (const? 8 123))
+    icmp IntPred.ule (LLVM.xor e_2 (const? 8 123))
       (LLVM.and (lshr (const? 8 7) e_1) (lshr (const? 8 (-1)) e)) := by
     simp_alive_undef
     simp_alive_ops
@@ -63,9 +63,9 @@ theorem src_is_mask_and_thm (e e_1 e_2 : IntW 8) :
 
 
 theorem src_is_mask_and_fail_mixed_thm (e e_1 e_2 : IntW 8) :
-  icmp IntPredicate.eq (LLVM.xor e_2 (const? 8 123))
+  icmp IntPred.eq (LLVM.xor e_2 (const? 8 123))
       (LLVM.and (LLVM.xor e_2 (const? 8 123)) (LLVM.and (ashr (const? 8 (-8)) e_1) (lshr (const? 8 (-1)) e))) ⊑
-    icmp IntPredicate.eq
+    icmp IntPred.eq
       (LLVM.or (LLVM.and (ashr (const? 8 (-8)) e_1) (lshr (const? 8 (-1)) e)) (LLVM.xor e_2 (const? 8 (-124))))
       (const? 8 (-1)) := by
     simp_alive_undef
@@ -77,9 +77,9 @@ theorem src_is_mask_and_fail_mixed_thm (e e_1 e_2 : IntW 8) :
 
 
 theorem src_is_mask_or_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.eq (LLVM.xor e_1 (const? 8 123))
+  icmp IntPred.eq (LLVM.xor e_1 (const? 8 123))
       (LLVM.and (LLVM.and (lshr (const? 8 (-1)) e) (const? 8 7)) (LLVM.xor e_1 (const? 8 123))) ⊑
-    icmp IntPredicate.ule (LLVM.xor e_1 (const? 8 123)) (LLVM.and (lshr (const? 8 (-1)) e) (const? 8 7)) := by
+    icmp IntPred.ule (LLVM.xor e_1 (const? 8 123)) (LLVM.and (lshr (const? 8 (-1)) e) (const? 8 7)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -89,9 +89,9 @@ theorem src_is_mask_or_thm (e e_1 : IntW 8) :
 
 
 theorem src_is_mask_xor_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.ne (LLVM.and (LLVM.xor e_1 (const? 8 123)) (LLVM.xor e (add e (const? 8 (-1)))))
+  icmp IntPred.ne (LLVM.and (LLVM.xor e_1 (const? 8 123)) (LLVM.xor e (add e (const? 8 (-1)))))
       (LLVM.xor e_1 (const? 8 123)) ⊑
-    icmp IntPredicate.ugt (LLVM.xor e_1 (const? 8 123)) (LLVM.xor e (add e (const? 8 (-1)))) := by
+    icmp IntPred.ugt (LLVM.xor e_1 (const? 8 123)) (LLVM.xor e (add e (const? 8 (-1)))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -101,10 +101,10 @@ theorem src_is_mask_xor_thm (e e_1 : IntW 8) :
 
 
 theorem src_is_mask_xor_fail_notmask_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.ne
+  icmp IntPred.ne
       (LLVM.and (LLVM.xor e_1 (const? 8 123)) (LLVM.xor (LLVM.xor e (add e (const? 8 (-1)))) (const? 8 (-1))))
       (LLVM.xor e_1 (const? 8 123)) ⊑
-    icmp IntPredicate.ne (LLVM.or (LLVM.xor e (sub (const? 8 0) e)) (LLVM.xor e_1 (const? 8 (-124))))
+    icmp IntPred.ne (LLVM.or (LLVM.xor e (sub (const? 8 0) e)) (LLVM.xor e_1 (const? 8 (-124))))
       (const? 8 (-1)) := by
     simp_alive_undef
     simp_alive_ops
@@ -115,10 +115,10 @@ theorem src_is_mask_xor_fail_notmask_thm (e e_1 : IntW 8) :
 
 
 theorem src_is_mask_select_thm (e e_1 : IntW 8) (e_2 : IntW 1) :
-  icmp IntPredicate.ne
+  icmp IntPred.ne
       (LLVM.and (select e_2 (LLVM.xor e_1 (add e_1 (const? 8 (-1)))) (const? 8 15)) (LLVM.xor e (const? 8 123)))
       (LLVM.xor e (const? 8 123)) ⊑
-    icmp IntPredicate.ugt (LLVM.xor e (const? 8 123))
+    icmp IntPred.ugt (LLVM.xor e (const? 8 123))
       (select e_2 (LLVM.xor e_1 (add e_1 (const? 8 (-1)))) (const? 8 15)) := by
     simp_alive_undef
     simp_alive_ops
@@ -129,9 +129,9 @@ theorem src_is_mask_select_thm (e e_1 : IntW 8) (e_2 : IntW 1) :
 
 
 theorem src_is_mask_shl_lshr_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.ne (const? 8 0)
+  icmp IntPred.ne (const? 8 0)
       (LLVM.and (LLVM.xor e_1 (const? 8 123)) (LLVM.xor (lshr (shl (const? 8 (-1)) e) e) (const? 8 (-1)))) ⊑
-    icmp IntPredicate.ugt (LLVM.xor e_1 (const? 8 122)) (lshr (const? 8 (-1)) e) := by
+    icmp IntPred.ugt (LLVM.xor e_1 (const? 8 122)) (lshr (const? 8 (-1)) e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -141,9 +141,9 @@ theorem src_is_mask_shl_lshr_thm (e e_1 : IntW 8) :
 
 
 theorem src_is_mask_shl_lshr_fail_not_allones_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.ne (const? 8 0)
+  icmp IntPred.ne (const? 8 0)
       (LLVM.and (LLVM.xor e_1 (const? 8 123)) (LLVM.xor (lshr (shl (const? 8 (-2)) e) e) (const? 8 (-1)))) ⊑
-    icmp IntPredicate.ne (LLVM.or (LLVM.xor e_1 (const? 8 (-124))) (LLVM.and (lshr (const? 8 (-1)) e) (const? 8 (-2))))
+    icmp IntPred.ne (LLVM.or (LLVM.xor e_1 (const? 8 (-124))) (LLVM.and (lshr (const? 8 (-1)) e) (const? 8 (-2))))
       (const? 8 (-1)) := by
     simp_alive_undef
     simp_alive_ops
@@ -154,10 +154,10 @@ theorem src_is_mask_shl_lshr_fail_not_allones_thm (e e_1 : IntW 8) :
 
 
 theorem src_is_mask_lshr_thm (e e_1 : IntW 8) (e_2 : IntW 1) (e_3 : IntW 8) :
-  icmp IntPredicate.ne (LLVM.xor e_3 (const? 8 123))
+  icmp IntPred.ne (LLVM.xor e_3 (const? 8 123))
       (LLVM.and (lshr (select e_2 (LLVM.xor e_1 (add e_1 (const? 8 (-1)))) (const? 8 15)) e)
         (LLVM.xor e_3 (const? 8 123))) ⊑
-    icmp IntPredicate.ugt (LLVM.xor e_3 (const? 8 123))
+    icmp IntPred.ugt (LLVM.xor e_3 (const? 8 123))
       (lshr (select e_2 (LLVM.xor e_1 (add e_1 (const? 8 (-1)))) (const? 8 15)) e) := by
     simp_alive_undef
     simp_alive_ops
@@ -168,11 +168,11 @@ theorem src_is_mask_lshr_thm (e e_1 : IntW 8) (e_2 : IntW 1) (e_3 : IntW 8) :
 
 
 theorem src_is_mask_ashr_thm (e e_1 : IntW 8) (e_2 : IntW 1) (e_3 : IntW 8) :
-  icmp IntPredicate.ult
+  icmp IntPred.ult
       (LLVM.and (LLVM.xor e_3 (const? 8 123))
         (ashr (select e_2 (LLVM.xor e_1 (add e_1 (const? 8 (-1)))) (const? 8 15)) e))
       (LLVM.xor e_3 (const? 8 123)) ⊑
-    icmp IntPredicate.ugt (LLVM.xor e_3 (const? 8 123))
+    icmp IntPred.ugt (LLVM.xor e_3 (const? 8 123))
       (ashr (select e_2 (LLVM.xor e_1 (add e_1 (const? 8 (-1)))) (const? 8 15)) e) := by
     simp_alive_undef
     simp_alive_ops
@@ -183,9 +183,9 @@ theorem src_is_mask_ashr_thm (e e_1 : IntW 8) (e_2 : IntW 1) (e_3 : IntW 8) :
 
 
 theorem src_is_mask_p2_m1_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.ult (LLVM.and (add (shl (const? 8 2) e_1) (const? 8 (-1))) (LLVM.xor e (const? 8 123)))
+  icmp IntPred.ult (LLVM.and (add (shl (const? 8 2) e_1) (const? 8 (-1))) (LLVM.xor e (const? 8 123)))
       (LLVM.xor e (const? 8 123)) ⊑
-    icmp IntPredicate.ugt (LLVM.xor e (const? 8 123)) (add (shl (const? 8 2) e_1) (const? 8 (-1))) := by
+    icmp IntPred.ugt (LLVM.xor e (const? 8 123)) (add (shl (const? 8 2) e_1) (const? 8 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -195,9 +195,9 @@ theorem src_is_mask_p2_m1_thm (e e_1 : IntW 8) :
 
 
 theorem src_is_notmask_sext_thm (e : IntW 8) (e_1 : IntW 16) :
-  icmp IntPredicate.ule (LLVM.xor e_1 (const? 16 123))
+  icmp IntPred.ule (LLVM.xor e_1 (const? 16 123))
       (LLVM.and (LLVM.xor (sext 16 (shl (const? 8 (-8)) e)) (const? 16 (-1))) (LLVM.xor e_1 (const? 16 123))) ⊑
-    icmp IntPredicate.uge (LLVM.xor e_1 (const? 16 (-128))) (sext 16 (shl (const? 8 (-8)) e)) := by
+    icmp IntPred.uge (LLVM.xor e_1 (const? 16 (-128))) (sext 16 (shl (const? 8 (-8)) e)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -207,10 +207,10 @@ theorem src_is_notmask_sext_thm (e : IntW 8) (e_1 : IntW 16) :
 
 
 theorem src_is_notmask_x_xor_neg_x_thm (e : IntW 8) (e_1 : IntW 1) (e_2 : IntW 8) :
-  icmp IntPredicate.eq
+  icmp IntPred.eq
       (LLVM.and (LLVM.xor e_2 (const? 8 123)) (select e_1 (LLVM.xor e (sub (const? 8 0) e)) (const? 8 (-8))))
       (const? 8 0) ⊑
-    icmp IntPredicate.ule (LLVM.xor e_2 (const? 8 123))
+    icmp IntPred.ule (LLVM.xor e_2 (const? 8 123))
       (select e_1 (LLVM.xor e (add e (const? 8 (-1)))) (const? 8 7)) := by
     simp_alive_undef
     simp_alive_ops
@@ -221,10 +221,10 @@ theorem src_is_notmask_x_xor_neg_x_thm (e : IntW 8) (e_1 : IntW 1) (e_2 : IntW 8
 
 
 theorem src_is_notmask_x_xor_neg_x_inv_thm (e e_1 : IntW 8) (e_2 : IntW 1) :
-  icmp IntPredicate.eq
+  icmp IntPred.eq
       (LLVM.and (select e_2 (LLVM.xor e_1 (sub (const? 8 0) e_1)) (const? 8 (-8))) (LLVM.xor e (const? 8 123)))
       (const? 8 0) ⊑
-    icmp IntPredicate.ule (LLVM.xor e (const? 8 123))
+    icmp IntPred.ule (LLVM.xor e (const? 8 123))
       (select e_2 (LLVM.xor e_1 (add e_1 (const? 8 (-1)))) (const? 8 7)) := by
     simp_alive_undef
     simp_alive_ops
@@ -235,10 +235,10 @@ theorem src_is_notmask_x_xor_neg_x_inv_thm (e e_1 : IntW 8) (e_2 : IntW 1) :
 
 
 theorem src_is_notmask_lshr_shl_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.eq
+  icmp IntPred.eq
       (LLVM.and (LLVM.xor (shl (lshr (const? 8 (-1)) e_1) e_1) (const? 8 (-1))) (LLVM.xor e (const? 8 123)))
       (LLVM.xor e (const? 8 123)) ⊑
-    icmp IntPredicate.uge (LLVM.xor e (const? 8 (-124)))
+    icmp IntPred.uge (LLVM.xor e (const? 8 (-124)))
       (shl (const? 8 (-1)) e_1 { «nsw» := true, «nuw» := false }) := by
     simp_alive_undef
     simp_alive_ops
@@ -249,10 +249,10 @@ theorem src_is_notmask_lshr_shl_thm (e e_1 : IntW 8) :
 
 
 theorem src_is_notmask_lshr_shl_fail_mismatch_shifts_thm (e e_1 e_2 : IntW 8) :
-  icmp IntPredicate.eq
+  icmp IntPred.eq
       (LLVM.and (LLVM.xor (shl (lshr (const? 8 (-1)) e_2) e_1) (const? 8 (-1))) (LLVM.xor e (const? 8 123)))
       (LLVM.xor e (const? 8 123)) ⊑
-    icmp IntPredicate.eq (LLVM.and (LLVM.xor e (const? 8 123)) (shl (lshr (const? 8 (-1)) e_2) e_1))
+    icmp IntPred.eq (LLVM.and (LLVM.xor e (const? 8 123)) (shl (lshr (const? 8 (-1)) e_2) e_1))
       (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
@@ -263,10 +263,10 @@ theorem src_is_notmask_lshr_shl_fail_mismatch_shifts_thm (e e_1 e_2 : IntW 8) :
 
 
 theorem src_is_notmask_ashr_thm (e : IntW 16) (e_1 : IntW 8) (e_2 : IntW 16) :
-  icmp IntPredicate.eq (LLVM.xor e_2 (const? 16 123))
+  icmp IntPred.eq (LLVM.xor e_2 (const? 16 123))
       (LLVM.and (LLVM.xor e_2 (const? 16 123))
         (LLVM.xor (ashr (sext 16 (shl (const? 8 (-32)) e_1)) e) (const? 16 (-1)))) ⊑
-    icmp IntPredicate.uge (LLVM.xor e_2 (const? 16 (-124))) (ashr (sext 16 (shl (const? 8 (-32)) e_1)) e) := by
+    icmp IntPred.uge (LLVM.xor e_2 (const? 16 (-124))) (ashr (sext 16 (shl (const? 8 (-32)) e_1)) e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -276,9 +276,9 @@ theorem src_is_notmask_ashr_thm (e : IntW 16) (e_1 : IntW 8) (e_2 : IntW 16) :
 
 
 theorem src_is_notmask_neg_p2_fail_not_invertable_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.eq (const? 8 0)
+  icmp IntPred.eq (const? 8 0)
       (LLVM.and (sub (const? 8 0) (LLVM.and (sub (const? 8 0) e_1) e_1)) (LLVM.xor e (const? 8 123))) ⊑
-    icmp IntPredicate.uge (LLVM.xor e (const? 8 (-124))) (LLVM.or e_1 (sub (const? 8 0) e_1)) := by
+    icmp IntPred.uge (LLVM.xor e (const? 8 (-124))) (LLVM.or e_1 (sub (const? 8 0) e_1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -288,8 +288,8 @@ theorem src_is_notmask_neg_p2_fail_not_invertable_thm (e e_1 : IntW 8) :
 
 
 theorem src_is_mask_const_slt_thm (e : IntW 8) :
-  icmp IntPredicate.slt (LLVM.xor e (const? 8 123)) (LLVM.and (LLVM.xor e (const? 8 123)) (const? 8 7)) ⊑
-    icmp IntPredicate.slt e (const? 8 0) := by
+  icmp IntPred.slt (LLVM.xor e (const? 8 123)) (LLVM.and (LLVM.xor e (const? 8 123)) (const? 8 7)) ⊑
+    icmp IntPred.slt e (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -299,8 +299,8 @@ theorem src_is_mask_const_slt_thm (e : IntW 8) :
 
 
 theorem src_is_mask_const_sgt_thm (e : IntW 8) :
-  icmp IntPredicate.sgt (LLVM.xor e (const? 8 123)) (LLVM.and (LLVM.xor e (const? 8 123)) (const? 8 7)) ⊑
-    icmp IntPredicate.sgt (LLVM.xor e (const? 8 123)) (const? 8 7) := by
+  icmp IntPred.sgt (LLVM.xor e (const? 8 123)) (LLVM.and (LLVM.xor e (const? 8 123)) (const? 8 7)) ⊑
+    icmp IntPred.sgt (LLVM.xor e (const? 8 123)) (const? 8 7) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -310,8 +310,8 @@ theorem src_is_mask_const_sgt_thm (e : IntW 8) :
 
 
 theorem src_is_mask_const_sle_thm (e : IntW 8) :
-  icmp IntPredicate.sle (LLVM.and (LLVM.xor e (const? 8 123)) (const? 8 31)) (LLVM.xor e (const? 8 123)) ⊑
-    icmp IntPredicate.sgt e (const? 8 (-1)) := by
+  icmp IntPred.sle (LLVM.and (LLVM.xor e (const? 8 123)) (const? 8 31)) (LLVM.xor e (const? 8 123)) ⊑
+    icmp IntPred.sgt e (const? 8 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -321,8 +321,8 @@ theorem src_is_mask_const_sle_thm (e : IntW 8) :
 
 
 theorem src_is_mask_const_sge_thm (e : IntW 8) :
-  icmp IntPredicate.sge (LLVM.and (LLVM.xor e (const? 8 123)) (const? 8 31)) (LLVM.xor e (const? 8 123)) ⊑
-    icmp IntPredicate.slt (LLVM.xor e (const? 8 123)) (const? 8 32) := by
+  icmp IntPred.sge (LLVM.and (LLVM.xor e (const? 8 123)) (const? 8 31)) (LLVM.xor e (const? 8 123)) ⊑
+    icmp IntPred.slt (LLVM.xor e (const? 8 123)) (const? 8 32) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -332,10 +332,10 @@ theorem src_is_mask_const_sge_thm (e : IntW 8) :
 
 
 theorem src_x_and_nmask_eq_thm (e e_1 : IntW 8) (e_2 : IntW 1) :
-  icmp IntPredicate.eq (select e_2 (shl (const? 8 (-1)) e_1) (const? 8 0))
+  icmp IntPred.eq (select e_2 (shl (const? 8 (-1)) e_1) (const? 8 0))
       (LLVM.and e (select e_2 (shl (const? 8 (-1)) e_1) (const? 8 0))) ⊑
     select (LLVM.xor e_2 (const? 1 1)) (const? 1 1)
-      (icmp IntPredicate.ule (shl (const? 8 (-1)) e_1 { «nsw» := true, «nuw» := false }) e) := by
+      (icmp IntPred.ule (shl (const? 8 (-1)) e_1 { «nsw» := true, «nuw» := false }) e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -345,9 +345,9 @@ theorem src_x_and_nmask_eq_thm (e e_1 : IntW 8) (e_2 : IntW 1) :
 
 
 theorem src_x_and_nmask_ne_thm (e : IntW 8) (e_1 : IntW 1) (e_2 : IntW 8) :
-  icmp IntPredicate.ne (LLVM.and e_2 (select e_1 (shl (const? 8 (-1)) e) (const? 8 0)))
+  icmp IntPred.ne (LLVM.and e_2 (select e_1 (shl (const? 8 (-1)) e) (const? 8 0)))
       (select e_1 (shl (const? 8 (-1)) e) (const? 8 0)) ⊑
-    select e_1 (icmp IntPredicate.ugt (shl (const? 8 (-1)) e { «nsw» := true, «nuw» := false }) e_2)
+    select e_1 (icmp IntPred.ugt (shl (const? 8 (-1)) e { «nsw» := true, «nuw» := false }) e_2)
       (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
@@ -358,9 +358,9 @@ theorem src_x_and_nmask_ne_thm (e : IntW 8) (e_1 : IntW 1) (e_2 : IntW 8) :
 
 
 theorem src_x_and_nmask_ult_thm (e : IntW 8) (e_1 : IntW 1) (e_2 : IntW 8) :
-  icmp IntPredicate.ult (LLVM.and e_2 (select e_1 (shl (const? 8 (-1)) e) (const? 8 0)))
+  icmp IntPred.ult (LLVM.and e_2 (select e_1 (shl (const? 8 (-1)) e) (const? 8 0)))
       (select e_1 (shl (const? 8 (-1)) e) (const? 8 0)) ⊑
-    select e_1 (icmp IntPredicate.ugt (shl (const? 8 (-1)) e { «nsw» := true, «nuw» := false }) e_2)
+    select e_1 (icmp IntPred.ugt (shl (const? 8 (-1)) e { «nsw» := true, «nuw» := false }) e_2)
       (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
@@ -371,10 +371,10 @@ theorem src_x_and_nmask_ult_thm (e : IntW 8) (e_1 : IntW 1) (e_2 : IntW 8) :
 
 
 theorem src_x_and_nmask_uge_thm (e : IntW 8) (e_1 : IntW 1) (e_2 : IntW 8) :
-  icmp IntPredicate.uge (LLVM.and e_2 (select e_1 (shl (const? 8 (-1)) e) (const? 8 0)))
+  icmp IntPred.uge (LLVM.and e_2 (select e_1 (shl (const? 8 (-1)) e) (const? 8 0)))
       (select e_1 (shl (const? 8 (-1)) e) (const? 8 0)) ⊑
     select (LLVM.xor e_1 (const? 1 1)) (const? 1 1)
-      (icmp IntPredicate.ule (shl (const? 8 (-1)) e { «nsw» := true, «nuw» := false }) e_2) := by
+      (icmp IntPred.ule (shl (const? 8 (-1)) e { «nsw» := true, «nuw» := false }) e_2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -384,8 +384,8 @@ theorem src_x_and_nmask_uge_thm (e : IntW 8) (e_1 : IntW 1) (e_2 : IntW 8) :
 
 
 theorem src_x_and_nmask_slt_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.slt (LLVM.and e_1 (shl (const? 8 (-1)) e)) (shl (const? 8 (-1)) e) ⊑
-    icmp IntPredicate.sgt (shl (const? 8 (-1)) e { «nsw» := true, «nuw» := false }) e_1 := by
+  icmp IntPred.slt (LLVM.and e_1 (shl (const? 8 (-1)) e)) (shl (const? 8 (-1)) e) ⊑
+    icmp IntPred.sgt (shl (const? 8 (-1)) e { «nsw» := true, «nuw» := false }) e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -395,8 +395,8 @@ theorem src_x_and_nmask_slt_thm (e e_1 : IntW 8) :
 
 
 theorem src_x_and_nmask_sge_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.sge (LLVM.and e_1 (shl (const? 8 (-1)) e)) (shl (const? 8 (-1)) e) ⊑
-    icmp IntPredicate.sle (shl (const? 8 (-1)) e { «nsw» := true, «nuw» := false }) e_1 := by
+  icmp IntPred.sge (LLVM.and e_1 (shl (const? 8 (-1)) e)) (shl (const? 8 (-1)) e) ⊑
+    icmp IntPred.sle (shl (const? 8 (-1)) e { «nsw» := true, «nuw» := false }) e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -406,9 +406,9 @@ theorem src_x_and_nmask_sge_thm (e e_1 : IntW 8) :
 
 
 theorem src_x_and_nmask_slt_fail_maybe_z_thm (e : IntW 8) (e_1 : IntW 1) (e_2 : IntW 8) :
-  icmp IntPredicate.slt (LLVM.and e_2 (select e_1 (shl (const? 8 (-1)) e) (const? 8 0)))
+  icmp IntPred.slt (LLVM.and e_2 (select e_1 (shl (const? 8 (-1)) e) (const? 8 0)))
       (select e_1 (shl (const? 8 (-1)) e) (const? 8 0)) ⊑
-    icmp IntPredicate.slt
+    icmp IntPred.slt
       (LLVM.and e_2 (select e_1 (shl (const? 8 (-1)) e { «nsw» := true, «nuw» := false }) (const? 8 0)))
       (select e_1 (shl (const? 8 (-1)) e { «nsw» := true, «nuw» := false }) (const? 8 0)) := by
     simp_alive_undef
@@ -420,9 +420,9 @@ theorem src_x_and_nmask_slt_fail_maybe_z_thm (e : IntW 8) (e_1 : IntW 1) (e_2 : 
 
 
 theorem src_x_and_nmask_sge_fail_maybe_z_thm (e : IntW 8) (e_1 : IntW 1) (e_2 : IntW 8) :
-  icmp IntPredicate.sge (LLVM.and e_2 (select e_1 (shl (const? 8 (-1)) e) (const? 8 0)))
+  icmp IntPred.sge (LLVM.and e_2 (select e_1 (shl (const? 8 (-1)) e) (const? 8 0)))
       (select e_1 (shl (const? 8 (-1)) e) (const? 8 0)) ⊑
-    icmp IntPredicate.sge
+    icmp IntPred.sge
       (LLVM.and e_2 (select e_1 (shl (const? 8 (-1)) e { «nsw» := true, «nuw» := false }) (const? 8 0)))
       (select e_1 (shl (const? 8 (-1)) e { «nsw» := true, «nuw» := false }) (const? 8 0)) := by
     simp_alive_undef
@@ -434,9 +434,9 @@ theorem src_x_and_nmask_sge_fail_maybe_z_thm (e : IntW 8) (e_1 : IntW 1) (e_2 : 
 
 
 theorem src_x_or_mask_ne_thm (e e_1 : IntW 8) (e_2 : IntW 1) :
-  icmp IntPredicate.ne (LLVM.or (select e_2 (lshr (const? 8 (-1)) e_1) (const? 8 0)) (LLVM.xor e (const? 8 (-1))))
+  icmp IntPred.ne (LLVM.or (select e_2 (lshr (const? 8 (-1)) e_1) (const? 8 0)) (LLVM.xor e (const? 8 (-1))))
       (const? 8 (-1)) ⊑
-    icmp IntPredicate.ugt e (select e_2 (lshr (const? 8 (-1)) e_1) (const? 8 0)) := by
+    icmp IntPred.ugt e (select e_2 (lshr (const? 8 (-1)) e_1) (const? 8 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gicmphandhshift_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gicmphandhshift_proof.lean
@@ -12,8 +12,8 @@ set_option Elab.async false
 
 section gicmphandhshift_proof
 theorem icmp_eq_and_pow2_shl1_thm (e : IntW 32) :
-  zext 32 (icmp IntPredicate.eq (LLVM.and (shl (const? 32 1) e) (const? 32 16)) (const? 32 0)) ⊑
-    zext 32 (icmp IntPredicate.ne e (const? 32 4)) := by
+  zext 32 (icmp IntPred.eq (LLVM.and (shl (const? 32 1) e) (const? 32 16)) (const? 32 0)) ⊑
+    zext 32 (icmp IntPred.ne e (const? 32 4)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -23,8 +23,8 @@ theorem icmp_eq_and_pow2_shl1_thm (e : IntW 32) :
 
 
 theorem icmp_ne_and_pow2_shl1_thm (e : IntW 32) :
-  zext 32 (icmp IntPredicate.ne (LLVM.and (shl (const? 32 1) e) (const? 32 16)) (const? 32 0)) ⊑
-    zext 32 (icmp IntPredicate.eq e (const? 32 4)) := by
+  zext 32 (icmp IntPred.ne (LLVM.and (shl (const? 32 1) e) (const? 32 16)) (const? 32 0)) ⊑
+    zext 32 (icmp IntPred.eq e (const? 32 4)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -34,8 +34,8 @@ theorem icmp_ne_and_pow2_shl1_thm (e : IntW 32) :
 
 
 theorem icmp_eq_and_pow2_shl_pow2_thm (e : IntW 32) :
-  zext 32 (icmp IntPredicate.eq (LLVM.and (shl (const? 32 2) e) (const? 32 16)) (const? 32 0)) ⊑
-    zext 32 (icmp IntPredicate.ne e (const? 32 3)) := by
+  zext 32 (icmp IntPred.eq (LLVM.and (shl (const? 32 2) e) (const? 32 16)) (const? 32 0)) ⊑
+    zext 32 (icmp IntPred.ne e (const? 32 3)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -45,8 +45,8 @@ theorem icmp_eq_and_pow2_shl_pow2_thm (e : IntW 32) :
 
 
 theorem icmp_ne_and_pow2_shl_pow2_thm (e : IntW 32) :
-  zext 32 (icmp IntPredicate.ne (LLVM.and (shl (const? 32 2) e) (const? 32 16)) (const? 32 0)) ⊑
-    zext 32 (icmp IntPredicate.eq e (const? 32 3)) := by
+  zext 32 (icmp IntPred.ne (LLVM.and (shl (const? 32 2) e) (const? 32 16)) (const? 32 0)) ⊑
+    zext 32 (icmp IntPred.eq e (const? 32 3)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -56,7 +56,7 @@ theorem icmp_ne_and_pow2_shl_pow2_thm (e : IntW 32) :
 
 
 theorem icmp_eq_and_pow2_shl_pow2_negative1_thm (e : IntW 32) :
-  zext 32 (icmp IntPredicate.eq (LLVM.and (shl (const? 32 11) e) (const? 32 16)) (const? 32 0)) ⊑
+  zext 32 (icmp IntPred.eq (LLVM.and (shl (const? 32 11) e) (const? 32 16)) (const? 32 0)) ⊑
     LLVM.xor (LLVM.and (lshr (shl (const? 32 11) e) (const? 32 4)) (const? 32 1)) (const? 32 1) := by
     simp_alive_undef
     simp_alive_ops
@@ -67,8 +67,8 @@ theorem icmp_eq_and_pow2_shl_pow2_negative1_thm (e : IntW 32) :
 
 
 theorem icmp_eq_and_pow2_shl_pow2_negative2_thm (e : IntW 32) :
-  zext 32 (icmp IntPredicate.eq (LLVM.and (shl (const? 32 2) e) (const? 32 14)) (const? 32 0)) ⊑
-    zext 32 (icmp IntPredicate.ugt e (const? 32 2)) := by
+  zext 32 (icmp IntPred.eq (LLVM.and (shl (const? 32 2) e) (const? 32 14)) (const? 32 0)) ⊑
+    zext 32 (icmp IntPred.ugt e (const? 32 2)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -78,7 +78,7 @@ theorem icmp_eq_and_pow2_shl_pow2_negative2_thm (e : IntW 32) :
 
 
 theorem icmp_eq_and_pow2_shl_pow2_negative3_thm (e : IntW 32) :
-  zext 32 (icmp IntPredicate.eq (LLVM.and (shl (const? 32 32) e) (const? 32 16)) (const? 32 0)) ⊑ const? 32 1 := by
+  zext 32 (icmp IntPred.eq (LLVM.and (shl (const? 32 32) e) (const? 32 16)) (const? 32 0)) ⊑ const? 32 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -88,8 +88,8 @@ theorem icmp_eq_and_pow2_shl_pow2_negative3_thm (e : IntW 32) :
 
 
 theorem icmp_eq_and_pow2_minus1_shl1_thm (e : IntW 32) :
-  zext 32 (icmp IntPredicate.eq (LLVM.and (shl (const? 32 1) e) (const? 32 15)) (const? 32 0)) ⊑
-    zext 32 (icmp IntPredicate.ugt e (const? 32 3)) := by
+  zext 32 (icmp IntPred.eq (LLVM.and (shl (const? 32 1) e) (const? 32 15)) (const? 32 0)) ⊑
+    zext 32 (icmp IntPred.ugt e (const? 32 3)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -99,8 +99,8 @@ theorem icmp_eq_and_pow2_minus1_shl1_thm (e : IntW 32) :
 
 
 theorem icmp_ne_and_pow2_minus1_shl1_thm (e : IntW 32) :
-  zext 32 (icmp IntPredicate.ne (LLVM.and (shl (const? 32 1) e) (const? 32 15)) (const? 32 0)) ⊑
-    zext 32 (icmp IntPredicate.ult e (const? 32 4)) := by
+  zext 32 (icmp IntPred.ne (LLVM.and (shl (const? 32 1) e) (const? 32 15)) (const? 32 0)) ⊑
+    zext 32 (icmp IntPred.ult e (const? 32 4)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -110,8 +110,8 @@ theorem icmp_ne_and_pow2_minus1_shl1_thm (e : IntW 32) :
 
 
 theorem icmp_eq_and_pow2_minus1_shl_pow2_thm (e : IntW 32) :
-  zext 32 (icmp IntPredicate.eq (LLVM.and (shl (const? 32 2) e) (const? 32 15)) (const? 32 0)) ⊑
-    zext 32 (icmp IntPredicate.ugt e (const? 32 2)) := by
+  zext 32 (icmp IntPred.eq (LLVM.and (shl (const? 32 2) e) (const? 32 15)) (const? 32 0)) ⊑
+    zext 32 (icmp IntPred.ugt e (const? 32 2)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -121,8 +121,8 @@ theorem icmp_eq_and_pow2_minus1_shl_pow2_thm (e : IntW 32) :
 
 
 theorem icmp_ne_and_pow2_minus1_shl_pow2_thm (e : IntW 32) :
-  zext 32 (icmp IntPredicate.ne (LLVM.and (shl (const? 32 2) e) (const? 32 15)) (const? 32 0)) ⊑
-    zext 32 (icmp IntPredicate.ult e (const? 32 3)) := by
+  zext 32 (icmp IntPred.ne (LLVM.and (shl (const? 32 2) e) (const? 32 15)) (const? 32 0)) ⊑
+    zext 32 (icmp IntPred.ult e (const? 32 3)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -132,7 +132,7 @@ theorem icmp_ne_and_pow2_minus1_shl_pow2_thm (e : IntW 32) :
 
 
 theorem icmp_eq_and_pow2_minus1_shl1_negative2_thm (e : IntW 32) :
-  zext 32 (icmp IntPredicate.eq (LLVM.and (shl (const? 32 32) e) (const? 32 15)) (const? 32 0)) ⊑ const? 32 1 := by
+  zext 32 (icmp IntPred.eq (LLVM.and (shl (const? 32 32) e) (const? 32 15)) (const? 32 0)) ⊑ const? 32 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -142,8 +142,8 @@ theorem icmp_eq_and_pow2_minus1_shl1_negative2_thm (e : IntW 32) :
 
 
 theorem icmp_eq_and1_lshr_pow2_thm (e : IntW 32) :
-  zext 32 (icmp IntPredicate.eq (LLVM.and (lshr (const? 32 8) e) (const? 32 1)) (const? 32 0)) ⊑
-    zext 32 (icmp IntPredicate.ne e (const? 32 3)) := by
+  zext 32 (icmp IntPred.eq (LLVM.and (lshr (const? 32 8) e) (const? 32 1)) (const? 32 0)) ⊑
+    zext 32 (icmp IntPred.ne e (const? 32 3)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -153,8 +153,8 @@ theorem icmp_eq_and1_lshr_pow2_thm (e : IntW 32) :
 
 
 theorem icmp_ne_and1_lshr_pow2_thm (e : IntW 32) :
-  zext 32 (icmp IntPredicate.eq (LLVM.and (lshr (const? 32 8) e) (const? 32 1)) (const? 32 0)) ⊑
-    zext 32 (icmp IntPredicate.ne e (const? 32 3)) := by
+  zext 32 (icmp IntPred.eq (LLVM.and (lshr (const? 32 8) e) (const? 32 1)) (const? 32 0)) ⊑
+    zext 32 (icmp IntPred.ne e (const? 32 3)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -164,8 +164,8 @@ theorem icmp_ne_and1_lshr_pow2_thm (e : IntW 32) :
 
 
 theorem icmp_eq_and_pow2_lshr_pow2_thm (e : IntW 32) :
-  zext 32 (icmp IntPredicate.eq (LLVM.and (lshr (const? 32 8) e) (const? 32 4)) (const? 32 0)) ⊑
-    zext 32 (icmp IntPredicate.ne e (const? 32 1)) := by
+  zext 32 (icmp IntPred.eq (LLVM.and (lshr (const? 32 8) e) (const? 32 4)) (const? 32 0)) ⊑
+    zext 32 (icmp IntPred.ne e (const? 32 1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -175,7 +175,7 @@ theorem icmp_eq_and_pow2_lshr_pow2_thm (e : IntW 32) :
 
 
 theorem icmp_eq_and_pow2_lshr_pow2_case2_thm (e : IntW 32) :
-  zext 32 (icmp IntPredicate.eq (LLVM.and (lshr (const? 32 4) e) (const? 32 8)) (const? 32 0)) ⊑ const? 32 1 := by
+  zext 32 (icmp IntPred.eq (LLVM.and (lshr (const? 32 4) e) (const? 32 8)) (const? 32 0)) ⊑ const? 32 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -185,8 +185,8 @@ theorem icmp_eq_and_pow2_lshr_pow2_case2_thm (e : IntW 32) :
 
 
 theorem icmp_ne_and_pow2_lshr_pow2_thm (e : IntW 32) :
-  zext 32 (icmp IntPredicate.eq (LLVM.and (lshr (const? 32 8) e) (const? 32 4)) (const? 32 0)) ⊑
-    zext 32 (icmp IntPredicate.ne e (const? 32 1)) := by
+  zext 32 (icmp IntPred.eq (LLVM.and (lshr (const? 32 8) e) (const? 32 4)) (const? 32 0)) ⊑
+    zext 32 (icmp IntPred.ne e (const? 32 1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -196,7 +196,7 @@ theorem icmp_ne_and_pow2_lshr_pow2_thm (e : IntW 32) :
 
 
 theorem icmp_ne_and_pow2_lshr_pow2_case2_thm (e : IntW 32) :
-  zext 32 (icmp IntPredicate.eq (LLVM.and (lshr (const? 32 4) e) (const? 32 8)) (const? 32 0)) ⊑ const? 32 1 := by
+  zext 32 (icmp IntPred.eq (LLVM.and (lshr (const? 32 4) e) (const? 32 8)) (const? 32 0)) ⊑ const? 32 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -206,8 +206,8 @@ theorem icmp_ne_and_pow2_lshr_pow2_case2_thm (e : IntW 32) :
 
 
 theorem icmp_eq_and1_lshr_pow2_minus_one_thm (e : IntW 32) :
-  zext 32 (icmp IntPredicate.eq (LLVM.and (lshr (const? 32 7) e) (const? 32 1)) (const? 32 0)) ⊑
-    zext 32 (icmp IntPredicate.ugt e (const? 32 2)) := by
+  zext 32 (icmp IntPred.eq (LLVM.and (lshr (const? 32 7) e) (const? 32 1)) (const? 32 0)) ⊑
+    zext 32 (icmp IntPred.ugt e (const? 32 2)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -217,8 +217,8 @@ theorem icmp_eq_and1_lshr_pow2_minus_one_thm (e : IntW 32) :
 
 
 theorem eq_and_shl_one_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.eq (LLVM.and (shl (const? 8 1) e_1) e) (shl (const? 8 1) e_1) ⊑
-    icmp IntPredicate.ne (LLVM.and (shl (const? 8 1) e_1 { «nsw» := false, «nuw» := true }) e) (const? 8 0) := by
+  icmp IntPred.eq (LLVM.and (shl (const? 8 1) e_1) e) (shl (const? 8 1) e_1) ⊑
+    icmp IntPred.ne (LLVM.and (shl (const? 8 1) e_1 { «nsw» := false, «nuw» := true }) e) (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -228,8 +228,8 @@ theorem eq_and_shl_one_thm (e e_1 : IntW 8) :
 
 
 theorem ne_and_lshr_minval_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.ne (LLVM.and (mul e_1 e_1) (lshr (const? 8 (-128)) e)) (lshr (const? 8 (-128)) e) ⊑
-    icmp IntPredicate.eq (LLVM.and (mul e_1 e_1) (lshr (const? 8 (-128)) e { «exact» := true })) (const? 8 0) := by
+  icmp IntPred.ne (LLVM.and (mul e_1 e_1) (lshr (const? 8 (-128)) e)) (lshr (const? 8 (-128)) e) ⊑
+    icmp IntPred.eq (LLVM.and (mul e_1 e_1) (lshr (const? 8 (-128)) e { «exact» := true })) (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -239,8 +239,8 @@ theorem ne_and_lshr_minval_thm (e e_1 : IntW 8) :
 
 
 theorem slt_and_shl_one_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.slt (LLVM.and e_1 (shl (const? 8 1) e)) (shl (const? 8 1) e) ⊑
-    icmp IntPredicate.slt (LLVM.and e_1 (shl (const? 8 1) e { «nsw» := false, «nuw» := true }))
+  icmp IntPred.slt (LLVM.and e_1 (shl (const? 8 1) e)) (shl (const? 8 1) e) ⊑
+    icmp IntPred.slt (LLVM.and e_1 (shl (const? 8 1) e { «nsw» := false, «nuw» := true }))
       (shl (const? 8 1) e { «nsw» := false, «nuw» := true }) := by
     simp_alive_undef
     simp_alive_ops
@@ -251,8 +251,8 @@ theorem slt_and_shl_one_thm (e e_1 : IntW 8) :
 
 
 theorem fold_eq_lhs_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.eq (LLVM.and (shl (const? 8 (-1)) e_1) e) (const? 8 0) ⊑
-    icmp IntPredicate.eq (lshr e e_1) (const? 8 0) := by
+  icmp IntPred.eq (LLVM.and (shl (const? 8 (-1)) e_1) e) (const? 8 0) ⊑
+    icmp IntPred.eq (lshr e e_1) (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -262,8 +262,8 @@ theorem fold_eq_lhs_thm (e e_1 : IntW 8) :
 
 
 theorem fold_eq_lhs_fail_eq_nonzero_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.eq (LLVM.and (shl (const? 8 (-1)) e_1) e) (const? 8 1) ⊑
-    icmp IntPredicate.eq (LLVM.and (shl (const? 8 (-1)) e_1 { «nsw» := true, «nuw» := false }) e) (const? 8 1) := by
+  icmp IntPred.eq (LLVM.and (shl (const? 8 (-1)) e_1) e) (const? 8 1) ⊑
+    icmp IntPred.eq (LLVM.and (shl (const? 8 (-1)) e_1 { «nsw» := true, «nuw» := false }) e) (const? 8 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -273,8 +273,8 @@ theorem fold_eq_lhs_fail_eq_nonzero_thm (e e_1 : IntW 8) :
 
 
 theorem fold_ne_rhs_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.ne (LLVM.and (LLVM.xor e_1 (const? 8 123)) (shl (const? 8 (-1)) e)) (const? 8 0) ⊑
-    icmp IntPredicate.ne (lshr (LLVM.xor e_1 (const? 8 123)) e) (const? 8 0) := by
+  icmp IntPred.ne (LLVM.and (LLVM.xor e_1 (const? 8 123)) (shl (const? 8 (-1)) e)) (const? 8 0) ⊑
+    icmp IntPred.ne (lshr (LLVM.xor e_1 (const? 8 123)) e) (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -284,8 +284,8 @@ theorem fold_ne_rhs_thm (e e_1 : IntW 8) :
 
 
 theorem fold_ne_rhs_fail_shift_not_1s_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.ne (LLVM.and (LLVM.xor e_1 (const? 8 123)) (shl (const? 8 (-2)) e)) (const? 8 0) ⊑
-    icmp IntPredicate.ne (LLVM.and (LLVM.xor e_1 (const? 8 122)) (shl (const? 8 (-2)) e)) (const? 8 0) := by
+  icmp IntPred.ne (LLVM.and (LLVM.xor e_1 (const? 8 123)) (shl (const? 8 (-2)) e)) (const? 8 0) ⊑
+    icmp IntPred.ne (LLVM.and (LLVM.xor e_1 (const? 8 122)) (shl (const? 8 (-2)) e)) (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -295,8 +295,8 @@ theorem fold_ne_rhs_fail_shift_not_1s_thm (e e_1 : IntW 8) :
 
 
 theorem test_shr_and_1_ne_0_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.ne (LLVM.and (lshr e_1 e) (const? 32 1)) (const? 32 0) ⊑
-    icmp IntPredicate.ne (LLVM.and e_1 (shl (const? 32 1) e { «nsw» := false, «nuw» := true })) (const? 32 0) := by
+  icmp IntPred.ne (LLVM.and (lshr e_1 e) (const? 32 1)) (const? 32 0) ⊑
+    icmp IntPred.ne (LLVM.and e_1 (shl (const? 32 1) e { «nsw» := false, «nuw» := true })) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -306,8 +306,8 @@ theorem test_shr_and_1_ne_0_thm (e e_1 : IntW 32) :
 
 
 theorem test_shr_and_1_ne_0_samesign_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.ne (LLVM.and (lshr e_1 e) (const? 32 1)) (const? 32 0) ⊑
-    icmp IntPredicate.ne (LLVM.and e_1 (shl (const? 32 1) e { «nsw» := false, «nuw» := true })) (const? 32 0) := by
+  icmp IntPred.ne (LLVM.and (lshr e_1 e) (const? 32 1)) (const? 32 0) ⊑
+    icmp IntPred.ne (LLVM.and e_1 (shl (const? 32 1) e { «nsw» := false, «nuw» := true })) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -317,8 +317,8 @@ theorem test_shr_and_1_ne_0_samesign_thm (e e_1 : IntW 32) :
 
 
 theorem test_const_shr_and_1_ne_0_thm (e : IntW 32) :
-  icmp IntPredicate.ne (LLVM.and (lshr (const? 32 42) e) (const? 32 1)) (const? 32 0) ⊑
-    icmp IntPredicate.ne (LLVM.and (shl (const? 32 1) e { «nsw» := false, «nuw» := true }) (const? 32 42))
+  icmp IntPred.ne (LLVM.and (lshr (const? 32 42) e) (const? 32 1)) (const? 32 0) ⊑
+    icmp IntPred.ne (LLVM.and (shl (const? 32 1) e { «nsw» := false, «nuw» := true }) (const? 32 42))
       (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
@@ -329,8 +329,8 @@ theorem test_const_shr_and_1_ne_0_thm (e : IntW 32) :
 
 
 theorem test_not_const_shr_and_1_ne_0_thm (e : IntW 32) :
-  icmp IntPredicate.eq (LLVM.and (lshr (const? 32 42) e) (const? 32 1)) (const? 32 0) ⊑
-    icmp IntPredicate.eq (LLVM.and (shl (const? 32 1) e { «nsw» := false, «nuw» := true }) (const? 32 42))
+  icmp IntPred.eq (LLVM.and (lshr (const? 32 42) e) (const? 32 1)) (const? 32 0) ⊑
+    icmp IntPred.eq (LLVM.and (shl (const? 32 1) e { «nsw» := false, «nuw» := true }) (const? 32 42))
       (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
@@ -341,8 +341,8 @@ theorem test_not_const_shr_and_1_ne_0_thm (e : IntW 32) :
 
 
 theorem test_const_shr_exact_and_1_ne_0_thm (e : IntW 32) :
-  icmp IntPredicate.ne (LLVM.and (lshr (const? 32 42) e { «exact» := true }) (const? 32 1)) (const? 32 0) ⊑
-    icmp IntPredicate.ne (LLVM.and (shl (const? 32 1) e { «nsw» := false, «nuw» := true }) (const? 32 42))
+  icmp IntPred.ne (LLVM.and (lshr (const? 32 42) e { «exact» := true }) (const? 32 1)) (const? 32 0) ⊑
+    icmp IntPred.ne (LLVM.and (shl (const? 32 1) e { «nsw» := false, «nuw» := true }) (const? 32 42))
       (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
@@ -353,7 +353,7 @@ theorem test_const_shr_exact_and_1_ne_0_thm (e : IntW 32) :
 
 
 theorem test_const_shr_and_1_ne_0_i1_negative_thm (e : IntW 1) :
-  icmp IntPredicate.ne (LLVM.and (lshr (const? 1 1) e) (const? 1 1)) (const? 1 0) ⊑ const? 1 1 := by
+  icmp IntPred.ne (LLVM.and (lshr (const? 1 1) e) (const? 1 1)) (const? 1 0) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gicmphbinop_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gicmphbinop_proof.lean
@@ -12,7 +12,7 @@ set_option Elab.async false
 
 section gicmphbinop_proof
 theorem mul_unkV_oddC_eq_thm (e : IntW 32) :
-  icmp IntPredicate.eq (mul e (const? 32 3)) (const? 32 0) ⊑ icmp IntPredicate.eq e (const? 32 0) := by
+  icmp IntPred.eq (mul e (const? 32 3)) (const? 32 0) ⊑ icmp IntPred.eq e (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -22,8 +22,8 @@ theorem mul_unkV_oddC_eq_thm (e : IntW 32) :
 
 
 theorem mul_unkV_oddC_sge_thm (e : IntW 8) :
-  icmp IntPredicate.sge (mul e (const? 8 3)) (const? 8 0) ⊑
-    icmp IntPredicate.sgt (mul e (const? 8 3)) (const? 8 (-1)) := by
+  icmp IntPred.sge (mul e (const? 8 3)) (const? 8 0) ⊑
+    icmp IntPred.sgt (mul e (const? 8 3)) (const? 8 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -33,8 +33,8 @@ theorem mul_unkV_oddC_sge_thm (e : IntW 8) :
 
 
 theorem mul_unkV_evenC_ne_thm (e : IntW 64) :
-  icmp IntPredicate.ne (mul e (const? 64 4)) (const? 64 0) ⊑
-    icmp IntPredicate.ne (LLVM.and e (const? 64 4611686018427387903)) (const? 64 0) := by
+  icmp IntPred.ne (mul e (const? 64 4)) (const? 64 0) ⊑
+    icmp IntPred.ne (LLVM.and e (const? 64 4611686018427387903)) (const? 64 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -44,8 +44,8 @@ theorem mul_unkV_evenC_ne_thm (e : IntW 64) :
 
 
 theorem mul_setnzV_unkV_nuw_eq_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.eq (mul (LLVM.or e_1 (const? 8 2)) e { «nsw» := false, «nuw» := true }) (const? 8 0) ⊑
-    icmp IntPredicate.eq e (const? 8 0) := by
+  icmp IntPred.eq (mul (LLVM.or e_1 (const? 8 2)) e { «nsw» := false, «nuw» := true }) (const? 8 0) ⊑
+    icmp IntPred.eq e (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gicmphcustomhdl_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gicmphcustomhdl_proof.lean
@@ -12,10 +12,10 @@ set_option Elab.async false
 
 section gicmphcustomhdl_proof
 theorem icmp_and_ashr_multiuse_thm (e : IntW 32) :
-  LLVM.and (icmp IntPredicate.ne (LLVM.and (ashr e (const? 32 4)) (const? 32 15)) (const? 32 14))
-      (icmp IntPredicate.ne (LLVM.and (ashr e (const? 32 4)) (const? 32 31)) (const? 32 27)) ⊑
-    LLVM.and (icmp IntPredicate.ne (LLVM.and e (const? 32 240)) (const? 32 224))
-      (icmp IntPredicate.ne (LLVM.and e (const? 32 496)) (const? 32 432)) := by
+  LLVM.and (icmp IntPred.ne (LLVM.and (ashr e (const? 32 4)) (const? 32 15)) (const? 32 14))
+      (icmp IntPred.ne (LLVM.and (ashr e (const? 32 4)) (const? 32 31)) (const? 32 27)) ⊑
+    LLVM.and (icmp IntPred.ne (LLVM.and e (const? 32 240)) (const? 32 224))
+      (icmp IntPred.ne (LLVM.and e (const? 32 496)) (const? 32 432)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -25,10 +25,10 @@ theorem icmp_and_ashr_multiuse_thm (e : IntW 32) :
 
 
 theorem icmp_and_ashr_multiuse_logical_thm (e : IntW 32) :
-  select (icmp IntPredicate.ne (LLVM.and (ashr e (const? 32 4)) (const? 32 15)) (const? 32 14))
-      (icmp IntPredicate.ne (LLVM.and (ashr e (const? 32 4)) (const? 32 31)) (const? 32 27)) (const? 1 0) ⊑
-    LLVM.and (icmp IntPredicate.ne (LLVM.and e (const? 32 240)) (const? 32 224))
-      (icmp IntPredicate.ne (LLVM.and e (const? 32 496)) (const? 32 432)) := by
+  select (icmp IntPred.ne (LLVM.and (ashr e (const? 32 4)) (const? 32 15)) (const? 32 14))
+      (icmp IntPred.ne (LLVM.and (ashr e (const? 32 4)) (const? 32 31)) (const? 32 27)) (const? 1 0) ⊑
+    LLVM.and (icmp IntPred.ne (LLVM.and e (const? 32 240)) (const? 32 224))
+      (icmp IntPred.ne (LLVM.and e (const? 32 496)) (const? 32 432)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -38,8 +38,8 @@ theorem icmp_and_ashr_multiuse_logical_thm (e : IntW 32) :
 
 
 theorem icmp_lshr_and_overshift_thm (e : IntW 8) :
-  icmp IntPredicate.ne (LLVM.and (lshr e (const? 8 5)) (const? 8 15)) (const? 8 0) ⊑
-    icmp IntPredicate.ugt e (const? 8 31) := by
+  icmp IntPred.ne (LLVM.and (lshr e (const? 8 5)) (const? 8 15)) (const? 8 0) ⊑
+    icmp IntPred.ugt e (const? 8 31) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gicmphdivhconstant_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gicmphdivhconstant_proof.lean
@@ -12,8 +12,8 @@ set_option Elab.async false
 
 section gicmphdivhconstant_proof
 theorem is_rem2_neg_i8_thm (e : IntW 8) :
-  icmp IntPredicate.slt (LLVM.srem e (const? 8 2)) (const? 8 0) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 8 (-127))) (const? 8 (-127)) := by
+  icmp IntPred.slt (LLVM.srem e (const? 8 2)) (const? 8 0) ⊑
+    icmp IntPred.eq (LLVM.and e (const? 8 (-127))) (const? 8 (-127)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -23,8 +23,8 @@ theorem is_rem2_neg_i8_thm (e : IntW 8) :
 
 
 theorem is_rem32_pos_i8_thm (e : IntW 8) :
-  icmp IntPredicate.sgt (LLVM.srem e (const? 8 32)) (const? 8 0) ⊑
-    icmp IntPredicate.sgt (LLVM.and e (const? 8 (-97))) (const? 8 0) := by
+  icmp IntPred.sgt (LLVM.srem e (const? 8 32)) (const? 8 0) ⊑
+    icmp IntPred.sgt (LLVM.and e (const? 8 (-97))) (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -34,8 +34,8 @@ theorem is_rem32_pos_i8_thm (e : IntW 8) :
 
 
 theorem is_rem4_neg_i16_thm (e : IntW 16) :
-  icmp IntPredicate.slt (LLVM.srem e (const? 16 4)) (const? 16 0) ⊑
-    icmp IntPredicate.ugt (LLVM.and e (const? 16 (-32765))) (const? 16 (-32768)) := by
+  icmp IntPred.slt (LLVM.srem e (const? 16 4)) (const? 16 0) ⊑
+    icmp IntPred.ugt (LLVM.and e (const? 16 (-32765))) (const? 16 (-32768)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -45,8 +45,8 @@ theorem is_rem4_neg_i16_thm (e : IntW 16) :
 
 
 theorem udiv_eq_umax_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.eq (LLVM.udiv e_1 e) (const? 8 (-1)) ⊑
-    LLVM.and (icmp IntPredicate.eq e_1 (const? 8 (-1))) (icmp IntPredicate.eq e (const? 8 1)) := by
+  icmp IntPred.eq (LLVM.udiv e_1 e) (const? 8 (-1)) ⊑
+    LLVM.and (icmp IntPred.eq e_1 (const? 8 (-1))) (icmp IntPred.eq e (const? 8 1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -56,8 +56,8 @@ theorem udiv_eq_umax_thm (e e_1 : IntW 8) :
 
 
 theorem udiv_eq_big_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.eq (LLVM.udiv e_1 e) (const? 8 (-128)) ⊑
-    LLVM.and (icmp IntPredicate.eq e_1 (const? 8 (-128))) (icmp IntPredicate.eq e (const? 8 1)) := by
+  icmp IntPred.eq (LLVM.udiv e_1 e) (const? 8 (-128)) ⊑
+    LLVM.and (icmp IntPred.eq e_1 (const? 8 (-128))) (icmp IntPred.eq e (const? 8 1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -67,8 +67,8 @@ theorem udiv_eq_big_thm (e e_1 : IntW 8) :
 
 
 theorem udiv_ne_big_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.ne (LLVM.udiv e_1 e) (const? 8 (-128)) ⊑
-    LLVM.or (icmp IntPredicate.ne e_1 (const? 8 (-128))) (icmp IntPredicate.ne e (const? 8 1)) := by
+  icmp IntPred.ne (LLVM.udiv e_1 e) (const? 8 (-128)) ⊑
+    LLVM.or (icmp IntPred.ne e_1 (const? 8 (-128))) (icmp IntPred.ne e (const? 8 1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -78,8 +78,8 @@ theorem udiv_ne_big_thm (e e_1 : IntW 8) :
 
 
 theorem sdiv_eq_smin_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.eq (LLVM.sdiv e_1 e) (const? 8 (-128)) ⊑
-    LLVM.and (icmp IntPredicate.eq e_1 (const? 8 (-128))) (icmp IntPredicate.eq e (const? 8 1)) := by
+  icmp IntPred.eq (LLVM.sdiv e_1 e) (const? 8 (-128)) ⊑
+    LLVM.and (icmp IntPred.eq e_1 (const? 8 (-128))) (icmp IntPred.eq e (const? 8 1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -89,8 +89,8 @@ theorem sdiv_eq_smin_thm (e e_1 : IntW 8) :
 
 
 theorem sdiv_ult_smin_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.ult (LLVM.sdiv e_1 e) (const? 8 (-128)) ⊑
-    icmp IntPredicate.sgt (LLVM.sdiv e_1 e) (const? 8 (-1)) := by
+  icmp IntPred.ult (LLVM.sdiv e_1 e) (const? 8 (-128)) ⊑
+    icmp IntPred.sgt (LLVM.sdiv e_1 e) (const? 8 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -100,7 +100,7 @@ theorem sdiv_ult_smin_thm (e e_1 : IntW 8) :
 
 
 theorem sdiv_x_by_const_cmp_x_thm (e : IntW 32) :
-  icmp IntPredicate.eq (LLVM.sdiv e (const? 32 13)) e ⊑ icmp IntPredicate.eq e (const? 32 0) := by
+  icmp IntPred.eq (LLVM.sdiv e (const? 32 13)) e ⊑ icmp IntPred.eq e (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -110,7 +110,7 @@ theorem sdiv_x_by_const_cmp_x_thm (e : IntW 32) :
 
 
 theorem udiv_x_by_const_cmp_x_thm (e : IntW 32) :
-  icmp IntPredicate.slt (LLVM.udiv e (const? 32 123)) e ⊑ icmp IntPredicate.sgt e (const? 32 0) := by
+  icmp IntPred.slt (LLVM.udiv e (const? 32 123)) e ⊑ icmp IntPred.sgt e (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -120,7 +120,7 @@ theorem udiv_x_by_const_cmp_x_thm (e : IntW 32) :
 
 
 theorem lshr_x_by_const_cmp_x_thm (e : IntW 32) :
-  icmp IntPredicate.eq (lshr e (const? 32 1)) e ⊑ icmp IntPredicate.eq e (const? 32 0) := by
+  icmp IntPred.eq (lshr e (const? 32 1)) e ⊑ icmp IntPred.eq e (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -130,7 +130,7 @@ theorem lshr_x_by_const_cmp_x_thm (e : IntW 32) :
 
 
 theorem lshr_by_const_cmp_sge_value_thm (e : IntW 32) :
-  icmp IntPredicate.sge (lshr e (const? 32 3)) e ⊑ icmp IntPredicate.slt e (const? 32 1) := by
+  icmp IntPred.sge (lshr e (const? 32 3)) e ⊑ icmp IntPred.slt e (const? 32 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -140,7 +140,7 @@ theorem lshr_by_const_cmp_sge_value_thm (e : IntW 32) :
 
 
 theorem ashr_x_by_const_cmp_sge_x_thm (e : IntW 32) :
-  icmp IntPredicate.sge (ashr e (const? 32 5)) e ⊑ icmp IntPredicate.slt e (const? 32 1) := by
+  icmp IntPred.sge (ashr e (const? 32 5)) e ⊑ icmp IntPred.slt e (const? 32 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gicmphequalityhtest_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gicmphequalityhtest_proof.lean
@@ -12,9 +12,9 @@ set_option Elab.async false
 
 section gicmphequalityhtest_proof
 theorem icmp_equality_test_thm (e e_1 e_2 : IntW 64) :
-  select (icmp IntPredicate.eq e_2 e_1) (icmp IntPredicate.eq e e_1)
-      (select (LLVM.xor (icmp IntPredicate.eq e e_1) (const? 1 1)) (icmp IntPredicate.eq e_2 e) (const? 1 0)) ⊑
-    icmp IntPredicate.eq e_2 e := by
+  select (icmp IntPred.eq e_2 e_1) (icmp IntPred.eq e e_1)
+      (select (LLVM.xor (icmp IntPred.eq e e_1) (const? 1 1)) (icmp IntPred.eq e_2 e) (const? 1 0)) ⊑
+    icmp IntPred.eq e_2 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -24,10 +24,10 @@ theorem icmp_equality_test_thm (e e_1 e_2 : IntW 64) :
 
 
 theorem icmp_equality_test_constant_thm (e e_1 : IntW 42) :
-  select (icmp IntPredicate.eq e_1 (const? 42 (-42))) (icmp IntPredicate.eq e (const? 42 (-42)))
-      (select (LLVM.xor (icmp IntPredicate.eq e (const? 42 (-42))) (const? 1 1)) (icmp IntPredicate.eq e_1 e)
+  select (icmp IntPred.eq e_1 (const? 42 (-42))) (icmp IntPred.eq e (const? 42 (-42)))
+      (select (LLVM.xor (icmp IntPred.eq e (const? 42 (-42))) (const? 1 1)) (icmp IntPred.eq e_1 e)
         (const? 1 0)) ⊑
-    icmp IntPredicate.eq e_1 e := by
+    icmp IntPred.eq e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -37,10 +37,10 @@ theorem icmp_equality_test_constant_thm (e e_1 : IntW 42) :
 
 
 theorem icmp_equality_test_constant_samesign_thm (e e_1 : IntW 42) :
-  select (icmp IntPredicate.eq e_1 (const? 42 (-42))) (icmp IntPredicate.eq e (const? 42 (-42)))
-      (select (LLVM.xor (icmp IntPredicate.eq e (const? 42 (-42))) (const? 1 1)) (icmp IntPredicate.eq e_1 e)
+  select (icmp IntPred.eq e_1 (const? 42 (-42))) (icmp IntPred.eq e (const? 42 (-42)))
+      (select (LLVM.xor (icmp IntPred.eq e (const? 42 (-42))) (const? 1 1)) (icmp IntPred.eq e_1 e)
         (const? 1 0)) ⊑
-    icmp IntPredicate.eq e_1 e := by
+    icmp IntPred.eq e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -50,10 +50,10 @@ theorem icmp_equality_test_constant_samesign_thm (e e_1 : IntW 42) :
 
 
 theorem icmp_equality_test_swift_optional_pointers_thm (e e_1 : IntW 64) :
-  select (select (icmp IntPredicate.eq e_1 (const? 64 0)) (const? 1 1) (icmp IntPredicate.eq e (const? 64 0)))
-      (select (icmp IntPredicate.eq e_1 (const? 64 0)) (icmp IntPredicate.eq e (const? 64 0)) (const? 1 0))
-      (icmp IntPredicate.eq e_1 e) ⊑
-    icmp IntPredicate.eq e_1 e := by
+  select (select (icmp IntPred.eq e_1 (const? 64 0)) (const? 1 1) (icmp IntPred.eq e (const? 64 0)))
+      (select (icmp IntPred.eq e_1 (const? 64 0)) (icmp IntPred.eq e (const? 64 0)) (const? 1 0))
+      (icmp IntPred.eq e_1 e) ⊑
+    icmp IntPred.eq e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -63,9 +63,9 @@ theorem icmp_equality_test_swift_optional_pointers_thm (e e_1 : IntW 64) :
 
 
 theorem icmp_equality_test_commute_icmp1_thm (e e_1 e_2 : IntW 64) :
-  select (icmp IntPredicate.eq e_2 e_1) (icmp IntPredicate.eq e_2 e)
-      (select (LLVM.xor (icmp IntPredicate.eq e_2 e) (const? 1 1)) (icmp IntPredicate.eq e e_1) (const? 1 0)) ⊑
-    icmp IntPredicate.eq e e_1 := by
+  select (icmp IntPred.eq e_2 e_1) (icmp IntPred.eq e_2 e)
+      (select (LLVM.xor (icmp IntPred.eq e_2 e) (const? 1 1)) (icmp IntPred.eq e e_1) (const? 1 0)) ⊑
+    icmp IntPred.eq e e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -75,9 +75,9 @@ theorem icmp_equality_test_commute_icmp1_thm (e e_1 e_2 : IntW 64) :
 
 
 theorem icmp_equality_test_commute_icmp2_thm (e e_1 e_2 : IntW 64) :
-  select (icmp IntPredicate.eq e_2 e_1) (icmp IntPredicate.eq e e_2)
-      (select (LLVM.xor (icmp IntPredicate.eq e e_2) (const? 1 1)) (icmp IntPredicate.eq e e_1) (const? 1 0)) ⊑
-    icmp IntPredicate.eq e e_1 := by
+  select (icmp IntPred.eq e_2 e_1) (icmp IntPred.eq e e_2)
+      (select (LLVM.xor (icmp IntPred.eq e e_2) (const? 1 1)) (icmp IntPred.eq e e_1) (const? 1 0)) ⊑
+    icmp IntPred.eq e e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -87,9 +87,9 @@ theorem icmp_equality_test_commute_icmp2_thm (e e_1 e_2 : IntW 64) :
 
 
 theorem icmp_equality_test_commute_select1_thm (e e_1 e_2 : IntW 64) :
-  select (icmp IntPredicate.eq e_2 e_1) (icmp IntPredicate.eq e e_1)
-      (select (icmp IntPredicate.eq e e_1) (const? 1 0) (icmp IntPredicate.eq e_2 e)) ⊑
-    icmp IntPredicate.eq e_2 e := by
+  select (icmp IntPred.eq e_2 e_1) (icmp IntPred.eq e e_1)
+      (select (icmp IntPred.eq e e_1) (const? 1 0) (icmp IntPred.eq e_2 e)) ⊑
+    icmp IntPred.eq e_2 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -99,9 +99,9 @@ theorem icmp_equality_test_commute_select1_thm (e e_1 e_2 : IntW 64) :
 
 
 theorem icmp_equality_test_commute_select2_thm (e e_1 e_2 : IntW 64) :
-  select (LLVM.xor (icmp IntPredicate.eq e_2 e_1) (const? 1 1))
-      (select (icmp IntPredicate.eq e e_1) (const? 1 0) (icmp IntPredicate.eq e_2 e)) (icmp IntPredicate.eq e e_1) ⊑
-    icmp IntPredicate.eq e_2 e := by
+  select (LLVM.xor (icmp IntPred.eq e_2 e_1) (const? 1 1))
+      (select (icmp IntPred.eq e e_1) (const? 1 0) (icmp IntPred.eq e_2 e)) (icmp IntPred.eq e e_1) ⊑
+    icmp IntPred.eq e_2 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -111,10 +111,10 @@ theorem icmp_equality_test_commute_select2_thm (e e_1 e_2 : IntW 64) :
 
 
 theorem icmp_equality_test_wrong_and_thm (e e_1 e_2 : IntW 64) :
-  select (icmp IntPredicate.eq e_2 e_1) (icmp IntPredicate.eq e e_1)
-      (select (LLVM.xor (icmp IntPredicate.eq e e_1) (const? 1 1)) (const? 1 0) (icmp IntPredicate.eq e_2 e)) ⊑
-    select (icmp IntPredicate.eq e_2 e_1) (icmp IntPredicate.eq e e_1)
-      (select (icmp IntPredicate.eq e e_1) (icmp IntPredicate.eq e_2 e) (const? 1 0)) := by
+  select (icmp IntPred.eq e_2 e_1) (icmp IntPred.eq e e_1)
+      (select (LLVM.xor (icmp IntPred.eq e e_1) (const? 1 1)) (const? 1 0) (icmp IntPred.eq e_2 e)) ⊑
+    select (icmp IntPred.eq e_2 e_1) (icmp IntPred.eq e e_1)
+      (select (icmp IntPred.eq e e_1) (icmp IntPred.eq e_2 e) (const? 1 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gicmphequalityhxor_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gicmphequalityhxor_proof.lean
@@ -12,7 +12,7 @@ set_option Elab.async false
 
 section gicmphequalityhxor_proof
 theorem cmpeq_xor_cst1_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.eq (LLVM.xor e_1 (const? 32 10)) e ⊑ icmp IntPredicate.eq (LLVM.xor e_1 e) (const? 32 10) := by
+  icmp IntPred.eq (LLVM.xor e_1 (const? 32 10)) e ⊑ icmp IntPred.eq (LLVM.xor e_1 e) (const? 32 10) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -22,7 +22,7 @@ theorem cmpeq_xor_cst1_thm (e e_1 : IntW 32) :
 
 
 theorem cmpeq_xor_cst3_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.eq (LLVM.xor e_1 (const? 32 10)) (LLVM.xor e (const? 32 10)) ⊑ icmp IntPredicate.eq e_1 e := by
+  icmp IntPred.eq (LLVM.xor e_1 (const? 32 10)) (LLVM.xor e (const? 32 10)) ⊑ icmp IntPred.eq e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -32,7 +32,7 @@ theorem cmpeq_xor_cst3_thm (e e_1 : IntW 32) :
 
 
 theorem cmpne_xor_cst1_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.ne (LLVM.xor e_1 (const? 32 10)) e ⊑ icmp IntPredicate.ne (LLVM.xor e_1 e) (const? 32 10) := by
+  icmp IntPred.ne (LLVM.xor e_1 (const? 32 10)) e ⊑ icmp IntPred.ne (LLVM.xor e_1 e) (const? 32 10) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -42,7 +42,7 @@ theorem cmpne_xor_cst1_thm (e e_1 : IntW 32) :
 
 
 theorem cmpne_xor_cst3_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.ne (LLVM.xor e_1 (const? 32 10)) (LLVM.xor e (const? 32 10)) ⊑ icmp IntPredicate.ne e_1 e := by
+  icmp IntPred.ne (LLVM.xor e_1 (const? 32 10)) (LLVM.xor e (const? 32 10)) ⊑ icmp IntPred.ne e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -52,8 +52,8 @@ theorem cmpne_xor_cst3_thm (e e_1 : IntW 32) :
 
 
 theorem cmpeq_xor_cst1_commuted_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.eq (mul e_1 e_1) (LLVM.xor e (const? 32 10)) ⊑
-    icmp IntPredicate.eq (LLVM.xor e (mul e_1 e_1)) (const? 32 10) := by
+  icmp IntPred.eq (mul e_1 e_1) (LLVM.xor e (const? 32 10)) ⊑
+    icmp IntPred.eq (LLVM.xor e (mul e_1 e_1)) (const? 32 10) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -63,9 +63,9 @@ theorem cmpeq_xor_cst1_commuted_thm (e e_1 : IntW 32) :
 
 
 theorem foo1_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.eq (LLVM.and e_1 (const? 32 (-2147483648)))
+  icmp IntPred.eq (LLVM.and e_1 (const? 32 (-2147483648)))
       (LLVM.and (LLVM.xor e (const? 32 (-1))) (const? 32 (-2147483648))) ⊑
-    icmp IntPredicate.slt (LLVM.xor e e_1) (const? 32 0) := by
+    icmp IntPred.slt (LLVM.xor e e_1) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -75,9 +75,9 @@ theorem foo1_thm (e e_1 : IntW 32) :
 
 
 theorem foo2_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.eq (LLVM.and e_1 (const? 32 (-2147483648)))
+  icmp IntPred.eq (LLVM.and e_1 (const? 32 (-2147483648)))
       (LLVM.xor (LLVM.and e (const? 32 (-2147483648))) (const? 32 (-2147483648))) ⊑
-    icmp IntPredicate.slt (LLVM.xor e e_1) (const? 32 0) := by
+    icmp IntPred.slt (LLVM.xor e e_1) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gicmphexthext_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gicmphexthext_proof.lean
@@ -12,7 +12,7 @@ set_option Elab.async false
 
 section gicmphexthext_proof
 theorem zext_zext_sgt_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.sgt (zext 32 e_1) (zext 32 e) ⊑ icmp IntPredicate.ugt e_1 e := by
+  icmp IntPred.sgt (zext 32 e_1) (zext 32 e) ⊑ icmp IntPred.ugt e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -22,7 +22,7 @@ theorem zext_zext_sgt_thm (e e_1 : IntW 8) :
 
 
 theorem zext_zext_eq_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.eq (zext 32 e_1) (zext 32 e) ⊑ icmp IntPredicate.eq e_1 e := by
+  icmp IntPred.eq (zext 32 e_1) (zext 32 e) ⊑ icmp IntPred.eq e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -32,7 +32,7 @@ theorem zext_zext_eq_thm (e e_1 : IntW 8) :
 
 
 theorem zext_zext_sle_op0_narrow_thm (e : IntW 16) (e_1 : IntW 8) :
-  icmp IntPredicate.sle (zext 32 e_1) (zext 32 e) ⊑ icmp IntPredicate.uge e (zext 16 e_1) := by
+  icmp IntPred.sle (zext 32 e_1) (zext 32 e) ⊑ icmp IntPred.uge e (zext 16 e_1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -42,7 +42,7 @@ theorem zext_zext_sle_op0_narrow_thm (e : IntW 16) (e_1 : IntW 8) :
 
 
 theorem zext_zext_ule_op0_wide_thm (e : IntW 8) (e_1 : IntW 9) :
-  icmp IntPredicate.ule (zext 32 e_1) (zext 32 e) ⊑ icmp IntPredicate.ule e_1 (zext 9 e) := by
+  icmp IntPred.ule (zext 32 e_1) (zext 32 e) ⊑ icmp IntPred.ule e_1 (zext 9 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -52,7 +52,7 @@ theorem zext_zext_ule_op0_wide_thm (e : IntW 8) (e_1 : IntW 9) :
 
 
 theorem sext_sext_slt_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.slt (sext 32 e_1) (sext 32 e) ⊑ icmp IntPredicate.slt e_1 e := by
+  icmp IntPred.slt (sext 32 e_1) (sext 32 e) ⊑ icmp IntPred.slt e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -62,7 +62,7 @@ theorem sext_sext_slt_thm (e e_1 : IntW 8) :
 
 
 theorem sext_sext_ult_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.ult (sext 32 e_1) (sext 32 e) ⊑ icmp IntPredicate.ult e_1 e := by
+  icmp IntPred.ult (sext 32 e_1) (sext 32 e) ⊑ icmp IntPred.ult e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -72,7 +72,7 @@ theorem sext_sext_ult_thm (e e_1 : IntW 8) :
 
 
 theorem sext_sext_ne_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.ne (sext 32 e_1) (sext 32 e) ⊑ icmp IntPredicate.ne e_1 e := by
+  icmp IntPred.ne (sext 32 e_1) (sext 32 e) ⊑ icmp IntPred.ne e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -82,7 +82,7 @@ theorem sext_sext_ne_thm (e e_1 : IntW 8) :
 
 
 theorem sext_sext_sge_op0_narrow_thm (e : IntW 8) (e_1 : IntW 5) :
-  icmp IntPredicate.sge (sext 32 e_1) (sext 32 e) ⊑ icmp IntPredicate.sle e (sext 8 e_1) := by
+  icmp IntPred.sge (sext 32 e_1) (sext 32 e) ⊑ icmp IntPred.sle e (sext 8 e_1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -92,7 +92,7 @@ theorem sext_sext_sge_op0_narrow_thm (e : IntW 8) (e_1 : IntW 5) :
 
 
 theorem zext_nneg_sext_sgt_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.sgt (zext 32 e_1 { «nneg» := true }) (sext 32 e) ⊑ icmp IntPredicate.sgt e_1 e := by
+  icmp IntPred.sgt (zext 32 e_1 { «nneg» := true }) (sext 32 e) ⊑ icmp IntPred.sgt e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -102,7 +102,7 @@ theorem zext_nneg_sext_sgt_thm (e e_1 : IntW 8) :
 
 
 theorem zext_nneg_sext_ugt_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.ugt (zext 32 e_1 { «nneg» := true }) (sext 32 e) ⊑ icmp IntPredicate.ugt e_1 e := by
+  icmp IntPred.ugt (zext 32 e_1 { «nneg» := true }) (sext 32 e) ⊑ icmp IntPred.ugt e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -112,7 +112,7 @@ theorem zext_nneg_sext_ugt_thm (e e_1 : IntW 8) :
 
 
 theorem zext_nneg_sext_eq_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.eq (zext 32 e_1 { «nneg» := true }) (sext 32 e) ⊑ icmp IntPredicate.eq e_1 e := by
+  icmp IntPred.eq (zext 32 e_1 { «nneg» := true }) (sext 32 e) ⊑ icmp IntPred.eq e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -122,7 +122,7 @@ theorem zext_nneg_sext_eq_thm (e e_1 : IntW 8) :
 
 
 theorem zext_nneg_sext_sle_op0_narrow_thm (e : IntW 16) (e_1 : IntW 8) :
-  icmp IntPredicate.sle (zext 32 e_1 { «nneg» := true }) (sext 32 e) ⊑ icmp IntPredicate.sge e (sext 16 e_1) := by
+  icmp IntPred.sle (zext 32 e_1 { «nneg» := true }) (sext 32 e) ⊑ icmp IntPred.sge e (sext 16 e_1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -132,7 +132,7 @@ theorem zext_nneg_sext_sle_op0_narrow_thm (e : IntW 16) (e_1 : IntW 8) :
 
 
 theorem zext_nneg_sext_ule_op0_wide_thm (e : IntW 8) (e_1 : IntW 9) :
-  icmp IntPredicate.ule (zext 32 e_1 { «nneg» := true }) (sext 32 e) ⊑ icmp IntPredicate.ule e_1 (sext 9 e) := by
+  icmp IntPred.ule (zext 32 e_1 { «nneg» := true }) (sext 32 e) ⊑ icmp IntPred.ule e_1 (sext 9 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -142,7 +142,7 @@ theorem zext_nneg_sext_ule_op0_wide_thm (e : IntW 8) (e_1 : IntW 9) :
 
 
 theorem sext_zext_nneg_slt_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.slt (sext 32 e_1) (zext 32 e { «nneg» := true }) ⊑ icmp IntPredicate.slt e_1 e := by
+  icmp IntPred.slt (sext 32 e_1) (zext 32 e { «nneg» := true }) ⊑ icmp IntPred.slt e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -152,7 +152,7 @@ theorem sext_zext_nneg_slt_thm (e e_1 : IntW 8) :
 
 
 theorem sext_zext_nneg_ult_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.ult (sext 32 e_1) (zext 32 e { «nneg» := true }) ⊑ icmp IntPredicate.ult e_1 e := by
+  icmp IntPred.ult (sext 32 e_1) (zext 32 e { «nneg» := true }) ⊑ icmp IntPred.ult e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -162,7 +162,7 @@ theorem sext_zext_nneg_ult_thm (e e_1 : IntW 8) :
 
 
 theorem sext_zext_nneg_sge_op0_narrow_thm (e : IntW 8) (e_1 : IntW 5) :
-  icmp IntPredicate.sge (sext 32 e_1) (zext 32 e { «nneg» := true }) ⊑ icmp IntPredicate.sle e (sext 8 e_1) := by
+  icmp IntPred.sge (sext 32 e_1) (zext 32 e { «nneg» := true }) ⊑ icmp IntPred.sle e (sext 8 e_1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -172,7 +172,7 @@ theorem sext_zext_nneg_sge_op0_narrow_thm (e : IntW 8) (e_1 : IntW 5) :
 
 
 theorem sext_zext_nneg_uge_op0_wide_thm (e : IntW 8) (e_1 : IntW 16) :
-  icmp IntPredicate.uge (sext 32 e_1) (zext 32 e { «nneg» := true }) ⊑ icmp IntPredicate.uge e_1 (sext 16 e) := by
+  icmp IntPred.uge (sext 32 e_1) (zext 32 e { «nneg» := true }) ⊑ icmp IntPred.uge e_1 (sext 16 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -182,8 +182,8 @@ theorem sext_zext_nneg_uge_op0_wide_thm (e : IntW 8) (e_1 : IntW 16) :
 
 
 theorem zext_sext_sgt_known_nonneg_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.sgt (zext 32 (LLVM.udiv (const? 8 127) e_1)) (sext 32 e) ⊑
-    icmp IntPredicate.sgt (LLVM.udiv (const? 8 127) e_1) e := by
+  icmp IntPred.sgt (zext 32 (LLVM.udiv (const? 8 127) e_1)) (sext 32 e) ⊑
+    icmp IntPred.sgt (LLVM.udiv (const? 8 127) e_1) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -193,8 +193,8 @@ theorem zext_sext_sgt_known_nonneg_thm (e e_1 : IntW 8) :
 
 
 theorem zext_sext_ugt_known_nonneg_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.ugt (zext 32 (LLVM.and e_1 (const? 8 127))) (sext 32 e) ⊑
-    icmp IntPredicate.ugt (LLVM.and e_1 (const? 8 127)) e := by
+  icmp IntPred.ugt (zext 32 (LLVM.and e_1 (const? 8 127))) (sext 32 e) ⊑
+    icmp IntPred.ugt (LLVM.and e_1 (const? 8 127)) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -204,8 +204,8 @@ theorem zext_sext_ugt_known_nonneg_thm (e e_1 : IntW 8) :
 
 
 theorem zext_sext_eq_known_nonneg_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.eq (zext 32 (lshr e_1 (const? 8 1))) (sext 32 e) ⊑
-    icmp IntPredicate.eq (lshr e_1 (const? 8 1)) e := by
+  icmp IntPred.eq (zext 32 (lshr e_1 (const? 8 1))) (sext 32 e) ⊑
+    icmp IntPred.eq (lshr e_1 (const? 8 1)) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -215,8 +215,8 @@ theorem zext_sext_eq_known_nonneg_thm (e e_1 : IntW 8) :
 
 
 theorem zext_sext_sle_known_nonneg_op0_narrow_thm (e : IntW 16) (e_1 : IntW 8) :
-  icmp IntPredicate.sle (zext 32 (LLVM.and e_1 (const? 8 12))) (sext 32 e) ⊑
-    icmp IntPredicate.sge e (zext 16 (LLVM.and e_1 (const? 8 12)) { «nneg» := true }) := by
+  icmp IntPred.sle (zext 32 (LLVM.and e_1 (const? 8 12))) (sext 32 e) ⊑
+    icmp IntPred.sge e (zext 16 (LLVM.and e_1 (const? 8 12)) { «nneg» := true }) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -226,8 +226,8 @@ theorem zext_sext_sle_known_nonneg_op0_narrow_thm (e : IntW 16) (e_1 : IntW 8) :
 
 
 theorem zext_sext_ule_known_nonneg_op0_wide_thm (e : IntW 8) (e_1 : IntW 9) :
-  icmp IntPredicate.ule (zext 32 (urem e_1 (const? 9 254))) (sext 32 e) ⊑
-    icmp IntPredicate.ule (urem e_1 (const? 9 254)) (sext 9 e) := by
+  icmp IntPred.ule (zext 32 (urem e_1 (const? 9 254))) (sext 32 e) ⊑
+    icmp IntPred.ule (urem e_1 (const? 9 254)) (sext 9 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -237,8 +237,8 @@ theorem zext_sext_ule_known_nonneg_op0_wide_thm (e : IntW 8) (e_1 : IntW 9) :
 
 
 theorem sext_zext_slt_known_nonneg_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.slt (sext 32 e_1) (zext 32 (LLVM.and e (const? 8 126))) ⊑
-    icmp IntPredicate.slt e_1 (LLVM.and e (const? 8 126)) := by
+  icmp IntPred.slt (sext 32 e_1) (zext 32 (LLVM.and e (const? 8 126))) ⊑
+    icmp IntPred.slt e_1 (LLVM.and e (const? 8 126)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -248,8 +248,8 @@ theorem sext_zext_slt_known_nonneg_thm (e e_1 : IntW 8) :
 
 
 theorem sext_zext_ult_known_nonneg_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.ult (sext 32 e_1) (zext 32 (lshr e (const? 8 6))) ⊑
-    icmp IntPredicate.ult e_1 (lshr e (const? 8 6)) := by
+  icmp IntPred.ult (sext 32 e_1) (zext 32 (lshr e (const? 8 6))) ⊑
+    icmp IntPred.ult e_1 (lshr e (const? 8 6)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -259,8 +259,8 @@ theorem sext_zext_ult_known_nonneg_thm (e e_1 : IntW 8) :
 
 
 theorem sext_zext_ne_known_nonneg_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.ne (sext 32 e_1) (zext 32 (LLVM.udiv e (const? 8 6))) ⊑
-    icmp IntPredicate.ne e_1 (LLVM.udiv e (const? 8 6)) := by
+  icmp IntPred.ne (sext 32 e_1) (zext 32 (LLVM.udiv e (const? 8 6))) ⊑
+    icmp IntPred.ne e_1 (LLVM.udiv e (const? 8 6)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -270,8 +270,8 @@ theorem sext_zext_ne_known_nonneg_thm (e e_1 : IntW 8) :
 
 
 theorem sext_zext_uge_known_nonneg_op0_wide_thm (e : IntW 8) (e_1 : IntW 16) :
-  icmp IntPredicate.uge (sext 32 e_1) (zext 32 (LLVM.and e (const? 8 12))) ⊑
-    icmp IntPredicate.uge e_1 (zext 16 (LLVM.and e (const? 8 12)) { «nneg» := true }) := by
+  icmp IntPred.uge (sext 32 e_1) (zext 32 (LLVM.and e (const? 8 12))) ⊑
+    icmp IntPred.uge e_1 (zext 16 (LLVM.and e (const? 8 12)) { «nneg» := true }) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -281,7 +281,7 @@ theorem sext_zext_uge_known_nonneg_op0_wide_thm (e : IntW 8) (e_1 : IntW 16) :
 
 
 theorem zext_eq_sext_thm (e e_1 : IntW 1) :
-  icmp IntPredicate.eq (zext 32 e_1) (sext 32 e) ⊑ LLVM.xor (LLVM.or e_1 e) (const? 1 1) := by
+  icmp IntPred.eq (zext 32 e_1) (sext 32 e) ⊑ LLVM.xor (LLVM.or e_1 e) (const? 1 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gicmphlogical_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gicmphlogical_proof.lean
@@ -12,9 +12,9 @@ set_option Elab.async false
 
 section gicmphlogical_proof
 theorem masked_and_notallzeroes_thm (e : IntW 32) :
-  LLVM.and (icmp IntPredicate.ne (LLVM.and e (const? 32 7)) (const? 32 0))
-      (icmp IntPredicate.ne (LLVM.and e (const? 32 39)) (const? 32 0)) ⊑
-    icmp IntPredicate.ne (LLVM.and e (const? 32 7)) (const? 32 0) := by
+  LLVM.and (icmp IntPred.ne (LLVM.and e (const? 32 7)) (const? 32 0))
+      (icmp IntPred.ne (LLVM.and e (const? 32 39)) (const? 32 0)) ⊑
+    icmp IntPred.ne (LLVM.and e (const? 32 7)) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -24,9 +24,9 @@ theorem masked_and_notallzeroes_thm (e : IntW 32) :
 
 
 theorem masked_and_notallzeroes_logical_thm (e : IntW 32) :
-  select (icmp IntPredicate.ne (LLVM.and e (const? 32 7)) (const? 32 0))
-      (icmp IntPredicate.ne (LLVM.and e (const? 32 39)) (const? 32 0)) (const? 1 0) ⊑
-    icmp IntPredicate.ne (LLVM.and e (const? 32 7)) (const? 32 0) := by
+  select (icmp IntPred.ne (LLVM.and e (const? 32 7)) (const? 32 0))
+      (icmp IntPred.ne (LLVM.and e (const? 32 39)) (const? 32 0)) (const? 1 0) ⊑
+    icmp IntPred.ne (LLVM.and e (const? 32 7)) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -36,9 +36,9 @@ theorem masked_and_notallzeroes_logical_thm (e : IntW 32) :
 
 
 theorem masked_or_allzeroes_thm (e : IntW 32) :
-  LLVM.or (icmp IntPredicate.eq (LLVM.and e (const? 32 7)) (const? 32 0))
-      (icmp IntPredicate.eq (LLVM.and e (const? 32 39)) (const? 32 0)) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 32 7)) (const? 32 0) := by
+  LLVM.or (icmp IntPred.eq (LLVM.and e (const? 32 7)) (const? 32 0))
+      (icmp IntPred.eq (LLVM.and e (const? 32 39)) (const? 32 0)) ⊑
+    icmp IntPred.eq (LLVM.and e (const? 32 7)) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -48,9 +48,9 @@ theorem masked_or_allzeroes_thm (e : IntW 32) :
 
 
 theorem masked_or_allzeroes_logical_thm (e : IntW 32) :
-  select (icmp IntPredicate.eq (LLVM.and e (const? 32 7)) (const? 32 0)) (const? 1 1)
-      (icmp IntPredicate.eq (LLVM.and e (const? 32 39)) (const? 32 0)) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 32 7)) (const? 32 0) := by
+  select (icmp IntPred.eq (LLVM.and e (const? 32 7)) (const? 32 0)) (const? 1 1)
+      (icmp IntPred.eq (LLVM.and e (const? 32 39)) (const? 32 0)) ⊑
+    icmp IntPred.eq (LLVM.and e (const? 32 7)) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -60,9 +60,9 @@ theorem masked_or_allzeroes_logical_thm (e : IntW 32) :
 
 
 theorem masked_and_notallones_thm (e : IntW 32) :
-  LLVM.and (icmp IntPredicate.ne (LLVM.and e (const? 32 7)) (const? 32 7))
-      (icmp IntPredicate.ne (LLVM.and e (const? 32 39)) (const? 32 39)) ⊑
-    icmp IntPredicate.ne (LLVM.and e (const? 32 7)) (const? 32 7) := by
+  LLVM.and (icmp IntPred.ne (LLVM.and e (const? 32 7)) (const? 32 7))
+      (icmp IntPred.ne (LLVM.and e (const? 32 39)) (const? 32 39)) ⊑
+    icmp IntPred.ne (LLVM.and e (const? 32 7)) (const? 32 7) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -72,9 +72,9 @@ theorem masked_and_notallones_thm (e : IntW 32) :
 
 
 theorem masked_and_notallones_logical_thm (e : IntW 32) :
-  select (icmp IntPredicate.ne (LLVM.and e (const? 32 7)) (const? 32 7))
-      (icmp IntPredicate.ne (LLVM.and e (const? 32 39)) (const? 32 39)) (const? 1 0) ⊑
-    icmp IntPredicate.ne (LLVM.and e (const? 32 7)) (const? 32 7) := by
+  select (icmp IntPred.ne (LLVM.and e (const? 32 7)) (const? 32 7))
+      (icmp IntPred.ne (LLVM.and e (const? 32 39)) (const? 32 39)) (const? 1 0) ⊑
+    icmp IntPred.ne (LLVM.and e (const? 32 7)) (const? 32 7) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -84,9 +84,9 @@ theorem masked_and_notallones_logical_thm (e : IntW 32) :
 
 
 theorem masked_or_allones_thm (e : IntW 32) :
-  LLVM.or (icmp IntPredicate.eq (LLVM.and e (const? 32 7)) (const? 32 7))
-      (icmp IntPredicate.eq (LLVM.and e (const? 32 39)) (const? 32 39)) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 32 7)) (const? 32 7) := by
+  LLVM.or (icmp IntPred.eq (LLVM.and e (const? 32 7)) (const? 32 7))
+      (icmp IntPred.eq (LLVM.and e (const? 32 39)) (const? 32 39)) ⊑
+    icmp IntPred.eq (LLVM.and e (const? 32 7)) (const? 32 7) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -96,9 +96,9 @@ theorem masked_or_allones_thm (e : IntW 32) :
 
 
 theorem masked_or_allones_logical_thm (e : IntW 32) :
-  select (icmp IntPredicate.eq (LLVM.and e (const? 32 7)) (const? 32 7)) (const? 1 1)
-      (icmp IntPredicate.eq (LLVM.and e (const? 32 39)) (const? 32 39)) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 32 7)) (const? 32 7) := by
+  select (icmp IntPred.eq (LLVM.and e (const? 32 7)) (const? 32 7)) (const? 1 1)
+      (icmp IntPred.eq (LLVM.and e (const? 32 39)) (const? 32 39)) ⊑
+    icmp IntPred.eq (LLVM.and e (const? 32 7)) (const? 32 7) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -108,8 +108,8 @@ theorem masked_or_allones_logical_thm (e : IntW 32) :
 
 
 theorem masked_and_notA_thm (e : IntW 32) :
-  LLVM.and (icmp IntPredicate.ne (LLVM.and e (const? 32 14)) e) (icmp IntPredicate.ne (LLVM.and e (const? 32 78)) e) ⊑
-    icmp IntPredicate.ne (LLVM.and e (const? 32 (-79))) (const? 32 0) := by
+  LLVM.and (icmp IntPred.ne (LLVM.and e (const? 32 14)) e) (icmp IntPred.ne (LLVM.and e (const? 32 78)) e) ⊑
+    icmp IntPred.ne (LLVM.and e (const? 32 (-79))) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -119,9 +119,9 @@ theorem masked_and_notA_thm (e : IntW 32) :
 
 
 theorem masked_and_notA_logical_thm (e : IntW 32) :
-  select (icmp IntPredicate.ne (LLVM.and e (const? 32 14)) e) (icmp IntPredicate.ne (LLVM.and e (const? 32 78)) e)
+  select (icmp IntPred.ne (LLVM.and e (const? 32 14)) e) (icmp IntPred.ne (LLVM.and e (const? 32 78)) e)
       (const? 1 0) ⊑
-    icmp IntPredicate.ne (LLVM.and e (const? 32 (-79))) (const? 32 0) := by
+    icmp IntPred.ne (LLVM.and e (const? 32 (-79))) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -131,8 +131,8 @@ theorem masked_and_notA_logical_thm (e : IntW 32) :
 
 
 theorem masked_and_notA_slightly_optimized_thm (e : IntW 32) :
-  LLVM.and (icmp IntPredicate.uge e (const? 32 8)) (icmp IntPredicate.ne (LLVM.and e (const? 32 39)) e) ⊑
-    icmp IntPredicate.ne (LLVM.and e (const? 32 (-40))) (const? 32 0) := by
+  LLVM.and (icmp IntPred.uge e (const? 32 8)) (icmp IntPred.ne (LLVM.and e (const? 32 39)) e) ⊑
+    icmp IntPred.ne (LLVM.and e (const? 32 (-40))) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -142,8 +142,8 @@ theorem masked_and_notA_slightly_optimized_thm (e : IntW 32) :
 
 
 theorem masked_and_notA_slightly_optimized_logical_thm (e : IntW 32) :
-  select (icmp IntPredicate.uge e (const? 32 8)) (icmp IntPredicate.ne (LLVM.and e (const? 32 39)) e) (const? 1 0) ⊑
-    icmp IntPredicate.ne (LLVM.and e (const? 32 (-40))) (const? 32 0) := by
+  select (icmp IntPred.uge e (const? 32 8)) (icmp IntPred.ne (LLVM.and e (const? 32 39)) e) (const? 1 0) ⊑
+    icmp IntPred.ne (LLVM.and e (const? 32 (-40))) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -153,8 +153,8 @@ theorem masked_and_notA_slightly_optimized_logical_thm (e : IntW 32) :
 
 
 theorem masked_or_A_thm (e : IntW 32) :
-  LLVM.or (icmp IntPredicate.eq (LLVM.and e (const? 32 14)) e) (icmp IntPredicate.eq (LLVM.and e (const? 32 78)) e) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 32 (-79))) (const? 32 0) := by
+  LLVM.or (icmp IntPred.eq (LLVM.and e (const? 32 14)) e) (icmp IntPred.eq (LLVM.and e (const? 32 78)) e) ⊑
+    icmp IntPred.eq (LLVM.and e (const? 32 (-79))) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -164,9 +164,9 @@ theorem masked_or_A_thm (e : IntW 32) :
 
 
 theorem masked_or_A_logical_thm (e : IntW 32) :
-  select (icmp IntPredicate.eq (LLVM.and e (const? 32 14)) e) (const? 1 1)
-      (icmp IntPredicate.eq (LLVM.and e (const? 32 78)) e) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 32 (-79))) (const? 32 0) := by
+  select (icmp IntPred.eq (LLVM.and e (const? 32 14)) e) (const? 1 1)
+      (icmp IntPred.eq (LLVM.and e (const? 32 78)) e) ⊑
+    icmp IntPred.eq (LLVM.and e (const? 32 (-79))) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -176,8 +176,8 @@ theorem masked_or_A_logical_thm (e : IntW 32) :
 
 
 theorem masked_or_A_slightly_optimized_thm (e : IntW 32) :
-  LLVM.or (icmp IntPredicate.ult e (const? 32 8)) (icmp IntPredicate.eq (LLVM.and e (const? 32 39)) e) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 32 (-40))) (const? 32 0) := by
+  LLVM.or (icmp IntPred.ult e (const? 32 8)) (icmp IntPred.eq (LLVM.and e (const? 32 39)) e) ⊑
+    icmp IntPred.eq (LLVM.and e (const? 32 (-40))) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -187,8 +187,8 @@ theorem masked_or_A_slightly_optimized_thm (e : IntW 32) :
 
 
 theorem masked_or_A_slightly_optimized_logical_thm (e : IntW 32) :
-  select (icmp IntPredicate.ult e (const? 32 8)) (const? 1 1) (icmp IntPredicate.eq (LLVM.and e (const? 32 39)) e) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 32 (-40))) (const? 32 0) := by
+  select (icmp IntPred.ult e (const? 32 8)) (const? 1 1) (icmp IntPred.eq (LLVM.and e (const? 32 39)) e) ⊑
+    icmp IntPred.eq (LLVM.and e (const? 32 (-40))) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -198,10 +198,10 @@ theorem masked_or_A_slightly_optimized_logical_thm (e : IntW 32) :
 
 
 theorem masked_or_allzeroes_notoptimised_logical_thm (e : IntW 32) :
-  select (icmp IntPredicate.eq (LLVM.and e (const? 32 15)) (const? 32 0)) (const? 1 1)
-      (icmp IntPredicate.eq (LLVM.and e (const? 32 39)) (const? 32 0)) ⊑
-    LLVM.or (icmp IntPredicate.eq (LLVM.and e (const? 32 15)) (const? 32 0))
-      (icmp IntPredicate.eq (LLVM.and e (const? 32 39)) (const? 32 0)) := by
+  select (icmp IntPred.eq (LLVM.and e (const? 32 15)) (const? 32 0)) (const? 1 1)
+      (icmp IntPred.eq (LLVM.and e (const? 32 39)) (const? 32 0)) ⊑
+    LLVM.or (icmp IntPred.eq (LLVM.and e (const? 32 15)) (const? 32 0))
+      (icmp IntPred.eq (LLVM.and e (const? 32 39)) (const? 32 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -211,8 +211,8 @@ theorem masked_or_allzeroes_notoptimised_logical_thm (e : IntW 32) :
 
 
 theorem nomask_lhs_thm (e : IntW 32) :
-  LLVM.or (icmp IntPredicate.eq e (const? 32 0)) (icmp IntPredicate.eq (LLVM.and e (const? 32 1)) (const? 32 0)) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 32 1)) (const? 32 0) := by
+  LLVM.or (icmp IntPred.eq e (const? 32 0)) (icmp IntPred.eq (LLVM.and e (const? 32 1)) (const? 32 0)) ⊑
+    icmp IntPred.eq (LLVM.and e (const? 32 1)) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -222,9 +222,9 @@ theorem nomask_lhs_thm (e : IntW 32) :
 
 
 theorem nomask_lhs_logical_thm (e : IntW 32) :
-  select (icmp IntPredicate.eq e (const? 32 0)) (const? 1 1)
-      (icmp IntPredicate.eq (LLVM.and e (const? 32 1)) (const? 32 0)) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 32 1)) (const? 32 0) := by
+  select (icmp IntPred.eq e (const? 32 0)) (const? 1 1)
+      (icmp IntPred.eq (LLVM.and e (const? 32 1)) (const? 32 0)) ⊑
+    icmp IntPred.eq (LLVM.and e (const? 32 1)) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -234,8 +234,8 @@ theorem nomask_lhs_logical_thm (e : IntW 32) :
 
 
 theorem nomask_rhs_thm (e : IntW 32) :
-  LLVM.or (icmp IntPredicate.eq (LLVM.and e (const? 32 1)) (const? 32 0)) (icmp IntPredicate.eq e (const? 32 0)) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 32 1)) (const? 32 0) := by
+  LLVM.or (icmp IntPred.eq (LLVM.and e (const? 32 1)) (const? 32 0)) (icmp IntPred.eq e (const? 32 0)) ⊑
+    icmp IntPred.eq (LLVM.and e (const? 32 1)) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -245,9 +245,9 @@ theorem nomask_rhs_thm (e : IntW 32) :
 
 
 theorem nomask_rhs_logical_thm (e : IntW 32) :
-  select (icmp IntPredicate.eq (LLVM.and e (const? 32 1)) (const? 32 0)) (const? 1 1)
-      (icmp IntPredicate.eq e (const? 32 0)) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 32 1)) (const? 32 0) := by
+  select (icmp IntPred.eq (LLVM.and e (const? 32 1)) (const? 32 0)) (const? 1 1)
+      (icmp IntPred.eq e (const? 32 0)) ⊑
+    icmp IntPred.eq (LLVM.and e (const? 32 1)) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -257,8 +257,8 @@ theorem nomask_rhs_logical_thm (e : IntW 32) :
 
 
 theorem fold_mask_cmps_to_false_thm (e : IntW 32) :
-  LLVM.and (icmp IntPredicate.eq e (const? 32 2147483647))
-      (icmp IntPredicate.eq (LLVM.and e (const? 32 2147483647)) (const? 32 0)) ⊑
+  LLVM.and (icmp IntPred.eq e (const? 32 2147483647))
+      (icmp IntPred.eq (LLVM.and e (const? 32 2147483647)) (const? 32 0)) ⊑
     const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
@@ -269,8 +269,8 @@ theorem fold_mask_cmps_to_false_thm (e : IntW 32) :
 
 
 theorem fold_mask_cmps_to_false_logical_thm (e : IntW 32) :
-  select (icmp IntPredicate.eq e (const? 32 2147483647))
-      (icmp IntPredicate.eq (LLVM.and e (const? 32 2147483647)) (const? 32 0)) (const? 1 0) ⊑
+  select (icmp IntPred.eq e (const? 32 2147483647))
+      (icmp IntPred.eq (LLVM.and e (const? 32 2147483647)) (const? 32 0)) (const? 1 0) ⊑
     const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
@@ -281,8 +281,8 @@ theorem fold_mask_cmps_to_false_logical_thm (e : IntW 32) :
 
 
 theorem fold_mask_cmps_to_true_thm (e : IntW 32) :
-  LLVM.or (icmp IntPredicate.ne e (const? 32 2147483647))
-      (icmp IntPredicate.ne (LLVM.and e (const? 32 2147483647)) (const? 32 0)) ⊑
+  LLVM.or (icmp IntPred.ne e (const? 32 2147483647))
+      (icmp IntPred.ne (LLVM.and e (const? 32 2147483647)) (const? 32 0)) ⊑
     const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
@@ -293,8 +293,8 @@ theorem fold_mask_cmps_to_true_thm (e : IntW 32) :
 
 
 theorem fold_mask_cmps_to_true_logical_thm (e : IntW 32) :
-  select (icmp IntPredicate.ne e (const? 32 2147483647)) (const? 1 1)
-      (icmp IntPredicate.ne (LLVM.and e (const? 32 2147483647)) (const? 32 0)) ⊑
+  select (icmp IntPred.ne e (const? 32 2147483647)) (const? 1 1)
+      (icmp IntPred.ne (LLVM.and e (const? 32 2147483647)) (const? 32 0)) ⊑
     const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
@@ -305,8 +305,8 @@ theorem fold_mask_cmps_to_true_logical_thm (e : IntW 32) :
 
 
 theorem cmpeq_bitwise_thm (e e_1 e_2 e_3 : IntW 8) :
-  icmp IntPredicate.eq (LLVM.or (LLVM.xor e_3 e_2) (LLVM.xor e_1 e)) (const? 8 0) ⊑
-    LLVM.and (icmp IntPredicate.eq e_3 e_2) (icmp IntPredicate.eq e_1 e) := by
+  icmp IntPred.eq (LLVM.or (LLVM.xor e_3 e_2) (LLVM.xor e_1 e)) (const? 8 0) ⊑
+    LLVM.and (icmp IntPred.eq e_3 e_2) (icmp IntPred.eq e_1 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -316,10 +316,10 @@ theorem cmpeq_bitwise_thm (e e_1 e_2 e_3 : IntW 8) :
 
 
 theorem masked_icmps_mask_notallzeros_bmask_mixed_0_logical_thm (e : IntW 32) :
-  select (icmp IntPredicate.ne (LLVM.and e (const? 32 12)) (const? 32 0))
-      (icmp IntPredicate.eq (LLVM.and e (const? 32 3)) (const? 32 1)) (const? 1 0) ⊑
-    LLVM.and (icmp IntPredicate.ne (LLVM.and e (const? 32 12)) (const? 32 0))
-      (icmp IntPredicate.eq (LLVM.and e (const? 32 3)) (const? 32 1)) := by
+  select (icmp IntPred.ne (LLVM.and e (const? 32 12)) (const? 32 0))
+      (icmp IntPred.eq (LLVM.and e (const? 32 3)) (const? 32 1)) (const? 1 0) ⊑
+    LLVM.and (icmp IntPred.ne (LLVM.and e (const? 32 12)) (const? 32 0))
+      (icmp IntPred.eq (LLVM.and e (const? 32 3)) (const? 32 1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -329,9 +329,9 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_0_logical_thm (e : IntW 32) :
 
 
 theorem masked_icmps_mask_notallzeros_bmask_mixed_1_thm (e : IntW 32) :
-  LLVM.and (icmp IntPredicate.ne (LLVM.and e (const? 32 12)) (const? 32 0))
-      (icmp IntPredicate.eq (LLVM.and e (const? 32 7)) (const? 32 1)) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 32 15)) (const? 32 9) := by
+  LLVM.and (icmp IntPred.ne (LLVM.and e (const? 32 12)) (const? 32 0))
+      (icmp IntPred.eq (LLVM.and e (const? 32 7)) (const? 32 1)) ⊑
+    icmp IntPred.eq (LLVM.and e (const? 32 15)) (const? 32 9) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -341,9 +341,9 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_1_thm (e : IntW 32) :
 
 
 theorem masked_icmps_mask_notallzeros_bmask_mixed_1_logical_thm (e : IntW 32) :
-  select (icmp IntPredicate.ne (LLVM.and e (const? 32 12)) (const? 32 0))
-      (icmp IntPredicate.eq (LLVM.and e (const? 32 7)) (const? 32 1)) (const? 1 0) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 32 15)) (const? 32 9) := by
+  select (icmp IntPred.ne (LLVM.and e (const? 32 12)) (const? 32 0))
+      (icmp IntPred.eq (LLVM.and e (const? 32 7)) (const? 32 1)) (const? 1 0) ⊑
+    icmp IntPred.eq (LLVM.and e (const? 32 15)) (const? 32 9) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -353,10 +353,10 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_1_logical_thm (e : IntW 32) :
 
 
 theorem masked_icmps_mask_notallzeros_bmask_mixed_1b_logical_thm (e : IntW 32) :
-  select (icmp IntPredicate.ne (LLVM.and e (const? 32 14)) (const? 32 0))
-      (icmp IntPredicate.eq (LLVM.and e (const? 32 3)) (const? 32 1)) (const? 1 0) ⊑
-    LLVM.and (icmp IntPredicate.ne (LLVM.and e (const? 32 14)) (const? 32 0))
-      (icmp IntPredicate.eq (LLVM.and e (const? 32 3)) (const? 32 1)) := by
+  select (icmp IntPred.ne (LLVM.and e (const? 32 14)) (const? 32 0))
+      (icmp IntPred.eq (LLVM.and e (const? 32 3)) (const? 32 1)) (const? 1 0) ⊑
+    LLVM.and (icmp IntPred.ne (LLVM.and e (const? 32 14)) (const? 32 0))
+      (icmp IntPred.eq (LLVM.and e (const? 32 3)) (const? 32 1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -366,8 +366,8 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_1b_logical_thm (e : IntW 32) :
 
 
 theorem masked_icmps_mask_notallzeros_bmask_mixed_2_thm (e : IntW 32) :
-  LLVM.and (icmp IntPredicate.ne (LLVM.and e (const? 32 3)) (const? 32 0))
-      (icmp IntPredicate.eq (LLVM.and e (const? 32 7)) (const? 32 0)) ⊑
+  LLVM.and (icmp IntPred.ne (LLVM.and e (const? 32 3)) (const? 32 0))
+      (icmp IntPred.eq (LLVM.and e (const? 32 7)) (const? 32 0)) ⊑
     const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
@@ -378,8 +378,8 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_2_thm (e : IntW 32) :
 
 
 theorem masked_icmps_mask_notallzeros_bmask_mixed_2_logical_thm (e : IntW 32) :
-  select (icmp IntPredicate.ne (LLVM.and e (const? 32 3)) (const? 32 0))
-      (icmp IntPredicate.eq (LLVM.and e (const? 32 7)) (const? 32 0)) (const? 1 0) ⊑
+  select (icmp IntPred.ne (LLVM.and e (const? 32 3)) (const? 32 0))
+      (icmp IntPred.eq (LLVM.and e (const? 32 7)) (const? 32 0)) (const? 1 0) ⊑
     const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
@@ -390,9 +390,9 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_2_logical_thm (e : IntW 32) :
 
 
 theorem masked_icmps_mask_notallzeros_bmask_mixed_3_thm (e : IntW 32) :
-  LLVM.and (icmp IntPredicate.ne (LLVM.and e (const? 32 15)) (const? 32 0))
-      (icmp IntPredicate.eq (LLVM.and e (const? 32 7)) (const? 32 0)) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 32 15)) (const? 32 8) := by
+  LLVM.and (icmp IntPred.ne (LLVM.and e (const? 32 15)) (const? 32 0))
+      (icmp IntPred.eq (LLVM.and e (const? 32 7)) (const? 32 0)) ⊑
+    icmp IntPred.eq (LLVM.and e (const? 32 15)) (const? 32 8) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -402,9 +402,9 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_3_thm (e : IntW 32) :
 
 
 theorem masked_icmps_mask_notallzeros_bmask_mixed_3_logical_thm (e : IntW 32) :
-  select (icmp IntPredicate.ne (LLVM.and e (const? 32 15)) (const? 32 0))
-      (icmp IntPredicate.eq (LLVM.and e (const? 32 7)) (const? 32 0)) (const? 1 0) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 32 15)) (const? 32 8) := by
+  select (icmp IntPred.ne (LLVM.and e (const? 32 15)) (const? 32 0))
+      (icmp IntPred.eq (LLVM.and e (const? 32 7)) (const? 32 0)) (const? 1 0) ⊑
+    icmp IntPred.eq (LLVM.and e (const? 32 15)) (const? 32 8) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -414,10 +414,10 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_3_logical_thm (e : IntW 32) :
 
 
 theorem masked_icmps_mask_notallzeros_bmask_mixed_3b_logical_thm (e : IntW 32) :
-  select (icmp IntPredicate.ne (LLVM.and e (const? 32 15)) (const? 32 0))
-      (icmp IntPredicate.eq (LLVM.and e (const? 32 3)) (const? 32 0)) (const? 1 0) ⊑
-    LLVM.and (icmp IntPredicate.ne (LLVM.and e (const? 32 15)) (const? 32 0))
-      (icmp IntPredicate.eq (LLVM.and e (const? 32 3)) (const? 32 0)) := by
+  select (icmp IntPred.ne (LLVM.and e (const? 32 15)) (const? 32 0))
+      (icmp IntPred.eq (LLVM.and e (const? 32 3)) (const? 32 0)) (const? 1 0) ⊑
+    LLVM.and (icmp IntPred.ne (LLVM.and e (const? 32 15)) (const? 32 0))
+      (icmp IntPred.eq (LLVM.and e (const? 32 3)) (const? 32 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -427,9 +427,9 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_3b_logical_thm (e : IntW 32) :
 
 
 theorem masked_icmps_mask_notallzeros_bmask_mixed_4_thm (e : IntW 32) :
-  LLVM.and (icmp IntPredicate.ne (LLVM.and e (const? 32 255)) (const? 32 0))
-      (icmp IntPredicate.eq (LLVM.and e (const? 32 15)) (const? 32 8)) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 32 15)) (const? 32 8) := by
+  LLVM.and (icmp IntPred.ne (LLVM.and e (const? 32 255)) (const? 32 0))
+      (icmp IntPred.eq (LLVM.and e (const? 32 15)) (const? 32 8)) ⊑
+    icmp IntPred.eq (LLVM.and e (const? 32 15)) (const? 32 8) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -439,9 +439,9 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_4_thm (e : IntW 32) :
 
 
 theorem masked_icmps_mask_notallzeros_bmask_mixed_4_logical_thm (e : IntW 32) :
-  select (icmp IntPredicate.ne (LLVM.and e (const? 32 255)) (const? 32 0))
-      (icmp IntPredicate.eq (LLVM.and e (const? 32 15)) (const? 32 8)) (const? 1 0) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 32 15)) (const? 32 8) := by
+  select (icmp IntPred.ne (LLVM.and e (const? 32 255)) (const? 32 0))
+      (icmp IntPred.eq (LLVM.and e (const? 32 15)) (const? 32 8)) (const? 1 0) ⊑
+    icmp IntPred.eq (LLVM.and e (const? 32 15)) (const? 32 8) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -451,9 +451,9 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_4_logical_thm (e : IntW 32) :
 
 
 theorem masked_icmps_mask_notallzeros_bmask_mixed_5_thm (e : IntW 32) :
-  LLVM.and (icmp IntPredicate.ne (LLVM.and e (const? 32 15)) (const? 32 0))
-      (icmp IntPredicate.eq (LLVM.and e (const? 32 15)) (const? 32 8)) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 32 15)) (const? 32 8) := by
+  LLVM.and (icmp IntPred.ne (LLVM.and e (const? 32 15)) (const? 32 0))
+      (icmp IntPred.eq (LLVM.and e (const? 32 15)) (const? 32 8)) ⊑
+    icmp IntPred.eq (LLVM.and e (const? 32 15)) (const? 32 8) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -463,9 +463,9 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_5_thm (e : IntW 32) :
 
 
 theorem masked_icmps_mask_notallzeros_bmask_mixed_5_logical_thm (e : IntW 32) :
-  select (icmp IntPredicate.ne (LLVM.and e (const? 32 15)) (const? 32 0))
-      (icmp IntPredicate.eq (LLVM.and e (const? 32 15)) (const? 32 8)) (const? 1 0) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 32 15)) (const? 32 8) := by
+  select (icmp IntPred.ne (LLVM.and e (const? 32 15)) (const? 32 0))
+      (icmp IntPred.eq (LLVM.and e (const? 32 15)) (const? 32 8)) (const? 1 0) ⊑
+    icmp IntPred.eq (LLVM.and e (const? 32 15)) (const? 32 8) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -475,9 +475,9 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_5_logical_thm (e : IntW 32) :
 
 
 theorem masked_icmps_mask_notallzeros_bmask_mixed_6_thm (e : IntW 32) :
-  LLVM.and (icmp IntPredicate.ne (LLVM.and e (const? 32 12)) (const? 32 0))
-      (icmp IntPredicate.eq (LLVM.and e (const? 32 15)) (const? 32 8)) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 32 15)) (const? 32 8) := by
+  LLVM.and (icmp IntPred.ne (LLVM.and e (const? 32 12)) (const? 32 0))
+      (icmp IntPred.eq (LLVM.and e (const? 32 15)) (const? 32 8)) ⊑
+    icmp IntPred.eq (LLVM.and e (const? 32 15)) (const? 32 8) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -487,9 +487,9 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_6_thm (e : IntW 32) :
 
 
 theorem masked_icmps_mask_notallzeros_bmask_mixed_6_logical_thm (e : IntW 32) :
-  select (icmp IntPredicate.ne (LLVM.and e (const? 32 12)) (const? 32 0))
-      (icmp IntPredicate.eq (LLVM.and e (const? 32 15)) (const? 32 8)) (const? 1 0) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 32 15)) (const? 32 8) := by
+  select (icmp IntPred.ne (LLVM.and e (const? 32 12)) (const? 32 0))
+      (icmp IntPred.eq (LLVM.and e (const? 32 15)) (const? 32 8)) (const? 1 0) ⊑
+    icmp IntPred.eq (LLVM.and e (const? 32 15)) (const? 32 8) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -499,8 +499,8 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_6_logical_thm (e : IntW 32) :
 
 
 theorem masked_icmps_mask_notallzeros_bmask_mixed_7_thm (e : IntW 32) :
-  LLVM.and (icmp IntPredicate.ne (LLVM.and e (const? 32 7)) (const? 32 0))
-      (icmp IntPredicate.eq (LLVM.and e (const? 32 15)) (const? 32 8)) ⊑
+  LLVM.and (icmp IntPred.ne (LLVM.and e (const? 32 7)) (const? 32 0))
+      (icmp IntPred.eq (LLVM.and e (const? 32 15)) (const? 32 8)) ⊑
     const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
@@ -511,8 +511,8 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_7_thm (e : IntW 32) :
 
 
 theorem masked_icmps_mask_notallzeros_bmask_mixed_7_logical_thm (e : IntW 32) :
-  select (icmp IntPredicate.ne (LLVM.and e (const? 32 7)) (const? 32 0))
-      (icmp IntPredicate.eq (LLVM.and e (const? 32 15)) (const? 32 8)) (const? 1 0) ⊑
+  select (icmp IntPred.ne (LLVM.and e (const? 32 7)) (const? 32 0))
+      (icmp IntPred.eq (LLVM.and e (const? 32 15)) (const? 32 8)) (const? 1 0) ⊑
     const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
@@ -523,8 +523,8 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_7_logical_thm (e : IntW 32) :
 
 
 theorem masked_icmps_mask_notallzeros_bmask_mixed_7b_thm (e : IntW 32) :
-  LLVM.and (icmp IntPredicate.ne (LLVM.and e (const? 32 6)) (const? 32 0))
-      (icmp IntPredicate.eq (LLVM.and e (const? 32 15)) (const? 32 8)) ⊑
+  LLVM.and (icmp IntPred.ne (LLVM.and e (const? 32 6)) (const? 32 0))
+      (icmp IntPred.eq (LLVM.and e (const? 32 15)) (const? 32 8)) ⊑
     const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
@@ -535,8 +535,8 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_7b_thm (e : IntW 32) :
 
 
 theorem masked_icmps_mask_notallzeros_bmask_mixed_7b_logical_thm (e : IntW 32) :
-  select (icmp IntPredicate.ne (LLVM.and e (const? 32 6)) (const? 32 0))
-      (icmp IntPredicate.eq (LLVM.and e (const? 32 15)) (const? 32 8)) (const? 1 0) ⊑
+  select (icmp IntPred.ne (LLVM.and e (const? 32 6)) (const? 32 0))
+      (icmp IntPred.eq (LLVM.and e (const? 32 15)) (const? 32 8)) (const? 1 0) ⊑
     const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
@@ -547,10 +547,10 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_7b_logical_thm (e : IntW 32) :
 
 
 theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_0_logical_thm (e : IntW 32) :
-  select (icmp IntPredicate.eq (LLVM.and e (const? 32 12)) (const? 32 0)) (const? 1 1)
-      (icmp IntPredicate.ne (LLVM.and e (const? 32 3)) (const? 32 1)) ⊑
-    LLVM.or (icmp IntPredicate.eq (LLVM.and e (const? 32 12)) (const? 32 0))
-      (icmp IntPredicate.ne (LLVM.and e (const? 32 3)) (const? 32 1)) := by
+  select (icmp IntPred.eq (LLVM.and e (const? 32 12)) (const? 32 0)) (const? 1 1)
+      (icmp IntPred.ne (LLVM.and e (const? 32 3)) (const? 32 1)) ⊑
+    LLVM.or (icmp IntPred.eq (LLVM.and e (const? 32 12)) (const? 32 0))
+      (icmp IntPred.ne (LLVM.and e (const? 32 3)) (const? 32 1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -560,9 +560,9 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_0_logical_thm (e : Int
 
 
 theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_1_thm (e : IntW 32) :
-  LLVM.or (icmp IntPredicate.eq (LLVM.and e (const? 32 12)) (const? 32 0))
-      (icmp IntPredicate.ne (LLVM.and e (const? 32 7)) (const? 32 1)) ⊑
-    icmp IntPredicate.ne (LLVM.and e (const? 32 15)) (const? 32 9) := by
+  LLVM.or (icmp IntPred.eq (LLVM.and e (const? 32 12)) (const? 32 0))
+      (icmp IntPred.ne (LLVM.and e (const? 32 7)) (const? 32 1)) ⊑
+    icmp IntPred.ne (LLVM.and e (const? 32 15)) (const? 32 9) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -572,9 +572,9 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_1_thm (e : IntW 32) :
 
 
 theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_1_logical_thm (e : IntW 32) :
-  select (icmp IntPredicate.eq (LLVM.and e (const? 32 12)) (const? 32 0)) (const? 1 1)
-      (icmp IntPredicate.ne (LLVM.and e (const? 32 7)) (const? 32 1)) ⊑
-    icmp IntPredicate.ne (LLVM.and e (const? 32 15)) (const? 32 9) := by
+  select (icmp IntPred.eq (LLVM.and e (const? 32 12)) (const? 32 0)) (const? 1 1)
+      (icmp IntPred.ne (LLVM.and e (const? 32 7)) (const? 32 1)) ⊑
+    icmp IntPred.ne (LLVM.and e (const? 32 15)) (const? 32 9) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -584,10 +584,10 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_1_logical_thm (e : Int
 
 
 theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_1b_logical_thm (e : IntW 32) :
-  select (icmp IntPredicate.eq (LLVM.and e (const? 32 14)) (const? 32 0)) (const? 1 1)
-      (icmp IntPredicate.ne (LLVM.and e (const? 32 3)) (const? 32 1)) ⊑
-    LLVM.or (icmp IntPredicate.eq (LLVM.and e (const? 32 14)) (const? 32 0))
-      (icmp IntPredicate.ne (LLVM.and e (const? 32 3)) (const? 32 1)) := by
+  select (icmp IntPred.eq (LLVM.and e (const? 32 14)) (const? 32 0)) (const? 1 1)
+      (icmp IntPred.ne (LLVM.and e (const? 32 3)) (const? 32 1)) ⊑
+    LLVM.or (icmp IntPred.eq (LLVM.and e (const? 32 14)) (const? 32 0))
+      (icmp IntPred.ne (LLVM.and e (const? 32 3)) (const? 32 1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -597,8 +597,8 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_1b_logical_thm (e : In
 
 
 theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_2_thm (e : IntW 32) :
-  LLVM.or (icmp IntPredicate.eq (LLVM.and e (const? 32 3)) (const? 32 0))
-      (icmp IntPredicate.ne (LLVM.and e (const? 32 7)) (const? 32 0)) ⊑
+  LLVM.or (icmp IntPred.eq (LLVM.and e (const? 32 3)) (const? 32 0))
+      (icmp IntPred.ne (LLVM.and e (const? 32 7)) (const? 32 0)) ⊑
     const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
@@ -609,8 +609,8 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_2_thm (e : IntW 32) :
 
 
 theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_2_logical_thm (e : IntW 32) :
-  select (icmp IntPredicate.eq (LLVM.and e (const? 32 3)) (const? 32 0)) (const? 1 1)
-      (icmp IntPredicate.ne (LLVM.and e (const? 32 7)) (const? 32 0)) ⊑
+  select (icmp IntPred.eq (LLVM.and e (const? 32 3)) (const? 32 0)) (const? 1 1)
+      (icmp IntPred.ne (LLVM.and e (const? 32 7)) (const? 32 0)) ⊑
     const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
@@ -621,9 +621,9 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_2_logical_thm (e : Int
 
 
 theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_3_thm (e : IntW 32) :
-  LLVM.or (icmp IntPredicate.eq (LLVM.and e (const? 32 15)) (const? 32 0))
-      (icmp IntPredicate.ne (LLVM.and e (const? 32 7)) (const? 32 0)) ⊑
-    icmp IntPredicate.ne (LLVM.and e (const? 32 15)) (const? 32 8) := by
+  LLVM.or (icmp IntPred.eq (LLVM.and e (const? 32 15)) (const? 32 0))
+      (icmp IntPred.ne (LLVM.and e (const? 32 7)) (const? 32 0)) ⊑
+    icmp IntPred.ne (LLVM.and e (const? 32 15)) (const? 32 8) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -633,9 +633,9 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_3_thm (e : IntW 32) :
 
 
 theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_3_logical_thm (e : IntW 32) :
-  select (icmp IntPredicate.eq (LLVM.and e (const? 32 15)) (const? 32 0)) (const? 1 1)
-      (icmp IntPredicate.ne (LLVM.and e (const? 32 7)) (const? 32 0)) ⊑
-    icmp IntPredicate.ne (LLVM.and e (const? 32 15)) (const? 32 8) := by
+  select (icmp IntPred.eq (LLVM.and e (const? 32 15)) (const? 32 0)) (const? 1 1)
+      (icmp IntPred.ne (LLVM.and e (const? 32 7)) (const? 32 0)) ⊑
+    icmp IntPred.ne (LLVM.and e (const? 32 15)) (const? 32 8) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -645,10 +645,10 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_3_logical_thm (e : Int
 
 
 theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_3b_logical_thm (e : IntW 32) :
-  select (icmp IntPredicate.eq (LLVM.and e (const? 32 15)) (const? 32 0)) (const? 1 1)
-      (icmp IntPredicate.ne (LLVM.and e (const? 32 3)) (const? 32 0)) ⊑
-    LLVM.or (icmp IntPredicate.eq (LLVM.and e (const? 32 15)) (const? 32 0))
-      (icmp IntPredicate.ne (LLVM.and e (const? 32 3)) (const? 32 0)) := by
+  select (icmp IntPred.eq (LLVM.and e (const? 32 15)) (const? 32 0)) (const? 1 1)
+      (icmp IntPred.ne (LLVM.and e (const? 32 3)) (const? 32 0)) ⊑
+    LLVM.or (icmp IntPred.eq (LLVM.and e (const? 32 15)) (const? 32 0))
+      (icmp IntPred.ne (LLVM.and e (const? 32 3)) (const? 32 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -658,9 +658,9 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_3b_logical_thm (e : In
 
 
 theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_4_thm (e : IntW 32) :
-  LLVM.or (icmp IntPredicate.eq (LLVM.and e (const? 32 255)) (const? 32 0))
-      (icmp IntPredicate.ne (LLVM.and e (const? 32 15)) (const? 32 8)) ⊑
-    icmp IntPredicate.ne (LLVM.and e (const? 32 15)) (const? 32 8) := by
+  LLVM.or (icmp IntPred.eq (LLVM.and e (const? 32 255)) (const? 32 0))
+      (icmp IntPred.ne (LLVM.and e (const? 32 15)) (const? 32 8)) ⊑
+    icmp IntPred.ne (LLVM.and e (const? 32 15)) (const? 32 8) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -670,9 +670,9 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_4_thm (e : IntW 32) :
 
 
 theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_4_logical_thm (e : IntW 32) :
-  select (icmp IntPredicate.eq (LLVM.and e (const? 32 255)) (const? 32 0)) (const? 1 1)
-      (icmp IntPredicate.ne (LLVM.and e (const? 32 15)) (const? 32 8)) ⊑
-    icmp IntPredicate.ne (LLVM.and e (const? 32 15)) (const? 32 8) := by
+  select (icmp IntPred.eq (LLVM.and e (const? 32 255)) (const? 32 0)) (const? 1 1)
+      (icmp IntPred.ne (LLVM.and e (const? 32 15)) (const? 32 8)) ⊑
+    icmp IntPred.ne (LLVM.and e (const? 32 15)) (const? 32 8) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -682,9 +682,9 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_4_logical_thm (e : Int
 
 
 theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_5_thm (e : IntW 32) :
-  LLVM.or (icmp IntPredicate.eq (LLVM.and e (const? 32 15)) (const? 32 0))
-      (icmp IntPredicate.ne (LLVM.and e (const? 32 15)) (const? 32 8)) ⊑
-    icmp IntPredicate.ne (LLVM.and e (const? 32 15)) (const? 32 8) := by
+  LLVM.or (icmp IntPred.eq (LLVM.and e (const? 32 15)) (const? 32 0))
+      (icmp IntPred.ne (LLVM.and e (const? 32 15)) (const? 32 8)) ⊑
+    icmp IntPred.ne (LLVM.and e (const? 32 15)) (const? 32 8) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -694,9 +694,9 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_5_thm (e : IntW 32) :
 
 
 theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_5_logical_thm (e : IntW 32) :
-  select (icmp IntPredicate.eq (LLVM.and e (const? 32 15)) (const? 32 0)) (const? 1 1)
-      (icmp IntPredicate.ne (LLVM.and e (const? 32 15)) (const? 32 8)) ⊑
-    icmp IntPredicate.ne (LLVM.and e (const? 32 15)) (const? 32 8) := by
+  select (icmp IntPred.eq (LLVM.and e (const? 32 15)) (const? 32 0)) (const? 1 1)
+      (icmp IntPred.ne (LLVM.and e (const? 32 15)) (const? 32 8)) ⊑
+    icmp IntPred.ne (LLVM.and e (const? 32 15)) (const? 32 8) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -706,9 +706,9 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_5_logical_thm (e : Int
 
 
 theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_6_thm (e : IntW 32) :
-  LLVM.or (icmp IntPredicate.eq (LLVM.and e (const? 32 12)) (const? 32 0))
-      (icmp IntPredicate.ne (LLVM.and e (const? 32 15)) (const? 32 8)) ⊑
-    icmp IntPredicate.ne (LLVM.and e (const? 32 15)) (const? 32 8) := by
+  LLVM.or (icmp IntPred.eq (LLVM.and e (const? 32 12)) (const? 32 0))
+      (icmp IntPred.ne (LLVM.and e (const? 32 15)) (const? 32 8)) ⊑
+    icmp IntPred.ne (LLVM.and e (const? 32 15)) (const? 32 8) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -718,9 +718,9 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_6_thm (e : IntW 32) :
 
 
 theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_6_logical_thm (e : IntW 32) :
-  select (icmp IntPredicate.eq (LLVM.and e (const? 32 12)) (const? 32 0)) (const? 1 1)
-      (icmp IntPredicate.ne (LLVM.and e (const? 32 15)) (const? 32 8)) ⊑
-    icmp IntPredicate.ne (LLVM.and e (const? 32 15)) (const? 32 8) := by
+  select (icmp IntPred.eq (LLVM.and e (const? 32 12)) (const? 32 0)) (const? 1 1)
+      (icmp IntPred.ne (LLVM.and e (const? 32 15)) (const? 32 8)) ⊑
+    icmp IntPred.ne (LLVM.and e (const? 32 15)) (const? 32 8) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -730,8 +730,8 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_6_logical_thm (e : Int
 
 
 theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_7_thm (e : IntW 32) :
-  LLVM.or (icmp IntPredicate.eq (LLVM.and e (const? 32 7)) (const? 32 0))
-      (icmp IntPredicate.ne (LLVM.and e (const? 32 15)) (const? 32 8)) ⊑
+  LLVM.or (icmp IntPred.eq (LLVM.and e (const? 32 7)) (const? 32 0))
+      (icmp IntPred.ne (LLVM.and e (const? 32 15)) (const? 32 8)) ⊑
     const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
@@ -742,8 +742,8 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_7_thm (e : IntW 32) :
 
 
 theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_7_logical_thm (e : IntW 32) :
-  select (icmp IntPredicate.eq (LLVM.and e (const? 32 7)) (const? 32 0)) (const? 1 1)
-      (icmp IntPredicate.ne (LLVM.and e (const? 32 15)) (const? 32 8)) ⊑
+  select (icmp IntPred.eq (LLVM.and e (const? 32 7)) (const? 32 0)) (const? 1 1)
+      (icmp IntPred.ne (LLVM.and e (const? 32 15)) (const? 32 8)) ⊑
     const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
@@ -754,8 +754,8 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_7_logical_thm (e : Int
 
 
 theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_7b_thm (e : IntW 32) :
-  LLVM.or (icmp IntPredicate.eq (LLVM.and e (const? 32 6)) (const? 32 0))
-      (icmp IntPredicate.ne (LLVM.and e (const? 32 15)) (const? 32 8)) ⊑
+  LLVM.or (icmp IntPred.eq (LLVM.and e (const? 32 6)) (const? 32 0))
+      (icmp IntPred.ne (LLVM.and e (const? 32 15)) (const? 32 8)) ⊑
     const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
@@ -766,8 +766,8 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_7b_thm (e : IntW 32) :
 
 
 theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_7b_logical_thm (e : IntW 32) :
-  select (icmp IntPredicate.eq (LLVM.and e (const? 32 6)) (const? 32 0)) (const? 1 1)
-      (icmp IntPredicate.ne (LLVM.and e (const? 32 15)) (const? 32 8)) ⊑
+  select (icmp IntPred.eq (LLVM.and e (const? 32 6)) (const? 32 0)) (const? 1 1)
+      (icmp IntPred.ne (LLVM.and e (const? 32 15)) (const? 32 8)) ⊑
     const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
@@ -778,10 +778,10 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_7b_logical_thm (e : In
 
 
 theorem masked_icmps_mask_notallzeros_bmask_mixed_swapped_0_logical_thm (e : IntW 32) :
-  select (icmp IntPredicate.eq (LLVM.and e (const? 32 3)) (const? 32 1))
-      (icmp IntPredicate.ne (LLVM.and e (const? 32 12)) (const? 32 0)) (const? 1 0) ⊑
-    LLVM.and (icmp IntPredicate.eq (LLVM.and e (const? 32 3)) (const? 32 1))
-      (icmp IntPredicate.ne (LLVM.and e (const? 32 12)) (const? 32 0)) := by
+  select (icmp IntPred.eq (LLVM.and e (const? 32 3)) (const? 32 1))
+      (icmp IntPred.ne (LLVM.and e (const? 32 12)) (const? 32 0)) (const? 1 0) ⊑
+    LLVM.and (icmp IntPred.eq (LLVM.and e (const? 32 3)) (const? 32 1))
+      (icmp IntPred.ne (LLVM.and e (const? 32 12)) (const? 32 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -791,9 +791,9 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_swapped_0_logical_thm (e : Int
 
 
 theorem masked_icmps_mask_notallzeros_bmask_mixed_swapped_1_thm (e : IntW 32) :
-  LLVM.and (icmp IntPredicate.eq (LLVM.and e (const? 32 7)) (const? 32 1))
-      (icmp IntPredicate.ne (LLVM.and e (const? 32 12)) (const? 32 0)) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 32 15)) (const? 32 9) := by
+  LLVM.and (icmp IntPred.eq (LLVM.and e (const? 32 7)) (const? 32 1))
+      (icmp IntPred.ne (LLVM.and e (const? 32 12)) (const? 32 0)) ⊑
+    icmp IntPred.eq (LLVM.and e (const? 32 15)) (const? 32 9) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -803,9 +803,9 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_swapped_1_thm (e : IntW 32) :
 
 
 theorem masked_icmps_mask_notallzeros_bmask_mixed_swapped_1_logical_thm (e : IntW 32) :
-  select (icmp IntPredicate.eq (LLVM.and e (const? 32 7)) (const? 32 1))
-      (icmp IntPredicate.ne (LLVM.and e (const? 32 12)) (const? 32 0)) (const? 1 0) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 32 15)) (const? 32 9) := by
+  select (icmp IntPred.eq (LLVM.and e (const? 32 7)) (const? 32 1))
+      (icmp IntPred.ne (LLVM.and e (const? 32 12)) (const? 32 0)) (const? 1 0) ⊑
+    icmp IntPred.eq (LLVM.and e (const? 32 15)) (const? 32 9) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -815,10 +815,10 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_swapped_1_logical_thm (e : Int
 
 
 theorem masked_icmps_mask_notallzeros_bmask_mixed_swapped_1b_logical_thm (e : IntW 32) :
-  select (icmp IntPredicate.eq (LLVM.and e (const? 32 3)) (const? 32 1))
-      (icmp IntPredicate.ne (LLVM.and e (const? 32 14)) (const? 32 0)) (const? 1 0) ⊑
-    LLVM.and (icmp IntPredicate.eq (LLVM.and e (const? 32 3)) (const? 32 1))
-      (icmp IntPredicate.ne (LLVM.and e (const? 32 14)) (const? 32 0)) := by
+  select (icmp IntPred.eq (LLVM.and e (const? 32 3)) (const? 32 1))
+      (icmp IntPred.ne (LLVM.and e (const? 32 14)) (const? 32 0)) (const? 1 0) ⊑
+    LLVM.and (icmp IntPred.eq (LLVM.and e (const? 32 3)) (const? 32 1))
+      (icmp IntPred.ne (LLVM.and e (const? 32 14)) (const? 32 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -828,8 +828,8 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_swapped_1b_logical_thm (e : In
 
 
 theorem masked_icmps_mask_notallzeros_bmask_mixed_swapped_2_thm (e : IntW 32) :
-  LLVM.and (icmp IntPredicate.eq (LLVM.and e (const? 32 7)) (const? 32 0))
-      (icmp IntPredicate.ne (LLVM.and e (const? 32 3)) (const? 32 0)) ⊑
+  LLVM.and (icmp IntPred.eq (LLVM.and e (const? 32 7)) (const? 32 0))
+      (icmp IntPred.ne (LLVM.and e (const? 32 3)) (const? 32 0)) ⊑
     const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
@@ -840,8 +840,8 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_swapped_2_thm (e : IntW 32) :
 
 
 theorem masked_icmps_mask_notallzeros_bmask_mixed_swapped_2_logical_thm (e : IntW 32) :
-  select (icmp IntPredicate.eq (LLVM.and e (const? 32 7)) (const? 32 0))
-      (icmp IntPredicate.ne (LLVM.and e (const? 32 3)) (const? 32 0)) (const? 1 0) ⊑
+  select (icmp IntPred.eq (LLVM.and e (const? 32 7)) (const? 32 0))
+      (icmp IntPred.ne (LLVM.and e (const? 32 3)) (const? 32 0)) (const? 1 0) ⊑
     const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
@@ -852,9 +852,9 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_swapped_2_logical_thm (e : Int
 
 
 theorem masked_icmps_mask_notallzeros_bmask_mixed_swapped_3_thm (e : IntW 32) :
-  LLVM.and (icmp IntPredicate.eq (LLVM.and e (const? 32 7)) (const? 32 0))
-      (icmp IntPredicate.ne (LLVM.and e (const? 32 15)) (const? 32 0)) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 32 15)) (const? 32 8) := by
+  LLVM.and (icmp IntPred.eq (LLVM.and e (const? 32 7)) (const? 32 0))
+      (icmp IntPred.ne (LLVM.and e (const? 32 15)) (const? 32 0)) ⊑
+    icmp IntPred.eq (LLVM.and e (const? 32 15)) (const? 32 8) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -864,9 +864,9 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_swapped_3_thm (e : IntW 32) :
 
 
 theorem masked_icmps_mask_notallzeros_bmask_mixed_swapped_3_logical_thm (e : IntW 32) :
-  select (icmp IntPredicate.eq (LLVM.and e (const? 32 7)) (const? 32 0))
-      (icmp IntPredicate.ne (LLVM.and e (const? 32 15)) (const? 32 0)) (const? 1 0) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 32 15)) (const? 32 8) := by
+  select (icmp IntPred.eq (LLVM.and e (const? 32 7)) (const? 32 0))
+      (icmp IntPred.ne (LLVM.and e (const? 32 15)) (const? 32 0)) (const? 1 0) ⊑
+    icmp IntPred.eq (LLVM.and e (const? 32 15)) (const? 32 8) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -876,10 +876,10 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_swapped_3_logical_thm (e : Int
 
 
 theorem masked_icmps_mask_notallzeros_bmask_mixed_swapped_3b_logical_thm (e : IntW 32) :
-  select (icmp IntPredicate.eq (LLVM.and e (const? 32 3)) (const? 32 0))
-      (icmp IntPredicate.ne (LLVM.and e (const? 32 15)) (const? 32 0)) (const? 1 0) ⊑
-    LLVM.and (icmp IntPredicate.eq (LLVM.and e (const? 32 3)) (const? 32 0))
-      (icmp IntPredicate.ne (LLVM.and e (const? 32 15)) (const? 32 0)) := by
+  select (icmp IntPred.eq (LLVM.and e (const? 32 3)) (const? 32 0))
+      (icmp IntPred.ne (LLVM.and e (const? 32 15)) (const? 32 0)) (const? 1 0) ⊑
+    LLVM.and (icmp IntPred.eq (LLVM.and e (const? 32 3)) (const? 32 0))
+      (icmp IntPred.ne (LLVM.and e (const? 32 15)) (const? 32 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -889,9 +889,9 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_swapped_3b_logical_thm (e : In
 
 
 theorem masked_icmps_mask_notallzeros_bmask_mixed_swapped_4_thm (e : IntW 32) :
-  LLVM.and (icmp IntPredicate.eq (LLVM.and e (const? 32 15)) (const? 32 8))
-      (icmp IntPredicate.ne (LLVM.and e (const? 32 255)) (const? 32 0)) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 32 15)) (const? 32 8) := by
+  LLVM.and (icmp IntPred.eq (LLVM.and e (const? 32 15)) (const? 32 8))
+      (icmp IntPred.ne (LLVM.and e (const? 32 255)) (const? 32 0)) ⊑
+    icmp IntPred.eq (LLVM.and e (const? 32 15)) (const? 32 8) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -901,9 +901,9 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_swapped_4_thm (e : IntW 32) :
 
 
 theorem masked_icmps_mask_notallzeros_bmask_mixed_swapped_4_logical_thm (e : IntW 32) :
-  select (icmp IntPredicate.eq (LLVM.and e (const? 32 15)) (const? 32 8))
-      (icmp IntPredicate.ne (LLVM.and e (const? 32 255)) (const? 32 0)) (const? 1 0) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 32 15)) (const? 32 8) := by
+  select (icmp IntPred.eq (LLVM.and e (const? 32 15)) (const? 32 8))
+      (icmp IntPred.ne (LLVM.and e (const? 32 255)) (const? 32 0)) (const? 1 0) ⊑
+    icmp IntPred.eq (LLVM.and e (const? 32 15)) (const? 32 8) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -913,9 +913,9 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_swapped_4_logical_thm (e : Int
 
 
 theorem masked_icmps_mask_notallzeros_bmask_mixed_swapped_5_thm (e : IntW 32) :
-  LLVM.and (icmp IntPredicate.eq (LLVM.and e (const? 32 15)) (const? 32 8))
-      (icmp IntPredicate.ne (LLVM.and e (const? 32 15)) (const? 32 0)) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 32 15)) (const? 32 8) := by
+  LLVM.and (icmp IntPred.eq (LLVM.and e (const? 32 15)) (const? 32 8))
+      (icmp IntPred.ne (LLVM.and e (const? 32 15)) (const? 32 0)) ⊑
+    icmp IntPred.eq (LLVM.and e (const? 32 15)) (const? 32 8) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -925,9 +925,9 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_swapped_5_thm (e : IntW 32) :
 
 
 theorem masked_icmps_mask_notallzeros_bmask_mixed_swapped_5_logical_thm (e : IntW 32) :
-  select (icmp IntPredicate.eq (LLVM.and e (const? 32 15)) (const? 32 8))
-      (icmp IntPredicate.ne (LLVM.and e (const? 32 15)) (const? 32 0)) (const? 1 0) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 32 15)) (const? 32 8) := by
+  select (icmp IntPred.eq (LLVM.and e (const? 32 15)) (const? 32 8))
+      (icmp IntPred.ne (LLVM.and e (const? 32 15)) (const? 32 0)) (const? 1 0) ⊑
+    icmp IntPred.eq (LLVM.and e (const? 32 15)) (const? 32 8) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -937,9 +937,9 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_swapped_5_logical_thm (e : Int
 
 
 theorem masked_icmps_mask_notallzeros_bmask_mixed_swapped_6_thm (e : IntW 32) :
-  LLVM.and (icmp IntPredicate.eq (LLVM.and e (const? 32 15)) (const? 32 8))
-      (icmp IntPredicate.ne (LLVM.and e (const? 32 12)) (const? 32 0)) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 32 15)) (const? 32 8) := by
+  LLVM.and (icmp IntPred.eq (LLVM.and e (const? 32 15)) (const? 32 8))
+      (icmp IntPred.ne (LLVM.and e (const? 32 12)) (const? 32 0)) ⊑
+    icmp IntPred.eq (LLVM.and e (const? 32 15)) (const? 32 8) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -949,9 +949,9 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_swapped_6_thm (e : IntW 32) :
 
 
 theorem masked_icmps_mask_notallzeros_bmask_mixed_swapped_6_logical_thm (e : IntW 32) :
-  select (icmp IntPredicate.eq (LLVM.and e (const? 32 15)) (const? 32 8))
-      (icmp IntPredicate.ne (LLVM.and e (const? 32 12)) (const? 32 0)) (const? 1 0) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 32 15)) (const? 32 8) := by
+  select (icmp IntPred.eq (LLVM.and e (const? 32 15)) (const? 32 8))
+      (icmp IntPred.ne (LLVM.and e (const? 32 12)) (const? 32 0)) (const? 1 0) ⊑
+    icmp IntPred.eq (LLVM.and e (const? 32 15)) (const? 32 8) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -961,8 +961,8 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_swapped_6_logical_thm (e : Int
 
 
 theorem masked_icmps_mask_notallzeros_bmask_mixed_swapped_7_thm (e : IntW 32) :
-  LLVM.and (icmp IntPredicate.eq (LLVM.and e (const? 32 15)) (const? 32 8))
-      (icmp IntPredicate.ne (LLVM.and e (const? 32 7)) (const? 32 0)) ⊑
+  LLVM.and (icmp IntPred.eq (LLVM.and e (const? 32 15)) (const? 32 8))
+      (icmp IntPred.ne (LLVM.and e (const? 32 7)) (const? 32 0)) ⊑
     const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
@@ -973,8 +973,8 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_swapped_7_thm (e : IntW 32) :
 
 
 theorem masked_icmps_mask_notallzeros_bmask_mixed_swapped_7_logical_thm (e : IntW 32) :
-  select (icmp IntPredicate.eq (LLVM.and e (const? 32 15)) (const? 32 8))
-      (icmp IntPredicate.ne (LLVM.and e (const? 32 7)) (const? 32 0)) (const? 1 0) ⊑
+  select (icmp IntPred.eq (LLVM.and e (const? 32 15)) (const? 32 8))
+      (icmp IntPred.ne (LLVM.and e (const? 32 7)) (const? 32 0)) (const? 1 0) ⊑
     const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
@@ -985,8 +985,8 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_swapped_7_logical_thm (e : Int
 
 
 theorem masked_icmps_mask_notallzeros_bmask_mixed_swapped_7b_thm (e : IntW 32) :
-  LLVM.and (icmp IntPredicate.eq (LLVM.and e (const? 32 15)) (const? 32 8))
-      (icmp IntPredicate.ne (LLVM.and e (const? 32 6)) (const? 32 0)) ⊑
+  LLVM.and (icmp IntPred.eq (LLVM.and e (const? 32 15)) (const? 32 8))
+      (icmp IntPred.ne (LLVM.and e (const? 32 6)) (const? 32 0)) ⊑
     const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
@@ -997,8 +997,8 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_swapped_7b_thm (e : IntW 32) :
 
 
 theorem masked_icmps_mask_notallzeros_bmask_mixed_swapped_7b_logical_thm (e : IntW 32) :
-  select (icmp IntPredicate.eq (LLVM.and e (const? 32 15)) (const? 32 8))
-      (icmp IntPredicate.ne (LLVM.and e (const? 32 6)) (const? 32 0)) (const? 1 0) ⊑
+  select (icmp IntPred.eq (LLVM.and e (const? 32 15)) (const? 32 8))
+      (icmp IntPred.ne (LLVM.and e (const? 32 6)) (const? 32 0)) (const? 1 0) ⊑
     const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
@@ -1009,10 +1009,10 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_swapped_7b_logical_thm (e : In
 
 
 theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_swapped_0_logical_thm (e : IntW 32) :
-  select (icmp IntPredicate.ne (LLVM.and e (const? 32 3)) (const? 32 1)) (const? 1 1)
-      (icmp IntPredicate.eq (LLVM.and e (const? 32 12)) (const? 32 0)) ⊑
-    LLVM.or (icmp IntPredicate.ne (LLVM.and e (const? 32 3)) (const? 32 1))
-      (icmp IntPredicate.eq (LLVM.and e (const? 32 12)) (const? 32 0)) := by
+  select (icmp IntPred.ne (LLVM.and e (const? 32 3)) (const? 32 1)) (const? 1 1)
+      (icmp IntPred.eq (LLVM.and e (const? 32 12)) (const? 32 0)) ⊑
+    LLVM.or (icmp IntPred.ne (LLVM.and e (const? 32 3)) (const? 32 1))
+      (icmp IntPred.eq (LLVM.and e (const? 32 12)) (const? 32 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1022,9 +1022,9 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_swapped_0_logical_thm 
 
 
 theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_swapped_1_thm (e : IntW 32) :
-  LLVM.or (icmp IntPredicate.ne (LLVM.and e (const? 32 7)) (const? 32 1))
-      (icmp IntPredicate.eq (LLVM.and e (const? 32 12)) (const? 32 0)) ⊑
-    icmp IntPredicate.ne (LLVM.and e (const? 32 15)) (const? 32 9) := by
+  LLVM.or (icmp IntPred.ne (LLVM.and e (const? 32 7)) (const? 32 1))
+      (icmp IntPred.eq (LLVM.and e (const? 32 12)) (const? 32 0)) ⊑
+    icmp IntPred.ne (LLVM.and e (const? 32 15)) (const? 32 9) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1034,9 +1034,9 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_swapped_1_thm (e : Int
 
 
 theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_swapped_1_logical_thm (e : IntW 32) :
-  select (icmp IntPredicate.ne (LLVM.and e (const? 32 7)) (const? 32 1)) (const? 1 1)
-      (icmp IntPredicate.eq (LLVM.and e (const? 32 12)) (const? 32 0)) ⊑
-    icmp IntPredicate.ne (LLVM.and e (const? 32 15)) (const? 32 9) := by
+  select (icmp IntPred.ne (LLVM.and e (const? 32 7)) (const? 32 1)) (const? 1 1)
+      (icmp IntPred.eq (LLVM.and e (const? 32 12)) (const? 32 0)) ⊑
+    icmp IntPred.ne (LLVM.and e (const? 32 15)) (const? 32 9) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1046,10 +1046,10 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_swapped_1_logical_thm 
 
 
 theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_swapped_1b_logical_thm (e : IntW 32) :
-  select (icmp IntPredicate.ne (LLVM.and e (const? 32 3)) (const? 32 1)) (const? 1 1)
-      (icmp IntPredicate.eq (LLVM.and e (const? 32 14)) (const? 32 0)) ⊑
-    LLVM.or (icmp IntPredicate.ne (LLVM.and e (const? 32 3)) (const? 32 1))
-      (icmp IntPredicate.eq (LLVM.and e (const? 32 14)) (const? 32 0)) := by
+  select (icmp IntPred.ne (LLVM.and e (const? 32 3)) (const? 32 1)) (const? 1 1)
+      (icmp IntPred.eq (LLVM.and e (const? 32 14)) (const? 32 0)) ⊑
+    LLVM.or (icmp IntPred.ne (LLVM.and e (const? 32 3)) (const? 32 1))
+      (icmp IntPred.eq (LLVM.and e (const? 32 14)) (const? 32 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1059,8 +1059,8 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_swapped_1b_logical_thm
 
 
 theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_swapped_2_thm (e : IntW 32) :
-  LLVM.or (icmp IntPredicate.ne (LLVM.and e (const? 32 7)) (const? 32 0))
-      (icmp IntPredicate.eq (LLVM.and e (const? 32 3)) (const? 32 0)) ⊑
+  LLVM.or (icmp IntPred.ne (LLVM.and e (const? 32 7)) (const? 32 0))
+      (icmp IntPred.eq (LLVM.and e (const? 32 3)) (const? 32 0)) ⊑
     const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
@@ -1071,8 +1071,8 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_swapped_2_thm (e : Int
 
 
 theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_swapped_2_logical_thm (e : IntW 32) :
-  select (icmp IntPredicate.ne (LLVM.and e (const? 32 7)) (const? 32 0)) (const? 1 1)
-      (icmp IntPredicate.eq (LLVM.and e (const? 32 3)) (const? 32 0)) ⊑
+  select (icmp IntPred.ne (LLVM.and e (const? 32 7)) (const? 32 0)) (const? 1 1)
+      (icmp IntPred.eq (LLVM.and e (const? 32 3)) (const? 32 0)) ⊑
     const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
@@ -1083,9 +1083,9 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_swapped_2_logical_thm 
 
 
 theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_swapped_3_thm (e : IntW 32) :
-  LLVM.or (icmp IntPredicate.ne (LLVM.and e (const? 32 7)) (const? 32 0))
-      (icmp IntPredicate.eq (LLVM.and e (const? 32 15)) (const? 32 0)) ⊑
-    icmp IntPredicate.ne (LLVM.and e (const? 32 15)) (const? 32 8) := by
+  LLVM.or (icmp IntPred.ne (LLVM.and e (const? 32 7)) (const? 32 0))
+      (icmp IntPred.eq (LLVM.and e (const? 32 15)) (const? 32 0)) ⊑
+    icmp IntPred.ne (LLVM.and e (const? 32 15)) (const? 32 8) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1095,9 +1095,9 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_swapped_3_thm (e : Int
 
 
 theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_swapped_3_logical_thm (e : IntW 32) :
-  select (icmp IntPredicate.ne (LLVM.and e (const? 32 7)) (const? 32 0)) (const? 1 1)
-      (icmp IntPredicate.eq (LLVM.and e (const? 32 15)) (const? 32 0)) ⊑
-    icmp IntPredicate.ne (LLVM.and e (const? 32 15)) (const? 32 8) := by
+  select (icmp IntPred.ne (LLVM.and e (const? 32 7)) (const? 32 0)) (const? 1 1)
+      (icmp IntPred.eq (LLVM.and e (const? 32 15)) (const? 32 0)) ⊑
+    icmp IntPred.ne (LLVM.and e (const? 32 15)) (const? 32 8) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1107,10 +1107,10 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_swapped_3_logical_thm 
 
 
 theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_swapped_3b_logical_thm (e : IntW 32) :
-  select (icmp IntPredicate.ne (LLVM.and e (const? 32 3)) (const? 32 0)) (const? 1 1)
-      (icmp IntPredicate.eq (LLVM.and e (const? 32 15)) (const? 32 0)) ⊑
-    LLVM.or (icmp IntPredicate.ne (LLVM.and e (const? 32 3)) (const? 32 0))
-      (icmp IntPredicate.eq (LLVM.and e (const? 32 15)) (const? 32 0)) := by
+  select (icmp IntPred.ne (LLVM.and e (const? 32 3)) (const? 32 0)) (const? 1 1)
+      (icmp IntPred.eq (LLVM.and e (const? 32 15)) (const? 32 0)) ⊑
+    LLVM.or (icmp IntPred.ne (LLVM.and e (const? 32 3)) (const? 32 0))
+      (icmp IntPred.eq (LLVM.and e (const? 32 15)) (const? 32 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1120,9 +1120,9 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_swapped_3b_logical_thm
 
 
 theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_swapped_4_thm (e : IntW 32) :
-  LLVM.or (icmp IntPredicate.ne (LLVM.and e (const? 32 15)) (const? 32 8))
-      (icmp IntPredicate.eq (LLVM.and e (const? 32 255)) (const? 32 0)) ⊑
-    icmp IntPredicate.ne (LLVM.and e (const? 32 15)) (const? 32 8) := by
+  LLVM.or (icmp IntPred.ne (LLVM.and e (const? 32 15)) (const? 32 8))
+      (icmp IntPred.eq (LLVM.and e (const? 32 255)) (const? 32 0)) ⊑
+    icmp IntPred.ne (LLVM.and e (const? 32 15)) (const? 32 8) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1132,9 +1132,9 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_swapped_4_thm (e : Int
 
 
 theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_swapped_4_logical_thm (e : IntW 32) :
-  select (icmp IntPredicate.ne (LLVM.and e (const? 32 15)) (const? 32 8)) (const? 1 1)
-      (icmp IntPredicate.eq (LLVM.and e (const? 32 255)) (const? 32 0)) ⊑
-    icmp IntPredicate.ne (LLVM.and e (const? 32 15)) (const? 32 8) := by
+  select (icmp IntPred.ne (LLVM.and e (const? 32 15)) (const? 32 8)) (const? 1 1)
+      (icmp IntPred.eq (LLVM.and e (const? 32 255)) (const? 32 0)) ⊑
+    icmp IntPred.ne (LLVM.and e (const? 32 15)) (const? 32 8) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1144,9 +1144,9 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_swapped_4_logical_thm 
 
 
 theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_swapped_5_thm (e : IntW 32) :
-  LLVM.or (icmp IntPredicate.ne (LLVM.and e (const? 32 15)) (const? 32 8))
-      (icmp IntPredicate.eq (LLVM.and e (const? 32 15)) (const? 32 0)) ⊑
-    icmp IntPredicate.ne (LLVM.and e (const? 32 15)) (const? 32 8) := by
+  LLVM.or (icmp IntPred.ne (LLVM.and e (const? 32 15)) (const? 32 8))
+      (icmp IntPred.eq (LLVM.and e (const? 32 15)) (const? 32 0)) ⊑
+    icmp IntPred.ne (LLVM.and e (const? 32 15)) (const? 32 8) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1156,9 +1156,9 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_swapped_5_thm (e : Int
 
 
 theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_swapped_5_logical_thm (e : IntW 32) :
-  select (icmp IntPredicate.ne (LLVM.and e (const? 32 15)) (const? 32 8)) (const? 1 1)
-      (icmp IntPredicate.eq (LLVM.and e (const? 32 15)) (const? 32 0)) ⊑
-    icmp IntPredicate.ne (LLVM.and e (const? 32 15)) (const? 32 8) := by
+  select (icmp IntPred.ne (LLVM.and e (const? 32 15)) (const? 32 8)) (const? 1 1)
+      (icmp IntPred.eq (LLVM.and e (const? 32 15)) (const? 32 0)) ⊑
+    icmp IntPred.ne (LLVM.and e (const? 32 15)) (const? 32 8) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1168,9 +1168,9 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_swapped_5_logical_thm 
 
 
 theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_swapped_6_thm (e : IntW 32) :
-  LLVM.or (icmp IntPredicate.ne (LLVM.and e (const? 32 15)) (const? 32 8))
-      (icmp IntPredicate.eq (LLVM.and e (const? 32 12)) (const? 32 0)) ⊑
-    icmp IntPredicate.ne (LLVM.and e (const? 32 15)) (const? 32 8) := by
+  LLVM.or (icmp IntPred.ne (LLVM.and e (const? 32 15)) (const? 32 8))
+      (icmp IntPred.eq (LLVM.and e (const? 32 12)) (const? 32 0)) ⊑
+    icmp IntPred.ne (LLVM.and e (const? 32 15)) (const? 32 8) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1180,9 +1180,9 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_swapped_6_thm (e : Int
 
 
 theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_swapped_6_logical_thm (e : IntW 32) :
-  select (icmp IntPredicate.ne (LLVM.and e (const? 32 15)) (const? 32 8)) (const? 1 1)
-      (icmp IntPredicate.eq (LLVM.and e (const? 32 12)) (const? 32 0)) ⊑
-    icmp IntPredicate.ne (LLVM.and e (const? 32 15)) (const? 32 8) := by
+  select (icmp IntPred.ne (LLVM.and e (const? 32 15)) (const? 32 8)) (const? 1 1)
+      (icmp IntPred.eq (LLVM.and e (const? 32 12)) (const? 32 0)) ⊑
+    icmp IntPred.ne (LLVM.and e (const? 32 15)) (const? 32 8) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1192,8 +1192,8 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_swapped_6_logical_thm 
 
 
 theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_swapped_7_thm (e : IntW 32) :
-  LLVM.or (icmp IntPredicate.ne (LLVM.and e (const? 32 15)) (const? 32 8))
-      (icmp IntPredicate.eq (LLVM.and e (const? 32 7)) (const? 32 0)) ⊑
+  LLVM.or (icmp IntPred.ne (LLVM.and e (const? 32 15)) (const? 32 8))
+      (icmp IntPred.eq (LLVM.and e (const? 32 7)) (const? 32 0)) ⊑
     const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
@@ -1204,8 +1204,8 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_swapped_7_thm (e : Int
 
 
 theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_swapped_7_logical_thm (e : IntW 32) :
-  select (icmp IntPredicate.ne (LLVM.and e (const? 32 15)) (const? 32 8)) (const? 1 1)
-      (icmp IntPredicate.eq (LLVM.and e (const? 32 7)) (const? 32 0)) ⊑
+  select (icmp IntPred.ne (LLVM.and e (const? 32 15)) (const? 32 8)) (const? 1 1)
+      (icmp IntPred.eq (LLVM.and e (const? 32 7)) (const? 32 0)) ⊑
     const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
@@ -1216,8 +1216,8 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_swapped_7_logical_thm 
 
 
 theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_swapped_7b_thm (e : IntW 32) :
-  LLVM.or (icmp IntPredicate.ne (LLVM.and e (const? 32 15)) (const? 32 8))
-      (icmp IntPredicate.eq (LLVM.and e (const? 32 6)) (const? 32 0)) ⊑
+  LLVM.or (icmp IntPred.ne (LLVM.and e (const? 32 15)) (const? 32 8))
+      (icmp IntPred.eq (LLVM.and e (const? 32 6)) (const? 32 0)) ⊑
     const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
@@ -1228,8 +1228,8 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_swapped_7b_thm (e : In
 
 
 theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_swapped_7b_logical_thm (e : IntW 32) :
-  select (icmp IntPredicate.ne (LLVM.and e (const? 32 15)) (const? 32 8)) (const? 1 1)
-      (icmp IntPredicate.eq (LLVM.and e (const? 32 6)) (const? 32 0)) ⊑
+  select (icmp IntPred.ne (LLVM.and e (const? 32 15)) (const? 32 8)) (const? 1 1)
+      (icmp IntPred.eq (LLVM.and e (const? 32 6)) (const? 32 0)) ⊑
     const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
@@ -1240,9 +1240,9 @@ theorem masked_icmps_mask_notallzeros_bmask_mixed_negated_swapped_7b_logical_thm
 
 
 theorem masked_icmps_bmask_notmixed_or_thm (e : IntW 32) :
-  LLVM.or (icmp IntPredicate.eq (LLVM.and e (const? 32 15)) (const? 32 3))
-      (icmp IntPredicate.eq (LLVM.and e (const? 32 255)) (const? 32 243)) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 32 15)) (const? 32 3) := by
+  LLVM.or (icmp IntPred.eq (LLVM.and e (const? 32 15)) (const? 32 3))
+      (icmp IntPred.eq (LLVM.and e (const? 32 255)) (const? 32 243)) ⊑
+    icmp IntPred.eq (LLVM.and e (const? 32 15)) (const? 32 3) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1252,9 +1252,9 @@ theorem masked_icmps_bmask_notmixed_or_thm (e : IntW 32) :
 
 
 theorem masked_icmps_bmask_notmixed_and_thm (e : IntW 32) :
-  LLVM.and (icmp IntPredicate.ne (LLVM.and e (const? 32 15)) (const? 32 3))
-      (icmp IntPredicate.ne (LLVM.and e (const? 32 255)) (const? 32 243)) ⊑
-    icmp IntPredicate.ne (LLVM.and e (const? 32 15)) (const? 32 3) := by
+  LLVM.and (icmp IntPred.ne (LLVM.and e (const? 32 15)) (const? 32 3))
+      (icmp IntPred.ne (LLVM.and e (const? 32 255)) (const? 32 243)) ⊑
+    icmp IntPred.ne (LLVM.and e (const? 32 15)) (const? 32 3) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1264,9 +1264,9 @@ theorem masked_icmps_bmask_notmixed_and_thm (e : IntW 32) :
 
 
 theorem masked_icmps_bmask_notmixed_and_expected_false_thm (e : IntW 32) :
-  LLVM.and (icmp IntPredicate.ne (LLVM.and e (const? 32 3)) (const? 32 15))
-      (icmp IntPredicate.ne (LLVM.and e (const? 32 255)) (const? 32 242)) ⊑
-    icmp IntPredicate.ne (LLVM.and e (const? 32 255)) (const? 32 242) := by
+  LLVM.and (icmp IntPred.ne (LLVM.and e (const? 32 3)) (const? 32 15))
+      (icmp IntPred.ne (LLVM.and e (const? 32 255)) (const? 32 242)) ⊑
+    icmp IntPred.ne (LLVM.and e (const? 32 255)) (const? 32 242) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gicmphmul_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gicmphmul_proof.lean
@@ -12,8 +12,8 @@ set_option Elab.async false
 
 section gicmphmul_proof
 theorem squared_nsw_eq0_thm (e : IntW 5) :
-  icmp IntPredicate.eq (mul e e { «nsw» := true, «nuw» := false }) (const? 5 0) ⊑
-    icmp IntPredicate.eq e (const? 5 0) := by
+  icmp IntPred.eq (mul e e { «nsw» := true, «nuw» := false }) (const? 5 0) ⊑
+    icmp IntPred.eq e (const? 5 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -23,8 +23,8 @@ theorem squared_nsw_eq0_thm (e : IntW 5) :
 
 
 theorem squared_nsw_sgt0_thm (e : IntW 5) :
-  icmp IntPredicate.sgt (mul e e { «nsw» := true, «nuw» := false }) (const? 5 0) ⊑
-    icmp IntPredicate.ne e (const? 5 0) := by
+  icmp IntPred.sgt (mul e e { «nsw» := true, «nuw» := false }) (const? 5 0) ⊑
+    icmp IntPred.ne e (const? 5 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -34,8 +34,8 @@ theorem squared_nsw_sgt0_thm (e : IntW 5) :
 
 
 theorem slt_positive_multip_rem_zero_thm (e : IntW 8) :
-  icmp IntPredicate.slt (mul e (const? 8 7) { «nsw» := true, «nuw» := false }) (const? 8 21) ⊑
-    icmp IntPredicate.slt e (const? 8 3) := by
+  icmp IntPred.slt (mul e (const? 8 7) { «nsw» := true, «nuw» := false }) (const? 8 21) ⊑
+    icmp IntPred.slt e (const? 8 3) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -45,8 +45,8 @@ theorem slt_positive_multip_rem_zero_thm (e : IntW 8) :
 
 
 theorem slt_negative_multip_rem_zero_thm (e : IntW 8) :
-  icmp IntPredicate.slt (mul e (const? 8 (-7)) { «nsw» := true, «nuw» := false }) (const? 8 21) ⊑
-    icmp IntPredicate.sgt e (const? 8 (-3)) := by
+  icmp IntPred.slt (mul e (const? 8 (-7)) { «nsw» := true, «nuw» := false }) (const? 8 21) ⊑
+    icmp IntPred.sgt e (const? 8 (-3)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -56,8 +56,8 @@ theorem slt_negative_multip_rem_zero_thm (e : IntW 8) :
 
 
 theorem slt_positive_multip_rem_nz_thm (e : IntW 8) :
-  icmp IntPredicate.slt (mul e (const? 8 5) { «nsw» := true, «nuw» := false }) (const? 8 21) ⊑
-    icmp IntPredicate.slt e (const? 8 5) := by
+  icmp IntPred.slt (mul e (const? 8 5) { «nsw» := true, «nuw» := false }) (const? 8 21) ⊑
+    icmp IntPred.slt e (const? 8 5) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -67,8 +67,8 @@ theorem slt_positive_multip_rem_nz_thm (e : IntW 8) :
 
 
 theorem ult_rem_zero_thm (e : IntW 8) :
-  icmp IntPredicate.ult (mul e (const? 8 7) { «nsw» := false, «nuw» := true }) (const? 8 21) ⊑
-    icmp IntPredicate.ult e (const? 8 3) := by
+  icmp IntPred.ult (mul e (const? 8 7) { «nsw» := false, «nuw» := true }) (const? 8 21) ⊑
+    icmp IntPred.ult e (const? 8 3) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -78,8 +78,8 @@ theorem ult_rem_zero_thm (e : IntW 8) :
 
 
 theorem ult_rem_zero_nsw_thm (e : IntW 8) :
-  icmp IntPredicate.ult (mul e (const? 8 7) { «nsw» := true, «nuw» := true }) (const? 8 21) ⊑
-    icmp IntPredicate.ult e (const? 8 3) := by
+  icmp IntPred.ult (mul e (const? 8 7) { «nsw» := true, «nuw» := true }) (const? 8 21) ⊑
+    icmp IntPred.ult e (const? 8 3) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -89,8 +89,8 @@ theorem ult_rem_zero_nsw_thm (e : IntW 8) :
 
 
 theorem ult_rem_nz_thm (e : IntW 8) :
-  icmp IntPredicate.ult (mul e (const? 8 5) { «nsw» := false, «nuw» := true }) (const? 8 21) ⊑
-    icmp IntPredicate.ult e (const? 8 5) := by
+  icmp IntPred.ult (mul e (const? 8 5) { «nsw» := false, «nuw» := true }) (const? 8 21) ⊑
+    icmp IntPred.ult e (const? 8 5) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -100,8 +100,8 @@ theorem ult_rem_nz_thm (e : IntW 8) :
 
 
 theorem ult_rem_nz_nsw_thm (e : IntW 8) :
-  icmp IntPredicate.ult (mul e (const? 8 5) { «nsw» := true, «nuw» := true }) (const? 8 21) ⊑
-    icmp IntPredicate.ult e (const? 8 5) := by
+  icmp IntPred.ult (mul e (const? 8 5) { «nsw» := true, «nuw» := true }) (const? 8 21) ⊑
+    icmp IntPred.ult e (const? 8 5) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -111,8 +111,8 @@ theorem ult_rem_nz_nsw_thm (e : IntW 8) :
 
 
 theorem sgt_positive_multip_rem_zero_thm (e : IntW 8) :
-  icmp IntPredicate.sgt (mul e (const? 8 7) { «nsw» := true, «nuw» := false }) (const? 8 21) ⊑
-    icmp IntPredicate.sgt e (const? 8 3) := by
+  icmp IntPred.sgt (mul e (const? 8 7) { «nsw» := true, «nuw» := false }) (const? 8 21) ⊑
+    icmp IntPred.sgt e (const? 8 3) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -122,8 +122,8 @@ theorem sgt_positive_multip_rem_zero_thm (e : IntW 8) :
 
 
 theorem sgt_negative_multip_rem_zero_thm (e : IntW 8) :
-  icmp IntPredicate.sgt (mul e (const? 8 (-7)) { «nsw» := true, «nuw» := false }) (const? 8 21) ⊑
-    icmp IntPredicate.slt e (const? 8 (-3)) := by
+  icmp IntPred.sgt (mul e (const? 8 (-7)) { «nsw» := true, «nuw» := false }) (const? 8 21) ⊑
+    icmp IntPred.slt e (const? 8 (-3)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -133,8 +133,8 @@ theorem sgt_negative_multip_rem_zero_thm (e : IntW 8) :
 
 
 theorem sgt_positive_multip_rem_nz_thm (e : IntW 8) :
-  icmp IntPredicate.sgt (mul e (const? 8 5) { «nsw» := true, «nuw» := false }) (const? 8 21) ⊑
-    icmp IntPredicate.sgt e (const? 8 4) := by
+  icmp IntPred.sgt (mul e (const? 8 5) { «nsw» := true, «nuw» := false }) (const? 8 21) ⊑
+    icmp IntPred.sgt e (const? 8 4) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -144,8 +144,8 @@ theorem sgt_positive_multip_rem_nz_thm (e : IntW 8) :
 
 
 theorem ugt_rem_zero_thm (e : IntW 8) :
-  icmp IntPredicate.ugt (mul e (const? 8 7) { «nsw» := false, «nuw» := true }) (const? 8 21) ⊑
-    icmp IntPredicate.ugt e (const? 8 3) := by
+  icmp IntPred.ugt (mul e (const? 8 7) { «nsw» := false, «nuw» := true }) (const? 8 21) ⊑
+    icmp IntPred.ugt e (const? 8 3) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -155,8 +155,8 @@ theorem ugt_rem_zero_thm (e : IntW 8) :
 
 
 theorem ugt_rem_zero_nsw_thm (e : IntW 8) :
-  icmp IntPredicate.ugt (mul e (const? 8 7) { «nsw» := true, «nuw» := true }) (const? 8 21) ⊑
-    icmp IntPredicate.ugt e (const? 8 3) := by
+  icmp IntPred.ugt (mul e (const? 8 7) { «nsw» := true, «nuw» := true }) (const? 8 21) ⊑
+    icmp IntPred.ugt e (const? 8 3) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -166,8 +166,8 @@ theorem ugt_rem_zero_nsw_thm (e : IntW 8) :
 
 
 theorem ugt_rem_nz_thm (e : IntW 8) :
-  icmp IntPredicate.ugt (mul e (const? 8 5) { «nsw» := false, «nuw» := true }) (const? 8 21) ⊑
-    icmp IntPredicate.ugt e (const? 8 4) := by
+  icmp IntPred.ugt (mul e (const? 8 5) { «nsw» := false, «nuw» := true }) (const? 8 21) ⊑
+    icmp IntPred.ugt e (const? 8 4) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -177,8 +177,8 @@ theorem ugt_rem_nz_thm (e : IntW 8) :
 
 
 theorem ugt_rem_nz_nsw_thm (e : IntW 8) :
-  icmp IntPredicate.ugt (mul e (const? 8 5) { «nsw» := true, «nuw» := true }) (const? 8 21) ⊑
-    icmp IntPredicate.ugt e (const? 8 4) := by
+  icmp IntPred.ugt (mul e (const? 8 5) { «nsw» := true, «nuw» := true }) (const? 8 21) ⊑
+    icmp IntPred.ugt e (const? 8 4) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -188,8 +188,8 @@ theorem ugt_rem_nz_nsw_thm (e : IntW 8) :
 
 
 theorem eq_nsw_rem_zero_thm (e : IntW 8) :
-  icmp IntPredicate.eq (mul e (const? 8 (-5)) { «nsw» := true, «nuw» := false }) (const? 8 20) ⊑
-    icmp IntPredicate.eq e (const? 8 (-4)) := by
+  icmp IntPred.eq (mul e (const? 8 (-5)) { «nsw» := true, «nuw» := false }) (const? 8 20) ⊑
+    icmp IntPred.eq e (const? 8 (-4)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -199,7 +199,7 @@ theorem eq_nsw_rem_zero_thm (e : IntW 8) :
 
 
 theorem eq_nsw_rem_nz_thm (e : IntW 8) :
-  icmp IntPredicate.eq (mul e (const? 8 5) { «nsw» := true, «nuw» := false }) (const? 8 (-11)) ⊑ const? 1 0 := by
+  icmp IntPred.eq (mul e (const? 8 5) { «nsw» := true, «nuw» := false }) (const? 8 (-11)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -209,7 +209,7 @@ theorem eq_nsw_rem_nz_thm (e : IntW 8) :
 
 
 theorem ne_nsw_rem_nz_thm (e : IntW 8) :
-  icmp IntPredicate.ne (mul e (const? 8 5) { «nsw» := true, «nuw» := false }) (const? 8 (-126)) ⊑ const? 1 1 := by
+  icmp IntPred.ne (mul e (const? 8 5) { «nsw» := true, «nuw» := false }) (const? 8 (-126)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -219,8 +219,8 @@ theorem ne_nsw_rem_nz_thm (e : IntW 8) :
 
 
 theorem ne_nuw_rem_zero_thm (e : IntW 8) :
-  icmp IntPredicate.ne (mul e (const? 8 5) { «nsw» := false, «nuw» := true }) (const? 8 (-126)) ⊑
-    icmp IntPredicate.ne e (const? 8 26) := by
+  icmp IntPred.ne (mul e (const? 8 5) { «nsw» := false, «nuw» := true }) (const? 8 (-126)) ⊑
+    icmp IntPred.ne e (const? 8 26) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -230,7 +230,7 @@ theorem ne_nuw_rem_zero_thm (e : IntW 8) :
 
 
 theorem eq_nuw_rem_nz_thm (e : IntW 8) :
-  icmp IntPredicate.eq (mul e (const? 8 (-5)) { «nsw» := false, «nuw» := true }) (const? 8 20) ⊑ const? 1 0 := by
+  icmp IntPred.eq (mul e (const? 8 (-5)) { «nsw» := false, «nuw» := true }) (const? 8 20) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -240,7 +240,7 @@ theorem eq_nuw_rem_nz_thm (e : IntW 8) :
 
 
 theorem ne_nuw_rem_nz_thm (e : IntW 8) :
-  icmp IntPredicate.ne (mul e (const? 8 5) { «nsw» := false, «nuw» := true }) (const? 8 (-30)) ⊑ const? 1 1 := by
+  icmp IntPred.ne (mul e (const? 8 5) { «nsw» := false, «nuw» := true }) (const? 8 (-30)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -250,7 +250,7 @@ theorem ne_nuw_rem_nz_thm (e : IntW 8) :
 
 
 theorem sgt_minnum_thm (e : IntW 8) :
-  icmp IntPredicate.sgt (mul e (const? 8 7) { «nsw» := true, «nuw» := false }) (const? 8 (-128)) ⊑ const? 1 1 := by
+  icmp IntPred.sgt (mul e (const? 8 7) { «nsw» := true, «nuw» := false }) (const? 8 (-128)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -260,7 +260,7 @@ theorem sgt_minnum_thm (e : IntW 8) :
 
 
 theorem ule_bignum_thm (e : IntW 8) :
-  icmp IntPredicate.ule (mul e (const? 8 (-1))) (const? 8 0) ⊑ icmp IntPredicate.eq e (const? 8 0) := by
+  icmp IntPred.ule (mul e (const? 8 (-1))) (const? 8 0) ⊑ icmp IntPred.eq e (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -270,7 +270,7 @@ theorem ule_bignum_thm (e : IntW 8) :
 
 
 theorem sgt_mulzero_thm (e : IntW 8) :
-  icmp IntPredicate.sgt (mul e (const? 8 0) { «nsw» := true, «nuw» := false }) (const? 8 21) ⊑ const? 1 0 := by
+  icmp IntPred.sgt (mul e (const? 8 0) { «nsw» := true, «nuw» := false }) (const? 8 21) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -280,7 +280,7 @@ theorem sgt_mulzero_thm (e : IntW 8) :
 
 
 theorem eq_rem_zero_nonuw_thm (e : IntW 8) :
-  icmp IntPredicate.eq (mul e (const? 8 5)) (const? 8 20) ⊑ icmp IntPredicate.eq e (const? 8 4) := by
+  icmp IntPred.eq (mul e (const? 8 5)) (const? 8 20) ⊑ icmp IntPred.eq e (const? 8 4) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -290,7 +290,7 @@ theorem eq_rem_zero_nonuw_thm (e : IntW 8) :
 
 
 theorem ne_rem_zero_nonuw_thm (e : IntW 8) :
-  icmp IntPredicate.ne (mul e (const? 8 5)) (const? 8 30) ⊑ icmp IntPredicate.ne e (const? 8 6) := by
+  icmp IntPred.ne (mul e (const? 8 5)) (const? 8 30) ⊑ icmp IntPred.ne e (const? 8 6) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -300,7 +300,7 @@ theorem ne_rem_zero_nonuw_thm (e : IntW 8) :
 
 
 theorem mul_constant_eq_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.eq (mul e_1 (const? 32 5)) (mul e (const? 32 5)) ⊑ icmp IntPredicate.eq e_1 e := by
+  icmp IntPred.eq (mul e_1 (const? 32 5)) (mul e (const? 32 5)) ⊑ icmp IntPred.eq e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -310,9 +310,9 @@ theorem mul_constant_eq_thm (e e_1 : IntW 32) :
 
 
 theorem mul_constant_eq_nsw_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.eq (mul e_1 (const? 32 6) { «nsw» := true, «nuw» := false })
+  icmp IntPred.eq (mul e_1 (const? 32 6) { «nsw» := true, «nuw» := false })
       (mul e (const? 32 6) { «nsw» := true, «nuw» := false }) ⊑
-    icmp IntPredicate.eq e_1 e := by
+    icmp IntPred.eq e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -322,9 +322,9 @@ theorem mul_constant_eq_nsw_thm (e e_1 : IntW 32) :
 
 
 theorem mul_constant_nuw_eq_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.eq (mul e_1 (const? 32 22) { «nsw» := false, «nuw» := true })
+  icmp IntPred.eq (mul e_1 (const? 32 22) { «nsw» := false, «nuw» := true })
       (mul e (const? 32 22) { «nsw» := false, «nuw» := true }) ⊑
-    icmp IntPredicate.eq e_1 e := by
+    icmp IntPred.eq e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -334,8 +334,8 @@ theorem mul_constant_nuw_eq_thm (e e_1 : IntW 32) :
 
 
 theorem mul_constant_partial_nuw_eq_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.eq (mul e_1 (const? 32 44)) (mul e (const? 32 44) { «nsw» := false, «nuw» := true }) ⊑
-    icmp IntPredicate.eq (LLVM.and (LLVM.xor e_1 e) (const? 32 1073741823)) (const? 32 0) := by
+  icmp IntPred.eq (mul e_1 (const? 32 44)) (mul e (const? 32 44) { «nsw» := false, «nuw» := true }) ⊑
+    icmp IntPred.eq (LLVM.and (LLVM.xor e_1 e) (const? 32 1073741823)) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -345,9 +345,9 @@ theorem mul_constant_partial_nuw_eq_thm (e e_1 : IntW 32) :
 
 
 theorem mul_constant_mismatch_wrap_eq_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.eq (mul e_1 (const? 32 54) { «nsw» := true, «nuw» := false })
+  icmp IntPred.eq (mul e_1 (const? 32 54) { «nsw» := true, «nuw» := false })
       (mul e (const? 32 54) { «nsw» := false, «nuw» := true }) ⊑
-    icmp IntPredicate.eq (LLVM.and (LLVM.xor e_1 e) (const? 32 2147483647)) (const? 32 0) := by
+    icmp IntPred.eq (LLVM.and (LLVM.xor e_1 e) (const? 32 2147483647)) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -357,8 +357,8 @@ theorem mul_constant_mismatch_wrap_eq_thm (e e_1 : IntW 32) :
 
 
 theorem eq_mul_constants_with_tz_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.ne (mul e_1 (const? 32 12)) (mul e (const? 32 12)) ⊑
-    icmp IntPredicate.ne (LLVM.and (LLVM.xor e_1 e) (const? 32 1073741823)) (const? 32 0) := by
+  icmp IntPred.ne (mul e_1 (const? 32 12)) (mul e (const? 32 12)) ⊑
+    icmp IntPred.ne (LLVM.and (LLVM.xor e_1 e) (const? 32 1073741823)) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -368,7 +368,7 @@ theorem eq_mul_constants_with_tz_thm (e e_1 : IntW 32) :
 
 
 theorem mul_of_bool_thm (e : IntW 8) (e_1 : IntW 32) :
-  icmp IntPredicate.ugt (mul (LLVM.and e_1 (const? 32 1)) (zext 32 e)) (const? 32 255) ⊑ const? 1 0 := by
+  icmp IntPred.ugt (mul (LLVM.and e_1 (const? 32 1)) (zext 32 e)) (const? 32 255) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -378,7 +378,7 @@ theorem mul_of_bool_thm (e : IntW 8) (e_1 : IntW 32) :
 
 
 theorem mul_of_bool_commute_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.ugt (mul (LLVM.and e_1 (const? 32 255)) (LLVM.and e (const? 32 1))) (const? 32 255) ⊑
+  icmp IntPred.ugt (mul (LLVM.and e_1 (const? 32 255)) (LLVM.and e (const? 32 1))) (const? 32 255) ⊑
     const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
@@ -389,7 +389,7 @@ theorem mul_of_bool_commute_thm (e e_1 : IntW 32) :
 
 
 theorem mul_of_bools_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.ult (mul (LLVM.and e_1 (const? 32 1)) (LLVM.and e (const? 32 1))) (const? 32 2) ⊑
+  icmp IntPred.ult (mul (LLVM.and e_1 (const? 32 1)) (LLVM.and e (const? 32 1))) (const? 32 2) ⊑
     const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
@@ -400,8 +400,8 @@ theorem mul_of_bools_thm (e e_1 : IntW 32) :
 
 
 theorem not_mul_of_bool_thm (e : IntW 8) (e_1 : IntW 32) :
-  icmp IntPredicate.ugt (mul (LLVM.and e_1 (const? 32 3)) (zext 32 e)) (const? 32 255) ⊑
-    icmp IntPredicate.ugt (mul (LLVM.and e_1 (const? 32 3)) (zext 32 e) { «nsw» := true, «nuw» := true })
+  icmp IntPred.ugt (mul (LLVM.and e_1 (const? 32 3)) (zext 32 e)) (const? 32 255) ⊑
+    icmp IntPred.ugt (mul (LLVM.and e_1 (const? 32 3)) (zext 32 e) { «nsw» := true, «nuw» := true })
       (const? 32 255) := by
     simp_alive_undef
     simp_alive_ops
@@ -412,8 +412,8 @@ theorem not_mul_of_bool_thm (e : IntW 8) (e_1 : IntW 32) :
 
 
 theorem not_mul_of_bool_commute_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.ugt (mul (LLVM.and e_1 (const? 32 255)) (lshr e (const? 32 30))) (const? 32 255) ⊑
-    icmp IntPredicate.ugt (mul (LLVM.and e_1 (const? 32 255)) (lshr e (const? 32 30)) { «nsw» := true, «nuw» := true })
+  icmp IntPred.ugt (mul (LLVM.and e_1 (const? 32 255)) (lshr e (const? 32 30))) (const? 32 255) ⊑
+    icmp IntPred.ugt (mul (LLVM.and e_1 (const? 32 255)) (lshr e (const? 32 30)) { «nsw» := true, «nuw» := true })
       (const? 32 255) := by
     simp_alive_undef
     simp_alive_ops
@@ -424,7 +424,7 @@ theorem not_mul_of_bool_commute_thm (e e_1 : IntW 32) :
 
 
 theorem mul_of_bool_no_lz_other_op_thm (e : IntW 8) (e_1 : IntW 32) :
-  icmp IntPredicate.sgt (mul (LLVM.and e_1 (const? 32 1)) (sext 32 e) { «nsw» := true, «nuw» := true })
+  icmp IntPred.sgt (mul (LLVM.and e_1 (const? 32 1)) (sext 32 e) { «nsw» := true, «nuw» := true })
       (const? 32 127) ⊑
     const? 1 0 := by
     simp_alive_undef
@@ -436,7 +436,7 @@ theorem mul_of_bool_no_lz_other_op_thm (e : IntW 8) (e_1 : IntW 32) :
 
 
 theorem mul_of_pow2_thm (e : IntW 8) (e_1 : IntW 32) :
-  icmp IntPredicate.ugt (mul (LLVM.and e_1 (const? 32 2)) (zext 32 e)) (const? 32 510) ⊑ const? 1 0 := by
+  icmp IntPred.ugt (mul (LLVM.and e_1 (const? 32 2)) (zext 32 e)) (const? 32 510) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -446,7 +446,7 @@ theorem mul_of_pow2_thm (e : IntW 8) (e_1 : IntW 32) :
 
 
 theorem mul_of_pow2_commute_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.ugt (mul (LLVM.and e_1 (const? 32 255)) (LLVM.and e (const? 32 4))) (const? 32 1020) ⊑
+  icmp IntPred.ugt (mul (LLVM.and e_1 (const? 32 255)) (LLVM.and e (const? 32 4))) (const? 32 1020) ⊑
     const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
@@ -467,8 +467,8 @@ theorem mul_of_pow2s_thm (e e_1 : IntW 32) :
 
 
 theorem not_mul_of_pow2_thm (e : IntW 8) (e_1 : IntW 32) :
-  icmp IntPredicate.ugt (mul (LLVM.and e_1 (const? 32 6)) (zext 32 e)) (const? 32 1530) ⊑
-    icmp IntPredicate.ugt (mul (LLVM.and e_1 (const? 32 6)) (zext 32 e) { «nsw» := true, «nuw» := true })
+  icmp IntPred.ugt (mul (LLVM.and e_1 (const? 32 6)) (zext 32 e)) (const? 32 1530) ⊑
+    icmp IntPred.ugt (mul (LLVM.and e_1 (const? 32 6)) (zext 32 e) { «nsw» := true, «nuw» := true })
       (const? 32 1530) := by
     simp_alive_undef
     simp_alive_ops
@@ -479,8 +479,8 @@ theorem not_mul_of_pow2_thm (e : IntW 8) (e_1 : IntW 32) :
 
 
 theorem not_mul_of_pow2_commute_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.ugt (mul (LLVM.and e_1 (const? 32 255)) (LLVM.and e (const? 32 12))) (const? 32 3060) ⊑
-    icmp IntPredicate.ugt
+  icmp IntPred.ugt (mul (LLVM.and e_1 (const? 32 255)) (LLVM.and e (const? 32 12))) (const? 32 3060) ⊑
+    icmp IntPred.ugt
       (mul (LLVM.and e_1 (const? 32 255)) (LLVM.and e (const? 32 12)) { «nsw» := true, «nuw» := true })
       (const? 32 3060) := by
     simp_alive_undef
@@ -492,7 +492,7 @@ theorem not_mul_of_pow2_commute_thm (e e_1 : IntW 32) :
 
 
 theorem splat_mul_known_lz_thm (e : IntW 32) :
-  icmp IntPredicate.eq (lshr (mul (zext 128 e) (const? 128 18446744078004518913)) (const? 128 96)) (const? 128 0) ⊑
+  icmp IntPred.eq (lshr (mul (zext 128 e) (const? 128 18446744078004518913)) (const? 128 96)) (const? 128 0) ⊑
     const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
@@ -503,8 +503,8 @@ theorem splat_mul_known_lz_thm (e : IntW 32) :
 
 
 theorem splat_mul_unknown_lz_thm (e : IntW 32) :
-  icmp IntPredicate.eq (lshr (mul (zext 128 e) (const? 128 18446744078004518913)) (const? 128 95)) (const? 128 0) ⊑
-    icmp IntPredicate.sgt e (const? 32 (-1)) := by
+  icmp IntPred.eq (lshr (mul (zext 128 e) (const? 128 18446744078004518913)) (const? 128 95)) (const? 128 0) ⊑
+    icmp IntPred.sgt e (const? 32 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -514,12 +514,12 @@ theorem splat_mul_unknown_lz_thm (e : IntW 32) :
 
 
 theorem reused_mul_nuw_xy_z_selectnonzero_ugt_thm (e e_1 e_2 : IntW 8) :
-  select (icmp IntPredicate.ne e_2 (const? 8 0))
-      (icmp IntPredicate.ugt (mul e_1 e_2 { «nsw» := false, «nuw» := true })
+  select (icmp IntPred.ne e_2 (const? 8 0))
+      (icmp IntPred.ugt (mul e_1 e_2 { «nsw» := false, «nuw» := true })
         (mul e e_2 { «nsw» := false, «nuw» := true }))
       (const? 1 1) ⊑
-    select (icmp IntPredicate.eq e_2 (const? 8 0)) (const? 1 1)
-      (icmp IntPredicate.ugt (mul e_1 e_2 { «nsw» := false, «nuw» := true })
+    select (icmp IntPred.eq e_2 (const? 8 0)) (const? 1 1)
+      (icmp IntPred.ugt (mul e_1 e_2 { «nsw» := false, «nuw» := true })
         (mul e e_2 { «nsw» := false, «nuw» := true })) := by
     simp_alive_undef
     simp_alive_ops
@@ -530,9 +530,9 @@ theorem reused_mul_nuw_xy_z_selectnonzero_ugt_thm (e e_1 e_2 : IntW 8) :
 
 
 theorem icmp_eq_mul_nsw_nonequal_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.eq (mul e_1 e { «nsw» := true, «nuw» := false })
+  icmp IntPred.eq (mul e_1 e { «nsw» := true, «nuw» := false })
       (mul (add e_1 (const? 8 1)) e { «nsw» := true, «nuw» := false }) ⊑
-    icmp IntPredicate.eq e (const? 8 0) := by
+    icmp IntPred.eq e (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -542,9 +542,9 @@ theorem icmp_eq_mul_nsw_nonequal_thm (e e_1 : IntW 8) :
 
 
 theorem icmp_eq_mul_nuw_nonequal_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.eq (mul e_1 e { «nsw» := false, «nuw» := true })
+  icmp IntPred.eq (mul e_1 e { «nsw» := false, «nuw» := true })
       (mul (add e_1 (const? 8 1)) e { «nsw» := false, «nuw» := true }) ⊑
-    icmp IntPredicate.eq e (const? 8 0) := by
+    icmp IntPred.eq e (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -554,9 +554,9 @@ theorem icmp_eq_mul_nuw_nonequal_thm (e e_1 : IntW 8) :
 
 
 theorem icmp_eq_mul_nsw_nonequal_commuted_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.eq (mul e_1 e { «nsw» := true, «nuw» := false })
+  icmp IntPred.eq (mul e_1 e { «nsw» := true, «nuw» := false })
       (mul e (add e_1 (const? 8 1)) { «nsw» := true, «nuw» := false }) ⊑
-    icmp IntPredicate.eq e (const? 8 0) := by
+    icmp IntPred.eq e (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -566,9 +566,9 @@ theorem icmp_eq_mul_nsw_nonequal_commuted_thm (e e_1 : IntW 8) :
 
 
 theorem icmp_ne_mul_nsw_nonequal_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.ne (mul e_1 e { «nsw» := true, «nuw» := false })
+  icmp IntPred.ne (mul e_1 e { «nsw» := true, «nuw» := false })
       (mul (add e_1 (const? 8 1)) e { «nsw» := true, «nuw» := false }) ⊑
-    icmp IntPredicate.ne e (const? 8 0) := by
+    icmp IntPred.ne e (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -578,9 +578,9 @@ theorem icmp_ne_mul_nsw_nonequal_thm (e e_1 : IntW 8) :
 
 
 theorem icmp_mul_nsw_slt_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.slt (mul e_1 (const? 8 7) { «nsw» := true, «nuw» := false })
+  icmp IntPred.slt (mul e_1 (const? 8 7) { «nsw» := true, «nuw» := false })
       (mul e (const? 8 7) { «nsw» := true, «nuw» := false }) ⊑
-    icmp IntPredicate.slt e_1 e := by
+    icmp IntPred.slt e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -590,9 +590,9 @@ theorem icmp_mul_nsw_slt_thm (e e_1 : IntW 8) :
 
 
 theorem icmp_mul_nsw_sle_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.sle (mul e_1 (const? 8 7) { «nsw» := true, «nuw» := false })
+  icmp IntPred.sle (mul e_1 (const? 8 7) { «nsw» := true, «nuw» := false })
       (mul e (const? 8 7) { «nsw» := true, «nuw» := false }) ⊑
-    icmp IntPredicate.sle e_1 e := by
+    icmp IntPred.sle e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -602,9 +602,9 @@ theorem icmp_mul_nsw_sle_thm (e e_1 : IntW 8) :
 
 
 theorem icmp_mul_nsw_sgt_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.sgt (mul e_1 (const? 8 7) { «nsw» := true, «nuw» := false })
+  icmp IntPred.sgt (mul e_1 (const? 8 7) { «nsw» := true, «nuw» := false })
       (mul e (const? 8 7) { «nsw» := true, «nuw» := false }) ⊑
-    icmp IntPredicate.sgt e_1 e := by
+    icmp IntPred.sgt e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -614,9 +614,9 @@ theorem icmp_mul_nsw_sgt_thm (e e_1 : IntW 8) :
 
 
 theorem icmp_mul_nsw_sge_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.sge (mul e_1 (const? 8 7) { «nsw» := true, «nuw» := false })
+  icmp IntPred.sge (mul e_1 (const? 8 7) { «nsw» := true, «nuw» := false })
       (mul e (const? 8 7) { «nsw» := true, «nuw» := false }) ⊑
-    icmp IntPredicate.sge e_1 e := by
+    icmp IntPred.sge e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -626,9 +626,9 @@ theorem icmp_mul_nsw_sge_thm (e e_1 : IntW 8) :
 
 
 theorem icmp_mul_nsw_slt_neg_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.slt (mul e_1 (const? 8 (-7)) { «nsw» := true, «nuw» := false })
+  icmp IntPred.slt (mul e_1 (const? 8 (-7)) { «nsw» := true, «nuw» := false })
       (mul e (const? 8 (-7)) { «nsw» := true, «nuw» := false }) ⊑
-    icmp IntPredicate.sgt e_1 e := by
+    icmp IntPred.sgt e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gicmphmulhand_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gicmphmulhand_proof.lean
@@ -12,8 +12,8 @@ set_option Elab.async false
 
 section gicmphmulhand_proof
 theorem mul_mask_pow2_eq0_thm (e : IntW 8) :
-  icmp IntPredicate.eq (LLVM.and (mul e (const? 8 44)) (const? 8 4)) (const? 8 0) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 8 1)) (const? 8 0) := by
+  icmp IntPred.eq (LLVM.and (mul e (const? 8 44)) (const? 8 4)) (const? 8 0) ⊑
+    icmp IntPred.eq (LLVM.and e (const? 8 1)) (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -23,8 +23,8 @@ theorem mul_mask_pow2_eq0_thm (e : IntW 8) :
 
 
 theorem mul_mask_pow2_sgt0_thm (e : IntW 8) :
-  icmp IntPredicate.sgt (LLVM.and (mul e (const? 8 44)) (const? 8 4)) (const? 8 0) ⊑
-    icmp IntPredicate.ne (LLVM.and e (const? 8 1)) (const? 8 0) := by
+  icmp IntPred.sgt (LLVM.and (mul e (const? 8 44)) (const? 8 4)) (const? 8 0) ⊑
+    icmp IntPred.ne (LLVM.and e (const? 8 1)) (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -34,8 +34,8 @@ theorem mul_mask_pow2_sgt0_thm (e : IntW 8) :
 
 
 theorem mul_mask_fakepow2_ne0_thm (e : IntW 8) :
-  icmp IntPredicate.ne (LLVM.and (mul e (const? 8 44)) (const? 8 5)) (const? 8 0) ⊑
-    icmp IntPredicate.ne (LLVM.and e (const? 8 1)) (const? 8 0) := by
+  icmp IntPred.ne (LLVM.and (mul e (const? 8 44)) (const? 8 5)) (const? 8 0) ⊑
+    icmp IntPred.ne (LLVM.and e (const? 8 1)) (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -45,8 +45,8 @@ theorem mul_mask_fakepow2_ne0_thm (e : IntW 8) :
 
 
 theorem mul_mask_pow2_eq4_thm (e : IntW 8) :
-  icmp IntPredicate.eq (LLVM.and (mul e (const? 8 44)) (const? 8 4)) (const? 8 4) ⊑
-    icmp IntPredicate.ne (LLVM.and e (const? 8 1)) (const? 8 0) := by
+  icmp IntPred.eq (LLVM.and (mul e (const? 8 44)) (const? 8 4)) (const? 8 4) ⊑
+    icmp IntPred.ne (LLVM.and e (const? 8 1)) (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -56,8 +56,8 @@ theorem mul_mask_pow2_eq4_thm (e : IntW 8) :
 
 
 theorem mul_mask_notpow2_ne_thm (e : IntW 8) :
-  icmp IntPredicate.ne (LLVM.and (mul e (const? 8 60)) (const? 8 12)) (const? 8 0) ⊑
-    icmp IntPredicate.ne (LLVM.and (mul e (const? 8 12)) (const? 8 12)) (const? 8 0) := by
+  icmp IntPred.ne (LLVM.and (mul e (const? 8 60)) (const? 8 12)) (const? 8 0) ⊑
+    icmp IntPred.ne (LLVM.and (mul e (const? 8 12)) (const? 8 12)) (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -67,8 +67,8 @@ theorem mul_mask_notpow2_ne_thm (e : IntW 8) :
 
 
 theorem pr40493_thm (e : IntW 32) :
-  icmp IntPredicate.eq (LLVM.and (mul e (const? 32 12)) (const? 32 4)) (const? 32 0) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 32 1)) (const? 32 0) := by
+  icmp IntPred.eq (LLVM.and (mul e (const? 32 12)) (const? 32 4)) (const? 32 0) ⊑
+    icmp IntPred.eq (LLVM.and e (const? 32 1)) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -78,8 +78,8 @@ theorem pr40493_thm (e : IntW 32) :
 
 
 theorem pr40493_neg1_thm (e : IntW 32) :
-  icmp IntPredicate.eq (LLVM.and (mul e (const? 32 11)) (const? 32 4)) (const? 32 0) ⊑
-    icmp IntPredicate.eq (LLVM.and (mul e (const? 32 3)) (const? 32 4)) (const? 32 0) := by
+  icmp IntPred.eq (LLVM.and (mul e (const? 32 11)) (const? 32 4)) (const? 32 0) ⊑
+    icmp IntPred.eq (LLVM.and (mul e (const? 32 3)) (const? 32 4)) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -89,8 +89,8 @@ theorem pr40493_neg1_thm (e : IntW 32) :
 
 
 theorem pr40493_neg2_thm (e : IntW 32) :
-  icmp IntPredicate.eq (LLVM.and (mul e (const? 32 12)) (const? 32 15)) (const? 32 0) ⊑
-    icmp IntPredicate.eq (LLVM.and (mul e (const? 32 12)) (const? 32 12)) (const? 32 0) := by
+  icmp IntPred.eq (LLVM.and (mul e (const? 32 12)) (const? 32 15)) (const? 32 0) ⊑
+    icmp IntPred.eq (LLVM.and (mul e (const? 32 12)) (const? 32 12)) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -110,11 +110,11 @@ theorem pr40493_neg3_thm (e : IntW 32) :
 
 
 theorem pr51551_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.eq
+  icmp IntPred.eq
       (LLVM.and (mul (LLVM.or (LLVM.and e_1 (const? 32 (-7))) (const? 32 1)) e { «nsw» := true, «nuw» := false })
         (const? 32 3))
       (const? 32 0) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 32 3)) (const? 32 0) := by
+    icmp IntPred.eq (LLVM.and e (const? 32 3)) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -124,11 +124,11 @@ theorem pr51551_thm (e e_1 : IntW 32) :
 
 
 theorem pr51551_2_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.eq
+  icmp IntPred.eq
       (LLVM.and (mul (LLVM.or (LLVM.and e_1 (const? 32 (-7))) (const? 32 1)) e { «nsw» := true, «nuw» := false })
         (const? 32 1))
       (const? 32 0) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 32 1)) (const? 32 0) := by
+    icmp IntPred.eq (LLVM.and e (const? 32 1)) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -138,11 +138,11 @@ theorem pr51551_2_thm (e e_1 : IntW 32) :
 
 
 theorem pr51551_neg1_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.eq
+  icmp IntPred.eq
       (LLVM.and (mul (LLVM.or (LLVM.and e_1 (const? 32 (-3))) (const? 32 1)) e { «nsw» := true, «nuw» := false })
         (const? 32 7))
       (const? 32 0) ⊑
-    icmp IntPredicate.eq
+    icmp IntPred.eq
       (LLVM.and (mul (LLVM.or (LLVM.and e_1 (const? 32 4)) (const? 32 1) { «disjoint» := true }) e) (const? 32 7))
       (const? 32 0) := by
     simp_alive_undef
@@ -154,10 +154,10 @@ theorem pr51551_neg1_thm (e e_1 : IntW 32) :
 
 
 theorem pr51551_neg2_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.eq
+  icmp IntPred.eq
       (LLVM.and (mul (LLVM.and e_1 (const? 32 (-7))) e { «nsw» := true, «nuw» := false }) (const? 32 7)) (const? 32 0) ⊑
     select (LLVM.xor (trunc 1 e_1) (const? 1 1)) (const? 1 1)
-      (icmp IntPredicate.eq (LLVM.and e (const? 32 7)) (const? 32 0)) := by
+      (icmp IntPred.eq (LLVM.and e (const? 32 7)) (const? 32 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gicmphofhandhx_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gicmphofhandhx_proof.lean
@@ -12,7 +12,7 @@ set_option Elab.async false
 
 section gicmphofhandhx_proof
 theorem icmp_ult_x_y_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.ult (LLVM.and e_1 e) e_1 ⊑ icmp IntPredicate.ne (LLVM.and e_1 e) e_1 := by
+  icmp IntPred.ult (LLVM.and e_1 e) e_1 ⊑ icmp IntPred.ne (LLVM.and e_1 e) e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -22,8 +22,8 @@ theorem icmp_ult_x_y_thm (e e_1 : IntW 8) :
 
 
 theorem icmp_ult_x_y_2_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.ugt (mul e_1 e_1) (LLVM.and (mul e_1 e_1) e) ⊑
-    icmp IntPredicate.ne (LLVM.and (mul e_1 e_1) e) (mul e_1 e_1) := by
+  icmp IntPred.ugt (mul e_1 e_1) (LLVM.and (mul e_1 e_1) e) ⊑
+    icmp IntPred.ne (LLVM.and (mul e_1 e_1) e) (mul e_1 e_1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -33,8 +33,8 @@ theorem icmp_ult_x_y_2_thm (e e_1 : IntW 8) :
 
 
 theorem icmp_uge_x_y_2_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.ule (mul e_1 e_1) (LLVM.and (mul e_1 e_1) e) ⊑
-    icmp IntPredicate.eq (LLVM.and (mul e_1 e_1) e) (mul e_1 e_1) := by
+  icmp IntPred.ule (mul e_1 e_1) (LLVM.and (mul e_1 e_1) e) ⊑
+    icmp IntPred.eq (LLVM.and (mul e_1 e_1) e) (mul e_1 e_1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -44,7 +44,7 @@ theorem icmp_uge_x_y_2_thm (e e_1 : IntW 8) :
 
 
 theorem icmp_sle_x_negy_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.sle (LLVM.and (LLVM.or e_1 (const? 8 (-128))) e) e ⊑ const? 1 1 := by
+  icmp IntPred.sle (LLVM.and (LLVM.or e_1 (const? 8 (-128))) e) e ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -54,8 +54,8 @@ theorem icmp_sle_x_negy_thm (e e_1 : IntW 8) :
 
 
 theorem icmp_eq_x_invertable_y_todo_thm (e : IntW 1) (e_1 : IntW 8) :
-  icmp IntPredicate.eq e_1 (LLVM.and e_1 (select e (const? 8 7) (const? 8 24))) ⊑
-    icmp IntPredicate.eq (LLVM.and e_1 (select e (const? 8 (-8)) (const? 8 (-25)))) (const? 8 0) := by
+  icmp IntPred.eq e_1 (LLVM.and e_1 (select e (const? 8 7) (const? 8 24))) ⊑
+    icmp IntPred.eq (LLVM.and e_1 (select e (const? 8 (-8)) (const? 8 (-25)))) (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -65,8 +65,8 @@ theorem icmp_eq_x_invertable_y_todo_thm (e : IntW 1) (e_1 : IntW 8) :
 
 
 theorem icmp_eq_x_invertable_y_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.eq e_1 (LLVM.and e_1 (LLVM.xor e (const? 8 (-1)))) ⊑
-    icmp IntPredicate.eq (LLVM.and e_1 e) (const? 8 0) := by
+  icmp IntPred.eq e_1 (LLVM.and e_1 (LLVM.xor e (const? 8 (-1)))) ⊑
+    icmp IntPred.eq (LLVM.and e_1 e) (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -76,8 +76,8 @@ theorem icmp_eq_x_invertable_y_thm (e e_1 : IntW 8) :
 
 
 theorem icmp_eq_x_invertable_y2_todo_thm (e : IntW 8) (e_1 : IntW 1) :
-  icmp IntPredicate.eq (select e_1 (const? 8 7) (const? 8 24)) (LLVM.and e (select e_1 (const? 8 7) (const? 8 24))) ⊑
-    icmp IntPredicate.eq (LLVM.or e (select e_1 (const? 8 (-8)) (const? 8 (-25)))) (const? 8 (-1)) := by
+  icmp IntPred.eq (select e_1 (const? 8 7) (const? 8 24)) (LLVM.and e (select e_1 (const? 8 7) (const? 8 24))) ⊑
+    icmp IntPred.eq (LLVM.or e (select e_1 (const? 8 (-8)) (const? 8 (-25)))) (const? 8 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -87,8 +87,8 @@ theorem icmp_eq_x_invertable_y2_todo_thm (e : IntW 8) (e_1 : IntW 1) :
 
 
 theorem icmp_eq_x_invertable_y2_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.eq (LLVM.xor e_1 (const? 8 (-1))) (LLVM.and e (LLVM.xor e_1 (const? 8 (-1)))) ⊑
-    icmp IntPredicate.eq (LLVM.or e e_1) (const? 8 (-1)) := by
+  icmp IntPred.eq (LLVM.xor e_1 (const? 8 (-1))) (LLVM.and e (LLVM.xor e_1 (const? 8 (-1)))) ⊑
+    icmp IntPred.eq (LLVM.or e e_1) (const? 8 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gicmphofhorhx_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gicmphofhorhx_proof.lean
@@ -12,7 +12,7 @@ set_option Elab.async false
 
 section gicmphofhorhx_proof
 theorem or_ugt_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.ugt (LLVM.or e_1 e) e_1 ⊑ icmp IntPredicate.ne (LLVM.or e_1 e) e_1 := by
+  icmp IntPred.ugt (LLVM.or e_1 e) e_1 ⊑ icmp IntPred.ne (LLVM.or e_1 e) e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -22,8 +22,8 @@ theorem or_ugt_thm (e e_1 : IntW 8) :
 
 
 theorem or_eq_notY_eq_0_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.eq (LLVM.or e_1 (LLVM.xor e (const? 8 (-1)))) (LLVM.xor e (const? 8 (-1))) ⊑
-    icmp IntPredicate.eq (LLVM.and e_1 e) (const? 8 0) := by
+  icmp IntPred.eq (LLVM.or e_1 (LLVM.xor e (const? 8 (-1)))) (LLVM.xor e (const? 8 (-1))) ⊑
+    icmp IntPred.eq (LLVM.and e_1 e) (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -33,8 +33,8 @@ theorem or_eq_notY_eq_0_thm (e e_1 : IntW 8) :
 
 
 theorem or_ne_notY_eq_1s_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.ne (LLVM.or e_1 (LLVM.xor e (const? 8 (-1)))) e_1 ⊑
-    icmp IntPredicate.ne (LLVM.or e_1 e) (const? 8 (-1)) := by
+  icmp IntPred.ne (LLVM.or e_1 (LLVM.xor e (const? 8 (-1)))) e_1 ⊑
+    icmp IntPred.ne (LLVM.or e_1 e) (const? 8 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -44,8 +44,8 @@ theorem or_ne_notY_eq_1s_thm (e e_1 : IntW 8) :
 
 
 theorem or_ne_notY_eq_1s_fail_bad_not_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.ne (LLVM.or e_1 (LLVM.xor e (const? 8 (-2)))) e_1 ⊑
-    icmp IntPredicate.ne (LLVM.or e_1 (LLVM.xor e (const? 8 1))) (const? 8 (-1)) := by
+  icmp IntPred.ne (LLVM.or e_1 (LLVM.xor e (const? 8 (-2)))) e_1 ⊑
+    icmp IntPred.ne (LLVM.or e_1 (LLVM.xor e (const? 8 1))) (const? 8 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -55,8 +55,8 @@ theorem or_ne_notY_eq_1s_fail_bad_not_thm (e e_1 : IntW 8) :
 
 
 theorem or_simplify_ule_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.ule (LLVM.or (LLVM.or e_1 (const? 8 1)) (LLVM.and e (const? 8 (-2)))) (LLVM.and e (const? 8 (-2))) ⊑
-    icmp IntPredicate.ule (LLVM.or (LLVM.or e_1 e) (const? 8 1)) (LLVM.and e (const? 8 (-2))) := by
+  icmp IntPred.ule (LLVM.or (LLVM.or e_1 (const? 8 1)) (LLVM.and e (const? 8 (-2)))) (LLVM.and e (const? 8 (-2))) ⊑
+    icmp IntPred.ule (LLVM.or (LLVM.or e_1 e) (const? 8 1)) (LLVM.and e (const? 8 (-2))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -66,7 +66,7 @@ theorem or_simplify_ule_thm (e e_1 : IntW 8) :
 
 
 theorem or_simplify_uge_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.uge (LLVM.and e_1 (const? 8 127))
+  icmp IntPred.uge (LLVM.and e_1 (const? 8 127))
       (LLVM.or (LLVM.or e (const? 8 (-127))) (LLVM.and e_1 (const? 8 127))) ⊑
     const? 1 0 := by
     simp_alive_undef
@@ -78,8 +78,8 @@ theorem or_simplify_uge_thm (e e_1 : IntW 8) :
 
 
 theorem or_simplify_ule_fail_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.ule (LLVM.or (LLVM.or e_1 (const? 8 64)) (LLVM.and e (const? 8 127))) (LLVM.and e (const? 8 127)) ⊑
-    icmp IntPredicate.ule (LLVM.or (LLVM.or e_1 (LLVM.and e (const? 8 127))) (const? 8 64))
+  icmp IntPred.ule (LLVM.or (LLVM.or e_1 (const? 8 64)) (LLVM.and e (const? 8 127))) (LLVM.and e (const? 8 127)) ⊑
+    icmp IntPred.ule (LLVM.or (LLVM.or e_1 (LLVM.and e (const? 8 127))) (const? 8 64))
       (LLVM.and e (const? 8 127)) := by
     simp_alive_undef
     simp_alive_ops
@@ -90,8 +90,8 @@ theorem or_simplify_ule_fail_thm (e e_1 : IntW 8) :
 
 
 theorem or_simplify_ugt_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.ugt (LLVM.or (LLVM.or e_1 (const? 8 1)) (LLVM.and e (const? 8 (-2)))) (LLVM.and e (const? 8 (-2))) ⊑
-    icmp IntPredicate.ugt (LLVM.or (LLVM.or e_1 e) (const? 8 1)) (LLVM.and e (const? 8 (-2))) := by
+  icmp IntPred.ugt (LLVM.or (LLVM.or e_1 (const? 8 1)) (LLVM.and e (const? 8 (-2)))) (LLVM.and e (const? 8 (-2))) ⊑
+    icmp IntPred.ugt (LLVM.or (LLVM.or e_1 e) (const? 8 1)) (LLVM.and e (const? 8 (-2))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -101,9 +101,9 @@ theorem or_simplify_ugt_thm (e e_1 : IntW 8) :
 
 
 theorem or_simplify_ult_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.ult (LLVM.and e_1 (const? 8 (-5)))
+  icmp IntPred.ult (LLVM.and e_1 (const? 8 (-5)))
       (LLVM.or (LLVM.or e (const? 8 36)) (LLVM.and e_1 (const? 8 (-5)))) ⊑
-    icmp IntPredicate.ult (LLVM.and e_1 (const? 8 (-5))) (LLVM.or (LLVM.or e e_1) (const? 8 36)) := by
+    icmp IntPred.ult (LLVM.and e_1 (const? 8 (-5))) (LLVM.or (LLVM.or e e_1) (const? 8 36)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -113,8 +113,8 @@ theorem or_simplify_ult_thm (e e_1 : IntW 8) :
 
 
 theorem or_simplify_ugt_fail_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.ugt (LLVM.or (LLVM.and e_1 (const? 8 (-2))) (LLVM.or e (const? 8 1))) (LLVM.or e (const? 8 1)) ⊑
-    icmp IntPredicate.ne (LLVM.or e_1 (LLVM.or e (const? 8 1))) (LLVM.or e (const? 8 1)) := by
+  icmp IntPred.ugt (LLVM.or (LLVM.and e_1 (const? 8 (-2))) (LLVM.or e (const? 8 1))) (LLVM.or e (const? 8 1)) ⊑
+    icmp IntPred.ne (LLVM.or e_1 (LLVM.or e (const? 8 1))) (LLVM.or e (const? 8 1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -124,9 +124,9 @@ theorem or_simplify_ugt_fail_thm (e e_1 : IntW 8) :
 
 
 theorem icmp_eq_x_invertable_y2_todo_thm (e e_1 : IntW 8) (e_2 : IntW 1) :
-  icmp IntPredicate.eq (select e_2 (const? 8 7) (LLVM.xor e_1 (const? 8 (-1))))
+  icmp IntPred.eq (select e_2 (const? 8 7) (LLVM.xor e_1 (const? 8 (-1))))
       (LLVM.or e (select e_2 (const? 8 7) (LLVM.xor e_1 (const? 8 (-1))))) ⊑
-    icmp IntPredicate.eq (LLVM.and e (select e_2 (const? 8 (-8)) e_1)) (const? 8 0) := by
+    icmp IntPred.eq (LLVM.and e (select e_2 (const? 8 (-8)) e_1)) (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -136,8 +136,8 @@ theorem icmp_eq_x_invertable_y2_todo_thm (e e_1 : IntW 8) (e_2 : IntW 1) :
 
 
 theorem icmp_eq_x_invertable_y2_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.eq (LLVM.xor e_1 (const? 8 (-1))) (LLVM.or e (LLVM.xor e_1 (const? 8 (-1)))) ⊑
-    icmp IntPredicate.eq (LLVM.and e e_1) (const? 8 0) := by
+  icmp IntPred.eq (LLVM.xor e_1 (const? 8 (-1))) (LLVM.or e (LLVM.xor e_1 (const? 8 (-1)))) ⊑
+    icmp IntPred.eq (LLVM.and e e_1) (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -147,7 +147,7 @@ theorem icmp_eq_x_invertable_y2_thm (e e_1 : IntW 8) :
 
 
 theorem PR38139_thm (e : IntW 8) :
-  icmp IntPredicate.ne (LLVM.or e (const? 8 (-64))) e ⊑ icmp IntPredicate.ult e (const? 8 (-64)) := by
+  icmp IntPred.ne (LLVM.or e (const? 8 (-64))) e ⊑ icmp IntPred.ult e (const? 8 (-64)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gicmphofhtrunchext_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gicmphofhtrunchext_proof.lean
@@ -12,8 +12,8 @@ set_option Elab.async false
 
 section gicmphofhtrunchext_proof
 theorem trunc_unsigned_nuw_thm (e e_1 : IntW 16) :
-  icmp IntPredicate.ult (trunc 8 e_1 { «nsw» := false, «nuw» := true }) (trunc 8 e { «nsw» := false, «nuw» := true }) ⊑
-    icmp IntPredicate.ult e_1 e := by
+  icmp IntPred.ult (trunc 8 e_1 { «nsw» := false, «nuw» := true }) (trunc 8 e { «nsw» := false, «nuw» := true }) ⊑
+    icmp IntPred.ult e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -23,8 +23,8 @@ theorem trunc_unsigned_nuw_thm (e e_1 : IntW 16) :
 
 
 theorem trunc_unsigned_nsw_thm (e e_1 : IntW 16) :
-  icmp IntPredicate.ult (trunc 8 e_1 { «nsw» := true, «nuw» := false }) (trunc 8 e { «nsw» := true, «nuw» := false }) ⊑
-    icmp IntPredicate.ult e_1 e := by
+  icmp IntPred.ult (trunc 8 e_1 { «nsw» := true, «nuw» := false }) (trunc 8 e { «nsw» := true, «nuw» := false }) ⊑
+    icmp IntPred.ult e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -34,8 +34,8 @@ theorem trunc_unsigned_nsw_thm (e e_1 : IntW 16) :
 
 
 theorem trunc_unsigned_both_thm (e e_1 : IntW 16) :
-  icmp IntPredicate.ult (trunc 8 e_1 { «nsw» := true, «nuw» := true }) (trunc 8 e { «nsw» := true, «nuw» := true }) ⊑
-    icmp IntPredicate.ult e_1 e := by
+  icmp IntPred.ult (trunc 8 e_1 { «nsw» := true, «nuw» := true }) (trunc 8 e { «nsw» := true, «nuw» := true }) ⊑
+    icmp IntPred.ult e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -45,8 +45,8 @@ theorem trunc_unsigned_both_thm (e e_1 : IntW 16) :
 
 
 theorem trunc_signed_nsw_thm (e e_1 : IntW 16) :
-  icmp IntPredicate.slt (trunc 8 e_1 { «nsw» := true, «nuw» := false }) (trunc 8 e { «nsw» := true, «nuw» := false }) ⊑
-    icmp IntPredicate.slt e_1 e := by
+  icmp IntPred.slt (trunc 8 e_1 { «nsw» := true, «nuw» := false }) (trunc 8 e { «nsw» := true, «nuw» := false }) ⊑
+    icmp IntPred.slt e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -56,8 +56,8 @@ theorem trunc_signed_nsw_thm (e e_1 : IntW 16) :
 
 
 theorem trunc_signed_both_thm (e e_1 : IntW 16) :
-  icmp IntPredicate.slt (trunc 8 e_1 { «nsw» := true, «nuw» := true }) (trunc 8 e { «nsw» := true, «nuw» := true }) ⊑
-    icmp IntPredicate.slt e_1 e := by
+  icmp IntPred.slt (trunc 8 e_1 { «nsw» := true, «nuw» := true }) (trunc 8 e { «nsw» := true, «nuw» := true }) ⊑
+    icmp IntPred.slt e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -67,8 +67,8 @@ theorem trunc_signed_both_thm (e e_1 : IntW 16) :
 
 
 theorem trunc_equality_nuw_thm (e e_1 : IntW 16) :
-  icmp IntPredicate.eq (trunc 8 e_1 { «nsw» := false, «nuw» := true }) (trunc 8 e { «nsw» := false, «nuw» := true }) ⊑
-    icmp IntPredicate.eq e_1 e := by
+  icmp IntPred.eq (trunc 8 e_1 { «nsw» := false, «nuw» := true }) (trunc 8 e { «nsw» := false, «nuw» := true }) ⊑
+    icmp IntPred.eq e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -78,8 +78,8 @@ theorem trunc_equality_nuw_thm (e e_1 : IntW 16) :
 
 
 theorem trunc_equality_nsw_thm (e e_1 : IntW 16) :
-  icmp IntPredicate.eq (trunc 8 e_1 { «nsw» := true, «nuw» := false }) (trunc 8 e { «nsw» := true, «nuw» := false }) ⊑
-    icmp IntPredicate.eq e_1 e := by
+  icmp IntPred.eq (trunc 8 e_1 { «nsw» := true, «nuw» := false }) (trunc 8 e { «nsw» := true, «nuw» := false }) ⊑
+    icmp IntPred.eq e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -89,8 +89,8 @@ theorem trunc_equality_nsw_thm (e e_1 : IntW 16) :
 
 
 theorem trunc_equality_both_thm (e e_1 : IntW 16) :
-  icmp IntPredicate.eq (trunc 8 e_1 { «nsw» := true, «nuw» := true }) (trunc 8 e { «nsw» := true, «nuw» := true }) ⊑
-    icmp IntPredicate.eq e_1 e := by
+  icmp IntPred.eq (trunc 8 e_1 { «nsw» := true, «nuw» := true }) (trunc 8 e { «nsw» := true, «nuw» := true }) ⊑
+    icmp IntPred.eq e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -100,8 +100,8 @@ theorem trunc_equality_both_thm (e e_1 : IntW 16) :
 
 
 theorem trunc_unsigned_nuw_zext_thm (e : IntW 8) (e_1 : IntW 32) :
-  icmp IntPredicate.ult (trunc 16 e_1 { «nsw» := false, «nuw» := true }) (zext 16 e) ⊑
-    icmp IntPredicate.ult e_1 (zext 32 e) := by
+  icmp IntPred.ult (trunc 16 e_1 { «nsw» := false, «nuw» := true }) (zext 16 e) ⊑
+    icmp IntPred.ult e_1 (zext 32 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -111,8 +111,8 @@ theorem trunc_unsigned_nuw_zext_thm (e : IntW 8) (e_1 : IntW 32) :
 
 
 theorem trunc_unsigned_nsw_zext_thm (e : IntW 8) (e_1 : IntW 32) :
-  icmp IntPredicate.ult (trunc 16 e_1 { «nsw» := true, «nuw» := false }) (zext 16 e) ⊑
-    icmp IntPredicate.ult e_1 (zext 32 e) := by
+  icmp IntPred.ult (trunc 16 e_1 { «nsw» := true, «nuw» := false }) (zext 16 e) ⊑
+    icmp IntPred.ult e_1 (zext 32 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -122,8 +122,8 @@ theorem trunc_unsigned_nsw_zext_thm (e : IntW 8) (e_1 : IntW 32) :
 
 
 theorem trunc_unsigned_nsw_sext_thm (e : IntW 8) (e_1 : IntW 32) :
-  icmp IntPredicate.ult (trunc 16 e_1 { «nsw» := true, «nuw» := false }) (sext 16 e) ⊑
-    icmp IntPredicate.ult e_1 (sext 32 e) := by
+  icmp IntPred.ult (trunc 16 e_1 { «nsw» := true, «nuw» := false }) (sext 16 e) ⊑
+    icmp IntPred.ult e_1 (sext 32 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -133,8 +133,8 @@ theorem trunc_unsigned_nsw_sext_thm (e : IntW 8) (e_1 : IntW 32) :
 
 
 theorem trunc_signed_nsw_sext_thm (e : IntW 8) (e_1 : IntW 32) :
-  icmp IntPredicate.slt (trunc 16 e_1 { «nsw» := true, «nuw» := false }) (sext 16 e) ⊑
-    icmp IntPredicate.slt e_1 (sext 32 e) := by
+  icmp IntPred.slt (trunc 16 e_1 { «nsw» := true, «nuw» := false }) (sext 16 e) ⊑
+    icmp IntPred.slt e_1 (sext 32 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -144,8 +144,8 @@ theorem trunc_signed_nsw_sext_thm (e : IntW 8) (e_1 : IntW 32) :
 
 
 theorem trunc_signed_nsw_zext_thm (e : IntW 8) (e_1 : IntW 32) :
-  icmp IntPredicate.slt (trunc 16 e_1 { «nsw» := true, «nuw» := false }) (zext 16 e) ⊑
-    icmp IntPredicate.slt e_1 (zext 32 e) := by
+  icmp IntPred.slt (trunc 16 e_1 { «nsw» := true, «nuw» := false }) (zext 16 e) ⊑
+    icmp IntPred.slt e_1 (zext 32 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -155,8 +155,8 @@ theorem trunc_signed_nsw_zext_thm (e : IntW 8) (e_1 : IntW 32) :
 
 
 theorem trunc_equality_nuw_zext_thm (e : IntW 8) (e_1 : IntW 32) :
-  icmp IntPredicate.ne (trunc 16 e_1 { «nsw» := false, «nuw» := true }) (zext 16 e) ⊑
-    icmp IntPredicate.ne e_1 (zext 32 e) := by
+  icmp IntPred.ne (trunc 16 e_1 { «nsw» := false, «nuw» := true }) (zext 16 e) ⊑
+    icmp IntPred.ne e_1 (zext 32 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -166,8 +166,8 @@ theorem trunc_equality_nuw_zext_thm (e : IntW 8) (e_1 : IntW 32) :
 
 
 theorem trunc_equality_nsw_zext_thm (e : IntW 8) (e_1 : IntW 32) :
-  icmp IntPredicate.ne (trunc 16 e_1 { «nsw» := true, «nuw» := false }) (zext 16 e) ⊑
-    icmp IntPredicate.ne e_1 (zext 32 e) := by
+  icmp IntPred.ne (trunc 16 e_1 { «nsw» := true, «nuw» := false }) (zext 16 e) ⊑
+    icmp IntPred.ne e_1 (zext 32 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -177,8 +177,8 @@ theorem trunc_equality_nsw_zext_thm (e : IntW 8) (e_1 : IntW 32) :
 
 
 theorem trunc_equality_nsw_sext_thm (e : IntW 8) (e_1 : IntW 32) :
-  icmp IntPredicate.ne (trunc 16 e_1 { «nsw» := true, «nuw» := false }) (sext 16 e) ⊑
-    icmp IntPredicate.ne e_1 (sext 32 e) := by
+  icmp IntPred.ne (trunc 16 e_1 { «nsw» := true, «nuw» := false }) (sext 16 e) ⊑
+    icmp IntPred.ne e_1 (sext 32 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -188,8 +188,8 @@ theorem trunc_equality_nsw_sext_thm (e : IntW 8) (e_1 : IntW 32) :
 
 
 theorem trunc_equality_both_sext_thm (e : IntW 8) (e_1 : IntW 32) :
-  icmp IntPredicate.ne (trunc 16 e_1 { «nsw» := true, «nuw» := true }) (sext 16 e) ⊑
-    icmp IntPredicate.ne e_1 (sext 32 e) := by
+  icmp IntPred.ne (trunc 16 e_1 { «nsw» := true, «nuw» := true }) (sext 16 e) ⊑
+    icmp IntPred.ne e_1 (sext 32 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -199,8 +199,8 @@ theorem trunc_equality_both_sext_thm (e : IntW 8) (e_1 : IntW 32) :
 
 
 theorem test_eq1_thm (e : IntW 16) (e_1 : IntW 32) :
-  icmp IntPredicate.eq (trunc 8 e_1 { «nsw» := true, «nuw» := false }) (trunc 8 e { «nsw» := true, «nuw» := false }) ⊑
-    icmp IntPredicate.eq e_1 (sext 32 e) := by
+  icmp IntPred.eq (trunc 8 e_1 { «nsw» := true, «nuw» := false }) (trunc 8 e { «nsw» := true, «nuw» := false }) ⊑
+    icmp IntPred.eq e_1 (sext 32 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -210,8 +210,8 @@ theorem test_eq1_thm (e : IntW 16) (e_1 : IntW 32) :
 
 
 theorem test_eq2_thm (e : IntW 32) (e_1 : IntW 16) :
-  icmp IntPredicate.eq (trunc 8 e_1 { «nsw» := true, «nuw» := false }) (trunc 8 e { «nsw» := true, «nuw» := false }) ⊑
-    icmp IntPredicate.eq e_1 (trunc 16 e) := by
+  icmp IntPred.eq (trunc 8 e_1 { «nsw» := true, «nuw» := false }) (trunc 8 e { «nsw» := true, «nuw» := false }) ⊑
+    icmp IntPred.eq e_1 (trunc 16 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -221,8 +221,8 @@ theorem test_eq2_thm (e : IntW 32) (e_1 : IntW 16) :
 
 
 theorem test_ult_thm (e : IntW 16) (e_1 : IntW 32) :
-  icmp IntPredicate.ult (trunc 8 e_1 { «nsw» := true, «nuw» := false }) (trunc 8 e { «nsw» := true, «nuw» := false }) ⊑
-    icmp IntPredicate.ult e_1 (sext 32 e) := by
+  icmp IntPred.ult (trunc 8 e_1 { «nsw» := true, «nuw» := false }) (trunc 8 e { «nsw» := true, «nuw» := false }) ⊑
+    icmp IntPred.ult e_1 (sext 32 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -232,8 +232,8 @@ theorem test_ult_thm (e : IntW 16) (e_1 : IntW 32) :
 
 
 theorem test_slt_thm (e : IntW 16) (e_1 : IntW 32) :
-  icmp IntPredicate.slt (trunc 8 e_1 { «nsw» := true, «nuw» := false }) (trunc 8 e { «nsw» := true, «nuw» := false }) ⊑
-    icmp IntPredicate.slt e_1 (sext 32 e) := by
+  icmp IntPred.slt (trunc 8 e_1 { «nsw» := true, «nuw» := false }) (trunc 8 e { «nsw» := true, «nuw» := false }) ⊑
+    icmp IntPred.slt e_1 (sext 32 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -243,8 +243,8 @@ theorem test_slt_thm (e : IntW 16) (e_1 : IntW 32) :
 
 
 theorem test_ult_nuw_thm (e : IntW 16) (e_1 : IntW 32) :
-  icmp IntPredicate.ult (trunc 8 e_1 { «nsw» := true, «nuw» := true }) (trunc 8 e { «nsw» := true, «nuw» := true }) ⊑
-    icmp IntPredicate.ult e_1 (zext 32 e) := by
+  icmp IntPred.ult (trunc 8 e_1 { «nsw» := true, «nuw» := true }) (trunc 8 e { «nsw» := true, «nuw» := true }) ⊑
+    icmp IntPred.ult e_1 (zext 32 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -254,8 +254,8 @@ theorem test_ult_nuw_thm (e : IntW 16) (e_1 : IntW 32) :
 
 
 theorem test_slt_nuw_thm (e : IntW 16) (e_1 : IntW 32) :
-  icmp IntPredicate.slt (trunc 8 e_1 { «nsw» := true, «nuw» := true }) (trunc 8 e { «nsw» := true, «nuw» := true }) ⊑
-    icmp IntPredicate.slt e_1 (zext 32 e) := by
+  icmp IntPred.slt (trunc 8 e_1 { «nsw» := true, «nuw» := true }) (trunc 8 e { «nsw» := true, «nuw» := true }) ⊑
+    icmp IntPred.slt e_1 (zext 32 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gicmphofhxorhx_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gicmphofhxorhx_proof.lean
@@ -12,8 +12,8 @@ set_option Elab.async false
 
 section gicmphofhxorhx_proof
 theorem test_xor_ne_thm (e e_1 e_2 : IntW 8) :
-  icmp IntPredicate.ne (LLVM.xor e_2 (const? 8 (-1))) (LLVM.xor (LLVM.xor e_1 (const? 8 (-1))) e) ⊑
-    icmp IntPredicate.ne e_2 (LLVM.xor e_1 e) := by
+  icmp IntPred.ne (LLVM.xor e_2 (const? 8 (-1))) (LLVM.xor (LLVM.xor e_1 (const? 8 (-1))) e) ⊑
+    icmp IntPred.ne e_2 (LLVM.xor e_1 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -23,8 +23,8 @@ theorem test_xor_ne_thm (e e_1 e_2 : IntW 8) :
 
 
 theorem test_xor_eq_thm (e e_1 e_2 : IntW 8) :
-  icmp IntPredicate.eq (LLVM.xor e_2 (const? 8 (-1))) (LLVM.xor (LLVM.xor e_1 (const? 8 (-1))) e) ⊑
-    icmp IntPredicate.eq e_2 (LLVM.xor e_1 e) := by
+  icmp IntPred.eq (LLVM.xor e_2 (const? 8 (-1))) (LLVM.xor (LLVM.xor e_1 (const? 8 (-1))) e) ⊑
+    icmp IntPred.eq e_2 (LLVM.xor e_1 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -34,8 +34,8 @@ theorem test_xor_eq_thm (e e_1 e_2 : IntW 8) :
 
 
 theorem test_slt_xor_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.slt (LLVM.xor (LLVM.xor e_1 (const? 32 (-1))) e) (LLVM.xor e_1 (const? 32 (-1))) ⊑
-    icmp IntPredicate.sgt (LLVM.xor e e_1) e_1 := by
+  icmp IntPred.slt (LLVM.xor (LLVM.xor e_1 (const? 32 (-1))) e) (LLVM.xor e_1 (const? 32 (-1))) ⊑
+    icmp IntPred.sgt (LLVM.xor e e_1) e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -45,8 +45,8 @@ theorem test_slt_xor_thm (e e_1 : IntW 32) :
 
 
 theorem test_sle_xor_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.sle (LLVM.xor (LLVM.xor e_1 (const? 32 (-1))) e) (LLVM.xor e_1 (const? 32 (-1))) ⊑
-    icmp IntPredicate.sge (LLVM.xor e e_1) e_1 := by
+  icmp IntPred.sle (LLVM.xor (LLVM.xor e_1 (const? 32 (-1))) e) (LLVM.xor e_1 (const? 32 (-1))) ⊑
+    icmp IntPred.sge (LLVM.xor e e_1) e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -56,8 +56,8 @@ theorem test_sle_xor_thm (e e_1 : IntW 32) :
 
 
 theorem test_sgt_xor_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.sgt (LLVM.xor (LLVM.xor e_1 (const? 32 (-1))) e) (LLVM.xor e_1 (const? 32 (-1))) ⊑
-    icmp IntPredicate.slt (LLVM.xor e e_1) e_1 := by
+  icmp IntPred.sgt (LLVM.xor (LLVM.xor e_1 (const? 32 (-1))) e) (LLVM.xor e_1 (const? 32 (-1))) ⊑
+    icmp IntPred.slt (LLVM.xor e e_1) e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -67,8 +67,8 @@ theorem test_sgt_xor_thm (e e_1 : IntW 32) :
 
 
 theorem test_sge_xor_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.sge (LLVM.xor (LLVM.xor e_1 (const? 32 (-1))) e) (LLVM.xor e_1 (const? 32 (-1))) ⊑
-    icmp IntPredicate.sle (LLVM.xor e e_1) e_1 := by
+  icmp IntPred.sge (LLVM.xor (LLVM.xor e_1 (const? 32 (-1))) e) (LLVM.xor e_1 (const? 32 (-1))) ⊑
+    icmp IntPred.sle (LLVM.xor e e_1) e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -78,8 +78,8 @@ theorem test_sge_xor_thm (e e_1 : IntW 32) :
 
 
 theorem test_ult_xor_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.ult (LLVM.xor (LLVM.xor e_1 (const? 32 (-1))) e) (LLVM.xor e_1 (const? 32 (-1))) ⊑
-    icmp IntPredicate.ugt (LLVM.xor e e_1) e_1 := by
+  icmp IntPred.ult (LLVM.xor (LLVM.xor e_1 (const? 32 (-1))) e) (LLVM.xor e_1 (const? 32 (-1))) ⊑
+    icmp IntPred.ugt (LLVM.xor e e_1) e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -89,8 +89,8 @@ theorem test_ult_xor_thm (e e_1 : IntW 32) :
 
 
 theorem test_ule_xor_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.ule (LLVM.xor (LLVM.xor e_1 (const? 32 (-1))) e) (LLVM.xor e_1 (const? 32 (-1))) ⊑
-    icmp IntPredicate.uge (LLVM.xor e e_1) e_1 := by
+  icmp IntPred.ule (LLVM.xor (LLVM.xor e_1 (const? 32 (-1))) e) (LLVM.xor e_1 (const? 32 (-1))) ⊑
+    icmp IntPred.uge (LLVM.xor e e_1) e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -100,8 +100,8 @@ theorem test_ule_xor_thm (e e_1 : IntW 32) :
 
 
 theorem test_ugt_xor_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.ugt (LLVM.xor (LLVM.xor e_1 (const? 32 (-1))) e) (LLVM.xor e_1 (const? 32 (-1))) ⊑
-    icmp IntPredicate.ult (LLVM.xor e e_1) e_1 := by
+  icmp IntPred.ugt (LLVM.xor (LLVM.xor e_1 (const? 32 (-1))) e) (LLVM.xor e_1 (const? 32 (-1))) ⊑
+    icmp IntPred.ult (LLVM.xor e e_1) e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -111,8 +111,8 @@ theorem test_ugt_xor_thm (e e_1 : IntW 32) :
 
 
 theorem test_uge_xor_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.uge (LLVM.xor (LLVM.xor e_1 (const? 32 (-1))) e) (LLVM.xor e_1 (const? 32 (-1))) ⊑
-    icmp IntPredicate.ule (LLVM.xor e e_1) e_1 := by
+  icmp IntPred.uge (LLVM.xor (LLVM.xor e_1 (const? 32 (-1))) e) (LLVM.xor e_1 (const? 32 (-1))) ⊑
+    icmp IntPred.ule (LLVM.xor e e_1) e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -122,8 +122,8 @@ theorem test_uge_xor_thm (e e_1 : IntW 32) :
 
 
 theorem xor_sge_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.sge (mul e_1 e_1) (LLVM.xor (LLVM.or e (const? 8 (-128))) (mul e_1 e_1)) ⊑
-    icmp IntPredicate.slt (LLVM.xor (LLVM.or e (const? 8 (-128))) (mul e_1 e_1)) (mul e_1 e_1) := by
+  icmp IntPred.sge (mul e_1 e_1) (LLVM.xor (LLVM.or e (const? 8 (-128))) (mul e_1 e_1)) ⊑
+    icmp IntPred.slt (LLVM.xor (LLVM.or e (const? 8 (-128))) (mul e_1 e_1)) (mul e_1 e_1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -133,8 +133,8 @@ theorem xor_sge_thm (e e_1 : IntW 8) :
 
 
 theorem xor_ugt_2_thm (e e_1 e_2 : IntW 8) :
-  icmp IntPredicate.ugt (add e_2 e_1) (LLVM.xor (add e_2 e_1) (LLVM.or (LLVM.and e (const? 8 63)) (const? 8 64))) ⊑
-    icmp IntPredicate.ugt (add e_2 e_1)
+  icmp IntPred.ugt (add e_2 e_1) (LLVM.xor (add e_2 e_1) (LLVM.or (LLVM.and e (const? 8 63)) (const? 8 64))) ⊑
+    icmp IntPred.ugt (add e_2 e_1)
       (LLVM.xor (add e_2 e_1) (LLVM.or (LLVM.and e (const? 8 63)) (const? 8 64) { «disjoint» := true })) := by
     simp_alive_undef
     simp_alive_ops

--- a/SSA/Projects/InstCombine/tests/proofs/gicmphorhofhselecthwithhzero_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gicmphorhofhselecthwithhzero_proof.lean
@@ -12,9 +12,9 @@ set_option Elab.async false
 
 section gicmphorhofhselecthwithhzero_proof
 theorem src_tv_eq_thm (e e_1 : IntW 8) (e_2 : IntW 1) :
-  icmp IntPredicate.eq (LLVM.or (select e_2 (const? 8 0) (add e_1 (const? 8 1) { «nsw» := false, «nuw» := true })) e)
+  icmp IntPred.eq (LLVM.or (select e_2 (const? 8 0) (add e_1 (const? 8 1) { «nsw» := false, «nuw» := true })) e)
       (const? 8 0) ⊑
-    LLVM.and (icmp IntPredicate.eq e (const? 8 0)) e_2 := by
+    LLVM.and (icmp IntPred.eq e (const? 8 0)) e_2 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -24,9 +24,9 @@ theorem src_tv_eq_thm (e e_1 : IntW 8) (e_2 : IntW 1) :
 
 
 theorem src_fv_ne_thm (e e_1 : IntW 8) (e_2 : IntW 1) :
-  icmp IntPredicate.ne (LLVM.or (select e_2 (add e_1 (const? 8 1) { «nsw» := false, «nuw» := true }) (const? 8 0)) e)
+  icmp IntPred.ne (LLVM.or (select e_2 (add e_1 (const? 8 1) { «nsw» := false, «nuw» := true }) (const? 8 0)) e)
       (const? 8 0) ⊑
-    LLVM.or (icmp IntPredicate.ne e (const? 8 0)) e_2 := by
+    LLVM.or (icmp IntPred.ne e (const? 8 0)) e_2 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -36,9 +36,9 @@ theorem src_fv_ne_thm (e e_1 : IntW 8) (e_2 : IntW 1) :
 
 
 theorem src_tv_ne_thm (e e_1 : IntW 8) (e_2 : IntW 1) :
-  icmp IntPredicate.ne (LLVM.or (select e_2 (const? 8 0) (add e_1 (const? 8 1) { «nsw» := false, «nuw» := true })) e)
+  icmp IntPred.ne (LLVM.or (select e_2 (const? 8 0) (add e_1 (const? 8 1) { «nsw» := false, «nuw» := true })) e)
       (const? 8 0) ⊑
-    LLVM.or (icmp IntPredicate.ne e (const? 8 0)) (LLVM.xor e_2 (const? 1 1)) := by
+    LLVM.or (icmp IntPred.ne e (const? 8 0)) (LLVM.xor e_2 (const? 1 1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -48,9 +48,9 @@ theorem src_tv_ne_thm (e e_1 : IntW 8) (e_2 : IntW 1) :
 
 
 theorem src_fv_eq_thm (e e_1 : IntW 8) (e_2 : IntW 1) :
-  icmp IntPredicate.eq (LLVM.or (select e_2 (add e_1 (const? 8 1) { «nsw» := false, «nuw» := true }) (const? 8 0)) e)
+  icmp IntPred.eq (LLVM.or (select e_2 (add e_1 (const? 8 1) { «nsw» := false, «nuw» := true }) (const? 8 0)) e)
       (const? 8 0) ⊑
-    LLVM.and (icmp IntPredicate.eq e (const? 8 0)) (LLVM.xor e_2 (const? 1 1)) := by
+    LLVM.and (icmp IntPred.eq e (const? 8 0)) (LLVM.xor e_2 (const? 1 1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gicmphpower2handhicmphshiftedhmask_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gicmphpower2handhicmphshiftedhmask_proof.lean
@@ -12,9 +12,9 @@ set_option Elab.async false
 
 section gicmphpower2handhicmphshiftedhmask_proof
 theorem icmp_power2_and_icmp_shifted_mask_2147483648_1610612736_thm (e : IntW 32) :
-  LLVM.and (icmp IntPredicate.ult e (const? 32 (-2147483648)))
-      (icmp IntPredicate.ne (LLVM.and e (const? 32 1610612736)) (const? 32 1610612736)) ⊑
-    icmp IntPredicate.ult e (const? 32 1610612736) := by
+  LLVM.and (icmp IntPred.ult e (const? 32 (-2147483648)))
+      (icmp IntPred.ne (LLVM.and e (const? 32 1610612736)) (const? 32 1610612736)) ⊑
+    icmp IntPred.ult e (const? 32 1610612736) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -24,9 +24,9 @@ theorem icmp_power2_and_icmp_shifted_mask_2147483648_1610612736_thm (e : IntW 32
 
 
 theorem icmp_power2_and_icmp_shifted_mask_swapped_2147483648_1610612736_thm (e : IntW 32) :
-  LLVM.and (icmp IntPredicate.ne (LLVM.and e (const? 32 1610612736)) (const? 32 1610612736))
-      (icmp IntPredicate.ult e (const? 32 (-2147483648))) ⊑
-    icmp IntPredicate.ult e (const? 32 1610612736) := by
+  LLVM.and (icmp IntPred.ne (LLVM.and e (const? 32 1610612736)) (const? 32 1610612736))
+      (icmp IntPred.ult e (const? 32 (-2147483648))) ⊑
+    icmp IntPred.ult e (const? 32 1610612736) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -36,9 +36,9 @@ theorem icmp_power2_and_icmp_shifted_mask_swapped_2147483648_1610612736_thm (e :
 
 
 theorem icmp_power2_and_icmp_shifted_mask_2147483648_2147483647_thm (e : IntW 32) :
-  LLVM.and (icmp IntPredicate.ult e (const? 32 (-2147483648)))
-      (icmp IntPredicate.ne (LLVM.and e (const? 32 2147483647)) (const? 32 2147483647)) ⊑
-    icmp IntPredicate.ult e (const? 32 2147483647) := by
+  LLVM.and (icmp IntPred.ult e (const? 32 (-2147483648)))
+      (icmp IntPred.ne (LLVM.and e (const? 32 2147483647)) (const? 32 2147483647)) ⊑
+    icmp IntPred.ult e (const? 32 2147483647) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -48,9 +48,9 @@ theorem icmp_power2_and_icmp_shifted_mask_2147483648_2147483647_thm (e : IntW 32
 
 
 theorem icmp_power2_and_icmp_shifted_mask_swapped_2147483648_2147483647_thm (e : IntW 32) :
-  LLVM.and (icmp IntPredicate.ne (LLVM.and e (const? 32 2147483647)) (const? 32 2147483647))
-      (icmp IntPredicate.ult e (const? 32 (-2147483648))) ⊑
-    icmp IntPredicate.ult e (const? 32 2147483647) := by
+  LLVM.and (icmp IntPred.ne (LLVM.and e (const? 32 2147483647)) (const? 32 2147483647))
+      (icmp IntPred.ult e (const? 32 (-2147483648))) ⊑
+    icmp IntPred.ult e (const? 32 2147483647) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -60,9 +60,9 @@ theorem icmp_power2_and_icmp_shifted_mask_swapped_2147483648_2147483647_thm (e :
 
 
 theorem icmp_power2_and_icmp_shifted_mask_2147483648_805306368_thm (e : IntW 32) :
-  LLVM.and (icmp IntPredicate.ult e (const? 32 1073741824))
-      (icmp IntPredicate.ne (LLVM.and e (const? 32 805306368)) (const? 32 805306368)) ⊑
-    icmp IntPredicate.ult e (const? 32 805306368) := by
+  LLVM.and (icmp IntPred.ult e (const? 32 1073741824))
+      (icmp IntPred.ne (LLVM.and e (const? 32 805306368)) (const? 32 805306368)) ⊑
+    icmp IntPred.ult e (const? 32 805306368) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -72,9 +72,9 @@ theorem icmp_power2_and_icmp_shifted_mask_2147483648_805306368_thm (e : IntW 32)
 
 
 theorem icmp_power2_and_icmp_shifted_mask_swapped_2147483648_805306368_thm (e : IntW 32) :
-  LLVM.and (icmp IntPredicate.ne (LLVM.and e (const? 32 805306368)) (const? 32 805306368))
-      (icmp IntPredicate.ult e (const? 32 1073741824)) ⊑
-    icmp IntPredicate.ult e (const? 32 805306368) := by
+  LLVM.and (icmp IntPred.ne (LLVM.and e (const? 32 805306368)) (const? 32 805306368))
+      (icmp IntPred.ult e (const? 32 1073741824)) ⊑
+    icmp IntPred.ult e (const? 32 805306368) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -84,9 +84,9 @@ theorem icmp_power2_and_icmp_shifted_mask_swapped_2147483648_805306368_thm (e : 
 
 
 theorem icmp_power2_and_icmp_shifted_mask_1073741824_1073741823_thm (e : IntW 32) :
-  LLVM.and (icmp IntPredicate.ult e (const? 32 1073741824))
-      (icmp IntPredicate.ne (LLVM.and e (const? 32 1073741823)) (const? 32 1073741823)) ⊑
-    icmp IntPredicate.ult e (const? 32 1073741823) := by
+  LLVM.and (icmp IntPred.ult e (const? 32 1073741824))
+      (icmp IntPred.ne (LLVM.and e (const? 32 1073741823)) (const? 32 1073741823)) ⊑
+    icmp IntPred.ult e (const? 32 1073741823) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -96,9 +96,9 @@ theorem icmp_power2_and_icmp_shifted_mask_1073741824_1073741823_thm (e : IntW 32
 
 
 theorem icmp_power2_and_icmp_shifted_mask_swapped_1073741824_1073741823_thm (e : IntW 32) :
-  LLVM.and (icmp IntPredicate.ne (LLVM.and e (const? 32 1073741823)) (const? 32 1073741823))
-      (icmp IntPredicate.ult e (const? 32 1073741824)) ⊑
-    icmp IntPredicate.ult e (const? 32 1073741823) := by
+  LLVM.and (icmp IntPred.ne (LLVM.and e (const? 32 1073741823)) (const? 32 1073741823))
+      (icmp IntPred.ult e (const? 32 1073741824)) ⊑
+    icmp IntPred.ult e (const? 32 1073741823) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -108,8 +108,8 @@ theorem icmp_power2_and_icmp_shifted_mask_swapped_1073741824_1073741823_thm (e :
 
 
 theorem icmp_power2_and_icmp_shifted_mask_8_7_thm (e : IntW 32) :
-  LLVM.and (icmp IntPredicate.ult e (const? 32 8)) (icmp IntPredicate.ne (LLVM.and e (const? 32 7)) (const? 32 7)) ⊑
-    icmp IntPredicate.ult e (const? 32 7) := by
+  LLVM.and (icmp IntPred.ult e (const? 32 8)) (icmp IntPred.ne (LLVM.and e (const? 32 7)) (const? 32 7)) ⊑
+    icmp IntPred.ult e (const? 32 7) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -119,8 +119,8 @@ theorem icmp_power2_and_icmp_shifted_mask_8_7_thm (e : IntW 32) :
 
 
 theorem icmp_power2_and_icmp_shifted_mask_swapped_8_7_thm (e : IntW 32) :
-  LLVM.and (icmp IntPredicate.ne (LLVM.and e (const? 32 7)) (const? 32 7)) (icmp IntPredicate.ult e (const? 32 8)) ⊑
-    icmp IntPredicate.ult e (const? 32 7) := by
+  LLVM.and (icmp IntPred.ne (LLVM.and e (const? 32 7)) (const? 32 7)) (icmp IntPred.ult e (const? 32 8)) ⊑
+    icmp IntPred.ult e (const? 32 7) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -130,8 +130,8 @@ theorem icmp_power2_and_icmp_shifted_mask_swapped_8_7_thm (e : IntW 32) :
 
 
 theorem icmp_power2_and_icmp_shifted_mask_8_6_thm (e : IntW 32) :
-  LLVM.and (icmp IntPredicate.ult e (const? 32 8)) (icmp IntPredicate.ne (LLVM.and e (const? 32 6)) (const? 32 6)) ⊑
-    icmp IntPredicate.ult e (const? 32 6) := by
+  LLVM.and (icmp IntPred.ult e (const? 32 8)) (icmp IntPred.ne (LLVM.and e (const? 32 6)) (const? 32 6)) ⊑
+    icmp IntPred.ult e (const? 32 6) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -141,8 +141,8 @@ theorem icmp_power2_and_icmp_shifted_mask_8_6_thm (e : IntW 32) :
 
 
 theorem icmp_power2_and_icmp_shifted_mask_swapped_8_6_thm (e : IntW 32) :
-  LLVM.and (icmp IntPredicate.ne (LLVM.and e (const? 32 6)) (const? 32 6)) (icmp IntPredicate.ult e (const? 32 8)) ⊑
-    icmp IntPredicate.ult e (const? 32 6) := by
+  LLVM.and (icmp IntPred.ne (LLVM.and e (const? 32 6)) (const? 32 6)) (icmp IntPred.ult e (const? 32 8)) ⊑
+    icmp IntPred.ult e (const? 32 6) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gicmphrange_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gicmphrange_proof.lean
@@ -12,7 +12,7 @@ set_option Elab.async false
 
 section gicmphrange_proof
 theorem ugt_zext_thm (e : IntW 8) (e_1 : IntW 1) :
-  icmp IntPredicate.ugt (zext 8 e_1) e ⊑ LLVM.and (icmp IntPredicate.eq e (const? 8 0)) e_1 := by
+  icmp IntPred.ugt (zext 8 e_1) e ⊑ LLVM.and (icmp IntPred.eq e (const? 8 0)) e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -22,7 +22,7 @@ theorem ugt_zext_thm (e : IntW 8) (e_1 : IntW 1) :
 
 
 theorem uge_zext_thm (e : IntW 8) (e_1 : IntW 1) :
-  icmp IntPredicate.uge (zext 8 e_1) e ⊑ icmp IntPredicate.ule e (zext 8 e_1) := by
+  icmp IntPred.uge (zext 8 e_1) e ⊑ icmp IntPred.ule e (zext 8 e_1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -32,7 +32,7 @@ theorem uge_zext_thm (e : IntW 8) (e_1 : IntW 1) :
 
 
 theorem sub_ult_zext_thm (e : IntW 1) (e_1 e_2 : IntW 8) :
-  icmp IntPredicate.ult (sub e_2 e_1) (zext 8 e) ⊑ LLVM.and (icmp IntPredicate.eq e_2 e_1) e := by
+  icmp IntPred.ult (sub e_2 e_1) (zext 8 e) ⊑ LLVM.and (icmp IntPred.eq e_2 e_1) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -42,8 +42,8 @@ theorem sub_ult_zext_thm (e : IntW 1) (e_1 e_2 : IntW 8) :
 
 
 theorem zext_ult_zext_thm (e : IntW 1) (e_1 : IntW 8) :
-  icmp IntPredicate.ult (zext 16 (mul e_1 e_1)) (zext 16 e) ⊑
-    LLVM.and (icmp IntPredicate.eq (mul e_1 e_1) (const? 8 0)) e := by
+  icmp IntPred.ult (zext 16 (mul e_1 e_1)) (zext 16 e) ⊑
+    LLVM.and (icmp IntPred.eq (mul e_1 e_1) (const? 8 0)) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -53,7 +53,7 @@ theorem zext_ult_zext_thm (e : IntW 1) (e_1 : IntW 8) :
 
 
 theorem uge_sext_thm (e : IntW 8) (e_1 : IntW 1) :
-  icmp IntPredicate.uge (sext 8 e_1) e ⊑ LLVM.or (icmp IntPredicate.eq e (const? 8 0)) e_1 := by
+  icmp IntPred.uge (sext 8 e_1) e ⊑ LLVM.or (icmp IntPred.eq e (const? 8 0)) e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -63,7 +63,7 @@ theorem uge_sext_thm (e : IntW 8) (e_1 : IntW 1) :
 
 
 theorem ugt_sext_thm (e : IntW 8) (e_1 : IntW 1) :
-  icmp IntPredicate.ugt (sext 8 e_1) e ⊑ icmp IntPredicate.ult e (sext 8 e_1) := by
+  icmp IntPred.ugt (sext 8 e_1) e ⊑ icmp IntPred.ult e (sext 8 e_1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -73,7 +73,7 @@ theorem ugt_sext_thm (e : IntW 8) (e_1 : IntW 1) :
 
 
 theorem sub_ule_sext_thm (e : IntW 1) (e_1 e_2 : IntW 8) :
-  icmp IntPredicate.ule (sub e_2 e_1) (sext 8 e) ⊑ LLVM.or (icmp IntPredicate.eq e_2 e_1) e := by
+  icmp IntPred.ule (sub e_2 e_1) (sext 8 e) ⊑ LLVM.or (icmp IntPred.eq e_2 e_1) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -83,8 +83,8 @@ theorem sub_ule_sext_thm (e : IntW 1) (e_1 e_2 : IntW 8) :
 
 
 theorem sext_ule_sext_thm (e : IntW 1) (e_1 : IntW 8) :
-  icmp IntPredicate.ule (sext 16 (mul e_1 e_1)) (sext 16 e) ⊑
-    LLVM.or (icmp IntPredicate.eq (mul e_1 e_1) (const? 8 0)) e := by
+  icmp IntPred.ule (sext 16 (mul e_1 e_1)) (sext 16 e) ⊑
+    LLVM.or (icmp IntPred.eq (mul e_1 e_1) (const? 8 0)) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -94,7 +94,7 @@ theorem sext_ule_sext_thm (e : IntW 1) (e_1 : IntW 8) :
 
 
 theorem zext_sext_add_icmp_slt_minus1_thm (e e_1 : IntW 1) :
-  icmp IntPredicate.slt (add (zext 8 e_1) (sext 8 e)) (const? 8 (-1)) ⊑ const? 1 0 := by
+  icmp IntPred.slt (add (zext 8 e_1) (sext 8 e)) (const? 8 (-1)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -104,7 +104,7 @@ theorem zext_sext_add_icmp_slt_minus1_thm (e e_1 : IntW 1) :
 
 
 theorem zext_sext_add_icmp_sgt_1_thm (e e_1 : IntW 1) :
-  icmp IntPredicate.sgt (add (zext 8 e_1) (sext 8 e)) (const? 8 1) ⊑ const? 1 0 := by
+  icmp IntPred.sgt (add (zext 8 e_1) (sext 8 e)) (const? 8 1) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -114,7 +114,7 @@ theorem zext_sext_add_icmp_sgt_1_thm (e e_1 : IntW 1) :
 
 
 theorem zext_sext_add_icmp_sgt_minus2_thm (e e_1 : IntW 1) :
-  icmp IntPredicate.sgt (add (zext 8 e_1) (sext 8 e)) (const? 8 (-2)) ⊑ const? 1 1 := by
+  icmp IntPred.sgt (add (zext 8 e_1) (sext 8 e)) (const? 8 (-2)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -124,7 +124,7 @@ theorem zext_sext_add_icmp_sgt_minus2_thm (e e_1 : IntW 1) :
 
 
 theorem zext_sext_add_icmp_slt_2_thm (e e_1 : IntW 1) :
-  icmp IntPredicate.slt (add (zext 8 e_1) (sext 8 e)) (const? 8 2) ⊑ const? 1 1 := by
+  icmp IntPred.slt (add (zext 8 e_1) (sext 8 e)) (const? 8 2) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -134,7 +134,7 @@ theorem zext_sext_add_icmp_slt_2_thm (e e_1 : IntW 1) :
 
 
 theorem zext_sext_add_icmp_i128_thm (e e_1 : IntW 1) :
-  icmp IntPredicate.sgt (add (zext 128 e_1) (sext 128 e)) (const? 128 9223372036854775808) ⊑ const? 1 0 := by
+  icmp IntPred.sgt (add (zext 128 e_1) (sext 128 e)) (const? 128 9223372036854775808) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -144,7 +144,7 @@ theorem zext_sext_add_icmp_i128_thm (e e_1 : IntW 1) :
 
 
 theorem zext_sext_add_icmp_eq_minus1_thm (e e_1 : IntW 1) :
-  icmp IntPredicate.eq (add (zext 8 e_1) (sext 8 e)) (const? 8 (-1)) ⊑ LLVM.and e (LLVM.xor e_1 (const? 1 1)) := by
+  icmp IntPred.eq (add (zext 8 e_1) (sext 8 e)) (const? 8 (-1)) ⊑ LLVM.and e (LLVM.xor e_1 (const? 1 1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -154,7 +154,7 @@ theorem zext_sext_add_icmp_eq_minus1_thm (e e_1 : IntW 1) :
 
 
 theorem zext_sext_add_icmp_ne_minus1_thm (e e_1 : IntW 1) :
-  icmp IntPredicate.ne (add (zext 8 e_1) (sext 8 e)) (const? 8 (-1)) ⊑ LLVM.or e_1 (LLVM.xor e (const? 1 1)) := by
+  icmp IntPred.ne (add (zext 8 e_1) (sext 8 e)) (const? 8 (-1)) ⊑ LLVM.or e_1 (LLVM.xor e (const? 1 1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -164,7 +164,7 @@ theorem zext_sext_add_icmp_ne_minus1_thm (e e_1 : IntW 1) :
 
 
 theorem zext_sext_add_icmp_sgt_minus1_thm (e e_1 : IntW 1) :
-  icmp IntPredicate.sgt (add (zext 8 e_1) (sext 8 e)) (const? 8 (-1)) ⊑ LLVM.or e_1 (LLVM.xor e (const? 1 1)) := by
+  icmp IntPred.sgt (add (zext 8 e_1) (sext 8 e)) (const? 8 (-1)) ⊑ LLVM.or e_1 (LLVM.xor e (const? 1 1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -174,7 +174,7 @@ theorem zext_sext_add_icmp_sgt_minus1_thm (e e_1 : IntW 1) :
 
 
 theorem zext_sext_add_icmp_ult_minus1_thm (e e_1 : IntW 1) :
-  icmp IntPredicate.ult (add (zext 8 e_1) (sext 8 e)) (const? 8 (-1)) ⊑ LLVM.or e_1 (LLVM.xor e (const? 1 1)) := by
+  icmp IntPred.ult (add (zext 8 e_1) (sext 8 e)) (const? 8 (-1)) ⊑ LLVM.or e_1 (LLVM.xor e (const? 1 1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -184,7 +184,7 @@ theorem zext_sext_add_icmp_ult_minus1_thm (e e_1 : IntW 1) :
 
 
 theorem zext_sext_add_icmp_sgt_0_thm (e e_1 : IntW 1) :
-  icmp IntPredicate.sgt (add (zext 8 e_1) (sext 8 e)) (const? 8 0) ⊑ LLVM.and e_1 (LLVM.xor e (const? 1 1)) := by
+  icmp IntPred.sgt (add (zext 8 e_1) (sext 8 e)) (const? 8 0) ⊑ LLVM.and e_1 (LLVM.xor e (const? 1 1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -194,7 +194,7 @@ theorem zext_sext_add_icmp_sgt_0_thm (e e_1 : IntW 1) :
 
 
 theorem zext_sext_add_icmp_slt_0_thm (e e_1 : IntW 1) :
-  icmp IntPredicate.slt (add (zext 8 e_1) (sext 8 e)) (const? 8 0) ⊑ LLVM.and e (LLVM.xor e_1 (const? 1 1)) := by
+  icmp IntPred.slt (add (zext 8 e_1) (sext 8 e)) (const? 8 0) ⊑ LLVM.and e (LLVM.xor e_1 (const? 1 1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -204,7 +204,7 @@ theorem zext_sext_add_icmp_slt_0_thm (e e_1 : IntW 1) :
 
 
 theorem zext_sext_add_icmp_eq_1_thm (e e_1 : IntW 1) :
-  icmp IntPredicate.eq (add (zext 8 e_1) (sext 8 e)) (const? 8 1) ⊑ LLVM.and e_1 (LLVM.xor e (const? 1 1)) := by
+  icmp IntPred.eq (add (zext 8 e_1) (sext 8 e)) (const? 8 1) ⊑ LLVM.and e_1 (LLVM.xor e (const? 1 1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -214,7 +214,7 @@ theorem zext_sext_add_icmp_eq_1_thm (e e_1 : IntW 1) :
 
 
 theorem zext_sext_add_icmp_ne_1_thm (e e_1 : IntW 1) :
-  icmp IntPredicate.ne (add (zext 8 e_1) (sext 8 e)) (const? 8 1) ⊑ LLVM.or e (LLVM.xor e_1 (const? 1 1)) := by
+  icmp IntPred.ne (add (zext 8 e_1) (sext 8 e)) (const? 8 1) ⊑ LLVM.or e (LLVM.xor e_1 (const? 1 1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -224,7 +224,7 @@ theorem zext_sext_add_icmp_ne_1_thm (e e_1 : IntW 1) :
 
 
 theorem zext_sext_add_icmp_slt_1_thm (e e_1 : IntW 1) :
-  icmp IntPredicate.slt (add (zext 8 e_1) (sext 8 e)) (const? 8 1) ⊑ LLVM.or e (LLVM.xor e_1 (const? 1 1)) := by
+  icmp IntPred.slt (add (zext 8 e_1) (sext 8 e)) (const? 8 1) ⊑ LLVM.or e (LLVM.xor e_1 (const? 1 1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -234,7 +234,7 @@ theorem zext_sext_add_icmp_slt_1_thm (e e_1 : IntW 1) :
 
 
 theorem zext_sext_add_icmp_ugt_1_thm (e e_1 : IntW 1) :
-  icmp IntPredicate.ugt (add (zext 8 e_1) (sext 8 e)) (const? 8 1) ⊑ LLVM.and e (LLVM.xor e_1 (const? 1 1)) := by
+  icmp IntPred.ugt (add (zext 8 e_1) (sext 8 e)) (const? 8 1) ⊑ LLVM.and e (LLVM.xor e_1 (const? 1 1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -244,8 +244,8 @@ theorem zext_sext_add_icmp_ugt_1_thm (e e_1 : IntW 1) :
 
 
 theorem zext_sext_add_icmp_slt_1_rhs_not_const_thm (e : IntW 8) (e_1 e_2 : IntW 1) :
-  icmp IntPredicate.slt (add (zext 8 e_2) (sext 8 e_1)) e ⊑
-    icmp IntPredicate.slt (add (zext 8 e_2) (sext 8 e_1) { «nsw» := true, «nuw» := false }) e := by
+  icmp IntPred.slt (add (zext 8 e_2) (sext 8 e_1)) e ⊑
+    icmp IntPred.slt (add (zext 8 e_2) (sext 8 e_1) { «nsw» := true, «nuw» := false }) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -255,8 +255,8 @@ theorem zext_sext_add_icmp_slt_1_rhs_not_const_thm (e : IntW 8) (e_1 e_2 : IntW 
 
 
 theorem zext_sext_add_icmp_slt_1_type_not_i1_thm (e : IntW 1) (e_1 : IntW 2) :
-  icmp IntPredicate.slt (add (zext 8 e_1) (sext 8 e)) (const? 8 1) ⊑
-    icmp IntPredicate.slt (add (zext 8 e_1) (sext 8 e) { «nsw» := true, «nuw» := false }) (const? 8 1) := by
+  icmp IntPred.slt (add (zext 8 e_1) (sext 8 e)) (const? 8 1) ⊑
+    icmp IntPred.slt (add (zext 8 e_1) (sext 8 e) { «nsw» := true, «nuw» := false }) (const? 8 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -266,7 +266,7 @@ theorem zext_sext_add_icmp_slt_1_type_not_i1_thm (e : IntW 1) (e_1 : IntW 2) :
 
 
 theorem icmp_ne_zext_eq_zero_thm (e : IntW 32) :
-  icmp IntPredicate.ne (zext 32 (icmp IntPredicate.eq e (const? 32 0))) e ⊑ const? 1 1 := by
+  icmp IntPred.ne (zext 32 (icmp IntPred.eq e (const? 32 0))) e ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -276,8 +276,8 @@ theorem icmp_ne_zext_eq_zero_thm (e : IntW 32) :
 
 
 theorem icmp_ne_zext_ne_zero_thm (e : IntW 32) :
-  icmp IntPredicate.ne (zext 32 (icmp IntPredicate.ne e (const? 32 0))) e ⊑
-    icmp IntPredicate.ugt e (const? 32 1) := by
+  icmp IntPred.ne (zext 32 (icmp IntPred.ne e (const? 32 0))) e ⊑
+    icmp IntPred.ugt e (const? 32 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -287,7 +287,7 @@ theorem icmp_ne_zext_ne_zero_thm (e : IntW 32) :
 
 
 theorem icmp_eq_zext_eq_zero_thm (e : IntW 32) :
-  icmp IntPredicate.eq (zext 32 (icmp IntPredicate.eq e (const? 32 0))) e ⊑ const? 1 0 := by
+  icmp IntPred.eq (zext 32 (icmp IntPred.eq e (const? 32 0))) e ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -297,8 +297,8 @@ theorem icmp_eq_zext_eq_zero_thm (e : IntW 32) :
 
 
 theorem icmp_eq_zext_ne_zero_thm (e : IntW 32) :
-  icmp IntPredicate.eq (zext 32 (icmp IntPredicate.ne e (const? 32 0))) e ⊑
-    icmp IntPredicate.ult e (const? 32 2) := by
+  icmp IntPred.eq (zext 32 (icmp IntPred.ne e (const? 32 0))) e ⊑
+    icmp IntPred.ult e (const? 32 2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -308,8 +308,8 @@ theorem icmp_eq_zext_ne_zero_thm (e : IntW 32) :
 
 
 theorem icmp_ne_zext_eq_one_thm (e : IntW 32) :
-  icmp IntPredicate.ne (zext 32 (icmp IntPredicate.eq e (const? 32 1))) e ⊑
-    icmp IntPredicate.ugt e (const? 32 1) := by
+  icmp IntPred.ne (zext 32 (icmp IntPred.eq e (const? 32 1))) e ⊑
+    icmp IntPred.ugt e (const? 32 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -319,7 +319,7 @@ theorem icmp_ne_zext_eq_one_thm (e : IntW 32) :
 
 
 theorem icmp_ne_zext_ne_one_thm (e : IntW 32) :
-  icmp IntPredicate.ne (zext 32 (icmp IntPredicate.ne e (const? 32 1))) e ⊑ const? 1 1 := by
+  icmp IntPred.ne (zext 32 (icmp IntPred.ne e (const? 32 1))) e ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -329,8 +329,8 @@ theorem icmp_ne_zext_ne_one_thm (e : IntW 32) :
 
 
 theorem icmp_eq_zext_eq_one_thm (e : IntW 32) :
-  icmp IntPredicate.eq (zext 32 (icmp IntPredicate.eq e (const? 32 1))) e ⊑
-    icmp IntPredicate.ult e (const? 32 2) := by
+  icmp IntPred.eq (zext 32 (icmp IntPred.eq e (const? 32 1))) e ⊑
+    icmp IntPred.ult e (const? 32 2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -340,7 +340,7 @@ theorem icmp_eq_zext_eq_one_thm (e : IntW 32) :
 
 
 theorem icmp_eq_zext_ne_one_thm (e : IntW 32) :
-  icmp IntPredicate.eq (zext 32 (icmp IntPredicate.ne e (const? 32 1))) e ⊑ const? 1 0 := by
+  icmp IntPred.eq (zext 32 (icmp IntPred.ne e (const? 32 1))) e ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -350,8 +350,8 @@ theorem icmp_eq_zext_ne_one_thm (e : IntW 32) :
 
 
 theorem icmp_ne_zext_eq_non_boolean_thm (e : IntW 32) :
-  icmp IntPredicate.ne (zext 32 (icmp IntPredicate.eq e (const? 32 2))) e ⊑
-    icmp IntPredicate.ne e (const? 32 0) := by
+  icmp IntPred.ne (zext 32 (icmp IntPred.eq e (const? 32 2))) e ⊑
+    icmp IntPred.ne e (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -361,8 +361,8 @@ theorem icmp_ne_zext_eq_non_boolean_thm (e : IntW 32) :
 
 
 theorem icmp_ne_zext_ne_non_boolean_thm (e : IntW 32) :
-  icmp IntPredicate.ne (zext 32 (icmp IntPredicate.ne e (const? 32 2))) e ⊑
-    icmp IntPredicate.ne e (const? 32 1) := by
+  icmp IntPred.ne (zext 32 (icmp IntPred.ne e (const? 32 2))) e ⊑
+    icmp IntPred.ne e (const? 32 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -372,8 +372,8 @@ theorem icmp_ne_zext_ne_non_boolean_thm (e : IntW 32) :
 
 
 theorem icmp_eq_zext_eq_non_boolean_thm (e : IntW 32) :
-  icmp IntPredicate.eq (zext 32 (icmp IntPredicate.eq e (const? 32 2))) e ⊑
-    icmp IntPredicate.eq e (const? 32 0) := by
+  icmp IntPred.eq (zext 32 (icmp IntPred.eq e (const? 32 2))) e ⊑
+    icmp IntPred.eq e (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -383,8 +383,8 @@ theorem icmp_eq_zext_eq_non_boolean_thm (e : IntW 32) :
 
 
 theorem icmp_eq_zext_ne_non_boolean_thm (e : IntW 32) :
-  icmp IntPredicate.eq (zext 32 (icmp IntPredicate.ne e (const? 32 2))) e ⊑
-    icmp IntPredicate.eq e (const? 32 1) := by
+  icmp IntPred.eq (zext 32 (icmp IntPred.ne e (const? 32 2))) e ⊑
+    icmp IntPred.eq e (const? 32 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -394,7 +394,7 @@ theorem icmp_eq_zext_ne_non_boolean_thm (e : IntW 32) :
 
 
 theorem icmp_ne_sext_eq_zero_thm (e : IntW 32) :
-  icmp IntPredicate.ne (sext 32 (icmp IntPredicate.eq e (const? 32 0))) e ⊑ const? 1 1 := by
+  icmp IntPred.ne (sext 32 (icmp IntPred.eq e (const? 32 0))) e ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -404,8 +404,8 @@ theorem icmp_ne_sext_eq_zero_thm (e : IntW 32) :
 
 
 theorem icmp_ne_sext_ne_zero_thm (e : IntW 32) :
-  icmp IntPredicate.ne (sext 32 (icmp IntPredicate.ne e (const? 32 0))) e ⊑
-    icmp IntPredicate.ult (add e (const? 32 (-1))) (const? 32 (-2)) := by
+  icmp IntPred.ne (sext 32 (icmp IntPred.ne e (const? 32 0))) e ⊑
+    icmp IntPred.ult (add e (const? 32 (-1))) (const? 32 (-2)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -415,7 +415,7 @@ theorem icmp_ne_sext_ne_zero_thm (e : IntW 32) :
 
 
 theorem icmp_eq_sext_eq_zero_thm (e : IntW 32) :
-  icmp IntPredicate.eq (sext 32 (icmp IntPredicate.eq e (const? 32 0))) e ⊑ const? 1 0 := by
+  icmp IntPred.eq (sext 32 (icmp IntPred.eq e (const? 32 0))) e ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -425,8 +425,8 @@ theorem icmp_eq_sext_eq_zero_thm (e : IntW 32) :
 
 
 theorem icmp_eq_sext_ne_zero_thm (e : IntW 32) :
-  icmp IntPredicate.eq (sext 32 (icmp IntPredicate.ne e (const? 32 0))) e ⊑
-    icmp IntPredicate.ult (add e (const? 32 1)) (const? 32 2) := by
+  icmp IntPred.eq (sext 32 (icmp IntPred.ne e (const? 32 0))) e ⊑
+    icmp IntPred.ult (add e (const? 32 1)) (const? 32 2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -436,8 +436,8 @@ theorem icmp_eq_sext_ne_zero_thm (e : IntW 32) :
 
 
 theorem icmp_ne_sext_eq_allones_thm (e : IntW 32) :
-  icmp IntPredicate.ne (sext 32 (icmp IntPredicate.eq e (const? 32 (-1)))) e ⊑
-    icmp IntPredicate.ult (add e (const? 32 (-1))) (const? 32 (-2)) := by
+  icmp IntPred.ne (sext 32 (icmp IntPred.eq e (const? 32 (-1)))) e ⊑
+    icmp IntPred.ult (add e (const? 32 (-1))) (const? 32 (-2)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -447,7 +447,7 @@ theorem icmp_ne_sext_eq_allones_thm (e : IntW 32) :
 
 
 theorem icmp_ne_sext_ne_allones_thm (e : IntW 32) :
-  icmp IntPredicate.ne (sext 32 (icmp IntPredicate.ne e (const? 32 (-1)))) e ⊑ const? 1 1 := by
+  icmp IntPred.ne (sext 32 (icmp IntPred.ne e (const? 32 (-1)))) e ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -457,8 +457,8 @@ theorem icmp_ne_sext_ne_allones_thm (e : IntW 32) :
 
 
 theorem icmp_eq_sext_eq_allones_thm (e : IntW 32) :
-  icmp IntPredicate.eq (sext 32 (icmp IntPredicate.eq e (const? 32 (-1)))) e ⊑
-    icmp IntPredicate.ult (add e (const? 32 1)) (const? 32 2) := by
+  icmp IntPred.eq (sext 32 (icmp IntPred.eq e (const? 32 (-1)))) e ⊑
+    icmp IntPred.ult (add e (const? 32 1)) (const? 32 2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -468,7 +468,7 @@ theorem icmp_eq_sext_eq_allones_thm (e : IntW 32) :
 
 
 theorem icmp_eq_sext_ne_allones_thm (e : IntW 32) :
-  icmp IntPredicate.eq (sext 32 (icmp IntPredicate.ne e (const? 32 (-1)))) e ⊑ const? 1 0 := by
+  icmp IntPred.eq (sext 32 (icmp IntPred.ne e (const? 32 (-1)))) e ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -478,8 +478,8 @@ theorem icmp_eq_sext_ne_allones_thm (e : IntW 32) :
 
 
 theorem icmp_ne_sext_eq_otherwise_thm (e : IntW 32) :
-  icmp IntPredicate.ne (sext 32 (icmp IntPredicate.eq e (const? 32 2))) e ⊑
-    icmp IntPredicate.ne e (const? 32 0) := by
+  icmp IntPred.ne (sext 32 (icmp IntPred.eq e (const? 32 2))) e ⊑
+    icmp IntPred.ne e (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -489,8 +489,8 @@ theorem icmp_ne_sext_eq_otherwise_thm (e : IntW 32) :
 
 
 theorem icmp_ne_sext_ne_otherwise_thm (e : IntW 32) :
-  icmp IntPredicate.ne (sext 32 (icmp IntPredicate.ne e (const? 32 2))) e ⊑
-    icmp IntPredicate.ne e (const? 32 (-1)) := by
+  icmp IntPred.ne (sext 32 (icmp IntPred.ne e (const? 32 2))) e ⊑
+    icmp IntPred.ne e (const? 32 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -500,8 +500,8 @@ theorem icmp_ne_sext_ne_otherwise_thm (e : IntW 32) :
 
 
 theorem icmp_eq_sext_eq_otherwise_thm (e : IntW 32) :
-  icmp IntPredicate.eq (sext 32 (icmp IntPredicate.eq e (const? 32 2))) e ⊑
-    icmp IntPredicate.eq e (const? 32 0) := by
+  icmp IntPred.eq (sext 32 (icmp IntPred.eq e (const? 32 2))) e ⊑
+    icmp IntPred.eq e (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -511,8 +511,8 @@ theorem icmp_eq_sext_eq_otherwise_thm (e : IntW 32) :
 
 
 theorem icmp_eq_sext_ne_otherwise_thm (e : IntW 32) :
-  icmp IntPredicate.eq (sext 32 (icmp IntPredicate.ne e (const? 32 2))) e ⊑
-    icmp IntPredicate.eq e (const? 32 (-1)) := by
+  icmp IntPred.eq (sext 32 (icmp IntPred.ne e (const? 32 2))) e ⊑
+    icmp IntPred.eq e (const? 32 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -522,8 +522,8 @@ theorem icmp_eq_sext_ne_otherwise_thm (e : IntW 32) :
 
 
 theorem icmp_ne_sext_ne_zero_i128_thm (e : IntW 128) :
-  icmp IntPredicate.ne (sext 128 (icmp IntPredicate.ne e (const? 128 0))) e ⊑
-    icmp IntPredicate.ult (add e (const? 128 (-1))) (const? 128 (-2)) := by
+  icmp IntPred.ne (sext 128 (icmp IntPred.ne e (const? 128 0))) e ⊑
+    icmp IntPred.ult (add e (const? 128 (-1))) (const? 128 (-2)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -533,8 +533,8 @@ theorem icmp_ne_sext_ne_zero_i128_thm (e : IntW 128) :
 
 
 theorem icmp_ne_sext_ne_otherwise_i128_thm (e : IntW 128) :
-  icmp IntPredicate.ne (sext 128 (icmp IntPredicate.ne e (const? 128 2))) e ⊑
-    icmp IntPredicate.ne e (const? 128 (-1)) := by
+  icmp IntPred.ne (sext 128 (icmp IntPred.ne e (const? 128 2))) e ⊑
+    icmp IntPred.ne e (const? 128 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -544,8 +544,8 @@ theorem icmp_ne_sext_ne_otherwise_i128_thm (e : IntW 128) :
 
 
 theorem icmp_ne_sext_sgt_zero_nofold_thm (e : IntW 32) :
-  icmp IntPredicate.ne (sext 32 (icmp IntPredicate.sgt e (const? 32 0))) e ⊑
-    icmp IntPredicate.ne e (sext 32 (icmp IntPredicate.sgt e (const? 32 0))) := by
+  icmp IntPred.ne (sext 32 (icmp IntPred.sgt e (const? 32 0))) e ⊑
+    icmp IntPred.ne e (sext 32 (icmp IntPred.sgt e (const? 32 0))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -555,8 +555,8 @@ theorem icmp_ne_sext_sgt_zero_nofold_thm (e : IntW 32) :
 
 
 theorem icmp_slt_sext_ne_zero_nofold_thm (e : IntW 32) :
-  icmp IntPredicate.slt (sext 32 (icmp IntPredicate.ne e (const? 32 0))) e ⊑
-    icmp IntPredicate.sgt e (sext 32 (icmp IntPredicate.ne e (const? 32 0))) := by
+  icmp IntPred.slt (sext 32 (icmp IntPred.ne e (const? 32 0))) e ⊑
+    icmp IntPred.sgt e (sext 32 (icmp IntPred.ne e (const? 32 0))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -566,8 +566,8 @@ theorem icmp_slt_sext_ne_zero_nofold_thm (e : IntW 32) :
 
 
 theorem icmp_ne_sext_slt_allones_nofold_thm (e : IntW 32) :
-  icmp IntPredicate.ne (sext 32 (icmp IntPredicate.slt e (const? 32 (-1)))) e ⊑
-    icmp IntPredicate.ne e (sext 32 (icmp IntPredicate.slt e (const? 32 (-1)))) := by
+  icmp IntPred.ne (sext 32 (icmp IntPred.slt e (const? 32 (-1)))) e ⊑
+    icmp IntPred.ne e (sext 32 (icmp IntPred.slt e (const? 32 (-1)))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -577,8 +577,8 @@ theorem icmp_ne_sext_slt_allones_nofold_thm (e : IntW 32) :
 
 
 theorem icmp_slt_sext_ne_allones_nofold_thm (e : IntW 32) :
-  icmp IntPredicate.slt (sext 32 (icmp IntPredicate.ne e (const? 32 (-1)))) e ⊑
-    icmp IntPredicate.sgt e (sext 32 (icmp IntPredicate.ne e (const? 32 (-1)))) := by
+  icmp IntPred.slt (sext 32 (icmp IntPred.ne e (const? 32 (-1)))) e ⊑
+    icmp IntPred.sgt e (sext 32 (icmp IntPred.ne e (const? 32 (-1)))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -588,8 +588,8 @@ theorem icmp_slt_sext_ne_allones_nofold_thm (e : IntW 32) :
 
 
 theorem icmp_ne_sext_slt_otherwise_nofold_thm (e : IntW 32) :
-  icmp IntPredicate.ne (sext 32 (icmp IntPredicate.slt e (const? 32 2))) e ⊑
-    icmp IntPredicate.ne e (sext 32 (icmp IntPredicate.slt e (const? 32 2))) := by
+  icmp IntPred.ne (sext 32 (icmp IntPred.slt e (const? 32 2))) e ⊑
+    icmp IntPred.ne e (sext 32 (icmp IntPred.slt e (const? 32 2))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -599,8 +599,8 @@ theorem icmp_ne_sext_slt_otherwise_nofold_thm (e : IntW 32) :
 
 
 theorem icmp_slt_sext_ne_otherwise_nofold_thm (e : IntW 32) :
-  icmp IntPredicate.slt (sext 32 (icmp IntPredicate.ne e (const? 32 2))) e ⊑
-    icmp IntPredicate.sgt e (sext 32 (icmp IntPredicate.ne e (const? 32 2))) := by
+  icmp IntPred.slt (sext 32 (icmp IntPred.ne e (const? 32 2))) e ⊑
+    icmp IntPred.sgt e (sext 32 (icmp IntPred.ne e (const? 32 2))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gicmphselect_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gicmphselect_proof.lean
@@ -12,8 +12,8 @@ set_option Elab.async false
 
 section gicmphselect_proof
 theorem icmp_select_const_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.eq (select (icmp IntPredicate.eq e_1 (const? 8 0)) (const? 8 0) e) (const? 8 0) ⊑
-    select (icmp IntPredicate.eq e_1 (const? 8 0)) (const? 1 1) (icmp IntPredicate.eq e (const? 8 0)) := by
+  icmp IntPred.eq (select (icmp IntPred.eq e_1 (const? 8 0)) (const? 8 0) e) (const? 8 0) ⊑
+    select (icmp IntPred.eq e_1 (const? 8 0)) (const? 1 1) (icmp IntPred.eq e (const? 8 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -23,8 +23,8 @@ theorem icmp_select_const_thm (e e_1 : IntW 8) :
 
 
 theorem icmp_select_var_thm (e e_1 e_2 : IntW 8) :
-  icmp IntPredicate.eq (select (icmp IntPredicate.eq e_2 (const? 8 0)) e_1 e) e_1 ⊑
-    select (icmp IntPredicate.eq e_2 (const? 8 0)) (const? 1 1) (icmp IntPredicate.eq e e_1) := by
+  icmp IntPred.eq (select (icmp IntPred.eq e_2 (const? 8 0)) e_1 e) e_1 ⊑
+    select (icmp IntPred.eq e_2 (const? 8 0)) (const? 1 1) (icmp IntPred.eq e e_1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -34,10 +34,10 @@ theorem icmp_select_var_thm (e e_1 e_2 : IntW 8) :
 
 
 theorem icmp_select_var_commuted_thm (e e_1 e_2 : IntW 8) :
-  icmp IntPredicate.eq (LLVM.udiv (const? 8 42) e_2)
-      (select (icmp IntPredicate.eq e_1 (const? 8 0)) (LLVM.udiv (const? 8 42) e_2) e) ⊑
-    select (icmp IntPredicate.eq e_1 (const? 8 0)) (const? 1 1)
-      (icmp IntPredicate.eq e (LLVM.udiv (const? 8 42) e_2)) := by
+  icmp IntPred.eq (LLVM.udiv (const? 8 42) e_2)
+      (select (icmp IntPred.eq e_1 (const? 8 0)) (LLVM.udiv (const? 8 42) e_2) e) ⊑
+    select (icmp IntPred.eq e_1 (const? 8 0)) (const? 1 1)
+      (icmp IntPred.eq e (LLVM.udiv (const? 8 42) e_2)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -47,9 +47,9 @@ theorem icmp_select_var_commuted_thm (e e_1 e_2 : IntW 8) :
 
 
 theorem icmp_select_var_select_thm (e e_1 : IntW 8) (e_2 : IntW 1) :
-  icmp IntPredicate.eq (select e_2 e_1 e) (select (icmp IntPredicate.eq e_1 (const? 8 0)) (select e_2 e_1 e) e) ⊑
-    select (select (icmp IntPredicate.eq e_1 (const? 8 0)) (const? 1 1) (LLVM.xor e_2 (const? 1 1))) (const? 1 1)
-      (icmp IntPredicate.eq e_1 e) := by
+  icmp IntPred.eq (select e_2 e_1 e) (select (icmp IntPred.eq e_1 (const? 8 0)) (select e_2 e_1 e) e) ⊑
+    select (select (icmp IntPred.eq e_1 (const? 8 0)) (const? 1 1) (LLVM.xor e_2 (const? 1 1))) (const? 1 1)
+      (icmp IntPred.eq e_1 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -59,9 +59,9 @@ theorem icmp_select_var_select_thm (e e_1 : IntW 8) (e_2 : IntW 1) :
 
 
 theorem icmp_select_var_both_fold_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.eq (select (icmp IntPredicate.eq e_1 (const? 8 0)) (LLVM.or e (const? 8 1)) (const? 8 2))
+  icmp IntPred.eq (select (icmp IntPred.eq e_1 (const? 8 0)) (LLVM.or e (const? 8 1)) (const? 8 2))
       (LLVM.or e (const? 8 1)) ⊑
-    icmp IntPredicate.eq e_1 (const? 8 0) := by
+    icmp IntPred.eq e_1 (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -71,8 +71,8 @@ theorem icmp_select_var_both_fold_thm (e e_1 : IntW 8) :
 
 
 theorem icmp_select_var_pred_ne_thm (e e_1 e_2 : IntW 8) :
-  icmp IntPredicate.ne (select (icmp IntPredicate.eq e_2 (const? 8 0)) e_1 e) e_1 ⊑
-    select (icmp IntPredicate.ne e_2 (const? 8 0)) (icmp IntPredicate.ne e e_1) (const? 1 0) := by
+  icmp IntPred.ne (select (icmp IntPred.eq e_2 (const? 8 0)) e_1 e) e_1 ⊑
+    select (icmp IntPred.ne e_2 (const? 8 0)) (icmp IntPred.ne e e_1) (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -82,10 +82,10 @@ theorem icmp_select_var_pred_ne_thm (e e_1 e_2 : IntW 8) :
 
 
 theorem icmp_select_var_pred_ult_thm (e e_1 e_2 : IntW 8) :
-  icmp IntPredicate.ult (select (icmp IntPredicate.eq e_2 (const? 8 0)) e_1 e)
+  icmp IntPred.ult (select (icmp IntPred.eq e_2 (const? 8 0)) e_1 e)
       (add e_1 (const? 8 2) { «nsw» := false, «nuw» := true }) ⊑
-    select (icmp IntPredicate.eq e_2 (const? 8 0)) (const? 1 1)
-      (icmp IntPredicate.ult e (add e_1 (const? 8 2) { «nsw» := false, «nuw» := true })) := by
+    select (icmp IntPred.eq e_2 (const? 8 0)) (const? 1 1)
+      (icmp IntPred.ult e (add e_1 (const? 8 2) { «nsw» := false, «nuw» := true })) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -95,10 +95,10 @@ theorem icmp_select_var_pred_ult_thm (e e_1 e_2 : IntW 8) :
 
 
 theorem icmp_select_var_pred_uge_thm (e e_1 e_2 : IntW 8) :
-  icmp IntPredicate.uge (select (icmp IntPredicate.eq e_2 (const? 8 0)) e_1 e)
+  icmp IntPred.uge (select (icmp IntPred.eq e_2 (const? 8 0)) e_1 e)
       (add e_1 (const? 8 2) { «nsw» := false, «nuw» := true }) ⊑
-    select (icmp IntPredicate.ne e_2 (const? 8 0))
-      (icmp IntPredicate.uge e (add e_1 (const? 8 2) { «nsw» := false, «nuw» := true })) (const? 1 0) := by
+    select (icmp IntPred.ne e_2 (const? 8 0))
+      (icmp IntPred.uge e (add e_1 (const? 8 2) { «nsw» := false, «nuw» := true })) (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -108,10 +108,10 @@ theorem icmp_select_var_pred_uge_thm (e e_1 e_2 : IntW 8) :
 
 
 theorem icmp_select_var_pred_uge_commuted_thm (e e_1 e_2 : IntW 8) :
-  icmp IntPredicate.uge (add e_2 (const? 8 2) { «nsw» := false, «nuw» := true })
-      (select (icmp IntPredicate.eq e_1 (const? 8 0)) e_2 e) ⊑
-    select (icmp IntPredicate.eq e_1 (const? 8 0)) (const? 1 1)
-      (icmp IntPredicate.ule e (add e_2 (const? 8 2) { «nsw» := false, «nuw» := true })) := by
+  icmp IntPred.uge (add e_2 (const? 8 2) { «nsw» := false, «nuw» := true })
+      (select (icmp IntPred.eq e_1 (const? 8 0)) e_2 e) ⊑
+    select (icmp IntPred.eq e_1 (const? 8 0)) (const? 1 1)
+      (icmp IntPred.ule e (add e_2 (const? 8 2) { «nsw» := false, «nuw» := true })) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -121,8 +121,8 @@ theorem icmp_select_var_pred_uge_commuted_thm (e e_1 e_2 : IntW 8) :
 
 
 theorem icmp_select_implied_cond_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.eq (select (icmp IntPredicate.eq e_1 (const? 8 0)) (const? 8 0) e) e_1 ⊑
-    select (icmp IntPredicate.eq e_1 (const? 8 0)) (const? 1 1) (icmp IntPredicate.eq e e_1) := by
+  icmp IntPred.eq (select (icmp IntPred.eq e_1 (const? 8 0)) (const? 8 0) e) e_1 ⊑
+    select (icmp IntPred.eq e_1 (const? 8 0)) (const? 1 1) (icmp IntPred.eq e e_1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -132,8 +132,8 @@ theorem icmp_select_implied_cond_thm (e e_1 : IntW 8) :
 
 
 theorem icmp_select_implied_cond_ne_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.ne (select (icmp IntPredicate.eq e_1 (const? 8 0)) (const? 8 0) e) e_1 ⊑
-    select (icmp IntPredicate.ne e_1 (const? 8 0)) (icmp IntPredicate.ne e e_1) (const? 1 0) := by
+  icmp IntPred.ne (select (icmp IntPred.eq e_1 (const? 8 0)) (const? 8 0) e) e_1 ⊑
+    select (icmp IntPred.ne e_1 (const? 8 0)) (icmp IntPred.ne e e_1) (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -143,8 +143,8 @@ theorem icmp_select_implied_cond_ne_thm (e e_1 : IntW 8) :
 
 
 theorem icmp_select_implied_cond_swapped_select_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.eq (select (icmp IntPredicate.eq e_1 (const? 8 0)) e (const? 8 0)) e_1 ⊑
-    select (icmp IntPredicate.eq e_1 (const? 8 0)) (icmp IntPredicate.eq e (const? 8 0)) (const? 1 0) := by
+  icmp IntPred.eq (select (icmp IntPred.eq e_1 (const? 8 0)) e (const? 8 0)) e_1 ⊑
+    select (icmp IntPred.eq e_1 (const? 8 0)) (icmp IntPred.eq e (const? 8 0)) (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -154,8 +154,8 @@ theorem icmp_select_implied_cond_swapped_select_thm (e e_1 : IntW 8) :
 
 
 theorem icmp_select_implied_cond_relational_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.ult (select (icmp IntPredicate.ugt e_1 (const? 8 10)) (const? 8 10) e) e_1 ⊑
-    select (icmp IntPredicate.ugt e_1 (const? 8 10)) (const? 1 1) (icmp IntPredicate.ult e e_1) := by
+  icmp IntPred.ult (select (icmp IntPred.ugt e_1 (const? 8 10)) (const? 8 10) e) e_1 ⊑
+    select (icmp IntPred.ugt e_1 (const? 8 10)) (const? 1 1) (icmp IntPred.ult e e_1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -165,7 +165,7 @@ theorem icmp_select_implied_cond_relational_thm (e e_1 : IntW 8) :
 
 
 theorem select_constants_and_icmp_eq0_thm (e e_1 : IntW 1) :
-  icmp IntPredicate.eq (LLVM.and (select e_1 (const? 8 2) (const? 8 1)) (select e (const? 8 2) (const? 8 1)))
+  icmp IntPred.eq (LLVM.and (select e_1 (const? 8 2) (const? 8 1)) (select e (const? 8 2) (const? 8 1)))
       (const? 8 0) ⊑
     LLVM.xor e_1 e := by
     simp_alive_undef
@@ -177,7 +177,7 @@ theorem select_constants_and_icmp_eq0_thm (e e_1 : IntW 1) :
 
 
 theorem select_constants_and_icmp_eq0_common_bit_thm (e e_1 : IntW 1) :
-  icmp IntPredicate.eq (LLVM.and (select e_1 (const? 8 2) (const? 8 3)) (select e (const? 8 2) (const? 8 3)))
+  icmp IntPred.eq (LLVM.and (select e_1 (const? 8 2) (const? 8 3)) (select e (const? 8 2) (const? 8 3)))
       (const? 8 0) ⊑
     const? 1 0 := by
     simp_alive_undef
@@ -189,7 +189,7 @@ theorem select_constants_and_icmp_eq0_common_bit_thm (e e_1 : IntW 1) :
 
 
 theorem select_constants_and_icmp_eq0_zero_tval_thm (e e_1 : IntW 1) :
-  icmp IntPredicate.eq (LLVM.and (select e_1 (const? 8 0) (const? 8 12)) (select e (const? 8 0) (const? 8 12)))
+  icmp IntPred.eq (LLVM.and (select e_1 (const? 8 0) (const? 8 12)) (select e (const? 8 0) (const? 8 12)))
       (const? 8 0) ⊑
     select e_1 (const? 1 1) e := by
     simp_alive_undef
@@ -201,7 +201,7 @@ theorem select_constants_and_icmp_eq0_zero_tval_thm (e e_1 : IntW 1) :
 
 
 theorem select_constants_and_icmp_eq0_zero_fval_thm (e e_1 : IntW 1) :
-  icmp IntPredicate.eq (LLVM.and (select e_1 (const? 8 12) (const? 8 0)) (select e (const? 8 12) (const? 8 0)))
+  icmp IntPred.eq (LLVM.and (select e_1 (const? 8 12) (const? 8 0)) (select e (const? 8 12) (const? 8 0)))
       (const? 8 0) ⊑
     LLVM.xor (select e_1 e (const? 1 0)) (const? 1 1) := by
     simp_alive_undef
@@ -213,7 +213,7 @@ theorem select_constants_and_icmp_eq0_zero_fval_thm (e e_1 : IntW 1) :
 
 
 theorem select_constants_and_icmp_ne0_thm (e e_1 : IntW 1) :
-  icmp IntPredicate.ne (LLVM.and (select e_1 (const? 8 2) (const? 8 1)) (select e (const? 8 2) (const? 8 1)))
+  icmp IntPred.ne (LLVM.and (select e_1 (const? 8 2) (const? 8 1)) (select e (const? 8 2) (const? 8 1)))
       (const? 8 0) ⊑
     LLVM.xor (LLVM.xor e_1 e) (const? 1 1) := by
     simp_alive_undef
@@ -225,7 +225,7 @@ theorem select_constants_and_icmp_ne0_thm (e e_1 : IntW 1) :
 
 
 theorem select_constants_and_icmp_ne0_common_bit_thm (e e_1 : IntW 1) :
-  icmp IntPredicate.ne (LLVM.and (select e_1 (const? 8 2) (const? 8 3)) (select e (const? 8 2) (const? 8 3)))
+  icmp IntPred.ne (LLVM.and (select e_1 (const? 8 2) (const? 8 3)) (select e (const? 8 2) (const? 8 3)))
       (const? 8 0) ⊑
     const? 1 1 := by
     simp_alive_undef
@@ -237,7 +237,7 @@ theorem select_constants_and_icmp_ne0_common_bit_thm (e e_1 : IntW 1) :
 
 
 theorem select_constants_and_icmp_ne0_zero_tval_thm (e e_1 : IntW 1) :
-  icmp IntPredicate.ne (LLVM.and (select e_1 (const? 8 0) (const? 8 12)) (select e (const? 8 0) (const? 8 12)))
+  icmp IntPred.ne (LLVM.and (select e_1 (const? 8 0) (const? 8 12)) (select e (const? 8 0) (const? 8 12)))
       (const? 8 0) ⊑
     LLVM.xor (select e_1 (const? 1 1) e) (const? 1 1) := by
     simp_alive_undef
@@ -249,7 +249,7 @@ theorem select_constants_and_icmp_ne0_zero_tval_thm (e e_1 : IntW 1) :
 
 
 theorem select_constants_and_icmp_ne0_zero_fval_thm (e e_1 : IntW 1) :
-  icmp IntPredicate.ne (LLVM.and (select e_1 (const? 8 12) (const? 8 0)) (select e (const? 8 12) (const? 8 0)))
+  icmp IntPred.ne (LLVM.and (select e_1 (const? 8 12) (const? 8 0)) (select e (const? 8 12) (const? 8 0)))
       (const? 8 0) ⊑
     select e_1 e (const? 1 0) := by
     simp_alive_undef
@@ -261,7 +261,7 @@ theorem select_constants_and_icmp_ne0_zero_fval_thm (e e_1 : IntW 1) :
 
 
 theorem icmp_eq_select_thm (e e_1 : IntW 32) (e_2 : IntW 1) :
-  icmp IntPredicate.eq (select e_2 e_1 e) (select e_2 e e_1) ⊑ icmp IntPredicate.eq e_1 e := by
+  icmp IntPred.eq (select e_2 e_1 e) (select e_2 e e_1) ⊑ icmp IntPred.eq e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gicmphselecthimplieshcommonhop_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gicmphselecthimplieshcommonhop_proof.lean
@@ -12,8 +12,8 @@ set_option Elab.async false
 
 section gicmphselecthimplieshcommonhop_proof
 theorem sgt_3_impliesF_eq_2_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.eq (select (icmp IntPredicate.sgt e_1 (const? 8 3)) (const? 8 2) e) e_1 ⊑
-    select (icmp IntPredicate.slt e_1 (const? 8 4)) (icmp IntPredicate.eq e e_1) (const? 1 0) := by
+  icmp IntPred.eq (select (icmp IntPred.sgt e_1 (const? 8 3)) (const? 8 2) e) e_1 ⊑
+    select (icmp IntPred.slt e_1 (const? 8 4)) (icmp IntPred.eq e e_1) (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -23,8 +23,8 @@ theorem sgt_3_impliesF_eq_2_thm (e e_1 : IntW 8) :
 
 
 theorem sgt_3_impliesT_sgt_2_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.sgt (select (icmp IntPredicate.sgt e_1 (const? 8 3)) (const? 8 2) e) e_1 ⊑
-    select (icmp IntPredicate.slt e_1 (const? 8 4)) (icmp IntPredicate.sgt e e_1) (const? 1 0) := by
+  icmp IntPred.sgt (select (icmp IntPred.sgt e_1 (const? 8 3)) (const? 8 2) e) e_1 ⊑
+    select (icmp IntPred.slt e_1 (const? 8 4)) (icmp IntPred.sgt e e_1) (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -34,8 +34,8 @@ theorem sgt_3_impliesT_sgt_2_thm (e e_1 : IntW 8) :
 
 
 theorem sgt_x_impliesF_eq_smin_todo_thm (e e_1 e_2 : IntW 8) :
-  icmp IntPredicate.eq (select (icmp IntPredicate.sgt e_2 e_1) (const? 8 (-128)) e) e_2 ⊑
-    select (icmp IntPredicate.sle e_2 e_1) (icmp IntPredicate.eq e e_2) (const? 1 0) := by
+  icmp IntPred.eq (select (icmp IntPred.sgt e_2 e_1) (const? 8 (-128)) e) e_2 ⊑
+    select (icmp IntPred.sle e_2 e_1) (icmp IntPred.eq e e_2) (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -45,8 +45,8 @@ theorem sgt_x_impliesF_eq_smin_todo_thm (e e_1 e_2 : IntW 8) :
 
 
 theorem slt_x_impliesT_ne_smin_todo_thm (e e_1 e_2 : IntW 8) :
-  icmp IntPredicate.ne e_2 (select (icmp IntPredicate.slt e_2 e_1) (const? 8 127) e) ⊑
-    select (icmp IntPredicate.slt e_2 e_1) (const? 1 1) (icmp IntPredicate.ne e e_2) := by
+  icmp IntPred.ne e_2 (select (icmp IntPred.slt e_2 e_1) (const? 8 127) e) ⊑
+    select (icmp IntPred.slt e_2 e_1) (const? 1 1) (icmp IntPred.ne e e_2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -56,8 +56,8 @@ theorem slt_x_impliesT_ne_smin_todo_thm (e e_1 e_2 : IntW 8) :
 
 
 theorem ult_x_impliesT_eq_umax_todo_thm (e e_1 e_2 : IntW 8) :
-  icmp IntPredicate.ne (select (icmp IntPredicate.ugt e_2 e_1) (const? 8 (-1)) e) e_1 ⊑
-    select (icmp IntPredicate.ugt e_2 e_1) (const? 1 1) (icmp IntPredicate.ne e e_1) := by
+  icmp IntPred.ne (select (icmp IntPred.ugt e_2 e_1) (const? 8 (-1)) e) e_1 ⊑
+    select (icmp IntPred.ugt e_2 e_1) (const? 1 1) (icmp IntPred.ne e e_1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -67,8 +67,8 @@ theorem ult_x_impliesT_eq_umax_todo_thm (e e_1 e_2 : IntW 8) :
 
 
 theorem ult_1_impliesF_eq_1_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.eq e_1 (select (icmp IntPredicate.ult e_1 (const? 8 1)) (const? 8 1) e) ⊑
-    select (icmp IntPredicate.ne e_1 (const? 8 0)) (icmp IntPredicate.eq e e_1) (const? 1 0) := by
+  icmp IntPred.eq e_1 (select (icmp IntPred.ult e_1 (const? 8 1)) (const? 8 1) e) ⊑
+    select (icmp IntPred.ne e_1 (const? 8 0)) (icmp IntPred.eq e e_1) (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gicmphshl_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gicmphshl_proof.lean
@@ -12,8 +12,8 @@ set_option Elab.async false
 
 section gicmphshl_proof
 theorem shl_nuw_eq_0_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.eq (shl e_1 e { «nsw» := false, «nuw» := true }) (const? 8 0) ⊑
-    icmp IntPredicate.eq e_1 (const? 8 0) := by
+  icmp IntPred.eq (shl e_1 e { «nsw» := false, «nuw» := true }) (const? 8 0) ⊑
+    icmp IntPred.eq e_1 (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -23,8 +23,8 @@ theorem shl_nuw_eq_0_thm (e e_1 : IntW 8) :
 
 
 theorem shl_nsw_slt_1_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.slt (shl e_1 e { «nsw» := true, «nuw» := false }) (const? 8 1) ⊑
-    icmp IntPredicate.slt e_1 (const? 8 1) := by
+  icmp IntPred.slt (shl e_1 e { «nsw» := true, «nuw» := false }) (const? 8 1) ⊑
+    icmp IntPred.slt e_1 (const? 8 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -34,8 +34,8 @@ theorem shl_nsw_slt_1_thm (e e_1 : IntW 8) :
 
 
 theorem shl_nsw_sgt_n1_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.sgt (shl e_1 e { «nsw» := true, «nuw» := false }) (const? 8 (-1)) ⊑
-    icmp IntPredicate.sgt e_1 (const? 8 (-1)) := by
+  icmp IntPred.sgt (shl e_1 e { «nsw» := true, «nuw» := false }) (const? 8 (-1)) ⊑
+    icmp IntPred.sgt e_1 (const? 8 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -45,8 +45,8 @@ theorem shl_nsw_sgt_n1_thm (e e_1 : IntW 8) :
 
 
 theorem shl_nsw_nuw_ult_Csle0_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.ult (shl e_1 e { «nsw» := true, «nuw» := true }) (const? 8 (-19)) ⊑
-    icmp IntPredicate.ult e_1 (const? 8 (-19)) := by
+  icmp IntPred.ult (shl e_1 e { «nsw» := true, «nuw» := true }) (const? 8 (-19)) ⊑
+    icmp IntPred.ult e_1 (const? 8 (-19)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -56,8 +56,8 @@ theorem shl_nsw_nuw_ult_Csle0_thm (e e_1 : IntW 8) :
 
 
 theorem shl_nsw_ule_Csle0_fail_missing_flag_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.ule (shl e_1 e { «nsw» := true, «nuw» := false }) (const? 8 (-19)) ⊑
-    icmp IntPredicate.ult (shl e_1 e { «nsw» := true, «nuw» := false }) (const? 8 (-18)) := by
+  icmp IntPred.ule (shl e_1 e { «nsw» := true, «nuw» := false }) (const? 8 (-19)) ⊑
+    icmp IntPred.ult (shl e_1 e { «nsw» := true, «nuw» := false }) (const? 8 (-18)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -67,8 +67,8 @@ theorem shl_nsw_ule_Csle0_fail_missing_flag_thm (e e_1 : IntW 8) :
 
 
 theorem shl_nsw_nuw_uge_Csle0_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.uge (shl e_1 e { «nsw» := true, «nuw» := true }) (const? 8 (-120)) ⊑
-    icmp IntPredicate.ugt e_1 (const? 8 (-121)) := by
+  icmp IntPred.uge (shl e_1 e { «nsw» := true, «nuw» := true }) (const? 8 (-120)) ⊑
+    icmp IntPred.ugt e_1 (const? 8 (-121)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gicmphshlh1hoverflow_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gicmphshlh1hoverflow_proof.lean
@@ -12,7 +12,7 @@ set_option Elab.async false
 
 section gicmphshlh1hoverflow_proof
 theorem icmp_shl_ugt_1_thm (e : IntW 8) :
-  icmp IntPredicate.ugt (shl e (const? 8 1)) e ⊑ icmp IntPredicate.sgt e (const? 8 0) := by
+  icmp IntPred.ugt (shl e (const? 8 1)) e ⊑ icmp IntPred.sgt e (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -22,8 +22,8 @@ theorem icmp_shl_ugt_1_thm (e : IntW 8) :
 
 
 theorem icmp_shl_uge_2_thm (e : IntW 5) :
-  icmp IntPredicate.uge (add (const? 5 10) e) (shl (add (const? 5 10) e) (const? 5 1)) ⊑
-    icmp IntPredicate.slt (add e (const? 5 10)) (const? 5 1) := by
+  icmp IntPred.uge (add (const? 5 10) e) (shl (add (const? 5 10) e) (const? 5 1)) ⊑
+    icmp IntPred.slt (add e (const? 5 10)) (const? 5 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -33,8 +33,8 @@ theorem icmp_shl_uge_2_thm (e : IntW 5) :
 
 
 theorem icmp_shl_ule_2_thm (e : IntW 8) :
-  icmp IntPredicate.ule (add (const? 8 42) e) (shl (add (const? 8 42) e) (const? 8 1)) ⊑
-    icmp IntPredicate.sgt (add e (const? 8 42)) (const? 8 (-1)) := by
+  icmp IntPred.ule (add (const? 8 42) e) (shl (add (const? 8 42) e) (const? 8 1)) ⊑
+    icmp IntPred.sgt (add e (const? 8 42)) (const? 8 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -44,7 +44,7 @@ theorem icmp_shl_ule_2_thm (e : IntW 8) :
 
 
 theorem icmp_shl_eq_1_thm (e : IntW 8) :
-  icmp IntPredicate.eq (shl e (const? 8 1)) e ⊑ icmp IntPredicate.eq e (const? 8 0) := by
+  icmp IntPred.eq (shl e (const? 8 1)) e ⊑ icmp IntPred.eq e (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -54,8 +54,8 @@ theorem icmp_shl_eq_1_thm (e : IntW 8) :
 
 
 theorem icmp_shl_ne_2_thm (e : IntW 8) :
-  icmp IntPredicate.ne (LLVM.sdiv (const? 8 42) e) (shl (LLVM.sdiv (const? 8 42) e) (const? 8 1)) ⊑
-    icmp IntPredicate.ne (LLVM.sdiv (const? 8 42) e) (const? 8 0) := by
+  icmp IntPred.ne (LLVM.sdiv (const? 8 42) e) (shl (LLVM.sdiv (const? 8 42) e) (const? 8 1)) ⊑
+    icmp IntPred.ne (LLVM.sdiv (const? 8 42) e) (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gicmphshlhnsw_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gicmphshlhnsw_proof.lean
@@ -12,8 +12,8 @@ set_option Elab.async false
 
 section gicmphshlhnsw_proof
 theorem icmp_shl_nsw_sgt_thm (e : IntW 32) :
-  icmp IntPredicate.sgt (shl e (const? 32 21) { «nsw» := true, «nuw» := false }) (const? 32 0) ⊑
-    icmp IntPredicate.sgt e (const? 32 0) := by
+  icmp IntPred.sgt (shl e (const? 32 21) { «nsw» := true, «nuw» := false }) (const? 32 0) ⊑
+    icmp IntPred.sgt e (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -23,8 +23,8 @@ theorem icmp_shl_nsw_sgt_thm (e : IntW 32) :
 
 
 theorem icmp_shl_nsw_sge0_thm (e : IntW 32) :
-  icmp IntPredicate.sge (shl e (const? 32 21) { «nsw» := true, «nuw» := false }) (const? 32 0) ⊑
-    icmp IntPredicate.sgt e (const? 32 (-1)) := by
+  icmp IntPred.sge (shl e (const? 32 21) { «nsw» := true, «nuw» := false }) (const? 32 0) ⊑
+    icmp IntPred.sgt e (const? 32 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -34,8 +34,8 @@ theorem icmp_shl_nsw_sge0_thm (e : IntW 32) :
 
 
 theorem icmp_shl_nsw_sge1_thm (e : IntW 32) :
-  icmp IntPredicate.sge (shl e (const? 32 21) { «nsw» := true, «nuw» := false }) (const? 32 1) ⊑
-    icmp IntPredicate.sgt e (const? 32 0) := by
+  icmp IntPred.sge (shl e (const? 32 21) { «nsw» := true, «nuw» := false }) (const? 32 1) ⊑
+    icmp IntPred.sgt e (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -45,8 +45,8 @@ theorem icmp_shl_nsw_sge1_thm (e : IntW 32) :
 
 
 theorem icmp_shl_nsw_eq_thm (e : IntW 32) :
-  icmp IntPredicate.eq (shl e (const? 32 5) { «nsw» := true, «nuw» := false }) (const? 32 0) ⊑
-    icmp IntPredicate.eq e (const? 32 0) := by
+  icmp IntPred.eq (shl e (const? 32 5) { «nsw» := true, «nuw» := false }) (const? 32 0) ⊑
+    icmp IntPred.eq e (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -56,8 +56,8 @@ theorem icmp_shl_nsw_eq_thm (e : IntW 32) :
 
 
 theorem icmp_sgt1_thm (e : IntW 8) :
-  icmp IntPredicate.sgt (shl e (const? 8 1) { «nsw» := true, «nuw» := false }) (const? 8 (-128)) ⊑
-    icmp IntPredicate.ne e (const? 8 (-64)) := by
+  icmp IntPred.sgt (shl e (const? 8 1) { «nsw» := true, «nuw» := false }) (const? 8 (-128)) ⊑
+    icmp IntPred.ne e (const? 8 (-64)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -67,8 +67,8 @@ theorem icmp_sgt1_thm (e : IntW 8) :
 
 
 theorem icmp_sgt2_thm (e : IntW 8) :
-  icmp IntPredicate.sgt (shl e (const? 8 1) { «nsw» := true, «nuw» := false }) (const? 8 (-127)) ⊑
-    icmp IntPredicate.sgt e (const? 8 (-64)) := by
+  icmp IntPred.sgt (shl e (const? 8 1) { «nsw» := true, «nuw» := false }) (const? 8 (-127)) ⊑
+    icmp IntPred.sgt e (const? 8 (-64)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -78,8 +78,8 @@ theorem icmp_sgt2_thm (e : IntW 8) :
 
 
 theorem icmp_sgt3_thm (e : IntW 8) :
-  icmp IntPredicate.sgt (shl e (const? 8 1) { «nsw» := true, «nuw» := false }) (const? 8 (-16)) ⊑
-    icmp IntPredicate.sgt e (const? 8 (-8)) := by
+  icmp IntPred.sgt (shl e (const? 8 1) { «nsw» := true, «nuw» := false }) (const? 8 (-16)) ⊑
+    icmp IntPred.sgt e (const? 8 (-8)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -89,8 +89,8 @@ theorem icmp_sgt3_thm (e : IntW 8) :
 
 
 theorem icmp_sgt4_thm (e : IntW 8) :
-  icmp IntPredicate.sgt (shl e (const? 8 1) { «nsw» := true, «nuw» := false }) (const? 8 (-2)) ⊑
-    icmp IntPredicate.sgt e (const? 8 (-1)) := by
+  icmp IntPred.sgt (shl e (const? 8 1) { «nsw» := true, «nuw» := false }) (const? 8 (-2)) ⊑
+    icmp IntPred.sgt e (const? 8 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -100,8 +100,8 @@ theorem icmp_sgt4_thm (e : IntW 8) :
 
 
 theorem icmp_sgt5_thm (e : IntW 8) :
-  icmp IntPredicate.sgt (shl e (const? 8 1) { «nsw» := true, «nuw» := false }) (const? 8 1) ⊑
-    icmp IntPredicate.sgt e (const? 8 0) := by
+  icmp IntPred.sgt (shl e (const? 8 1) { «nsw» := true, «nuw» := false }) (const? 8 1) ⊑
+    icmp IntPred.sgt e (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -111,8 +111,8 @@ theorem icmp_sgt5_thm (e : IntW 8) :
 
 
 theorem icmp_sgt6_thm (e : IntW 8) :
-  icmp IntPredicate.sgt (shl e (const? 8 1) { «nsw» := true, «nuw» := false }) (const? 8 16) ⊑
-    icmp IntPredicate.sgt e (const? 8 8) := by
+  icmp IntPred.sgt (shl e (const? 8 1) { «nsw» := true, «nuw» := false }) (const? 8 16) ⊑
+    icmp IntPred.sgt e (const? 8 8) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -122,8 +122,8 @@ theorem icmp_sgt6_thm (e : IntW 8) :
 
 
 theorem icmp_sgt7_thm (e : IntW 8) :
-  icmp IntPredicate.sgt (shl e (const? 8 1) { «nsw» := true, «nuw» := false }) (const? 8 124) ⊑
-    icmp IntPredicate.sgt e (const? 8 62) := by
+  icmp IntPred.sgt (shl e (const? 8 1) { «nsw» := true, «nuw» := false }) (const? 8 124) ⊑
+    icmp IntPred.sgt e (const? 8 62) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -133,8 +133,8 @@ theorem icmp_sgt7_thm (e : IntW 8) :
 
 
 theorem icmp_sgt8_thm (e : IntW 8) :
-  icmp IntPredicate.sgt (shl e (const? 8 1) { «nsw» := true, «nuw» := false }) (const? 8 125) ⊑
-    icmp IntPredicate.eq e (const? 8 63) := by
+  icmp IntPred.sgt (shl e (const? 8 1) { «nsw» := true, «nuw» := false }) (const? 8 125) ⊑
+    icmp IntPred.eq e (const? 8 63) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -144,8 +144,8 @@ theorem icmp_sgt8_thm (e : IntW 8) :
 
 
 theorem icmp_sgt9_thm (e : IntW 8) :
-  icmp IntPredicate.sgt (shl e (const? 8 7) { «nsw» := true, «nuw» := false }) (const? 8 (-128)) ⊑
-    icmp IntPredicate.eq e (const? 8 0) := by
+  icmp IntPred.sgt (shl e (const? 8 7) { «nsw» := true, «nuw» := false }) (const? 8 (-128)) ⊑
+    icmp IntPred.eq e (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -155,8 +155,8 @@ theorem icmp_sgt9_thm (e : IntW 8) :
 
 
 theorem icmp_sgt10_thm (e : IntW 8) :
-  icmp IntPredicate.sgt (shl e (const? 8 7) { «nsw» := true, «nuw» := false }) (const? 8 (-127)) ⊑
-    icmp IntPredicate.sgt e (const? 8 (-1)) := by
+  icmp IntPred.sgt (shl e (const? 8 7) { «nsw» := true, «nuw» := false }) (const? 8 (-127)) ⊑
+    icmp IntPred.sgt e (const? 8 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -166,8 +166,8 @@ theorem icmp_sgt10_thm (e : IntW 8) :
 
 
 theorem icmp_sgt11_thm (e : IntW 8) :
-  icmp IntPredicate.sgt (shl e (const? 8 7) { «nsw» := true, «nuw» := false }) (const? 8 (-2)) ⊑
-    icmp IntPredicate.sgt e (const? 8 (-1)) := by
+  icmp IntPred.sgt (shl e (const? 8 7) { «nsw» := true, «nuw» := false }) (const? 8 (-2)) ⊑
+    icmp IntPred.sgt e (const? 8 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -177,8 +177,8 @@ theorem icmp_sgt11_thm (e : IntW 8) :
 
 
 theorem icmp_sle1_thm (e : IntW 8) :
-  icmp IntPredicate.sle (shl e (const? 8 1) { «nsw» := true, «nuw» := false }) (const? 8 (-128)) ⊑
-    icmp IntPredicate.eq e (const? 8 (-64)) := by
+  icmp IntPred.sle (shl e (const? 8 1) { «nsw» := true, «nuw» := false }) (const? 8 (-128)) ⊑
+    icmp IntPred.eq e (const? 8 (-64)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -188,8 +188,8 @@ theorem icmp_sle1_thm (e : IntW 8) :
 
 
 theorem icmp_sle2_thm (e : IntW 8) :
-  icmp IntPredicate.sle (shl e (const? 8 1) { «nsw» := true, «nuw» := false }) (const? 8 (-127)) ⊑
-    icmp IntPredicate.slt e (const? 8 (-63)) := by
+  icmp IntPred.sle (shl e (const? 8 1) { «nsw» := true, «nuw» := false }) (const? 8 (-127)) ⊑
+    icmp IntPred.slt e (const? 8 (-63)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -199,8 +199,8 @@ theorem icmp_sle2_thm (e : IntW 8) :
 
 
 theorem icmp_sle3_thm (e : IntW 8) :
-  icmp IntPredicate.sle (shl e (const? 8 1) { «nsw» := true, «nuw» := false }) (const? 8 (-16)) ⊑
-    icmp IntPredicate.slt e (const? 8 (-7)) := by
+  icmp IntPred.sle (shl e (const? 8 1) { «nsw» := true, «nuw» := false }) (const? 8 (-16)) ⊑
+    icmp IntPred.slt e (const? 8 (-7)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -210,8 +210,8 @@ theorem icmp_sle3_thm (e : IntW 8) :
 
 
 theorem icmp_sle4_thm (e : IntW 8) :
-  icmp IntPredicate.sle (shl e (const? 8 1) { «nsw» := true, «nuw» := false }) (const? 8 (-2)) ⊑
-    icmp IntPredicate.slt e (const? 8 0) := by
+  icmp IntPred.sle (shl e (const? 8 1) { «nsw» := true, «nuw» := false }) (const? 8 (-2)) ⊑
+    icmp IntPred.slt e (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -221,8 +221,8 @@ theorem icmp_sle4_thm (e : IntW 8) :
 
 
 theorem icmp_sle5_thm (e : IntW 8) :
-  icmp IntPredicate.sle (shl e (const? 8 1) { «nsw» := true, «nuw» := false }) (const? 8 1) ⊑
-    icmp IntPredicate.slt e (const? 8 1) := by
+  icmp IntPred.sle (shl e (const? 8 1) { «nsw» := true, «nuw» := false }) (const? 8 1) ⊑
+    icmp IntPred.slt e (const? 8 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -232,8 +232,8 @@ theorem icmp_sle5_thm (e : IntW 8) :
 
 
 theorem icmp_sle6_thm (e : IntW 8) :
-  icmp IntPredicate.sle (shl e (const? 8 1) { «nsw» := true, «nuw» := false }) (const? 8 16) ⊑
-    icmp IntPredicate.slt e (const? 8 9) := by
+  icmp IntPred.sle (shl e (const? 8 1) { «nsw» := true, «nuw» := false }) (const? 8 16) ⊑
+    icmp IntPred.slt e (const? 8 9) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -243,8 +243,8 @@ theorem icmp_sle6_thm (e : IntW 8) :
 
 
 theorem icmp_sle7_thm (e : IntW 8) :
-  icmp IntPredicate.sle (shl e (const? 8 1) { «nsw» := true, «nuw» := false }) (const? 8 124) ⊑
-    icmp IntPredicate.slt e (const? 8 63) := by
+  icmp IntPred.sle (shl e (const? 8 1) { «nsw» := true, «nuw» := false }) (const? 8 124) ⊑
+    icmp IntPred.slt e (const? 8 63) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -254,8 +254,8 @@ theorem icmp_sle7_thm (e : IntW 8) :
 
 
 theorem icmp_sle8_thm (e : IntW 8) :
-  icmp IntPredicate.sle (shl e (const? 8 1) { «nsw» := true, «nuw» := false }) (const? 8 125) ⊑
-    icmp IntPredicate.ne e (const? 8 63) := by
+  icmp IntPred.sle (shl e (const? 8 1) { «nsw» := true, «nuw» := false }) (const? 8 125) ⊑
+    icmp IntPred.ne e (const? 8 63) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -265,8 +265,8 @@ theorem icmp_sle8_thm (e : IntW 8) :
 
 
 theorem icmp_sle9_thm (e : IntW 8) :
-  icmp IntPredicate.sle (shl e (const? 8 7) { «nsw» := true, «nuw» := false }) (const? 8 (-128)) ⊑
-    icmp IntPredicate.ne e (const? 8 0) := by
+  icmp IntPred.sle (shl e (const? 8 7) { «nsw» := true, «nuw» := false }) (const? 8 (-128)) ⊑
+    icmp IntPred.ne e (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -276,8 +276,8 @@ theorem icmp_sle9_thm (e : IntW 8) :
 
 
 theorem icmp_sle10_thm (e : IntW 8) :
-  icmp IntPredicate.sle (shl e (const? 8 7) { «nsw» := true, «nuw» := false }) (const? 8 (-127)) ⊑
-    icmp IntPredicate.slt e (const? 8 0) := by
+  icmp IntPred.sle (shl e (const? 8 7) { «nsw» := true, «nuw» := false }) (const? 8 (-127)) ⊑
+    icmp IntPred.slt e (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -287,8 +287,8 @@ theorem icmp_sle10_thm (e : IntW 8) :
 
 
 theorem icmp_sle11_thm (e : IntW 8) :
-  icmp IntPredicate.sle (shl e (const? 8 7) { «nsw» := true, «nuw» := false }) (const? 8 (-2)) ⊑
-    icmp IntPredicate.slt e (const? 8 0) := by
+  icmp IntPred.sle (shl e (const? 8 7) { «nsw» := true, «nuw» := false }) (const? 8 (-2)) ⊑
+    icmp IntPred.slt e (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -298,8 +298,8 @@ theorem icmp_sle11_thm (e : IntW 8) :
 
 
 theorem icmp_eq1_thm (e : IntW 8) :
-  icmp IntPredicate.eq (shl e (const? 8 1) { «nsw» := true, «nuw» := false }) (const? 8 12) ⊑
-    icmp IntPredicate.eq e (const? 8 6) := by
+  icmp IntPred.eq (shl e (const? 8 1) { «nsw» := true, «nuw» := false }) (const? 8 12) ⊑
+    icmp IntPred.eq e (const? 8 6) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -309,8 +309,8 @@ theorem icmp_eq1_thm (e : IntW 8) :
 
 
 theorem icmp_ne1_thm (e : IntW 8) :
-  icmp IntPredicate.ne (shl e (const? 8 6) { «nsw» := true, «nuw» := false }) (const? 8 (-128)) ⊑
-    icmp IntPredicate.ne e (const? 8 (-2)) := by
+  icmp IntPred.ne (shl e (const? 8 6) { «nsw» := true, «nuw» := false }) (const? 8 (-128)) ⊑
+    icmp IntPred.ne e (const? 8 (-2)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gicmphshlhnuw_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gicmphshlhnuw_proof.lean
@@ -12,8 +12,8 @@ set_option Elab.async false
 
 section gicmphshlhnuw_proof
 theorem icmp_ugt_32_thm (e : IntW 64) :
-  icmp IntPredicate.ugt (shl e (const? 64 32) { «nsw» := false, «nuw» := true }) (const? 64 4294967295) ⊑
-    icmp IntPredicate.ne e (const? 64 0) := by
+  icmp IntPred.ugt (shl e (const? 64 32) { «nsw» := false, «nuw» := true }) (const? 64 4294967295) ⊑
+    icmp IntPred.ne e (const? 64 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -23,8 +23,8 @@ theorem icmp_ugt_32_thm (e : IntW 64) :
 
 
 theorem icmp_ule_64_thm (e : IntW 128) :
-  icmp IntPredicate.ule (shl e (const? 128 64) { «nsw» := false, «nuw» := true }) (const? 128 18446744073709551615) ⊑
-    icmp IntPredicate.eq e (const? 128 0) := by
+  icmp IntPred.ule (shl e (const? 128 64) { «nsw» := false, «nuw» := true }) (const? 128 18446744073709551615) ⊑
+    icmp IntPred.eq e (const? 128 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -34,8 +34,8 @@ theorem icmp_ule_64_thm (e : IntW 128) :
 
 
 theorem icmp_ugt_16_thm (e : IntW 64) :
-  icmp IntPredicate.ugt (shl e (const? 64 16) { «nsw» := false, «nuw» := true }) (const? 64 1048575) ⊑
-    icmp IntPredicate.ugt e (const? 64 15) := by
+  icmp IntPred.ugt (shl e (const? 64 16) { «nsw» := false, «nuw» := true }) (const? 64 1048575) ⊑
+    icmp IntPred.ugt e (const? 64 15) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -45,8 +45,8 @@ theorem icmp_ugt_16_thm (e : IntW 64) :
 
 
 theorem icmp_ult_8_thm (e : IntW 64) :
-  icmp IntPredicate.ult (shl e (const? 64 8) { «nsw» := false, «nuw» := true }) (const? 64 4095) ⊑
-    icmp IntPredicate.ult e (const? 64 16) := by
+  icmp IntPred.ult (shl e (const? 64 8) { «nsw» := false, «nuw» := true }) (const? 64 4095) ⊑
+    icmp IntPred.ult e (const? 64 16) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -56,10 +56,10 @@ theorem icmp_ult_8_thm (e : IntW 64) :
 
 
 theorem fold_icmp_shl_nuw_c1_thm (e : IntW 32) :
-  icmp IntPredicate.ult
+  icmp IntPred.ult
       (shl (const? 32 2) (LLVM.and (lshr e (const? 32 12)) (const? 32 15)) { «nsw» := false, «nuw» := true })
       (const? 32 4) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 32 61440)) (const? 32 0) := by
+    icmp IntPred.eq (LLVM.and e (const? 32 61440)) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -69,8 +69,8 @@ theorem fold_icmp_shl_nuw_c1_thm (e : IntW 32) :
 
 
 theorem fold_icmp_shl_nuw_c2_thm (e : IntW 32) :
-  icmp IntPredicate.ult (shl (const? 32 16) e { «nsw» := false, «nuw» := true }) (const? 32 64) ⊑
-    icmp IntPredicate.ult e (const? 32 2) := by
+  icmp IntPred.ult (shl (const? 32 16) e { «nsw» := false, «nuw» := true }) (const? 32 64) ⊑
+    icmp IntPred.ult e (const? 32 2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -80,8 +80,8 @@ theorem fold_icmp_shl_nuw_c2_thm (e : IntW 32) :
 
 
 theorem fold_icmp_shl_nuw_c2_non_pow2_thm (e : IntW 32) :
-  icmp IntPredicate.ult (shl (const? 32 48) e { «nsw» := false, «nuw» := true }) (const? 32 192) ⊑
-    icmp IntPredicate.ult e (const? 32 2) := by
+  icmp IntPred.ult (shl (const? 32 48) e { «nsw» := false, «nuw» := true }) (const? 32 192) ⊑
+    icmp IntPred.ult e (const? 32 2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -91,8 +91,8 @@ theorem fold_icmp_shl_nuw_c2_non_pow2_thm (e : IntW 32) :
 
 
 theorem fold_icmp_shl_nuw_c2_div_non_pow2_thm (e : IntW 32) :
-  icmp IntPredicate.ult (shl (const? 32 2) e { «nsw» := false, «nuw» := true }) (const? 32 60) ⊑
-    icmp IntPredicate.ult e (const? 32 5) := by
+  icmp IntPred.ult (shl (const? 32 2) e { «nsw» := false, «nuw» := true }) (const? 32 60) ⊑
+    icmp IntPred.ult e (const? 32 5) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -102,8 +102,8 @@ theorem fold_icmp_shl_nuw_c2_div_non_pow2_thm (e : IntW 32) :
 
 
 theorem fold_icmp_shl_nuw_c3_thm (e : IntW 32) :
-  icmp IntPredicate.uge (shl (const? 32 48) e { «nsw» := false, «nuw» := true }) (const? 32 144) ⊑
-    icmp IntPredicate.ugt e (const? 32 1) := by
+  icmp IntPred.uge (shl (const? 32 48) e { «nsw» := false, «nuw» := true }) (const? 32 144) ⊑
+    icmp IntPred.ugt e (const? 32 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -113,8 +113,8 @@ theorem fold_icmp_shl_nuw_c3_thm (e : IntW 32) :
 
 
 theorem fold_icmp_shl_nuw_c2_indivisible_thm (e : IntW 32) :
-  icmp IntPredicate.ult (shl (const? 32 16) e { «nsw» := false, «nuw» := true }) (const? 32 63) ⊑
-    icmp IntPredicate.ult e (const? 32 2) := by
+  icmp IntPred.ult (shl (const? 32 16) e { «nsw» := false, «nuw» := true }) (const? 32 63) ⊑
+    icmp IntPred.ult e (const? 32 2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -124,7 +124,7 @@ theorem fold_icmp_shl_nuw_c2_indivisible_thm (e : IntW 32) :
 
 
 theorem fold_icmp_shl_nuw_c2_precondition1_thm (e : IntW 32) :
-  icmp IntPredicate.ult (shl (const? 32 0) e { «nsw» := false, «nuw» := true }) (const? 32 63) ⊑ const? 1 1 := by
+  icmp IntPred.ult (shl (const? 32 0) e { «nsw» := false, «nuw» := true }) (const? 32 63) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -134,7 +134,7 @@ theorem fold_icmp_shl_nuw_c2_precondition1_thm (e : IntW 32) :
 
 
 theorem fold_icmp_shl_nuw_c2_precondition2_thm (e : IntW 32) :
-  icmp IntPredicate.ult (shl (const? 32 127) e { «nsw» := false, «nuw» := true }) (const? 32 63) ⊑ const? 1 0 := by
+  icmp IntPred.ult (shl (const? 32 127) e { «nsw» := false, «nuw» := true }) (const? 32 63) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -144,7 +144,7 @@ theorem fold_icmp_shl_nuw_c2_precondition2_thm (e : IntW 32) :
 
 
 theorem fold_icmp_shl_nuw_c2_precondition3_thm (e : IntW 32) :
-  icmp IntPredicate.ult (shl (const? 32 1) e { «nsw» := false, «nuw» := true }) (const? 32 1) ⊑ const? 1 0 := by
+  icmp IntPred.ult (shl (const? 32 1) e { «nsw» := false, «nuw» := true }) (const? 32 1) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gicmphshr_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gicmphshr_proof.lean
@@ -12,7 +12,7 @@ set_option Elab.async false
 
 section gicmphshr_proof
 theorem lshr_eq_msb_low_last_zero_thm (e : IntW 8) :
-  icmp IntPredicate.eq (lshr (const? 8 127) e) (const? 8 0) ⊑ icmp IntPredicate.ugt e (const? 8 6) := by
+  icmp IntPred.eq (lshr (const? 8 127) e) (const? 8 0) ⊑ icmp IntPred.ugt e (const? 8 6) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -22,7 +22,7 @@ theorem lshr_eq_msb_low_last_zero_thm (e : IntW 8) :
 
 
 theorem ashr_eq_msb_low_second_zero_thm (e : IntW 8) :
-  icmp IntPredicate.eq (ashr (const? 8 127) e) (const? 8 0) ⊑ icmp IntPredicate.ugt e (const? 8 6) := by
+  icmp IntPred.eq (ashr (const? 8 127) e) (const? 8 0) ⊑ icmp IntPred.ugt e (const? 8 6) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -32,7 +32,7 @@ theorem ashr_eq_msb_low_second_zero_thm (e : IntW 8) :
 
 
 theorem lshr_ne_msb_low_last_zero_thm (e : IntW 8) :
-  icmp IntPredicate.ne (lshr (const? 8 127) e) (const? 8 0) ⊑ icmp IntPredicate.ult e (const? 8 7) := by
+  icmp IntPred.ne (lshr (const? 8 127) e) (const? 8 0) ⊑ icmp IntPred.ult e (const? 8 7) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -42,7 +42,7 @@ theorem lshr_ne_msb_low_last_zero_thm (e : IntW 8) :
 
 
 theorem ashr_ne_msb_low_second_zero_thm (e : IntW 8) :
-  icmp IntPredicate.ne (ashr (const? 8 127) e) (const? 8 0) ⊑ icmp IntPredicate.ult e (const? 8 7) := by
+  icmp IntPred.ne (ashr (const? 8 127) e) (const? 8 0) ⊑ icmp IntPred.ult e (const? 8 7) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -52,7 +52,7 @@ theorem ashr_ne_msb_low_second_zero_thm (e : IntW 8) :
 
 
 theorem ashr_eq_both_equal_thm (e : IntW 8) :
-  icmp IntPredicate.eq (ashr (const? 8 (-128)) e) (const? 8 (-128)) ⊑ icmp IntPredicate.eq e (const? 8 0) := by
+  icmp IntPred.eq (ashr (const? 8 (-128)) e) (const? 8 (-128)) ⊑ icmp IntPred.eq e (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -62,7 +62,7 @@ theorem ashr_eq_both_equal_thm (e : IntW 8) :
 
 
 theorem ashr_ne_both_equal_thm (e : IntW 8) :
-  icmp IntPredicate.ne (ashr (const? 8 (-128)) e) (const? 8 (-128)) ⊑ icmp IntPredicate.ne e (const? 8 0) := by
+  icmp IntPred.ne (ashr (const? 8 (-128)) e) (const? 8 (-128)) ⊑ icmp IntPred.ne e (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -72,7 +72,7 @@ theorem ashr_ne_both_equal_thm (e : IntW 8) :
 
 
 theorem lshr_eq_both_equal_thm (e : IntW 8) :
-  icmp IntPredicate.eq (lshr (const? 8 127) e) (const? 8 127) ⊑ icmp IntPredicate.eq e (const? 8 0) := by
+  icmp IntPred.eq (lshr (const? 8 127) e) (const? 8 127) ⊑ icmp IntPred.eq e (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -82,7 +82,7 @@ theorem lshr_eq_both_equal_thm (e : IntW 8) :
 
 
 theorem lshr_ne_both_equal_thm (e : IntW 8) :
-  icmp IntPredicate.ne (lshr (const? 8 127) e) (const? 8 127) ⊑ icmp IntPredicate.ne e (const? 8 0) := by
+  icmp IntPred.ne (lshr (const? 8 127) e) (const? 8 127) ⊑ icmp IntPred.ne e (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -92,8 +92,8 @@ theorem lshr_ne_both_equal_thm (e : IntW 8) :
 
 
 theorem exact_ashr_eq_both_equal_thm (e : IntW 8) :
-  icmp IntPredicate.eq (ashr (const? 8 (-128)) e { «exact» := true }) (const? 8 (-128)) ⊑
-    icmp IntPredicate.eq e (const? 8 0) := by
+  icmp IntPred.eq (ashr (const? 8 (-128)) e { «exact» := true }) (const? 8 (-128)) ⊑
+    icmp IntPred.eq e (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -103,8 +103,8 @@ theorem exact_ashr_eq_both_equal_thm (e : IntW 8) :
 
 
 theorem exact_ashr_ne_both_equal_thm (e : IntW 8) :
-  icmp IntPredicate.ne (ashr (const? 8 (-128)) e { «exact» := true }) (const? 8 (-128)) ⊑
-    icmp IntPredicate.ne e (const? 8 0) := by
+  icmp IntPred.ne (ashr (const? 8 (-128)) e { «exact» := true }) (const? 8 (-128)) ⊑
+    icmp IntPred.ne e (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -114,8 +114,8 @@ theorem exact_ashr_ne_both_equal_thm (e : IntW 8) :
 
 
 theorem exact_lshr_eq_both_equal_thm (e : IntW 8) :
-  icmp IntPredicate.eq (lshr (const? 8 126) e { «exact» := true }) (const? 8 126) ⊑
-    icmp IntPredicate.eq e (const? 8 0) := by
+  icmp IntPred.eq (lshr (const? 8 126) e { «exact» := true }) (const? 8 126) ⊑
+    icmp IntPred.eq e (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -125,8 +125,8 @@ theorem exact_lshr_eq_both_equal_thm (e : IntW 8) :
 
 
 theorem exact_lshr_ne_both_equal_thm (e : IntW 8) :
-  icmp IntPredicate.ne (lshr (const? 8 126) e { «exact» := true }) (const? 8 126) ⊑
-    icmp IntPredicate.ne e (const? 8 0) := by
+  icmp IntPred.ne (lshr (const? 8 126) e { «exact» := true }) (const? 8 126) ⊑
+    icmp IntPred.ne e (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -136,8 +136,8 @@ theorem exact_lshr_ne_both_equal_thm (e : IntW 8) :
 
 
 theorem exact_lshr_eq_opposite_msb_thm (e : IntW 8) :
-  icmp IntPredicate.eq (lshr (const? 8 (-128)) e { «exact» := true }) (const? 8 1) ⊑
-    icmp IntPredicate.eq e (const? 8 7) := by
+  icmp IntPred.eq (lshr (const? 8 (-128)) e { «exact» := true }) (const? 8 1) ⊑
+    icmp IntPred.eq e (const? 8 7) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -147,7 +147,7 @@ theorem exact_lshr_eq_opposite_msb_thm (e : IntW 8) :
 
 
 theorem lshr_eq_opposite_msb_thm (e : IntW 8) :
-  icmp IntPredicate.eq (lshr (const? 8 (-128)) e) (const? 8 1) ⊑ icmp IntPredicate.eq e (const? 8 7) := by
+  icmp IntPred.eq (lshr (const? 8 (-128)) e) (const? 8 1) ⊑ icmp IntPred.eq e (const? 8 7) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -157,8 +157,8 @@ theorem lshr_eq_opposite_msb_thm (e : IntW 8) :
 
 
 theorem exact_lshr_ne_opposite_msb_thm (e : IntW 8) :
-  icmp IntPredicate.ne (lshr (const? 8 (-128)) e { «exact» := true }) (const? 8 1) ⊑
-    icmp IntPredicate.ne e (const? 8 7) := by
+  icmp IntPred.ne (lshr (const? 8 (-128)) e { «exact» := true }) (const? 8 1) ⊑
+    icmp IntPred.ne e (const? 8 7) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -168,7 +168,7 @@ theorem exact_lshr_ne_opposite_msb_thm (e : IntW 8) :
 
 
 theorem lshr_ne_opposite_msb_thm (e : IntW 8) :
-  icmp IntPredicate.ne (lshr (const? 8 (-128)) e) (const? 8 1) ⊑ icmp IntPredicate.ne e (const? 8 7) := by
+  icmp IntPred.ne (lshr (const? 8 (-128)) e) (const? 8 1) ⊑ icmp IntPred.ne e (const? 8 7) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -178,8 +178,8 @@ theorem lshr_ne_opposite_msb_thm (e : IntW 8) :
 
 
 theorem exact_ashr_eq_thm (e : IntW 8) :
-  icmp IntPredicate.eq (ashr (const? 8 (-128)) e { «exact» := true }) (const? 8 (-1)) ⊑
-    icmp IntPredicate.eq e (const? 8 7) := by
+  icmp IntPred.eq (ashr (const? 8 (-128)) e { «exact» := true }) (const? 8 (-1)) ⊑
+    icmp IntPred.eq e (const? 8 7) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -189,8 +189,8 @@ theorem exact_ashr_eq_thm (e : IntW 8) :
 
 
 theorem exact_ashr_ne_thm (e : IntW 8) :
-  icmp IntPredicate.ne (ashr (const? 8 (-128)) e { «exact» := true }) (const? 8 (-1)) ⊑
-    icmp IntPredicate.ne e (const? 8 7) := by
+  icmp IntPred.ne (ashr (const? 8 (-128)) e { «exact» := true }) (const? 8 (-1)) ⊑
+    icmp IntPred.ne e (const? 8 7) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -200,8 +200,8 @@ theorem exact_ashr_ne_thm (e : IntW 8) :
 
 
 theorem exact_lshr_eq_thm (e : IntW 8) :
-  icmp IntPredicate.eq (lshr (const? 8 4) e { «exact» := true }) (const? 8 1) ⊑
-    icmp IntPredicate.eq e (const? 8 2) := by
+  icmp IntPred.eq (lshr (const? 8 4) e { «exact» := true }) (const? 8 1) ⊑
+    icmp IntPred.eq e (const? 8 2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -211,8 +211,8 @@ theorem exact_lshr_eq_thm (e : IntW 8) :
 
 
 theorem exact_lshr_ne_thm (e : IntW 8) :
-  icmp IntPredicate.ne (lshr (const? 8 4) e { «exact» := true }) (const? 8 1) ⊑
-    icmp IntPredicate.ne e (const? 8 2) := by
+  icmp IntPred.ne (lshr (const? 8 4) e { «exact» := true }) (const? 8 1) ⊑
+    icmp IntPred.ne e (const? 8 2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -222,7 +222,7 @@ theorem exact_lshr_ne_thm (e : IntW 8) :
 
 
 theorem nonexact_ashr_eq_thm (e : IntW 8) :
-  icmp IntPredicate.eq (ashr (const? 8 (-128)) e) (const? 8 (-1)) ⊑ icmp IntPredicate.eq e (const? 8 7) := by
+  icmp IntPred.eq (ashr (const? 8 (-128)) e) (const? 8 (-1)) ⊑ icmp IntPred.eq e (const? 8 7) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -232,7 +232,7 @@ theorem nonexact_ashr_eq_thm (e : IntW 8) :
 
 
 theorem nonexact_ashr_ne_thm (e : IntW 8) :
-  icmp IntPredicate.ne (ashr (const? 8 (-128)) e) (const? 8 (-1)) ⊑ icmp IntPredicate.ne e (const? 8 7) := by
+  icmp IntPred.ne (ashr (const? 8 (-128)) e) (const? 8 (-1)) ⊑ icmp IntPred.ne e (const? 8 7) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -242,7 +242,7 @@ theorem nonexact_ashr_ne_thm (e : IntW 8) :
 
 
 theorem nonexact_lshr_eq_thm (e : IntW 8) :
-  icmp IntPredicate.eq (lshr (const? 8 4) e) (const? 8 1) ⊑ icmp IntPredicate.eq e (const? 8 2) := by
+  icmp IntPred.eq (lshr (const? 8 4) e) (const? 8 1) ⊑ icmp IntPred.eq e (const? 8 2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -252,7 +252,7 @@ theorem nonexact_lshr_eq_thm (e : IntW 8) :
 
 
 theorem nonexact_lshr_ne_thm (e : IntW 8) :
-  icmp IntPredicate.ne (lshr (const? 8 4) e) (const? 8 1) ⊑ icmp IntPredicate.ne e (const? 8 2) := by
+  icmp IntPred.ne (lshr (const? 8 4) e) (const? 8 1) ⊑ icmp IntPred.ne e (const? 8 2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -262,8 +262,8 @@ theorem nonexact_lshr_ne_thm (e : IntW 8) :
 
 
 theorem exact_lshr_eq_exactdiv_thm (e : IntW 8) :
-  icmp IntPredicate.eq (lshr (const? 8 80) e { «exact» := true }) (const? 8 5) ⊑
-    icmp IntPredicate.eq e (const? 8 4) := by
+  icmp IntPred.eq (lshr (const? 8 80) e { «exact» := true }) (const? 8 5) ⊑
+    icmp IntPred.eq e (const? 8 4) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -273,8 +273,8 @@ theorem exact_lshr_eq_exactdiv_thm (e : IntW 8) :
 
 
 theorem exact_lshr_ne_exactdiv_thm (e : IntW 8) :
-  icmp IntPredicate.ne (lshr (const? 8 80) e { «exact» := true }) (const? 8 5) ⊑
-    icmp IntPredicate.ne e (const? 8 4) := by
+  icmp IntPred.ne (lshr (const? 8 80) e { «exact» := true }) (const? 8 5) ⊑
+    icmp IntPred.ne e (const? 8 4) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -284,7 +284,7 @@ theorem exact_lshr_ne_exactdiv_thm (e : IntW 8) :
 
 
 theorem nonexact_lshr_eq_exactdiv_thm (e : IntW 8) :
-  icmp IntPredicate.eq (lshr (const? 8 80) e) (const? 8 5) ⊑ icmp IntPredicate.eq e (const? 8 4) := by
+  icmp IntPred.eq (lshr (const? 8 80) e) (const? 8 5) ⊑ icmp IntPred.eq e (const? 8 4) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -294,7 +294,7 @@ theorem nonexact_lshr_eq_exactdiv_thm (e : IntW 8) :
 
 
 theorem nonexact_lshr_ne_exactdiv_thm (e : IntW 8) :
-  icmp IntPredicate.ne (lshr (const? 8 80) e) (const? 8 5) ⊑ icmp IntPredicate.ne e (const? 8 4) := by
+  icmp IntPred.ne (lshr (const? 8 80) e) (const? 8 5) ⊑ icmp IntPred.ne e (const? 8 4) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -304,8 +304,8 @@ theorem nonexact_lshr_ne_exactdiv_thm (e : IntW 8) :
 
 
 theorem exact_ashr_eq_exactdiv_thm (e : IntW 8) :
-  icmp IntPredicate.eq (ashr (const? 8 (-80)) e { «exact» := true }) (const? 8 (-5)) ⊑
-    icmp IntPredicate.eq e (const? 8 4) := by
+  icmp IntPred.eq (ashr (const? 8 (-80)) e { «exact» := true }) (const? 8 (-5)) ⊑
+    icmp IntPred.eq e (const? 8 4) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -315,8 +315,8 @@ theorem exact_ashr_eq_exactdiv_thm (e : IntW 8) :
 
 
 theorem exact_ashr_ne_exactdiv_thm (e : IntW 8) :
-  icmp IntPredicate.ne (ashr (const? 8 (-80)) e { «exact» := true }) (const? 8 (-5)) ⊑
-    icmp IntPredicate.ne e (const? 8 4) := by
+  icmp IntPred.ne (ashr (const? 8 (-80)) e { «exact» := true }) (const? 8 (-5)) ⊑
+    icmp IntPred.ne e (const? 8 4) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -326,7 +326,7 @@ theorem exact_ashr_ne_exactdiv_thm (e : IntW 8) :
 
 
 theorem nonexact_ashr_eq_exactdiv_thm (e : IntW 8) :
-  icmp IntPredicate.eq (ashr (const? 8 (-80)) e) (const? 8 (-5)) ⊑ icmp IntPredicate.eq e (const? 8 4) := by
+  icmp IntPred.eq (ashr (const? 8 (-80)) e) (const? 8 (-5)) ⊑ icmp IntPred.eq e (const? 8 4) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -336,7 +336,7 @@ theorem nonexact_ashr_eq_exactdiv_thm (e : IntW 8) :
 
 
 theorem nonexact_ashr_ne_exactdiv_thm (e : IntW 8) :
-  icmp IntPredicate.ne (ashr (const? 8 (-80)) e) (const? 8 (-5)) ⊑ icmp IntPredicate.ne e (const? 8 4) := by
+  icmp IntPred.ne (ashr (const? 8 (-80)) e) (const? 8 (-5)) ⊑ icmp IntPred.ne e (const? 8 4) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -346,7 +346,7 @@ theorem nonexact_ashr_ne_exactdiv_thm (e : IntW 8) :
 
 
 theorem exact_lshr_eq_noexactdiv_thm (e : IntW 8) :
-  icmp IntPredicate.eq (lshr (const? 8 80) e { «exact» := true }) (const? 8 31) ⊑ const? 1 0 := by
+  icmp IntPred.eq (lshr (const? 8 80) e { «exact» := true }) (const? 8 31) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -356,7 +356,7 @@ theorem exact_lshr_eq_noexactdiv_thm (e : IntW 8) :
 
 
 theorem exact_lshr_ne_noexactdiv_thm (e : IntW 8) :
-  icmp IntPredicate.ne (lshr (const? 8 80) e { «exact» := true }) (const? 8 31) ⊑ const? 1 1 := by
+  icmp IntPred.ne (lshr (const? 8 80) e { «exact» := true }) (const? 8 31) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -365,7 +365,7 @@ theorem exact_lshr_ne_noexactdiv_thm (e : IntW 8) :
     all_goals sorry
 
 
-theorem nonexact_lshr_eq_noexactdiv_thm (e : IntW 8) : icmp IntPredicate.eq (lshr (const? 8 80) e) (const? 8 31) ⊑ const? 1 0 := by
+theorem nonexact_lshr_eq_noexactdiv_thm (e : IntW 8) : icmp IntPred.eq (lshr (const? 8 80) e) (const? 8 31) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -374,7 +374,7 @@ theorem nonexact_lshr_eq_noexactdiv_thm (e : IntW 8) : icmp IntPredicate.eq (lsh
     all_goals sorry
 
 
-theorem nonexact_lshr_ne_noexactdiv_thm (e : IntW 8) : icmp IntPredicate.ne (lshr (const? 8 80) e) (const? 8 31) ⊑ const? 1 1 := by
+theorem nonexact_lshr_ne_noexactdiv_thm (e : IntW 8) : icmp IntPred.ne (lshr (const? 8 80) e) (const? 8 31) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -384,7 +384,7 @@ theorem nonexact_lshr_ne_noexactdiv_thm (e : IntW 8) : icmp IntPredicate.ne (lsh
 
 
 theorem exact_ashr_eq_noexactdiv_thm (e : IntW 8) :
-  icmp IntPredicate.eq (ashr (const? 8 (-80)) e { «exact» := true }) (const? 8 (-31)) ⊑ const? 1 0 := by
+  icmp IntPred.eq (ashr (const? 8 (-80)) e { «exact» := true }) (const? 8 (-31)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -394,7 +394,7 @@ theorem exact_ashr_eq_noexactdiv_thm (e : IntW 8) :
 
 
 theorem exact_ashr_ne_noexactdiv_thm (e : IntW 8) :
-  icmp IntPredicate.ne (ashr (const? 8 (-80)) e { «exact» := true }) (const? 8 (-31)) ⊑ const? 1 1 := by
+  icmp IntPred.ne (ashr (const? 8 (-80)) e { «exact» := true }) (const? 8 (-31)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -403,7 +403,7 @@ theorem exact_ashr_ne_noexactdiv_thm (e : IntW 8) :
     all_goals sorry
 
 
-theorem nonexact_ashr_eq_noexactdiv_thm (e : IntW 8) : icmp IntPredicate.eq (ashr (const? 8 (-80)) e) (const? 8 (-31)) ⊑ const? 1 0 := by
+theorem nonexact_ashr_eq_noexactdiv_thm (e : IntW 8) : icmp IntPred.eq (ashr (const? 8 (-80)) e) (const? 8 (-31)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -412,7 +412,7 @@ theorem nonexact_ashr_eq_noexactdiv_thm (e : IntW 8) : icmp IntPredicate.eq (ash
     all_goals sorry
 
 
-theorem nonexact_ashr_ne_noexactdiv_thm (e : IntW 8) : icmp IntPredicate.ne (ashr (const? 8 (-80)) e) (const? 8 (-31)) ⊑ const? 1 1 := by
+theorem nonexact_ashr_ne_noexactdiv_thm (e : IntW 8) : icmp IntPred.ne (ashr (const? 8 (-80)) e) (const? 8 (-31)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -421,7 +421,7 @@ theorem nonexact_ashr_ne_noexactdiv_thm (e : IntW 8) : icmp IntPredicate.ne (ash
     all_goals sorry
 
 
-theorem nonexact_lshr_eq_noexactlog_thm (e : IntW 8) : icmp IntPredicate.eq (lshr (const? 8 90) e) (const? 8 30) ⊑ const? 1 0 := by
+theorem nonexact_lshr_eq_noexactlog_thm (e : IntW 8) : icmp IntPred.eq (lshr (const? 8 90) e) (const? 8 30) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -430,7 +430,7 @@ theorem nonexact_lshr_eq_noexactlog_thm (e : IntW 8) : icmp IntPredicate.eq (lsh
     all_goals sorry
 
 
-theorem nonexact_lshr_ne_noexactlog_thm (e : IntW 8) : icmp IntPredicate.ne (lshr (const? 8 90) e) (const? 8 30) ⊑ const? 1 1 := by
+theorem nonexact_lshr_ne_noexactlog_thm (e : IntW 8) : icmp IntPred.ne (lshr (const? 8 90) e) (const? 8 30) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -439,7 +439,7 @@ theorem nonexact_lshr_ne_noexactlog_thm (e : IntW 8) : icmp IntPredicate.ne (lsh
     all_goals sorry
 
 
-theorem nonexact_ashr_eq_noexactlog_thm (e : IntW 8) : icmp IntPredicate.eq (ashr (const? 8 (-90)) e) (const? 8 (-30)) ⊑ const? 1 0 := by
+theorem nonexact_ashr_eq_noexactlog_thm (e : IntW 8) : icmp IntPred.eq (ashr (const? 8 (-90)) e) (const? 8 (-30)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -448,7 +448,7 @@ theorem nonexact_ashr_eq_noexactlog_thm (e : IntW 8) : icmp IntPredicate.eq (ash
     all_goals sorry
 
 
-theorem nonexact_ashr_ne_noexactlog_thm (e : IntW 8) : icmp IntPredicate.ne (ashr (const? 8 (-90)) e) (const? 8 (-30)) ⊑ const? 1 1 := by
+theorem nonexact_ashr_ne_noexactlog_thm (e : IntW 8) : icmp IntPred.ne (ashr (const? 8 (-90)) e) (const? 8 (-30)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -458,7 +458,7 @@ theorem nonexact_ashr_ne_noexactlog_thm (e : IntW 8) : icmp IntPredicate.ne (ash
 
 
 theorem PR20945_thm (e : IntW 32) :
-  icmp IntPredicate.ne (ashr (const? 32 (-9)) e) (const? 32 (-5)) ⊑ icmp IntPredicate.ne e (const? 32 1) := by
+  icmp IntPred.ne (ashr (const? 32 (-9)) e) (const? 32 (-5)) ⊑ icmp IntPred.ne e (const? 32 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -468,7 +468,7 @@ theorem PR20945_thm (e : IntW 32) :
 
 
 theorem PR21222_thm (e : IntW 32) :
-  icmp IntPredicate.eq (ashr (const? 32 (-93)) e) (const? 32 (-2)) ⊑ icmp IntPredicate.eq e (const? 32 6) := by
+  icmp IntPred.eq (ashr (const? 32 (-93)) e) (const? 32 (-2)) ⊑ icmp IntPred.eq e (const? 32 6) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -478,8 +478,8 @@ theorem PR21222_thm (e : IntW 32) :
 
 
 theorem PR24873_thm (e : IntW 64) :
-  icmp IntPredicate.eq (ashr (const? 64 (-4611686018427387904)) e) (const? 64 (-1)) ⊑
-    icmp IntPredicate.ugt e (const? 64 61) := by
+  icmp IntPred.eq (ashr (const? 64 (-4611686018427387904)) e) (const? 64 (-1)) ⊑
+    icmp IntPred.ugt e (const? 64 61) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -489,7 +489,7 @@ theorem PR24873_thm (e : IntW 64) :
 
 
 theorem ashr_exact_eq_0_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.eq (ashr e_1 e { «exact» := true }) (const? 32 0) ⊑ icmp IntPredicate.eq e_1 (const? 32 0) := by
+  icmp IntPred.eq (ashr e_1 e { «exact» := true }) (const? 32 0) ⊑ icmp IntPred.eq e_1 (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -499,7 +499,7 @@ theorem ashr_exact_eq_0_thm (e e_1 : IntW 32) :
 
 
 theorem lshr_exact_ne_0_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.ne (lshr e_1 e { «exact» := true }) (const? 32 0) ⊑ icmp IntPredicate.ne e_1 (const? 32 0) := by
+  icmp IntPred.ne (lshr e_1 e { «exact» := true }) (const? 32 0) ⊑ icmp IntPred.ne e_1 (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -509,7 +509,7 @@ theorem lshr_exact_ne_0_thm (e e_1 : IntW 32) :
 
 
 theorem ashr_ugt_0_thm (e : IntW 4) :
-  icmp IntPredicate.ugt (ashr e (const? 4 1)) (const? 4 0) ⊑ icmp IntPredicate.ugt e (const? 4 1) := by
+  icmp IntPred.ugt (ashr e (const? 4 1)) (const? 4 0) ⊑ icmp IntPred.ugt e (const? 4 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -519,7 +519,7 @@ theorem ashr_ugt_0_thm (e : IntW 4) :
 
 
 theorem ashr_ugt_1_thm (e : IntW 4) :
-  icmp IntPredicate.ugt (ashr e (const? 4 1)) (const? 4 1) ⊑ icmp IntPredicate.ugt e (const? 4 3) := by
+  icmp IntPred.ugt (ashr e (const? 4 1)) (const? 4 1) ⊑ icmp IntPred.ugt e (const? 4 3) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -529,7 +529,7 @@ theorem ashr_ugt_1_thm (e : IntW 4) :
 
 
 theorem ashr_ugt_2_thm (e : IntW 4) :
-  icmp IntPredicate.ugt (ashr e (const? 4 1)) (const? 4 2) ⊑ icmp IntPredicate.ugt e (const? 4 5) := by
+  icmp IntPred.ugt (ashr e (const? 4 1)) (const? 4 2) ⊑ icmp IntPred.ugt e (const? 4 5) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -539,7 +539,7 @@ theorem ashr_ugt_2_thm (e : IntW 4) :
 
 
 theorem ashr_ugt_3_thm (e : IntW 4) :
-  icmp IntPredicate.ugt (ashr e (const? 4 1)) (const? 4 3) ⊑ icmp IntPredicate.slt e (const? 4 0) := by
+  icmp IntPred.ugt (ashr e (const? 4 1)) (const? 4 3) ⊑ icmp IntPred.slt e (const? 4 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -549,7 +549,7 @@ theorem ashr_ugt_3_thm (e : IntW 4) :
 
 
 theorem ashr_ugt_4_thm (e : IntW 4) :
-  icmp IntPredicate.ugt (ashr e (const? 4 1)) (const? 4 4) ⊑ icmp IntPredicate.slt e (const? 4 0) := by
+  icmp IntPred.ugt (ashr e (const? 4 1)) (const? 4 4) ⊑ icmp IntPred.slt e (const? 4 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -559,7 +559,7 @@ theorem ashr_ugt_4_thm (e : IntW 4) :
 
 
 theorem ashr_ugt_5_thm (e : IntW 4) :
-  icmp IntPredicate.ugt (ashr e (const? 4 1)) (const? 4 5) ⊑ icmp IntPredicate.slt e (const? 4 0) := by
+  icmp IntPred.ugt (ashr e (const? 4 1)) (const? 4 5) ⊑ icmp IntPred.slt e (const? 4 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -569,7 +569,7 @@ theorem ashr_ugt_5_thm (e : IntW 4) :
 
 
 theorem ashr_ugt_6_thm (e : IntW 4) :
-  icmp IntPredicate.ugt (ashr e (const? 4 1)) (const? 4 6) ⊑ icmp IntPredicate.slt e (const? 4 0) := by
+  icmp IntPred.ugt (ashr e (const? 4 1)) (const? 4 6) ⊑ icmp IntPred.slt e (const? 4 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -579,7 +579,7 @@ theorem ashr_ugt_6_thm (e : IntW 4) :
 
 
 theorem ashr_ugt_7_thm (e : IntW 4) :
-  icmp IntPredicate.ugt (ashr e (const? 4 1)) (const? 4 7) ⊑ icmp IntPredicate.slt e (const? 4 0) := by
+  icmp IntPred.ugt (ashr e (const? 4 1)) (const? 4 7) ⊑ icmp IntPred.slt e (const? 4 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -589,7 +589,7 @@ theorem ashr_ugt_7_thm (e : IntW 4) :
 
 
 theorem ashr_ugt_8_thm (e : IntW 4) :
-  icmp IntPredicate.ugt (ashr e (const? 4 1)) (const? 4 (-8)) ⊑ icmp IntPredicate.slt e (const? 4 0) := by
+  icmp IntPred.ugt (ashr e (const? 4 1)) (const? 4 (-8)) ⊑ icmp IntPred.slt e (const? 4 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -599,7 +599,7 @@ theorem ashr_ugt_8_thm (e : IntW 4) :
 
 
 theorem ashr_ugt_9_thm (e : IntW 4) :
-  icmp IntPredicate.ugt (ashr e (const? 4 1)) (const? 4 (-7)) ⊑ icmp IntPredicate.slt e (const? 4 0) := by
+  icmp IntPred.ugt (ashr e (const? 4 1)) (const? 4 (-7)) ⊑ icmp IntPred.slt e (const? 4 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -609,7 +609,7 @@ theorem ashr_ugt_9_thm (e : IntW 4) :
 
 
 theorem ashr_ugt_10_thm (e : IntW 4) :
-  icmp IntPredicate.ugt (ashr e (const? 4 1)) (const? 4 (-6)) ⊑ icmp IntPredicate.slt e (const? 4 0) := by
+  icmp IntPred.ugt (ashr e (const? 4 1)) (const? 4 (-6)) ⊑ icmp IntPred.slt e (const? 4 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -619,7 +619,7 @@ theorem ashr_ugt_10_thm (e : IntW 4) :
 
 
 theorem ashr_ugt_11_thm (e : IntW 4) :
-  icmp IntPredicate.ugt (ashr e (const? 4 1)) (const? 4 (-5)) ⊑ icmp IntPredicate.slt e (const? 4 0) := by
+  icmp IntPred.ugt (ashr e (const? 4 1)) (const? 4 (-5)) ⊑ icmp IntPred.slt e (const? 4 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -629,7 +629,7 @@ theorem ashr_ugt_11_thm (e : IntW 4) :
 
 
 theorem ashr_ugt_12_thm (e : IntW 4) :
-  icmp IntPredicate.ugt (ashr e (const? 4 1)) (const? 4 (-4)) ⊑ icmp IntPredicate.ugt e (const? 4 (-7)) := by
+  icmp IntPred.ugt (ashr e (const? 4 1)) (const? 4 (-4)) ⊑ icmp IntPred.ugt e (const? 4 (-7)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -639,7 +639,7 @@ theorem ashr_ugt_12_thm (e : IntW 4) :
 
 
 theorem ashr_ugt_13_thm (e : IntW 4) :
-  icmp IntPredicate.ugt (ashr e (const? 4 1)) (const? 4 (-3)) ⊑ icmp IntPredicate.ugt e (const? 4 (-5)) := by
+  icmp IntPred.ugt (ashr e (const? 4 1)) (const? 4 (-3)) ⊑ icmp IntPred.ugt e (const? 4 (-5)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -649,7 +649,7 @@ theorem ashr_ugt_13_thm (e : IntW 4) :
 
 
 theorem ashr_ugt_14_thm (e : IntW 4) :
-  icmp IntPredicate.ugt (ashr e (const? 4 1)) (const? 4 (-2)) ⊑ icmp IntPredicate.ugt e (const? 4 (-3)) := by
+  icmp IntPred.ugt (ashr e (const? 4 1)) (const? 4 (-2)) ⊑ icmp IntPred.ugt e (const? 4 (-3)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -658,7 +658,7 @@ theorem ashr_ugt_14_thm (e : IntW 4) :
     all_goals sorry
 
 
-theorem ashr_ugt_15_thm (e : IntW 4) : icmp IntPredicate.ugt (ashr e (const? 4 1)) (const? 4 (-1)) ⊑ const? 1 0 := by
+theorem ashr_ugt_15_thm (e : IntW 4) : icmp IntPred.ugt (ashr e (const? 4 1)) (const? 4 (-1)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -667,7 +667,7 @@ theorem ashr_ugt_15_thm (e : IntW 4) : icmp IntPredicate.ugt (ashr e (const? 4 1
     all_goals sorry
 
 
-theorem ashr_ult_0_thm (e : IntW 4) : icmp IntPredicate.ult (ashr e (const? 4 1)) (const? 4 0) ⊑ const? 1 0 := by
+theorem ashr_ult_0_thm (e : IntW 4) : icmp IntPred.ult (ashr e (const? 4 1)) (const? 4 0) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -677,7 +677,7 @@ theorem ashr_ult_0_thm (e : IntW 4) : icmp IntPredicate.ult (ashr e (const? 4 1)
 
 
 theorem ashr_ult_1_thm (e : IntW 4) :
-  icmp IntPredicate.ult (ashr e (const? 4 1)) (const? 4 1) ⊑ icmp IntPredicate.ult e (const? 4 2) := by
+  icmp IntPred.ult (ashr e (const? 4 1)) (const? 4 1) ⊑ icmp IntPred.ult e (const? 4 2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -687,7 +687,7 @@ theorem ashr_ult_1_thm (e : IntW 4) :
 
 
 theorem ashr_ult_2_thm (e : IntW 4) :
-  icmp IntPredicate.ult (ashr e (const? 4 1)) (const? 4 2) ⊑ icmp IntPredicate.ult e (const? 4 4) := by
+  icmp IntPred.ult (ashr e (const? 4 1)) (const? 4 2) ⊑ icmp IntPred.ult e (const? 4 4) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -697,7 +697,7 @@ theorem ashr_ult_2_thm (e : IntW 4) :
 
 
 theorem ashr_ult_3_thm (e : IntW 4) :
-  icmp IntPredicate.ult (ashr e (const? 4 1)) (const? 4 3) ⊑ icmp IntPredicate.ult e (const? 4 6) := by
+  icmp IntPred.ult (ashr e (const? 4 1)) (const? 4 3) ⊑ icmp IntPred.ult e (const? 4 6) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -707,7 +707,7 @@ theorem ashr_ult_3_thm (e : IntW 4) :
 
 
 theorem ashr_ult_4_thm (e : IntW 4) :
-  icmp IntPredicate.ult (ashr e (const? 4 1)) (const? 4 4) ⊑ icmp IntPredicate.sgt e (const? 4 (-1)) := by
+  icmp IntPred.ult (ashr e (const? 4 1)) (const? 4 4) ⊑ icmp IntPred.sgt e (const? 4 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -717,7 +717,7 @@ theorem ashr_ult_4_thm (e : IntW 4) :
 
 
 theorem ashr_ult_5_thm (e : IntW 4) :
-  icmp IntPredicate.ult (ashr e (const? 4 1)) (const? 4 5) ⊑ icmp IntPredicate.sgt e (const? 4 (-1)) := by
+  icmp IntPred.ult (ashr e (const? 4 1)) (const? 4 5) ⊑ icmp IntPred.sgt e (const? 4 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -727,7 +727,7 @@ theorem ashr_ult_5_thm (e : IntW 4) :
 
 
 theorem ashr_ult_6_thm (e : IntW 4) :
-  icmp IntPredicate.ult (ashr e (const? 4 1)) (const? 4 6) ⊑ icmp IntPredicate.sgt e (const? 4 (-1)) := by
+  icmp IntPred.ult (ashr e (const? 4 1)) (const? 4 6) ⊑ icmp IntPred.sgt e (const? 4 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -737,7 +737,7 @@ theorem ashr_ult_6_thm (e : IntW 4) :
 
 
 theorem ashr_ult_7_thm (e : IntW 4) :
-  icmp IntPredicate.ult (ashr e (const? 4 1)) (const? 4 7) ⊑ icmp IntPredicate.sgt e (const? 4 (-1)) := by
+  icmp IntPred.ult (ashr e (const? 4 1)) (const? 4 7) ⊑ icmp IntPred.sgt e (const? 4 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -747,7 +747,7 @@ theorem ashr_ult_7_thm (e : IntW 4) :
 
 
 theorem ashr_ult_8_thm (e : IntW 4) :
-  icmp IntPredicate.ult (ashr e (const? 4 1)) (const? 4 (-8)) ⊑ icmp IntPredicate.sgt e (const? 4 (-1)) := by
+  icmp IntPred.ult (ashr e (const? 4 1)) (const? 4 (-8)) ⊑ icmp IntPred.sgt e (const? 4 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -757,7 +757,7 @@ theorem ashr_ult_8_thm (e : IntW 4) :
 
 
 theorem ashr_ult_9_thm (e : IntW 4) :
-  icmp IntPredicate.ult (ashr e (const? 4 1)) (const? 4 (-7)) ⊑ icmp IntPredicate.sgt e (const? 4 (-1)) := by
+  icmp IntPred.ult (ashr e (const? 4 1)) (const? 4 (-7)) ⊑ icmp IntPred.sgt e (const? 4 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -767,7 +767,7 @@ theorem ashr_ult_9_thm (e : IntW 4) :
 
 
 theorem ashr_ult_10_thm (e : IntW 4) :
-  icmp IntPredicate.ult (ashr e (const? 4 1)) (const? 4 (-6)) ⊑ icmp IntPredicate.sgt e (const? 4 (-1)) := by
+  icmp IntPred.ult (ashr e (const? 4 1)) (const? 4 (-6)) ⊑ icmp IntPred.sgt e (const? 4 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -777,7 +777,7 @@ theorem ashr_ult_10_thm (e : IntW 4) :
 
 
 theorem ashr_ult_11_thm (e : IntW 4) :
-  icmp IntPredicate.ult (ashr e (const? 4 1)) (const? 4 (-5)) ⊑ icmp IntPredicate.sgt e (const? 4 (-1)) := by
+  icmp IntPred.ult (ashr e (const? 4 1)) (const? 4 (-5)) ⊑ icmp IntPred.sgt e (const? 4 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -787,7 +787,7 @@ theorem ashr_ult_11_thm (e : IntW 4) :
 
 
 theorem ashr_ult_12_thm (e : IntW 4) :
-  icmp IntPredicate.ult (ashr e (const? 4 1)) (const? 4 (-4)) ⊑ icmp IntPredicate.sgt e (const? 4 (-1)) := by
+  icmp IntPred.ult (ashr e (const? 4 1)) (const? 4 (-4)) ⊑ icmp IntPred.sgt e (const? 4 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -797,7 +797,7 @@ theorem ashr_ult_12_thm (e : IntW 4) :
 
 
 theorem ashr_ult_13_thm (e : IntW 4) :
-  icmp IntPredicate.ult (ashr e (const? 4 1)) (const? 4 (-3)) ⊑ icmp IntPredicate.ult e (const? 4 (-6)) := by
+  icmp IntPred.ult (ashr e (const? 4 1)) (const? 4 (-3)) ⊑ icmp IntPred.ult e (const? 4 (-6)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -807,7 +807,7 @@ theorem ashr_ult_13_thm (e : IntW 4) :
 
 
 theorem ashr_ult_14_thm (e : IntW 4) :
-  icmp IntPredicate.ult (ashr e (const? 4 1)) (const? 4 (-2)) ⊑ icmp IntPredicate.ult e (const? 4 (-4)) := by
+  icmp IntPred.ult (ashr e (const? 4 1)) (const? 4 (-2)) ⊑ icmp IntPred.ult e (const? 4 (-4)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -817,7 +817,7 @@ theorem ashr_ult_14_thm (e : IntW 4) :
 
 
 theorem ashr_ult_15_thm (e : IntW 4) :
-  icmp IntPredicate.ult (ashr e (const? 4 1)) (const? 4 (-1)) ⊑ icmp IntPredicate.ult e (const? 4 (-2)) := by
+  icmp IntPred.ult (ashr e (const? 4 1)) (const? 4 (-1)) ⊑ icmp IntPred.ult e (const? 4 (-2)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -827,7 +827,7 @@ theorem ashr_ult_15_thm (e : IntW 4) :
 
 
 theorem lshr_pow2_ugt_thm (e : IntW 8) :
-  icmp IntPredicate.ugt (lshr (const? 8 2) e) (const? 8 1) ⊑ icmp IntPredicate.eq e (const? 8 0) := by
+  icmp IntPred.ugt (lshr (const? 8 2) e) (const? 8 1) ⊑ icmp IntPred.eq e (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -837,7 +837,7 @@ theorem lshr_pow2_ugt_thm (e : IntW 8) :
 
 
 theorem lshr_pow2_ugt1_thm (e : IntW 8) :
-  icmp IntPredicate.ugt (lshr (const? 8 (-128)) e) (const? 8 1) ⊑ icmp IntPredicate.ult e (const? 8 7) := by
+  icmp IntPred.ugt (lshr (const? 8 (-128)) e) (const? 8 1) ⊑ icmp IntPred.ult e (const? 8 7) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -847,8 +847,8 @@ theorem lshr_pow2_ugt1_thm (e : IntW 8) :
 
 
 theorem ashr_pow2_ugt_thm (e : IntW 8) :
-  icmp IntPredicate.ugt (ashr (const? 8 (-128)) e) (const? 8 (-96)) ⊑
-    icmp IntPredicate.ugt (ashr (const? 8 (-128)) e { «exact» := true }) (const? 8 (-96)) := by
+  icmp IntPred.ugt (ashr (const? 8 (-128)) e) (const? 8 (-96)) ⊑
+    icmp IntPred.ugt (ashr (const? 8 (-128)) e { «exact» := true }) (const? 8 (-96)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -858,8 +858,8 @@ theorem ashr_pow2_ugt_thm (e : IntW 8) :
 
 
 theorem lshr_pow2_sgt_thm (e : IntW 8) :
-  icmp IntPredicate.sgt (lshr (const? 8 (-128)) e) (const? 8 3) ⊑
-    icmp IntPredicate.sgt (lshr (const? 8 (-128)) e { «exact» := true }) (const? 8 3) := by
+  icmp IntPred.sgt (lshr (const? 8 (-128)) e) (const? 8 3) ⊑
+    icmp IntPred.sgt (lshr (const? 8 (-128)) e { «exact» := true }) (const? 8 3) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -869,7 +869,7 @@ theorem lshr_pow2_sgt_thm (e : IntW 8) :
 
 
 theorem lshr_pow2_ult_thm (e : IntW 8) :
-  icmp IntPredicate.ult (lshr (const? 8 4) e) (const? 8 2) ⊑ icmp IntPredicate.ugt e (const? 8 1) := by
+  icmp IntPred.ult (lshr (const? 8 4) e) (const? 8 2) ⊑ icmp IntPred.ugt e (const? 8 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -879,7 +879,7 @@ theorem lshr_pow2_ult_thm (e : IntW 8) :
 
 
 theorem lshr_pow2_ult_equal_constants_thm (e : IntW 32) :
-  icmp IntPredicate.ult (lshr (const? 32 16) e) (const? 32 16) ⊑ icmp IntPredicate.ne e (const? 32 0) := by
+  icmp IntPred.ult (lshr (const? 32 16) e) (const? 32 16) ⊑ icmp IntPred.ne e (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -889,7 +889,7 @@ theorem lshr_pow2_ult_equal_constants_thm (e : IntW 32) :
 
 
 theorem lshr_pow2_ult_smin_thm (e : IntW 8) :
-  icmp IntPredicate.ult (lshr (const? 8 (-128)) e) (const? 8 (-128)) ⊑ icmp IntPredicate.ne e (const? 8 0) := by
+  icmp IntPred.ult (lshr (const? 8 (-128)) e) (const? 8 (-128)) ⊑ icmp IntPred.ne e (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -899,8 +899,8 @@ theorem lshr_pow2_ult_smin_thm (e : IntW 8) :
 
 
 theorem ashr_pow2_ult_thm (e : IntW 8) :
-  icmp IntPredicate.ult (ashr (const? 8 (-128)) e) (const? 8 (-96)) ⊑
-    icmp IntPredicate.ult (ashr (const? 8 (-128)) e { «exact» := true }) (const? 8 (-96)) := by
+  icmp IntPred.ult (ashr (const? 8 (-128)) e) (const? 8 (-96)) ⊑
+    icmp IntPred.ult (ashr (const? 8 (-128)) e { «exact» := true }) (const? 8 (-96)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -910,8 +910,8 @@ theorem ashr_pow2_ult_thm (e : IntW 8) :
 
 
 theorem lshr_pow2_slt_thm (e : IntW 8) :
-  icmp IntPredicate.slt (lshr (const? 8 (-128)) e) (const? 8 3) ⊑
-    icmp IntPredicate.slt (lshr (const? 8 (-128)) e { «exact» := true }) (const? 8 3) := by
+  icmp IntPred.slt (lshr (const? 8 (-128)) e) (const? 8 3) ⊑
+    icmp IntPred.slt (lshr (const? 8 (-128)) e { «exact» := true }) (const? 8 3) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -921,7 +921,7 @@ theorem lshr_pow2_slt_thm (e : IntW 8) :
 
 
 theorem lshr_neg_sgt_minus_1_thm (e : IntW 8) :
-  icmp IntPredicate.sgt (lshr (const? 8 (-17)) e) (const? 8 (-1)) ⊑ icmp IntPredicate.ne e (const? 8 0) := by
+  icmp IntPred.sgt (lshr (const? 8 (-17)) e) (const? 8 (-1)) ⊑ icmp IntPred.ne e (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -931,7 +931,7 @@ theorem lshr_neg_sgt_minus_1_thm (e : IntW 8) :
 
 
 theorem lshr_neg_slt_zero_thm (e : IntW 8) :
-  icmp IntPredicate.slt (lshr (const? 8 (-17)) e) (const? 8 0) ⊑ icmp IntPredicate.eq e (const? 8 0) := by
+  icmp IntPred.slt (lshr (const? 8 (-17)) e) (const? 8 0) ⊑ icmp IntPred.eq e (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -941,8 +941,8 @@ theorem lshr_neg_slt_zero_thm (e : IntW 8) :
 
 
 theorem exactly_one_set_signbit_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.eq (lshr e_1 (const? 8 7)) (zext 8 (icmp IntPredicate.sgt e (const? 8 (-1)))) ⊑
-    icmp IntPredicate.slt (LLVM.xor e_1 e) (const? 8 0) := by
+  icmp IntPred.eq (lshr e_1 (const? 8 7)) (zext 8 (icmp IntPred.sgt e (const? 8 (-1)))) ⊑
+    icmp IntPred.slt (LLVM.xor e_1 e) (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -952,8 +952,8 @@ theorem exactly_one_set_signbit_thm (e e_1 : IntW 8) :
 
 
 theorem same_signbit_wrong_type_thm (e : IntW 32) (e_1 : IntW 8) :
-  icmp IntPredicate.ne (lshr e_1 (const? 8 7)) (zext 8 (icmp IntPredicate.sgt e (const? 32 (-1)))) ⊑
-    LLVM.xor (icmp IntPredicate.slt e_1 (const? 8 0)) (icmp IntPredicate.sgt e (const? 32 (-1))) := by
+  icmp IntPred.ne (lshr e_1 (const? 8 7)) (zext 8 (icmp IntPred.sgt e (const? 32 (-1)))) ⊑
+    LLVM.xor (icmp IntPred.slt e_1 (const? 8 0)) (icmp IntPred.sgt e (const? 32 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -963,8 +963,8 @@ theorem same_signbit_wrong_type_thm (e : IntW 32) (e_1 : IntW 8) :
 
 
 theorem exactly_one_set_signbit_wrong_pred_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.sgt (lshr e_1 (const? 8 7)) (zext 8 (icmp IntPredicate.sgt e (const? 8 (-1)))) ⊑
-    icmp IntPredicate.slt (LLVM.and e e_1) (const? 8 0) := by
+  icmp IntPred.sgt (lshr e_1 (const? 8 7)) (zext 8 (icmp IntPred.sgt e (const? 8 (-1)))) ⊑
+    icmp IntPred.slt (LLVM.and e e_1) (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -974,8 +974,8 @@ theorem exactly_one_set_signbit_wrong_pred_thm (e e_1 : IntW 8) :
 
 
 theorem exactly_one_set_signbit_signed_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.eq (ashr e_1 (const? 8 7)) (sext 8 (icmp IntPredicate.sgt e (const? 8 (-1)))) ⊑
-    icmp IntPredicate.slt (LLVM.xor e_1 e) (const? 8 0) := by
+  icmp IntPred.eq (ashr e_1 (const? 8 7)) (sext 8 (icmp IntPred.sgt e (const? 8 (-1)))) ⊑
+    icmp IntPred.slt (LLVM.xor e_1 e) (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -985,8 +985,8 @@ theorem exactly_one_set_signbit_signed_thm (e e_1 : IntW 8) :
 
 
 theorem same_signbit_wrong_type_signed_thm (e : IntW 32) (e_1 : IntW 8) :
-  icmp IntPredicate.ne (ashr e_1 (const? 8 7)) (sext 8 (icmp IntPredicate.sgt e (const? 32 (-1)))) ⊑
-    LLVM.xor (icmp IntPredicate.slt e_1 (const? 8 0)) (icmp IntPredicate.sgt e (const? 32 (-1))) := by
+  icmp IntPred.ne (ashr e_1 (const? 8 7)) (sext 8 (icmp IntPred.sgt e (const? 32 (-1)))) ⊑
+    LLVM.xor (icmp IntPred.slt e_1 (const? 8 0)) (icmp IntPred.sgt e (const? 32 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -996,8 +996,8 @@ theorem same_signbit_wrong_type_signed_thm (e : IntW 32) (e_1 : IntW 8) :
 
 
 theorem slt_zero_ult_i1_thm (e : IntW 32) (e_1 : IntW 1) :
-  icmp IntPredicate.ult (zext 32 e_1) (lshr e (const? 32 31)) ⊑
-    LLVM.and (icmp IntPredicate.slt e (const? 32 0)) (LLVM.xor e_1 (const? 1 1)) := by
+  icmp IntPred.ult (zext 32 e_1) (lshr e (const? 32 31)) ⊑
+    LLVM.and (icmp IntPred.slt e (const? 32 0)) (LLVM.xor e_1 (const? 1 1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1007,8 +1007,8 @@ theorem slt_zero_ult_i1_thm (e : IntW 32) (e_1 : IntW 1) :
 
 
 theorem slt_zero_ult_i1_fail1_thm (e : IntW 32) (e_1 : IntW 1) :
-  icmp IntPredicate.ult (zext 32 e_1) (lshr e (const? 32 30)) ⊑
-    icmp IntPredicate.ugt (lshr e (const? 32 30)) (zext 32 e_1) := by
+  icmp IntPred.ult (zext 32 e_1) (lshr e (const? 32 30)) ⊑
+    icmp IntPred.ugt (lshr e (const? 32 30)) (zext 32 e_1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1018,8 +1018,8 @@ theorem slt_zero_ult_i1_fail1_thm (e : IntW 32) (e_1 : IntW 1) :
 
 
 theorem slt_zero_ult_i1_fail2_thm (e : IntW 32) (e_1 : IntW 1) :
-  icmp IntPredicate.ult (zext 32 e_1) (ashr e (const? 32 31)) ⊑
-    icmp IntPredicate.ugt (ashr e (const? 32 31)) (zext 32 e_1) := by
+  icmp IntPred.ult (zext 32 e_1) (ashr e (const? 32 31)) ⊑
+    icmp IntPred.ugt (ashr e (const? 32 31)) (zext 32 e_1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1029,8 +1029,8 @@ theorem slt_zero_ult_i1_fail2_thm (e : IntW 32) (e_1 : IntW 1) :
 
 
 theorem slt_zero_slt_i1_fail_thm (e : IntW 32) (e_1 : IntW 1) :
-  icmp IntPredicate.slt (zext 32 e_1) (lshr e (const? 32 31)) ⊑
-    LLVM.and (icmp IntPredicate.slt e (const? 32 0)) (LLVM.xor e_1 (const? 1 1)) := by
+  icmp IntPred.slt (zext 32 e_1) (lshr e (const? 32 31)) ⊑
+    LLVM.and (icmp IntPred.slt e (const? 32 0)) (LLVM.xor e_1 (const? 1 1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1040,8 +1040,8 @@ theorem slt_zero_slt_i1_fail_thm (e : IntW 32) (e_1 : IntW 1) :
 
 
 theorem slt_zero_eq_i1_signed_thm (e : IntW 32) (e_1 : IntW 1) :
-  icmp IntPredicate.eq (sext 32 e_1) (ashr e (const? 32 31)) ⊑
-    LLVM.xor (icmp IntPredicate.sgt e (const? 32 (-1))) e_1 := by
+  icmp IntPred.eq (sext 32 e_1) (ashr e (const? 32 31)) ⊑
+    LLVM.xor (icmp IntPred.sgt e (const? 32 (-1))) e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1051,8 +1051,8 @@ theorem slt_zero_eq_i1_signed_thm (e : IntW 32) (e_1 : IntW 1) :
 
 
 theorem slt_zero_eq_i1_fail_signed_thm (e : IntW 32) (e_1 : IntW 1) :
-  icmp IntPredicate.eq (sext 32 e_1) (lshr e (const? 32 31)) ⊑
-    icmp IntPredicate.eq (lshr e (const? 32 31)) (sext 32 e_1) := by
+  icmp IntPred.eq (sext 32 e_1) (lshr e (const? 32 31)) ⊑
+    icmp IntPred.eq (lshr e (const? 32 31)) (sext 32 e_1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gicmphshrhlthgt_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gicmphshrhlthgt_proof.lean
@@ -12,7 +12,7 @@ set_option Elab.async false
 
 section gicmphshrhlthgt_proof
 theorem lshrugt_01_00_thm (e : IntW 4) :
-  icmp IntPredicate.ugt (lshr e (const? 4 1)) (const? 4 0) ⊑ icmp IntPredicate.ugt e (const? 4 1) := by
+  icmp IntPred.ugt (lshr e (const? 4 1)) (const? 4 0) ⊑ icmp IntPred.ugt e (const? 4 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -22,7 +22,7 @@ theorem lshrugt_01_00_thm (e : IntW 4) :
 
 
 theorem lshrugt_01_01_thm (e : IntW 4) :
-  icmp IntPredicate.ugt (lshr e (const? 4 1)) (const? 4 1) ⊑ icmp IntPredicate.ugt e (const? 4 3) := by
+  icmp IntPred.ugt (lshr e (const? 4 1)) (const? 4 1) ⊑ icmp IntPred.ugt e (const? 4 3) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -32,7 +32,7 @@ theorem lshrugt_01_01_thm (e : IntW 4) :
 
 
 theorem lshrugt_01_02_thm (e : IntW 4) :
-  icmp IntPredicate.ugt (lshr e (const? 4 1)) (const? 4 2) ⊑ icmp IntPredicate.ugt e (const? 4 5) := by
+  icmp IntPred.ugt (lshr e (const? 4 1)) (const? 4 2) ⊑ icmp IntPred.ugt e (const? 4 5) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -42,7 +42,7 @@ theorem lshrugt_01_02_thm (e : IntW 4) :
 
 
 theorem lshrugt_01_03_thm (e : IntW 4) :
-  icmp IntPredicate.ugt (lshr e (const? 4 1)) (const? 4 3) ⊑ icmp IntPredicate.slt e (const? 4 0) := by
+  icmp IntPred.ugt (lshr e (const? 4 1)) (const? 4 3) ⊑ icmp IntPred.slt e (const? 4 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -52,7 +52,7 @@ theorem lshrugt_01_03_thm (e : IntW 4) :
 
 
 theorem lshrugt_01_04_thm (e : IntW 4) :
-  icmp IntPredicate.ugt (lshr e (const? 4 1)) (const? 4 4) ⊑ icmp IntPredicate.ugt e (const? 4 (-7)) := by
+  icmp IntPred.ugt (lshr e (const? 4 1)) (const? 4 4) ⊑ icmp IntPred.ugt e (const? 4 (-7)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -62,7 +62,7 @@ theorem lshrugt_01_04_thm (e : IntW 4) :
 
 
 theorem lshrugt_01_05_thm (e : IntW 4) :
-  icmp IntPredicate.ugt (lshr e (const? 4 1)) (const? 4 5) ⊑ icmp IntPredicate.ugt e (const? 4 (-5)) := by
+  icmp IntPred.ugt (lshr e (const? 4 1)) (const? 4 5) ⊑ icmp IntPred.ugt e (const? 4 (-5)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -72,7 +72,7 @@ theorem lshrugt_01_05_thm (e : IntW 4) :
 
 
 theorem lshrugt_01_06_thm (e : IntW 4) :
-  icmp IntPredicate.ugt (lshr e (const? 4 1)) (const? 4 6) ⊑ icmp IntPredicate.ugt e (const? 4 (-3)) := by
+  icmp IntPred.ugt (lshr e (const? 4 1)) (const? 4 6) ⊑ icmp IntPred.ugt e (const? 4 (-3)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -81,7 +81,7 @@ theorem lshrugt_01_06_thm (e : IntW 4) :
     all_goals sorry
 
 
-theorem lshrugt_01_07_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4 1)) (const? 4 7) ⊑ const? 1 0 := by
+theorem lshrugt_01_07_thm (e : IntW 4) : icmp IntPred.ugt (lshr e (const? 4 1)) (const? 4 7) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -90,7 +90,7 @@ theorem lshrugt_01_07_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4
     all_goals sorry
 
 
-theorem lshrugt_01_08_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4 1)) (const? 4 (-8)) ⊑ const? 1 0 := by
+theorem lshrugt_01_08_thm (e : IntW 4) : icmp IntPred.ugt (lshr e (const? 4 1)) (const? 4 (-8)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -99,7 +99,7 @@ theorem lshrugt_01_08_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4
     all_goals sorry
 
 
-theorem lshrugt_01_09_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4 1)) (const? 4 (-7)) ⊑ const? 1 0 := by
+theorem lshrugt_01_09_thm (e : IntW 4) : icmp IntPred.ugt (lshr e (const? 4 1)) (const? 4 (-7)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -108,7 +108,7 @@ theorem lshrugt_01_09_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4
     all_goals sorry
 
 
-theorem lshrugt_01_10_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4 1)) (const? 4 (-6)) ⊑ const? 1 0 := by
+theorem lshrugt_01_10_thm (e : IntW 4) : icmp IntPred.ugt (lshr e (const? 4 1)) (const? 4 (-6)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -117,7 +117,7 @@ theorem lshrugt_01_10_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4
     all_goals sorry
 
 
-theorem lshrugt_01_11_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4 1)) (const? 4 (-5)) ⊑ const? 1 0 := by
+theorem lshrugt_01_11_thm (e : IntW 4) : icmp IntPred.ugt (lshr e (const? 4 1)) (const? 4 (-5)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -126,7 +126,7 @@ theorem lshrugt_01_11_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4
     all_goals sorry
 
 
-theorem lshrugt_01_12_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4 1)) (const? 4 (-4)) ⊑ const? 1 0 := by
+theorem lshrugt_01_12_thm (e : IntW 4) : icmp IntPred.ugt (lshr e (const? 4 1)) (const? 4 (-4)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -135,7 +135,7 @@ theorem lshrugt_01_12_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4
     all_goals sorry
 
 
-theorem lshrugt_01_13_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4 1)) (const? 4 (-3)) ⊑ const? 1 0 := by
+theorem lshrugt_01_13_thm (e : IntW 4) : icmp IntPred.ugt (lshr e (const? 4 1)) (const? 4 (-3)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -144,7 +144,7 @@ theorem lshrugt_01_13_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4
     all_goals sorry
 
 
-theorem lshrugt_01_14_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4 1)) (const? 4 (-2)) ⊑ const? 1 0 := by
+theorem lshrugt_01_14_thm (e : IntW 4) : icmp IntPred.ugt (lshr e (const? 4 1)) (const? 4 (-2)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -153,7 +153,7 @@ theorem lshrugt_01_14_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4
     all_goals sorry
 
 
-theorem lshrugt_01_15_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4 1)) (const? 4 (-1)) ⊑ const? 1 0 := by
+theorem lshrugt_01_15_thm (e : IntW 4) : icmp IntPred.ugt (lshr e (const? 4 1)) (const? 4 (-1)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -163,7 +163,7 @@ theorem lshrugt_01_15_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4
 
 
 theorem lshrugt_02_00_thm (e : IntW 4) :
-  icmp IntPredicate.ugt (lshr e (const? 4 2)) (const? 4 0) ⊑ icmp IntPredicate.ugt e (const? 4 3) := by
+  icmp IntPred.ugt (lshr e (const? 4 2)) (const? 4 0) ⊑ icmp IntPred.ugt e (const? 4 3) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -173,7 +173,7 @@ theorem lshrugt_02_00_thm (e : IntW 4) :
 
 
 theorem lshrugt_02_01_thm (e : IntW 4) :
-  icmp IntPredicate.ugt (lshr e (const? 4 2)) (const? 4 1) ⊑ icmp IntPredicate.slt e (const? 4 0) := by
+  icmp IntPred.ugt (lshr e (const? 4 2)) (const? 4 1) ⊑ icmp IntPred.slt e (const? 4 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -183,7 +183,7 @@ theorem lshrugt_02_01_thm (e : IntW 4) :
 
 
 theorem lshrugt_02_02_thm (e : IntW 4) :
-  icmp IntPredicate.ugt (lshr e (const? 4 2)) (const? 4 2) ⊑ icmp IntPredicate.ugt e (const? 4 (-5)) := by
+  icmp IntPred.ugt (lshr e (const? 4 2)) (const? 4 2) ⊑ icmp IntPred.ugt e (const? 4 (-5)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -192,7 +192,7 @@ theorem lshrugt_02_02_thm (e : IntW 4) :
     all_goals sorry
 
 
-theorem lshrugt_02_03_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4 2)) (const? 4 3) ⊑ const? 1 0 := by
+theorem lshrugt_02_03_thm (e : IntW 4) : icmp IntPred.ugt (lshr e (const? 4 2)) (const? 4 3) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -201,7 +201,7 @@ theorem lshrugt_02_03_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4
     all_goals sorry
 
 
-theorem lshrugt_02_04_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4 2)) (const? 4 4) ⊑ const? 1 0 := by
+theorem lshrugt_02_04_thm (e : IntW 4) : icmp IntPred.ugt (lshr e (const? 4 2)) (const? 4 4) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -210,7 +210,7 @@ theorem lshrugt_02_04_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4
     all_goals sorry
 
 
-theorem lshrugt_02_05_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4 2)) (const? 4 5) ⊑ const? 1 0 := by
+theorem lshrugt_02_05_thm (e : IntW 4) : icmp IntPred.ugt (lshr e (const? 4 2)) (const? 4 5) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -219,7 +219,7 @@ theorem lshrugt_02_05_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4
     all_goals sorry
 
 
-theorem lshrugt_02_06_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4 2)) (const? 4 6) ⊑ const? 1 0 := by
+theorem lshrugt_02_06_thm (e : IntW 4) : icmp IntPred.ugt (lshr e (const? 4 2)) (const? 4 6) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -228,7 +228,7 @@ theorem lshrugt_02_06_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4
     all_goals sorry
 
 
-theorem lshrugt_02_07_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4 2)) (const? 4 7) ⊑ const? 1 0 := by
+theorem lshrugt_02_07_thm (e : IntW 4) : icmp IntPred.ugt (lshr e (const? 4 2)) (const? 4 7) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -237,7 +237,7 @@ theorem lshrugt_02_07_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4
     all_goals sorry
 
 
-theorem lshrugt_02_08_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4 2)) (const? 4 (-8)) ⊑ const? 1 0 := by
+theorem lshrugt_02_08_thm (e : IntW 4) : icmp IntPred.ugt (lshr e (const? 4 2)) (const? 4 (-8)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -246,7 +246,7 @@ theorem lshrugt_02_08_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4
     all_goals sorry
 
 
-theorem lshrugt_02_09_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4 2)) (const? 4 (-7)) ⊑ const? 1 0 := by
+theorem lshrugt_02_09_thm (e : IntW 4) : icmp IntPred.ugt (lshr e (const? 4 2)) (const? 4 (-7)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -255,7 +255,7 @@ theorem lshrugt_02_09_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4
     all_goals sorry
 
 
-theorem lshrugt_02_10_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4 2)) (const? 4 (-6)) ⊑ const? 1 0 := by
+theorem lshrugt_02_10_thm (e : IntW 4) : icmp IntPred.ugt (lshr e (const? 4 2)) (const? 4 (-6)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -264,7 +264,7 @@ theorem lshrugt_02_10_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4
     all_goals sorry
 
 
-theorem lshrugt_02_11_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4 2)) (const? 4 (-5)) ⊑ const? 1 0 := by
+theorem lshrugt_02_11_thm (e : IntW 4) : icmp IntPred.ugt (lshr e (const? 4 2)) (const? 4 (-5)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -273,7 +273,7 @@ theorem lshrugt_02_11_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4
     all_goals sorry
 
 
-theorem lshrugt_02_12_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4 2)) (const? 4 (-4)) ⊑ const? 1 0 := by
+theorem lshrugt_02_12_thm (e : IntW 4) : icmp IntPred.ugt (lshr e (const? 4 2)) (const? 4 (-4)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -282,7 +282,7 @@ theorem lshrugt_02_12_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4
     all_goals sorry
 
 
-theorem lshrugt_02_13_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4 2)) (const? 4 (-3)) ⊑ const? 1 0 := by
+theorem lshrugt_02_13_thm (e : IntW 4) : icmp IntPred.ugt (lshr e (const? 4 2)) (const? 4 (-3)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -291,7 +291,7 @@ theorem lshrugt_02_13_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4
     all_goals sorry
 
 
-theorem lshrugt_02_14_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4 2)) (const? 4 (-2)) ⊑ const? 1 0 := by
+theorem lshrugt_02_14_thm (e : IntW 4) : icmp IntPred.ugt (lshr e (const? 4 2)) (const? 4 (-2)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -300,7 +300,7 @@ theorem lshrugt_02_14_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4
     all_goals sorry
 
 
-theorem lshrugt_02_15_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4 2)) (const? 4 (-1)) ⊑ const? 1 0 := by
+theorem lshrugt_02_15_thm (e : IntW 4) : icmp IntPred.ugt (lshr e (const? 4 2)) (const? 4 (-1)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -310,7 +310,7 @@ theorem lshrugt_02_15_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4
 
 
 theorem lshrugt_03_00_thm (e : IntW 4) :
-  icmp IntPredicate.ugt (lshr e (const? 4 3)) (const? 4 0) ⊑ icmp IntPredicate.slt e (const? 4 0) := by
+  icmp IntPred.ugt (lshr e (const? 4 3)) (const? 4 0) ⊑ icmp IntPred.slt e (const? 4 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -319,7 +319,7 @@ theorem lshrugt_03_00_thm (e : IntW 4) :
     all_goals sorry
 
 
-theorem lshrugt_03_01_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4 3)) (const? 4 1) ⊑ const? 1 0 := by
+theorem lshrugt_03_01_thm (e : IntW 4) : icmp IntPred.ugt (lshr e (const? 4 3)) (const? 4 1) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -328,7 +328,7 @@ theorem lshrugt_03_01_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4
     all_goals sorry
 
 
-theorem lshrugt_03_02_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4 3)) (const? 4 2) ⊑ const? 1 0 := by
+theorem lshrugt_03_02_thm (e : IntW 4) : icmp IntPred.ugt (lshr e (const? 4 3)) (const? 4 2) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -337,7 +337,7 @@ theorem lshrugt_03_02_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4
     all_goals sorry
 
 
-theorem lshrugt_03_03_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4 3)) (const? 4 3) ⊑ const? 1 0 := by
+theorem lshrugt_03_03_thm (e : IntW 4) : icmp IntPred.ugt (lshr e (const? 4 3)) (const? 4 3) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -346,7 +346,7 @@ theorem lshrugt_03_03_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4
     all_goals sorry
 
 
-theorem lshrugt_03_04_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4 3)) (const? 4 4) ⊑ const? 1 0 := by
+theorem lshrugt_03_04_thm (e : IntW 4) : icmp IntPred.ugt (lshr e (const? 4 3)) (const? 4 4) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -355,7 +355,7 @@ theorem lshrugt_03_04_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4
     all_goals sorry
 
 
-theorem lshrugt_03_05_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4 3)) (const? 4 5) ⊑ const? 1 0 := by
+theorem lshrugt_03_05_thm (e : IntW 4) : icmp IntPred.ugt (lshr e (const? 4 3)) (const? 4 5) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -364,7 +364,7 @@ theorem lshrugt_03_05_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4
     all_goals sorry
 
 
-theorem lshrugt_03_06_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4 3)) (const? 4 6) ⊑ const? 1 0 := by
+theorem lshrugt_03_06_thm (e : IntW 4) : icmp IntPred.ugt (lshr e (const? 4 3)) (const? 4 6) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -373,7 +373,7 @@ theorem lshrugt_03_06_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4
     all_goals sorry
 
 
-theorem lshrugt_03_07_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4 3)) (const? 4 7) ⊑ const? 1 0 := by
+theorem lshrugt_03_07_thm (e : IntW 4) : icmp IntPred.ugt (lshr e (const? 4 3)) (const? 4 7) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -382,7 +382,7 @@ theorem lshrugt_03_07_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4
     all_goals sorry
 
 
-theorem lshrugt_03_08_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4 3)) (const? 4 (-8)) ⊑ const? 1 0 := by
+theorem lshrugt_03_08_thm (e : IntW 4) : icmp IntPred.ugt (lshr e (const? 4 3)) (const? 4 (-8)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -391,7 +391,7 @@ theorem lshrugt_03_08_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4
     all_goals sorry
 
 
-theorem lshrugt_03_09_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4 3)) (const? 4 (-7)) ⊑ const? 1 0 := by
+theorem lshrugt_03_09_thm (e : IntW 4) : icmp IntPred.ugt (lshr e (const? 4 3)) (const? 4 (-7)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -400,7 +400,7 @@ theorem lshrugt_03_09_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4
     all_goals sorry
 
 
-theorem lshrugt_03_10_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4 3)) (const? 4 (-6)) ⊑ const? 1 0 := by
+theorem lshrugt_03_10_thm (e : IntW 4) : icmp IntPred.ugt (lshr e (const? 4 3)) (const? 4 (-6)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -409,7 +409,7 @@ theorem lshrugt_03_10_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4
     all_goals sorry
 
 
-theorem lshrugt_03_11_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4 3)) (const? 4 (-5)) ⊑ const? 1 0 := by
+theorem lshrugt_03_11_thm (e : IntW 4) : icmp IntPred.ugt (lshr e (const? 4 3)) (const? 4 (-5)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -418,7 +418,7 @@ theorem lshrugt_03_11_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4
     all_goals sorry
 
 
-theorem lshrugt_03_12_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4 3)) (const? 4 (-4)) ⊑ const? 1 0 := by
+theorem lshrugt_03_12_thm (e : IntW 4) : icmp IntPred.ugt (lshr e (const? 4 3)) (const? 4 (-4)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -427,7 +427,7 @@ theorem lshrugt_03_12_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4
     all_goals sorry
 
 
-theorem lshrugt_03_13_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4 3)) (const? 4 (-3)) ⊑ const? 1 0 := by
+theorem lshrugt_03_13_thm (e : IntW 4) : icmp IntPred.ugt (lshr e (const? 4 3)) (const? 4 (-3)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -436,7 +436,7 @@ theorem lshrugt_03_13_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4
     all_goals sorry
 
 
-theorem lshrugt_03_14_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4 3)) (const? 4 (-2)) ⊑ const? 1 0 := by
+theorem lshrugt_03_14_thm (e : IntW 4) : icmp IntPred.ugt (lshr e (const? 4 3)) (const? 4 (-2)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -445,7 +445,7 @@ theorem lshrugt_03_14_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4
     all_goals sorry
 
 
-theorem lshrugt_03_15_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4 3)) (const? 4 (-1)) ⊑ const? 1 0 := by
+theorem lshrugt_03_15_thm (e : IntW 4) : icmp IntPred.ugt (lshr e (const? 4 3)) (const? 4 (-1)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -454,7 +454,7 @@ theorem lshrugt_03_15_thm (e : IntW 4) : icmp IntPredicate.ugt (lshr e (const? 4
     all_goals sorry
 
 
-theorem lshrult_01_00_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4 1)) (const? 4 0) ⊑ const? 1 0 := by
+theorem lshrult_01_00_thm (e : IntW 4) : icmp IntPred.ult (lshr e (const? 4 1)) (const? 4 0) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -464,7 +464,7 @@ theorem lshrult_01_00_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4
 
 
 theorem lshrult_01_01_thm (e : IntW 4) :
-  icmp IntPredicate.ult (lshr e (const? 4 1)) (const? 4 1) ⊑ icmp IntPredicate.ult e (const? 4 2) := by
+  icmp IntPred.ult (lshr e (const? 4 1)) (const? 4 1) ⊑ icmp IntPred.ult e (const? 4 2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -474,7 +474,7 @@ theorem lshrult_01_01_thm (e : IntW 4) :
 
 
 theorem lshrult_01_02_thm (e : IntW 4) :
-  icmp IntPredicate.ult (lshr e (const? 4 1)) (const? 4 2) ⊑ icmp IntPredicate.ult e (const? 4 4) := by
+  icmp IntPred.ult (lshr e (const? 4 1)) (const? 4 2) ⊑ icmp IntPred.ult e (const? 4 4) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -484,7 +484,7 @@ theorem lshrult_01_02_thm (e : IntW 4) :
 
 
 theorem lshrult_01_03_thm (e : IntW 4) :
-  icmp IntPredicate.ult (lshr e (const? 4 1)) (const? 4 3) ⊑ icmp IntPredicate.ult e (const? 4 6) := by
+  icmp IntPred.ult (lshr e (const? 4 1)) (const? 4 3) ⊑ icmp IntPred.ult e (const? 4 6) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -494,7 +494,7 @@ theorem lshrult_01_03_thm (e : IntW 4) :
 
 
 theorem lshrult_01_04_thm (e : IntW 4) :
-  icmp IntPredicate.ult (lshr e (const? 4 1)) (const? 4 4) ⊑ icmp IntPredicate.sgt e (const? 4 (-1)) := by
+  icmp IntPred.ult (lshr e (const? 4 1)) (const? 4 4) ⊑ icmp IntPred.sgt e (const? 4 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -504,7 +504,7 @@ theorem lshrult_01_04_thm (e : IntW 4) :
 
 
 theorem lshrult_01_05_thm (e : IntW 4) :
-  icmp IntPredicate.ult (lshr e (const? 4 1)) (const? 4 5) ⊑ icmp IntPredicate.ult e (const? 4 (-6)) := by
+  icmp IntPred.ult (lshr e (const? 4 1)) (const? 4 5) ⊑ icmp IntPred.ult e (const? 4 (-6)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -514,7 +514,7 @@ theorem lshrult_01_05_thm (e : IntW 4) :
 
 
 theorem lshrult_01_06_thm (e : IntW 4) :
-  icmp IntPredicate.ult (lshr e (const? 4 1)) (const? 4 6) ⊑ icmp IntPredicate.ult e (const? 4 (-4)) := by
+  icmp IntPred.ult (lshr e (const? 4 1)) (const? 4 6) ⊑ icmp IntPred.ult e (const? 4 (-4)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -524,7 +524,7 @@ theorem lshrult_01_06_thm (e : IntW 4) :
 
 
 theorem lshrult_01_07_thm (e : IntW 4) :
-  icmp IntPredicate.ult (lshr e (const? 4 1)) (const? 4 7) ⊑ icmp IntPredicate.ult e (const? 4 (-2)) := by
+  icmp IntPred.ult (lshr e (const? 4 1)) (const? 4 7) ⊑ icmp IntPred.ult e (const? 4 (-2)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -533,7 +533,7 @@ theorem lshrult_01_07_thm (e : IntW 4) :
     all_goals sorry
 
 
-theorem lshrult_01_08_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4 1)) (const? 4 (-8)) ⊑ const? 1 1 := by
+theorem lshrult_01_08_thm (e : IntW 4) : icmp IntPred.ult (lshr e (const? 4 1)) (const? 4 (-8)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -542,7 +542,7 @@ theorem lshrult_01_08_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4
     all_goals sorry
 
 
-theorem lshrult_01_09_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4 1)) (const? 4 (-7)) ⊑ const? 1 1 := by
+theorem lshrult_01_09_thm (e : IntW 4) : icmp IntPred.ult (lshr e (const? 4 1)) (const? 4 (-7)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -551,7 +551,7 @@ theorem lshrult_01_09_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4
     all_goals sorry
 
 
-theorem lshrult_01_10_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4 1)) (const? 4 (-6)) ⊑ const? 1 1 := by
+theorem lshrult_01_10_thm (e : IntW 4) : icmp IntPred.ult (lshr e (const? 4 1)) (const? 4 (-6)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -560,7 +560,7 @@ theorem lshrult_01_10_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4
     all_goals sorry
 
 
-theorem lshrult_01_11_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4 1)) (const? 4 (-5)) ⊑ const? 1 1 := by
+theorem lshrult_01_11_thm (e : IntW 4) : icmp IntPred.ult (lshr e (const? 4 1)) (const? 4 (-5)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -569,7 +569,7 @@ theorem lshrult_01_11_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4
     all_goals sorry
 
 
-theorem lshrult_01_12_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4 1)) (const? 4 (-4)) ⊑ const? 1 1 := by
+theorem lshrult_01_12_thm (e : IntW 4) : icmp IntPred.ult (lshr e (const? 4 1)) (const? 4 (-4)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -578,7 +578,7 @@ theorem lshrult_01_12_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4
     all_goals sorry
 
 
-theorem lshrult_01_13_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4 1)) (const? 4 (-3)) ⊑ const? 1 1 := by
+theorem lshrult_01_13_thm (e : IntW 4) : icmp IntPred.ult (lshr e (const? 4 1)) (const? 4 (-3)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -587,7 +587,7 @@ theorem lshrult_01_13_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4
     all_goals sorry
 
 
-theorem lshrult_01_14_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4 1)) (const? 4 (-2)) ⊑ const? 1 1 := by
+theorem lshrult_01_14_thm (e : IntW 4) : icmp IntPred.ult (lshr e (const? 4 1)) (const? 4 (-2)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -596,7 +596,7 @@ theorem lshrult_01_14_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4
     all_goals sorry
 
 
-theorem lshrult_01_15_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4 1)) (const? 4 (-1)) ⊑ const? 1 1 := by
+theorem lshrult_01_15_thm (e : IntW 4) : icmp IntPred.ult (lshr e (const? 4 1)) (const? 4 (-1)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -605,7 +605,7 @@ theorem lshrult_01_15_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4
     all_goals sorry
 
 
-theorem lshrult_02_00_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4 2)) (const? 4 0) ⊑ const? 1 0 := by
+theorem lshrult_02_00_thm (e : IntW 4) : icmp IntPred.ult (lshr e (const? 4 2)) (const? 4 0) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -615,7 +615,7 @@ theorem lshrult_02_00_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4
 
 
 theorem lshrult_02_01_thm (e : IntW 4) :
-  icmp IntPredicate.ult (lshr e (const? 4 2)) (const? 4 1) ⊑ icmp IntPredicate.ult e (const? 4 4) := by
+  icmp IntPred.ult (lshr e (const? 4 2)) (const? 4 1) ⊑ icmp IntPred.ult e (const? 4 4) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -625,7 +625,7 @@ theorem lshrult_02_01_thm (e : IntW 4) :
 
 
 theorem lshrult_02_02_thm (e : IntW 4) :
-  icmp IntPredicate.ult (lshr e (const? 4 2)) (const? 4 2) ⊑ icmp IntPredicate.sgt e (const? 4 (-1)) := by
+  icmp IntPred.ult (lshr e (const? 4 2)) (const? 4 2) ⊑ icmp IntPred.sgt e (const? 4 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -635,7 +635,7 @@ theorem lshrult_02_02_thm (e : IntW 4) :
 
 
 theorem lshrult_02_03_thm (e : IntW 4) :
-  icmp IntPredicate.ult (lshr e (const? 4 2)) (const? 4 3) ⊑ icmp IntPredicate.ult e (const? 4 (-4)) := by
+  icmp IntPred.ult (lshr e (const? 4 2)) (const? 4 3) ⊑ icmp IntPred.ult e (const? 4 (-4)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -644,7 +644,7 @@ theorem lshrult_02_03_thm (e : IntW 4) :
     all_goals sorry
 
 
-theorem lshrult_02_04_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4 2)) (const? 4 4) ⊑ const? 1 1 := by
+theorem lshrult_02_04_thm (e : IntW 4) : icmp IntPred.ult (lshr e (const? 4 2)) (const? 4 4) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -653,7 +653,7 @@ theorem lshrult_02_04_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4
     all_goals sorry
 
 
-theorem lshrult_02_05_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4 2)) (const? 4 5) ⊑ const? 1 1 := by
+theorem lshrult_02_05_thm (e : IntW 4) : icmp IntPred.ult (lshr e (const? 4 2)) (const? 4 5) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -662,7 +662,7 @@ theorem lshrult_02_05_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4
     all_goals sorry
 
 
-theorem lshrult_02_06_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4 2)) (const? 4 6) ⊑ const? 1 1 := by
+theorem lshrult_02_06_thm (e : IntW 4) : icmp IntPred.ult (lshr e (const? 4 2)) (const? 4 6) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -671,7 +671,7 @@ theorem lshrult_02_06_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4
     all_goals sorry
 
 
-theorem lshrult_02_07_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4 2)) (const? 4 7) ⊑ const? 1 1 := by
+theorem lshrult_02_07_thm (e : IntW 4) : icmp IntPred.ult (lshr e (const? 4 2)) (const? 4 7) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -680,7 +680,7 @@ theorem lshrult_02_07_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4
     all_goals sorry
 
 
-theorem lshrult_02_08_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4 2)) (const? 4 (-8)) ⊑ const? 1 1 := by
+theorem lshrult_02_08_thm (e : IntW 4) : icmp IntPred.ult (lshr e (const? 4 2)) (const? 4 (-8)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -689,7 +689,7 @@ theorem lshrult_02_08_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4
     all_goals sorry
 
 
-theorem lshrult_02_09_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4 2)) (const? 4 (-7)) ⊑ const? 1 1 := by
+theorem lshrult_02_09_thm (e : IntW 4) : icmp IntPred.ult (lshr e (const? 4 2)) (const? 4 (-7)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -698,7 +698,7 @@ theorem lshrult_02_09_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4
     all_goals sorry
 
 
-theorem lshrult_02_10_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4 2)) (const? 4 (-6)) ⊑ const? 1 1 := by
+theorem lshrult_02_10_thm (e : IntW 4) : icmp IntPred.ult (lshr e (const? 4 2)) (const? 4 (-6)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -707,7 +707,7 @@ theorem lshrult_02_10_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4
     all_goals sorry
 
 
-theorem lshrult_02_11_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4 2)) (const? 4 (-5)) ⊑ const? 1 1 := by
+theorem lshrult_02_11_thm (e : IntW 4) : icmp IntPred.ult (lshr e (const? 4 2)) (const? 4 (-5)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -716,7 +716,7 @@ theorem lshrult_02_11_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4
     all_goals sorry
 
 
-theorem lshrult_02_12_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4 2)) (const? 4 (-4)) ⊑ const? 1 1 := by
+theorem lshrult_02_12_thm (e : IntW 4) : icmp IntPred.ult (lshr e (const? 4 2)) (const? 4 (-4)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -725,7 +725,7 @@ theorem lshrult_02_12_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4
     all_goals sorry
 
 
-theorem lshrult_02_13_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4 2)) (const? 4 (-3)) ⊑ const? 1 1 := by
+theorem lshrult_02_13_thm (e : IntW 4) : icmp IntPred.ult (lshr e (const? 4 2)) (const? 4 (-3)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -734,7 +734,7 @@ theorem lshrult_02_13_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4
     all_goals sorry
 
 
-theorem lshrult_02_14_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4 2)) (const? 4 (-2)) ⊑ const? 1 1 := by
+theorem lshrult_02_14_thm (e : IntW 4) : icmp IntPred.ult (lshr e (const? 4 2)) (const? 4 (-2)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -743,7 +743,7 @@ theorem lshrult_02_14_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4
     all_goals sorry
 
 
-theorem lshrult_02_15_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4 2)) (const? 4 (-1)) ⊑ const? 1 1 := by
+theorem lshrult_02_15_thm (e : IntW 4) : icmp IntPred.ult (lshr e (const? 4 2)) (const? 4 (-1)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -752,7 +752,7 @@ theorem lshrult_02_15_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4
     all_goals sorry
 
 
-theorem lshrult_03_00_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4 3)) (const? 4 0) ⊑ const? 1 0 := by
+theorem lshrult_03_00_thm (e : IntW 4) : icmp IntPred.ult (lshr e (const? 4 3)) (const? 4 0) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -762,7 +762,7 @@ theorem lshrult_03_00_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4
 
 
 theorem lshrult_03_01_thm (e : IntW 4) :
-  icmp IntPredicate.ult (lshr e (const? 4 3)) (const? 4 1) ⊑ icmp IntPredicate.sgt e (const? 4 (-1)) := by
+  icmp IntPred.ult (lshr e (const? 4 3)) (const? 4 1) ⊑ icmp IntPred.sgt e (const? 4 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -771,7 +771,7 @@ theorem lshrult_03_01_thm (e : IntW 4) :
     all_goals sorry
 
 
-theorem lshrult_03_02_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4 3)) (const? 4 2) ⊑ const? 1 1 := by
+theorem lshrult_03_02_thm (e : IntW 4) : icmp IntPred.ult (lshr e (const? 4 3)) (const? 4 2) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -780,7 +780,7 @@ theorem lshrult_03_02_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4
     all_goals sorry
 
 
-theorem lshrult_03_03_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4 3)) (const? 4 3) ⊑ const? 1 1 := by
+theorem lshrult_03_03_thm (e : IntW 4) : icmp IntPred.ult (lshr e (const? 4 3)) (const? 4 3) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -789,7 +789,7 @@ theorem lshrult_03_03_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4
     all_goals sorry
 
 
-theorem lshrult_03_04_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4 3)) (const? 4 4) ⊑ const? 1 1 := by
+theorem lshrult_03_04_thm (e : IntW 4) : icmp IntPred.ult (lshr e (const? 4 3)) (const? 4 4) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -798,7 +798,7 @@ theorem lshrult_03_04_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4
     all_goals sorry
 
 
-theorem lshrult_03_05_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4 3)) (const? 4 5) ⊑ const? 1 1 := by
+theorem lshrult_03_05_thm (e : IntW 4) : icmp IntPred.ult (lshr e (const? 4 3)) (const? 4 5) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -807,7 +807,7 @@ theorem lshrult_03_05_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4
     all_goals sorry
 
 
-theorem lshrult_03_06_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4 3)) (const? 4 6) ⊑ const? 1 1 := by
+theorem lshrult_03_06_thm (e : IntW 4) : icmp IntPred.ult (lshr e (const? 4 3)) (const? 4 6) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -816,7 +816,7 @@ theorem lshrult_03_06_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4
     all_goals sorry
 
 
-theorem lshrult_03_07_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4 3)) (const? 4 7) ⊑ const? 1 1 := by
+theorem lshrult_03_07_thm (e : IntW 4) : icmp IntPred.ult (lshr e (const? 4 3)) (const? 4 7) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -825,7 +825,7 @@ theorem lshrult_03_07_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4
     all_goals sorry
 
 
-theorem lshrult_03_08_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4 3)) (const? 4 (-8)) ⊑ const? 1 1 := by
+theorem lshrult_03_08_thm (e : IntW 4) : icmp IntPred.ult (lshr e (const? 4 3)) (const? 4 (-8)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -834,7 +834,7 @@ theorem lshrult_03_08_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4
     all_goals sorry
 
 
-theorem lshrult_03_09_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4 3)) (const? 4 (-7)) ⊑ const? 1 1 := by
+theorem lshrult_03_09_thm (e : IntW 4) : icmp IntPred.ult (lshr e (const? 4 3)) (const? 4 (-7)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -843,7 +843,7 @@ theorem lshrult_03_09_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4
     all_goals sorry
 
 
-theorem lshrult_03_10_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4 3)) (const? 4 (-6)) ⊑ const? 1 1 := by
+theorem lshrult_03_10_thm (e : IntW 4) : icmp IntPred.ult (lshr e (const? 4 3)) (const? 4 (-6)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -852,7 +852,7 @@ theorem lshrult_03_10_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4
     all_goals sorry
 
 
-theorem lshrult_03_11_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4 3)) (const? 4 (-5)) ⊑ const? 1 1 := by
+theorem lshrult_03_11_thm (e : IntW 4) : icmp IntPred.ult (lshr e (const? 4 3)) (const? 4 (-5)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -861,7 +861,7 @@ theorem lshrult_03_11_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4
     all_goals sorry
 
 
-theorem lshrult_03_12_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4 3)) (const? 4 (-4)) ⊑ const? 1 1 := by
+theorem lshrult_03_12_thm (e : IntW 4) : icmp IntPred.ult (lshr e (const? 4 3)) (const? 4 (-4)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -870,7 +870,7 @@ theorem lshrult_03_12_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4
     all_goals sorry
 
 
-theorem lshrult_03_13_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4 3)) (const? 4 (-3)) ⊑ const? 1 1 := by
+theorem lshrult_03_13_thm (e : IntW 4) : icmp IntPred.ult (lshr e (const? 4 3)) (const? 4 (-3)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -879,7 +879,7 @@ theorem lshrult_03_13_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4
     all_goals sorry
 
 
-theorem lshrult_03_14_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4 3)) (const? 4 (-2)) ⊑ const? 1 1 := by
+theorem lshrult_03_14_thm (e : IntW 4) : icmp IntPred.ult (lshr e (const? 4 3)) (const? 4 (-2)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -888,7 +888,7 @@ theorem lshrult_03_14_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4
     all_goals sorry
 
 
-theorem lshrult_03_15_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4 3)) (const? 4 (-1)) ⊑ const? 1 1 := by
+theorem lshrult_03_15_thm (e : IntW 4) : icmp IntPred.ult (lshr e (const? 4 3)) (const? 4 (-1)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -898,7 +898,7 @@ theorem lshrult_03_15_thm (e : IntW 4) : icmp IntPredicate.ult (lshr e (const? 4
 
 
 theorem ashrsgt_01_00_thm (e : IntW 4) :
-  icmp IntPredicate.sgt (ashr e (const? 4 1)) (const? 4 0) ⊑ icmp IntPredicate.sgt e (const? 4 1) := by
+  icmp IntPred.sgt (ashr e (const? 4 1)) (const? 4 0) ⊑ icmp IntPred.sgt e (const? 4 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -908,7 +908,7 @@ theorem ashrsgt_01_00_thm (e : IntW 4) :
 
 
 theorem ashrsgt_01_01_thm (e : IntW 4) :
-  icmp IntPredicate.sgt (ashr e (const? 4 1)) (const? 4 1) ⊑ icmp IntPredicate.sgt e (const? 4 3) := by
+  icmp IntPred.sgt (ashr e (const? 4 1)) (const? 4 1) ⊑ icmp IntPred.sgt e (const? 4 3) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -918,7 +918,7 @@ theorem ashrsgt_01_01_thm (e : IntW 4) :
 
 
 theorem ashrsgt_01_02_thm (e : IntW 4) :
-  icmp IntPredicate.sgt (ashr e (const? 4 1)) (const? 4 2) ⊑ icmp IntPredicate.sgt e (const? 4 5) := by
+  icmp IntPred.sgt (ashr e (const? 4 1)) (const? 4 2) ⊑ icmp IntPred.sgt e (const? 4 5) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -927,7 +927,7 @@ theorem ashrsgt_01_02_thm (e : IntW 4) :
     all_goals sorry
 
 
-theorem ashrsgt_01_03_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4 1)) (const? 4 3) ⊑ const? 1 0 := by
+theorem ashrsgt_01_03_thm (e : IntW 4) : icmp IntPred.sgt (ashr e (const? 4 1)) (const? 4 3) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -936,7 +936,7 @@ theorem ashrsgt_01_03_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4
     all_goals sorry
 
 
-theorem ashrsgt_01_04_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4 1)) (const? 4 4) ⊑ const? 1 0 := by
+theorem ashrsgt_01_04_thm (e : IntW 4) : icmp IntPred.sgt (ashr e (const? 4 1)) (const? 4 4) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -945,7 +945,7 @@ theorem ashrsgt_01_04_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4
     all_goals sorry
 
 
-theorem ashrsgt_01_05_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4 1)) (const? 4 5) ⊑ const? 1 0 := by
+theorem ashrsgt_01_05_thm (e : IntW 4) : icmp IntPred.sgt (ashr e (const? 4 1)) (const? 4 5) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -954,7 +954,7 @@ theorem ashrsgt_01_05_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4
     all_goals sorry
 
 
-theorem ashrsgt_01_06_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4 1)) (const? 4 6) ⊑ const? 1 0 := by
+theorem ashrsgt_01_06_thm (e : IntW 4) : icmp IntPred.sgt (ashr e (const? 4 1)) (const? 4 6) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -963,7 +963,7 @@ theorem ashrsgt_01_06_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4
     all_goals sorry
 
 
-theorem ashrsgt_01_07_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4 1)) (const? 4 7) ⊑ const? 1 0 := by
+theorem ashrsgt_01_07_thm (e : IntW 4) : icmp IntPred.sgt (ashr e (const? 4 1)) (const? 4 7) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -972,7 +972,7 @@ theorem ashrsgt_01_07_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4
     all_goals sorry
 
 
-theorem ashrsgt_01_08_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4 1)) (const? 4 (-8)) ⊑ const? 1 1 := by
+theorem ashrsgt_01_08_thm (e : IntW 4) : icmp IntPred.sgt (ashr e (const? 4 1)) (const? 4 (-8)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -981,7 +981,7 @@ theorem ashrsgt_01_08_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4
     all_goals sorry
 
 
-theorem ashrsgt_01_09_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4 1)) (const? 4 (-7)) ⊑ const? 1 1 := by
+theorem ashrsgt_01_09_thm (e : IntW 4) : icmp IntPred.sgt (ashr e (const? 4 1)) (const? 4 (-7)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -990,7 +990,7 @@ theorem ashrsgt_01_09_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4
     all_goals sorry
 
 
-theorem ashrsgt_01_10_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4 1)) (const? 4 (-6)) ⊑ const? 1 1 := by
+theorem ashrsgt_01_10_thm (e : IntW 4) : icmp IntPred.sgt (ashr e (const? 4 1)) (const? 4 (-6)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -999,7 +999,7 @@ theorem ashrsgt_01_10_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4
     all_goals sorry
 
 
-theorem ashrsgt_01_11_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4 1)) (const? 4 (-5)) ⊑ const? 1 1 := by
+theorem ashrsgt_01_11_thm (e : IntW 4) : icmp IntPred.sgt (ashr e (const? 4 1)) (const? 4 (-5)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1009,7 +1009,7 @@ theorem ashrsgt_01_11_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4
 
 
 theorem ashrsgt_01_12_thm (e : IntW 4) :
-  icmp IntPredicate.sgt (ashr e (const? 4 1)) (const? 4 (-4)) ⊑ icmp IntPredicate.sgt e (const? 4 (-7)) := by
+  icmp IntPred.sgt (ashr e (const? 4 1)) (const? 4 (-4)) ⊑ icmp IntPred.sgt e (const? 4 (-7)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1019,7 +1019,7 @@ theorem ashrsgt_01_12_thm (e : IntW 4) :
 
 
 theorem ashrsgt_01_13_thm (e : IntW 4) :
-  icmp IntPredicate.sgt (ashr e (const? 4 1)) (const? 4 (-3)) ⊑ icmp IntPredicate.sgt e (const? 4 (-5)) := by
+  icmp IntPred.sgt (ashr e (const? 4 1)) (const? 4 (-3)) ⊑ icmp IntPred.sgt e (const? 4 (-5)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1029,7 +1029,7 @@ theorem ashrsgt_01_13_thm (e : IntW 4) :
 
 
 theorem ashrsgt_01_14_thm (e : IntW 4) :
-  icmp IntPredicate.sgt (ashr e (const? 4 1)) (const? 4 (-2)) ⊑ icmp IntPredicate.sgt e (const? 4 (-3)) := by
+  icmp IntPred.sgt (ashr e (const? 4 1)) (const? 4 (-2)) ⊑ icmp IntPred.sgt e (const? 4 (-3)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1039,7 +1039,7 @@ theorem ashrsgt_01_14_thm (e : IntW 4) :
 
 
 theorem ashrsgt_01_15_thm (e : IntW 4) :
-  icmp IntPredicate.sgt (ashr e (const? 4 1)) (const? 4 (-1)) ⊑ icmp IntPredicate.sgt e (const? 4 (-1)) := by
+  icmp IntPred.sgt (ashr e (const? 4 1)) (const? 4 (-1)) ⊑ icmp IntPred.sgt e (const? 4 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1049,7 +1049,7 @@ theorem ashrsgt_01_15_thm (e : IntW 4) :
 
 
 theorem ashrsgt_02_00_thm (e : IntW 4) :
-  icmp IntPredicate.sgt (ashr e (const? 4 2)) (const? 4 0) ⊑ icmp IntPredicate.sgt e (const? 4 3) := by
+  icmp IntPred.sgt (ashr e (const? 4 2)) (const? 4 0) ⊑ icmp IntPred.sgt e (const? 4 3) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1058,7 +1058,7 @@ theorem ashrsgt_02_00_thm (e : IntW 4) :
     all_goals sorry
 
 
-theorem ashrsgt_02_01_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4 2)) (const? 4 1) ⊑ const? 1 0 := by
+theorem ashrsgt_02_01_thm (e : IntW 4) : icmp IntPred.sgt (ashr e (const? 4 2)) (const? 4 1) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1067,7 +1067,7 @@ theorem ashrsgt_02_01_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4
     all_goals sorry
 
 
-theorem ashrsgt_02_02_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4 2)) (const? 4 2) ⊑ const? 1 0 := by
+theorem ashrsgt_02_02_thm (e : IntW 4) : icmp IntPred.sgt (ashr e (const? 4 2)) (const? 4 2) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1076,7 +1076,7 @@ theorem ashrsgt_02_02_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4
     all_goals sorry
 
 
-theorem ashrsgt_02_03_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4 2)) (const? 4 3) ⊑ const? 1 0 := by
+theorem ashrsgt_02_03_thm (e : IntW 4) : icmp IntPred.sgt (ashr e (const? 4 2)) (const? 4 3) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1085,7 +1085,7 @@ theorem ashrsgt_02_03_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4
     all_goals sorry
 
 
-theorem ashrsgt_02_04_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4 2)) (const? 4 4) ⊑ const? 1 0 := by
+theorem ashrsgt_02_04_thm (e : IntW 4) : icmp IntPred.sgt (ashr e (const? 4 2)) (const? 4 4) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1094,7 +1094,7 @@ theorem ashrsgt_02_04_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4
     all_goals sorry
 
 
-theorem ashrsgt_02_05_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4 2)) (const? 4 5) ⊑ const? 1 0 := by
+theorem ashrsgt_02_05_thm (e : IntW 4) : icmp IntPred.sgt (ashr e (const? 4 2)) (const? 4 5) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1103,7 +1103,7 @@ theorem ashrsgt_02_05_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4
     all_goals sorry
 
 
-theorem ashrsgt_02_06_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4 2)) (const? 4 6) ⊑ const? 1 0 := by
+theorem ashrsgt_02_06_thm (e : IntW 4) : icmp IntPred.sgt (ashr e (const? 4 2)) (const? 4 6) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1112,7 +1112,7 @@ theorem ashrsgt_02_06_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4
     all_goals sorry
 
 
-theorem ashrsgt_02_07_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4 2)) (const? 4 7) ⊑ const? 1 0 := by
+theorem ashrsgt_02_07_thm (e : IntW 4) : icmp IntPred.sgt (ashr e (const? 4 2)) (const? 4 7) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1121,7 +1121,7 @@ theorem ashrsgt_02_07_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4
     all_goals sorry
 
 
-theorem ashrsgt_02_08_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4 2)) (const? 4 (-8)) ⊑ const? 1 1 := by
+theorem ashrsgt_02_08_thm (e : IntW 4) : icmp IntPred.sgt (ashr e (const? 4 2)) (const? 4 (-8)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1130,7 +1130,7 @@ theorem ashrsgt_02_08_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4
     all_goals sorry
 
 
-theorem ashrsgt_02_09_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4 2)) (const? 4 (-7)) ⊑ const? 1 1 := by
+theorem ashrsgt_02_09_thm (e : IntW 4) : icmp IntPred.sgt (ashr e (const? 4 2)) (const? 4 (-7)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1139,7 +1139,7 @@ theorem ashrsgt_02_09_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4
     all_goals sorry
 
 
-theorem ashrsgt_02_10_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4 2)) (const? 4 (-6)) ⊑ const? 1 1 := by
+theorem ashrsgt_02_10_thm (e : IntW 4) : icmp IntPred.sgt (ashr e (const? 4 2)) (const? 4 (-6)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1148,7 +1148,7 @@ theorem ashrsgt_02_10_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4
     all_goals sorry
 
 
-theorem ashrsgt_02_11_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4 2)) (const? 4 (-5)) ⊑ const? 1 1 := by
+theorem ashrsgt_02_11_thm (e : IntW 4) : icmp IntPred.sgt (ashr e (const? 4 2)) (const? 4 (-5)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1157,7 +1157,7 @@ theorem ashrsgt_02_11_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4
     all_goals sorry
 
 
-theorem ashrsgt_02_12_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4 2)) (const? 4 (-4)) ⊑ const? 1 1 := by
+theorem ashrsgt_02_12_thm (e : IntW 4) : icmp IntPred.sgt (ashr e (const? 4 2)) (const? 4 (-4)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1166,7 +1166,7 @@ theorem ashrsgt_02_12_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4
     all_goals sorry
 
 
-theorem ashrsgt_02_13_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4 2)) (const? 4 (-3)) ⊑ const? 1 1 := by
+theorem ashrsgt_02_13_thm (e : IntW 4) : icmp IntPred.sgt (ashr e (const? 4 2)) (const? 4 (-3)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1176,7 +1176,7 @@ theorem ashrsgt_02_13_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4
 
 
 theorem ashrsgt_02_14_thm (e : IntW 4) :
-  icmp IntPredicate.sgt (ashr e (const? 4 2)) (const? 4 (-2)) ⊑ icmp IntPredicate.sgt e (const? 4 (-5)) := by
+  icmp IntPred.sgt (ashr e (const? 4 2)) (const? 4 (-2)) ⊑ icmp IntPred.sgt e (const? 4 (-5)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1186,7 +1186,7 @@ theorem ashrsgt_02_14_thm (e : IntW 4) :
 
 
 theorem ashrsgt_02_15_thm (e : IntW 4) :
-  icmp IntPredicate.sgt (ashr e (const? 4 2)) (const? 4 (-1)) ⊑ icmp IntPredicate.sgt e (const? 4 (-1)) := by
+  icmp IntPred.sgt (ashr e (const? 4 2)) (const? 4 (-1)) ⊑ icmp IntPred.sgt e (const? 4 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1195,7 +1195,7 @@ theorem ashrsgt_02_15_thm (e : IntW 4) :
     all_goals sorry
 
 
-theorem ashrsgt_03_00_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4 3)) (const? 4 0) ⊑ const? 1 0 := by
+theorem ashrsgt_03_00_thm (e : IntW 4) : icmp IntPred.sgt (ashr e (const? 4 3)) (const? 4 0) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1204,7 +1204,7 @@ theorem ashrsgt_03_00_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4
     all_goals sorry
 
 
-theorem ashrsgt_03_01_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4 3)) (const? 4 1) ⊑ const? 1 0 := by
+theorem ashrsgt_03_01_thm (e : IntW 4) : icmp IntPred.sgt (ashr e (const? 4 3)) (const? 4 1) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1213,7 +1213,7 @@ theorem ashrsgt_03_01_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4
     all_goals sorry
 
 
-theorem ashrsgt_03_02_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4 3)) (const? 4 2) ⊑ const? 1 0 := by
+theorem ashrsgt_03_02_thm (e : IntW 4) : icmp IntPred.sgt (ashr e (const? 4 3)) (const? 4 2) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1222,7 +1222,7 @@ theorem ashrsgt_03_02_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4
     all_goals sorry
 
 
-theorem ashrsgt_03_03_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4 3)) (const? 4 3) ⊑ const? 1 0 := by
+theorem ashrsgt_03_03_thm (e : IntW 4) : icmp IntPred.sgt (ashr e (const? 4 3)) (const? 4 3) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1231,7 +1231,7 @@ theorem ashrsgt_03_03_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4
     all_goals sorry
 
 
-theorem ashrsgt_03_04_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4 3)) (const? 4 4) ⊑ const? 1 0 := by
+theorem ashrsgt_03_04_thm (e : IntW 4) : icmp IntPred.sgt (ashr e (const? 4 3)) (const? 4 4) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1240,7 +1240,7 @@ theorem ashrsgt_03_04_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4
     all_goals sorry
 
 
-theorem ashrsgt_03_05_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4 3)) (const? 4 5) ⊑ const? 1 0 := by
+theorem ashrsgt_03_05_thm (e : IntW 4) : icmp IntPred.sgt (ashr e (const? 4 3)) (const? 4 5) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1249,7 +1249,7 @@ theorem ashrsgt_03_05_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4
     all_goals sorry
 
 
-theorem ashrsgt_03_06_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4 3)) (const? 4 6) ⊑ const? 1 0 := by
+theorem ashrsgt_03_06_thm (e : IntW 4) : icmp IntPred.sgt (ashr e (const? 4 3)) (const? 4 6) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1258,7 +1258,7 @@ theorem ashrsgt_03_06_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4
     all_goals sorry
 
 
-theorem ashrsgt_03_07_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4 3)) (const? 4 7) ⊑ const? 1 0 := by
+theorem ashrsgt_03_07_thm (e : IntW 4) : icmp IntPred.sgt (ashr e (const? 4 3)) (const? 4 7) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1267,7 +1267,7 @@ theorem ashrsgt_03_07_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4
     all_goals sorry
 
 
-theorem ashrsgt_03_08_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4 3)) (const? 4 (-8)) ⊑ const? 1 1 := by
+theorem ashrsgt_03_08_thm (e : IntW 4) : icmp IntPred.sgt (ashr e (const? 4 3)) (const? 4 (-8)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1276,7 +1276,7 @@ theorem ashrsgt_03_08_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4
     all_goals sorry
 
 
-theorem ashrsgt_03_09_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4 3)) (const? 4 (-7)) ⊑ const? 1 1 := by
+theorem ashrsgt_03_09_thm (e : IntW 4) : icmp IntPred.sgt (ashr e (const? 4 3)) (const? 4 (-7)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1285,7 +1285,7 @@ theorem ashrsgt_03_09_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4
     all_goals sorry
 
 
-theorem ashrsgt_03_10_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4 3)) (const? 4 (-6)) ⊑ const? 1 1 := by
+theorem ashrsgt_03_10_thm (e : IntW 4) : icmp IntPred.sgt (ashr e (const? 4 3)) (const? 4 (-6)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1294,7 +1294,7 @@ theorem ashrsgt_03_10_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4
     all_goals sorry
 
 
-theorem ashrsgt_03_11_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4 3)) (const? 4 (-5)) ⊑ const? 1 1 := by
+theorem ashrsgt_03_11_thm (e : IntW 4) : icmp IntPred.sgt (ashr e (const? 4 3)) (const? 4 (-5)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1303,7 +1303,7 @@ theorem ashrsgt_03_11_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4
     all_goals sorry
 
 
-theorem ashrsgt_03_12_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4 3)) (const? 4 (-4)) ⊑ const? 1 1 := by
+theorem ashrsgt_03_12_thm (e : IntW 4) : icmp IntPred.sgt (ashr e (const? 4 3)) (const? 4 (-4)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1312,7 +1312,7 @@ theorem ashrsgt_03_12_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4
     all_goals sorry
 
 
-theorem ashrsgt_03_13_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4 3)) (const? 4 (-3)) ⊑ const? 1 1 := by
+theorem ashrsgt_03_13_thm (e : IntW 4) : icmp IntPred.sgt (ashr e (const? 4 3)) (const? 4 (-3)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1321,7 +1321,7 @@ theorem ashrsgt_03_13_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4
     all_goals sorry
 
 
-theorem ashrsgt_03_14_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4 3)) (const? 4 (-2)) ⊑ const? 1 1 := by
+theorem ashrsgt_03_14_thm (e : IntW 4) : icmp IntPred.sgt (ashr e (const? 4 3)) (const? 4 (-2)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1331,7 +1331,7 @@ theorem ashrsgt_03_14_thm (e : IntW 4) : icmp IntPredicate.sgt (ashr e (const? 4
 
 
 theorem ashrsgt_03_15_thm (e : IntW 4) :
-  icmp IntPredicate.sgt (ashr e (const? 4 3)) (const? 4 (-1)) ⊑ icmp IntPredicate.sgt e (const? 4 (-1)) := by
+  icmp IntPred.sgt (ashr e (const? 4 3)) (const? 4 (-1)) ⊑ icmp IntPred.sgt e (const? 4 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1341,7 +1341,7 @@ theorem ashrsgt_03_15_thm (e : IntW 4) :
 
 
 theorem ashrslt_01_00_thm (e : IntW 4) :
-  icmp IntPredicate.slt (ashr e (const? 4 1)) (const? 4 0) ⊑ icmp IntPredicate.slt e (const? 4 0) := by
+  icmp IntPred.slt (ashr e (const? 4 1)) (const? 4 0) ⊑ icmp IntPred.slt e (const? 4 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1351,7 +1351,7 @@ theorem ashrslt_01_00_thm (e : IntW 4) :
 
 
 theorem ashrslt_01_01_thm (e : IntW 4) :
-  icmp IntPredicate.slt (ashr e (const? 4 1)) (const? 4 1) ⊑ icmp IntPredicate.slt e (const? 4 2) := by
+  icmp IntPred.slt (ashr e (const? 4 1)) (const? 4 1) ⊑ icmp IntPred.slt e (const? 4 2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1361,7 +1361,7 @@ theorem ashrslt_01_01_thm (e : IntW 4) :
 
 
 theorem ashrslt_01_02_thm (e : IntW 4) :
-  icmp IntPredicate.slt (ashr e (const? 4 1)) (const? 4 2) ⊑ icmp IntPredicate.slt e (const? 4 4) := by
+  icmp IntPred.slt (ashr e (const? 4 1)) (const? 4 2) ⊑ icmp IntPred.slt e (const? 4 4) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1371,7 +1371,7 @@ theorem ashrslt_01_02_thm (e : IntW 4) :
 
 
 theorem ashrslt_01_03_thm (e : IntW 4) :
-  icmp IntPredicate.slt (ashr e (const? 4 1)) (const? 4 3) ⊑ icmp IntPredicate.slt e (const? 4 6) := by
+  icmp IntPred.slt (ashr e (const? 4 1)) (const? 4 3) ⊑ icmp IntPred.slt e (const? 4 6) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1380,7 +1380,7 @@ theorem ashrslt_01_03_thm (e : IntW 4) :
     all_goals sorry
 
 
-theorem ashrslt_01_04_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4 1)) (const? 4 4) ⊑ const? 1 1 := by
+theorem ashrslt_01_04_thm (e : IntW 4) : icmp IntPred.slt (ashr e (const? 4 1)) (const? 4 4) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1389,7 +1389,7 @@ theorem ashrslt_01_04_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4
     all_goals sorry
 
 
-theorem ashrslt_01_05_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4 1)) (const? 4 5) ⊑ const? 1 1 := by
+theorem ashrslt_01_05_thm (e : IntW 4) : icmp IntPred.slt (ashr e (const? 4 1)) (const? 4 5) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1398,7 +1398,7 @@ theorem ashrslt_01_05_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4
     all_goals sorry
 
 
-theorem ashrslt_01_06_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4 1)) (const? 4 6) ⊑ const? 1 1 := by
+theorem ashrslt_01_06_thm (e : IntW 4) : icmp IntPred.slt (ashr e (const? 4 1)) (const? 4 6) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1407,7 +1407,7 @@ theorem ashrslt_01_06_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4
     all_goals sorry
 
 
-theorem ashrslt_01_07_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4 1)) (const? 4 7) ⊑ const? 1 1 := by
+theorem ashrslt_01_07_thm (e : IntW 4) : icmp IntPred.slt (ashr e (const? 4 1)) (const? 4 7) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1416,7 +1416,7 @@ theorem ashrslt_01_07_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4
     all_goals sorry
 
 
-theorem ashrslt_01_08_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4 1)) (const? 4 (-8)) ⊑ const? 1 0 := by
+theorem ashrslt_01_08_thm (e : IntW 4) : icmp IntPred.slt (ashr e (const? 4 1)) (const? 4 (-8)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1425,7 +1425,7 @@ theorem ashrslt_01_08_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4
     all_goals sorry
 
 
-theorem ashrslt_01_09_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4 1)) (const? 4 (-7)) ⊑ const? 1 0 := by
+theorem ashrslt_01_09_thm (e : IntW 4) : icmp IntPred.slt (ashr e (const? 4 1)) (const? 4 (-7)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1434,7 +1434,7 @@ theorem ashrslt_01_09_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4
     all_goals sorry
 
 
-theorem ashrslt_01_10_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4 1)) (const? 4 (-6)) ⊑ const? 1 0 := by
+theorem ashrslt_01_10_thm (e : IntW 4) : icmp IntPred.slt (ashr e (const? 4 1)) (const? 4 (-6)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1443,7 +1443,7 @@ theorem ashrslt_01_10_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4
     all_goals sorry
 
 
-theorem ashrslt_01_11_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4 1)) (const? 4 (-5)) ⊑ const? 1 0 := by
+theorem ashrslt_01_11_thm (e : IntW 4) : icmp IntPred.slt (ashr e (const? 4 1)) (const? 4 (-5)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1452,7 +1452,7 @@ theorem ashrslt_01_11_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4
     all_goals sorry
 
 
-theorem ashrslt_01_12_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4 1)) (const? 4 (-4)) ⊑ const? 1 0 := by
+theorem ashrslt_01_12_thm (e : IntW 4) : icmp IntPred.slt (ashr e (const? 4 1)) (const? 4 (-4)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1462,7 +1462,7 @@ theorem ashrslt_01_12_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4
 
 
 theorem ashrslt_01_13_thm (e : IntW 4) :
-  icmp IntPredicate.slt (ashr e (const? 4 1)) (const? 4 (-3)) ⊑ icmp IntPredicate.slt e (const? 4 (-6)) := by
+  icmp IntPred.slt (ashr e (const? 4 1)) (const? 4 (-3)) ⊑ icmp IntPred.slt e (const? 4 (-6)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1472,7 +1472,7 @@ theorem ashrslt_01_13_thm (e : IntW 4) :
 
 
 theorem ashrslt_01_14_thm (e : IntW 4) :
-  icmp IntPredicate.slt (ashr e (const? 4 1)) (const? 4 (-2)) ⊑ icmp IntPredicate.slt e (const? 4 (-4)) := by
+  icmp IntPred.slt (ashr e (const? 4 1)) (const? 4 (-2)) ⊑ icmp IntPred.slt e (const? 4 (-4)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1482,7 +1482,7 @@ theorem ashrslt_01_14_thm (e : IntW 4) :
 
 
 theorem ashrslt_01_15_thm (e : IntW 4) :
-  icmp IntPredicate.slt (ashr e (const? 4 1)) (const? 4 (-1)) ⊑ icmp IntPredicate.slt e (const? 4 (-2)) := by
+  icmp IntPred.slt (ashr e (const? 4 1)) (const? 4 (-1)) ⊑ icmp IntPred.slt e (const? 4 (-2)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1492,7 +1492,7 @@ theorem ashrslt_01_15_thm (e : IntW 4) :
 
 
 theorem ashrslt_02_00_thm (e : IntW 4) :
-  icmp IntPredicate.slt (ashr e (const? 4 2)) (const? 4 0) ⊑ icmp IntPredicate.slt e (const? 4 0) := by
+  icmp IntPred.slt (ashr e (const? 4 2)) (const? 4 0) ⊑ icmp IntPred.slt e (const? 4 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1502,7 +1502,7 @@ theorem ashrslt_02_00_thm (e : IntW 4) :
 
 
 theorem ashrslt_02_01_thm (e : IntW 4) :
-  icmp IntPredicate.slt (ashr e (const? 4 2)) (const? 4 1) ⊑ icmp IntPredicate.slt e (const? 4 4) := by
+  icmp IntPred.slt (ashr e (const? 4 2)) (const? 4 1) ⊑ icmp IntPred.slt e (const? 4 4) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1511,7 +1511,7 @@ theorem ashrslt_02_01_thm (e : IntW 4) :
     all_goals sorry
 
 
-theorem ashrslt_02_02_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4 2)) (const? 4 2) ⊑ const? 1 1 := by
+theorem ashrslt_02_02_thm (e : IntW 4) : icmp IntPred.slt (ashr e (const? 4 2)) (const? 4 2) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1520,7 +1520,7 @@ theorem ashrslt_02_02_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4
     all_goals sorry
 
 
-theorem ashrslt_02_03_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4 2)) (const? 4 3) ⊑ const? 1 1 := by
+theorem ashrslt_02_03_thm (e : IntW 4) : icmp IntPred.slt (ashr e (const? 4 2)) (const? 4 3) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1529,7 +1529,7 @@ theorem ashrslt_02_03_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4
     all_goals sorry
 
 
-theorem ashrslt_02_04_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4 2)) (const? 4 4) ⊑ const? 1 1 := by
+theorem ashrslt_02_04_thm (e : IntW 4) : icmp IntPred.slt (ashr e (const? 4 2)) (const? 4 4) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1538,7 +1538,7 @@ theorem ashrslt_02_04_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4
     all_goals sorry
 
 
-theorem ashrslt_02_05_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4 2)) (const? 4 5) ⊑ const? 1 1 := by
+theorem ashrslt_02_05_thm (e : IntW 4) : icmp IntPred.slt (ashr e (const? 4 2)) (const? 4 5) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1547,7 +1547,7 @@ theorem ashrslt_02_05_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4
     all_goals sorry
 
 
-theorem ashrslt_02_06_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4 2)) (const? 4 6) ⊑ const? 1 1 := by
+theorem ashrslt_02_06_thm (e : IntW 4) : icmp IntPred.slt (ashr e (const? 4 2)) (const? 4 6) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1556,7 +1556,7 @@ theorem ashrslt_02_06_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4
     all_goals sorry
 
 
-theorem ashrslt_02_07_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4 2)) (const? 4 7) ⊑ const? 1 1 := by
+theorem ashrslt_02_07_thm (e : IntW 4) : icmp IntPred.slt (ashr e (const? 4 2)) (const? 4 7) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1565,7 +1565,7 @@ theorem ashrslt_02_07_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4
     all_goals sorry
 
 
-theorem ashrslt_02_08_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4 2)) (const? 4 (-8)) ⊑ const? 1 0 := by
+theorem ashrslt_02_08_thm (e : IntW 4) : icmp IntPred.slt (ashr e (const? 4 2)) (const? 4 (-8)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1574,7 +1574,7 @@ theorem ashrslt_02_08_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4
     all_goals sorry
 
 
-theorem ashrslt_02_09_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4 2)) (const? 4 (-7)) ⊑ const? 1 0 := by
+theorem ashrslt_02_09_thm (e : IntW 4) : icmp IntPred.slt (ashr e (const? 4 2)) (const? 4 (-7)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1583,7 +1583,7 @@ theorem ashrslt_02_09_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4
     all_goals sorry
 
 
-theorem ashrslt_02_10_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4 2)) (const? 4 (-6)) ⊑ const? 1 0 := by
+theorem ashrslt_02_10_thm (e : IntW 4) : icmp IntPred.slt (ashr e (const? 4 2)) (const? 4 (-6)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1592,7 +1592,7 @@ theorem ashrslt_02_10_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4
     all_goals sorry
 
 
-theorem ashrslt_02_11_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4 2)) (const? 4 (-5)) ⊑ const? 1 0 := by
+theorem ashrslt_02_11_thm (e : IntW 4) : icmp IntPred.slt (ashr e (const? 4 2)) (const? 4 (-5)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1601,7 +1601,7 @@ theorem ashrslt_02_11_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4
     all_goals sorry
 
 
-theorem ashrslt_02_12_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4 2)) (const? 4 (-4)) ⊑ const? 1 0 := by
+theorem ashrslt_02_12_thm (e : IntW 4) : icmp IntPred.slt (ashr e (const? 4 2)) (const? 4 (-4)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1610,7 +1610,7 @@ theorem ashrslt_02_12_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4
     all_goals sorry
 
 
-theorem ashrslt_02_13_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4 2)) (const? 4 (-3)) ⊑ const? 1 0 := by
+theorem ashrslt_02_13_thm (e : IntW 4) : icmp IntPred.slt (ashr e (const? 4 2)) (const? 4 (-3)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1619,7 +1619,7 @@ theorem ashrslt_02_13_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4
     all_goals sorry
 
 
-theorem ashrslt_02_14_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4 2)) (const? 4 (-2)) ⊑ const? 1 0 := by
+theorem ashrslt_02_14_thm (e : IntW 4) : icmp IntPred.slt (ashr e (const? 4 2)) (const? 4 (-2)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1629,7 +1629,7 @@ theorem ashrslt_02_14_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4
 
 
 theorem ashrslt_02_15_thm (e : IntW 4) :
-  icmp IntPredicate.slt (ashr e (const? 4 2)) (const? 4 (-1)) ⊑ icmp IntPredicate.slt e (const? 4 (-4)) := by
+  icmp IntPred.slt (ashr e (const? 4 2)) (const? 4 (-1)) ⊑ icmp IntPred.slt e (const? 4 (-4)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1639,7 +1639,7 @@ theorem ashrslt_02_15_thm (e : IntW 4) :
 
 
 theorem ashrslt_03_00_thm (e : IntW 4) :
-  icmp IntPredicate.slt (ashr e (const? 4 3)) (const? 4 0) ⊑ icmp IntPredicate.slt e (const? 4 0) := by
+  icmp IntPred.slt (ashr e (const? 4 3)) (const? 4 0) ⊑ icmp IntPred.slt e (const? 4 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1648,7 +1648,7 @@ theorem ashrslt_03_00_thm (e : IntW 4) :
     all_goals sorry
 
 
-theorem ashrslt_03_01_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4 3)) (const? 4 1) ⊑ const? 1 1 := by
+theorem ashrslt_03_01_thm (e : IntW 4) : icmp IntPred.slt (ashr e (const? 4 3)) (const? 4 1) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1657,7 +1657,7 @@ theorem ashrslt_03_01_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4
     all_goals sorry
 
 
-theorem ashrslt_03_02_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4 3)) (const? 4 2) ⊑ const? 1 1 := by
+theorem ashrslt_03_02_thm (e : IntW 4) : icmp IntPred.slt (ashr e (const? 4 3)) (const? 4 2) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1666,7 +1666,7 @@ theorem ashrslt_03_02_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4
     all_goals sorry
 
 
-theorem ashrslt_03_03_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4 3)) (const? 4 3) ⊑ const? 1 1 := by
+theorem ashrslt_03_03_thm (e : IntW 4) : icmp IntPred.slt (ashr e (const? 4 3)) (const? 4 3) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1675,7 +1675,7 @@ theorem ashrslt_03_03_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4
     all_goals sorry
 
 
-theorem ashrslt_03_04_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4 3)) (const? 4 4) ⊑ const? 1 1 := by
+theorem ashrslt_03_04_thm (e : IntW 4) : icmp IntPred.slt (ashr e (const? 4 3)) (const? 4 4) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1684,7 +1684,7 @@ theorem ashrslt_03_04_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4
     all_goals sorry
 
 
-theorem ashrslt_03_05_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4 3)) (const? 4 5) ⊑ const? 1 1 := by
+theorem ashrslt_03_05_thm (e : IntW 4) : icmp IntPred.slt (ashr e (const? 4 3)) (const? 4 5) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1693,7 +1693,7 @@ theorem ashrslt_03_05_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4
     all_goals sorry
 
 
-theorem ashrslt_03_06_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4 3)) (const? 4 6) ⊑ const? 1 1 := by
+theorem ashrslt_03_06_thm (e : IntW 4) : icmp IntPred.slt (ashr e (const? 4 3)) (const? 4 6) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1702,7 +1702,7 @@ theorem ashrslt_03_06_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4
     all_goals sorry
 
 
-theorem ashrslt_03_07_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4 3)) (const? 4 7) ⊑ const? 1 1 := by
+theorem ashrslt_03_07_thm (e : IntW 4) : icmp IntPred.slt (ashr e (const? 4 3)) (const? 4 7) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1711,7 +1711,7 @@ theorem ashrslt_03_07_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4
     all_goals sorry
 
 
-theorem ashrslt_03_08_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4 3)) (const? 4 (-8)) ⊑ const? 1 0 := by
+theorem ashrslt_03_08_thm (e : IntW 4) : icmp IntPred.slt (ashr e (const? 4 3)) (const? 4 (-8)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1720,7 +1720,7 @@ theorem ashrslt_03_08_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4
     all_goals sorry
 
 
-theorem ashrslt_03_09_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4 3)) (const? 4 (-7)) ⊑ const? 1 0 := by
+theorem ashrslt_03_09_thm (e : IntW 4) : icmp IntPred.slt (ashr e (const? 4 3)) (const? 4 (-7)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1729,7 +1729,7 @@ theorem ashrslt_03_09_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4
     all_goals sorry
 
 
-theorem ashrslt_03_10_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4 3)) (const? 4 (-6)) ⊑ const? 1 0 := by
+theorem ashrslt_03_10_thm (e : IntW 4) : icmp IntPred.slt (ashr e (const? 4 3)) (const? 4 (-6)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1738,7 +1738,7 @@ theorem ashrslt_03_10_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4
     all_goals sorry
 
 
-theorem ashrslt_03_11_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4 3)) (const? 4 (-5)) ⊑ const? 1 0 := by
+theorem ashrslt_03_11_thm (e : IntW 4) : icmp IntPred.slt (ashr e (const? 4 3)) (const? 4 (-5)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1747,7 +1747,7 @@ theorem ashrslt_03_11_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4
     all_goals sorry
 
 
-theorem ashrslt_03_12_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4 3)) (const? 4 (-4)) ⊑ const? 1 0 := by
+theorem ashrslt_03_12_thm (e : IntW 4) : icmp IntPred.slt (ashr e (const? 4 3)) (const? 4 (-4)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1756,7 +1756,7 @@ theorem ashrslt_03_12_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4
     all_goals sorry
 
 
-theorem ashrslt_03_13_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4 3)) (const? 4 (-3)) ⊑ const? 1 0 := by
+theorem ashrslt_03_13_thm (e : IntW 4) : icmp IntPred.slt (ashr e (const? 4 3)) (const? 4 (-3)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1765,7 +1765,7 @@ theorem ashrslt_03_13_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4
     all_goals sorry
 
 
-theorem ashrslt_03_14_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4 3)) (const? 4 (-2)) ⊑ const? 1 0 := by
+theorem ashrslt_03_14_thm (e : IntW 4) : icmp IntPred.slt (ashr e (const? 4 3)) (const? 4 (-2)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1774,7 +1774,7 @@ theorem ashrslt_03_14_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4
     all_goals sorry
 
 
-theorem ashrslt_03_15_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4 3)) (const? 4 (-1)) ⊑ const? 1 0 := by
+theorem ashrslt_03_15_thm (e : IntW 4) : icmp IntPred.slt (ashr e (const? 4 3)) (const? 4 (-1)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1784,8 +1784,8 @@ theorem ashrslt_03_15_thm (e : IntW 4) : icmp IntPredicate.slt (ashr e (const? 4
 
 
 theorem lshrugt_01_00_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ugt (lshr e (const? 4 1) { «exact» := true }) (const? 4 0) ⊑
-    icmp IntPredicate.ne e (const? 4 0) := by
+  icmp IntPred.ugt (lshr e (const? 4 1) { «exact» := true }) (const? 4 0) ⊑
+    icmp IntPred.ne e (const? 4 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1795,8 +1795,8 @@ theorem lshrugt_01_00_exact_thm (e : IntW 4) :
 
 
 theorem lshrugt_01_01_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ugt (lshr e (const? 4 1) { «exact» := true }) (const? 4 1) ⊑
-    icmp IntPredicate.ugt e (const? 4 2) := by
+  icmp IntPred.ugt (lshr e (const? 4 1) { «exact» := true }) (const? 4 1) ⊑
+    icmp IntPred.ugt e (const? 4 2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1806,8 +1806,8 @@ theorem lshrugt_01_01_exact_thm (e : IntW 4) :
 
 
 theorem lshrugt_01_02_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ugt (lshr e (const? 4 1) { «exact» := true }) (const? 4 2) ⊑
-    icmp IntPredicate.ugt e (const? 4 4) := by
+  icmp IntPred.ugt (lshr e (const? 4 1) { «exact» := true }) (const? 4 2) ⊑
+    icmp IntPred.ugt e (const? 4 4) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1817,8 +1817,8 @@ theorem lshrugt_01_02_exact_thm (e : IntW 4) :
 
 
 theorem lshrugt_01_03_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ugt (lshr e (const? 4 1) { «exact» := true }) (const? 4 3) ⊑
-    icmp IntPredicate.ugt e (const? 4 6) := by
+  icmp IntPred.ugt (lshr e (const? 4 1) { «exact» := true }) (const? 4 3) ⊑
+    icmp IntPred.ugt e (const? 4 6) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1828,8 +1828,8 @@ theorem lshrugt_01_03_exact_thm (e : IntW 4) :
 
 
 theorem lshrugt_01_04_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ugt (lshr e (const? 4 1) { «exact» := true }) (const? 4 4) ⊑
-    icmp IntPredicate.ugt e (const? 4 (-8)) := by
+  icmp IntPred.ugt (lshr e (const? 4 1) { «exact» := true }) (const? 4 4) ⊑
+    icmp IntPred.ugt e (const? 4 (-8)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1839,8 +1839,8 @@ theorem lshrugt_01_04_exact_thm (e : IntW 4) :
 
 
 theorem lshrugt_01_05_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ugt (lshr e (const? 4 1) { «exact» := true }) (const? 4 5) ⊑
-    icmp IntPredicate.ugt e (const? 4 (-6)) := by
+  icmp IntPred.ugt (lshr e (const? 4 1) { «exact» := true }) (const? 4 5) ⊑
+    icmp IntPred.ugt e (const? 4 (-6)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1850,8 +1850,8 @@ theorem lshrugt_01_05_exact_thm (e : IntW 4) :
 
 
 theorem lshrugt_01_06_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ugt (lshr e (const? 4 1) { «exact» := true }) (const? 4 6) ⊑
-    icmp IntPredicate.eq e (const? 4 (-2)) := by
+  icmp IntPred.ugt (lshr e (const? 4 1) { «exact» := true }) (const? 4 6) ⊑
+    icmp IntPred.eq e (const? 4 (-2)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1861,7 +1861,7 @@ theorem lshrugt_01_06_exact_thm (e : IntW 4) :
 
 
 theorem lshrugt_01_07_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ugt (lshr e (const? 4 1) { «exact» := true }) (const? 4 7) ⊑ const? 1 0 := by
+  icmp IntPred.ugt (lshr e (const? 4 1) { «exact» := true }) (const? 4 7) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1871,7 +1871,7 @@ theorem lshrugt_01_07_exact_thm (e : IntW 4) :
 
 
 theorem lshrugt_01_08_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ugt (lshr e (const? 4 1) { «exact» := true }) (const? 4 (-8)) ⊑ const? 1 0 := by
+  icmp IntPred.ugt (lshr e (const? 4 1) { «exact» := true }) (const? 4 (-8)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1881,7 +1881,7 @@ theorem lshrugt_01_08_exact_thm (e : IntW 4) :
 
 
 theorem lshrugt_01_09_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ugt (lshr e (const? 4 1) { «exact» := true }) (const? 4 (-7)) ⊑ const? 1 0 := by
+  icmp IntPred.ugt (lshr e (const? 4 1) { «exact» := true }) (const? 4 (-7)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1891,7 +1891,7 @@ theorem lshrugt_01_09_exact_thm (e : IntW 4) :
 
 
 theorem lshrugt_01_10_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ugt (lshr e (const? 4 1) { «exact» := true }) (const? 4 (-6)) ⊑ const? 1 0 := by
+  icmp IntPred.ugt (lshr e (const? 4 1) { «exact» := true }) (const? 4 (-6)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1901,7 +1901,7 @@ theorem lshrugt_01_10_exact_thm (e : IntW 4) :
 
 
 theorem lshrugt_01_11_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ugt (lshr e (const? 4 1) { «exact» := true }) (const? 4 (-5)) ⊑ const? 1 0 := by
+  icmp IntPred.ugt (lshr e (const? 4 1) { «exact» := true }) (const? 4 (-5)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1911,7 +1911,7 @@ theorem lshrugt_01_11_exact_thm (e : IntW 4) :
 
 
 theorem lshrugt_01_12_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ugt (lshr e (const? 4 1) { «exact» := true }) (const? 4 (-4)) ⊑ const? 1 0 := by
+  icmp IntPred.ugt (lshr e (const? 4 1) { «exact» := true }) (const? 4 (-4)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1921,7 +1921,7 @@ theorem lshrugt_01_12_exact_thm (e : IntW 4) :
 
 
 theorem lshrugt_01_13_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ugt (lshr e (const? 4 1) { «exact» := true }) (const? 4 (-3)) ⊑ const? 1 0 := by
+  icmp IntPred.ugt (lshr e (const? 4 1) { «exact» := true }) (const? 4 (-3)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1931,7 +1931,7 @@ theorem lshrugt_01_13_exact_thm (e : IntW 4) :
 
 
 theorem lshrugt_01_14_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ugt (lshr e (const? 4 1) { «exact» := true }) (const? 4 (-2)) ⊑ const? 1 0 := by
+  icmp IntPred.ugt (lshr e (const? 4 1) { «exact» := true }) (const? 4 (-2)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1941,7 +1941,7 @@ theorem lshrugt_01_14_exact_thm (e : IntW 4) :
 
 
 theorem lshrugt_01_15_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ugt (lshr e (const? 4 1) { «exact» := true }) (const? 4 (-1)) ⊑ const? 1 0 := by
+  icmp IntPred.ugt (lshr e (const? 4 1) { «exact» := true }) (const? 4 (-1)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1951,8 +1951,8 @@ theorem lshrugt_01_15_exact_thm (e : IntW 4) :
 
 
 theorem lshrugt_02_00_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ugt (lshr e (const? 4 2) { «exact» := true }) (const? 4 0) ⊑
-    icmp IntPredicate.ne e (const? 4 0) := by
+  icmp IntPred.ugt (lshr e (const? 4 2) { «exact» := true }) (const? 4 0) ⊑
+    icmp IntPred.ne e (const? 4 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1962,8 +1962,8 @@ theorem lshrugt_02_00_exact_thm (e : IntW 4) :
 
 
 theorem lshrugt_02_01_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ugt (lshr e (const? 4 2) { «exact» := true }) (const? 4 1) ⊑
-    icmp IntPredicate.ugt e (const? 4 4) := by
+  icmp IntPred.ugt (lshr e (const? 4 2) { «exact» := true }) (const? 4 1) ⊑
+    icmp IntPred.ugt e (const? 4 4) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1973,8 +1973,8 @@ theorem lshrugt_02_01_exact_thm (e : IntW 4) :
 
 
 theorem lshrugt_02_02_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ugt (lshr e (const? 4 2) { «exact» := true }) (const? 4 2) ⊑
-    icmp IntPredicate.eq e (const? 4 (-4)) := by
+  icmp IntPred.ugt (lshr e (const? 4 2) { «exact» := true }) (const? 4 2) ⊑
+    icmp IntPred.eq e (const? 4 (-4)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1984,7 +1984,7 @@ theorem lshrugt_02_02_exact_thm (e : IntW 4) :
 
 
 theorem lshrugt_02_03_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ugt (lshr e (const? 4 2) { «exact» := true }) (const? 4 3) ⊑ const? 1 0 := by
+  icmp IntPred.ugt (lshr e (const? 4 2) { «exact» := true }) (const? 4 3) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -1994,7 +1994,7 @@ theorem lshrugt_02_03_exact_thm (e : IntW 4) :
 
 
 theorem lshrugt_02_04_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ugt (lshr e (const? 4 2) { «exact» := true }) (const? 4 4) ⊑ const? 1 0 := by
+  icmp IntPred.ugt (lshr e (const? 4 2) { «exact» := true }) (const? 4 4) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2004,7 +2004,7 @@ theorem lshrugt_02_04_exact_thm (e : IntW 4) :
 
 
 theorem lshrugt_02_05_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ugt (lshr e (const? 4 2) { «exact» := true }) (const? 4 5) ⊑ const? 1 0 := by
+  icmp IntPred.ugt (lshr e (const? 4 2) { «exact» := true }) (const? 4 5) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2014,7 +2014,7 @@ theorem lshrugt_02_05_exact_thm (e : IntW 4) :
 
 
 theorem lshrugt_02_06_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ugt (lshr e (const? 4 2) { «exact» := true }) (const? 4 6) ⊑ const? 1 0 := by
+  icmp IntPred.ugt (lshr e (const? 4 2) { «exact» := true }) (const? 4 6) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2024,7 +2024,7 @@ theorem lshrugt_02_06_exact_thm (e : IntW 4) :
 
 
 theorem lshrugt_02_07_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ugt (lshr e (const? 4 2) { «exact» := true }) (const? 4 7) ⊑ const? 1 0 := by
+  icmp IntPred.ugt (lshr e (const? 4 2) { «exact» := true }) (const? 4 7) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2034,7 +2034,7 @@ theorem lshrugt_02_07_exact_thm (e : IntW 4) :
 
 
 theorem lshrugt_02_08_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ugt (lshr e (const? 4 2) { «exact» := true }) (const? 4 (-8)) ⊑ const? 1 0 := by
+  icmp IntPred.ugt (lshr e (const? 4 2) { «exact» := true }) (const? 4 (-8)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2044,7 +2044,7 @@ theorem lshrugt_02_08_exact_thm (e : IntW 4) :
 
 
 theorem lshrugt_02_09_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ugt (lshr e (const? 4 2) { «exact» := true }) (const? 4 (-7)) ⊑ const? 1 0 := by
+  icmp IntPred.ugt (lshr e (const? 4 2) { «exact» := true }) (const? 4 (-7)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2054,7 +2054,7 @@ theorem lshrugt_02_09_exact_thm (e : IntW 4) :
 
 
 theorem lshrugt_02_10_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ugt (lshr e (const? 4 2) { «exact» := true }) (const? 4 (-6)) ⊑ const? 1 0 := by
+  icmp IntPred.ugt (lshr e (const? 4 2) { «exact» := true }) (const? 4 (-6)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2064,7 +2064,7 @@ theorem lshrugt_02_10_exact_thm (e : IntW 4) :
 
 
 theorem lshrugt_02_11_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ugt (lshr e (const? 4 2) { «exact» := true }) (const? 4 (-5)) ⊑ const? 1 0 := by
+  icmp IntPred.ugt (lshr e (const? 4 2) { «exact» := true }) (const? 4 (-5)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2074,7 +2074,7 @@ theorem lshrugt_02_11_exact_thm (e : IntW 4) :
 
 
 theorem lshrugt_02_12_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ugt (lshr e (const? 4 2) { «exact» := true }) (const? 4 (-4)) ⊑ const? 1 0 := by
+  icmp IntPred.ugt (lshr e (const? 4 2) { «exact» := true }) (const? 4 (-4)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2084,7 +2084,7 @@ theorem lshrugt_02_12_exact_thm (e : IntW 4) :
 
 
 theorem lshrugt_02_13_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ugt (lshr e (const? 4 2) { «exact» := true }) (const? 4 (-3)) ⊑ const? 1 0 := by
+  icmp IntPred.ugt (lshr e (const? 4 2) { «exact» := true }) (const? 4 (-3)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2094,7 +2094,7 @@ theorem lshrugt_02_13_exact_thm (e : IntW 4) :
 
 
 theorem lshrugt_02_14_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ugt (lshr e (const? 4 2) { «exact» := true }) (const? 4 (-2)) ⊑ const? 1 0 := by
+  icmp IntPred.ugt (lshr e (const? 4 2) { «exact» := true }) (const? 4 (-2)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2104,7 +2104,7 @@ theorem lshrugt_02_14_exact_thm (e : IntW 4) :
 
 
 theorem lshrugt_02_15_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ugt (lshr e (const? 4 2) { «exact» := true }) (const? 4 (-1)) ⊑ const? 1 0 := by
+  icmp IntPred.ugt (lshr e (const? 4 2) { «exact» := true }) (const? 4 (-1)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2114,8 +2114,8 @@ theorem lshrugt_02_15_exact_thm (e : IntW 4) :
 
 
 theorem lshrugt_03_00_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ugt (lshr e (const? 4 3) { «exact» := true }) (const? 4 0) ⊑
-    icmp IntPredicate.ne e (const? 4 0) := by
+  icmp IntPred.ugt (lshr e (const? 4 3) { «exact» := true }) (const? 4 0) ⊑
+    icmp IntPred.ne e (const? 4 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2125,7 +2125,7 @@ theorem lshrugt_03_00_exact_thm (e : IntW 4) :
 
 
 theorem lshrugt_03_01_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ugt (lshr e (const? 4 3) { «exact» := true }) (const? 4 1) ⊑ const? 1 0 := by
+  icmp IntPred.ugt (lshr e (const? 4 3) { «exact» := true }) (const? 4 1) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2135,7 +2135,7 @@ theorem lshrugt_03_01_exact_thm (e : IntW 4) :
 
 
 theorem lshrugt_03_02_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ugt (lshr e (const? 4 3) { «exact» := true }) (const? 4 2) ⊑ const? 1 0 := by
+  icmp IntPred.ugt (lshr e (const? 4 3) { «exact» := true }) (const? 4 2) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2145,7 +2145,7 @@ theorem lshrugt_03_02_exact_thm (e : IntW 4) :
 
 
 theorem lshrugt_03_03_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ugt (lshr e (const? 4 3) { «exact» := true }) (const? 4 3) ⊑ const? 1 0 := by
+  icmp IntPred.ugt (lshr e (const? 4 3) { «exact» := true }) (const? 4 3) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2155,7 +2155,7 @@ theorem lshrugt_03_03_exact_thm (e : IntW 4) :
 
 
 theorem lshrugt_03_04_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ugt (lshr e (const? 4 3) { «exact» := true }) (const? 4 4) ⊑ const? 1 0 := by
+  icmp IntPred.ugt (lshr e (const? 4 3) { «exact» := true }) (const? 4 4) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2165,7 +2165,7 @@ theorem lshrugt_03_04_exact_thm (e : IntW 4) :
 
 
 theorem lshrugt_03_05_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ugt (lshr e (const? 4 3) { «exact» := true }) (const? 4 5) ⊑ const? 1 0 := by
+  icmp IntPred.ugt (lshr e (const? 4 3) { «exact» := true }) (const? 4 5) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2175,7 +2175,7 @@ theorem lshrugt_03_05_exact_thm (e : IntW 4) :
 
 
 theorem lshrugt_03_06_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ugt (lshr e (const? 4 3) { «exact» := true }) (const? 4 6) ⊑ const? 1 0 := by
+  icmp IntPred.ugt (lshr e (const? 4 3) { «exact» := true }) (const? 4 6) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2185,7 +2185,7 @@ theorem lshrugt_03_06_exact_thm (e : IntW 4) :
 
 
 theorem lshrugt_03_07_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ugt (lshr e (const? 4 3) { «exact» := true }) (const? 4 7) ⊑ const? 1 0 := by
+  icmp IntPred.ugt (lshr e (const? 4 3) { «exact» := true }) (const? 4 7) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2195,7 +2195,7 @@ theorem lshrugt_03_07_exact_thm (e : IntW 4) :
 
 
 theorem lshrugt_03_08_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ugt (lshr e (const? 4 3) { «exact» := true }) (const? 4 (-8)) ⊑ const? 1 0 := by
+  icmp IntPred.ugt (lshr e (const? 4 3) { «exact» := true }) (const? 4 (-8)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2205,7 +2205,7 @@ theorem lshrugt_03_08_exact_thm (e : IntW 4) :
 
 
 theorem lshrugt_03_09_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ugt (lshr e (const? 4 3) { «exact» := true }) (const? 4 (-7)) ⊑ const? 1 0 := by
+  icmp IntPred.ugt (lshr e (const? 4 3) { «exact» := true }) (const? 4 (-7)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2215,7 +2215,7 @@ theorem lshrugt_03_09_exact_thm (e : IntW 4) :
 
 
 theorem lshrugt_03_10_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ugt (lshr e (const? 4 3) { «exact» := true }) (const? 4 (-6)) ⊑ const? 1 0 := by
+  icmp IntPred.ugt (lshr e (const? 4 3) { «exact» := true }) (const? 4 (-6)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2225,7 +2225,7 @@ theorem lshrugt_03_10_exact_thm (e : IntW 4) :
 
 
 theorem lshrugt_03_11_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ugt (lshr e (const? 4 3) { «exact» := true }) (const? 4 (-5)) ⊑ const? 1 0 := by
+  icmp IntPred.ugt (lshr e (const? 4 3) { «exact» := true }) (const? 4 (-5)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2235,7 +2235,7 @@ theorem lshrugt_03_11_exact_thm (e : IntW 4) :
 
 
 theorem lshrugt_03_12_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ugt (lshr e (const? 4 3) { «exact» := true }) (const? 4 (-4)) ⊑ const? 1 0 := by
+  icmp IntPred.ugt (lshr e (const? 4 3) { «exact» := true }) (const? 4 (-4)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2245,7 +2245,7 @@ theorem lshrugt_03_12_exact_thm (e : IntW 4) :
 
 
 theorem lshrugt_03_13_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ugt (lshr e (const? 4 3) { «exact» := true }) (const? 4 (-3)) ⊑ const? 1 0 := by
+  icmp IntPred.ugt (lshr e (const? 4 3) { «exact» := true }) (const? 4 (-3)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2255,7 +2255,7 @@ theorem lshrugt_03_13_exact_thm (e : IntW 4) :
 
 
 theorem lshrugt_03_14_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ugt (lshr e (const? 4 3) { «exact» := true }) (const? 4 (-2)) ⊑ const? 1 0 := by
+  icmp IntPred.ugt (lshr e (const? 4 3) { «exact» := true }) (const? 4 (-2)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2265,7 +2265,7 @@ theorem lshrugt_03_14_exact_thm (e : IntW 4) :
 
 
 theorem lshrugt_03_15_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ugt (lshr e (const? 4 3) { «exact» := true }) (const? 4 (-1)) ⊑ const? 1 0 := by
+  icmp IntPred.ugt (lshr e (const? 4 3) { «exact» := true }) (const? 4 (-1)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2275,8 +2275,8 @@ theorem lshrugt_03_15_exact_thm (e : IntW 4) :
 
 
 theorem ashr_eq_exact_thm (e : IntW 8) :
-  icmp IntPredicate.eq (ashr e (const? 8 3) { «exact» := true }) (const? 8 10) ⊑
-    icmp IntPredicate.eq e (const? 8 80) := by
+  icmp IntPred.eq (ashr e (const? 8 3) { «exact» := true }) (const? 8 10) ⊑
+    icmp IntPred.eq e (const? 8 80) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2286,8 +2286,8 @@ theorem ashr_eq_exact_thm (e : IntW 8) :
 
 
 theorem ashr_ne_exact_thm (e : IntW 8) :
-  icmp IntPredicate.ne (ashr e (const? 8 3) { «exact» := true }) (const? 8 10) ⊑
-    icmp IntPredicate.ne e (const? 8 80) := by
+  icmp IntPred.ne (ashr e (const? 8 3) { «exact» := true }) (const? 8 10) ⊑
+    icmp IntPred.ne e (const? 8 80) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2297,8 +2297,8 @@ theorem ashr_ne_exact_thm (e : IntW 8) :
 
 
 theorem ashr_ugt_exact_thm (e : IntW 8) :
-  icmp IntPredicate.ugt (ashr e (const? 8 3) { «exact» := true }) (const? 8 10) ⊑
-    icmp IntPredicate.ugt e (const? 8 80) := by
+  icmp IntPred.ugt (ashr e (const? 8 3) { «exact» := true }) (const? 8 10) ⊑
+    icmp IntPred.ugt e (const? 8 80) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2308,8 +2308,8 @@ theorem ashr_ugt_exact_thm (e : IntW 8) :
 
 
 theorem ashr_uge_exact_thm (e : IntW 8) :
-  icmp IntPredicate.uge (ashr e (const? 8 3) { «exact» := true }) (const? 8 10) ⊑
-    icmp IntPredicate.ugt e (const? 8 72) := by
+  icmp IntPred.uge (ashr e (const? 8 3) { «exact» := true }) (const? 8 10) ⊑
+    icmp IntPred.ugt e (const? 8 72) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2319,8 +2319,8 @@ theorem ashr_uge_exact_thm (e : IntW 8) :
 
 
 theorem ashr_ult_exact_thm (e : IntW 8) :
-  icmp IntPredicate.ult (ashr e (const? 8 3) { «exact» := true }) (const? 8 10) ⊑
-    icmp IntPredicate.ult e (const? 8 80) := by
+  icmp IntPred.ult (ashr e (const? 8 3) { «exact» := true }) (const? 8 10) ⊑
+    icmp IntPred.ult e (const? 8 80) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2330,8 +2330,8 @@ theorem ashr_ult_exact_thm (e : IntW 8) :
 
 
 theorem ashr_ule_exact_thm (e : IntW 8) :
-  icmp IntPredicate.ule (ashr e (const? 8 3) { «exact» := true }) (const? 8 10) ⊑
-    icmp IntPredicate.ult e (const? 8 88) := by
+  icmp IntPred.ule (ashr e (const? 8 3) { «exact» := true }) (const? 8 10) ⊑
+    icmp IntPred.ult e (const? 8 88) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2341,8 +2341,8 @@ theorem ashr_ule_exact_thm (e : IntW 8) :
 
 
 theorem ashr_sgt_exact_thm (e : IntW 8) :
-  icmp IntPredicate.sgt (ashr e (const? 8 3) { «exact» := true }) (const? 8 10) ⊑
-    icmp IntPredicate.sgt e (const? 8 80) := by
+  icmp IntPred.sgt (ashr e (const? 8 3) { «exact» := true }) (const? 8 10) ⊑
+    icmp IntPred.sgt e (const? 8 80) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2352,8 +2352,8 @@ theorem ashr_sgt_exact_thm (e : IntW 8) :
 
 
 theorem ashr_sge_exact_thm (e : IntW 8) :
-  icmp IntPredicate.sge (ashr e (const? 8 3) { «exact» := true }) (const? 8 10) ⊑
-    icmp IntPredicate.sgt e (const? 8 72) := by
+  icmp IntPred.sge (ashr e (const? 8 3) { «exact» := true }) (const? 8 10) ⊑
+    icmp IntPred.sgt e (const? 8 72) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2363,8 +2363,8 @@ theorem ashr_sge_exact_thm (e : IntW 8) :
 
 
 theorem ashr_slt_exact_thm (e : IntW 8) :
-  icmp IntPredicate.slt (ashr e (const? 8 3) { «exact» := true }) (const? 8 10) ⊑
-    icmp IntPredicate.slt e (const? 8 80) := by
+  icmp IntPred.slt (ashr e (const? 8 3) { «exact» := true }) (const? 8 10) ⊑
+    icmp IntPred.slt e (const? 8 80) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2374,8 +2374,8 @@ theorem ashr_slt_exact_thm (e : IntW 8) :
 
 
 theorem ashr_sle_exact_thm (e : IntW 8) :
-  icmp IntPredicate.sle (ashr e (const? 8 3) { «exact» := true }) (const? 8 10) ⊑
-    icmp IntPredicate.slt e (const? 8 88) := by
+  icmp IntPred.sle (ashr e (const? 8 3) { «exact» := true }) (const? 8 10) ⊑
+    icmp IntPred.slt e (const? 8 88) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2385,8 +2385,8 @@ theorem ashr_sle_exact_thm (e : IntW 8) :
 
 
 theorem ashr_eq_noexact_thm (e : IntW 8) :
-  icmp IntPredicate.eq (ashr e (const? 8 3)) (const? 8 10) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 8 (-8))) (const? 8 80) := by
+  icmp IntPred.eq (ashr e (const? 8 3)) (const? 8 10) ⊑
+    icmp IntPred.eq (LLVM.and e (const? 8 (-8))) (const? 8 80) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2396,8 +2396,8 @@ theorem ashr_eq_noexact_thm (e : IntW 8) :
 
 
 theorem ashr_ne_noexact_thm (e : IntW 8) :
-  icmp IntPredicate.ne (ashr e (const? 8 3)) (const? 8 10) ⊑
-    icmp IntPredicate.ne (LLVM.and e (const? 8 (-8))) (const? 8 80) := by
+  icmp IntPred.ne (ashr e (const? 8 3)) (const? 8 10) ⊑
+    icmp IntPred.ne (LLVM.and e (const? 8 (-8))) (const? 8 80) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2407,7 +2407,7 @@ theorem ashr_ne_noexact_thm (e : IntW 8) :
 
 
 theorem ashr_ugt_noexact_thm (e : IntW 8) :
-  icmp IntPredicate.ugt (ashr e (const? 8 3)) (const? 8 10) ⊑ icmp IntPredicate.ugt e (const? 8 87) := by
+  icmp IntPred.ugt (ashr e (const? 8 3)) (const? 8 10) ⊑ icmp IntPred.ugt e (const? 8 87) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2417,7 +2417,7 @@ theorem ashr_ugt_noexact_thm (e : IntW 8) :
 
 
 theorem ashr_uge_noexact_thm (e : IntW 8) :
-  icmp IntPredicate.uge (ashr e (const? 8 3)) (const? 8 10) ⊑ icmp IntPredicate.ugt e (const? 8 79) := by
+  icmp IntPred.uge (ashr e (const? 8 3)) (const? 8 10) ⊑ icmp IntPred.ugt e (const? 8 79) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2427,7 +2427,7 @@ theorem ashr_uge_noexact_thm (e : IntW 8) :
 
 
 theorem ashr_ult_noexact_thm (e : IntW 8) :
-  icmp IntPredicate.ult (ashr e (const? 8 3)) (const? 8 10) ⊑ icmp IntPredicate.ult e (const? 8 80) := by
+  icmp IntPred.ult (ashr e (const? 8 3)) (const? 8 10) ⊑ icmp IntPred.ult e (const? 8 80) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2437,7 +2437,7 @@ theorem ashr_ult_noexact_thm (e : IntW 8) :
 
 
 theorem ashr_ule_noexact_thm (e : IntW 8) :
-  icmp IntPredicate.ule (ashr e (const? 8 3)) (const? 8 10) ⊑ icmp IntPredicate.ult e (const? 8 88) := by
+  icmp IntPred.ule (ashr e (const? 8 3)) (const? 8 10) ⊑ icmp IntPred.ult e (const? 8 88) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2447,7 +2447,7 @@ theorem ashr_ule_noexact_thm (e : IntW 8) :
 
 
 theorem ashr_sgt_noexact_thm (e : IntW 8) :
-  icmp IntPredicate.sgt (ashr e (const? 8 3)) (const? 8 10) ⊑ icmp IntPredicate.sgt e (const? 8 87) := by
+  icmp IntPred.sgt (ashr e (const? 8 3)) (const? 8 10) ⊑ icmp IntPred.sgt e (const? 8 87) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2457,7 +2457,7 @@ theorem ashr_sgt_noexact_thm (e : IntW 8) :
 
 
 theorem ashr_sge_noexact_thm (e : IntW 8) :
-  icmp IntPredicate.sge (ashr e (const? 8 3)) (const? 8 10) ⊑ icmp IntPredicate.sgt e (const? 8 79) := by
+  icmp IntPred.sge (ashr e (const? 8 3)) (const? 8 10) ⊑ icmp IntPred.sgt e (const? 8 79) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2467,7 +2467,7 @@ theorem ashr_sge_noexact_thm (e : IntW 8) :
 
 
 theorem ashr_slt_noexact_thm (e : IntW 8) :
-  icmp IntPredicate.slt (ashr e (const? 8 3)) (const? 8 10) ⊑ icmp IntPredicate.slt e (const? 8 80) := by
+  icmp IntPred.slt (ashr e (const? 8 3)) (const? 8 10) ⊑ icmp IntPred.slt e (const? 8 80) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2477,7 +2477,7 @@ theorem ashr_slt_noexact_thm (e : IntW 8) :
 
 
 theorem ashr_sle_noexact_thm (e : IntW 8) :
-  icmp IntPredicate.sle (ashr e (const? 8 3)) (const? 8 10) ⊑ icmp IntPredicate.slt e (const? 8 88) := by
+  icmp IntPred.sle (ashr e (const? 8 3)) (const? 8 10) ⊑ icmp IntPred.slt e (const? 8 88) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2486,7 +2486,7 @@ theorem ashr_sle_noexact_thm (e : IntW 8) :
     all_goals sorry
 
 
-theorem ashr_sgt_overflow_thm (e : IntW 8) : icmp IntPredicate.sgt (ashr e (const? 8 1)) (const? 8 63) ⊑ const? 1 0 := by
+theorem ashr_sgt_overflow_thm (e : IntW 8) : icmp IntPred.sgt (ashr e (const? 8 1)) (const? 8 63) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2496,7 +2496,7 @@ theorem ashr_sgt_overflow_thm (e : IntW 8) : icmp IntPredicate.sgt (ashr e (cons
 
 
 theorem lshrult_01_00_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ult (lshr e (const? 4 1) { «exact» := true }) (const? 4 0) ⊑ const? 1 0 := by
+  icmp IntPred.ult (lshr e (const? 4 1) { «exact» := true }) (const? 4 0) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2506,8 +2506,8 @@ theorem lshrult_01_00_exact_thm (e : IntW 4) :
 
 
 theorem lshrult_01_01_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ult (lshr e (const? 4 1) { «exact» := true }) (const? 4 1) ⊑
-    icmp IntPredicate.eq e (const? 4 0) := by
+  icmp IntPred.ult (lshr e (const? 4 1) { «exact» := true }) (const? 4 1) ⊑
+    icmp IntPred.eq e (const? 4 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2517,8 +2517,8 @@ theorem lshrult_01_01_exact_thm (e : IntW 4) :
 
 
 theorem lshrult_01_02_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ult (lshr e (const? 4 1) { «exact» := true }) (const? 4 2) ⊑
-    icmp IntPredicate.ult e (const? 4 4) := by
+  icmp IntPred.ult (lshr e (const? 4 1) { «exact» := true }) (const? 4 2) ⊑
+    icmp IntPred.ult e (const? 4 4) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2528,8 +2528,8 @@ theorem lshrult_01_02_exact_thm (e : IntW 4) :
 
 
 theorem lshrult_01_03_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ult (lshr e (const? 4 1) { «exact» := true }) (const? 4 3) ⊑
-    icmp IntPredicate.ult e (const? 4 6) := by
+  icmp IntPred.ult (lshr e (const? 4 1) { «exact» := true }) (const? 4 3) ⊑
+    icmp IntPred.ult e (const? 4 6) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2539,8 +2539,8 @@ theorem lshrult_01_03_exact_thm (e : IntW 4) :
 
 
 theorem lshrult_01_04_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ult (lshr e (const? 4 1) { «exact» := true }) (const? 4 4) ⊑
-    icmp IntPredicate.sgt e (const? 4 (-1)) := by
+  icmp IntPred.ult (lshr e (const? 4 1) { «exact» := true }) (const? 4 4) ⊑
+    icmp IntPred.sgt e (const? 4 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2550,8 +2550,8 @@ theorem lshrult_01_04_exact_thm (e : IntW 4) :
 
 
 theorem lshrult_01_05_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ult (lshr e (const? 4 1) { «exact» := true }) (const? 4 5) ⊑
-    icmp IntPredicate.ult e (const? 4 (-6)) := by
+  icmp IntPred.ult (lshr e (const? 4 1) { «exact» := true }) (const? 4 5) ⊑
+    icmp IntPred.ult e (const? 4 (-6)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2561,8 +2561,8 @@ theorem lshrult_01_05_exact_thm (e : IntW 4) :
 
 
 theorem lshrult_01_06_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ult (lshr e (const? 4 1) { «exact» := true }) (const? 4 6) ⊑
-    icmp IntPredicate.ult e (const? 4 (-4)) := by
+  icmp IntPred.ult (lshr e (const? 4 1) { «exact» := true }) (const? 4 6) ⊑
+    icmp IntPred.ult e (const? 4 (-4)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2572,8 +2572,8 @@ theorem lshrult_01_06_exact_thm (e : IntW 4) :
 
 
 theorem lshrult_01_07_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ult (lshr e (const? 4 1) { «exact» := true }) (const? 4 7) ⊑
-    icmp IntPredicate.ne e (const? 4 (-2)) := by
+  icmp IntPred.ult (lshr e (const? 4 1) { «exact» := true }) (const? 4 7) ⊑
+    icmp IntPred.ne e (const? 4 (-2)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2583,7 +2583,7 @@ theorem lshrult_01_07_exact_thm (e : IntW 4) :
 
 
 theorem lshrult_01_08_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ult (lshr e (const? 4 1) { «exact» := true }) (const? 4 (-8)) ⊑ const? 1 1 := by
+  icmp IntPred.ult (lshr e (const? 4 1) { «exact» := true }) (const? 4 (-8)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2593,7 +2593,7 @@ theorem lshrult_01_08_exact_thm (e : IntW 4) :
 
 
 theorem lshrult_01_09_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ult (lshr e (const? 4 1) { «exact» := true }) (const? 4 (-7)) ⊑ const? 1 1 := by
+  icmp IntPred.ult (lshr e (const? 4 1) { «exact» := true }) (const? 4 (-7)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2603,7 +2603,7 @@ theorem lshrult_01_09_exact_thm (e : IntW 4) :
 
 
 theorem lshrult_01_10_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ult (lshr e (const? 4 1) { «exact» := true }) (const? 4 (-6)) ⊑ const? 1 1 := by
+  icmp IntPred.ult (lshr e (const? 4 1) { «exact» := true }) (const? 4 (-6)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2613,7 +2613,7 @@ theorem lshrult_01_10_exact_thm (e : IntW 4) :
 
 
 theorem lshrult_01_11_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ult (lshr e (const? 4 1) { «exact» := true }) (const? 4 (-5)) ⊑ const? 1 1 := by
+  icmp IntPred.ult (lshr e (const? 4 1) { «exact» := true }) (const? 4 (-5)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2623,7 +2623,7 @@ theorem lshrult_01_11_exact_thm (e : IntW 4) :
 
 
 theorem lshrult_01_12_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ult (lshr e (const? 4 1) { «exact» := true }) (const? 4 (-4)) ⊑ const? 1 1 := by
+  icmp IntPred.ult (lshr e (const? 4 1) { «exact» := true }) (const? 4 (-4)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2633,7 +2633,7 @@ theorem lshrult_01_12_exact_thm (e : IntW 4) :
 
 
 theorem lshrult_01_13_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ult (lshr e (const? 4 1) { «exact» := true }) (const? 4 (-3)) ⊑ const? 1 1 := by
+  icmp IntPred.ult (lshr e (const? 4 1) { «exact» := true }) (const? 4 (-3)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2643,7 +2643,7 @@ theorem lshrult_01_13_exact_thm (e : IntW 4) :
 
 
 theorem lshrult_01_14_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ult (lshr e (const? 4 1) { «exact» := true }) (const? 4 (-2)) ⊑ const? 1 1 := by
+  icmp IntPred.ult (lshr e (const? 4 1) { «exact» := true }) (const? 4 (-2)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2653,7 +2653,7 @@ theorem lshrult_01_14_exact_thm (e : IntW 4) :
 
 
 theorem lshrult_01_15_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ult (lshr e (const? 4 1) { «exact» := true }) (const? 4 (-1)) ⊑ const? 1 1 := by
+  icmp IntPred.ult (lshr e (const? 4 1) { «exact» := true }) (const? 4 (-1)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2663,7 +2663,7 @@ theorem lshrult_01_15_exact_thm (e : IntW 4) :
 
 
 theorem lshrult_02_00_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ult (lshr e (const? 4 2) { «exact» := true }) (const? 4 0) ⊑ const? 1 0 := by
+  icmp IntPred.ult (lshr e (const? 4 2) { «exact» := true }) (const? 4 0) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2673,8 +2673,8 @@ theorem lshrult_02_00_exact_thm (e : IntW 4) :
 
 
 theorem lshrult_02_01_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ult (lshr e (const? 4 2) { «exact» := true }) (const? 4 1) ⊑
-    icmp IntPredicate.eq e (const? 4 0) := by
+  icmp IntPred.ult (lshr e (const? 4 2) { «exact» := true }) (const? 4 1) ⊑
+    icmp IntPred.eq e (const? 4 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2684,8 +2684,8 @@ theorem lshrult_02_01_exact_thm (e : IntW 4) :
 
 
 theorem lshrult_02_02_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ult (lshr e (const? 4 2) { «exact» := true }) (const? 4 2) ⊑
-    icmp IntPredicate.sgt e (const? 4 (-1)) := by
+  icmp IntPred.ult (lshr e (const? 4 2) { «exact» := true }) (const? 4 2) ⊑
+    icmp IntPred.sgt e (const? 4 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2695,8 +2695,8 @@ theorem lshrult_02_02_exact_thm (e : IntW 4) :
 
 
 theorem lshrult_02_03_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ult (lshr e (const? 4 2) { «exact» := true }) (const? 4 3) ⊑
-    icmp IntPredicate.ne e (const? 4 (-4)) := by
+  icmp IntPred.ult (lshr e (const? 4 2) { «exact» := true }) (const? 4 3) ⊑
+    icmp IntPred.ne e (const? 4 (-4)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2706,7 +2706,7 @@ theorem lshrult_02_03_exact_thm (e : IntW 4) :
 
 
 theorem lshrult_02_04_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ult (lshr e (const? 4 2) { «exact» := true }) (const? 4 4) ⊑ const? 1 1 := by
+  icmp IntPred.ult (lshr e (const? 4 2) { «exact» := true }) (const? 4 4) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2716,7 +2716,7 @@ theorem lshrult_02_04_exact_thm (e : IntW 4) :
 
 
 theorem lshrult_02_05_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ult (lshr e (const? 4 2) { «exact» := true }) (const? 4 5) ⊑ const? 1 1 := by
+  icmp IntPred.ult (lshr e (const? 4 2) { «exact» := true }) (const? 4 5) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2726,7 +2726,7 @@ theorem lshrult_02_05_exact_thm (e : IntW 4) :
 
 
 theorem lshrult_02_06_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ult (lshr e (const? 4 2) { «exact» := true }) (const? 4 6) ⊑ const? 1 1 := by
+  icmp IntPred.ult (lshr e (const? 4 2) { «exact» := true }) (const? 4 6) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2736,7 +2736,7 @@ theorem lshrult_02_06_exact_thm (e : IntW 4) :
 
 
 theorem lshrult_02_07_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ult (lshr e (const? 4 2) { «exact» := true }) (const? 4 7) ⊑ const? 1 1 := by
+  icmp IntPred.ult (lshr e (const? 4 2) { «exact» := true }) (const? 4 7) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2746,7 +2746,7 @@ theorem lshrult_02_07_exact_thm (e : IntW 4) :
 
 
 theorem lshrult_02_08_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ult (lshr e (const? 4 2) { «exact» := true }) (const? 4 (-8)) ⊑ const? 1 1 := by
+  icmp IntPred.ult (lshr e (const? 4 2) { «exact» := true }) (const? 4 (-8)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2756,7 +2756,7 @@ theorem lshrult_02_08_exact_thm (e : IntW 4) :
 
 
 theorem lshrult_02_09_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ult (lshr e (const? 4 2) { «exact» := true }) (const? 4 (-7)) ⊑ const? 1 1 := by
+  icmp IntPred.ult (lshr e (const? 4 2) { «exact» := true }) (const? 4 (-7)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2766,7 +2766,7 @@ theorem lshrult_02_09_exact_thm (e : IntW 4) :
 
 
 theorem lshrult_02_10_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ult (lshr e (const? 4 2) { «exact» := true }) (const? 4 (-6)) ⊑ const? 1 1 := by
+  icmp IntPred.ult (lshr e (const? 4 2) { «exact» := true }) (const? 4 (-6)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2776,7 +2776,7 @@ theorem lshrult_02_10_exact_thm (e : IntW 4) :
 
 
 theorem lshrult_02_11_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ult (lshr e (const? 4 2) { «exact» := true }) (const? 4 (-5)) ⊑ const? 1 1 := by
+  icmp IntPred.ult (lshr e (const? 4 2) { «exact» := true }) (const? 4 (-5)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2786,7 +2786,7 @@ theorem lshrult_02_11_exact_thm (e : IntW 4) :
 
 
 theorem lshrult_02_12_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ult (lshr e (const? 4 2) { «exact» := true }) (const? 4 (-4)) ⊑ const? 1 1 := by
+  icmp IntPred.ult (lshr e (const? 4 2) { «exact» := true }) (const? 4 (-4)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2796,7 +2796,7 @@ theorem lshrult_02_12_exact_thm (e : IntW 4) :
 
 
 theorem lshrult_02_13_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ult (lshr e (const? 4 2) { «exact» := true }) (const? 4 (-3)) ⊑ const? 1 1 := by
+  icmp IntPred.ult (lshr e (const? 4 2) { «exact» := true }) (const? 4 (-3)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2806,7 +2806,7 @@ theorem lshrult_02_13_exact_thm (e : IntW 4) :
 
 
 theorem lshrult_02_14_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ult (lshr e (const? 4 2) { «exact» := true }) (const? 4 (-2)) ⊑ const? 1 1 := by
+  icmp IntPred.ult (lshr e (const? 4 2) { «exact» := true }) (const? 4 (-2)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2816,7 +2816,7 @@ theorem lshrult_02_14_exact_thm (e : IntW 4) :
 
 
 theorem lshrult_02_15_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ult (lshr e (const? 4 2) { «exact» := true }) (const? 4 (-1)) ⊑ const? 1 1 := by
+  icmp IntPred.ult (lshr e (const? 4 2) { «exact» := true }) (const? 4 (-1)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2826,7 +2826,7 @@ theorem lshrult_02_15_exact_thm (e : IntW 4) :
 
 
 theorem lshrult_03_00_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ult (lshr e (const? 4 3) { «exact» := true }) (const? 4 0) ⊑ const? 1 0 := by
+  icmp IntPred.ult (lshr e (const? 4 3) { «exact» := true }) (const? 4 0) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2836,8 +2836,8 @@ theorem lshrult_03_00_exact_thm (e : IntW 4) :
 
 
 theorem lshrult_03_01_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ult (lshr e (const? 4 3) { «exact» := true }) (const? 4 1) ⊑
-    icmp IntPredicate.eq e (const? 4 0) := by
+  icmp IntPred.ult (lshr e (const? 4 3) { «exact» := true }) (const? 4 1) ⊑
+    icmp IntPred.eq e (const? 4 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2847,7 +2847,7 @@ theorem lshrult_03_01_exact_thm (e : IntW 4) :
 
 
 theorem lshrult_03_02_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ult (lshr e (const? 4 3) { «exact» := true }) (const? 4 2) ⊑ const? 1 1 := by
+  icmp IntPred.ult (lshr e (const? 4 3) { «exact» := true }) (const? 4 2) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2857,7 +2857,7 @@ theorem lshrult_03_02_exact_thm (e : IntW 4) :
 
 
 theorem lshrult_03_03_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ult (lshr e (const? 4 3) { «exact» := true }) (const? 4 3) ⊑ const? 1 1 := by
+  icmp IntPred.ult (lshr e (const? 4 3) { «exact» := true }) (const? 4 3) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2867,7 +2867,7 @@ theorem lshrult_03_03_exact_thm (e : IntW 4) :
 
 
 theorem lshrult_03_04_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ult (lshr e (const? 4 3) { «exact» := true }) (const? 4 4) ⊑ const? 1 1 := by
+  icmp IntPred.ult (lshr e (const? 4 3) { «exact» := true }) (const? 4 4) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2877,7 +2877,7 @@ theorem lshrult_03_04_exact_thm (e : IntW 4) :
 
 
 theorem lshrult_03_05_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ult (lshr e (const? 4 3) { «exact» := true }) (const? 4 5) ⊑ const? 1 1 := by
+  icmp IntPred.ult (lshr e (const? 4 3) { «exact» := true }) (const? 4 5) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2887,7 +2887,7 @@ theorem lshrult_03_05_exact_thm (e : IntW 4) :
 
 
 theorem lshrult_03_06_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ult (lshr e (const? 4 3) { «exact» := true }) (const? 4 6) ⊑ const? 1 1 := by
+  icmp IntPred.ult (lshr e (const? 4 3) { «exact» := true }) (const? 4 6) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2897,7 +2897,7 @@ theorem lshrult_03_06_exact_thm (e : IntW 4) :
 
 
 theorem lshrult_03_07_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ult (lshr e (const? 4 3) { «exact» := true }) (const? 4 7) ⊑ const? 1 1 := by
+  icmp IntPred.ult (lshr e (const? 4 3) { «exact» := true }) (const? 4 7) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2907,7 +2907,7 @@ theorem lshrult_03_07_exact_thm (e : IntW 4) :
 
 
 theorem lshrult_03_08_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ult (lshr e (const? 4 3) { «exact» := true }) (const? 4 (-8)) ⊑ const? 1 1 := by
+  icmp IntPred.ult (lshr e (const? 4 3) { «exact» := true }) (const? 4 (-8)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2917,7 +2917,7 @@ theorem lshrult_03_08_exact_thm (e : IntW 4) :
 
 
 theorem lshrult_03_09_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ult (lshr e (const? 4 3) { «exact» := true }) (const? 4 (-7)) ⊑ const? 1 1 := by
+  icmp IntPred.ult (lshr e (const? 4 3) { «exact» := true }) (const? 4 (-7)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2927,7 +2927,7 @@ theorem lshrult_03_09_exact_thm (e : IntW 4) :
 
 
 theorem lshrult_03_10_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ult (lshr e (const? 4 3) { «exact» := true }) (const? 4 (-6)) ⊑ const? 1 1 := by
+  icmp IntPred.ult (lshr e (const? 4 3) { «exact» := true }) (const? 4 (-6)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2937,7 +2937,7 @@ theorem lshrult_03_10_exact_thm (e : IntW 4) :
 
 
 theorem lshrult_03_11_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ult (lshr e (const? 4 3) { «exact» := true }) (const? 4 (-5)) ⊑ const? 1 1 := by
+  icmp IntPred.ult (lshr e (const? 4 3) { «exact» := true }) (const? 4 (-5)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2947,7 +2947,7 @@ theorem lshrult_03_11_exact_thm (e : IntW 4) :
 
 
 theorem lshrult_03_12_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ult (lshr e (const? 4 3) { «exact» := true }) (const? 4 (-4)) ⊑ const? 1 1 := by
+  icmp IntPred.ult (lshr e (const? 4 3) { «exact» := true }) (const? 4 (-4)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2957,7 +2957,7 @@ theorem lshrult_03_12_exact_thm (e : IntW 4) :
 
 
 theorem lshrult_03_13_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ult (lshr e (const? 4 3) { «exact» := true }) (const? 4 (-3)) ⊑ const? 1 1 := by
+  icmp IntPred.ult (lshr e (const? 4 3) { «exact» := true }) (const? 4 (-3)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2967,7 +2967,7 @@ theorem lshrult_03_13_exact_thm (e : IntW 4) :
 
 
 theorem lshrult_03_14_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ult (lshr e (const? 4 3) { «exact» := true }) (const? 4 (-2)) ⊑ const? 1 1 := by
+  icmp IntPred.ult (lshr e (const? 4 3) { «exact» := true }) (const? 4 (-2)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2977,7 +2977,7 @@ theorem lshrult_03_14_exact_thm (e : IntW 4) :
 
 
 theorem lshrult_03_15_exact_thm (e : IntW 4) :
-  icmp IntPredicate.ult (lshr e (const? 4 3) { «exact» := true }) (const? 4 (-1)) ⊑ const? 1 1 := by
+  icmp IntPred.ult (lshr e (const? 4 3) { «exact» := true }) (const? 4 (-1)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2987,8 +2987,8 @@ theorem lshrult_03_15_exact_thm (e : IntW 4) :
 
 
 theorem ashrsgt_01_00_exact_thm (e : IntW 4) :
-  icmp IntPredicate.sgt (ashr e (const? 4 1) { «exact» := true }) (const? 4 0) ⊑
-    icmp IntPredicate.sgt e (const? 4 0) := by
+  icmp IntPred.sgt (ashr e (const? 4 1) { «exact» := true }) (const? 4 0) ⊑
+    icmp IntPred.sgt e (const? 4 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -2998,8 +2998,8 @@ theorem ashrsgt_01_00_exact_thm (e : IntW 4) :
 
 
 theorem ashrsgt_01_01_exact_thm (e : IntW 4) :
-  icmp IntPredicate.sgt (ashr e (const? 4 1) { «exact» := true }) (const? 4 1) ⊑
-    icmp IntPredicate.sgt e (const? 4 2) := by
+  icmp IntPred.sgt (ashr e (const? 4 1) { «exact» := true }) (const? 4 1) ⊑
+    icmp IntPred.sgt e (const? 4 2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3009,8 +3009,8 @@ theorem ashrsgt_01_01_exact_thm (e : IntW 4) :
 
 
 theorem ashrsgt_01_02_exact_thm (e : IntW 4) :
-  icmp IntPredicate.sgt (ashr e (const? 4 1) { «exact» := true }) (const? 4 2) ⊑
-    icmp IntPredicate.sgt e (const? 4 4) := by
+  icmp IntPred.sgt (ashr e (const? 4 1) { «exact» := true }) (const? 4 2) ⊑
+    icmp IntPred.sgt e (const? 4 4) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3020,7 +3020,7 @@ theorem ashrsgt_01_02_exact_thm (e : IntW 4) :
 
 
 theorem ashrsgt_01_03_exact_thm (e : IntW 4) :
-  icmp IntPredicate.sgt (ashr e (const? 4 1) { «exact» := true }) (const? 4 3) ⊑ const? 1 0 := by
+  icmp IntPred.sgt (ashr e (const? 4 1) { «exact» := true }) (const? 4 3) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3030,7 +3030,7 @@ theorem ashrsgt_01_03_exact_thm (e : IntW 4) :
 
 
 theorem ashrsgt_01_04_exact_thm (e : IntW 4) :
-  icmp IntPredicate.sgt (ashr e (const? 4 1) { «exact» := true }) (const? 4 4) ⊑ const? 1 0 := by
+  icmp IntPred.sgt (ashr e (const? 4 1) { «exact» := true }) (const? 4 4) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3040,7 +3040,7 @@ theorem ashrsgt_01_04_exact_thm (e : IntW 4) :
 
 
 theorem ashrsgt_01_05_exact_thm (e : IntW 4) :
-  icmp IntPredicate.sgt (ashr e (const? 4 1) { «exact» := true }) (const? 4 5) ⊑ const? 1 0 := by
+  icmp IntPred.sgt (ashr e (const? 4 1) { «exact» := true }) (const? 4 5) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3050,7 +3050,7 @@ theorem ashrsgt_01_05_exact_thm (e : IntW 4) :
 
 
 theorem ashrsgt_01_06_exact_thm (e : IntW 4) :
-  icmp IntPredicate.sgt (ashr e (const? 4 1) { «exact» := true }) (const? 4 6) ⊑ const? 1 0 := by
+  icmp IntPred.sgt (ashr e (const? 4 1) { «exact» := true }) (const? 4 6) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3060,7 +3060,7 @@ theorem ashrsgt_01_06_exact_thm (e : IntW 4) :
 
 
 theorem ashrsgt_01_07_exact_thm (e : IntW 4) :
-  icmp IntPredicate.sgt (ashr e (const? 4 1) { «exact» := true }) (const? 4 7) ⊑ const? 1 0 := by
+  icmp IntPred.sgt (ashr e (const? 4 1) { «exact» := true }) (const? 4 7) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3070,7 +3070,7 @@ theorem ashrsgt_01_07_exact_thm (e : IntW 4) :
 
 
 theorem ashrsgt_01_08_exact_thm (e : IntW 4) :
-  icmp IntPredicate.sgt (ashr e (const? 4 1) { «exact» := true }) (const? 4 (-8)) ⊑ const? 1 1 := by
+  icmp IntPred.sgt (ashr e (const? 4 1) { «exact» := true }) (const? 4 (-8)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3080,7 +3080,7 @@ theorem ashrsgt_01_08_exact_thm (e : IntW 4) :
 
 
 theorem ashrsgt_01_09_exact_thm (e : IntW 4) :
-  icmp IntPredicate.sgt (ashr e (const? 4 1) { «exact» := true }) (const? 4 (-7)) ⊑ const? 1 1 := by
+  icmp IntPred.sgt (ashr e (const? 4 1) { «exact» := true }) (const? 4 (-7)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3090,7 +3090,7 @@ theorem ashrsgt_01_09_exact_thm (e : IntW 4) :
 
 
 theorem ashrsgt_01_10_exact_thm (e : IntW 4) :
-  icmp IntPredicate.sgt (ashr e (const? 4 1) { «exact» := true }) (const? 4 (-6)) ⊑ const? 1 1 := by
+  icmp IntPred.sgt (ashr e (const? 4 1) { «exact» := true }) (const? 4 (-6)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3100,7 +3100,7 @@ theorem ashrsgt_01_10_exact_thm (e : IntW 4) :
 
 
 theorem ashrsgt_01_11_exact_thm (e : IntW 4) :
-  icmp IntPredicate.sgt (ashr e (const? 4 1) { «exact» := true }) (const? 4 (-5)) ⊑ const? 1 1 := by
+  icmp IntPred.sgt (ashr e (const? 4 1) { «exact» := true }) (const? 4 (-5)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3110,8 +3110,8 @@ theorem ashrsgt_01_11_exact_thm (e : IntW 4) :
 
 
 theorem ashrsgt_01_12_exact_thm (e : IntW 4) :
-  icmp IntPredicate.sgt (ashr e (const? 4 1) { «exact» := true }) (const? 4 (-4)) ⊑
-    icmp IntPredicate.ne e (const? 4 (-8)) := by
+  icmp IntPred.sgt (ashr e (const? 4 1) { «exact» := true }) (const? 4 (-4)) ⊑
+    icmp IntPred.ne e (const? 4 (-8)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3121,8 +3121,8 @@ theorem ashrsgt_01_12_exact_thm (e : IntW 4) :
 
 
 theorem ashrsgt_01_13_exact_thm (e : IntW 4) :
-  icmp IntPredicate.sgt (ashr e (const? 4 1) { «exact» := true }) (const? 4 (-3)) ⊑
-    icmp IntPredicate.sgt e (const? 4 (-6)) := by
+  icmp IntPred.sgt (ashr e (const? 4 1) { «exact» := true }) (const? 4 (-3)) ⊑
+    icmp IntPred.sgt e (const? 4 (-6)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3132,8 +3132,8 @@ theorem ashrsgt_01_13_exact_thm (e : IntW 4) :
 
 
 theorem ashrsgt_01_14_exact_thm (e : IntW 4) :
-  icmp IntPredicate.sgt (ashr e (const? 4 1) { «exact» := true }) (const? 4 (-2)) ⊑
-    icmp IntPredicate.sgt e (const? 4 (-4)) := by
+  icmp IntPred.sgt (ashr e (const? 4 1) { «exact» := true }) (const? 4 (-2)) ⊑
+    icmp IntPred.sgt e (const? 4 (-4)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3143,8 +3143,8 @@ theorem ashrsgt_01_14_exact_thm (e : IntW 4) :
 
 
 theorem ashrsgt_01_15_exact_thm (e : IntW 4) :
-  icmp IntPredicate.sgt (ashr e (const? 4 1) { «exact» := true }) (const? 4 (-1)) ⊑
-    icmp IntPredicate.sgt e (const? 4 (-1)) := by
+  icmp IntPred.sgt (ashr e (const? 4 1) { «exact» := true }) (const? 4 (-1)) ⊑
+    icmp IntPred.sgt e (const? 4 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3154,8 +3154,8 @@ theorem ashrsgt_01_15_exact_thm (e : IntW 4) :
 
 
 theorem ashrsgt_02_00_exact_thm (e : IntW 4) :
-  icmp IntPredicate.sgt (ashr e (const? 4 2) { «exact» := true }) (const? 4 0) ⊑
-    icmp IntPredicate.sgt e (const? 4 0) := by
+  icmp IntPred.sgt (ashr e (const? 4 2) { «exact» := true }) (const? 4 0) ⊑
+    icmp IntPred.sgt e (const? 4 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3165,7 +3165,7 @@ theorem ashrsgt_02_00_exact_thm (e : IntW 4) :
 
 
 theorem ashrsgt_02_01_exact_thm (e : IntW 4) :
-  icmp IntPredicate.sgt (ashr e (const? 4 2) { «exact» := true }) (const? 4 1) ⊑ const? 1 0 := by
+  icmp IntPred.sgt (ashr e (const? 4 2) { «exact» := true }) (const? 4 1) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3175,7 +3175,7 @@ theorem ashrsgt_02_01_exact_thm (e : IntW 4) :
 
 
 theorem ashrsgt_02_02_exact_thm (e : IntW 4) :
-  icmp IntPredicate.sgt (ashr e (const? 4 2) { «exact» := true }) (const? 4 2) ⊑ const? 1 0 := by
+  icmp IntPred.sgt (ashr e (const? 4 2) { «exact» := true }) (const? 4 2) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3185,7 +3185,7 @@ theorem ashrsgt_02_02_exact_thm (e : IntW 4) :
 
 
 theorem ashrsgt_02_03_exact_thm (e : IntW 4) :
-  icmp IntPredicate.sgt (ashr e (const? 4 2) { «exact» := true }) (const? 4 3) ⊑ const? 1 0 := by
+  icmp IntPred.sgt (ashr e (const? 4 2) { «exact» := true }) (const? 4 3) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3195,7 +3195,7 @@ theorem ashrsgt_02_03_exact_thm (e : IntW 4) :
 
 
 theorem ashrsgt_02_04_exact_thm (e : IntW 4) :
-  icmp IntPredicate.sgt (ashr e (const? 4 2) { «exact» := true }) (const? 4 4) ⊑ const? 1 0 := by
+  icmp IntPred.sgt (ashr e (const? 4 2) { «exact» := true }) (const? 4 4) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3205,7 +3205,7 @@ theorem ashrsgt_02_04_exact_thm (e : IntW 4) :
 
 
 theorem ashrsgt_02_05_exact_thm (e : IntW 4) :
-  icmp IntPredicate.sgt (ashr e (const? 4 2) { «exact» := true }) (const? 4 5) ⊑ const? 1 0 := by
+  icmp IntPred.sgt (ashr e (const? 4 2) { «exact» := true }) (const? 4 5) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3215,7 +3215,7 @@ theorem ashrsgt_02_05_exact_thm (e : IntW 4) :
 
 
 theorem ashrsgt_02_06_exact_thm (e : IntW 4) :
-  icmp IntPredicate.sgt (ashr e (const? 4 2) { «exact» := true }) (const? 4 6) ⊑ const? 1 0 := by
+  icmp IntPred.sgt (ashr e (const? 4 2) { «exact» := true }) (const? 4 6) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3225,7 +3225,7 @@ theorem ashrsgt_02_06_exact_thm (e : IntW 4) :
 
 
 theorem ashrsgt_02_07_exact_thm (e : IntW 4) :
-  icmp IntPredicate.sgt (ashr e (const? 4 2) { «exact» := true }) (const? 4 7) ⊑ const? 1 0 := by
+  icmp IntPred.sgt (ashr e (const? 4 2) { «exact» := true }) (const? 4 7) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3235,7 +3235,7 @@ theorem ashrsgt_02_07_exact_thm (e : IntW 4) :
 
 
 theorem ashrsgt_02_08_exact_thm (e : IntW 4) :
-  icmp IntPredicate.sgt (ashr e (const? 4 2) { «exact» := true }) (const? 4 (-8)) ⊑ const? 1 1 := by
+  icmp IntPred.sgt (ashr e (const? 4 2) { «exact» := true }) (const? 4 (-8)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3245,7 +3245,7 @@ theorem ashrsgt_02_08_exact_thm (e : IntW 4) :
 
 
 theorem ashrsgt_02_09_exact_thm (e : IntW 4) :
-  icmp IntPredicate.sgt (ashr e (const? 4 2) { «exact» := true }) (const? 4 (-7)) ⊑ const? 1 1 := by
+  icmp IntPred.sgt (ashr e (const? 4 2) { «exact» := true }) (const? 4 (-7)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3255,7 +3255,7 @@ theorem ashrsgt_02_09_exact_thm (e : IntW 4) :
 
 
 theorem ashrsgt_02_10_exact_thm (e : IntW 4) :
-  icmp IntPredicate.sgt (ashr e (const? 4 2) { «exact» := true }) (const? 4 (-6)) ⊑ const? 1 1 := by
+  icmp IntPred.sgt (ashr e (const? 4 2) { «exact» := true }) (const? 4 (-6)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3265,7 +3265,7 @@ theorem ashrsgt_02_10_exact_thm (e : IntW 4) :
 
 
 theorem ashrsgt_02_11_exact_thm (e : IntW 4) :
-  icmp IntPredicate.sgt (ashr e (const? 4 2) { «exact» := true }) (const? 4 (-5)) ⊑ const? 1 1 := by
+  icmp IntPred.sgt (ashr e (const? 4 2) { «exact» := true }) (const? 4 (-5)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3275,7 +3275,7 @@ theorem ashrsgt_02_11_exact_thm (e : IntW 4) :
 
 
 theorem ashrsgt_02_12_exact_thm (e : IntW 4) :
-  icmp IntPredicate.sgt (ashr e (const? 4 2) { «exact» := true }) (const? 4 (-4)) ⊑ const? 1 1 := by
+  icmp IntPred.sgt (ashr e (const? 4 2) { «exact» := true }) (const? 4 (-4)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3285,7 +3285,7 @@ theorem ashrsgt_02_12_exact_thm (e : IntW 4) :
 
 
 theorem ashrsgt_02_13_exact_thm (e : IntW 4) :
-  icmp IntPredicate.sgt (ashr e (const? 4 2) { «exact» := true }) (const? 4 (-3)) ⊑ const? 1 1 := by
+  icmp IntPred.sgt (ashr e (const? 4 2) { «exact» := true }) (const? 4 (-3)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3295,8 +3295,8 @@ theorem ashrsgt_02_13_exact_thm (e : IntW 4) :
 
 
 theorem ashrsgt_02_14_exact_thm (e : IntW 4) :
-  icmp IntPredicate.sgt (ashr e (const? 4 2) { «exact» := true }) (const? 4 (-2)) ⊑
-    icmp IntPredicate.ne e (const? 4 (-8)) := by
+  icmp IntPred.sgt (ashr e (const? 4 2) { «exact» := true }) (const? 4 (-2)) ⊑
+    icmp IntPred.ne e (const? 4 (-8)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3306,8 +3306,8 @@ theorem ashrsgt_02_14_exact_thm (e : IntW 4) :
 
 
 theorem ashrsgt_02_15_exact_thm (e : IntW 4) :
-  icmp IntPredicate.sgt (ashr e (const? 4 2) { «exact» := true }) (const? 4 (-1)) ⊑
-    icmp IntPredicate.sgt e (const? 4 (-1)) := by
+  icmp IntPred.sgt (ashr e (const? 4 2) { «exact» := true }) (const? 4 (-1)) ⊑
+    icmp IntPred.sgt e (const? 4 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3317,7 +3317,7 @@ theorem ashrsgt_02_15_exact_thm (e : IntW 4) :
 
 
 theorem ashrsgt_03_00_exact_thm (e : IntW 4) :
-  icmp IntPredicate.sgt (ashr e (const? 4 3) { «exact» := true }) (const? 4 0) ⊑ const? 1 0 := by
+  icmp IntPred.sgt (ashr e (const? 4 3) { «exact» := true }) (const? 4 0) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3327,7 +3327,7 @@ theorem ashrsgt_03_00_exact_thm (e : IntW 4) :
 
 
 theorem ashrsgt_03_01_exact_thm (e : IntW 4) :
-  icmp IntPredicate.sgt (ashr e (const? 4 3) { «exact» := true }) (const? 4 1) ⊑ const? 1 0 := by
+  icmp IntPred.sgt (ashr e (const? 4 3) { «exact» := true }) (const? 4 1) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3337,7 +3337,7 @@ theorem ashrsgt_03_01_exact_thm (e : IntW 4) :
 
 
 theorem ashrsgt_03_02_exact_thm (e : IntW 4) :
-  icmp IntPredicate.sgt (ashr e (const? 4 3) { «exact» := true }) (const? 4 2) ⊑ const? 1 0 := by
+  icmp IntPred.sgt (ashr e (const? 4 3) { «exact» := true }) (const? 4 2) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3347,7 +3347,7 @@ theorem ashrsgt_03_02_exact_thm (e : IntW 4) :
 
 
 theorem ashrsgt_03_03_exact_thm (e : IntW 4) :
-  icmp IntPredicate.sgt (ashr e (const? 4 3) { «exact» := true }) (const? 4 3) ⊑ const? 1 0 := by
+  icmp IntPred.sgt (ashr e (const? 4 3) { «exact» := true }) (const? 4 3) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3357,7 +3357,7 @@ theorem ashrsgt_03_03_exact_thm (e : IntW 4) :
 
 
 theorem ashrsgt_03_04_exact_thm (e : IntW 4) :
-  icmp IntPredicate.sgt (ashr e (const? 4 3) { «exact» := true }) (const? 4 4) ⊑ const? 1 0 := by
+  icmp IntPred.sgt (ashr e (const? 4 3) { «exact» := true }) (const? 4 4) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3367,7 +3367,7 @@ theorem ashrsgt_03_04_exact_thm (e : IntW 4) :
 
 
 theorem ashrsgt_03_05_exact_thm (e : IntW 4) :
-  icmp IntPredicate.sgt (ashr e (const? 4 3) { «exact» := true }) (const? 4 5) ⊑ const? 1 0 := by
+  icmp IntPred.sgt (ashr e (const? 4 3) { «exact» := true }) (const? 4 5) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3377,7 +3377,7 @@ theorem ashrsgt_03_05_exact_thm (e : IntW 4) :
 
 
 theorem ashrsgt_03_06_exact_thm (e : IntW 4) :
-  icmp IntPredicate.sgt (ashr e (const? 4 3) { «exact» := true }) (const? 4 6) ⊑ const? 1 0 := by
+  icmp IntPred.sgt (ashr e (const? 4 3) { «exact» := true }) (const? 4 6) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3387,7 +3387,7 @@ theorem ashrsgt_03_06_exact_thm (e : IntW 4) :
 
 
 theorem ashrsgt_03_07_exact_thm (e : IntW 4) :
-  icmp IntPredicate.sgt (ashr e (const? 4 3) { «exact» := true }) (const? 4 7) ⊑ const? 1 0 := by
+  icmp IntPred.sgt (ashr e (const? 4 3) { «exact» := true }) (const? 4 7) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3397,7 +3397,7 @@ theorem ashrsgt_03_07_exact_thm (e : IntW 4) :
 
 
 theorem ashrsgt_03_08_exact_thm (e : IntW 4) :
-  icmp IntPredicate.sgt (ashr e (const? 4 3) { «exact» := true }) (const? 4 (-8)) ⊑ const? 1 1 := by
+  icmp IntPred.sgt (ashr e (const? 4 3) { «exact» := true }) (const? 4 (-8)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3407,7 +3407,7 @@ theorem ashrsgt_03_08_exact_thm (e : IntW 4) :
 
 
 theorem ashrsgt_03_09_exact_thm (e : IntW 4) :
-  icmp IntPredicate.sgt (ashr e (const? 4 3) { «exact» := true }) (const? 4 (-7)) ⊑ const? 1 1 := by
+  icmp IntPred.sgt (ashr e (const? 4 3) { «exact» := true }) (const? 4 (-7)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3417,7 +3417,7 @@ theorem ashrsgt_03_09_exact_thm (e : IntW 4) :
 
 
 theorem ashrsgt_03_10_exact_thm (e : IntW 4) :
-  icmp IntPredicate.sgt (ashr e (const? 4 3) { «exact» := true }) (const? 4 (-6)) ⊑ const? 1 1 := by
+  icmp IntPred.sgt (ashr e (const? 4 3) { «exact» := true }) (const? 4 (-6)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3427,7 +3427,7 @@ theorem ashrsgt_03_10_exact_thm (e : IntW 4) :
 
 
 theorem ashrsgt_03_11_exact_thm (e : IntW 4) :
-  icmp IntPredicate.sgt (ashr e (const? 4 3) { «exact» := true }) (const? 4 (-5)) ⊑ const? 1 1 := by
+  icmp IntPred.sgt (ashr e (const? 4 3) { «exact» := true }) (const? 4 (-5)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3437,7 +3437,7 @@ theorem ashrsgt_03_11_exact_thm (e : IntW 4) :
 
 
 theorem ashrsgt_03_12_exact_thm (e : IntW 4) :
-  icmp IntPredicate.sgt (ashr e (const? 4 3) { «exact» := true }) (const? 4 (-4)) ⊑ const? 1 1 := by
+  icmp IntPred.sgt (ashr e (const? 4 3) { «exact» := true }) (const? 4 (-4)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3447,7 +3447,7 @@ theorem ashrsgt_03_12_exact_thm (e : IntW 4) :
 
 
 theorem ashrsgt_03_13_exact_thm (e : IntW 4) :
-  icmp IntPredicate.sgt (ashr e (const? 4 3) { «exact» := true }) (const? 4 (-3)) ⊑ const? 1 1 := by
+  icmp IntPred.sgt (ashr e (const? 4 3) { «exact» := true }) (const? 4 (-3)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3457,7 +3457,7 @@ theorem ashrsgt_03_13_exact_thm (e : IntW 4) :
 
 
 theorem ashrsgt_03_14_exact_thm (e : IntW 4) :
-  icmp IntPredicate.sgt (ashr e (const? 4 3) { «exact» := true }) (const? 4 (-2)) ⊑ const? 1 1 := by
+  icmp IntPred.sgt (ashr e (const? 4 3) { «exact» := true }) (const? 4 (-2)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3467,8 +3467,8 @@ theorem ashrsgt_03_14_exact_thm (e : IntW 4) :
 
 
 theorem ashrsgt_03_15_exact_thm (e : IntW 4) :
-  icmp IntPredicate.sgt (ashr e (const? 4 3) { «exact» := true }) (const? 4 (-1)) ⊑
-    icmp IntPredicate.sgt e (const? 4 (-1)) := by
+  icmp IntPred.sgt (ashr e (const? 4 3) { «exact» := true }) (const? 4 (-1)) ⊑
+    icmp IntPred.sgt e (const? 4 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3478,8 +3478,8 @@ theorem ashrsgt_03_15_exact_thm (e : IntW 4) :
 
 
 theorem ashrslt_01_00_exact_thm (e : IntW 4) :
-  icmp IntPredicate.slt (ashr e (const? 4 1) { «exact» := true }) (const? 4 0) ⊑
-    icmp IntPredicate.slt e (const? 4 0) := by
+  icmp IntPred.slt (ashr e (const? 4 1) { «exact» := true }) (const? 4 0) ⊑
+    icmp IntPred.slt e (const? 4 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3489,8 +3489,8 @@ theorem ashrslt_01_00_exact_thm (e : IntW 4) :
 
 
 theorem ashrslt_01_01_exact_thm (e : IntW 4) :
-  icmp IntPredicate.slt (ashr e (const? 4 1) { «exact» := true }) (const? 4 1) ⊑
-    icmp IntPredicate.slt e (const? 4 2) := by
+  icmp IntPred.slt (ashr e (const? 4 1) { «exact» := true }) (const? 4 1) ⊑
+    icmp IntPred.slt e (const? 4 2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3500,8 +3500,8 @@ theorem ashrslt_01_01_exact_thm (e : IntW 4) :
 
 
 theorem ashrslt_01_02_exact_thm (e : IntW 4) :
-  icmp IntPredicate.slt (ashr e (const? 4 1) { «exact» := true }) (const? 4 2) ⊑
-    icmp IntPredicate.slt e (const? 4 3) := by
+  icmp IntPred.slt (ashr e (const? 4 1) { «exact» := true }) (const? 4 2) ⊑
+    icmp IntPred.slt e (const? 4 3) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3511,8 +3511,8 @@ theorem ashrslt_01_02_exact_thm (e : IntW 4) :
 
 
 theorem ashrslt_01_03_exact_thm (e : IntW 4) :
-  icmp IntPredicate.slt (ashr e (const? 4 1) { «exact» := true }) (const? 4 3) ⊑
-    icmp IntPredicate.slt e (const? 4 5) := by
+  icmp IntPred.slt (ashr e (const? 4 1) { «exact» := true }) (const? 4 3) ⊑
+    icmp IntPred.slt e (const? 4 5) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3522,7 +3522,7 @@ theorem ashrslt_01_03_exact_thm (e : IntW 4) :
 
 
 theorem ashrslt_01_04_exact_thm (e : IntW 4) :
-  icmp IntPredicate.slt (ashr e (const? 4 1) { «exact» := true }) (const? 4 4) ⊑ const? 1 1 := by
+  icmp IntPred.slt (ashr e (const? 4 1) { «exact» := true }) (const? 4 4) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3532,7 +3532,7 @@ theorem ashrslt_01_04_exact_thm (e : IntW 4) :
 
 
 theorem ashrslt_01_05_exact_thm (e : IntW 4) :
-  icmp IntPredicate.slt (ashr e (const? 4 1) { «exact» := true }) (const? 4 5) ⊑ const? 1 1 := by
+  icmp IntPred.slt (ashr e (const? 4 1) { «exact» := true }) (const? 4 5) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3542,7 +3542,7 @@ theorem ashrslt_01_05_exact_thm (e : IntW 4) :
 
 
 theorem ashrslt_01_06_exact_thm (e : IntW 4) :
-  icmp IntPredicate.slt (ashr e (const? 4 1) { «exact» := true }) (const? 4 6) ⊑ const? 1 1 := by
+  icmp IntPred.slt (ashr e (const? 4 1) { «exact» := true }) (const? 4 6) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3552,7 +3552,7 @@ theorem ashrslt_01_06_exact_thm (e : IntW 4) :
 
 
 theorem ashrslt_01_07_exact_thm (e : IntW 4) :
-  icmp IntPredicate.slt (ashr e (const? 4 1) { «exact» := true }) (const? 4 7) ⊑ const? 1 1 := by
+  icmp IntPred.slt (ashr e (const? 4 1) { «exact» := true }) (const? 4 7) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3562,7 +3562,7 @@ theorem ashrslt_01_07_exact_thm (e : IntW 4) :
 
 
 theorem ashrslt_01_08_exact_thm (e : IntW 4) :
-  icmp IntPredicate.slt (ashr e (const? 4 1) { «exact» := true }) (const? 4 (-8)) ⊑ const? 1 0 := by
+  icmp IntPred.slt (ashr e (const? 4 1) { «exact» := true }) (const? 4 (-8)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3572,7 +3572,7 @@ theorem ashrslt_01_08_exact_thm (e : IntW 4) :
 
 
 theorem ashrslt_01_09_exact_thm (e : IntW 4) :
-  icmp IntPredicate.slt (ashr e (const? 4 1) { «exact» := true }) (const? 4 (-7)) ⊑ const? 1 0 := by
+  icmp IntPred.slt (ashr e (const? 4 1) { «exact» := true }) (const? 4 (-7)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3582,7 +3582,7 @@ theorem ashrslt_01_09_exact_thm (e : IntW 4) :
 
 
 theorem ashrslt_01_10_exact_thm (e : IntW 4) :
-  icmp IntPredicate.slt (ashr e (const? 4 1) { «exact» := true }) (const? 4 (-6)) ⊑ const? 1 0 := by
+  icmp IntPred.slt (ashr e (const? 4 1) { «exact» := true }) (const? 4 (-6)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3592,7 +3592,7 @@ theorem ashrslt_01_10_exact_thm (e : IntW 4) :
 
 
 theorem ashrslt_01_11_exact_thm (e : IntW 4) :
-  icmp IntPredicate.slt (ashr e (const? 4 1) { «exact» := true }) (const? 4 (-5)) ⊑ const? 1 0 := by
+  icmp IntPred.slt (ashr e (const? 4 1) { «exact» := true }) (const? 4 (-5)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3602,7 +3602,7 @@ theorem ashrslt_01_11_exact_thm (e : IntW 4) :
 
 
 theorem ashrslt_01_12_exact_thm (e : IntW 4) :
-  icmp IntPredicate.slt (ashr e (const? 4 1) { «exact» := true }) (const? 4 (-4)) ⊑ const? 1 0 := by
+  icmp IntPred.slt (ashr e (const? 4 1) { «exact» := true }) (const? 4 (-4)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3612,8 +3612,8 @@ theorem ashrslt_01_12_exact_thm (e : IntW 4) :
 
 
 theorem ashrslt_01_13_exact_thm (e : IntW 4) :
-  icmp IntPredicate.slt (ashr e (const? 4 1) { «exact» := true }) (const? 4 (-3)) ⊑
-    icmp IntPredicate.slt e (const? 4 (-6)) := by
+  icmp IntPred.slt (ashr e (const? 4 1) { «exact» := true }) (const? 4 (-3)) ⊑
+    icmp IntPred.slt e (const? 4 (-6)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3623,8 +3623,8 @@ theorem ashrslt_01_13_exact_thm (e : IntW 4) :
 
 
 theorem ashrslt_01_14_exact_thm (e : IntW 4) :
-  icmp IntPredicate.slt (ashr e (const? 4 1) { «exact» := true }) (const? 4 (-2)) ⊑
-    icmp IntPredicate.slt e (const? 4 (-4)) := by
+  icmp IntPred.slt (ashr e (const? 4 1) { «exact» := true }) (const? 4 (-2)) ⊑
+    icmp IntPred.slt e (const? 4 (-4)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3634,8 +3634,8 @@ theorem ashrslt_01_14_exact_thm (e : IntW 4) :
 
 
 theorem ashrslt_01_15_exact_thm (e : IntW 4) :
-  icmp IntPredicate.slt (ashr e (const? 4 1) { «exact» := true }) (const? 4 (-1)) ⊑
-    icmp IntPredicate.slt e (const? 4 (-2)) := by
+  icmp IntPred.slt (ashr e (const? 4 1) { «exact» := true }) (const? 4 (-1)) ⊑
+    icmp IntPred.slt e (const? 4 (-2)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3645,8 +3645,8 @@ theorem ashrslt_01_15_exact_thm (e : IntW 4) :
 
 
 theorem ashrslt_02_00_exact_thm (e : IntW 4) :
-  icmp IntPredicate.slt (ashr e (const? 4 2) { «exact» := true }) (const? 4 0) ⊑
-    icmp IntPredicate.slt e (const? 4 0) := by
+  icmp IntPred.slt (ashr e (const? 4 2) { «exact» := true }) (const? 4 0) ⊑
+    icmp IntPred.slt e (const? 4 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3656,8 +3656,8 @@ theorem ashrslt_02_00_exact_thm (e : IntW 4) :
 
 
 theorem ashrslt_02_01_exact_thm (e : IntW 4) :
-  icmp IntPredicate.slt (ashr e (const? 4 2) { «exact» := true }) (const? 4 1) ⊑
-    icmp IntPredicate.slt e (const? 4 4) := by
+  icmp IntPred.slt (ashr e (const? 4 2) { «exact» := true }) (const? 4 1) ⊑
+    icmp IntPred.slt e (const? 4 4) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3667,7 +3667,7 @@ theorem ashrslt_02_01_exact_thm (e : IntW 4) :
 
 
 theorem ashrslt_02_02_exact_thm (e : IntW 4) :
-  icmp IntPredicate.slt (ashr e (const? 4 2) { «exact» := true }) (const? 4 2) ⊑ const? 1 1 := by
+  icmp IntPred.slt (ashr e (const? 4 2) { «exact» := true }) (const? 4 2) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3677,7 +3677,7 @@ theorem ashrslt_02_02_exact_thm (e : IntW 4) :
 
 
 theorem ashrslt_02_03_exact_thm (e : IntW 4) :
-  icmp IntPredicate.slt (ashr e (const? 4 2) { «exact» := true }) (const? 4 3) ⊑ const? 1 1 := by
+  icmp IntPred.slt (ashr e (const? 4 2) { «exact» := true }) (const? 4 3) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3687,7 +3687,7 @@ theorem ashrslt_02_03_exact_thm (e : IntW 4) :
 
 
 theorem ashrslt_02_04_exact_thm (e : IntW 4) :
-  icmp IntPredicate.slt (ashr e (const? 4 2) { «exact» := true }) (const? 4 4) ⊑ const? 1 1 := by
+  icmp IntPred.slt (ashr e (const? 4 2) { «exact» := true }) (const? 4 4) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3697,7 +3697,7 @@ theorem ashrslt_02_04_exact_thm (e : IntW 4) :
 
 
 theorem ashrslt_02_05_exact_thm (e : IntW 4) :
-  icmp IntPredicate.slt (ashr e (const? 4 2) { «exact» := true }) (const? 4 5) ⊑ const? 1 1 := by
+  icmp IntPred.slt (ashr e (const? 4 2) { «exact» := true }) (const? 4 5) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3707,7 +3707,7 @@ theorem ashrslt_02_05_exact_thm (e : IntW 4) :
 
 
 theorem ashrslt_02_06_exact_thm (e : IntW 4) :
-  icmp IntPredicate.slt (ashr e (const? 4 2) { «exact» := true }) (const? 4 6) ⊑ const? 1 1 := by
+  icmp IntPred.slt (ashr e (const? 4 2) { «exact» := true }) (const? 4 6) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3717,7 +3717,7 @@ theorem ashrslt_02_06_exact_thm (e : IntW 4) :
 
 
 theorem ashrslt_02_07_exact_thm (e : IntW 4) :
-  icmp IntPredicate.slt (ashr e (const? 4 2) { «exact» := true }) (const? 4 7) ⊑ const? 1 1 := by
+  icmp IntPred.slt (ashr e (const? 4 2) { «exact» := true }) (const? 4 7) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3727,7 +3727,7 @@ theorem ashrslt_02_07_exact_thm (e : IntW 4) :
 
 
 theorem ashrslt_02_08_exact_thm (e : IntW 4) :
-  icmp IntPredicate.slt (ashr e (const? 4 2) { «exact» := true }) (const? 4 (-8)) ⊑ const? 1 0 := by
+  icmp IntPred.slt (ashr e (const? 4 2) { «exact» := true }) (const? 4 (-8)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3737,7 +3737,7 @@ theorem ashrslt_02_08_exact_thm (e : IntW 4) :
 
 
 theorem ashrslt_02_09_exact_thm (e : IntW 4) :
-  icmp IntPredicate.slt (ashr e (const? 4 2) { «exact» := true }) (const? 4 (-7)) ⊑ const? 1 0 := by
+  icmp IntPred.slt (ashr e (const? 4 2) { «exact» := true }) (const? 4 (-7)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3747,7 +3747,7 @@ theorem ashrslt_02_09_exact_thm (e : IntW 4) :
 
 
 theorem ashrslt_02_10_exact_thm (e : IntW 4) :
-  icmp IntPredicate.slt (ashr e (const? 4 2) { «exact» := true }) (const? 4 (-6)) ⊑ const? 1 0 := by
+  icmp IntPred.slt (ashr e (const? 4 2) { «exact» := true }) (const? 4 (-6)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3757,7 +3757,7 @@ theorem ashrslt_02_10_exact_thm (e : IntW 4) :
 
 
 theorem ashrslt_02_11_exact_thm (e : IntW 4) :
-  icmp IntPredicate.slt (ashr e (const? 4 2) { «exact» := true }) (const? 4 (-5)) ⊑ const? 1 0 := by
+  icmp IntPred.slt (ashr e (const? 4 2) { «exact» := true }) (const? 4 (-5)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3767,7 +3767,7 @@ theorem ashrslt_02_11_exact_thm (e : IntW 4) :
 
 
 theorem ashrslt_02_12_exact_thm (e : IntW 4) :
-  icmp IntPredicate.slt (ashr e (const? 4 2) { «exact» := true }) (const? 4 (-4)) ⊑ const? 1 0 := by
+  icmp IntPred.slt (ashr e (const? 4 2) { «exact» := true }) (const? 4 (-4)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3777,7 +3777,7 @@ theorem ashrslt_02_12_exact_thm (e : IntW 4) :
 
 
 theorem ashrslt_02_13_exact_thm (e : IntW 4) :
-  icmp IntPredicate.slt (ashr e (const? 4 2) { «exact» := true }) (const? 4 (-3)) ⊑ const? 1 0 := by
+  icmp IntPred.slt (ashr e (const? 4 2) { «exact» := true }) (const? 4 (-3)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3787,7 +3787,7 @@ theorem ashrslt_02_13_exact_thm (e : IntW 4) :
 
 
 theorem ashrslt_02_14_exact_thm (e : IntW 4) :
-  icmp IntPredicate.slt (ashr e (const? 4 2) { «exact» := true }) (const? 4 (-2)) ⊑ const? 1 0 := by
+  icmp IntPred.slt (ashr e (const? 4 2) { «exact» := true }) (const? 4 (-2)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3797,8 +3797,8 @@ theorem ashrslt_02_14_exact_thm (e : IntW 4) :
 
 
 theorem ashrslt_02_15_exact_thm (e : IntW 4) :
-  icmp IntPredicate.slt (ashr e (const? 4 2) { «exact» := true }) (const? 4 (-1)) ⊑
-    icmp IntPredicate.slt e (const? 4 (-4)) := by
+  icmp IntPred.slt (ashr e (const? 4 2) { «exact» := true }) (const? 4 (-1)) ⊑
+    icmp IntPred.slt e (const? 4 (-4)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3808,8 +3808,8 @@ theorem ashrslt_02_15_exact_thm (e : IntW 4) :
 
 
 theorem ashrslt_03_00_exact_thm (e : IntW 4) :
-  icmp IntPredicate.slt (ashr e (const? 4 3) { «exact» := true }) (const? 4 0) ⊑
-    icmp IntPredicate.slt e (const? 4 0) := by
+  icmp IntPred.slt (ashr e (const? 4 3) { «exact» := true }) (const? 4 0) ⊑
+    icmp IntPred.slt e (const? 4 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3819,7 +3819,7 @@ theorem ashrslt_03_00_exact_thm (e : IntW 4) :
 
 
 theorem ashrslt_03_01_exact_thm (e : IntW 4) :
-  icmp IntPredicate.slt (ashr e (const? 4 3) { «exact» := true }) (const? 4 1) ⊑ const? 1 1 := by
+  icmp IntPred.slt (ashr e (const? 4 3) { «exact» := true }) (const? 4 1) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3829,7 +3829,7 @@ theorem ashrslt_03_01_exact_thm (e : IntW 4) :
 
 
 theorem ashrslt_03_02_exact_thm (e : IntW 4) :
-  icmp IntPredicate.slt (ashr e (const? 4 3) { «exact» := true }) (const? 4 2) ⊑ const? 1 1 := by
+  icmp IntPred.slt (ashr e (const? 4 3) { «exact» := true }) (const? 4 2) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3839,7 +3839,7 @@ theorem ashrslt_03_02_exact_thm (e : IntW 4) :
 
 
 theorem ashrslt_03_03_exact_thm (e : IntW 4) :
-  icmp IntPredicate.slt (ashr e (const? 4 3) { «exact» := true }) (const? 4 3) ⊑ const? 1 1 := by
+  icmp IntPred.slt (ashr e (const? 4 3) { «exact» := true }) (const? 4 3) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3849,7 +3849,7 @@ theorem ashrslt_03_03_exact_thm (e : IntW 4) :
 
 
 theorem ashrslt_03_04_exact_thm (e : IntW 4) :
-  icmp IntPredicate.slt (ashr e (const? 4 3) { «exact» := true }) (const? 4 4) ⊑ const? 1 1 := by
+  icmp IntPred.slt (ashr e (const? 4 3) { «exact» := true }) (const? 4 4) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3859,7 +3859,7 @@ theorem ashrslt_03_04_exact_thm (e : IntW 4) :
 
 
 theorem ashrslt_03_05_exact_thm (e : IntW 4) :
-  icmp IntPredicate.slt (ashr e (const? 4 3) { «exact» := true }) (const? 4 5) ⊑ const? 1 1 := by
+  icmp IntPred.slt (ashr e (const? 4 3) { «exact» := true }) (const? 4 5) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3869,7 +3869,7 @@ theorem ashrslt_03_05_exact_thm (e : IntW 4) :
 
 
 theorem ashrslt_03_06_exact_thm (e : IntW 4) :
-  icmp IntPredicate.slt (ashr e (const? 4 3) { «exact» := true }) (const? 4 6) ⊑ const? 1 1 := by
+  icmp IntPred.slt (ashr e (const? 4 3) { «exact» := true }) (const? 4 6) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3879,7 +3879,7 @@ theorem ashrslt_03_06_exact_thm (e : IntW 4) :
 
 
 theorem ashrslt_03_07_exact_thm (e : IntW 4) :
-  icmp IntPredicate.slt (ashr e (const? 4 3) { «exact» := true }) (const? 4 7) ⊑ const? 1 1 := by
+  icmp IntPred.slt (ashr e (const? 4 3) { «exact» := true }) (const? 4 7) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3889,7 +3889,7 @@ theorem ashrslt_03_07_exact_thm (e : IntW 4) :
 
 
 theorem ashrslt_03_08_exact_thm (e : IntW 4) :
-  icmp IntPredicate.slt (ashr e (const? 4 3) { «exact» := true }) (const? 4 (-8)) ⊑ const? 1 0 := by
+  icmp IntPred.slt (ashr e (const? 4 3) { «exact» := true }) (const? 4 (-8)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3899,7 +3899,7 @@ theorem ashrslt_03_08_exact_thm (e : IntW 4) :
 
 
 theorem ashrslt_03_09_exact_thm (e : IntW 4) :
-  icmp IntPredicate.slt (ashr e (const? 4 3) { «exact» := true }) (const? 4 (-7)) ⊑ const? 1 0 := by
+  icmp IntPred.slt (ashr e (const? 4 3) { «exact» := true }) (const? 4 (-7)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3909,7 +3909,7 @@ theorem ashrslt_03_09_exact_thm (e : IntW 4) :
 
 
 theorem ashrslt_03_10_exact_thm (e : IntW 4) :
-  icmp IntPredicate.slt (ashr e (const? 4 3) { «exact» := true }) (const? 4 (-6)) ⊑ const? 1 0 := by
+  icmp IntPred.slt (ashr e (const? 4 3) { «exact» := true }) (const? 4 (-6)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3919,7 +3919,7 @@ theorem ashrslt_03_10_exact_thm (e : IntW 4) :
 
 
 theorem ashrslt_03_11_exact_thm (e : IntW 4) :
-  icmp IntPredicate.slt (ashr e (const? 4 3) { «exact» := true }) (const? 4 (-5)) ⊑ const? 1 0 := by
+  icmp IntPred.slt (ashr e (const? 4 3) { «exact» := true }) (const? 4 (-5)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3929,7 +3929,7 @@ theorem ashrslt_03_11_exact_thm (e : IntW 4) :
 
 
 theorem ashrslt_03_12_exact_thm (e : IntW 4) :
-  icmp IntPredicate.slt (ashr e (const? 4 3) { «exact» := true }) (const? 4 (-4)) ⊑ const? 1 0 := by
+  icmp IntPred.slt (ashr e (const? 4 3) { «exact» := true }) (const? 4 (-4)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3939,7 +3939,7 @@ theorem ashrslt_03_12_exact_thm (e : IntW 4) :
 
 
 theorem ashrslt_03_13_exact_thm (e : IntW 4) :
-  icmp IntPredicate.slt (ashr e (const? 4 3) { «exact» := true }) (const? 4 (-3)) ⊑ const? 1 0 := by
+  icmp IntPred.slt (ashr e (const? 4 3) { «exact» := true }) (const? 4 (-3)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3949,7 +3949,7 @@ theorem ashrslt_03_13_exact_thm (e : IntW 4) :
 
 
 theorem ashrslt_03_14_exact_thm (e : IntW 4) :
-  icmp IntPredicate.slt (ashr e (const? 4 3) { «exact» := true }) (const? 4 (-2)) ⊑ const? 1 0 := by
+  icmp IntPred.slt (ashr e (const? 4 3) { «exact» := true }) (const? 4 (-2)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3959,7 +3959,7 @@ theorem ashrslt_03_14_exact_thm (e : IntW 4) :
 
 
 theorem ashrslt_03_15_exact_thm (e : IntW 4) :
-  icmp IntPredicate.slt (ashr e (const? 4 3) { «exact» := true }) (const? 4 (-1)) ⊑ const? 1 0 := by
+  icmp IntPred.slt (ashr e (const? 4 3) { «exact» := true }) (const? 4 (-1)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3969,8 +3969,8 @@ theorem ashrslt_03_15_exact_thm (e : IntW 4) :
 
 
 theorem ashr_slt_exact_near_pow2_cmpval_thm (e : IntW 8) :
-  icmp IntPredicate.slt (ashr e (const? 8 1) { «exact» := true }) (const? 8 5) ⊑
-    icmp IntPredicate.slt e (const? 8 9) := by
+  icmp IntPred.slt (ashr e (const? 8 1) { «exact» := true }) (const? 8 5) ⊑
+    icmp IntPred.slt e (const? 8 9) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3980,8 +3980,8 @@ theorem ashr_slt_exact_near_pow2_cmpval_thm (e : IntW 8) :
 
 
 theorem ashr_ult_exact_near_pow2_cmpval_thm (e : IntW 8) :
-  icmp IntPredicate.ult (ashr e (const? 8 1) { «exact» := true }) (const? 8 5) ⊑
-    icmp IntPredicate.ult e (const? 8 9) := by
+  icmp IntPred.ult (ashr e (const? 8 1) { «exact» := true }) (const? 8 5) ⊑
+    icmp IntPred.ult e (const? 8 9) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -3991,7 +3991,7 @@ theorem ashr_ult_exact_near_pow2_cmpval_thm (e : IntW 8) :
 
 
 theorem negtest_near_pow2_cmpval_ashr_slt_noexact_thm (e : IntW 8) :
-  icmp IntPredicate.slt (ashr e (const? 8 1)) (const? 8 5) ⊑ icmp IntPredicate.slt e (const? 8 10) := by
+  icmp IntPred.slt (ashr e (const? 8 1)) (const? 8 5) ⊑ icmp IntPred.slt e (const? 8 10) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -4001,8 +4001,8 @@ theorem negtest_near_pow2_cmpval_ashr_slt_noexact_thm (e : IntW 8) :
 
 
 theorem negtest_near_pow2_cmpval_ashr_wrong_cmp_pred_thm (e : IntW 8) :
-  icmp IntPredicate.eq (ashr e (const? 8 1) { «exact» := true }) (const? 8 5) ⊑
-    icmp IntPredicate.eq e (const? 8 10) := by
+  icmp IntPred.eq (ashr e (const? 8 1) { «exact» := true }) (const? 8 5) ⊑
+    icmp IntPred.eq e (const? 8 10) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -4012,8 +4012,8 @@ theorem negtest_near_pow2_cmpval_ashr_wrong_cmp_pred_thm (e : IntW 8) :
 
 
 theorem negtest_near_pow2_cmpval_isnt_close_to_pow2_thm (e : IntW 8) :
-  icmp IntPredicate.slt (ashr e (const? 8 1) { «exact» := true }) (const? 8 6) ⊑
-    icmp IntPredicate.slt e (const? 8 12) := by
+  icmp IntPred.slt (ashr e (const? 8 1) { «exact» := true }) (const? 8 6) ⊑
+    icmp IntPred.slt e (const? 8 12) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -4023,8 +4023,8 @@ theorem negtest_near_pow2_cmpval_isnt_close_to_pow2_thm (e : IntW 8) :
 
 
 theorem negtest_near_pow2_cmpval_would_overflow_into_signbit_thm (e : IntW 8) :
-  icmp IntPredicate.ult (ashr e (const? 8 2) { «exact» := true }) (const? 8 33) ⊑
-    icmp IntPredicate.sgt e (const? 8 (-1)) := by
+  icmp IntPred.ult (ashr e (const? 8 2) { «exact» := true }) (const? 8 33) ⊑
+    icmp IntPred.sgt e (const? 8 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gicmphsignmask_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gicmphsignmask_proof.lean
@@ -12,8 +12,8 @@ set_option Elab.async false
 
 section gicmphsignmask_proof
 theorem cmp_x_and_negp2_with_eq_thm (e : IntW 8) :
-  icmp IntPredicate.eq (LLVM.and e (const? 8 (-2))) (const? 8 (-128)) ⊑
-    icmp IntPredicate.slt e (const? 8 (-126)) := by
+  icmp IntPred.eq (LLVM.and e (const? 8 (-2))) (const? 8 (-128)) ⊑
+    icmp IntPred.slt e (const? 8 (-126)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gicmphsub_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gicmphsub_proof.lean
@@ -12,8 +12,8 @@ set_option Elab.async false
 
 section gicmphsub_proof
 theorem test_nuw_and_unsigned_pred_thm (e : IntW 64) :
-  icmp IntPredicate.ult (sub (const? 64 10) e { «nsw» := false, «nuw» := true }) (const? 64 3) ⊑
-    icmp IntPredicate.ugt e (const? 64 7) := by
+  icmp IntPred.ult (sub (const? 64 10) e { «nsw» := false, «nuw» := true }) (const? 64 3) ⊑
+    icmp IntPred.ugt e (const? 64 7) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -23,8 +23,8 @@ theorem test_nuw_and_unsigned_pred_thm (e : IntW 64) :
 
 
 theorem test_nsw_and_signed_pred_thm (e : IntW 64) :
-  icmp IntPredicate.sgt (sub (const? 64 3) e { «nsw» := true, «nuw» := false }) (const? 64 10) ⊑
-    icmp IntPredicate.slt e (const? 64 (-7)) := by
+  icmp IntPred.sgt (sub (const? 64 3) e { «nsw» := true, «nuw» := false }) (const? 64 10) ⊑
+    icmp IntPred.slt e (const? 64 (-7)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -34,8 +34,8 @@ theorem test_nsw_and_signed_pred_thm (e : IntW 64) :
 
 
 theorem test_nuw_nsw_and_unsigned_pred_thm (e : IntW 64) :
-  icmp IntPredicate.ule (sub (const? 64 10) e { «nsw» := true, «nuw» := true }) (const? 64 3) ⊑
-    icmp IntPredicate.ugt e (const? 64 6) := by
+  icmp IntPred.ule (sub (const? 64 10) e { «nsw» := true, «nuw» := true }) (const? 64 3) ⊑
+    icmp IntPred.ugt e (const? 64 6) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -45,8 +45,8 @@ theorem test_nuw_nsw_and_unsigned_pred_thm (e : IntW 64) :
 
 
 theorem test_nuw_nsw_and_signed_pred_thm (e : IntW 64) :
-  icmp IntPredicate.slt (sub (const? 64 10) e { «nsw» := true, «nuw» := true }) (const? 64 3) ⊑
-    icmp IntPredicate.ugt e (const? 64 7) := by
+  icmp IntPred.slt (sub (const? 64 10) e { «nsw» := true, «nuw» := true }) (const? 64 3) ⊑
+    icmp IntPred.ugt e (const? 64 7) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -56,8 +56,8 @@ theorem test_nuw_nsw_and_signed_pred_thm (e : IntW 64) :
 
 
 theorem test_negative_nuw_and_signed_pred_thm (e : IntW 64) :
-  icmp IntPredicate.slt (sub (const? 64 10) e { «nsw» := false, «nuw» := true }) (const? 64 3) ⊑
-    icmp IntPredicate.ugt e (const? 64 7) := by
+  icmp IntPred.slt (sub (const? 64 10) e { «nsw» := false, «nuw» := true }) (const? 64 3) ⊑
+    icmp IntPred.ugt e (const? 64 7) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -67,8 +67,8 @@ theorem test_negative_nuw_and_signed_pred_thm (e : IntW 64) :
 
 
 theorem test_negative_nsw_and_unsigned_pred_thm (e : IntW 64) :
-  icmp IntPredicate.ult (sub (const? 64 10) e { «nsw» := true, «nuw» := false }) (const? 64 3) ⊑
-    icmp IntPredicate.ult (add e (const? 64 (-8))) (const? 64 3) := by
+  icmp IntPred.ult (sub (const? 64 10) e { «nsw» := true, «nuw» := false }) (const? 64 3) ⊑
+    icmp IntPred.ult (add e (const? 64 (-8))) (const? 64 3) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -78,7 +78,7 @@ theorem test_negative_nsw_and_unsigned_pred_thm (e : IntW 64) :
 
 
 theorem test_negative_combined_sub_unsigned_overflow_thm (e : IntW 64) :
-  icmp IntPredicate.ult (sub (const? 64 10) e { «nsw» := false, «nuw» := true }) (const? 64 11) ⊑ const? 1 1 := by
+  icmp IntPred.ult (sub (const? 64 10) e { «nsw» := false, «nuw» := true }) (const? 64 11) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -88,7 +88,7 @@ theorem test_negative_combined_sub_unsigned_overflow_thm (e : IntW 64) :
 
 
 theorem test_negative_combined_sub_signed_overflow_thm (e : IntW 8) :
-  icmp IntPredicate.slt (sub (const? 8 127) e { «nsw» := true, «nuw» := false }) (const? 8 (-1)) ⊑ const? 1 0 := by
+  icmp IntPred.slt (sub (const? 8 127) e { «nsw» := true, «nuw» := false }) (const? 8 (-1)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -98,7 +98,7 @@ theorem test_negative_combined_sub_signed_overflow_thm (e : IntW 8) :
 
 
 theorem test_sub_0_Y_eq_0_thm (e : IntW 8) :
-  icmp IntPredicate.eq (sub (const? 8 0) e) (const? 8 0) ⊑ icmp IntPredicate.eq e (const? 8 0) := by
+  icmp IntPred.eq (sub (const? 8 0) e) (const? 8 0) ⊑ icmp IntPred.eq e (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -108,7 +108,7 @@ theorem test_sub_0_Y_eq_0_thm (e : IntW 8) :
 
 
 theorem test_sub_0_Y_ne_0_thm (e : IntW 8) :
-  icmp IntPredicate.ne (sub (const? 8 0) e) (const? 8 0) ⊑ icmp IntPredicate.ne e (const? 8 0) := by
+  icmp IntPred.ne (sub (const? 8 0) e) (const? 8 0) ⊑ icmp IntPred.ne e (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -118,7 +118,7 @@ theorem test_sub_0_Y_ne_0_thm (e : IntW 8) :
 
 
 theorem test_sub_4_Y_ne_4_thm (e : IntW 8) :
-  icmp IntPredicate.ne (sub (const? 8 4) e) (const? 8 4) ⊑ icmp IntPredicate.ne e (const? 8 0) := by
+  icmp IntPred.ne (sub (const? 8 4) e) (const? 8 4) ⊑ icmp IntPred.ne e (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -128,7 +128,7 @@ theorem test_sub_4_Y_ne_4_thm (e : IntW 8) :
 
 
 theorem test_sub_127_Y_eq_127_thm (e : IntW 8) :
-  icmp IntPredicate.eq (sub (const? 8 127) e) (const? 8 127) ⊑ icmp IntPredicate.eq e (const? 8 0) := by
+  icmp IntPred.eq (sub (const? 8 127) e) (const? 8 127) ⊑ icmp IntPred.eq e (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -138,7 +138,7 @@ theorem test_sub_127_Y_eq_127_thm (e : IntW 8) :
 
 
 theorem test_sub_255_Y_eq_255_thm (e : IntW 8) :
-  icmp IntPredicate.eq (sub (const? 8 (-1)) e) (const? 8 (-1)) ⊑ icmp IntPredicate.eq e (const? 8 0) := by
+  icmp IntPred.eq (sub (const? 8 (-1)) e) (const? 8 (-1)) ⊑ icmp IntPred.eq e (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -148,8 +148,8 @@ theorem test_sub_255_Y_eq_255_thm (e : IntW 8) :
 
 
 theorem neg_sgt_42_thm (e : IntW 32) :
-  icmp IntPredicate.sgt (sub (const? 32 0) e) (const? 32 42) ⊑
-    icmp IntPredicate.slt (add e (const? 32 (-1))) (const? 32 (-43)) := by
+  icmp IntPred.sgt (sub (const? 32 0) e) (const? 32 42) ⊑
+    icmp IntPred.slt (add e (const? 32 (-1))) (const? 32 (-43)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -159,8 +159,8 @@ theorem neg_sgt_42_thm (e : IntW 32) :
 
 
 theorem neg_slt_42_thm (e : IntW 128) :
-  icmp IntPredicate.slt (sub (const? 128 0) e) (const? 128 42) ⊑
-    icmp IntPredicate.sgt (add e (const? 128 (-1))) (const? 128 (-43)) := by
+  icmp IntPred.slt (sub (const? 128 0) e) (const? 128 42) ⊑
+    icmp IntPred.sgt (add e (const? 128 (-1))) (const? 128 (-43)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -170,8 +170,8 @@ theorem neg_slt_42_thm (e : IntW 128) :
 
 
 theorem neg_slt_n1_thm (e : IntW 8) :
-  icmp IntPredicate.slt (sub (const? 8 0) e) (const? 8 (-1)) ⊑
-    icmp IntPredicate.sgt (add e (const? 8 (-1))) (const? 8 0) := by
+  icmp IntPred.slt (sub (const? 8 0) e) (const? 8 (-1)) ⊑
+    icmp IntPred.sgt (add e (const? 8 (-1))) (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -181,8 +181,8 @@ theorem neg_slt_n1_thm (e : IntW 8) :
 
 
 theorem neg_slt_0_thm (e : IntW 8) :
-  icmp IntPredicate.slt (sub (const? 8 0) e) (const? 8 0) ⊑
-    icmp IntPredicate.sgt (add e (const? 8 (-1))) (const? 8 (-1)) := by
+  icmp IntPred.slt (sub (const? 8 0) e) (const? 8 0) ⊑
+    icmp IntPred.sgt (add e (const? 8 (-1))) (const? 8 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -192,7 +192,7 @@ theorem neg_slt_0_thm (e : IntW 8) :
 
 
 theorem neg_slt_1_thm (e : IntW 8) :
-  icmp IntPredicate.slt (sub (const? 8 0) e) (const? 8 1) ⊑ icmp IntPredicate.ult e (const? 8 (-127)) := by
+  icmp IntPred.slt (sub (const? 8 0) e) (const? 8 1) ⊑ icmp IntPred.ult e (const? 8 (-127)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -202,8 +202,8 @@ theorem neg_slt_1_thm (e : IntW 8) :
 
 
 theorem neg_sgt_n1_thm (e : IntW 8) :
-  icmp IntPredicate.sgt (sub (const? 8 0) e) (const? 8 (-1)) ⊑
-    icmp IntPredicate.slt (add e (const? 8 (-1))) (const? 8 0) := by
+  icmp IntPred.sgt (sub (const? 8 0) e) (const? 8 (-1)) ⊑
+    icmp IntPred.slt (add e (const? 8 (-1))) (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -213,7 +213,7 @@ theorem neg_sgt_n1_thm (e : IntW 8) :
 
 
 theorem neg_sgt_0_thm (e : IntW 8) :
-  icmp IntPredicate.sgt (sub (const? 8 0) e) (const? 8 0) ⊑ icmp IntPredicate.ugt e (const? 8 (-128)) := by
+  icmp IntPred.sgt (sub (const? 8 0) e) (const? 8 0) ⊑ icmp IntPred.ugt e (const? 8 (-128)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -223,8 +223,8 @@ theorem neg_sgt_0_thm (e : IntW 8) :
 
 
 theorem neg_sgt_1_thm (e : IntW 8) :
-  icmp IntPredicate.sgt (sub (const? 8 0) e) (const? 8 1) ⊑
-    icmp IntPredicate.slt (add e (const? 8 (-1))) (const? 8 (-2)) := by
+  icmp IntPred.sgt (sub (const? 8 0) e) (const? 8 1) ⊑
+    icmp IntPred.slt (add e (const? 8 (-1))) (const? 8 (-2)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -234,8 +234,8 @@ theorem neg_sgt_1_thm (e : IntW 8) :
 
 
 theorem neg_nsw_slt_n1_thm (e : IntW 8) :
-  icmp IntPredicate.slt (sub (const? 8 0) e { «nsw» := true, «nuw» := false }) (const? 8 (-1)) ⊑
-    icmp IntPredicate.sgt e (const? 8 1) := by
+  icmp IntPred.slt (sub (const? 8 0) e { «nsw» := true, «nuw» := false }) (const? 8 (-1)) ⊑
+    icmp IntPred.sgt e (const? 8 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -245,8 +245,8 @@ theorem neg_nsw_slt_n1_thm (e : IntW 8) :
 
 
 theorem neg_nsw_slt_0_thm (e : IntW 8) :
-  icmp IntPredicate.slt (sub (const? 8 0) e { «nsw» := true, «nuw» := false }) (const? 8 0) ⊑
-    icmp IntPredicate.sgt e (const? 8 0) := by
+  icmp IntPred.slt (sub (const? 8 0) e { «nsw» := true, «nuw» := false }) (const? 8 0) ⊑
+    icmp IntPred.sgt e (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -256,8 +256,8 @@ theorem neg_nsw_slt_0_thm (e : IntW 8) :
 
 
 theorem neg_nsw_slt_1_thm (e : IntW 8) :
-  icmp IntPredicate.slt (sub (const? 8 0) e { «nsw» := true, «nuw» := false }) (const? 8 1) ⊑
-    icmp IntPredicate.sgt e (const? 8 (-1)) := by
+  icmp IntPred.slt (sub (const? 8 0) e { «nsw» := true, «nuw» := false }) (const? 8 1) ⊑
+    icmp IntPred.sgt e (const? 8 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -267,8 +267,8 @@ theorem neg_nsw_slt_1_thm (e : IntW 8) :
 
 
 theorem neg_nsw_sgt_n1_thm (e : IntW 8) :
-  icmp IntPredicate.sgt (sub (const? 8 0) e { «nsw» := true, «nuw» := false }) (const? 8 (-1)) ⊑
-    icmp IntPredicate.slt e (const? 8 1) := by
+  icmp IntPred.sgt (sub (const? 8 0) e { «nsw» := true, «nuw» := false }) (const? 8 (-1)) ⊑
+    icmp IntPred.slt e (const? 8 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -278,8 +278,8 @@ theorem neg_nsw_sgt_n1_thm (e : IntW 8) :
 
 
 theorem neg_nsw_sgt_0_thm (e : IntW 8) :
-  icmp IntPredicate.sgt (sub (const? 8 0) e { «nsw» := true, «nuw» := false }) (const? 8 0) ⊑
-    icmp IntPredicate.slt e (const? 8 0) := by
+  icmp IntPred.sgt (sub (const? 8 0) e { «nsw» := true, «nuw» := false }) (const? 8 0) ⊑
+    icmp IntPred.slt e (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -289,8 +289,8 @@ theorem neg_nsw_sgt_0_thm (e : IntW 8) :
 
 
 theorem neg_nsw_sgt_1_thm (e : IntW 8) :
-  icmp IntPredicate.sgt (sub (const? 8 0) e { «nsw» := true, «nuw» := false }) (const? 8 1) ⊑
-    icmp IntPredicate.slt e (const? 8 (-1)) := by
+  icmp IntPred.sgt (sub (const? 8 0) e { «nsw» := true, «nuw» := false }) (const? 8 1) ⊑
+    icmp IntPred.slt e (const? 8 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -300,8 +300,8 @@ theorem neg_nsw_sgt_1_thm (e : IntW 8) :
 
 
 theorem PR60818_ne_thm (e : IntW 32) :
-  icmp IntPredicate.ne (sub (const? 32 0) e) e ⊑
-    icmp IntPredicate.ne (LLVM.and e (const? 32 2147483647)) (const? 32 0) := by
+  icmp IntPred.ne (sub (const? 32 0) e) e ⊑
+    icmp IntPred.ne (LLVM.and e (const? 32 2147483647)) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -311,8 +311,8 @@ theorem PR60818_ne_thm (e : IntW 32) :
 
 
 theorem PR60818_eq_thm (e : IntW 32) :
-  icmp IntPredicate.eq (sub (const? 32 0) e) e ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 32 2147483647)) (const? 32 0) := by
+  icmp IntPred.eq (sub (const? 32 0) e) e ⊑
+    icmp IntPred.eq (LLVM.and e (const? 32 2147483647)) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -322,8 +322,8 @@ theorem PR60818_eq_thm (e : IntW 32) :
 
 
 theorem PR60818_eq_commuted_thm (e : IntW 32) :
-  icmp IntPredicate.eq (mul e (const? 32 43)) (sub (const? 32 0) (mul e (const? 32 43))) ⊑
-    icmp IntPredicate.eq (LLVM.and (mul e (const? 32 43)) (const? 32 2147483647)) (const? 32 0) := by
+  icmp IntPred.eq (mul e (const? 32 43)) (sub (const? 32 0) (mul e (const? 32 43))) ⊑
+    icmp IntPred.eq (LLVM.and (mul e (const? 32 43)) (const? 32 2147483647)) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -333,7 +333,7 @@ theorem PR60818_eq_commuted_thm (e : IntW 32) :
 
 
 theorem PR60818_sgt_thm (e : IntW 32) :
-  icmp IntPredicate.sgt (sub (const? 32 0) e) e ⊑ icmp IntPredicate.slt e (sub (const? 32 0) e) := by
+  icmp IntPred.sgt (sub (const? 32 0) e) e ⊑ icmp IntPred.slt e (sub (const? 32 0) e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gicmphtopbitssame_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gicmphtopbitssame_proof.lean
@@ -12,8 +12,8 @@ set_option Elab.async false
 
 section gicmphtopbitssame_proof
 theorem testi16i8_thm (e : IntW 16) :
-  icmp IntPredicate.eq (ashr (trunc 8 e) (const? 8 7)) (trunc 8 (lshr e (const? 16 8))) ⊑
-    icmp IntPredicate.ult (add e (const? 16 128)) (const? 16 256) := by
+  icmp IntPred.eq (ashr (trunc 8 e) (const? 8 7)) (trunc 8 (lshr e (const? 16 8))) ⊑
+    icmp IntPred.ult (add e (const? 16 128)) (const? 16 256) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -23,8 +23,8 @@ theorem testi16i8_thm (e : IntW 16) :
 
 
 theorem testi16i8_com_thm (e : IntW 16) :
-  icmp IntPredicate.eq (trunc 8 (lshr e (const? 16 8))) (ashr (trunc 8 e) (const? 8 7)) ⊑
-    icmp IntPredicate.ult (add e (const? 16 128)) (const? 16 256) := by
+  icmp IntPred.eq (trunc 8 (lshr e (const? 16 8))) (ashr (trunc 8 e) (const? 8 7)) ⊑
+    icmp IntPred.ult (add e (const? 16 128)) (const? 16 256) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -34,8 +34,8 @@ theorem testi16i8_com_thm (e : IntW 16) :
 
 
 theorem testi16i8_ne_thm (e : IntW 16) :
-  icmp IntPredicate.ne (ashr (trunc 8 e) (const? 8 7)) (trunc 8 (lshr e (const? 16 8))) ⊑
-    icmp IntPredicate.ult (add e (const? 16 (-128))) (const? 16 (-256)) := by
+  icmp IntPred.ne (ashr (trunc 8 e) (const? 8 7)) (trunc 8 (lshr e (const? 16 8))) ⊑
+    icmp IntPred.ult (add e (const? 16 (-128))) (const? 16 (-256)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -45,8 +45,8 @@ theorem testi16i8_ne_thm (e : IntW 16) :
 
 
 theorem testi16i8_ne_com_thm (e : IntW 16) :
-  icmp IntPredicate.ne (trunc 8 (lshr e (const? 16 8))) (ashr (trunc 8 e) (const? 8 7)) ⊑
-    icmp IntPredicate.ult (add e (const? 16 (-128))) (const? 16 (-256)) := by
+  icmp IntPred.ne (trunc 8 (lshr e (const? 16 8))) (ashr (trunc 8 e) (const? 8 7)) ⊑
+    icmp IntPred.ult (add e (const? 16 (-128))) (const? 16 (-256)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -56,8 +56,8 @@ theorem testi16i8_ne_com_thm (e : IntW 16) :
 
 
 theorem testi64i32_thm (e : IntW 64) :
-  icmp IntPredicate.eq (ashr (trunc 32 e) (const? 32 31)) (trunc 32 (lshr e (const? 64 32))) ⊑
-    icmp IntPredicate.ult (add e (const? 64 2147483648)) (const? 64 4294967296) := by
+  icmp IntPred.eq (ashr (trunc 32 e) (const? 32 31)) (trunc 32 (lshr e (const? 64 32))) ⊑
+    icmp IntPred.ult (add e (const? 64 2147483648)) (const? 64 4294967296) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -67,8 +67,8 @@ theorem testi64i32_thm (e : IntW 64) :
 
 
 theorem testi64i32_ne_thm (e : IntW 64) :
-  icmp IntPredicate.ne (ashr (trunc 32 e) (const? 32 31)) (trunc 32 (lshr e (const? 64 32))) ⊑
-    icmp IntPredicate.ult (add e (const? 64 (-2147483648))) (const? 64 (-4294967296)) := by
+  icmp IntPred.ne (ashr (trunc 32 e) (const? 32 31)) (trunc 32 (lshr e (const? 64 32))) ⊑
+    icmp IntPred.ult (add e (const? 64 (-2147483648))) (const? 64 (-4294967296)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -78,8 +78,8 @@ theorem testi64i32_ne_thm (e : IntW 64) :
 
 
 theorem wrongimm2_thm (e : IntW 16) :
-  icmp IntPredicate.eq (ashr (trunc 8 e) (const? 8 6)) (trunc 8 (lshr e (const? 16 8))) ⊑
-    icmp IntPredicate.eq (ashr (trunc 8 e) (const? 8 6))
+  icmp IntPred.eq (ashr (trunc 8 e) (const? 8 6)) (trunc 8 (lshr e (const? 16 8))) ⊑
+    icmp IntPred.eq (ashr (trunc 8 e) (const? 8 6))
       (trunc 8 (lshr e (const? 16 8)) { «nsw» := false, «nuw» := true }) := by
     simp_alive_undef
     simp_alive_ops
@@ -90,8 +90,8 @@ theorem wrongimm2_thm (e : IntW 16) :
 
 
 theorem slt_thm (e : IntW 64) :
-  icmp IntPredicate.slt (ashr (trunc 32 e) (const? 32 31)) (trunc 32 (lshr e (const? 64 32))) ⊑
-    icmp IntPredicate.slt (ashr (trunc 32 e) (const? 32 31))
+  icmp IntPred.slt (ashr (trunc 32 e) (const? 32 31)) (trunc 32 (lshr e (const? 64 32))) ⊑
+    icmp IntPred.slt (ashr (trunc 32 e) (const? 32 31))
       (trunc 32 (lshr e (const? 64 32)) { «nsw» := false, «nuw» := true }) := by
     simp_alive_undef
     simp_alive_ops

--- a/SSA/Projects/InstCombine/tests/proofs/gicmphtrunc_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gicmphtrunc_proof.lean
@@ -12,8 +12,8 @@ set_option Elab.async false
 
 section gicmphtrunc_proof
 theorem ult_2_thm (e : IntW 32) :
-  icmp IntPredicate.ult (trunc 8 e) (const? 8 2) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 32 254)) (const? 32 0) := by
+  icmp IntPred.ult (trunc 8 e) (const? 8 2) ⊑
+    icmp IntPred.eq (LLVM.and e (const? 32 254)) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -23,8 +23,8 @@ theorem ult_2_thm (e : IntW 32) :
 
 
 theorem ult_192_thm (e : IntW 32) :
-  icmp IntPredicate.ult (trunc 8 e) (const? 8 (-64)) ⊑
-    icmp IntPredicate.ne (LLVM.and e (const? 32 192)) (const? 32 192) := by
+  icmp IntPred.ult (trunc 8 e) (const? 8 (-64)) ⊑
+    icmp IntPred.ne (LLVM.and e (const? 32 192)) (const? 32 192) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -34,8 +34,8 @@ theorem ult_192_thm (e : IntW 32) :
 
 
 theorem ugt_3_thm (e : IntW 32) :
-  icmp IntPredicate.ugt (trunc 8 e) (const? 8 3) ⊑
-    icmp IntPredicate.ne (LLVM.and e (const? 32 252)) (const? 32 0) := by
+  icmp IntPred.ugt (trunc 8 e) (const? 8 3) ⊑
+    icmp IntPred.ne (LLVM.and e (const? 32 252)) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -45,8 +45,8 @@ theorem ugt_3_thm (e : IntW 32) :
 
 
 theorem ugt_253_thm (e : IntW 32) :
-  icmp IntPredicate.ugt (trunc 8 e) (const? 8 (-3)) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 32 254)) (const? 32 254) := by
+  icmp IntPred.ugt (trunc 8 e) (const? 8 (-3)) ⊑
+    icmp IntPred.eq (LLVM.and e (const? 32 254)) (const? 32 254) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -56,8 +56,8 @@ theorem ugt_253_thm (e : IntW 32) :
 
 
 theorem slt_0_thm (e : IntW 32) :
-  icmp IntPredicate.slt (trunc 8 e) (const? 8 0) ⊑
-    icmp IntPredicate.ne (LLVM.and e (const? 32 128)) (const? 32 0) := by
+  icmp IntPred.slt (trunc 8 e) (const? 8 0) ⊑
+    icmp IntPred.ne (LLVM.and e (const? 32 128)) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -67,8 +67,8 @@ theorem slt_0_thm (e : IntW 32) :
 
 
 theorem sgt_n1_thm (e : IntW 32) :
-  icmp IntPredicate.sgt (trunc 8 e) (const? 8 (-1)) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 32 128)) (const? 32 0) := by
+  icmp IntPred.sgt (trunc 8 e) (const? 8 (-1)) ⊑
+    icmp IntPred.eq (LLVM.and e (const? 32 128)) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -78,7 +78,7 @@ theorem sgt_n1_thm (e : IntW 32) :
 
 
 theorem shl1_trunc_eq0_thm (e : IntW 32) :
-  icmp IntPredicate.eq (trunc 16 (shl (const? 32 1) e)) (const? 16 0) ⊑ icmp IntPredicate.ugt e (const? 32 15) := by
+  icmp IntPred.eq (trunc 16 (shl (const? 32 1) e)) (const? 16 0) ⊑ icmp IntPred.ugt e (const? 32 15) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -88,8 +88,8 @@ theorem shl1_trunc_eq0_thm (e : IntW 32) :
 
 
 theorem shl1_trunc_sgt0_thm (e : IntW 9) :
-  icmp IntPredicate.sgt (trunc 6 (shl (const? 9 1) e)) (const? 6 0) ⊑
-    icmp IntPredicate.sgt (trunc 6 (shl (const? 9 1) e { «nsw» := false, «nuw» := true })) (const? 6 0) := by
+  icmp IntPred.sgt (trunc 6 (shl (const? 9 1) e)) (const? 6 0) ⊑
+    icmp IntPred.sgt (trunc 6 (shl (const? 9 1) e { «nsw» := false, «nuw» := true })) (const? 6 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -99,8 +99,8 @@ theorem shl1_trunc_sgt0_thm (e : IntW 9) :
 
 
 theorem shl1_trunc_sgt4_thm (e : IntW 32) :
-  icmp IntPredicate.sgt (trunc 16 (shl (const? 32 1) e)) (const? 16 4) ⊑
-    icmp IntPredicate.sgt (trunc 16 (shl (const? 32 1) e { «nsw» := false, «nuw» := true })) (const? 16 4) := by
+  icmp IntPred.sgt (trunc 16 (shl (const? 32 1) e)) (const? 16 4) ⊑
+    icmp IntPred.sgt (trunc 16 (shl (const? 32 1) e { «nsw» := false, «nuw» := true })) (const? 16 4) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gicmphugehofhnothofhshlhalloneshbyhbitshandhvalhtohicmpheqhofhlshrhvalhbyhbitshandh0_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gicmphugehofhnothofhshlhalloneshbyhbitshandhvalhtohicmpheqhofhlshrhvalhbyhbitshandh0_proof.lean
@@ -12,8 +12,8 @@ set_option Elab.async false
 
 section gicmphugehofhnothofhshlhalloneshbyhbitshandhvalhtohicmpheqhofhlshrhvalhbyhbitshandh0_proof
 theorem p0_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.uge (LLVM.xor (shl (const? 8 (-1)) e_1) (const? 8 (-1))) e ⊑
-    icmp IntPredicate.eq (lshr e e_1) (const? 8 0) := by
+  icmp IntPred.uge (LLVM.xor (shl (const? 8 (-1)) e_1) (const? 8 (-1))) e ⊑
+    icmp IntPred.eq (lshr e e_1) (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -23,9 +23,9 @@ theorem p0_thm (e e_1 : IntW 8) :
 
 
 theorem both_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.uge (LLVM.xor (shl (const? 8 (-1)) e_1) (const? 8 (-1)))
+  icmp IntPred.uge (LLVM.xor (shl (const? 8 (-1)) e_1) (const? 8 (-1)))
       (LLVM.xor (shl (const? 8 (-1)) e) (const? 8 (-1))) ⊑
-    icmp IntPredicate.ule (shl (const? 8 (-1)) e_1 { «nsw» := true, «nuw» := false })
+    icmp IntPred.ule (shl (const? 8 (-1)) e_1 { «nsw» := true, «nuw» := false })
       (shl (const? 8 (-1)) e { «nsw» := true, «nuw» := false }) := by
     simp_alive_undef
     simp_alive_ops
@@ -36,8 +36,8 @@ theorem both_thm (e e_1 : IntW 8) :
 
 
 theorem n0_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.uge (LLVM.xor (shl (const? 8 1) e_1) (const? 8 (-1))) e ⊑
-    icmp IntPredicate.ule e (LLVM.xor (shl (const? 8 1) e_1 { «nsw» := false, «nuw» := true }) (const? 8 (-1))) := by
+  icmp IntPred.uge (LLVM.xor (shl (const? 8 1) e_1) (const? 8 (-1))) e ⊑
+    icmp IntPred.ule e (LLVM.xor (shl (const? 8 1) e_1 { «nsw» := false, «nuw» := true }) (const? 8 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -47,8 +47,8 @@ theorem n0_thm (e e_1 : IntW 8) :
 
 
 theorem n1_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.uge (LLVM.xor (shl (const? 8 (-1)) e_1) (const? 8 1)) e ⊑
-    icmp IntPredicate.uge (LLVM.xor (shl (const? 8 (-1)) e_1 { «nsw» := true, «nuw» := false }) (const? 8 1)) e := by
+  icmp IntPred.uge (LLVM.xor (shl (const? 8 (-1)) e_1) (const? 8 1)) e ⊑
+    icmp IntPred.uge (LLVM.xor (shl (const? 8 (-1)) e_1 { «nsw» := true, «nuw» := false }) (const? 8 1)) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -58,8 +58,8 @@ theorem n1_thm (e e_1 : IntW 8) :
 
 
 theorem n3_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.ugt (LLVM.xor (shl (const? 8 (-1)) e_1) (const? 8 (-1))) e ⊑
-    icmp IntPredicate.ult e
+  icmp IntPred.ugt (LLVM.xor (shl (const? 8 (-1)) e_1) (const? 8 (-1))) e ⊑
+    icmp IntPred.ult e
       (LLVM.xor (shl (const? 8 (-1)) e_1 { «nsw» := true, «nuw» := false }) (const? 8 (-1))) := by
     simp_alive_undef
     simp_alive_ops

--- a/SSA/Projects/InstCombine/tests/proofs/gicmphugthofhshlh1hbyhbitshandhvalhtohicmpheqhofhlshrhvalhbyhbitshandh0_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gicmphugthofhshlh1hbyhbitshandhvalhtohicmpheqhofhlshrhvalhbyhbitshandh0_proof.lean
@@ -12,7 +12,7 @@ set_option Elab.async false
 
 section gicmphugthofhshlh1hbyhbitshandhvalhtohicmpheqhofhlshrhvalhbyhbitshandh0_proof
 theorem p0_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.ugt (shl (const? 8 1) e_1) e ⊑ icmp IntPredicate.eq (lshr e e_1) (const? 8 0) := by
+  icmp IntPred.ugt (shl (const? 8 1) e_1) e ⊑ icmp IntPred.eq (lshr e e_1) (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -22,8 +22,8 @@ theorem p0_thm (e e_1 : IntW 8) :
 
 
 theorem both_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.ugt (shl (const? 8 1) e_1) (shl (const? 8 1) e) ⊑
-    icmp IntPredicate.eq (lshr (shl (const? 8 1) e { «nsw» := false, «nuw» := true }) e_1) (const? 8 0) := by
+  icmp IntPred.ugt (shl (const? 8 1) e_1) (shl (const? 8 1) e) ⊑
+    icmp IntPred.eq (lshr (shl (const? 8 1) e { «nsw» := false, «nuw» := true }) e_1) (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -33,8 +33,8 @@ theorem both_thm (e e_1 : IntW 8) :
 
 
 theorem n2_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.uge (shl (const? 8 1) e_1) e ⊑
-    icmp IntPredicate.uge (shl (const? 8 1) e_1 { «nsw» := false, «nuw» := true }) e := by
+  icmp IntPred.uge (shl (const? 8 1) e_1) e ⊑
+    icmp IntPred.uge (shl (const? 8 1) e_1 { «nsw» := false, «nuw» := true }) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gicmphulehofhshlh1hbyhbitshandhvalhtohicmphnehofhlshrhvalhbyhbitshandh0_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gicmphulehofhshlh1hbyhbitshandhvalhtohicmphnehofhlshrhvalhbyhbitshandh0_proof.lean
@@ -12,7 +12,7 @@ set_option Elab.async false
 
 section gicmphulehofhshlh1hbyhbitshandhvalhtohicmphnehofhlshrhvalhbyhbitshandh0_proof
 theorem p0_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.ule (shl (const? 8 1) e_1) e ⊑ icmp IntPredicate.ne (lshr e e_1) (const? 8 0) := by
+  icmp IntPred.ule (shl (const? 8 1) e_1) e ⊑ icmp IntPred.ne (lshr e e_1) (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -22,8 +22,8 @@ theorem p0_thm (e e_1 : IntW 8) :
 
 
 theorem both_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.ule (shl (const? 8 1) e_1) (shl (const? 8 1) e) ⊑
-    icmp IntPredicate.ne (lshr (shl (const? 8 1) e { «nsw» := false, «nuw» := true }) e_1) (const? 8 0) := by
+  icmp IntPred.ule (shl (const? 8 1) e_1) (shl (const? 8 1) e) ⊑
+    icmp IntPred.ne (lshr (shl (const? 8 1) e { «nsw» := false, «nuw» := true }) e_1) (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -33,8 +33,8 @@ theorem both_thm (e e_1 : IntW 8) :
 
 
 theorem n2_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.ult (shl (const? 8 1) e_1) e ⊑
-    icmp IntPredicate.ult (shl (const? 8 1) e_1 { «nsw» := false, «nuw» := true }) e := by
+  icmp IntPred.ult (shl (const? 8 1) e_1) e ⊑
+    icmp IntPred.ult (shl (const? 8 1) e_1 { «nsw» := false, «nuw» := true }) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gicmphulthofhnothofhshlhalloneshbyhbitshandhvalhtohicmphnehofhlshrhvalhbyhbitshandh0_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gicmphulthofhnothofhshlhalloneshbyhbitshandhvalhtohicmphnehofhlshrhvalhbyhbitshandh0_proof.lean
@@ -12,8 +12,8 @@ set_option Elab.async false
 
 section gicmphulthofhnothofhshlhalloneshbyhbitshandhvalhtohicmphnehofhlshrhvalhbyhbitshandh0_proof
 theorem p0_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.ult (LLVM.xor (shl (const? 8 (-1)) e_1) (const? 8 (-1))) e ⊑
-    icmp IntPredicate.ne (lshr e e_1) (const? 8 0) := by
+  icmp IntPred.ult (LLVM.xor (shl (const? 8 (-1)) e_1) (const? 8 (-1))) e ⊑
+    icmp IntPred.ne (lshr e e_1) (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -23,9 +23,9 @@ theorem p0_thm (e e_1 : IntW 8) :
 
 
 theorem both_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.ult (LLVM.xor (shl (const? 8 (-1)) e_1) (const? 8 (-1)))
+  icmp IntPred.ult (LLVM.xor (shl (const? 8 (-1)) e_1) (const? 8 (-1)))
       (LLVM.xor (shl (const? 8 (-1)) e) (const? 8 (-1))) ⊑
-    icmp IntPredicate.ugt (shl (const? 8 (-1)) e_1 { «nsw» := true, «nuw» := false })
+    icmp IntPred.ugt (shl (const? 8 (-1)) e_1 { «nsw» := true, «nuw» := false })
       (shl (const? 8 (-1)) e { «nsw» := true, «nuw» := false }) := by
     simp_alive_undef
     simp_alive_ops
@@ -36,8 +36,8 @@ theorem both_thm (e e_1 : IntW 8) :
 
 
 theorem n0_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.ult (LLVM.xor (shl (const? 8 1) e_1) (const? 8 (-1))) e ⊑
-    icmp IntPredicate.ugt e (LLVM.xor (shl (const? 8 1) e_1 { «nsw» := false, «nuw» := true }) (const? 8 (-1))) := by
+  icmp IntPred.ult (LLVM.xor (shl (const? 8 1) e_1) (const? 8 (-1))) e ⊑
+    icmp IntPred.ugt e (LLVM.xor (shl (const? 8 1) e_1 { «nsw» := false, «nuw» := true }) (const? 8 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -47,8 +47,8 @@ theorem n0_thm (e e_1 : IntW 8) :
 
 
 theorem n1_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.ult (LLVM.xor (shl (const? 8 (-1)) e_1) (const? 8 1)) e ⊑
-    icmp IntPredicate.ult (LLVM.xor (shl (const? 8 (-1)) e_1 { «nsw» := true, «nuw» := false }) (const? 8 1)) e := by
+  icmp IntPred.ult (LLVM.xor (shl (const? 8 (-1)) e_1) (const? 8 1)) e ⊑
+    icmp IntPred.ult (LLVM.xor (shl (const? 8 (-1)) e_1 { «nsw» := true, «nuw» := false }) (const? 8 1)) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -58,8 +58,8 @@ theorem n1_thm (e e_1 : IntW 8) :
 
 
 theorem n3_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.ule (LLVM.xor (shl (const? 8 (-1)) e_1) (const? 8 (-1))) e ⊑
-    icmp IntPredicate.uge e
+  icmp IntPred.ule (LLVM.xor (shl (const? 8 (-1)) e_1) (const? 8 (-1))) e ⊑
+    icmp IntPred.uge e
       (LLVM.xor (shl (const? 8 (-1)) e_1 { «nsw» := true, «nuw» := false }) (const? 8 (-1))) := by
     simp_alive_undef
     simp_alive_ops

--- a/SSA/Projects/InstCombine/tests/proofs/gicmphwithhselects_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gicmphwithhselects_proof.lean
@@ -12,7 +12,7 @@ set_option Elab.async false
 
 section gicmphwithhselects_proof
 theorem both_sides_fold_slt_thm (e : IntW 32) (e_1 : IntW 1) :
-  icmp IntPredicate.slt (select e_1 (const? 32 9) e) (select e_1 (const? 32 1) e) ⊑ const? 1 0 := by
+  icmp IntPred.slt (select e_1 (const? 32 9) e) (select e_1 (const? 32 1) e) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -22,7 +22,7 @@ theorem both_sides_fold_slt_thm (e : IntW 32) (e_1 : IntW 1) :
 
 
 theorem both_sides_fold_eq_thm (e : IntW 32) (e_1 : IntW 1) :
-  icmp IntPredicate.eq (select e_1 (const? 32 9) e) (select e_1 (const? 32 1) e) ⊑ LLVM.xor e_1 (const? 1 1) := by
+  icmp IntPred.eq (select e_1 (const? 32 9) e) (select e_1 (const? 32 1) e) ⊑ LLVM.xor e_1 (const? 1 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -32,8 +32,8 @@ theorem both_sides_fold_eq_thm (e : IntW 32) (e_1 : IntW 1) :
 
 
 theorem one_side_fold_slt_thm (e e_1 e_2 : IntW 32) (e_3 : IntW 1) :
-  icmp IntPredicate.slt (select e_3 e_2 e_1) (select e_3 e e_1) ⊑
-    select e_3 (icmp IntPredicate.slt e_2 e) (const? 1 0) := by
+  icmp IntPred.slt (select e_3 e_2 e_1) (select e_3 e e_1) ⊑
+    select e_3 (icmp IntPred.slt e_2 e) (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -43,8 +43,8 @@ theorem one_side_fold_slt_thm (e e_1 e_2 : IntW 32) (e_3 : IntW 1) :
 
 
 theorem one_side_fold_sgt_thm (e e_1 e_2 : IntW 32) (e_3 : IntW 1) :
-  icmp IntPredicate.sgt (select e_3 e_2 e_1) (select e_3 e_2 e) ⊑
-    select (LLVM.xor e_3 (const? 1 1)) (icmp IntPredicate.sgt e_1 e) (const? 1 0) := by
+  icmp IntPred.sgt (select e_3 e_2 e_1) (select e_3 e_2 e) ⊑
+    select (LLVM.xor e_3 (const? 1 1)) (icmp IntPred.sgt e_1 e) (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -54,8 +54,8 @@ theorem one_side_fold_sgt_thm (e e_1 e_2 : IntW 32) (e_3 : IntW 1) :
 
 
 theorem one_side_fold_eq_thm (e e_1 e_2 : IntW 32) (e_3 : IntW 1) :
-  icmp IntPredicate.eq (select e_3 e_2 e_1) (select e_3 e e_1) ⊑
-    select (LLVM.xor e_3 (const? 1 1)) (const? 1 1) (icmp IntPredicate.eq e_2 e) := by
+  icmp IntPred.eq (select e_3 e_2 e_1) (select e_3 e e_1) ⊑
+    select (LLVM.xor e_3 (const? 1 1)) (const? 1 1) (icmp IntPred.eq e_2 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gicmphxorhsignbit_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gicmphxorhsignbit_proof.lean
@@ -12,8 +12,8 @@ set_option Elab.async false
 
 section gicmphxorhsignbit_proof
 theorem slt_to_ult_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.slt (LLVM.xor e_1 (const? 8 (-128))) (LLVM.xor e (const? 8 (-128))) ⊑
-    icmp IntPredicate.ult e_1 e := by
+  icmp IntPred.slt (LLVM.xor e_1 (const? 8 (-128))) (LLVM.xor e (const? 8 (-128))) ⊑
+    icmp IntPred.ult e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -23,8 +23,8 @@ theorem slt_to_ult_thm (e e_1 : IntW 8) :
 
 
 theorem ult_to_slt_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.ult (LLVM.xor e_1 (const? 8 (-128))) (LLVM.xor e (const? 8 (-128))) ⊑
-    icmp IntPredicate.slt e_1 e := by
+  icmp IntPred.ult (LLVM.xor e_1 (const? 8 (-128))) (LLVM.xor e (const? 8 (-128))) ⊑
+    icmp IntPred.slt e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -34,7 +34,7 @@ theorem ult_to_slt_thm (e e_1 : IntW 8) :
 
 
 theorem slt_to_ugt_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.slt (LLVM.xor e_1 (const? 8 127)) (LLVM.xor e (const? 8 127)) ⊑ icmp IntPredicate.ugt e_1 e := by
+  icmp IntPred.slt (LLVM.xor e_1 (const? 8 127)) (LLVM.xor e (const? 8 127)) ⊑ icmp IntPred.ugt e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -44,7 +44,7 @@ theorem slt_to_ugt_thm (e e_1 : IntW 8) :
 
 
 theorem ult_to_sgt_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.ult (LLVM.xor e_1 (const? 8 127)) (LLVM.xor e (const? 8 127)) ⊑ icmp IntPredicate.sgt e_1 e := by
+  icmp IntPred.ult (LLVM.xor e_1 (const? 8 127)) (LLVM.xor e (const? 8 127)) ⊑ icmp IntPred.sgt e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -54,8 +54,8 @@ theorem ult_to_sgt_thm (e e_1 : IntW 8) :
 
 
 theorem sge_to_ugt_thm (e : IntW 8) :
-  icmp IntPredicate.sge (LLVM.xor e (const? 8 (-128))) (const? 8 15) ⊑
-    icmp IntPredicate.ugt e (const? 8 (-114)) := by
+  icmp IntPred.sge (LLVM.xor e (const? 8 (-128))) (const? 8 15) ⊑
+    icmp IntPred.ugt e (const? 8 (-114)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -65,8 +65,8 @@ theorem sge_to_ugt_thm (e : IntW 8) :
 
 
 theorem uge_to_sgt_thm (e : IntW 8) :
-  icmp IntPredicate.uge (LLVM.xor e (const? 8 (-128))) (const? 8 15) ⊑
-    icmp IntPredicate.sgt e (const? 8 (-114)) := by
+  icmp IntPred.uge (LLVM.xor e (const? 8 (-128))) (const? 8 15) ⊑
+    icmp IntPred.sgt e (const? 8 (-114)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -76,7 +76,7 @@ theorem uge_to_sgt_thm (e : IntW 8) :
 
 
 theorem sge_to_ult_thm (e : IntW 8) :
-  icmp IntPredicate.sge (LLVM.xor e (const? 8 127)) (const? 8 15) ⊑ icmp IntPredicate.ult e (const? 8 113) := by
+  icmp IntPred.sge (LLVM.xor e (const? 8 127)) (const? 8 15) ⊑ icmp IntPred.ult e (const? 8 113) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -86,7 +86,7 @@ theorem sge_to_ult_thm (e : IntW 8) :
 
 
 theorem uge_to_slt_thm (e : IntW 8) :
-  icmp IntPredicate.uge (LLVM.xor e (const? 8 127)) (const? 8 15) ⊑ icmp IntPredicate.slt e (const? 8 113) := by
+  icmp IntPred.uge (LLVM.xor e (const? 8 127)) (const? 8 15) ⊑ icmp IntPred.slt e (const? 8 113) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -96,8 +96,8 @@ theorem uge_to_slt_thm (e : IntW 8) :
 
 
 theorem slt_zero_eq_i1_thm (e : IntW 32) (e_1 : IntW 1) :
-  icmp IntPredicate.eq (zext 32 e_1) (lshr e (const? 32 31)) ⊑
-    LLVM.xor (icmp IntPredicate.sgt e (const? 32 (-1))) e_1 := by
+  icmp IntPred.eq (zext 32 e_1) (lshr e (const? 32 31)) ⊑
+    LLVM.xor (icmp IntPred.sgt e (const? 32 (-1))) e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -107,8 +107,8 @@ theorem slt_zero_eq_i1_thm (e : IntW 32) (e_1 : IntW 1) :
 
 
 theorem slt_zero_eq_i1_fail_thm (e : IntW 32) (e_1 : IntW 1) :
-  icmp IntPredicate.eq (zext 32 e_1) (ashr e (const? 32 31)) ⊑
-    icmp IntPredicate.eq (ashr e (const? 32 31)) (zext 32 e_1) := by
+  icmp IntPred.eq (zext 32 e_1) (ashr e (const? 32 31)) ⊑
+    icmp IntPred.eq (ashr e (const? 32 31)) (zext 32 e_1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -118,8 +118,8 @@ theorem slt_zero_eq_i1_fail_thm (e : IntW 32) (e_1 : IntW 1) :
 
 
 theorem slt_zero_eq_ne_0_thm (e : IntW 32) :
-  icmp IntPredicate.eq (zext 32 (icmp IntPredicate.ne e (const? 32 0))) (lshr e (const? 32 31)) ⊑
-    icmp IntPredicate.slt e (const? 32 1) := by
+  icmp IntPred.eq (zext 32 (icmp IntPred.ne e (const? 32 0))) (lshr e (const? 32 31)) ⊑
+    icmp IntPred.slt e (const? 32 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -129,8 +129,8 @@ theorem slt_zero_eq_ne_0_thm (e : IntW 32) :
 
 
 theorem slt_zero_ne_ne_0_thm (e : IntW 32) :
-  icmp IntPredicate.ne (zext 32 (icmp IntPredicate.ne e (const? 32 0))) (lshr e (const? 32 31)) ⊑
-    icmp IntPredicate.sgt e (const? 32 0) := by
+  icmp IntPred.ne (zext 32 (icmp IntPred.ne e (const? 32 0))) (lshr e (const? 32 31)) ⊑
+    icmp IntPred.sgt e (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -140,8 +140,8 @@ theorem slt_zero_ne_ne_0_thm (e : IntW 32) :
 
 
 theorem slt_zero_ne_ne_b_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.ne (zext 32 (icmp IntPredicate.ne e_1 e)) (lshr e_1 (const? 32 31)) ⊑
-    LLVM.xor (icmp IntPredicate.slt e_1 (const? 32 0)) (icmp IntPredicate.ne e_1 e) := by
+  icmp IntPred.ne (zext 32 (icmp IntPred.ne e_1 e)) (lshr e_1 (const? 32 31)) ⊑
+    LLVM.xor (icmp IntPred.slt e_1 (const? 32 0)) (icmp IntPred.ne e_1 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -151,8 +151,8 @@ theorem slt_zero_ne_ne_b_thm (e e_1 : IntW 32) :
 
 
 theorem slt_zero_eq_ne_0_fail1_thm (e : IntW 32) :
-  icmp IntPredicate.eq (zext 32 (icmp IntPredicate.ne e (const? 32 0))) (ashr e (const? 32 31)) ⊑
-    icmp IntPredicate.eq (ashr e (const? 32 31)) (zext 32 (icmp IntPredicate.ne e (const? 32 0))) := by
+  icmp IntPred.eq (zext 32 (icmp IntPred.ne e (const? 32 0))) (ashr e (const? 32 31)) ⊑
+    icmp IntPred.eq (ashr e (const? 32 31)) (zext 32 (icmp IntPred.ne e (const? 32 0))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -162,8 +162,8 @@ theorem slt_zero_eq_ne_0_fail1_thm (e : IntW 32) :
 
 
 theorem slt_zero_eq_ne_0_fail2_thm (e : IntW 32) :
-  icmp IntPredicate.eq (zext 32 (icmp IntPredicate.ne e (const? 32 0))) (lshr e (const? 32 30)) ⊑
-    icmp IntPredicate.eq (lshr e (const? 32 30)) (zext 32 (icmp IntPredicate.ne e (const? 32 0))) := by
+  icmp IntPred.eq (zext 32 (icmp IntPred.ne e (const? 32 0))) (lshr e (const? 32 30)) ⊑
+    icmp IntPred.eq (lshr e (const? 32 30)) (zext 32 (icmp IntPred.ne e (const? 32 0))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gintegerhroundhuphpow2halignment_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gintegerhroundhuphpow2halignment_proof.lean
@@ -12,7 +12,7 @@ set_option Elab.async false
 
 section gintegerhroundhuphpow2halignment_proof
 theorem t0_thm (e : IntW 8) :
-  select (icmp IntPredicate.eq (LLVM.and e (const? 8 15)) (const? 8 0)) e
+  select (icmp IntPred.eq (LLVM.and e (const? 8 15)) (const? 8 0)) e
       (LLVM.and (add e (const? 8 16)) (const? 8 (-16))) ⊑
     LLVM.and (add e (const? 8 15)) (const? 8 (-16)) := by
     simp_alive_undef
@@ -24,7 +24,7 @@ theorem t0_thm (e : IntW 8) :
 
 
 theorem t1_thm (e : IntW 8) :
-  select (icmp IntPredicate.eq (LLVM.and e (const? 8 31)) (const? 8 0)) e
+  select (icmp IntPred.eq (LLVM.and e (const? 8 31)) (const? 8 0)) e
       (LLVM.and (add e (const? 8 32)) (const? 8 (-32))) ⊑
     LLVM.and (add e (const? 8 31)) (const? 8 (-32)) := by
     simp_alive_undef
@@ -36,7 +36,7 @@ theorem t1_thm (e : IntW 8) :
 
 
 theorem t2_thm (e : IntW 8) :
-  select (icmp IntPredicate.eq (LLVM.and e (const? 8 15)) (const? 8 0)) e
+  select (icmp IntPred.eq (LLVM.and e (const? 8 15)) (const? 8 0)) e
       (LLVM.and (add e (const? 8 15)) (const? 8 (-16))) ⊑
     LLVM.and (add e (const? 8 15)) (const? 8 (-16)) := by
     simp_alive_undef
@@ -48,9 +48,9 @@ theorem t2_thm (e : IntW 8) :
 
 
 theorem n9_wrong_x0_thm (e e_1 : IntW 8) :
-  select (icmp IntPredicate.eq (LLVM.and e_1 (const? 8 15)) (const? 8 0)) e
+  select (icmp IntPred.eq (LLVM.and e_1 (const? 8 15)) (const? 8 0)) e
       (LLVM.and (add e_1 (const? 8 16)) (const? 8 (-16))) ⊑
-    select (icmp IntPredicate.eq (LLVM.and e_1 (const? 8 15)) (const? 8 0)) e
+    select (icmp IntPred.eq (LLVM.and e_1 (const? 8 15)) (const? 8 0)) e
       (add (LLVM.and e_1 (const? 8 (-16))) (const? 8 16)) := by
     simp_alive_undef
     simp_alive_ops
@@ -61,9 +61,9 @@ theorem n9_wrong_x0_thm (e e_1 : IntW 8) :
 
 
 theorem n9_wrong_x1_thm (e e_1 : IntW 8) :
-  select (icmp IntPredicate.eq (LLVM.and e_1 (const? 8 15)) (const? 8 0)) e_1
+  select (icmp IntPred.eq (LLVM.and e_1 (const? 8 15)) (const? 8 0)) e_1
       (LLVM.and (add e (const? 8 16)) (const? 8 (-16))) ⊑
-    select (icmp IntPredicate.eq (LLVM.and e_1 (const? 8 15)) (const? 8 0)) e_1
+    select (icmp IntPred.eq (LLVM.and e_1 (const? 8 15)) (const? 8 0)) e_1
       (add (LLVM.and e (const? 8 (-16))) (const? 8 16)) := by
     simp_alive_undef
     simp_alive_ops
@@ -74,9 +74,9 @@ theorem n9_wrong_x1_thm (e e_1 : IntW 8) :
 
 
 theorem n9_wrong_x2_thm (e e_1 : IntW 8) :
-  select (icmp IntPredicate.eq (LLVM.and e_1 (const? 8 15)) (const? 8 0)) e
+  select (icmp IntPred.eq (LLVM.and e_1 (const? 8 15)) (const? 8 0)) e
       (LLVM.and (add e (const? 8 16)) (const? 8 (-16))) ⊑
-    select (icmp IntPredicate.eq (LLVM.and e_1 (const? 8 15)) (const? 8 0)) e
+    select (icmp IntPred.eq (LLVM.and e_1 (const? 8 15)) (const? 8 0)) e
       (add (LLVM.and e (const? 8 (-16))) (const? 8 16)) := by
     simp_alive_undef
     simp_alive_ops
@@ -87,9 +87,9 @@ theorem n9_wrong_x2_thm (e e_1 : IntW 8) :
 
 
 theorem n10_wrong_low_bit_mask_thm (e : IntW 8) :
-  select (icmp IntPredicate.eq (LLVM.and e (const? 8 31)) (const? 8 0)) e
+  select (icmp IntPred.eq (LLVM.and e (const? 8 31)) (const? 8 0)) e
       (LLVM.and (add e (const? 8 16)) (const? 8 (-16))) ⊑
-    select (icmp IntPredicate.eq (LLVM.and e (const? 8 31)) (const? 8 0)) e
+    select (icmp IntPred.eq (LLVM.and e (const? 8 31)) (const? 8 0)) e
       (add (LLVM.and e (const? 8 (-16))) (const? 8 16)) := by
     simp_alive_undef
     simp_alive_ops
@@ -100,9 +100,9 @@ theorem n10_wrong_low_bit_mask_thm (e : IntW 8) :
 
 
 theorem n12_wrong_bias_thm (e : IntW 8) :
-  select (icmp IntPredicate.eq (LLVM.and e (const? 8 15)) (const? 8 0)) e
+  select (icmp IntPred.eq (LLVM.and e (const? 8 15)) (const? 8 0)) e
       (LLVM.and (add e (const? 8 32)) (const? 8 (-16))) ⊑
-    select (icmp IntPredicate.eq (LLVM.and e (const? 8 15)) (const? 8 0)) e
+    select (icmp IntPred.eq (LLVM.and e (const? 8 15)) (const? 8 0)) e
       (add (LLVM.and e (const? 8 (-16))) (const? 8 32)) := by
     simp_alive_undef
     simp_alive_ops
@@ -113,9 +113,9 @@ theorem n12_wrong_bias_thm (e : IntW 8) :
 
 
 theorem n14_wrong_comparison_constant_thm (e : IntW 8) :
-  select (icmp IntPredicate.eq (LLVM.and e (const? 8 15)) (const? 8 1)) e
+  select (icmp IntPred.eq (LLVM.and e (const? 8 15)) (const? 8 1)) e
       (LLVM.and (add e (const? 8 16)) (const? 8 (-16))) ⊑
-    select (icmp IntPredicate.eq (LLVM.and e (const? 8 15)) (const? 8 1)) e
+    select (icmp IntPred.eq (LLVM.and e (const? 8 15)) (const? 8 1)) e
       (add (LLVM.and e (const? 8 (-16))) (const? 8 16)) := by
     simp_alive_undef
     simp_alive_ops
@@ -126,9 +126,9 @@ theorem n14_wrong_comparison_constant_thm (e : IntW 8) :
 
 
 theorem n15_wrong_comparison_predicate_and_constant_thm (e : IntW 8) :
-  select (icmp IntPredicate.ult (LLVM.and e (const? 8 15)) (const? 8 2)) e
+  select (icmp IntPred.ult (LLVM.and e (const? 8 15)) (const? 8 2)) e
       (LLVM.and (add e (const? 8 16)) (const? 8 (-16))) ⊑
-    select (icmp IntPredicate.eq (LLVM.and e (const? 8 14)) (const? 8 0)) e
+    select (icmp IntPred.eq (LLVM.and e (const? 8 14)) (const? 8 0)) e
       (add (LLVM.and e (const? 8 (-16))) (const? 8 16)) := by
     simp_alive_undef
     simp_alive_ops

--- a/SSA/Projects/InstCombine/tests/proofs/gknownhsignbithshift_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gknownhsignbithshift_proof.lean
@@ -12,7 +12,7 @@ set_option Elab.async false
 
 section gknownhsignbithshift_proof
 theorem test_shift_nonnegative_thm (e : IntW 32) :
-  icmp IntPredicate.sge (shl (lshr e (const? 32 2)) (const? 32 3) { «nsw» := true, «nuw» := false }) (const? 32 0) ⊑
+  icmp IntPred.sge (shl (lshr e (const? 32 2)) (const? 32 3) { «nsw» := true, «nuw» := false }) (const? 32 0) ⊑
     const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
@@ -23,7 +23,7 @@ theorem test_shift_nonnegative_thm (e : IntW 32) :
 
 
 theorem test_shift_negative_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.slt
+  icmp IntPred.slt
       (shl (LLVM.or e_1 (const? 32 (-2147483648))) (LLVM.and e (const? 32 7)) { «nsw» := true, «nuw» := false })
       (const? 32 0) ⊑
     const? 1 1 := by

--- a/SSA/Projects/InstCombine/tests/proofs/glogicalhselecthinseltpoison_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/glogicalhselecthinseltpoison_proof.lean
@@ -12,9 +12,9 @@ set_option Elab.async false
 
 section glogicalhselecthinseltpoison_proof
 theorem foo_thm (e e_1 e_2 e_3 : IntW 32) :
-  LLVM.or (LLVM.and e_3 (sext 32 (icmp IntPredicate.slt e_2 e_1)))
-      (LLVM.and e (LLVM.xor (sext 32 (icmp IntPredicate.slt e_2 e_1)) (const? 32 (-1)))) ⊑
-    select (icmp IntPredicate.slt e_2 e_1) e_3 e := by
+  LLVM.or (LLVM.and e_3 (sext 32 (icmp IntPred.slt e_2 e_1)))
+      (LLVM.and e (LLVM.xor (sext 32 (icmp IntPred.slt e_2 e_1)) (const? 32 (-1)))) ⊑
+    select (icmp IntPred.slt e_2 e_1) e_3 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -24,9 +24,9 @@ theorem foo_thm (e e_1 e_2 e_3 : IntW 32) :
 
 
 theorem bar_thm (e e_1 e_2 e_3 : IntW 32) :
-  LLVM.or (LLVM.and e_3 (LLVM.xor (sext 32 (icmp IntPredicate.slt e_2 e_1)) (const? 32 (-1))))
-      (LLVM.and e (sext 32 (icmp IntPredicate.slt e_2 e_1))) ⊑
-    select (icmp IntPredicate.slt e_2 e_1) e e_3 := by
+  LLVM.or (LLVM.and e_3 (LLVM.xor (sext 32 (icmp IntPred.slt e_2 e_1)) (const? 32 (-1))))
+      (LLVM.and e (sext 32 (icmp IntPred.slt e_2 e_1))) ⊑
+    select (icmp IntPred.slt e_2 e_1) e e_3 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -36,9 +36,9 @@ theorem bar_thm (e e_1 e_2 e_3 : IntW 32) :
 
 
 theorem goo_thm (e e_1 e_2 e_3 : IntW 32) :
-  LLVM.or (LLVM.and (select (icmp IntPredicate.slt e_3 e_2) (const? 32 (-1)) (const? 32 0)) e_1)
-      (LLVM.and (LLVM.xor (select (icmp IntPredicate.slt e_3 e_2) (const? 32 (-1)) (const? 32 0)) (const? 32 (-1))) e) ⊑
-    select (icmp IntPredicate.slt e_3 e_2) e_1 e := by
+  LLVM.or (LLVM.and (select (icmp IntPred.slt e_3 e_2) (const? 32 (-1)) (const? 32 0)) e_1)
+      (LLVM.and (LLVM.xor (select (icmp IntPred.slt e_3 e_2) (const? 32 (-1)) (const? 32 0)) (const? 32 (-1))) e) ⊑
+    select (icmp IntPred.slt e_3 e_2) e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -48,9 +48,9 @@ theorem goo_thm (e e_1 e_2 e_3 : IntW 32) :
 
 
 theorem poo_thm (e e_1 e_2 e_3 : IntW 32) :
-  LLVM.or (LLVM.and (select (icmp IntPredicate.slt e_3 e_2) (const? 32 (-1)) (const? 32 0)) e_1)
-      (LLVM.and (select (icmp IntPredicate.slt e_3 e_2) (const? 32 0) (const? 32 (-1))) e) ⊑
-    select (icmp IntPredicate.slt e_3 e_2) e_1 e := by
+  LLVM.or (LLVM.and (select (icmp IntPred.slt e_3 e_2) (const? 32 (-1)) (const? 32 0)) e_1)
+      (LLVM.and (select (icmp IntPred.slt e_3 e_2) (const? 32 0) (const? 32 (-1))) e) ⊑
+    select (icmp IntPred.slt e_3 e_2) e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -60,10 +60,10 @@ theorem poo_thm (e e_1 e_2 e_3 : IntW 32) :
 
 
 theorem fold_inverted_icmp_preds_thm (e e_1 e_2 e_3 : IntW 32) :
-  LLVM.or (select (icmp IntPredicate.slt e_3 e_2) e_1 (const? 32 0))
-      (select (icmp IntPredicate.sge e_3 e_2) e (const? 32 0)) ⊑
-    LLVM.or (select (icmp IntPredicate.slt e_3 e_2) e_1 (const? 32 0))
-      (select (icmp IntPredicate.slt e_3 e_2) (const? 32 0) e) := by
+  LLVM.or (select (icmp IntPred.slt e_3 e_2) e_1 (const? 32 0))
+      (select (icmp IntPred.sge e_3 e_2) e (const? 32 0)) ⊑
+    LLVM.or (select (icmp IntPred.slt e_3 e_2) e_1 (const? 32 0))
+      (select (icmp IntPred.slt e_3 e_2) (const? 32 0) e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -73,10 +73,10 @@ theorem fold_inverted_icmp_preds_thm (e e_1 e_2 e_3 : IntW 32) :
 
 
 theorem fold_inverted_icmp_preds_reverse_thm (e e_1 e_2 e_3 : IntW 32) :
-  LLVM.or (select (icmp IntPredicate.slt e_3 e_2) (const? 32 0) e_1)
-      (select (icmp IntPredicate.sge e_3 e_2) (const? 32 0) e) ⊑
-    LLVM.or (select (icmp IntPredicate.slt e_3 e_2) (const? 32 0) e_1)
-      (select (icmp IntPredicate.slt e_3 e_2) e (const? 32 0)) := by
+  LLVM.or (select (icmp IntPred.slt e_3 e_2) (const? 32 0) e_1)
+      (select (icmp IntPred.sge e_3 e_2) (const? 32 0) e) ⊑
+    LLVM.or (select (icmp IntPred.slt e_3 e_2) (const? 32 0) e_1)
+      (select (icmp IntPred.slt e_3 e_2) e (const? 32 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -86,9 +86,9 @@ theorem fold_inverted_icmp_preds_reverse_thm (e e_1 e_2 e_3 : IntW 32) :
 
 
 theorem par_thm (e e_1 e_2 e_3 : IntW 32) :
-  LLVM.or (LLVM.and (select (icmp IntPredicate.slt e_3 e_2) (const? 32 (-1)) (const? 32 0)) e_1)
-      (LLVM.and (LLVM.xor (select (icmp IntPredicate.slt e_3 e_2) (const? 32 (-1)) (const? 32 0)) (const? 32 (-1))) e) ⊑
-    select (icmp IntPredicate.slt e_3 e_2) e_1 e := by
+  LLVM.or (LLVM.and (select (icmp IntPred.slt e_3 e_2) (const? 32 (-1)) (const? 32 0)) e_1)
+      (LLVM.and (LLVM.xor (select (icmp IntPred.slt e_3 e_2) (const? 32 (-1)) (const? 32 0)) (const? 32 (-1))) e) ⊑
+    select (icmp IntPred.slt e_3 e_2) e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -169,8 +169,8 @@ theorem bools_multi_uses2_logical_thm (e e_1 e_2 : IntW 1) :
 
 theorem allSignBits_thm (e e_1 e_2 : IntW 32) :
   LLVM.or (LLVM.and e_2 (ashr e_1 (const? 32 31))) (LLVM.and (LLVM.xor (ashr e_1 (const? 32 31)) (const? 32 (-1))) e) ⊑
-    LLVM.or (select (icmp IntPredicate.slt e_1 (const? 32 0)) e_2 (const? 32 0))
-      (select (icmp IntPredicate.slt e_1 (const? 32 0)) (const? 32 0) e) := by
+    LLVM.or (select (icmp IntPred.slt e_1 (const? 32 0)) e_2 (const? 32 0))
+      (select (icmp IntPred.slt e_1 (const? 32 0)) (const? 32 0) e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/glshr_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/glshr_proof.lean
@@ -364,7 +364,7 @@ theorem lshr_sext_i1_to_i128_thm (e : IntW 1) :
     all_goals sorry
 
 
-theorem icmp_ule_thm (e e_1 : IntW 32) : icmp IntPredicate.ule (lshr e_1 e) e_1 ⊑ const? 1 1 := by
+theorem icmp_ule_thm (e e_1 : IntW 32) : icmp IntPred.ule (lshr e_1 e) e_1 ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -373,7 +373,7 @@ theorem icmp_ule_thm (e e_1 : IntW 32) : icmp IntPredicate.ule (lshr e_1 e) e_1 
     all_goals sorry
 
 
-theorem icmp_ugt_thm (e e_1 : IntW 32) : icmp IntPredicate.ugt (lshr e_1 e) e_1 ⊑ const? 1 0 := by
+theorem icmp_ugt_thm (e e_1 : IntW 32) : icmp IntPred.ugt (lshr e_1 e) e_1 ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -383,7 +383,7 @@ theorem icmp_ugt_thm (e e_1 : IntW 32) : icmp IntPredicate.ugt (lshr e_1 e) e_1 
 
 
 theorem not_signbit_thm (e : IntW 8) :
-  lshr (LLVM.xor e (const? 8 (-1))) (const? 8 7) ⊑ zext 8 (icmp IntPredicate.sgt e (const? 8 (-1))) := by
+  lshr (LLVM.xor e (const? 8 (-1))) (const? 8 7) ⊑ zext 8 (icmp IntPred.sgt e (const? 8 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -393,7 +393,7 @@ theorem not_signbit_thm (e : IntW 8) :
 
 
 theorem not_signbit_alt_xor_thm (e : IntW 8) :
-  lshr (LLVM.xor e (const? 8 (-2))) (const? 8 7) ⊑ zext 8 (icmp IntPredicate.sgt e (const? 8 (-1))) := by
+  lshr (LLVM.xor e (const? 8 (-2))) (const? 8 7) ⊑ zext 8 (icmp IntPred.sgt e (const? 8 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -404,7 +404,7 @@ theorem not_signbit_alt_xor_thm (e : IntW 8) :
 
 theorem not_signbit_zext_thm (e : IntW 16) :
   zext 32 (lshr (LLVM.xor e (const? 16 (-1))) (const? 16 15)) ⊑
-    zext 32 (icmp IntPredicate.sgt e (const? 16 (-1))) := by
+    zext 32 (icmp IntPred.sgt e (const? 16 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -415,7 +415,7 @@ theorem not_signbit_zext_thm (e : IntW 16) :
 
 theorem not_signbit_trunc_thm (e : IntW 16) :
   trunc 8 (lshr (LLVM.xor e (const? 16 (-1))) (const? 16 15)) ⊑
-    zext 8 (icmp IntPredicate.sgt e (const? 16 (-1))) := by
+    zext 8 (icmp IntPred.sgt e (const? 16 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -436,7 +436,7 @@ theorem bool_add_lshr_thm (e e_1 : IntW 1) :
 
 theorem not_bool_add_lshr_thm (e e_1 : IntW 2) :
   lshr (add (zext 4 e_1) (zext 4 e)) (const? 4 2) ⊑
-    zext 4 (icmp IntPredicate.ugt e (LLVM.xor e_1 (const? 2 (-1)))) := by
+    zext 4 (icmp IntPred.ugt e (LLVM.xor e_1 (const? 2 (-1)))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/glshrhandhnegChicmpeqhzero_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/glshrhandhnegChicmpeqhzero_proof.lean
@@ -12,8 +12,8 @@ set_option Elab.async false
 
 section glshrhandhnegChicmpeqhzero_proof
 theorem scalar_i8_lshr_and_negC_eq_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.eq (LLVM.and (lshr e_1 e) (const? 8 (-4))) (const? 8 0) ⊑
-    icmp IntPredicate.ult (lshr e_1 e) (const? 8 4) := by
+  icmp IntPred.eq (LLVM.and (lshr e_1 e) (const? 8 (-4))) (const? 8 0) ⊑
+    icmp IntPred.ult (lshr e_1 e) (const? 8 4) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -23,8 +23,8 @@ theorem scalar_i8_lshr_and_negC_eq_thm (e e_1 : IntW 8) :
 
 
 theorem scalar_i16_lshr_and_negC_eq_thm (e e_1 : IntW 16) :
-  icmp IntPredicate.eq (LLVM.and (lshr e_1 e) (const? 16 (-128))) (const? 16 0) ⊑
-    icmp IntPredicate.ult (lshr e_1 e) (const? 16 128) := by
+  icmp IntPred.eq (LLVM.and (lshr e_1 e) (const? 16 (-128))) (const? 16 0) ⊑
+    icmp IntPred.ult (lshr e_1 e) (const? 16 128) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -34,8 +34,8 @@ theorem scalar_i16_lshr_and_negC_eq_thm (e e_1 : IntW 16) :
 
 
 theorem scalar_i32_lshr_and_negC_eq_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.eq (LLVM.and (lshr e_1 e) (const? 32 (-262144))) (const? 32 0) ⊑
-    icmp IntPredicate.ult (lshr e_1 e) (const? 32 262144) := by
+  icmp IntPred.eq (LLVM.and (lshr e_1 e) (const? 32 (-262144))) (const? 32 0) ⊑
+    icmp IntPred.ult (lshr e_1 e) (const? 32 262144) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -45,8 +45,8 @@ theorem scalar_i32_lshr_and_negC_eq_thm (e e_1 : IntW 32) :
 
 
 theorem scalar_i64_lshr_and_negC_eq_thm (e e_1 : IntW 64) :
-  icmp IntPredicate.eq (LLVM.and (lshr e_1 e) (const? 64 (-8589934592))) (const? 64 0) ⊑
-    icmp IntPredicate.ult (lshr e_1 e) (const? 64 8589934592) := by
+  icmp IntPred.eq (LLVM.and (lshr e_1 e) (const? 64 (-8589934592))) (const? 64 0) ⊑
+    icmp IntPred.ult (lshr e_1 e) (const? 64 8589934592) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -56,8 +56,8 @@ theorem scalar_i64_lshr_and_negC_eq_thm (e e_1 : IntW 64) :
 
 
 theorem scalar_i32_lshr_and_negC_ne_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.ne (LLVM.and (lshr e_1 e) (const? 32 (-262144))) (const? 32 0) ⊑
-    icmp IntPredicate.ugt (lshr e_1 e) (const? 32 262143) := by
+  icmp IntPred.ne (LLVM.and (lshr e_1 e) (const? 32 (-262144))) (const? 32 0) ⊑
+    icmp IntPred.ugt (lshr e_1 e) (const? 32 262143) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -67,8 +67,8 @@ theorem scalar_i32_lshr_and_negC_ne_thm (e e_1 : IntW 32) :
 
 
 theorem scalar_i32_lshr_and_negC_eq_X_is_constant1_thm (e : IntW 32) :
-  icmp IntPredicate.eq (LLVM.and (lshr (const? 32 12345) e) (const? 32 (-8))) (const? 32 0) ⊑
-    icmp IntPredicate.ult (lshr (const? 32 12345) e) (const? 32 8) := by
+  icmp IntPred.eq (LLVM.and (lshr (const? 32 12345) e) (const? 32 (-8))) (const? 32 0) ⊑
+    icmp IntPred.ult (lshr (const? 32 12345) e) (const? 32 8) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -78,8 +78,8 @@ theorem scalar_i32_lshr_and_negC_eq_X_is_constant1_thm (e : IntW 32) :
 
 
 theorem scalar_i32_lshr_and_negC_eq_X_is_constant2_thm (e : IntW 32) :
-  icmp IntPredicate.eq (LLVM.and (lshr (const? 32 268435456) e) (const? 32 (-8))) (const? 32 0) ⊑
-    icmp IntPredicate.ugt e (const? 32 25) := by
+  icmp IntPred.eq (LLVM.and (lshr (const? 32 268435456) e) (const? 32 (-8))) (const? 32 0) ⊑
+    icmp IntPred.ugt e (const? 32 25) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -89,8 +89,8 @@ theorem scalar_i32_lshr_and_negC_eq_X_is_constant2_thm (e : IntW 32) :
 
 
 theorem scalar_i32_udiv_and_negC_eq_X_is_constant3_thm (e : IntW 32) :
-  icmp IntPredicate.ne (LLVM.and (LLVM.udiv (const? 32 12345) e) (const? 32 16376)) (const? 32 0) ⊑
-    icmp IntPredicate.ult e (const? 32 1544) := by
+  icmp IntPred.ne (LLVM.and (LLVM.udiv (const? 32 12345) e) (const? 32 16376)) (const? 32 0) ⊑
+    icmp IntPred.ult e (const? 32 1544) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -100,8 +100,8 @@ theorem scalar_i32_udiv_and_negC_eq_X_is_constant3_thm (e : IntW 32) :
 
 
 theorem scalar_i32_lshr_and_negC_slt_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.slt (LLVM.and (lshr e_1 e) (const? 32 (-8))) (const? 32 0) ⊑
-    icmp IntPredicate.slt (lshr e_1 e) (const? 32 0) := by
+  icmp IntPred.slt (LLVM.and (lshr e_1 e) (const? 32 (-8))) (const? 32 0) ⊑
+    icmp IntPred.slt (lshr e_1 e) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -111,7 +111,7 @@ theorem scalar_i32_lshr_and_negC_slt_thm (e e_1 : IntW 32) :
 
 
 theorem scalar_i32_lshr_and_negC_eq_nonzero_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.eq (LLVM.and (lshr e_1 e) (const? 32 (-8))) (const? 32 1) ⊑ const? 1 0 := by
+  icmp IntPred.eq (LLVM.and (lshr e_1 e) (const? 32 (-8))) (const? 32 1) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -121,8 +121,8 @@ theorem scalar_i32_lshr_and_negC_eq_nonzero_thm (e e_1 : IntW 32) :
 
 
 theorem scalar_i8_lshr_and_negC_eq_not_negatedPowerOf2_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.eq (LLVM.and (lshr e_1 e) (const? 8 (-3))) (const? 8 0) ⊑
-    icmp IntPredicate.eq (LLVM.and e_1 (shl (const? 8 (-3)) e)) (const? 8 0) := by
+  icmp IntPred.eq (LLVM.and (lshr e_1 e) (const? 8 (-3))) (const? 8 0) ⊑
+    icmp IntPred.eq (LLVM.and e_1 (shl (const? 8 (-3)) e)) (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/glshrhandhsignbithicmpeqhzero_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/glshrhandhsignbithicmpeqhzero_proof.lean
@@ -12,8 +12,8 @@ set_option Elab.async false
 
 section glshrhandhsignbithicmpeqhzero_proof
 theorem scalar_i8_lshr_and_signbit_eq_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.eq (LLVM.and (lshr e_1 e) (const? 8 (-128))) (const? 8 0) ⊑
-    icmp IntPredicate.sgt (lshr e_1 e) (const? 8 (-1)) := by
+  icmp IntPred.eq (LLVM.and (lshr e_1 e) (const? 8 (-128))) (const? 8 0) ⊑
+    icmp IntPred.sgt (lshr e_1 e) (const? 8 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -23,8 +23,8 @@ theorem scalar_i8_lshr_and_signbit_eq_thm (e e_1 : IntW 8) :
 
 
 theorem scalar_i16_lshr_and_signbit_eq_thm (e e_1 : IntW 16) :
-  icmp IntPredicate.eq (LLVM.and (lshr e_1 e) (const? 16 (-32768))) (const? 16 0) ⊑
-    icmp IntPredicate.sgt (lshr e_1 e) (const? 16 (-1)) := by
+  icmp IntPred.eq (LLVM.and (lshr e_1 e) (const? 16 (-32768))) (const? 16 0) ⊑
+    icmp IntPred.sgt (lshr e_1 e) (const? 16 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -34,8 +34,8 @@ theorem scalar_i16_lshr_and_signbit_eq_thm (e e_1 : IntW 16) :
 
 
 theorem scalar_i32_lshr_and_signbit_eq_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.eq (LLVM.and (lshr e_1 e) (const? 32 (-2147483648))) (const? 32 0) ⊑
-    icmp IntPredicate.sgt (lshr e_1 e) (const? 32 (-1)) := by
+  icmp IntPred.eq (LLVM.and (lshr e_1 e) (const? 32 (-2147483648))) (const? 32 0) ⊑
+    icmp IntPred.sgt (lshr e_1 e) (const? 32 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -45,8 +45,8 @@ theorem scalar_i32_lshr_and_signbit_eq_thm (e e_1 : IntW 32) :
 
 
 theorem scalar_i64_lshr_and_signbit_eq_thm (e e_1 : IntW 64) :
-  icmp IntPredicate.eq (LLVM.and (lshr e_1 e) (const? 64 (-9223372036854775808))) (const? 64 0) ⊑
-    icmp IntPredicate.sgt (lshr e_1 e) (const? 64 (-1)) := by
+  icmp IntPred.eq (LLVM.and (lshr e_1 e) (const? 64 (-9223372036854775808))) (const? 64 0) ⊑
+    icmp IntPred.sgt (lshr e_1 e) (const? 64 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -56,8 +56,8 @@ theorem scalar_i64_lshr_and_signbit_eq_thm (e e_1 : IntW 64) :
 
 
 theorem scalar_i32_lshr_and_signbit_ne_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.ne (LLVM.and (lshr e_1 e) (const? 32 (-2147483648))) (const? 32 0) ⊑
-    icmp IntPredicate.slt (lshr e_1 e) (const? 32 0) := by
+  icmp IntPred.ne (LLVM.and (lshr e_1 e) (const? 32 (-2147483648))) (const? 32 0) ⊑
+    icmp IntPred.slt (lshr e_1 e) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -67,7 +67,7 @@ theorem scalar_i32_lshr_and_signbit_ne_thm (e e_1 : IntW 32) :
 
 
 theorem scalar_i32_lshr_and_signbit_eq_X_is_constant1_thm (e : IntW 32) :
-  icmp IntPredicate.eq (LLVM.and (lshr (const? 32 12345) e) (const? 32 (-2147483648))) (const? 32 0) ⊑
+  icmp IntPred.eq (LLVM.and (lshr (const? 32 12345) e) (const? 32 (-2147483648))) (const? 32 0) ⊑
     const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
@@ -78,8 +78,8 @@ theorem scalar_i32_lshr_and_signbit_eq_X_is_constant1_thm (e : IntW 32) :
 
 
 theorem scalar_i32_lshr_and_negC_eq_X_is_constant2_thm (e : IntW 32) :
-  icmp IntPredicate.eq (LLVM.and (lshr (const? 32 (-2147483648)) e) (const? 32 (-2147483648))) (const? 32 0) ⊑
-    icmp IntPredicate.ne e (const? 32 0) := by
+  icmp IntPred.eq (LLVM.and (lshr (const? 32 (-2147483648)) e) (const? 32 (-2147483648))) (const? 32 0) ⊑
+    icmp IntPred.ne e (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -89,8 +89,8 @@ theorem scalar_i32_lshr_and_negC_eq_X_is_constant2_thm (e : IntW 32) :
 
 
 theorem scalar_i32_lshr_and_negC_slt_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.slt (LLVM.and (lshr e_1 e) (const? 32 (-2147483648))) (const? 32 0) ⊑
-    icmp IntPredicate.slt (lshr e_1 e) (const? 32 0) := by
+  icmp IntPred.slt (LLVM.and (lshr e_1 e) (const? 32 (-2147483648))) (const? 32 0) ⊑
+    icmp IntPred.slt (lshr e_1 e) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -100,7 +100,7 @@ theorem scalar_i32_lshr_and_negC_slt_thm (e e_1 : IntW 32) :
 
 
 theorem scalar_i32_lshr_and_negC_eq_nonzero_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.eq (LLVM.and (lshr e_1 e) (const? 32 (-2147483648))) (const? 32 1) ⊑ const? 1 0 := by
+  icmp IntPred.eq (LLVM.and (lshr e_1 e) (const? 32 (-2147483648))) (const? 32 1) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gmax_known_bits_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gmax_known_bits_proof.lean
@@ -14,7 +14,7 @@ section gmax_known_bits_proof
 theorem foo_thm (e : IntW 16) :
   LLVM.and
       (trunc 16
-        (select (icmp IntPredicate.ult (zext 32 (LLVM.and e (const? 16 255))) (const? 32 255))
+        (select (icmp IntPred.ult (zext 32 (LLVM.and e (const? 16 255))) (const? 32 255))
           (zext 32 (LLVM.and e (const? 16 255))) (const? 32 255)))
       (const? 16 255) ⊑
     LLVM.and e (const? 16 255) := by

--- a/SSA/Projects/InstCombine/tests/proofs/gmaxhofhnots_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gmaxhofhnots_proof.lean
@@ -13,10 +13,10 @@ set_option Elab.async false
 section gmaxhofhnots_proof
 theorem max_of_min_thm (e : IntW 32) :
   select
-      (icmp IntPredicate.sgt
-        (select (icmp IntPredicate.sgt e (const? 32 0)) (LLVM.xor e (const? 32 (-1))) (const? 32 (-1)))
+      (icmp IntPred.sgt
+        (select (icmp IntPred.sgt e (const? 32 0)) (LLVM.xor e (const? 32 (-1))) (const? 32 (-1)))
         (const? 32 (-1)))
-      (select (icmp IntPredicate.sgt e (const? 32 0)) (LLVM.xor e (const? 32 (-1))) (const? 32 (-1))) (const? 32 (-1)) ⊑
+      (select (icmp IntPred.sgt e (const? 32 0)) (LLVM.xor e (const? 32 (-1))) (const? 32 (-1))) (const? 32 (-1)) ⊑
     const? 32 (-1) := by
     simp_alive_undef
     simp_alive_ops
@@ -28,10 +28,10 @@ theorem max_of_min_thm (e : IntW 32) :
 
 theorem max_of_min_swap_thm (e : IntW 32) :
   select
-      (icmp IntPredicate.sgt
-        (select (icmp IntPredicate.slt e (const? 32 0)) (const? 32 (-1)) (LLVM.xor e (const? 32 (-1))))
+      (icmp IntPred.sgt
+        (select (icmp IntPred.slt e (const? 32 0)) (const? 32 (-1)) (LLVM.xor e (const? 32 (-1))))
         (const? 32 (-1)))
-      (select (icmp IntPredicate.slt e (const? 32 0)) (const? 32 (-1)) (LLVM.xor e (const? 32 (-1)))) (const? 32 (-1)) ⊑
+      (select (icmp IntPred.slt e (const? 32 0)) (const? 32 (-1)) (LLVM.xor e (const? 32 (-1)))) (const? 32 (-1)) ⊑
     const? 32 (-1) := by
     simp_alive_undef
     simp_alive_ops
@@ -43,10 +43,10 @@ theorem max_of_min_swap_thm (e : IntW 32) :
 
 theorem min_of_max_thm (e : IntW 32) :
   select
-      (icmp IntPredicate.slt
-        (select (icmp IntPredicate.slt e (const? 32 0)) (LLVM.xor e (const? 32 (-1))) (const? 32 (-1)))
+      (icmp IntPred.slt
+        (select (icmp IntPred.slt e (const? 32 0)) (LLVM.xor e (const? 32 (-1))) (const? 32 (-1)))
         (const? 32 (-1)))
-      (select (icmp IntPredicate.slt e (const? 32 0)) (LLVM.xor e (const? 32 (-1))) (const? 32 (-1))) (const? 32 (-1)) ⊑
+      (select (icmp IntPred.slt e (const? 32 0)) (LLVM.xor e (const? 32 (-1))) (const? 32 (-1))) (const? 32 (-1)) ⊑
     const? 32 (-1) := by
     simp_alive_undef
     simp_alive_ops
@@ -58,10 +58,10 @@ theorem min_of_max_thm (e : IntW 32) :
 
 theorem min_of_max_swap_thm (e : IntW 32) :
   select
-      (icmp IntPredicate.slt
-        (select (icmp IntPredicate.sgt e (const? 32 0)) (const? 32 (-1)) (LLVM.xor e (const? 32 (-1))))
+      (icmp IntPred.slt
+        (select (icmp IntPred.sgt e (const? 32 0)) (const? 32 (-1)) (LLVM.xor e (const? 32 (-1))))
         (const? 32 (-1)))
-      (select (icmp IntPredicate.sgt e (const? 32 0)) (const? 32 (-1)) (LLVM.xor e (const? 32 (-1)))) (const? 32 (-1)) ⊑
+      (select (icmp IntPred.sgt e (const? 32 0)) (const? 32 (-1)) (LLVM.xor e (const? 32 (-1)))) (const? 32 (-1)) ⊑
     const? 32 (-1) := by
     simp_alive_undef
     simp_alive_ops

--- a/SSA/Projects/InstCombine/tests/proofs/gmergehicmp_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gmergehicmp_proof.lean
@@ -12,9 +12,9 @@ set_option Elab.async false
 
 section gmergehicmp_proof
 theorem or_basic_thm (e : IntW 16) :
-  LLVM.or (icmp IntPredicate.ne (trunc 8 e) (const? 8 127))
-      (icmp IntPredicate.ne (LLVM.and e (const? 16 (-256))) (const? 16 17664)) ⊑
-    icmp IntPredicate.ne e (const? 16 17791) := by
+  LLVM.or (icmp IntPred.ne (trunc 8 e) (const? 8 127))
+      (icmp IntPred.ne (LLVM.and e (const? 16 (-256))) (const? 16 17664)) ⊑
+    icmp IntPred.ne e (const? 16 17791) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -24,9 +24,9 @@ theorem or_basic_thm (e : IntW 16) :
 
 
 theorem or_basic_commuted_thm (e : IntW 16) :
-  LLVM.or (icmp IntPredicate.ne (LLVM.and e (const? 16 (-256))) (const? 16 32512))
-      (icmp IntPredicate.ne (trunc 8 e) (const? 8 69)) ⊑
-    icmp IntPredicate.ne e (const? 16 32581) := by
+  LLVM.or (icmp IntPred.ne (LLVM.and e (const? 16 (-256))) (const? 16 32512))
+      (icmp IntPred.ne (trunc 8 e) (const? 8 69)) ⊑
+    icmp IntPred.ne e (const? 16 32581) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -36,9 +36,9 @@ theorem or_basic_commuted_thm (e : IntW 16) :
 
 
 theorem or_nontrivial_mask1_thm (e : IntW 16) :
-  LLVM.or (icmp IntPredicate.ne (trunc 8 e) (const? 8 127))
-      (icmp IntPredicate.ne (LLVM.and e (const? 16 3840)) (const? 16 1280)) ⊑
-    icmp IntPredicate.ne (LLVM.and e (const? 16 4095)) (const? 16 1407) := by
+  LLVM.or (icmp IntPred.ne (trunc 8 e) (const? 8 127))
+      (icmp IntPred.ne (LLVM.and e (const? 16 3840)) (const? 16 1280)) ⊑
+    icmp IntPred.ne (LLVM.and e (const? 16 4095)) (const? 16 1407) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -48,9 +48,9 @@ theorem or_nontrivial_mask1_thm (e : IntW 16) :
 
 
 theorem or_nontrivial_mask2_thm (e : IntW 16) :
-  LLVM.or (icmp IntPredicate.ne (trunc 8 e) (const? 8 127))
-      (icmp IntPredicate.ne (LLVM.and e (const? 16 (-4096))) (const? 16 20480)) ⊑
-    icmp IntPredicate.ne (LLVM.and e (const? 16 (-3841))) (const? 16 20607) := by
+  LLVM.or (icmp IntPred.ne (trunc 8 e) (const? 8 127))
+      (icmp IntPred.ne (LLVM.and e (const? 16 (-4096))) (const? 16 20480)) ⊑
+    icmp IntPred.ne (LLVM.and e (const? 16 (-3841))) (const? 16 20607) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -60,8 +60,8 @@ theorem or_nontrivial_mask2_thm (e : IntW 16) :
 
 
 theorem or_wrong_const1_thm (e : IntW 16) :
-  LLVM.or (icmp IntPredicate.ne (trunc 8 e) (const? 8 127))
-      (icmp IntPredicate.ne (LLVM.and e (const? 16 (-256))) (const? 16 17665)) ⊑
+  LLVM.or (icmp IntPred.ne (trunc 8 e) (const? 8 127))
+      (icmp IntPred.ne (LLVM.and e (const? 16 (-256))) (const? 16 17665)) ⊑
     const? 1 1 := by
     simp_alive_undef
     simp_alive_ops

--- a/SSA/Projects/InstCombine/tests/proofs/gminmaxhdemandbits_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gminmaxhdemandbits_proof.lean
@@ -12,7 +12,7 @@ set_option Elab.async false
 
 section gminmaxhdemandbits_proof
 theorem and_umax_less_thm (e : IntW 32) :
-  LLVM.and (select (icmp IntPredicate.ugt (const? 32 31) e) (const? 32 31) e) (const? 32 (-32)) ⊑
+  LLVM.and (select (icmp IntPred.ugt (const? 32 31) e) (const? 32 31) e) (const? 32 (-32)) ⊑
     LLVM.and e (const? 32 (-32)) := by
     simp_alive_undef
     simp_alive_ops
@@ -23,7 +23,7 @@ theorem and_umax_less_thm (e : IntW 32) :
 
 
 theorem and_umax_muchless_thm (e : IntW 32) :
-  LLVM.and (select (icmp IntPredicate.ugt (const? 32 12) e) (const? 32 12) e) (const? 32 (-32)) ⊑
+  LLVM.and (select (icmp IntPred.ugt (const? 32 12) e) (const? 32 12) e) (const? 32 (-32)) ⊑
     LLVM.and e (const? 32 (-32)) := by
     simp_alive_undef
     simp_alive_ops
@@ -34,7 +34,7 @@ theorem and_umax_muchless_thm (e : IntW 32) :
 
 
 theorem shr_umax_thm (e : IntW 32) :
-  lshr (select (icmp IntPredicate.ugt (const? 32 15) e) (const? 32 15) e) (const? 32 4) ⊑ lshr e (const? 32 4) := by
+  lshr (select (icmp IntPred.ugt (const? 32 15) e) (const? 32 15) e) (const? 32 4) ⊑ lshr e (const? 32 4) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -44,7 +44,7 @@ theorem shr_umax_thm (e : IntW 32) :
 
 
 theorem t_0_1_thm (e : IntW 8) :
-  LLVM.and (select (icmp IntPredicate.ugt e (const? 8 0)) e (const? 8 0)) (const? 8 1) ⊑
+  LLVM.and (select (icmp IntPred.ugt e (const? 8 0)) e (const? 8 0)) (const? 8 1) ⊑
     LLVM.and e (const? 8 1) := by
     simp_alive_undef
     simp_alive_ops
@@ -55,7 +55,7 @@ theorem t_0_1_thm (e : IntW 8) :
 
 
 theorem t_0_10_thm (e : IntW 8) :
-  LLVM.and (select (icmp IntPredicate.ugt e (const? 8 0)) e (const? 8 0)) (const? 8 10) ⊑
+  LLVM.and (select (icmp IntPred.ugt e (const? 8 0)) e (const? 8 0)) (const? 8 10) ⊑
     LLVM.and e (const? 8 10) := by
     simp_alive_undef
     simp_alive_ops
@@ -66,7 +66,7 @@ theorem t_0_10_thm (e : IntW 8) :
 
 
 theorem t_1_10_thm (e : IntW 8) :
-  LLVM.and (select (icmp IntPredicate.ugt e (const? 8 1)) e (const? 8 1)) (const? 8 10) ⊑
+  LLVM.and (select (icmp IntPred.ugt e (const? 8 1)) e (const? 8 1)) (const? 8 10) ⊑
     LLVM.and e (const? 8 10) := by
     simp_alive_undef
     simp_alive_ops
@@ -77,7 +77,7 @@ theorem t_1_10_thm (e : IntW 8) :
 
 
 theorem t_2_4_thm (e : IntW 8) :
-  LLVM.and (select (icmp IntPredicate.ugt e (const? 8 2)) e (const? 8 2)) (const? 8 4) ⊑
+  LLVM.and (select (icmp IntPred.ugt e (const? 8 2)) e (const? 8 2)) (const? 8 4) ⊑
     LLVM.and e (const? 8 4) := by
     simp_alive_undef
     simp_alive_ops
@@ -88,7 +88,7 @@ theorem t_2_4_thm (e : IntW 8) :
 
 
 theorem t_2_192_thm (e : IntW 8) :
-  LLVM.and (select (icmp IntPredicate.ugt e (const? 8 2)) e (const? 8 2)) (const? 8 (-64)) ⊑
+  LLVM.and (select (icmp IntPred.ugt e (const? 8 2)) e (const? 8 2)) (const? 8 (-64)) ⊑
     LLVM.and e (const? 8 (-64)) := by
     simp_alive_undef
     simp_alive_ops
@@ -99,7 +99,7 @@ theorem t_2_192_thm (e : IntW 8) :
 
 
 theorem t_2_63_or_thm (e : IntW 8) :
-  LLVM.or (select (icmp IntPredicate.ugt e (const? 8 2)) e (const? 8 2)) (const? 8 63) ⊑
+  LLVM.or (select (icmp IntPred.ugt e (const? 8 2)) e (const? 8 2)) (const? 8 63) ⊑
     LLVM.or e (const? 8 63) := by
     simp_alive_undef
     simp_alive_ops
@@ -110,7 +110,7 @@ theorem t_2_63_or_thm (e : IntW 8) :
 
 
 theorem and_umin_thm (e : IntW 32) :
-  LLVM.and (select (icmp IntPredicate.ult (const? 32 15) e) (const? 32 15) e) (const? 32 (-32)) ⊑ const? 32 0 := by
+  LLVM.and (select (icmp IntPred.ult (const? 32 15) e) (const? 32 15) e) (const? 32 (-32)) ⊑ const? 32 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -120,7 +120,7 @@ theorem and_umin_thm (e : IntW 32) :
 
 
 theorem or_umin_thm (e : IntW 32) :
-  LLVM.or (select (icmp IntPredicate.ult (const? 32 15) e) (const? 32 15) e) (const? 32 31) ⊑ const? 32 31 := by
+  LLVM.or (select (icmp IntPred.ult (const? 32 15) e) (const? 32 15) e) (const? 32 31) ⊑ const? 32 31 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -130,7 +130,7 @@ theorem or_umin_thm (e : IntW 32) :
 
 
 theorem or_min_31_30_thm (e : IntW 8) :
-  LLVM.or (select (icmp IntPredicate.ult e (const? 8 (-30))) e (const? 8 (-30))) (const? 8 31) ⊑
+  LLVM.or (select (icmp IntPred.ult e (const? 8 (-30))) e (const? 8 (-30))) (const? 8 31) ⊑
     LLVM.or e (const? 8 31) := by
     simp_alive_undef
     simp_alive_ops
@@ -141,7 +141,7 @@ theorem or_min_31_30_thm (e : IntW 8) :
 
 
 theorem and_min_7_7_thm (e : IntW 8) :
-  LLVM.and (select (icmp IntPredicate.ult e (const? 8 (-7))) e (const? 8 (-7))) (const? 8 (-8)) ⊑
+  LLVM.and (select (icmp IntPred.ult e (const? 8 (-7))) e (const? 8 (-7))) (const? 8 (-8)) ⊑
     LLVM.and e (const? 8 (-8)) := by
     simp_alive_undef
     simp_alive_ops
@@ -152,7 +152,7 @@ theorem and_min_7_7_thm (e : IntW 8) :
 
 
 theorem and_min_7_8_thm (e : IntW 8) :
-  LLVM.and (select (icmp IntPredicate.ult e (const? 8 (-8))) e (const? 8 (-8))) (const? 8 (-8)) ⊑
+  LLVM.and (select (icmp IntPred.ult e (const? 8 (-8))) e (const? 8 (-8))) (const? 8 (-8)) ⊑
     LLVM.and e (const? 8 (-8)) := by
     simp_alive_undef
     simp_alive_ops

--- a/SSA/Projects/InstCombine/tests/proofs/gminmaxhfold_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gminmaxhfold_proof.lean
@@ -12,9 +12,9 @@ set_option Elab.async false
 
 section gminmaxhfold_proof
 theorem add_umin_constant_limit_thm (e : IntW 32) :
-  select (icmp IntPredicate.ult (add e (const? 32 41) { «nsw» := false, «nuw» := true }) (const? 32 42))
+  select (icmp IntPred.ult (add e (const? 32 41) { «nsw» := false, «nuw» := true }) (const? 32 42))
       (add e (const? 32 41) { «nsw» := false, «nuw» := true }) (const? 32 42) ⊑
-    select (icmp IntPredicate.eq e (const? 32 0)) (const? 32 41) (const? 32 42) := by
+    select (icmp IntPred.eq e (const? 32 0)) (const? 32 41) (const? 32 42) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -24,7 +24,7 @@ theorem add_umin_constant_limit_thm (e : IntW 32) :
 
 
 theorem add_umin_simplify_thm (e : IntW 32) :
-  select (icmp IntPredicate.ult (add e (const? 32 42) { «nsw» := false, «nuw» := true }) (const? 32 42))
+  select (icmp IntPred.ult (add e (const? 32 42) { «nsw» := false, «nuw» := true }) (const? 32 42))
       (add e (const? 32 42) { «nsw» := false, «nuw» := true }) (const? 32 42) ⊑
     const? 32 42 := by
     simp_alive_undef
@@ -36,7 +36,7 @@ theorem add_umin_simplify_thm (e : IntW 32) :
 
 
 theorem add_umin_simplify2_thm (e : IntW 32) :
-  select (icmp IntPredicate.ult (add e (const? 32 43) { «nsw» := false, «nuw» := true }) (const? 32 42))
+  select (icmp IntPred.ult (add e (const? 32 43) { «nsw» := false, «nuw» := true }) (const? 32 42))
       (add e (const? 32 43) { «nsw» := false, «nuw» := true }) (const? 32 42) ⊑
     const? 32 42 := by
     simp_alive_undef
@@ -48,7 +48,7 @@ theorem add_umin_simplify2_thm (e : IntW 32) :
 
 
 theorem add_umax_simplify_thm (e : IntW 37) :
-  select (icmp IntPredicate.ugt (add e (const? 37 42) { «nsw» := false, «nuw» := true }) (const? 37 42))
+  select (icmp IntPred.ugt (add e (const? 37 42) { «nsw» := false, «nuw» := true }) (const? 37 42))
       (add e (const? 37 42) { «nsw» := false, «nuw» := true }) (const? 37 42) ⊑
     add e (const? 37 42) { «nsw» := false, «nuw» := true } := by
     simp_alive_undef
@@ -60,7 +60,7 @@ theorem add_umax_simplify_thm (e : IntW 37) :
 
 
 theorem add_umax_simplify2_thm (e : IntW 32) :
-  select (icmp IntPredicate.ugt (add e (const? 32 57) { «nsw» := false, «nuw» := true }) (const? 32 56))
+  select (icmp IntPred.ugt (add e (const? 32 57) { «nsw» := false, «nuw» := true }) (const? 32 56))
       (add e (const? 32 57) { «nsw» := false, «nuw» := true }) (const? 32 56) ⊑
     add e (const? 32 57) { «nsw» := false, «nuw» := true } := by
     simp_alive_undef
@@ -72,7 +72,7 @@ theorem add_umax_simplify2_thm (e : IntW 32) :
 
 
 theorem add_smin_simplify_thm (e : IntW 32) :
-  select (icmp IntPredicate.slt (add e (const? 32 (-3)) { «nsw» := true, «nuw» := false }) (const? 32 2147483644))
+  select (icmp IntPred.slt (add e (const? 32 (-3)) { «nsw» := true, «nuw» := false }) (const? 32 2147483644))
       (add e (const? 32 (-3)) { «nsw» := true, «nuw» := false }) (const? 32 2147483644) ⊑
     add e (const? 32 (-3)) { «nsw» := true, «nuw» := false } := by
     simp_alive_undef
@@ -84,7 +84,7 @@ theorem add_smin_simplify_thm (e : IntW 32) :
 
 
 theorem add_smin_simplify2_thm (e : IntW 32) :
-  select (icmp IntPredicate.slt (add e (const? 32 (-3)) { «nsw» := true, «nuw» := false }) (const? 32 2147483645))
+  select (icmp IntPred.slt (add e (const? 32 (-3)) { «nsw» := true, «nuw» := false }) (const? 32 2147483645))
       (add e (const? 32 (-3)) { «nsw» := true, «nuw» := false }) (const? 32 2147483645) ⊑
     add e (const? 32 (-3)) { «nsw» := true, «nuw» := false } := by
     simp_alive_undef
@@ -96,7 +96,7 @@ theorem add_smin_simplify2_thm (e : IntW 32) :
 
 
 theorem add_smax_simplify_thm (e : IntW 8) :
-  select (icmp IntPredicate.sgt (add e (const? 8 126) { «nsw» := true, «nuw» := false }) (const? 8 (-2)))
+  select (icmp IntPred.sgt (add e (const? 8 126) { «nsw» := true, «nuw» := false }) (const? 8 (-2)))
       (add e (const? 8 126) { «nsw» := true, «nuw» := false }) (const? 8 (-2)) ⊑
     add e (const? 8 126) { «nsw» := true, «nuw» := false } := by
     simp_alive_undef
@@ -108,7 +108,7 @@ theorem add_smax_simplify_thm (e : IntW 8) :
 
 
 theorem add_smax_simplify2_thm (e : IntW 8) :
-  select (icmp IntPredicate.sgt (add e (const? 8 127) { «nsw» := true, «nuw» := false }) (const? 8 (-2)))
+  select (icmp IntPred.sgt (add e (const? 8 127) { «nsw» := true, «nuw» := false }) (const? 8 (-2)))
       (add e (const? 8 127) { «nsw» := true, «nuw» := false }) (const? 8 (-2)) ⊑
     add e (const? 8 127) { «nsw» := true, «nuw» := false } := by
     simp_alive_undef
@@ -121,9 +121,9 @@ theorem add_smax_simplify2_thm (e : IntW 8) :
 
 theorem twoway_clamp_lt_thm (e : IntW 32) :
   select
-      (icmp IntPredicate.sgt (select (icmp IntPredicate.slt e (const? 32 13768)) e (const? 32 13768)) (const? 32 13767))
-      (select (icmp IntPredicate.slt e (const? 32 13768)) e (const? 32 13768)) (const? 32 13767) ⊑
-    select (icmp IntPredicate.sgt e (const? 32 13767)) (const? 32 13768) (const? 32 13767) := by
+      (icmp IntPred.sgt (select (icmp IntPred.slt e (const? 32 13768)) e (const? 32 13768)) (const? 32 13767))
+      (select (icmp IntPred.slt e (const? 32 13768)) e (const? 32 13768)) (const? 32 13767) ⊑
+    select (icmp IntPred.sgt e (const? 32 13767)) (const? 32 13768) (const? 32 13767) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gmodulo_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gmodulo_proof.lean
@@ -12,7 +12,7 @@ set_option Elab.async false
 
 section gmodulo_proof
 theorem modulo2_thm (e : IntW 32) :
-  add (select (icmp IntPredicate.slt (LLVM.srem e (const? 32 2)) (const? 32 0)) (const? 32 2) (const? 32 0))
+  add (select (icmp IntPred.slt (LLVM.srem e (const? 32 2)) (const? 32 0)) (const? 32 2) (const? 32 0))
       (LLVM.srem e (const? 32 2)) { «nsw» := true, «nuw» := false } ⊑
     LLVM.and e (const? 32 1) := by
     simp_alive_undef
@@ -24,7 +24,7 @@ theorem modulo2_thm (e : IntW 32) :
 
 
 theorem modulo4_thm (e : IntW 32) :
-  add (select (icmp IntPredicate.slt (LLVM.srem e (const? 32 4)) (const? 32 0)) (const? 32 4) (const? 32 0))
+  add (select (icmp IntPred.slt (LLVM.srem e (const? 32 4)) (const? 32 0)) (const? 32 4) (const? 32 0))
       (LLVM.srem e (const? 32 4)) { «nsw» := true, «nuw» := false } ⊑
     LLVM.and e (const? 32 3) := by
     simp_alive_undef
@@ -36,7 +36,7 @@ theorem modulo4_thm (e : IntW 32) :
 
 
 theorem modulo32_thm (e : IntW 32) :
-  add (select (icmp IntPredicate.slt (LLVM.srem e (const? 32 32)) (const? 32 0)) (const? 32 32) (const? 32 0))
+  add (select (icmp IntPred.slt (LLVM.srem e (const? 32 32)) (const? 32 0)) (const? 32 32) (const? 32 0))
       (LLVM.srem e (const? 32 32)) { «nsw» := true, «nuw» := false } ⊑
     LLVM.and e (const? 32 31) := by
     simp_alive_undef

--- a/SSA/Projects/InstCombine/tests/proofs/gnarrow_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gnarrow_proof.lean
@@ -12,7 +12,7 @@ set_option Elab.async false
 
 section gnarrow_proof
 theorem test1_thm (e e_1 : IntW 32) :
-  trunc 1 (LLVM.and (zext 32 (icmp IntPredicate.slt e_1 e)) (zext 32 (icmp IntPredicate.sgt e_1 e))) ⊑
+  trunc 1 (LLVM.and (zext 32 (icmp IntPred.slt e_1 e)) (zext 32 (icmp IntPred.sgt e_1 e))) ⊑
     const? 1 0 := by
     simp_alive_undef
     simp_alive_ops

--- a/SSA/Projects/InstCombine/tests/proofs/gnegatedhbitmask_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gnegatedhbitmask_proof.lean
@@ -91,7 +91,7 @@ theorem neg_signbit_thm (e : IntW 8) :
 
 
 theorem neg_not_signbit1_thm (e : IntW 8) :
-  sub (const? 32 1) (zext 32 (lshr e (const? 8 7))) ⊑ zext 32 (icmp IntPredicate.sgt e (const? 8 (-1))) := by
+  sub (const? 32 1) (zext 32 (lshr e (const? 8 7))) ⊑ zext 32 (icmp IntPred.sgt e (const? 8 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -125,7 +125,7 @@ theorem neg_not_signbit3_thm (e : IntW 8) :
 theorem neg_mask_thm (e : IntW 16) (e_1 : IntW 32) :
   LLVM.and (sub e_1 (sext 32 e) { «nsw» := true, «nuw» := false })
       (sub (const? 32 0) (zext 32 (lshr e (const? 16 15))) { «nsw» := true, «nuw» := false }) ⊑
-    select (icmp IntPredicate.slt e (const? 16 0)) (sub e_1 (sext 32 e) { «nsw» := true, «nuw» := false })
+    select (icmp IntPred.slt e (const? 16 0)) (sub e_1 (sext 32 e) { «nsw» := true, «nuw» := false })
       (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
@@ -138,7 +138,7 @@ theorem neg_mask_thm (e : IntW 16) (e_1 : IntW 32) :
 theorem neg_mask_const_thm (e : IntW 16) :
   LLVM.and (sub (const? 32 1000) (sext 32 e) { «nsw» := true, «nuw» := false })
       (sub (const? 32 0) (zext 32 (lshr e (const? 16 15))) { «nsw» := true, «nuw» := false }) ⊑
-    select (icmp IntPredicate.slt e (const? 16 0)) (sub (const? 32 1000) (sext 32 e) { «nsw» := true, «nuw» := false })
+    select (icmp IntPred.slt e (const? 16 0)) (sub (const? 32 1000) (sext 32 e) { «nsw» := true, «nuw» := false })
       (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops

--- a/SSA/Projects/InstCombine/tests/proofs/gnot_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gnot_proof.lean
@@ -21,7 +21,7 @@ theorem test1_thm (e : IntW 32) : LLVM.xor (LLVM.xor e (const? 32 (-1))) (const?
 
 
 theorem invert_icmp_thm (e e_1 : IntW 32) :
-  LLVM.xor (icmp IntPredicate.sle e_1 e) (const? 1 1) ⊑ icmp IntPredicate.sgt e_1 e := by
+  LLVM.xor (icmp IntPred.sle e_1 e) (const? 1 1) ⊑ icmp IntPred.sgt e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -31,8 +31,8 @@ theorem invert_icmp_thm (e e_1 : IntW 32) :
 
 
 theorem not_not_cmp_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.slt (LLVM.xor e_1 (const? 32 (-1))) (LLVM.xor e (const? 32 (-1))) ⊑
-    icmp IntPredicate.sgt e_1 e := by
+  icmp IntPred.slt (LLVM.xor e_1 (const? 32 (-1))) (LLVM.xor e (const? 32 (-1))) ⊑
+    icmp IntPred.sgt e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -42,8 +42,8 @@ theorem not_not_cmp_thm (e e_1 : IntW 32) :
 
 
 theorem not_cmp_constant_thm (e : IntW 32) :
-  icmp IntPredicate.ugt (LLVM.xor e (const? 32 (-1))) (const? 32 42) ⊑
-    icmp IntPredicate.ult e (const? 32 (-43)) := by
+  icmp IntPred.ugt (LLVM.xor e (const? 32 (-1))) (const? 32 42) ⊑
+    icmp IntPred.ult e (const? 32 (-43)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -154,8 +154,8 @@ theorem not_logicalOr_not_op1_thm (e e_1 : IntW 1) :
 
 
 theorem invert_both_cmp_operands_add_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.sgt (add e_1 (LLVM.xor e (const? 32 (-1)))) (const? 32 0) ⊑
-    icmp IntPredicate.slt (sub e e_1) (const? 32 (-1)) := by
+  icmp IntPred.sgt (add e_1 (LLVM.xor e (const? 32 (-1)))) (const? 32 0) ⊑
+    icmp IntPred.slt (sub e e_1) (const? 32 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -165,8 +165,8 @@ theorem invert_both_cmp_operands_add_thm (e e_1 : IntW 32) :
 
 
 theorem invert_both_cmp_operands_sub_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.ult (sub (LLVM.xor e_1 (const? 32 (-1))) e) (const? 32 42) ⊑
-    icmp IntPredicate.ugt (add e_1 e) (const? 32 (-43)) := by
+  icmp IntPred.ult (sub (LLVM.xor e_1 (const? 32 (-1))) e) (const? 32 42) ⊑
+    icmp IntPred.ugt (add e_1 e) (const? 32 (-43)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -176,9 +176,9 @@ theorem invert_both_cmp_operands_sub_thm (e e_1 : IntW 32) :
 
 
 theorem invert_both_cmp_operands_complex_thm (e e_1 e_2 : IntW 32) (e_3 : IntW 1) :
-  icmp IntPredicate.sle (select e_3 (add e_2 (LLVM.xor e_1 (const? 32 (-1)))) (LLVM.xor e (const? 32 (-1))))
+  icmp IntPred.sle (select e_3 (add e_2 (LLVM.xor e_1 (const? 32 (-1)))) (LLVM.xor e (const? 32 (-1))))
       (LLVM.xor e_2 (const? 32 (-1))) ⊑
-    icmp IntPredicate.sge (select e_3 (sub e_1 e_2) e) e_2 := by
+    icmp IntPred.sge (select e_3 (sub e_1 e_2) e) e_2 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -188,8 +188,8 @@ theorem invert_both_cmp_operands_complex_thm (e e_1 e_2 : IntW 32) (e_3 : IntW 1
 
 
 theorem test_sext_thm (e e_1 : IntW 32) :
-  LLVM.xor (add e_1 (sext 32 (icmp IntPredicate.eq e (const? 32 0)))) (const? 32 (-1)) ⊑
-    sub (sext 32 (icmp IntPredicate.ne e (const? 32 0))) e_1 := by
+  LLVM.xor (add e_1 (sext 32 (icmp IntPred.eq e (const? 32 0)))) (const? 32 (-1)) ⊑
+    sub (sext 32 (icmp IntPred.ne e (const? 32 0))) e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -212,7 +212,7 @@ theorem test_zext_nneg_thm (e : IntW 64) (e_1 : IntW 32) (e_2 : IntW 64) :
 theorem test_trunc_thm (e : IntW 8) :
   LLVM.xor (trunc 8 (ashr (add (zext 32 e) (const? 32 (-1)) { «nsw» := true, «nuw» := false }) (const? 32 31)))
       (const? 8 (-1)) ⊑
-    sext 8 (icmp IntPredicate.ne e (const? 8 0)) := by
+    sext 8 (icmp IntPred.ne e (const? 8 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -223,11 +223,11 @@ theorem test_trunc_thm (e : IntW 8) :
 
 theorem test_invert_demorgan_or2_thm (e e_1 e_2 : IntW 64) :
   LLVM.xor
-      (LLVM.or (LLVM.or (icmp IntPredicate.ugt e_2 (const? 64 23)) (icmp IntPredicate.ugt e_1 (const? 64 59)))
-        (icmp IntPredicate.ugt e (const? 64 59)))
+      (LLVM.or (LLVM.or (icmp IntPred.ugt e_2 (const? 64 23)) (icmp IntPred.ugt e_1 (const? 64 59)))
+        (icmp IntPred.ugt e (const? 64 59)))
       (const? 1 1) ⊑
-    LLVM.and (LLVM.and (icmp IntPredicate.ult e_2 (const? 64 24)) (icmp IntPredicate.ult e_1 (const? 64 60)))
-      (icmp IntPredicate.ult e (const? 64 60)) := by
+    LLVM.and (LLVM.and (icmp IntPred.ult e_2 (const? 64 24)) (icmp IntPred.ult e_1 (const? 64 60)))
+      (icmp IntPred.ult e (const? 64 60)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -240,17 +240,17 @@ theorem test_invert_demorgan_or3_thm (e e_1 : IntW 32) :
   LLVM.xor
       (LLVM.or
         (LLVM.or
-          (LLVM.or (icmp IntPredicate.eq e_1 (const? 32 178206))
-            (icmp IntPredicate.ult (add e (const? 32 (-195102))) (const? 32 1506)))
-          (icmp IntPredicate.ult (add e (const? 32 (-201547))) (const? 32 716213)))
-        (icmp IntPredicate.ult (add e (const? 32 (-918000))) (const? 32 196112)))
+          (LLVM.or (icmp IntPred.eq e_1 (const? 32 178206))
+            (icmp IntPred.ult (add e (const? 32 (-195102))) (const? 32 1506)))
+          (icmp IntPred.ult (add e (const? 32 (-201547))) (const? 32 716213)))
+        (icmp IntPred.ult (add e (const? 32 (-918000))) (const? 32 196112)))
       (const? 1 1) ⊑
     LLVM.and
       (LLVM.and
-        (LLVM.and (icmp IntPredicate.ne e_1 (const? 32 178206))
-          (icmp IntPredicate.ult (add e (const? 32 (-196608))) (const? 32 (-1506))))
-        (icmp IntPredicate.ult (add e (const? 32 (-917760))) (const? 32 (-716213))))
-      (icmp IntPredicate.ult (add e (const? 32 (-1114112))) (const? 32 (-196112))) := by
+        (LLVM.and (icmp IntPred.ne e_1 (const? 32 178206))
+          (icmp IntPred.ult (add e (const? 32 (-196608))) (const? 32 (-1506))))
+        (icmp IntPred.ult (add e (const? 32 (-917760))) (const? 32 (-716213))))
+      (icmp IntPred.ult (add e (const? 32 (-1114112))) (const? 32 (-196112))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -261,11 +261,11 @@ theorem test_invert_demorgan_or3_thm (e e_1 : IntW 32) :
 
 theorem test_invert_demorgan_logical_or_thm (e e_1 : IntW 64) :
   LLVM.xor
-      (LLVM.or (icmp IntPredicate.eq e_1 (const? 64 0))
-        (select (icmp IntPredicate.eq e_1 (const? 64 27)) (const? 1 1) (icmp IntPredicate.eq e (const? 64 0))))
+      (LLVM.or (icmp IntPred.eq e_1 (const? 64 0))
+        (select (icmp IntPred.eq e_1 (const? 64 27)) (const? 1 1) (icmp IntPred.eq e (const? 64 0))))
       (const? 1 1) ⊑
-    LLVM.and (icmp IntPredicate.ne e_1 (const? 64 0))
-      (select (icmp IntPredicate.ne e_1 (const? 64 27)) (icmp IntPredicate.ne e (const? 64 0)) (const? 1 0)) := by
+    LLVM.and (icmp IntPred.ne e_1 (const? 64 0))
+      (select (icmp IntPred.ne e_1 (const? 64 27)) (icmp IntPred.ne e (const? 64 0)) (const? 1 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -286,8 +286,8 @@ theorem test_invert_demorgan_and2_thm (e : IntW 64) :
 
 
 theorem test_invert_demorgan_and3_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.eq (LLVM.and (add e_1 (LLVM.xor e (const? 32 (-1)))) (const? 32 4095)) (const? 32 0) ⊑
-    icmp IntPredicate.eq (LLVM.and (sub e e_1) (const? 32 4095)) (const? 32 4095) := by
+  icmp IntPred.eq (LLVM.and (add e_1 (LLVM.xor e (const? 32 (-1)))) (const? 32 4095)) (const? 32 0) ⊑
+    icmp IntPred.eq (LLVM.and (sub e e_1) (const? 32 4095)) (const? 32 4095) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -298,11 +298,11 @@ theorem test_invert_demorgan_and3_thm (e e_1 : IntW 32) :
 
 theorem test_invert_demorgan_logical_and_thm (e e_1 : IntW 64) :
   LLVM.xor
-      (LLVM.or (icmp IntPredicate.eq e_1 (const? 64 0))
-        (select (icmp IntPredicate.eq e_1 (const? 64 27)) (icmp IntPredicate.eq e (const? 64 0)) (const? 1 0)))
+      (LLVM.or (icmp IntPred.eq e_1 (const? 64 0))
+        (select (icmp IntPred.eq e_1 (const? 64 27)) (icmp IntPred.eq e (const? 64 0)) (const? 1 0)))
       (const? 1 1) ⊑
-    LLVM.and (icmp IntPredicate.ne e_1 (const? 64 0))
-      (select (icmp IntPredicate.ne e_1 (const? 64 27)) (const? 1 1) (icmp IntPredicate.ne e (const? 64 0))) := by
+    LLVM.and (icmp IntPred.ne e_1 (const? 64 0))
+      (select (icmp IntPred.ne e_1 (const? 64 27)) (const? 1 1) (icmp IntPred.ne e (const? 64 0))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gomithuremhofhpowerhofhtwohorhzerohwhenhcomparinghwithhzero_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gomithuremhofhpowerhofhtwohorhzerohwhenhcomparinghwithhzero_proof.lean
@@ -12,8 +12,8 @@ set_option Elab.async false
 
 section gomithuremhofhpowerhofhtwohorhzerohwhenhcomparinghwithhzero_proof
 theorem p0_scalar_urem_by_const_thm (e : IntW 32) :
-  icmp IntPredicate.eq (urem (LLVM.and e (const? 32 128)) (const? 32 6)) (const? 32 0) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 32 128)) (const? 32 0) := by
+  icmp IntPred.eq (urem (LLVM.and e (const? 32 128)) (const? 32 6)) (const? 32 0) ⊑
+    icmp IntPred.eq (LLVM.and e (const? 32 128)) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -23,8 +23,8 @@ theorem p0_scalar_urem_by_const_thm (e : IntW 32) :
 
 
 theorem p1_scalar_urem_by_nonconst_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.eq (urem (LLVM.and e_1 (const? 32 128)) (LLVM.or e (const? 32 6))) (const? 32 0) ⊑
-    icmp IntPredicate.eq (LLVM.and e_1 (const? 32 128)) (const? 32 0) := by
+  icmp IntPred.eq (urem (LLVM.and e_1 (const? 32 128)) (LLVM.or e (const? 32 6))) (const? 32 0) ⊑
+    icmp IntPred.eq (LLVM.and e_1 (const? 32 128)) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -34,8 +34,8 @@ theorem p1_scalar_urem_by_nonconst_thm (e e_1 : IntW 32) :
 
 
 theorem p2_scalar_shifted_urem_by_const_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.eq (urem (shl (LLVM.and e_1 (const? 32 1)) e) (const? 32 3)) (const? 32 0) ⊑
-    icmp IntPredicate.eq (urem (shl (LLVM.and e_1 (const? 32 1)) e { «nsw» := false, «nuw» := true }) (const? 32 3))
+  icmp IntPred.eq (urem (shl (LLVM.and e_1 (const? 32 1)) e) (const? 32 3)) (const? 32 0) ⊑
+    icmp IntPred.eq (urem (shl (LLVM.and e_1 (const? 32 1)) e { «nsw» := false, «nuw» := true }) (const? 32 3))
       (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops

--- a/SSA/Projects/InstCombine/tests/proofs/gonehot_merge_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gonehot_merge_proof.lean
@@ -12,9 +12,9 @@ set_option Elab.async false
 
 section gonehot_merge_proof
 theorem and_consts_thm (e : IntW 32) :
-  LLVM.or (icmp IntPredicate.eq (LLVM.and (const? 32 4) e) (const? 32 0))
-      (icmp IntPredicate.eq (LLVM.and (const? 32 8) e) (const? 32 0)) ⊑
-    icmp IntPredicate.ne (LLVM.and e (const? 32 12)) (const? 32 12) := by
+  LLVM.or (icmp IntPred.eq (LLVM.and (const? 32 4) e) (const? 32 0))
+      (icmp IntPred.eq (LLVM.and (const? 32 8) e) (const? 32 0)) ⊑
+    icmp IntPred.ne (LLVM.and e (const? 32 12)) (const? 32 12) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -24,9 +24,9 @@ theorem and_consts_thm (e : IntW 32) :
 
 
 theorem and_consts_logical_thm (e : IntW 32) :
-  select (icmp IntPredicate.eq (LLVM.and (const? 32 4) e) (const? 32 0)) (const? 1 1)
-      (icmp IntPredicate.eq (LLVM.and (const? 32 8) e) (const? 32 0)) ⊑
-    icmp IntPredicate.ne (LLVM.and e (const? 32 12)) (const? 32 12) := by
+  select (icmp IntPred.eq (LLVM.and (const? 32 4) e) (const? 32 0)) (const? 1 1)
+      (icmp IntPred.eq (LLVM.and (const? 32 8) e) (const? 32 0)) ⊑
+    icmp IntPred.ne (LLVM.and e (const? 32 12)) (const? 32 12) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -36,9 +36,9 @@ theorem and_consts_logical_thm (e : IntW 32) :
 
 
 theorem foo1_and_thm (e e_1 e_2 : IntW 32) :
-  LLVM.or (icmp IntPredicate.eq (LLVM.and (shl (const? 32 1) e_2) e_1) (const? 32 0))
-      (icmp IntPredicate.eq (LLVM.and (shl (const? 32 1) e) e_1) (const? 32 0)) ⊑
-    icmp IntPredicate.ne
+  LLVM.or (icmp IntPred.eq (LLVM.and (shl (const? 32 1) e_2) e_1) (const? 32 0))
+      (icmp IntPred.eq (LLVM.and (shl (const? 32 1) e) e_1) (const? 32 0)) ⊑
+    icmp IntPred.ne
       (LLVM.and e_1
         (LLVM.or (shl (const? 32 1) e_2 { «nsw» := false, «nuw» := true })
           (shl (const? 32 1) e { «nsw» := false, «nuw» := true })))
@@ -53,9 +53,9 @@ theorem foo1_and_thm (e e_1 e_2 : IntW 32) :
 
 
 theorem foo1_and_commuted_thm (e e_1 e_2 : IntW 32) :
-  LLVM.or (icmp IntPredicate.eq (LLVM.and (mul e_2 e_2) (shl (const? 32 1) e_1)) (const? 32 0))
-      (icmp IntPredicate.eq (LLVM.and (shl (const? 32 1) e) (mul e_2 e_2)) (const? 32 0)) ⊑
-    icmp IntPredicate.ne
+  LLVM.or (icmp IntPred.eq (LLVM.and (mul e_2 e_2) (shl (const? 32 1) e_1)) (const? 32 0))
+      (icmp IntPred.eq (LLVM.and (shl (const? 32 1) e) (mul e_2 e_2)) (const? 32 0)) ⊑
+    icmp IntPred.ne
       (LLVM.and (mul e_2 e_2)
         (LLVM.or (shl (const? 32 1) e_1 { «nsw» := false, «nuw» := true })
           (shl (const? 32 1) e { «nsw» := false, «nuw» := true })))
@@ -70,9 +70,9 @@ theorem foo1_and_commuted_thm (e e_1 e_2 : IntW 32) :
 
 
 theorem or_consts_thm (e : IntW 32) :
-  LLVM.and (icmp IntPredicate.ne (LLVM.and (const? 32 4) e) (const? 32 0))
-      (icmp IntPredicate.ne (LLVM.and (const? 32 8) e) (const? 32 0)) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 32 12)) (const? 32 12) := by
+  LLVM.and (icmp IntPred.ne (LLVM.and (const? 32 4) e) (const? 32 0))
+      (icmp IntPred.ne (LLVM.and (const? 32 8) e) (const? 32 0)) ⊑
+    icmp IntPred.eq (LLVM.and e (const? 32 12)) (const? 32 12) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -82,9 +82,9 @@ theorem or_consts_thm (e : IntW 32) :
 
 
 theorem or_consts_logical_thm (e : IntW 32) :
-  select (icmp IntPredicate.ne (LLVM.and (const? 32 4) e) (const? 32 0))
-      (icmp IntPredicate.ne (LLVM.and (const? 32 8) e) (const? 32 0)) (const? 1 0) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 32 12)) (const? 32 12) := by
+  select (icmp IntPred.ne (LLVM.and (const? 32 4) e) (const? 32 0))
+      (icmp IntPred.ne (LLVM.and (const? 32 8) e) (const? 32 0)) (const? 1 0) ⊑
+    icmp IntPred.eq (LLVM.and e (const? 32 12)) (const? 32 12) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -94,9 +94,9 @@ theorem or_consts_logical_thm (e : IntW 32) :
 
 
 theorem foo1_or_thm (e e_1 e_2 : IntW 32) :
-  LLVM.and (icmp IntPredicate.ne (LLVM.and (shl (const? 32 1) e_2) e_1) (const? 32 0))
-      (icmp IntPredicate.ne (LLVM.and (shl (const? 32 1) e) e_1) (const? 32 0)) ⊑
-    icmp IntPredicate.eq
+  LLVM.and (icmp IntPred.ne (LLVM.and (shl (const? 32 1) e_2) e_1) (const? 32 0))
+      (icmp IntPred.ne (LLVM.and (shl (const? 32 1) e) e_1) (const? 32 0)) ⊑
+    icmp IntPred.eq
       (LLVM.and e_1
         (LLVM.or (shl (const? 32 1) e_2 { «nsw» := false, «nuw» := true })
           (shl (const? 32 1) e { «nsw» := false, «nuw» := true })))
@@ -111,9 +111,9 @@ theorem foo1_or_thm (e e_1 e_2 : IntW 32) :
 
 
 theorem foo1_or_commuted_thm (e e_1 e_2 : IntW 32) :
-  LLVM.and (icmp IntPredicate.ne (LLVM.and (mul e_2 e_2) (shl (const? 32 1) e_1)) (const? 32 0))
-      (icmp IntPredicate.ne (LLVM.and (shl (const? 32 1) e) (mul e_2 e_2)) (const? 32 0)) ⊑
-    icmp IntPredicate.eq
+  LLVM.and (icmp IntPred.ne (LLVM.and (mul e_2 e_2) (shl (const? 32 1) e_1)) (const? 32 0))
+      (icmp IntPred.ne (LLVM.and (shl (const? 32 1) e) (mul e_2 e_2)) (const? 32 0)) ⊑
+    icmp IntPred.eq
       (LLVM.and (mul e_2 e_2)
         (LLVM.or (shl (const? 32 1) e_1 { «nsw» := false, «nuw» := true })
           (shl (const? 32 1) e { «nsw» := false, «nuw» := true })))
@@ -128,9 +128,9 @@ theorem foo1_or_commuted_thm (e e_1 e_2 : IntW 32) :
 
 
 theorem foo1_and_signbit_lshr_thm (e e_1 e_2 : IntW 32) :
-  LLVM.or (icmp IntPredicate.eq (LLVM.and (shl (const? 32 1) e_2) e_1) (const? 32 0))
-      (icmp IntPredicate.eq (LLVM.and (lshr (const? 32 (-2147483648)) e) e_1) (const? 32 0)) ⊑
-    icmp IntPredicate.ne
+  LLVM.or (icmp IntPred.eq (LLVM.and (shl (const? 32 1) e_2) e_1) (const? 32 0))
+      (icmp IntPred.eq (LLVM.and (lshr (const? 32 (-2147483648)) e) e_1) (const? 32 0)) ⊑
+    icmp IntPred.ne
       (LLVM.and e_1
         (LLVM.or (shl (const? 32 1) e_2 { «nsw» := false, «nuw» := true })
           (lshr (const? 32 (-2147483648)) e { «exact» := true })))
@@ -145,9 +145,9 @@ theorem foo1_and_signbit_lshr_thm (e e_1 e_2 : IntW 32) :
 
 
 theorem foo1_or_signbit_lshr_thm (e e_1 e_2 : IntW 32) :
-  LLVM.and (icmp IntPredicate.ne (LLVM.and (shl (const? 32 1) e_2) e_1) (const? 32 0))
-      (icmp IntPredicate.ne (LLVM.and (lshr (const? 32 (-2147483648)) e) e_1) (const? 32 0)) ⊑
-    icmp IntPredicate.eq
+  LLVM.and (icmp IntPred.ne (LLVM.and (shl (const? 32 1) e_2) e_1) (const? 32 0))
+      (icmp IntPred.ne (LLVM.and (lshr (const? 32 (-2147483648)) e) e_1) (const? 32 0)) ⊑
+    icmp IntPred.eq
       (LLVM.and e_1
         (LLVM.or (shl (const? 32 1) e_2 { «nsw» := false, «nuw» := true })
           (lshr (const? 32 (-2147483648)) e { «exact» := true })))
@@ -162,11 +162,11 @@ theorem foo1_or_signbit_lshr_thm (e e_1 e_2 : IntW 32) :
 
 
 theorem foo1_and_signbit_lshr_without_shifting_signbit_thm (e e_1 e_2 : IntW 32) :
-  LLVM.or (icmp IntPredicate.eq (LLVM.and (shl (const? 32 1) e_2) e_1) (const? 32 0))
-      (icmp IntPredicate.sgt (shl e_1 e) (const? 32 (-1))) ⊑
+  LLVM.or (icmp IntPred.eq (LLVM.and (shl (const? 32 1) e_2) e_1) (const? 32 0))
+      (icmp IntPred.sgt (shl e_1 e) (const? 32 (-1))) ⊑
     LLVM.or
-      (icmp IntPredicate.eq (LLVM.and (shl (const? 32 1) e_2 { «nsw» := false, «nuw» := true }) e_1) (const? 32 0))
-      (icmp IntPredicate.sgt (shl e_1 e) (const? 32 (-1))) := by
+      (icmp IntPred.eq (LLVM.and (shl (const? 32 1) e_2 { «nsw» := false, «nuw» := true }) e_1) (const? 32 0))
+      (icmp IntPred.sgt (shl e_1 e) (const? 32 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -176,10 +176,10 @@ theorem foo1_and_signbit_lshr_without_shifting_signbit_thm (e e_1 e_2 : IntW 32)
 
 
 theorem foo1_and_signbit_lshr_without_shifting_signbit_logical_thm (e e_1 e_2 : IntW 32) :
-  select (icmp IntPredicate.eq (LLVM.and (shl (const? 32 1) e_2) e_1) (const? 32 0)) (const? 1 1)
-      (icmp IntPredicate.sgt (shl e_1 e) (const? 32 (-1))) ⊑
-    select (icmp IntPredicate.eq (LLVM.and (shl (const? 32 1) e_2 { «nsw» := false, «nuw» := true }) e_1) (const? 32 0))
-      (const? 1 1) (icmp IntPredicate.sgt (shl e_1 e) (const? 32 (-1))) := by
+  select (icmp IntPred.eq (LLVM.and (shl (const? 32 1) e_2) e_1) (const? 32 0)) (const? 1 1)
+      (icmp IntPred.sgt (shl e_1 e) (const? 32 (-1))) ⊑
+    select (icmp IntPred.eq (LLVM.and (shl (const? 32 1) e_2 { «nsw» := false, «nuw» := true }) e_1) (const? 32 0))
+      (const? 1 1) (icmp IntPred.sgt (shl e_1 e) (const? 32 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -189,11 +189,11 @@ theorem foo1_and_signbit_lshr_without_shifting_signbit_logical_thm (e e_1 e_2 : 
 
 
 theorem foo1_or_signbit_lshr_without_shifting_signbit_thm (e e_1 e_2 : IntW 32) :
-  LLVM.and (icmp IntPredicate.ne (LLVM.and (shl (const? 32 1) e_2) e_1) (const? 32 0))
-      (icmp IntPredicate.slt (shl e_1 e) (const? 32 0)) ⊑
+  LLVM.and (icmp IntPred.ne (LLVM.and (shl (const? 32 1) e_2) e_1) (const? 32 0))
+      (icmp IntPred.slt (shl e_1 e) (const? 32 0)) ⊑
     LLVM.and
-      (icmp IntPredicate.ne (LLVM.and (shl (const? 32 1) e_2 { «nsw» := false, «nuw» := true }) e_1) (const? 32 0))
-      (icmp IntPredicate.slt (shl e_1 e) (const? 32 0)) := by
+      (icmp IntPred.ne (LLVM.and (shl (const? 32 1) e_2 { «nsw» := false, «nuw» := true }) e_1) (const? 32 0))
+      (icmp IntPred.slt (shl e_1 e) (const? 32 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -203,10 +203,10 @@ theorem foo1_or_signbit_lshr_without_shifting_signbit_thm (e e_1 e_2 : IntW 32) 
 
 
 theorem foo1_or_signbit_lshr_without_shifting_signbit_logical_thm (e e_1 e_2 : IntW 32) :
-  select (icmp IntPredicate.ne (LLVM.and (shl (const? 32 1) e_2) e_1) (const? 32 0))
-      (icmp IntPredicate.slt (shl e_1 e) (const? 32 0)) (const? 1 0) ⊑
-    select (icmp IntPredicate.ne (LLVM.and (shl (const? 32 1) e_2 { «nsw» := false, «nuw» := true }) e_1) (const? 32 0))
-      (icmp IntPredicate.slt (shl e_1 e) (const? 32 0)) (const? 1 0) := by
+  select (icmp IntPred.ne (LLVM.and (shl (const? 32 1) e_2) e_1) (const? 32 0))
+      (icmp IntPred.slt (shl e_1 e) (const? 32 0)) (const? 1 0) ⊑
+    select (icmp IntPred.ne (LLVM.and (shl (const? 32 1) e_2 { «nsw» := false, «nuw» := true }) e_1) (const? 32 0))
+      (icmp IntPred.slt (shl e_1 e) (const? 32 0)) (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -216,8 +216,8 @@ theorem foo1_or_signbit_lshr_without_shifting_signbit_logical_thm (e e_1 e_2 : I
 
 
 theorem foo1_and_signbit_lshr_without_shifting_signbit_both_sides_thm (e e_1 e_2 : IntW 32) :
-  LLVM.or (icmp IntPredicate.sgt (shl e_2 e_1) (const? 32 (-1))) (icmp IntPredicate.sgt (shl e_2 e) (const? 32 (-1))) ⊑
-    icmp IntPredicate.sgt (LLVM.and (shl e_2 e_1) (shl e_2 e)) (const? 32 (-1)) := by
+  LLVM.or (icmp IntPred.sgt (shl e_2 e_1) (const? 32 (-1))) (icmp IntPred.sgt (shl e_2 e) (const? 32 (-1))) ⊑
+    icmp IntPred.sgt (LLVM.and (shl e_2 e_1) (shl e_2 e)) (const? 32 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -227,8 +227,8 @@ theorem foo1_and_signbit_lshr_without_shifting_signbit_both_sides_thm (e e_1 e_2
 
 
 theorem foo1_or_signbit_lshr_without_shifting_signbit_both_sides_thm (e e_1 e_2 : IntW 32) :
-  LLVM.and (icmp IntPredicate.slt (shl e_2 e_1) (const? 32 0)) (icmp IntPredicate.slt (shl e_2 e) (const? 32 0)) ⊑
-    icmp IntPredicate.slt (LLVM.and (shl e_2 e_1) (shl e_2 e)) (const? 32 0) := by
+  LLVM.and (icmp IntPred.slt (shl e_2 e_1) (const? 32 0)) (icmp IntPred.slt (shl e_2 e) (const? 32 0)) ⊑
+    icmp IntPred.slt (LLVM.and (shl e_2 e_1) (shl e_2 e)) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/goverflowhmul_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/goverflowhmul_proof.lean
@@ -12,10 +12,10 @@ set_option Elab.async false
 
 section goverflowhmul_proof
 theorem pr4917_3_thm (e e_1 : IntW 32) :
-  select (icmp IntPredicate.ugt (mul (zext 64 e_1) (zext 64 e)) (const? 64 4294967295)) (mul (zext 64 e_1) (zext 64 e))
+  select (icmp IntPred.ugt (mul (zext 64 e_1) (zext 64 e)) (const? 64 4294967295)) (mul (zext 64 e_1) (zext 64 e))
       (const? 64 111) ⊑
     select
-      (icmp IntPredicate.ugt (mul (zext 64 e_1) (zext 64 e) { «nsw» := false, «nuw» := true }) (const? 64 4294967295))
+      (icmp IntPred.ugt (mul (zext 64 e_1) (zext 64 e) { «nsw» := false, «nuw» := true }) (const? 64 4294967295))
       (mul (zext 64 e_1) (zext 64 e) { «nsw» := false, «nuw» := true }) (const? 64 111) := by
     simp_alive_undef
     simp_alive_ops
@@ -26,8 +26,8 @@ theorem pr4917_3_thm (e e_1 : IntW 32) :
 
 
 theorem mul_may_overflow_thm (e e_1 : IntW 32) :
-  zext 32 (icmp IntPredicate.ule (mul (zext 34 e_1) (zext 34 e)) (const? 34 4294967295)) ⊑
-    zext 32 (icmp IntPredicate.ult (mul (zext 34 e_1) (zext 34 e)) (const? 34 4294967296)) := by
+  zext 32 (icmp IntPred.ule (mul (zext 34 e_1) (zext 34 e)) (const? 34 4294967295)) ⊑
+    zext 32 (icmp IntPred.ult (mul (zext 34 e_1) (zext 34 e)) (const? 34 4294967296)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gpr17827_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gpr17827_proof.lean
@@ -12,10 +12,10 @@ set_option Elab.async false
 
 section gpr17827_proof
 theorem test_shift_and_cmp_changed1_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.slt
+  icmp IntPred.slt
       (ashr (shl (LLVM.or (LLVM.and e_1 (const? 8 8)) (LLVM.and e (const? 8 6))) (const? 8 5)) (const? 8 5))
       (const? 8 1) ⊑
-    icmp IntPredicate.slt (LLVM.and (shl e (const? 8 5)) (const? 8 (-64))) (const? 8 32) := by
+    icmp IntPred.slt (LLVM.and (shl e (const? 8 5)) (const? 8 (-64))) (const? 8 32) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -25,8 +25,8 @@ theorem test_shift_and_cmp_changed1_thm (e e_1 : IntW 8) :
 
 
 theorem test_shift_and_cmp_changed2_thm (e : IntW 8) :
-  icmp IntPredicate.ult (LLVM.and (shl e (const? 8 5)) (const? 8 (-64))) (const? 8 32) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 8 6)) (const? 8 0) := by
+  icmp IntPred.ult (LLVM.and (shl e (const? 8 5)) (const? 8 (-64))) (const? 8 32) ⊑
+    icmp IntPred.eq (LLVM.and e (const? 8 6)) (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -36,7 +36,7 @@ theorem test_shift_and_cmp_changed2_thm (e : IntW 8) :
 
 
 theorem test_shift_and_cmp_changed4_thm (e : IntW 8) :
-  icmp IntPredicate.slt (LLVM.and (lshr e (const? 8 5)) (const? 8 (-64))) (const? 8 32) ⊑ const? 1 1 := by
+  icmp IntPred.slt (LLVM.and (lshr e (const? 8 5)) (const? 8 (-64))) (const? 8 32) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gpr49688_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gpr49688_proof.lean
@@ -12,9 +12,9 @@ set_option Elab.async false
 
 section gpr49688_proof
 theorem f_thm (e : IntW 32) :
-  select (icmp IntPredicate.slt e (const? 32 0)) (const? 1 1) (icmp IntPredicate.sgt e (ashr (const? 32 7) e)) ⊑
-    select (icmp IntPredicate.slt e (const? 32 0)) (const? 1 1)
-      (icmp IntPredicate.sgt e (lshr (const? 32 7) e)) := by
+  select (icmp IntPred.slt e (const? 32 0)) (const? 1 1) (icmp IntPred.sgt e (ashr (const? 32 7) e)) ⊑
+    select (icmp IntPred.slt e (const? 32 0)) (const? 1 1)
+      (icmp IntPred.sgt e (lshr (const? 32 7) e)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -25,11 +25,11 @@ theorem f_thm (e : IntW 32) :
 
 theorem f2_thm (e e_1 : IntW 32) :
   zext 32
-      (select (icmp IntPredicate.slt e_1 (const? 32 0)) (const? 1 1)
-        (icmp IntPredicate.sgt e_1 (ashr (const? 32 7) e))) ⊑
+      (select (icmp IntPred.slt e_1 (const? 32 0)) (const? 1 1)
+        (icmp IntPred.sgt e_1 (ashr (const? 32 7) e))) ⊑
     zext 32
-      (select (icmp IntPredicate.slt e_1 (const? 32 0)) (const? 1 1)
-        (icmp IntPredicate.sgt e_1 (lshr (const? 32 7) e))) := by
+      (select (icmp IntPred.slt e_1 (const? 32 0)) (const? 1 1)
+        (icmp IntPred.sgt e_1 (lshr (const? 32 7) e))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gpr72433_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gpr72433_proof.lean
@@ -13,13 +13,13 @@ set_option Elab.async false
 section gpr72433_proof
 theorem widget_thm (e : IntW 32) :
   mul
-      (add (mul (const? 32 20) (sub (const? 32 2) (zext 32 (icmp IntPredicate.eq e (const? 32 0)))))
-        (LLVM.xor (zext 32 (icmp IntPredicate.eq e (const? 32 0))) (const? 32 1)))
-      (sub (const? 32 2) (zext 32 (icmp IntPredicate.eq e (const? 32 0)))) ⊑
+      (add (mul (const? 32 20) (sub (const? 32 2) (zext 32 (icmp IntPred.eq e (const? 32 0)))))
+        (LLVM.xor (zext 32 (icmp IntPred.eq e (const? 32 0))) (const? 32 1)))
+      (sub (const? 32 2) (zext 32 (icmp IntPred.eq e (const? 32 0)))) ⊑
     shl
-      (LLVM.or (shl (const? 32 20) (zext 32 (icmp IntPredicate.ne e (const? 32 0))) { «nsw» := true, «nuw» := true })
-        (zext 32 (icmp IntPredicate.ne e (const? 32 0))) { «disjoint» := true })
-      (zext 32 (icmp IntPredicate.ne e (const? 32 0))) { «nsw» := true, «nuw» := true } := by
+      (LLVM.or (shl (const? 32 20) (zext 32 (icmp IntPred.ne e (const? 32 0))) { «nsw» := true, «nuw» := true })
+        (zext 32 (icmp IntPred.ne e (const? 32 0))) { «disjoint» := true })
+      (zext 32 (icmp IntPred.ne e (const? 32 0))) { «nsw» := true, «nuw» := true } := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gpreventhcmphmerge_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gpreventhcmphmerge_proof.lean
@@ -12,9 +12,9 @@ set_option Elab.async false
 
 section gpreventhcmphmerge_proof
 theorem test1_thm (e e_1 : IntW 32) :
-  LLVM.or (icmp IntPredicate.eq (LLVM.xor e_1 (const? 32 5)) (const? 32 10))
-      (icmp IntPredicate.eq (LLVM.xor e_1 (const? 32 5)) e) ⊑
-    LLVM.or (icmp IntPredicate.eq e_1 (const? 32 15)) (icmp IntPredicate.eq (LLVM.xor e_1 e) (const? 32 5)) := by
+  LLVM.or (icmp IntPred.eq (LLVM.xor e_1 (const? 32 5)) (const? 32 10))
+      (icmp IntPred.eq (LLVM.xor e_1 (const? 32 5)) e) ⊑
+    LLVM.or (icmp IntPred.eq e_1 (const? 32 15)) (icmp IntPred.eq (LLVM.xor e_1 e) (const? 32 5)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -24,10 +24,10 @@ theorem test1_thm (e e_1 : IntW 32) :
 
 
 theorem test1_logical_thm (e e_1 : IntW 32) :
-  select (icmp IntPredicate.eq (LLVM.xor e_1 (const? 32 5)) (const? 32 10)) (const? 1 1)
-      (icmp IntPredicate.eq (LLVM.xor e_1 (const? 32 5)) e) ⊑
-    select (icmp IntPredicate.eq e_1 (const? 32 15)) (const? 1 1)
-      (icmp IntPredicate.eq (LLVM.xor e_1 e) (const? 32 5)) := by
+  select (icmp IntPred.eq (LLVM.xor e_1 (const? 32 5)) (const? 32 10)) (const? 1 1)
+      (icmp IntPred.eq (LLVM.xor e_1 (const? 32 5)) e) ⊑
+    select (icmp IntPred.eq e_1 (const? 32 15)) (const? 1 1)
+      (icmp IntPred.eq (LLVM.xor e_1 e) (const? 32 5)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -37,9 +37,9 @@ theorem test1_logical_thm (e e_1 : IntW 32) :
 
 
 theorem test2_thm (e e_1 : IntW 32) :
-  LLVM.xor (icmp IntPredicate.eq (LLVM.xor e_1 e) (const? 32 0))
-      (icmp IntPredicate.eq (LLVM.xor e_1 e) (const? 32 32)) ⊑
-    LLVM.xor (icmp IntPredicate.eq e_1 e) (icmp IntPredicate.eq (LLVM.xor e_1 e) (const? 32 32)) := by
+  LLVM.xor (icmp IntPred.eq (LLVM.xor e_1 e) (const? 32 0))
+      (icmp IntPred.eq (LLVM.xor e_1 e) (const? 32 32)) ⊑
+    LLVM.xor (icmp IntPred.eq e_1 e) (icmp IntPred.eq (LLVM.xor e_1 e) (const? 32 32)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -49,10 +49,10 @@ theorem test2_thm (e e_1 : IntW 32) :
 
 
 theorem test3_thm (e e_1 : IntW 32) :
-  LLVM.or (icmp IntPredicate.eq (sub e_1 e { «nsw» := true, «nuw» := false }) (const? 32 0))
-      (icmp IntPredicate.eq (sub e_1 e { «nsw» := true, «nuw» := false }) (const? 32 31)) ⊑
-    LLVM.or (icmp IntPredicate.eq e_1 e)
-      (icmp IntPredicate.eq (sub e_1 e { «nsw» := true, «nuw» := false }) (const? 32 31)) := by
+  LLVM.or (icmp IntPred.eq (sub e_1 e { «nsw» := true, «nuw» := false }) (const? 32 0))
+      (icmp IntPred.eq (sub e_1 e { «nsw» := true, «nuw» := false }) (const? 32 31)) ⊑
+    LLVM.or (icmp IntPred.eq e_1 e)
+      (icmp IntPred.eq (sub e_1 e { «nsw» := true, «nuw» := false }) (const? 32 31)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -62,10 +62,10 @@ theorem test3_thm (e e_1 : IntW 32) :
 
 
 theorem test3_logical_thm (e e_1 : IntW 32) :
-  select (icmp IntPredicate.eq (sub e_1 e { «nsw» := true, «nuw» := false }) (const? 32 0)) (const? 1 1)
-      (icmp IntPredicate.eq (sub e_1 e { «nsw» := true, «nuw» := false }) (const? 32 31)) ⊑
-    select (icmp IntPredicate.eq e_1 e) (const? 1 1)
-      (icmp IntPredicate.eq (sub e_1 e { «nsw» := true, «nuw» := false }) (const? 32 31)) := by
+  select (icmp IntPred.eq (sub e_1 e { «nsw» := true, «nuw» := false }) (const? 32 0)) (const? 1 1)
+      (icmp IntPred.eq (sub e_1 e { «nsw» := true, «nuw» := false }) (const? 32 31)) ⊑
+    select (icmp IntPred.eq e_1 e) (const? 1 1)
+      (icmp IntPred.eq (sub e_1 e { «nsw» := true, «nuw» := false }) (const? 32 31)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/grangehcheck_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/grangehcheck_proof.lean
@@ -12,8 +12,8 @@ set_option Elab.async false
 
 section grangehcheck_proof
 theorem test_and1_thm (e e_1 : IntW 32) :
-  LLVM.and (icmp IntPredicate.sge e_1 (const? 32 0)) (icmp IntPredicate.slt e_1 (LLVM.and e (const? 32 2147483647))) ⊑
-    icmp IntPredicate.ult e_1 (LLVM.and e (const? 32 2147483647)) := by
+  LLVM.and (icmp IntPred.sge e_1 (const? 32 0)) (icmp IntPred.slt e_1 (LLVM.and e (const? 32 2147483647))) ⊑
+    icmp IntPred.ult e_1 (LLVM.and e (const? 32 2147483647)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -23,9 +23,9 @@ theorem test_and1_thm (e e_1 : IntW 32) :
 
 
 theorem test_and1_logical_thm (e e_1 : IntW 32) :
-  select (icmp IntPredicate.sge e_1 (const? 32 0)) (icmp IntPredicate.slt e_1 (LLVM.and e (const? 32 2147483647)))
+  select (icmp IntPred.sge e_1 (const? 32 0)) (icmp IntPred.slt e_1 (LLVM.and e (const? 32 2147483647)))
       (const? 1 0) ⊑
-    select (icmp IntPredicate.sgt e_1 (const? 32 (-1))) (icmp IntPredicate.slt e_1 (LLVM.and e (const? 32 2147483647)))
+    select (icmp IntPred.sgt e_1 (const? 32 (-1))) (icmp IntPred.slt e_1 (LLVM.and e (const? 32 2147483647)))
       (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
@@ -36,9 +36,9 @@ theorem test_and1_logical_thm (e e_1 : IntW 32) :
 
 
 theorem test_and2_thm (e e_1 : IntW 32) :
-  LLVM.and (icmp IntPredicate.sgt e_1 (const? 32 (-1)))
-      (icmp IntPredicate.sle e_1 (LLVM.and e (const? 32 2147483647))) ⊑
-    icmp IntPredicate.ule e_1 (LLVM.and e (const? 32 2147483647)) := by
+  LLVM.and (icmp IntPred.sgt e_1 (const? 32 (-1)))
+      (icmp IntPred.sle e_1 (LLVM.and e (const? 32 2147483647))) ⊑
+    icmp IntPred.ule e_1 (LLVM.and e (const? 32 2147483647)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -48,8 +48,8 @@ theorem test_and2_thm (e e_1 : IntW 32) :
 
 
 theorem test_and3_thm (e e_1 : IntW 32) :
-  LLVM.and (icmp IntPredicate.sgt (LLVM.and e_1 (const? 32 2147483647)) e) (icmp IntPredicate.sge e (const? 32 0)) ⊑
-    icmp IntPredicate.ult e (LLVM.and e_1 (const? 32 2147483647)) := by
+  LLVM.and (icmp IntPred.sgt (LLVM.and e_1 (const? 32 2147483647)) e) (icmp IntPred.sge e (const? 32 0)) ⊑
+    icmp IntPred.ult e (LLVM.and e_1 (const? 32 2147483647)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -59,9 +59,9 @@ theorem test_and3_thm (e e_1 : IntW 32) :
 
 
 theorem test_and3_logical_thm (e e_1 : IntW 32) :
-  select (icmp IntPredicate.sgt (LLVM.and e_1 (const? 32 2147483647)) e) (icmp IntPredicate.sge e (const? 32 0))
+  select (icmp IntPred.sgt (LLVM.and e_1 (const? 32 2147483647)) e) (icmp IntPred.sge e (const? 32 0))
       (const? 1 0) ⊑
-    icmp IntPredicate.ult e (LLVM.and e_1 (const? 32 2147483647)) := by
+    icmp IntPred.ult e (LLVM.and e_1 (const? 32 2147483647)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -71,8 +71,8 @@ theorem test_and3_logical_thm (e e_1 : IntW 32) :
 
 
 theorem test_and4_thm (e e_1 : IntW 32) :
-  LLVM.and (icmp IntPredicate.sge (LLVM.and e_1 (const? 32 2147483647)) e) (icmp IntPredicate.sge e (const? 32 0)) ⊑
-    icmp IntPredicate.ule e (LLVM.and e_1 (const? 32 2147483647)) := by
+  LLVM.and (icmp IntPred.sge (LLVM.and e_1 (const? 32 2147483647)) e) (icmp IntPred.sge e (const? 32 0)) ⊑
+    icmp IntPred.ule e (LLVM.and e_1 (const? 32 2147483647)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -82,9 +82,9 @@ theorem test_and4_thm (e e_1 : IntW 32) :
 
 
 theorem test_and4_logical_thm (e e_1 : IntW 32) :
-  select (icmp IntPredicate.sge (LLVM.and e_1 (const? 32 2147483647)) e) (icmp IntPredicate.sge e (const? 32 0))
+  select (icmp IntPred.sge (LLVM.and e_1 (const? 32 2147483647)) e) (icmp IntPred.sge e (const? 32 0))
       (const? 1 0) ⊑
-    icmp IntPredicate.ule e (LLVM.and e_1 (const? 32 2147483647)) := by
+    icmp IntPred.ule e (LLVM.and e_1 (const? 32 2147483647)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -94,8 +94,8 @@ theorem test_and4_logical_thm (e e_1 : IntW 32) :
 
 
 theorem test_or1_thm (e e_1 : IntW 32) :
-  LLVM.or (icmp IntPredicate.slt e_1 (const? 32 0)) (icmp IntPredicate.sge e_1 (LLVM.and e (const? 32 2147483647))) ⊑
-    icmp IntPredicate.uge e_1 (LLVM.and e (const? 32 2147483647)) := by
+  LLVM.or (icmp IntPred.slt e_1 (const? 32 0)) (icmp IntPred.sge e_1 (LLVM.and e (const? 32 2147483647))) ⊑
+    icmp IntPred.uge e_1 (LLVM.and e (const? 32 2147483647)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -105,8 +105,8 @@ theorem test_or1_thm (e e_1 : IntW 32) :
 
 
 theorem test_or2_thm (e e_1 : IntW 32) :
-  LLVM.or (icmp IntPredicate.sle e_1 (const? 32 (-1))) (icmp IntPredicate.sgt e_1 (LLVM.and e (const? 32 2147483647))) ⊑
-    icmp IntPredicate.ugt e_1 (LLVM.and e (const? 32 2147483647)) := by
+  LLVM.or (icmp IntPred.sle e_1 (const? 32 (-1))) (icmp IntPred.sgt e_1 (LLVM.and e (const? 32 2147483647))) ⊑
+    icmp IntPred.ugt e_1 (LLVM.and e (const? 32 2147483647)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -116,10 +116,10 @@ theorem test_or2_thm (e e_1 : IntW 32) :
 
 
 theorem test_or2_logical_thm (e e_1 : IntW 32) :
-  select (icmp IntPredicate.sle e_1 (const? 32 (-1))) (const? 1 1)
-      (icmp IntPredicate.sgt e_1 (LLVM.and e (const? 32 2147483647))) ⊑
-    select (icmp IntPredicate.slt e_1 (const? 32 0)) (const? 1 1)
-      (icmp IntPredicate.sgt e_1 (LLVM.and e (const? 32 2147483647))) := by
+  select (icmp IntPred.sle e_1 (const? 32 (-1))) (const? 1 1)
+      (icmp IntPred.sgt e_1 (LLVM.and e (const? 32 2147483647))) ⊑
+    select (icmp IntPred.slt e_1 (const? 32 0)) (const? 1 1)
+      (icmp IntPred.sgt e_1 (LLVM.and e (const? 32 2147483647))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -129,8 +129,8 @@ theorem test_or2_logical_thm (e e_1 : IntW 32) :
 
 
 theorem test_or3_thm (e e_1 : IntW 32) :
-  LLVM.or (icmp IntPredicate.sle (LLVM.and e_1 (const? 32 2147483647)) e) (icmp IntPredicate.slt e (const? 32 0)) ⊑
-    icmp IntPredicate.uge e (LLVM.and e_1 (const? 32 2147483647)) := by
+  LLVM.or (icmp IntPred.sle (LLVM.and e_1 (const? 32 2147483647)) e) (icmp IntPred.slt e (const? 32 0)) ⊑
+    icmp IntPred.uge e (LLVM.and e_1 (const? 32 2147483647)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -140,9 +140,9 @@ theorem test_or3_thm (e e_1 : IntW 32) :
 
 
 theorem test_or3_logical_thm (e e_1 : IntW 32) :
-  select (icmp IntPredicate.sle (LLVM.and e_1 (const? 32 2147483647)) e) (const? 1 1)
-      (icmp IntPredicate.slt e (const? 32 0)) ⊑
-    icmp IntPredicate.uge e (LLVM.and e_1 (const? 32 2147483647)) := by
+  select (icmp IntPred.sle (LLVM.and e_1 (const? 32 2147483647)) e) (const? 1 1)
+      (icmp IntPred.slt e (const? 32 0)) ⊑
+    icmp IntPred.uge e (LLVM.and e_1 (const? 32 2147483647)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -152,8 +152,8 @@ theorem test_or3_logical_thm (e e_1 : IntW 32) :
 
 
 theorem test_or4_thm (e e_1 : IntW 32) :
-  LLVM.or (icmp IntPredicate.slt (LLVM.and e_1 (const? 32 2147483647)) e) (icmp IntPredicate.slt e (const? 32 0)) ⊑
-    icmp IntPredicate.ugt e (LLVM.and e_1 (const? 32 2147483647)) := by
+  LLVM.or (icmp IntPred.slt (LLVM.and e_1 (const? 32 2147483647)) e) (icmp IntPred.slt e (const? 32 0)) ⊑
+    icmp IntPred.ugt e (LLVM.and e_1 (const? 32 2147483647)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -163,9 +163,9 @@ theorem test_or4_thm (e e_1 : IntW 32) :
 
 
 theorem test_or4_logical_thm (e e_1 : IntW 32) :
-  select (icmp IntPredicate.slt (LLVM.and e_1 (const? 32 2147483647)) e) (const? 1 1)
-      (icmp IntPredicate.slt e (const? 32 0)) ⊑
-    icmp IntPredicate.ugt e (LLVM.and e_1 (const? 32 2147483647)) := by
+  select (icmp IntPred.slt (LLVM.and e_1 (const? 32 2147483647)) e) (const? 1 1)
+      (icmp IntPred.slt e (const? 32 0)) ⊑
+    icmp IntPred.ugt e (LLVM.and e_1 (const? 32 2147483647)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -175,10 +175,10 @@ theorem test_or4_logical_thm (e e_1 : IntW 32) :
 
 
 theorem negative1_logical_thm (e e_1 : IntW 32) :
-  select (icmp IntPredicate.slt e_1 (LLVM.and e (const? 32 2147483647))) (icmp IntPredicate.sgt e_1 (const? 32 0))
+  select (icmp IntPred.slt e_1 (LLVM.and e (const? 32 2147483647))) (icmp IntPred.sgt e_1 (const? 32 0))
       (const? 1 0) ⊑
-    LLVM.and (icmp IntPredicate.slt e_1 (LLVM.and e (const? 32 2147483647)))
-      (icmp IntPredicate.sgt e_1 (const? 32 0)) := by
+    LLVM.and (icmp IntPred.slt e_1 (LLVM.and e (const? 32 2147483647)))
+      (icmp IntPred.sgt e_1 (const? 32 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -188,8 +188,8 @@ theorem negative1_logical_thm (e e_1 : IntW 32) :
 
 
 theorem negative2_thm (e e_1 : IntW 32) :
-  LLVM.and (icmp IntPredicate.slt e_1 e) (icmp IntPredicate.sge e_1 (const? 32 0)) ⊑
-    LLVM.and (icmp IntPredicate.slt e_1 e) (icmp IntPredicate.sgt e_1 (const? 32 (-1))) := by
+  LLVM.and (icmp IntPred.slt e_1 e) (icmp IntPred.sge e_1 (const? 32 0)) ⊑
+    LLVM.and (icmp IntPred.slt e_1 e) (icmp IntPred.sgt e_1 (const? 32 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -199,8 +199,8 @@ theorem negative2_thm (e e_1 : IntW 32) :
 
 
 theorem negative2_logical_thm (e e_1 : IntW 32) :
-  select (icmp IntPredicate.slt e_1 e) (icmp IntPredicate.sge e_1 (const? 32 0)) (const? 1 0) ⊑
-    LLVM.and (icmp IntPredicate.slt e_1 e) (icmp IntPredicate.sgt e_1 (const? 32 (-1))) := by
+  select (icmp IntPred.slt e_1 e) (icmp IntPred.sge e_1 (const? 32 0)) (const? 1 0) ⊑
+    LLVM.and (icmp IntPred.slt e_1 e) (icmp IntPred.sgt e_1 (const? 32 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -210,9 +210,9 @@ theorem negative2_logical_thm (e e_1 : IntW 32) :
 
 
 theorem negative3_thm (e e_1 e_2 : IntW 32) :
-  LLVM.and (icmp IntPredicate.slt e_2 (LLVM.and e_1 (const? 32 2147483647))) (icmp IntPredicate.sge e (const? 32 0)) ⊑
-    LLVM.and (icmp IntPredicate.slt e_2 (LLVM.and e_1 (const? 32 2147483647)))
-      (icmp IntPredicate.sgt e (const? 32 (-1))) := by
+  LLVM.and (icmp IntPred.slt e_2 (LLVM.and e_1 (const? 32 2147483647))) (icmp IntPred.sge e (const? 32 0)) ⊑
+    LLVM.and (icmp IntPred.slt e_2 (LLVM.and e_1 (const? 32 2147483647)))
+      (icmp IntPred.sgt e (const? 32 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -222,9 +222,9 @@ theorem negative3_thm (e e_1 e_2 : IntW 32) :
 
 
 theorem negative3_logical_thm (e e_1 e_2 : IntW 32) :
-  select (icmp IntPredicate.slt e_2 (LLVM.and e_1 (const? 32 2147483647))) (icmp IntPredicate.sge e (const? 32 0))
+  select (icmp IntPred.slt e_2 (LLVM.and e_1 (const? 32 2147483647))) (icmp IntPred.sge e (const? 32 0))
       (const? 1 0) ⊑
-    select (icmp IntPredicate.slt e_2 (LLVM.and e_1 (const? 32 2147483647))) (icmp IntPredicate.sgt e (const? 32 (-1)))
+    select (icmp IntPred.slt e_2 (LLVM.and e_1 (const? 32 2147483647))) (icmp IntPred.sgt e (const? 32 (-1)))
       (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
@@ -235,9 +235,9 @@ theorem negative3_logical_thm (e e_1 e_2 : IntW 32) :
 
 
 theorem negative4_thm (e e_1 : IntW 32) :
-  LLVM.and (icmp IntPredicate.ne e_1 (LLVM.and e (const? 32 2147483647))) (icmp IntPredicate.sge e_1 (const? 32 0)) ⊑
-    LLVM.and (icmp IntPredicate.ne e_1 (LLVM.and e (const? 32 2147483647)))
-      (icmp IntPredicate.sgt e_1 (const? 32 (-1))) := by
+  LLVM.and (icmp IntPred.ne e_1 (LLVM.and e (const? 32 2147483647))) (icmp IntPred.sge e_1 (const? 32 0)) ⊑
+    LLVM.and (icmp IntPred.ne e_1 (LLVM.and e (const? 32 2147483647)))
+      (icmp IntPred.sgt e_1 (const? 32 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -247,10 +247,10 @@ theorem negative4_thm (e e_1 : IntW 32) :
 
 
 theorem negative4_logical_thm (e e_1 : IntW 32) :
-  select (icmp IntPredicate.ne e_1 (LLVM.and e (const? 32 2147483647))) (icmp IntPredicate.sge e_1 (const? 32 0))
+  select (icmp IntPred.ne e_1 (LLVM.and e (const? 32 2147483647))) (icmp IntPred.sge e_1 (const? 32 0))
       (const? 1 0) ⊑
-    LLVM.and (icmp IntPredicate.ne e_1 (LLVM.and e (const? 32 2147483647)))
-      (icmp IntPredicate.sgt e_1 (const? 32 (-1))) := by
+    LLVM.and (icmp IntPred.ne e_1 (LLVM.and e (const? 32 2147483647)))
+      (icmp IntPred.sgt e_1 (const? 32 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -260,7 +260,7 @@ theorem negative4_logical_thm (e e_1 : IntW 32) :
 
 
 theorem negative5_thm (e e_1 : IntW 32) :
-  LLVM.or (icmp IntPredicate.slt e_1 (LLVM.and e (const? 32 2147483647))) (icmp IntPredicate.sge e_1 (const? 32 0)) ⊑
+  LLVM.or (icmp IntPred.slt e_1 (LLVM.and e (const? 32 2147483647))) (icmp IntPred.sge e_1 (const? 32 0)) ⊑
     const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
@@ -271,8 +271,8 @@ theorem negative5_thm (e e_1 : IntW 32) :
 
 
 theorem negative5_logical_thm (e e_1 : IntW 32) :
-  select (icmp IntPredicate.slt e_1 (LLVM.and e (const? 32 2147483647))) (const? 1 1)
-      (icmp IntPredicate.sge e_1 (const? 32 0)) ⊑
+  select (icmp IntPred.slt e_1 (LLVM.and e (const? 32 2147483647))) (const? 1 1)
+      (icmp IntPred.sge e_1 (const? 32 0)) ⊑
     const? 1 1 := by
     simp_alive_undef
     simp_alive_ops

--- a/SSA/Projects/InstCombine/tests/proofs/grem_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/grem_proof.lean
@@ -30,8 +30,8 @@ theorem test3_thm (e : IntW 32) : urem e (const? 32 8) ⊑ LLVM.and e (const? 32
 
 
 theorem test3a_thm (e : IntW 32) :
-  icmp IntPredicate.ne (LLVM.srem e (const? 32 (-8))) (const? 32 0) ⊑
-    icmp IntPredicate.ne (LLVM.and e (const? 32 7)) (const? 32 0) := by
+  icmp IntPred.ne (LLVM.srem e (const? 32 (-8))) (const? 32 0) ⊑
+    icmp IntPred.ne (LLVM.and e (const? 32 7)) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -165,7 +165,7 @@ theorem test16_thm (e e_1 : IntW 32) :
     all_goals sorry
 
 
-theorem test17_thm (e : IntW 32) : urem (const? 32 1) e ⊑ zext 32 (icmp IntPredicate.ne e (const? 32 1)) := by
+theorem test17_thm (e : IntW 32) : urem (const? 32 1) e ⊑ zext 32 (icmp IntPred.ne e (const? 32 1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -175,9 +175,9 @@ theorem test17_thm (e : IntW 32) : urem (const? 32 1) e ⊑ zext 32 (icmp IntPre
 
 
 theorem test18_thm (e : IntW 16) (e_1 : IntW 32) :
-  urem e_1 (select (icmp IntPredicate.ne (LLVM.and e (const? 16 4)) (const? 16 0)) (const? 32 32) (const? 32 64)) ⊑
+  urem e_1 (select (icmp IntPred.ne (LLVM.and e (const? 16 4)) (const? 16 0)) (const? 32 32) (const? 32 64)) ⊑
     LLVM.and e_1
-      (select (icmp IntPredicate.eq (LLVM.and e (const? 16 4)) (const? 16 0)) (const? 32 63) (const? 32 31)) := by
+      (select (icmp IntPred.eq (LLVM.and e (const? 16 4)) (const? 16 0)) (const? 32 63) (const? 32 31)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -264,8 +264,8 @@ theorem test22_thm (e : IntW 32) :
 
 
 theorem test24_thm (e : IntW 32) :
-  icmp IntPredicate.ne (urem e (const? 32 (-2147483648))) (const? 32 0) ⊑
-    icmp IntPredicate.ne (LLVM.and e (const? 32 2147483647)) (const? 32 0) := by
+  icmp IntPred.ne (urem e (const? 32 (-2147483648))) (const? 32 0) ⊑
+    icmp IntPred.ne (LLVM.and e (const? 32 2147483647)) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -275,8 +275,8 @@ theorem test24_thm (e : IntW 32) :
 
 
 theorem test25_thm (e : IntW 32) :
-  icmp IntPredicate.ne (LLVM.srem e (const? 32 (-2147483648))) (const? 32 0) ⊑
-    icmp IntPredicate.ne (LLVM.and e (const? 32 2147483647)) (const? 32 0) := by
+  icmp IntPred.ne (LLVM.srem e (const? 32 (-2147483648))) (const? 32 0) ⊑
+    icmp IntPred.ne (LLVM.and e (const? 32 2147483647)) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -286,8 +286,8 @@ theorem test25_thm (e : IntW 32) :
 
 
 theorem test26_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.ne (LLVM.srem e_1 (shl (const? 32 1) e)) (const? 32 0) ⊑
-    icmp IntPredicate.ne
+  icmp IntPred.ne (LLVM.srem e_1 (shl (const? 32 1) e)) (const? 32 0) ⊑
+    icmp IntPred.ne
       (LLVM.and e_1 (LLVM.xor (shl (const? 32 (-1)) e { «nsw» := true, «nuw» := false }) (const? 32 (-1))))
       (const? 32 0) := by
     simp_alive_undef
@@ -299,8 +299,8 @@ theorem test26_thm (e e_1 : IntW 32) :
 
 
 theorem test28_thm (e : IntW 32) :
-  icmp IntPredicate.eq (LLVM.srem e (const? 32 (-2147483648))) (const? 32 0) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 32 2147483647)) (const? 32 0) := by
+  icmp IntPred.eq (LLVM.srem e (const? 32 (-2147483648))) (const? 32 0) ⊑
+    icmp IntPred.eq (LLVM.and e (const? 32 2147483647)) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -310,8 +310,8 @@ theorem test28_thm (e : IntW 32) :
 
 
 theorem positive_and_odd_eq_thm (e : IntW 32) :
-  icmp IntPredicate.eq (LLVM.srem e (const? 32 2)) (const? 32 1) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 32 (-2147483647))) (const? 32 1) := by
+  icmp IntPred.eq (LLVM.srem e (const? 32 2)) (const? 32 1) ⊑
+    icmp IntPred.eq (LLVM.and e (const? 32 (-2147483647))) (const? 32 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -321,8 +321,8 @@ theorem positive_and_odd_eq_thm (e : IntW 32) :
 
 
 theorem positive_and_odd_ne_thm (e : IntW 32) :
-  icmp IntPredicate.ne (LLVM.srem e (const? 32 2)) (const? 32 1) ⊑
-    icmp IntPredicate.ne (LLVM.and e (const? 32 (-2147483647))) (const? 32 1) := by
+  icmp IntPred.ne (LLVM.srem e (const? 32 2)) (const? 32 1) ⊑
+    icmp IntPred.ne (LLVM.and e (const? 32 (-2147483647))) (const? 32 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/greusehconstanthfromhselecthinhicmp_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/greusehconstanthfromhselecthinhicmp_proof.lean
@@ -12,8 +12,8 @@ set_option Elab.async false
 
 section greusehconstanthfromhselecthinhicmp_proof
 theorem p0_ult_65536_thm (e e_1 : IntW 32) :
-  select (icmp IntPredicate.ult e_1 (const? 32 65536)) e (const? 32 65535) ⊑
-    select (icmp IntPredicate.ugt e_1 (const? 32 65535)) (const? 32 65535) e := by
+  select (icmp IntPred.ult e_1 (const? 32 65536)) e (const? 32 65535) ⊑
+    select (icmp IntPred.ugt e_1 (const? 32 65535)) (const? 32 65535) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -23,8 +23,8 @@ theorem p0_ult_65536_thm (e e_1 : IntW 32) :
 
 
 theorem p1_ugt_thm (e e_1 : IntW 32) :
-  select (icmp IntPredicate.ugt e_1 (const? 32 65534)) e (const? 32 65535) ⊑
-    select (icmp IntPredicate.ult e_1 (const? 32 65535)) (const? 32 65535) e := by
+  select (icmp IntPred.ugt e_1 (const? 32 65534)) e (const? 32 65535) ⊑
+    select (icmp IntPred.ult e_1 (const? 32 65535)) (const? 32 65535) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -34,8 +34,8 @@ theorem p1_ugt_thm (e e_1 : IntW 32) :
 
 
 theorem p2_slt_65536_thm (e e_1 : IntW 32) :
-  select (icmp IntPredicate.slt e_1 (const? 32 65536)) e (const? 32 65535) ⊑
-    select (icmp IntPredicate.sgt e_1 (const? 32 65535)) (const? 32 65535) e := by
+  select (icmp IntPred.slt e_1 (const? 32 65536)) e (const? 32 65535) ⊑
+    select (icmp IntPred.sgt e_1 (const? 32 65535)) (const? 32 65535) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -45,8 +45,8 @@ theorem p2_slt_65536_thm (e e_1 : IntW 32) :
 
 
 theorem p3_sgt_thm (e e_1 : IntW 32) :
-  select (icmp IntPredicate.sgt e_1 (const? 32 65534)) e (const? 32 65535) ⊑
-    select (icmp IntPredicate.slt e_1 (const? 32 65535)) (const? 32 65535) e := by
+  select (icmp IntPred.sgt e_1 (const? 32 65534)) e (const? 32 65535) ⊑
+    select (icmp IntPred.slt e_1 (const? 32 65535)) (const? 32 65535) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -56,8 +56,8 @@ theorem p3_sgt_thm (e e_1 : IntW 32) :
 
 
 theorem p13_commutativity0_thm (e e_1 : IntW 32) :
-  select (icmp IntPredicate.ult e_1 (const? 32 65536)) (const? 32 65535) e ⊑
-    select (icmp IntPredicate.ugt e_1 (const? 32 65535)) e (const? 32 65535) := by
+  select (icmp IntPred.ult e_1 (const? 32 65536)) (const? 32 65535) e ⊑
+    select (icmp IntPred.ugt e_1 (const? 32 65535)) e (const? 32 65535) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -67,8 +67,8 @@ theorem p13_commutativity0_thm (e e_1 : IntW 32) :
 
 
 theorem p14_commutativity1_thm (e : IntW 32) :
-  select (icmp IntPredicate.ult e (const? 32 65536)) (const? 32 65535) (const? 32 42) ⊑
-    select (icmp IntPredicate.ugt e (const? 32 65535)) (const? 32 42) (const? 32 65535) := by
+  select (icmp IntPred.ult e (const? 32 65536)) (const? 32 65535) (const? 32 42) ⊑
+    select (icmp IntPred.ugt e (const? 32 65535)) (const? 32 42) (const? 32 65535) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -78,8 +78,8 @@ theorem p14_commutativity1_thm (e : IntW 32) :
 
 
 theorem p15_commutativity2_thm (e : IntW 32) :
-  select (icmp IntPredicate.ult e (const? 32 65536)) (const? 32 42) (const? 32 65535) ⊑
-    select (icmp IntPredicate.ugt e (const? 32 65535)) (const? 32 65535) (const? 32 42) := by
+  select (icmp IntPred.ult e (const? 32 65536)) (const? 32 42) (const? 32 65535) ⊑
+    select (icmp IntPred.ugt e (const? 32 65535)) (const? 32 65535) (const? 32 42) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -89,8 +89,8 @@ theorem p15_commutativity2_thm (e : IntW 32) :
 
 
 theorem t22_sign_check_thm (e e_1 : IntW 32) :
-  select (icmp IntPredicate.slt e_1 (const? 32 0)) (const? 32 (-1)) e ⊑
-    select (icmp IntPredicate.sgt e_1 (const? 32 (-1))) e (const? 32 (-1)) := by
+  select (icmp IntPred.slt e_1 (const? 32 0)) (const? 32 (-1)) e ⊑
+    select (icmp IntPred.sgt e_1 (const? 32 (-1))) e (const? 32 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -100,8 +100,8 @@ theorem t22_sign_check_thm (e e_1 : IntW 32) :
 
 
 theorem t22_sign_check2_thm (e e_1 : IntW 32) :
-  select (icmp IntPredicate.sgt e_1 (const? 32 (-1))) (const? 32 0) e ⊑
-    select (icmp IntPredicate.slt e_1 (const? 32 0)) e (const? 32 0) := by
+  select (icmp IntPred.sgt e_1 (const? 32 (-1))) (const? 32 0) e ⊑
+    select (icmp IntPred.slt e_1 (const? 32 0)) e (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gsaturatinghaddhsub_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gsaturatinghaddhsub_proof.lean
@@ -12,8 +12,8 @@ set_option Elab.async false
 
 section gsaturatinghaddhsub_proof
 theorem test_simplify_decrement_invalid_ne_thm (e : IntW 8) :
-  select (icmp IntPredicate.ne e (const? 8 0)) (const? 8 0) (sub e (const? 8 1)) ⊑
-    sext 8 (icmp IntPredicate.eq e (const? 8 0)) := by
+  select (icmp IntPred.ne e (const? 8 0)) (const? 8 0) (sub e (const? 8 1)) ⊑
+    sext 8 (icmp IntPred.eq e (const? 8 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -23,8 +23,8 @@ theorem test_simplify_decrement_invalid_ne_thm (e : IntW 8) :
 
 
 theorem test_invalid_simplify_sub2_thm (e : IntW 8) :
-  select (icmp IntPredicate.eq e (const? 8 0)) (const? 8 0) (sub e (const? 8 2)) ⊑
-    select (icmp IntPredicate.eq e (const? 8 0)) (const? 8 0) (add e (const? 8 (-2))) := by
+  select (icmp IntPred.eq e (const? 8 0)) (const? 8 0) (sub e (const? 8 2)) ⊑
+    select (icmp IntPred.eq e (const? 8 0)) (const? 8 0) (add e (const? 8 (-2))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -34,8 +34,8 @@ theorem test_invalid_simplify_sub2_thm (e : IntW 8) :
 
 
 theorem test_invalid_simplify_eq2_thm (e : IntW 8) :
-  select (icmp IntPredicate.eq e (const? 8 2)) (const? 8 0) (sub e (const? 8 1)) ⊑
-    select (icmp IntPredicate.eq e (const? 8 2)) (const? 8 0) (add e (const? 8 (-1))) := by
+  select (icmp IntPred.eq e (const? 8 2)) (const? 8 0) (sub e (const? 8 1)) ⊑
+    select (icmp IntPred.eq e (const? 8 2)) (const? 8 0) (add e (const? 8 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -45,8 +45,8 @@ theorem test_invalid_simplify_eq2_thm (e : IntW 8) :
 
 
 theorem test_invalid_simplify_select_1_thm (e : IntW 8) :
-  select (icmp IntPredicate.eq e (const? 8 0)) (const? 8 1) (sub e (const? 8 1)) ⊑
-    select (icmp IntPredicate.eq e (const? 8 0)) (const? 8 1) (add e (const? 8 (-1))) := by
+  select (icmp IntPred.eq e (const? 8 0)) (const? 8 1) (sub e (const? 8 1)) ⊑
+    select (icmp IntPred.eq e (const? 8 0)) (const? 8 1) (add e (const? 8 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -56,8 +56,8 @@ theorem test_invalid_simplify_select_1_thm (e : IntW 8) :
 
 
 theorem test_invalid_simplify_other_thm (e e_1 : IntW 8) :
-  select (icmp IntPredicate.eq e_1 (const? 8 0)) (const? 8 0) (sub e (const? 8 1)) ⊑
-    select (icmp IntPredicate.eq e_1 (const? 8 0)) (const? 8 0) (add e (const? 8 (-1))) := by
+  select (icmp IntPred.eq e_1 (const? 8 0)) (const? 8 0) (sub e (const? 8 1)) ⊑
+    select (icmp IntPred.eq e_1 (const? 8 0)) (const? 8 0) (add e (const? 8 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -67,8 +67,8 @@ theorem test_invalid_simplify_other_thm (e e_1 : IntW 8) :
 
 
 theorem uadd_sat_flipped_wrong_bounds_thm (e : IntW 32) :
-  select (icmp IntPredicate.uge e (const? 32 (-12))) (const? 32 (-1)) (add e (const? 32 9)) ⊑
-    select (icmp IntPredicate.ugt e (const? 32 (-13))) (const? 32 (-1)) (add e (const? 32 9)) := by
+  select (icmp IntPred.uge e (const? 32 (-12))) (const? 32 (-1)) (add e (const? 32 9)) ⊑
+    select (icmp IntPred.ugt e (const? 32 (-13))) (const? 32 (-1)) (add e (const? 32 9)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -78,8 +78,8 @@ theorem uadd_sat_flipped_wrong_bounds_thm (e : IntW 32) :
 
 
 theorem uadd_sat_flipped_wrong_bounds4_thm (e : IntW 32) :
-  select (icmp IntPredicate.uge e (const? 32 (-8))) (const? 32 (-1)) (add e (const? 32 9)) ⊑
-    select (icmp IntPredicate.ugt e (const? 32 (-9))) (const? 32 (-1)) (add e (const? 32 9)) := by
+  select (icmp IntPred.uge e (const? 32 (-8))) (const? 32 (-1)) (add e (const? 32 9)) ⊑
+    select (icmp IntPred.ugt e (const? 32 (-9))) (const? 32 (-1)) (add e (const? 32 9)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -89,8 +89,8 @@ theorem uadd_sat_flipped_wrong_bounds4_thm (e : IntW 32) :
 
 
 theorem uadd_sat_flipped_wrong_bounds6_thm (e : IntW 32) :
-  select (icmp IntPredicate.ule e (const? 32 (-12))) (add e (const? 32 9)) (const? 32 (-1)) ⊑
-    select (icmp IntPredicate.ult e (const? 32 (-11))) (add e (const? 32 9)) (const? 32 (-1)) := by
+  select (icmp IntPred.ule e (const? 32 (-12))) (add e (const? 32 9)) (const? 32 (-1)) ⊑
+    select (icmp IntPred.ult e (const? 32 (-11))) (add e (const? 32 9)) (const? 32 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -100,8 +100,8 @@ theorem uadd_sat_flipped_wrong_bounds6_thm (e : IntW 32) :
 
 
 theorem uadd_sat_flipped_wrong_bounds7_thm (e : IntW 32) :
-  select (icmp IntPredicate.ule e (const? 32 (-12))) (add e (const? 32 9)) (const? 32 (-1)) ⊑
-    select (icmp IntPredicate.ult e (const? 32 (-11))) (add e (const? 32 9)) (const? 32 (-1)) := by
+  select (icmp IntPred.ule e (const? 32 (-12))) (add e (const? 32 9)) (const? 32 (-1)) ⊑
+    select (icmp IntPred.ult e (const? 32 (-11))) (add e (const? 32 9)) (const? 32 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -111,7 +111,7 @@ theorem uadd_sat_flipped_wrong_bounds7_thm (e : IntW 32) :
 
 
 theorem uadd_sat_canon_nuw_thm (e e_1 : IntW 32) :
-  select (icmp IntPredicate.ult (add e_1 e { «nsw» := false, «nuw» := true }) e_1) (const? 32 (-1))
+  select (icmp IntPred.ult (add e_1 e { «nsw» := false, «nuw» := true }) e_1) (const? 32 (-1))
       (add e_1 e { «nsw» := false, «nuw» := true }) ⊑
     add e_1 e { «nsw» := false, «nuw» := true } := by
     simp_alive_undef
@@ -123,7 +123,7 @@ theorem uadd_sat_canon_nuw_thm (e e_1 : IntW 32) :
 
 
 theorem uadd_sat_canon_y_nuw_thm (e e_1 : IntW 32) :
-  select (icmp IntPredicate.ult (add e_1 e { «nsw» := false, «nuw» := true }) e) (const? 32 (-1))
+  select (icmp IntPred.ult (add e_1 e { «nsw» := false, «nuw» := true }) e) (const? 32 (-1))
       (add e_1 e { «nsw» := false, «nuw» := true }) ⊑
     add e_1 e { «nsw» := false, «nuw» := true } := by
     simp_alive_undef
@@ -135,8 +135,8 @@ theorem uadd_sat_canon_y_nuw_thm (e e_1 : IntW 32) :
 
 
 theorem uadd_sat_via_add_nonstrict_thm (e e_1 : IntW 32) :
-  select (icmp IntPredicate.ule (add e_1 e) e) (const? 32 (-1)) (add e_1 e) ⊑
-    select (icmp IntPredicate.ugt (add e_1 e) e) (add e_1 e) (const? 32 (-1)) := by
+  select (icmp IntPred.ule (add e_1 e) e) (const? 32 (-1)) (add e_1 e) ⊑
+    select (icmp IntPred.ugt (add e_1 e) e) (add e_1 e) (const? 32 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -146,8 +146,8 @@ theorem uadd_sat_via_add_nonstrict_thm (e e_1 : IntW 32) :
 
 
 theorem uadd_sat_via_add_swapped_cmp_nonstrict_thm (e e_1 : IntW 32) :
-  select (icmp IntPredicate.uge e_1 (add e e_1)) (const? 32 (-1)) (add e e_1) ⊑
-    select (icmp IntPredicate.ult e_1 (add e e_1)) (add e e_1) (const? 32 (-1)) := by
+  select (icmp IntPred.uge e_1 (add e e_1)) (const? 32 (-1)) (add e e_1) ⊑
+    select (icmp IntPred.ult e_1 (add e e_1)) (add e e_1) (const? 32 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gsdivhexacthbyhpowerhofhtwo_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gsdivhexacthbyhpowerhofhtwo_proof.lean
@@ -22,7 +22,7 @@ theorem t0_thm (e : IntW 8) :
 
 
 theorem n2_thm (e : IntW 8) :
-  LLVM.sdiv e (const? 8 (-128)) ⊑ zext 8 (icmp IntPredicate.eq e (const? 8 (-128))) := by
+  LLVM.sdiv e (const? 8 (-128)) ⊑ zext 8 (icmp IntPred.eq e (const? 8 (-128))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gsdivhicmp_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gsdivhicmp_proof.lean
@@ -12,8 +12,8 @@ set_option Elab.async false
 
 section gsdivhicmp_proof
 theorem sdiv_exact_eq_0_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.eq (LLVM.sdiv e_1 e { «exact» := true }) (const? 8 0) ⊑
-    icmp IntPredicate.eq e_1 (const? 8 0) := by
+  icmp IntPred.eq (LLVM.sdiv e_1 e { «exact» := true }) (const? 8 0) ⊑
+    icmp IntPred.eq e_1 (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -23,8 +23,8 @@ theorem sdiv_exact_eq_0_thm (e e_1 : IntW 8) :
 
 
 theorem udiv_exact_ne_0_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.ne (LLVM.udiv e_1 e { «exact» := true }) (const? 8 0) ⊑
-    icmp IntPredicate.ne e_1 (const? 8 0) := by
+  icmp IntPred.ne (LLVM.udiv e_1 e { «exact» := true }) (const? 8 0) ⊑
+    icmp IntPred.ne e_1 (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -34,8 +34,8 @@ theorem udiv_exact_ne_0_thm (e e_1 : IntW 8) :
 
 
 theorem sdiv_exact_ne_1_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.eq (LLVM.sdiv e_1 e { «exact» := true }) (const? 8 0) ⊑
-    icmp IntPredicate.eq e_1 (const? 8 0) := by
+  icmp IntPred.eq (LLVM.sdiv e_1 e { «exact» := true }) (const? 8 0) ⊑
+    icmp IntPred.eq e_1 (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -45,7 +45,7 @@ theorem sdiv_exact_ne_1_thm (e e_1 : IntW 8) :
 
 
 theorem udiv_exact_eq_1_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.ne (LLVM.udiv e_1 e { «exact» := true }) (const? 8 1) ⊑ icmp IntPredicate.ne e_1 e := by
+  icmp IntPred.ne (LLVM.udiv e_1 e { «exact» := true }) (const? 8 1) ⊑ icmp IntPred.ne e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -55,8 +55,8 @@ theorem udiv_exact_eq_1_thm (e e_1 : IntW 8) :
 
 
 theorem sdiv_exact_eq_9_no_of_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.eq (LLVM.sdiv e_1 (LLVM.and e (const? 8 7)) { «exact» := true }) (const? 8 9) ⊑
-    icmp IntPredicate.eq (mul (LLVM.and e (const? 8 7)) (const? 8 9) { «nsw» := true, «nuw» := true }) e_1 := by
+  icmp IntPred.eq (LLVM.sdiv e_1 (LLVM.and e (const? 8 7)) { «exact» := true }) (const? 8 9) ⊑
+    icmp IntPred.eq (mul (LLVM.and e (const? 8 7)) (const? 8 9) { «nsw» := true, «nuw» := true }) e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -66,8 +66,8 @@ theorem sdiv_exact_eq_9_no_of_thm (e e_1 : IntW 8) :
 
 
 theorem udiv_exact_ne_30_no_of_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.ne (LLVM.udiv e_1 (LLVM.and e (const? 8 7)) { «exact» := true }) (const? 8 30) ⊑
-    icmp IntPredicate.ne (mul (LLVM.and e (const? 8 7)) (const? 8 30) { «nsw» := false, «nuw» := true }) e_1 := by
+  icmp IntPred.ne (LLVM.udiv e_1 (LLVM.and e (const? 8 7)) { «exact» := true }) (const? 8 30) ⊑
+    icmp IntPred.ne (mul (LLVM.and e (const? 8 7)) (const? 8 30) { «nsw» := false, «nuw» := true }) e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gselect_meta_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gselect_meta_proof.lean
@@ -12,9 +12,9 @@ set_option Elab.async false
 
 section gselect_meta_proof
 theorem foo_thm (e : IntW 32) :
-  select (icmp IntPredicate.sgt e (const? 32 2)) (add e (const? 32 20) { «nsw» := true, «nuw» := false })
+  select (icmp IntPred.sgt e (const? 32 2)) (add e (const? 32 20) { «nsw» := true, «nuw» := false })
       (add e (const? 32 (-20))) ⊑
-    add e (select (icmp IntPredicate.sgt e (const? 32 2)) (const? 32 20) (const? 32 (-20))) := by
+    add e (select (icmp IntPred.sgt e (const? 32 2)) (const? 32 20) (const? 32 (-20))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -34,9 +34,9 @@ theorem shrink_select_thm (e : IntW 32) (e_1 : IntW 1) :
 
 
 theorem foo2_thm (e e_1 : IntW 32) :
-  select (icmp IntPredicate.sgt e_1 (const? 32 2)) (add e_1 e { «nsw» := true, «nuw» := false })
+  select (icmp IntPred.sgt e_1 (const? 32 2)) (add e_1 e { «nsw» := true, «nuw» := false })
       (sub e_1 e { «nsw» := true, «nuw» := false }) ⊑
-    add e_1 (select (icmp IntPredicate.sgt e_1 (const? 32 2)) e (sub (const? 32 0) e)) := by
+    add e_1 (select (icmp IntPred.sgt e_1 (const? 32 2)) e (sub (const? 32 0) e)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gselecthandhor_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gselecthandhor_proof.lean
@@ -70,8 +70,8 @@ theorem logical_or_not_cond_reuse_thm (e e_1 : IntW 1) :
 
 
 theorem logical_or_implies_thm (e : IntW 32) :
-  select (icmp IntPredicate.eq e (const? 32 0)) (const? 1 1) (icmp IntPredicate.eq e (const? 32 42)) ⊑
-    LLVM.or (icmp IntPredicate.eq e (const? 32 0)) (icmp IntPredicate.eq e (const? 32 42)) := by
+  select (icmp IntPred.eq e (const? 32 0)) (const? 1 1) (icmp IntPred.eq e (const? 32 42)) ⊑
+    LLVM.or (icmp IntPred.eq e (const? 32 0)) (icmp IntPred.eq e (const? 32 42)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -81,7 +81,7 @@ theorem logical_or_implies_thm (e : IntW 32) :
 
 
 theorem logical_or_implies_folds_thm (e : IntW 32) :
-  select (icmp IntPredicate.slt e (const? 32 0)) (const? 1 1) (icmp IntPredicate.sge e (const? 32 0)) ⊑
+  select (icmp IntPred.slt e (const? 32 0)) (const? 1 1) (icmp IntPred.sge e (const? 32 0)) ⊑
     const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
@@ -92,8 +92,8 @@ theorem logical_or_implies_folds_thm (e : IntW 32) :
 
 
 theorem logical_and_implies_thm (e : IntW 32) :
-  select (icmp IntPredicate.ne e (const? 32 0)) (icmp IntPredicate.ne e (const? 32 42)) (const? 1 0) ⊑
-    LLVM.and (icmp IntPredicate.ne e (const? 32 0)) (icmp IntPredicate.ne e (const? 32 42)) := by
+  select (icmp IntPred.ne e (const? 32 0)) (icmp IntPred.ne e (const? 32 42)) (const? 1 0) ⊑
+    LLVM.and (icmp IntPred.ne e (const? 32 0)) (icmp IntPred.ne e (const? 32 42)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -103,8 +103,8 @@ theorem logical_and_implies_thm (e : IntW 32) :
 
 
 theorem logical_and_implies_folds_thm (e : IntW 32) :
-  select (icmp IntPredicate.ugt e (const? 32 42)) (icmp IntPredicate.ne e (const? 32 0)) (const? 1 0) ⊑
-    icmp IntPredicate.ugt e (const? 32 42) := by
+  select (icmp IntPred.ugt e (const? 32 42)) (icmp IntPred.ne e (const? 32 0)) (const? 1 0) ⊑
+    icmp IntPred.ugt e (const? 32 42) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -220,8 +220,8 @@ theorem and_or2_wrong_operand_thm (e e_1 e_2 e_3 : IntW 1) :
 
 
 theorem and_or3_thm (e : IntW 1) (e_1 e_2 : IntW 32) (e_3 : IntW 1) :
-  select (LLVM.and e_3 (icmp IntPredicate.eq e_2 e_1)) e e_3 ⊑
-    select e_3 (select (icmp IntPredicate.ne e_2 e_1) (const? 1 1) e) (const? 1 0) := by
+  select (LLVM.and e_3 (icmp IntPred.eq e_2 e_1)) e e_3 ⊑
+    select e_3 (select (icmp IntPred.ne e_2 e_1) (const? 1 1) e) (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -231,8 +231,8 @@ theorem and_or3_thm (e : IntW 1) (e_1 e_2 : IntW 32) (e_3 : IntW 1) :
 
 
 theorem and_or3_commuted_thm (e e_1 : IntW 1) (e_2 e_3 : IntW 32) :
-  select (LLVM.and (icmp IntPredicate.eq e_3 e_2) e_1) e e_1 ⊑
-    select e_1 (select (icmp IntPredicate.ne e_3 e_2) (const? 1 1) e) (const? 1 0) := by
+  select (LLVM.and (icmp IntPred.eq e_3 e_2) e_1) e e_1 ⊑
+    select e_1 (select (icmp IntPred.ne e_3 e_2) (const? 1 1) e) (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -291,8 +291,8 @@ theorem pr64558_thm (e e_1 : IntW 1) : select (LLVM.and (LLVM.xor e_1 (const? 1 
 
 
 theorem or_and3_thm (e : IntW 1) (e_1 e_2 : IntW 32) (e_3 : IntW 1) :
-  select (LLVM.or e_3 (icmp IntPredicate.eq e_2 e_1)) e_3 e ⊑
-    select e_3 (const? 1 1) (select (icmp IntPredicate.ne e_2 e_1) e (const? 1 0)) := by
+  select (LLVM.or e_3 (icmp IntPred.eq e_2 e_1)) e_3 e ⊑
+    select e_3 (const? 1 1) (select (icmp IntPred.ne e_2 e_1) e (const? 1 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -302,8 +302,8 @@ theorem or_and3_thm (e : IntW 1) (e_1 e_2 : IntW 32) (e_3 : IntW 1) :
 
 
 theorem or_and3_commuted_thm (e e_1 : IntW 1) (e_2 e_3 : IntW 32) :
-  select (LLVM.or (icmp IntPredicate.eq e_3 e_2) e_1) e_1 e ⊑
-    select e_1 (const? 1 1) (select (icmp IntPredicate.ne e_3 e_2) e (const? 1 0)) := by
+  select (LLVM.or (icmp IntPred.eq e_3 e_2) e_1) e_1 e ⊑
+    select e_1 (const? 1 1) (select (icmp IntPred.ne e_3 e_2) e (const? 1 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -313,7 +313,7 @@ theorem or_and3_commuted_thm (e e_1 : IntW 1) (e_2 e_3 : IntW 32) :
 
 
 theorem test_or_eq_a_b_thm (e e_1 : IntW 8) (e_2 : IntW 1) :
-  select (LLVM.or e_2 (icmp IntPredicate.eq e_1 e)) e_1 e ⊑ select e_2 e_1 e := by
+  select (LLVM.or e_2 (icmp IntPred.eq e_1 e)) e_1 e ⊑ select e_2 e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -323,7 +323,7 @@ theorem test_or_eq_a_b_thm (e e_1 : IntW 8) (e_2 : IntW 1) :
 
 
 theorem test_and_ne_a_b_thm (e e_1 : IntW 8) (e_2 : IntW 1) :
-  select (LLVM.and e_2 (icmp IntPredicate.ne e_1 e)) e_1 e ⊑ select e_2 e_1 e := by
+  select (LLVM.and e_2 (icmp IntPred.ne e_1 e)) e_1 e ⊑ select e_2 e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -333,7 +333,7 @@ theorem test_and_ne_a_b_thm (e e_1 : IntW 8) (e_2 : IntW 1) :
 
 
 theorem test_or_eq_a_b_commuted_thm (e e_1 : IntW 8) (e_2 : IntW 1) :
-  select (LLVM.or e_2 (icmp IntPredicate.eq e_1 e)) e e_1 ⊑ select e_2 e e_1 := by
+  select (LLVM.or e_2 (icmp IntPred.eq e_1 e)) e e_1 ⊑ select e_2 e e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -343,7 +343,7 @@ theorem test_or_eq_a_b_commuted_thm (e e_1 : IntW 8) (e_2 : IntW 1) :
 
 
 theorem test_and_ne_a_b_commuted_thm (e e_1 : IntW 8) (e_2 : IntW 1) :
-  select (LLVM.and e_2 (icmp IntPredicate.ne e_1 e)) e e_1 ⊑ select e_2 e e_1 := by
+  select (LLVM.and e_2 (icmp IntPred.ne e_1 e)) e e_1 ⊑ select e_2 e e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -353,8 +353,8 @@ theorem test_and_ne_a_b_commuted_thm (e e_1 : IntW 8) (e_2 : IntW 1) :
 
 
 theorem test_or_eq_different_operands_thm (e e_1 e_2 : IntW 8) :
-  select (LLVM.or (icmp IntPredicate.eq e_2 e_1) (icmp IntPredicate.eq e e_2)) e_2 e ⊑
-    select (icmp IntPredicate.eq e_2 e_1) e_2 e := by
+  select (LLVM.or (icmp IntPred.eq e_2 e_1) (icmp IntPred.eq e e_2)) e_2 e ⊑
+    select (icmp IntPred.eq e_2 e_1) e_2 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -364,7 +364,7 @@ theorem test_or_eq_different_operands_thm (e e_1 e_2 : IntW 8) :
 
 
 theorem test_or_ne_a_b_thm (e e_1 : IntW 8) (e_2 : IntW 1) :
-  select (LLVM.or e_2 (icmp IntPredicate.ne e_1 e)) e_1 e ⊑ e_1 := by
+  select (LLVM.or e_2 (icmp IntPred.ne e_1 e)) e_1 e ⊑ e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -374,7 +374,7 @@ theorem test_or_ne_a_b_thm (e e_1 : IntW 8) (e_2 : IntW 1) :
 
 
 theorem test_logical_or_eq_a_b_thm (e e_1 : IntW 8) (e_2 : IntW 1) :
-  select (select e_2 (const? 1 1) (icmp IntPredicate.eq e_1 e)) e_1 e ⊑ select e_2 e_1 e := by
+  select (select e_2 (const? 1 1) (icmp IntPred.eq e_1 e)) e_1 e ⊑ select e_2 e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -384,7 +384,7 @@ theorem test_logical_or_eq_a_b_thm (e e_1 : IntW 8) (e_2 : IntW 1) :
 
 
 theorem test_logical_and_ne_a_b_thm (e e_1 : IntW 8) (e_2 : IntW 1) :
-  select (select e_2 (icmp IntPredicate.ne e_1 e) (const? 1 0)) e_1 e ⊑ select e_2 e_1 e := by
+  select (select e_2 (icmp IntPred.ne e_1 e) (const? 1 0)) e_1 e ⊑ select e_2 e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gselecthbinophcmp_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gselecthbinophcmp_proof.lean
@@ -12,8 +12,8 @@ set_option Elab.async false
 
 section gselecthbinophcmp_proof
 theorem select_xor_icmp_thm (e e_1 e_2 : IntW 32) :
-  select (icmp IntPredicate.eq e_2 (const? 32 0)) (LLVM.xor e_2 e_1) e ⊑
-    select (icmp IntPredicate.eq e_2 (const? 32 0)) e_1 e := by
+  select (icmp IntPred.eq e_2 (const? 32 0)) (LLVM.xor e_2 e_1) e ⊑
+    select (icmp IntPred.eq e_2 (const? 32 0)) e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -23,8 +23,8 @@ theorem select_xor_icmp_thm (e e_1 e_2 : IntW 32) :
 
 
 theorem select_xor_icmp2_thm (e e_1 e_2 : IntW 32) :
-  select (icmp IntPredicate.ne e_2 (const? 32 0)) e_1 (LLVM.xor e_2 e) ⊑
-    select (icmp IntPredicate.eq e_2 (const? 32 0)) e e_1 := by
+  select (icmp IntPred.ne e_2 (const? 32 0)) e_1 (LLVM.xor e_2 e) ⊑
+    select (icmp IntPred.eq e_2 (const? 32 0)) e e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -34,8 +34,8 @@ theorem select_xor_icmp2_thm (e e_1 e_2 : IntW 32) :
 
 
 theorem select_xor_icmp_meta_thm (e e_1 e_2 : IntW 32) :
-  select (icmp IntPredicate.eq e_2 (const? 32 0)) (LLVM.xor e_2 e_1) e ⊑
-    select (icmp IntPredicate.eq e_2 (const? 32 0)) e_1 e := by
+  select (icmp IntPred.eq e_2 (const? 32 0)) (LLVM.xor e_2 e_1) e ⊑
+    select (icmp IntPred.eq e_2 (const? 32 0)) e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -45,8 +45,8 @@ theorem select_xor_icmp_meta_thm (e e_1 e_2 : IntW 32) :
 
 
 theorem select_mul_icmp_thm (e e_1 e_2 : IntW 32) :
-  select (icmp IntPredicate.eq e_2 (const? 32 1)) (mul e_2 e_1) e ⊑
-    select (icmp IntPredicate.eq e_2 (const? 32 1)) e_1 e := by
+  select (icmp IntPred.eq e_2 (const? 32 1)) (mul e_2 e_1) e ⊑
+    select (icmp IntPred.eq e_2 (const? 32 1)) e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -56,8 +56,8 @@ theorem select_mul_icmp_thm (e e_1 e_2 : IntW 32) :
 
 
 theorem select_add_icmp_thm (e e_1 e_2 : IntW 32) :
-  select (icmp IntPredicate.eq e_2 (const? 32 0)) (add e_2 e_1) e ⊑
-    select (icmp IntPredicate.eq e_2 (const? 32 0)) e_1 e := by
+  select (icmp IntPred.eq e_2 (const? 32 0)) (add e_2 e_1) e ⊑
+    select (icmp IntPred.eq e_2 (const? 32 0)) e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -67,8 +67,8 @@ theorem select_add_icmp_thm (e e_1 e_2 : IntW 32) :
 
 
 theorem select_or_icmp_thm (e e_1 e_2 : IntW 32) :
-  select (icmp IntPredicate.eq e_2 (const? 32 0)) (LLVM.or e_2 e_1) e ⊑
-    select (icmp IntPredicate.eq e_2 (const? 32 0)) e_1 e := by
+  select (icmp IntPred.eq e_2 (const? 32 0)) (LLVM.or e_2 e_1) e ⊑
+    select (icmp IntPred.eq e_2 (const? 32 0)) e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -78,8 +78,8 @@ theorem select_or_icmp_thm (e e_1 e_2 : IntW 32) :
 
 
 theorem select_and_icmp_thm (e e_1 e_2 : IntW 32) :
-  select (icmp IntPredicate.eq e_2 (const? 32 (-1))) (LLVM.and e_2 e_1) e ⊑
-    select (icmp IntPredicate.eq e_2 (const? 32 (-1))) e_1 e := by
+  select (icmp IntPred.eq e_2 (const? 32 (-1))) (LLVM.and e_2 e_1) e ⊑
+    select (icmp IntPred.eq e_2 (const? 32 (-1))) e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -89,8 +89,8 @@ theorem select_and_icmp_thm (e e_1 e_2 : IntW 32) :
 
 
 theorem select_xor_inv_icmp_thm (e e_1 e_2 : IntW 32) :
-  select (icmp IntPredicate.eq e_2 (const? 32 0)) (LLVM.xor e_1 e_2) e ⊑
-    select (icmp IntPredicate.eq e_2 (const? 32 0)) e_1 e := by
+  select (icmp IntPred.eq e_2 (const? 32 0)) (LLVM.xor e_1 e_2) e ⊑
+    select (icmp IntPred.eq e_2 (const? 32 0)) e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -100,8 +100,8 @@ theorem select_xor_inv_icmp_thm (e e_1 e_2 : IntW 32) :
 
 
 theorem select_sub_icmp_thm (e e_1 e_2 : IntW 32) :
-  select (icmp IntPredicate.eq e_2 (const? 32 0)) (sub e_1 e_2) e ⊑
-    select (icmp IntPredicate.eq e_2 (const? 32 0)) e_1 e := by
+  select (icmp IntPred.eq e_2 (const? 32 0)) (sub e_1 e_2) e ⊑
+    select (icmp IntPred.eq e_2 (const? 32 0)) e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -111,8 +111,8 @@ theorem select_sub_icmp_thm (e e_1 e_2 : IntW 32) :
 
 
 theorem select_lshr_icmp_thm (e e_1 e_2 : IntW 32) :
-  select (icmp IntPredicate.eq e_2 (const? 32 0)) (lshr e_1 e_2) e ⊑
-    select (icmp IntPredicate.eq e_2 (const? 32 0)) e_1 e := by
+  select (icmp IntPred.eq e_2 (const? 32 0)) (lshr e_1 e_2) e ⊑
+    select (icmp IntPred.eq e_2 (const? 32 0)) e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -122,8 +122,8 @@ theorem select_lshr_icmp_thm (e e_1 e_2 : IntW 32) :
 
 
 theorem select_udiv_icmp_thm (e e_1 e_2 : IntW 32) :
-  select (icmp IntPredicate.eq e_2 (const? 32 1)) (LLVM.udiv e_1 e_2) e ⊑
-    select (icmp IntPredicate.eq e_2 (const? 32 1)) e_1 e := by
+  select (icmp IntPred.eq e_2 (const? 32 1)) (LLVM.udiv e_1 e_2) e ⊑
+    select (icmp IntPred.eq e_2 (const? 32 1)) e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -133,8 +133,8 @@ theorem select_udiv_icmp_thm (e e_1 e_2 : IntW 32) :
 
 
 theorem select_xor_icmp_bad_3_thm (e e_1 e_2 : IntW 32) :
-  select (icmp IntPredicate.eq e_2 (const? 32 3)) (LLVM.xor e_2 e_1) e ⊑
-    select (icmp IntPredicate.eq e_2 (const? 32 3)) (LLVM.xor e_1 (const? 32 3)) e := by
+  select (icmp IntPred.eq e_2 (const? 32 3)) (LLVM.xor e_2 e_1) e ⊑
+    select (icmp IntPred.eq e_2 (const? 32 3)) (LLVM.xor e_1 (const? 32 3)) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -144,8 +144,8 @@ theorem select_xor_icmp_bad_3_thm (e e_1 e_2 : IntW 32) :
 
 
 theorem select_xor_icmp_bad_5_thm (e e_1 e_2 : IntW 32) :
-  select (icmp IntPredicate.ne e_2 (const? 32 0)) (LLVM.xor e_2 e_1) e ⊑
-    select (icmp IntPredicate.eq e_2 (const? 32 0)) e (LLVM.xor e_2 e_1) := by
+  select (icmp IntPred.ne e_2 (const? 32 0)) (LLVM.xor e_2 e_1) e ⊑
+    select (icmp IntPred.eq e_2 (const? 32 0)) e (LLVM.xor e_2 e_1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -155,8 +155,8 @@ theorem select_xor_icmp_bad_5_thm (e e_1 e_2 : IntW 32) :
 
 
 theorem select_xor_icmp_bad_6_thm (e e_1 e_2 : IntW 32) :
-  select (icmp IntPredicate.ne e_2 (const? 32 1)) e_1 (LLVM.xor e_2 e) ⊑
-    select (icmp IntPredicate.eq e_2 (const? 32 1)) (LLVM.xor e (const? 32 1)) e_1 := by
+  select (icmp IntPred.ne e_2 (const? 32 1)) e_1 (LLVM.xor e_2 e) ⊑
+    select (icmp IntPred.eq e_2 (const? 32 1)) (LLVM.xor e (const? 32 1)) e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -166,8 +166,8 @@ theorem select_xor_icmp_bad_6_thm (e e_1 e_2 : IntW 32) :
 
 
 theorem select_mul_icmp_bad_thm (e e_1 e_2 : IntW 32) :
-  select (icmp IntPredicate.eq e_2 (const? 32 3)) (mul e_2 e_1) e ⊑
-    select (icmp IntPredicate.eq e_2 (const? 32 3)) (mul e_1 (const? 32 3)) e := by
+  select (icmp IntPred.eq e_2 (const? 32 3)) (mul e_2 e_1) e ⊑
+    select (icmp IntPred.eq e_2 (const? 32 3)) (mul e_1 (const? 32 3)) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -177,8 +177,8 @@ theorem select_mul_icmp_bad_thm (e e_1 e_2 : IntW 32) :
 
 
 theorem select_add_icmp_bad_thm (e e_1 e_2 : IntW 32) :
-  select (icmp IntPredicate.eq e_2 (const? 32 1)) (add e_2 e_1) e ⊑
-    select (icmp IntPredicate.eq e_2 (const? 32 1)) (add e_1 (const? 32 1)) e := by
+  select (icmp IntPred.eq e_2 (const? 32 1)) (add e_2 e_1) e ⊑
+    select (icmp IntPred.eq e_2 (const? 32 1)) (add e_1 (const? 32 1)) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -188,8 +188,8 @@ theorem select_add_icmp_bad_thm (e e_1 e_2 : IntW 32) :
 
 
 theorem select_and_icmp_zero_thm (e e_1 e_2 : IntW 32) :
-  select (icmp IntPredicate.eq e_2 (const? 32 0)) (LLVM.and e_2 e_1) e ⊑
-    select (icmp IntPredicate.eq e_2 (const? 32 0)) (const? 32 0) e := by
+  select (icmp IntPred.eq e_2 (const? 32 0)) (LLVM.and e_2 e_1) e ⊑
+    select (icmp IntPred.eq e_2 (const? 32 0)) (const? 32 0) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -199,8 +199,8 @@ theorem select_and_icmp_zero_thm (e e_1 e_2 : IntW 32) :
 
 
 theorem select_or_icmp_bad_thm (e e_1 e_2 : IntW 32) :
-  select (icmp IntPredicate.eq e_2 (const? 32 3)) (LLVM.or e_2 e_1) e ⊑
-    select (icmp IntPredicate.eq e_2 (const? 32 3)) (LLVM.or e_1 (const? 32 3)) e := by
+  select (icmp IntPred.eq e_2 (const? 32 3)) (LLVM.or e_2 e_1) e ⊑
+    select (icmp IntPred.eq e_2 (const? 32 3)) (LLVM.or e_1 (const? 32 3)) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -210,7 +210,7 @@ theorem select_or_icmp_bad_thm (e e_1 e_2 : IntW 32) :
 
 
 theorem select_lshr_icmp_const_thm (e : IntW 32) :
-  select (icmp IntPredicate.ugt e (const? 32 31)) (lshr e (const? 32 5)) (const? 32 0) ⊑ lshr e (const? 32 5) := by
+  select (icmp IntPred.ugt e (const? 32 31)) (lshr e (const? 32 5)) (const? 32 0) ⊑ lshr e (const? 32 5) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -220,7 +220,7 @@ theorem select_lshr_icmp_const_thm (e : IntW 32) :
 
 
 theorem select_lshr_icmp_const_reordered_thm (e : IntW 32) :
-  select (icmp IntPredicate.ult e (const? 32 32)) (const? 32 0) (lshr e (const? 32 5)) ⊑ lshr e (const? 32 5) := by
+  select (icmp IntPred.ult e (const? 32 32)) (const? 32 0) (lshr e (const? 32 5)) ⊑ lshr e (const? 32 5) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -230,7 +230,7 @@ theorem select_lshr_icmp_const_reordered_thm (e : IntW 32) :
 
 
 theorem select_exact_lshr_icmp_const_thm (e : IntW 32) :
-  select (icmp IntPredicate.ugt e (const? 32 31)) (lshr e (const? 32 5) { «exact» := true }) (const? 32 0) ⊑
+  select (icmp IntPred.ugt e (const? 32 31)) (lshr e (const? 32 5) { «exact» := true }) (const? 32 0) ⊑
     lshr e (const? 32 5) := by
     simp_alive_undef
     simp_alive_ops
@@ -241,8 +241,8 @@ theorem select_exact_lshr_icmp_const_thm (e : IntW 32) :
 
 
 theorem select_sub_icmp_bad_thm (e e_1 e_2 : IntW 32) :
-  select (icmp IntPredicate.eq e_2 (const? 32 0)) (sub e_2 e_1) e ⊑
-    select (icmp IntPredicate.eq e_2 (const? 32 0)) (sub (const? 32 0) e_1) e := by
+  select (icmp IntPred.eq e_2 (const? 32 0)) (sub e_2 e_1) e ⊑
+    select (icmp IntPred.eq e_2 (const? 32 0)) (sub (const? 32 0) e_1) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -252,8 +252,8 @@ theorem select_sub_icmp_bad_thm (e e_1 e_2 : IntW 32) :
 
 
 theorem select_sub_icmp_bad_2_thm (e e_1 e_2 : IntW 32) :
-  select (icmp IntPredicate.eq e_2 (const? 32 1)) (sub e_1 e_2) e ⊑
-    select (icmp IntPredicate.eq e_2 (const? 32 1)) (add e_1 (const? 32 (-1))) e := by
+  select (icmp IntPred.eq e_2 (const? 32 1)) (sub e_1 e_2) e ⊑
+    select (icmp IntPred.eq e_2 (const? 32 1)) (add e_1 (const? 32 (-1))) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -263,8 +263,8 @@ theorem select_sub_icmp_bad_2_thm (e e_1 e_2 : IntW 32) :
 
 
 theorem select_shl_icmp_bad_thm (e e_1 e_2 : IntW 32) :
-  select (icmp IntPredicate.eq e_2 (const? 32 1)) (shl e_1 e_2) e ⊑
-    select (icmp IntPredicate.eq e_2 (const? 32 1)) (shl e_1 (const? 32 1)) e := by
+  select (icmp IntPred.eq e_2 (const? 32 1)) (shl e_1 e_2) e ⊑
+    select (icmp IntPred.eq e_2 (const? 32 1)) (shl e_1 (const? 32 1)) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -274,8 +274,8 @@ theorem select_shl_icmp_bad_thm (e e_1 e_2 : IntW 32) :
 
 
 theorem select_lshr_icmp_bad_thm (e e_1 e_2 : IntW 32) :
-  select (icmp IntPredicate.eq e_2 (const? 32 1)) (lshr e_1 e_2) e ⊑
-    select (icmp IntPredicate.eq e_2 (const? 32 1)) (lshr e_1 (const? 32 1)) e := by
+  select (icmp IntPred.eq e_2 (const? 32 1)) (lshr e_1 e_2) e ⊑
+    select (icmp IntPred.eq e_2 (const? 32 1)) (lshr e_1 (const? 32 1)) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -285,8 +285,8 @@ theorem select_lshr_icmp_bad_thm (e e_1 e_2 : IntW 32) :
 
 
 theorem select_ashr_icmp_bad_thm (e e_1 e_2 : IntW 32) :
-  select (icmp IntPredicate.eq e_2 (const? 32 1)) (ashr e_1 e_2) e ⊑
-    select (icmp IntPredicate.eq e_2 (const? 32 1)) (ashr e_1 (const? 32 1)) e := by
+  select (icmp IntPred.eq e_2 (const? 32 1)) (ashr e_1 e_2) e ⊑
+    select (icmp IntPred.eq e_2 (const? 32 1)) (ashr e_1 (const? 32 1)) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -296,8 +296,8 @@ theorem select_ashr_icmp_bad_thm (e e_1 e_2 : IntW 32) :
 
 
 theorem select_replace_one_use_thm (e e_1 : IntW 32) :
-  select (icmp IntPredicate.eq e_1 (const? 32 0)) (sub e_1 e) e ⊑
-    select (icmp IntPredicate.eq e_1 (const? 32 0)) (sub (const? 32 0) e) e := by
+  select (icmp IntPred.eq e_1 (const? 32 0)) (sub e_1 e) e ⊑
+    select (icmp IntPred.eq e_1 (const? 32 0)) (sub (const? 32 0) e) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -307,8 +307,8 @@ theorem select_replace_one_use_thm (e e_1 : IntW 32) :
 
 
 theorem select_replace_nested_thm (e e_1 e_2 : IntW 32) :
-  select (icmp IntPredicate.eq e_2 (const? 32 0)) (add (sub e_1 e_2) e) e_1 ⊑
-    add e_1 (select (icmp IntPredicate.eq e_2 (const? 32 0)) e (const? 32 0)) := by
+  select (icmp IntPred.eq e_2 (const? 32 0)) (add (sub e_1 e_2) e) e_1 ⊑
+    add e_1 (select (icmp IntPred.eq e_2 (const? 32 0)) e (const? 32 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -318,8 +318,8 @@ theorem select_replace_nested_thm (e e_1 e_2 : IntW 32) :
 
 
 theorem select_replace_nested_no_simplify_thm (e e_1 e_2 : IntW 32) :
-  select (icmp IntPredicate.eq e_2 (const? 32 1)) (add (sub e_1 e_2) e) e_1 ⊑
-    select (icmp IntPredicate.eq e_2 (const? 32 1)) (add (add e_1 (const? 32 (-1))) e) e_1 := by
+  select (icmp IntPred.eq e_2 (const? 32 1)) (add (sub e_1 e_2) e) e_1 ⊑
+    select (icmp IntPred.eq e_2 (const? 32 1)) (add (add e_1 (const? 32 (-1))) e) e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -328,7 +328,7 @@ theorem select_replace_nested_no_simplify_thm (e e_1 e_2 : IntW 32) :
     all_goals sorry
 
 
-theorem select_replace_udiv_non_speculatable_thm (e e_1 : IntW 32) : select (icmp IntPredicate.eq e_1 (const? 32 0)) (LLVM.udiv e e_1) e ⊑ e := by
+theorem select_replace_udiv_non_speculatable_thm (e e_1 : IntW 32) : select (icmp IntPred.eq e_1 (const? 32 0)) (LLVM.udiv e e_1) e ⊑ e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gselecthbitext_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gselecthbitext_proof.lean
@@ -195,9 +195,9 @@ theorem test_zext4_thm (e e_1 : IntW 1) :
 
 
 theorem test_op_op_thm (e e_1 e_2 : IntW 32) :
-  select (icmp IntPredicate.sgt e_2 (const? 32 0)) (sext 32 (icmp IntPredicate.sgt e_1 (const? 32 0)))
-      (sext 32 (icmp IntPredicate.sgt e (const? 32 0))) ⊑
-    sext 32 (icmp IntPredicate.sgt (select (icmp IntPredicate.sgt e_2 (const? 32 0)) e_1 e) (const? 32 0)) := by
+  select (icmp IntPred.sgt e_2 (const? 32 0)) (sext 32 (icmp IntPred.sgt e_1 (const? 32 0)))
+      (sext 32 (icmp IntPred.sgt e (const? 32 0))) ⊑
+    sext 32 (icmp IntPred.sgt (select (icmp IntPred.sgt e_2 (const? 32 0)) e_1 e) (const? 32 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gselecthbitexthbitwisehops_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gselecthbitexthbitwisehops_proof.lean
@@ -12,7 +12,7 @@ set_option Elab.async false
 
 section gselecthbitexthbitwisehops_proof
 theorem sel_false_val_is_a_masked_shl_of_true_val1_thm (e : IntW 64) (e_1 : IntW 32) :
-  select (icmp IntPredicate.eq (LLVM.and e_1 (const? 32 15)) (const? 32 0)) e
+  select (icmp IntPred.eq (LLVM.and e_1 (const? 32 15)) (const? 32 0)) e
       (ashr e (zext 64 (shl (LLVM.and e_1 (const? 32 15)) (const? 32 2) { «nsw» := true, «nuw» := true }))) ⊑
     ashr e (zext 64 (LLVM.and (shl e_1 (const? 32 2)) (const? 32 60)) { «nneg» := true }) := by
     simp_alive_undef
@@ -25,7 +25,7 @@ theorem sel_false_val_is_a_masked_shl_of_true_val1_thm (e : IntW 64) (e_1 : IntW
 
 theorem sel_false_val_is_a_masked_shl_of_true_val2_thm (e : IntW 64) (e_1 : IntW 32) :
   select
-      (icmp IntPredicate.eq (shl (LLVM.and e_1 (const? 32 15)) (const? 32 2) { «nsw» := true, «nuw» := true })
+      (icmp IntPred.eq (shl (LLVM.and e_1 (const? 32 15)) (const? 32 2) { «nsw» := true, «nuw» := true })
         (const? 32 0))
       e (ashr e (zext 64 (shl (LLVM.and e_1 (const? 32 15)) (const? 32 2) { «nsw» := true, «nuw» := true }))) ⊑
     ashr e (zext 64 (LLVM.and (shl e_1 (const? 32 2)) (const? 32 60)) { «nneg» := true }) := by
@@ -38,7 +38,7 @@ theorem sel_false_val_is_a_masked_shl_of_true_val2_thm (e : IntW 64) (e_1 : IntW
 
 
 theorem sel_false_val_is_a_masked_lshr_of_true_val1_thm (e : IntW 64) (e_1 : IntW 32) :
-  select (icmp IntPredicate.eq (LLVM.and e_1 (const? 32 60)) (const? 32 0)) e
+  select (icmp IntPred.eq (LLVM.and e_1 (const? 32 60)) (const? 32 0)) e
       (ashr e (zext 64 (lshr (LLVM.and e_1 (const? 32 60)) (const? 32 2)))) ⊑
     ashr e (zext 64 (LLVM.and (lshr e_1 (const? 32 2)) (const? 32 15)) { «nneg» := true }) := by
     simp_alive_undef
@@ -50,7 +50,7 @@ theorem sel_false_val_is_a_masked_lshr_of_true_val1_thm (e : IntW 64) (e_1 : Int
 
 
 theorem sel_false_val_is_a_masked_lshr_of_true_val2_thm (e : IntW 64) (e_1 : IntW 32) :
-  select (icmp IntPredicate.eq (lshr (LLVM.and e_1 (const? 32 60)) (const? 32 2)) (const? 32 0)) e
+  select (icmp IntPred.eq (lshr (LLVM.and e_1 (const? 32 60)) (const? 32 2)) (const? 32 0)) e
       (ashr e (zext 64 (lshr (LLVM.and e_1 (const? 32 60)) (const? 32 2)))) ⊑
     ashr e (zext 64 (LLVM.and (lshr e_1 (const? 32 2)) (const? 32 15)) { «nneg» := true }) := by
     simp_alive_undef
@@ -62,7 +62,7 @@ theorem sel_false_val_is_a_masked_lshr_of_true_val2_thm (e : IntW 64) (e_1 : Int
 
 
 theorem sel_false_val_is_a_masked_ashr_of_true_val1_thm (e : IntW 64) (e_1 : IntW 32) :
-  select (icmp IntPredicate.eq (LLVM.and e_1 (const? 32 (-2147483588))) (const? 32 0)) e
+  select (icmp IntPred.eq (LLVM.and e_1 (const? 32 (-2147483588))) (const? 32 0)) e
       (ashr e (zext 64 (ashr (LLVM.and e_1 (const? 32 (-2147483588))) (const? 32 2)))) ⊑
     ashr e (zext 64 (LLVM.and (ashr e_1 (const? 32 2)) (const? 32 (-536870897))) { «nneg» := true }) := by
     simp_alive_undef
@@ -74,7 +74,7 @@ theorem sel_false_val_is_a_masked_ashr_of_true_val1_thm (e : IntW 64) (e_1 : Int
 
 
 theorem sel_false_val_is_a_masked_ashr_of_true_val2_thm (e : IntW 64) (e_1 : IntW 32) :
-  select (icmp IntPredicate.eq (ashr (LLVM.and e_1 (const? 32 (-2147483588))) (const? 32 2)) (const? 32 0)) e
+  select (icmp IntPred.eq (ashr (LLVM.and e_1 (const? 32 (-2147483588))) (const? 32 2)) (const? 32 0)) e
       (ashr e (zext 64 (ashr (LLVM.and e_1 (const? 32 (-2147483588))) (const? 32 2)))) ⊑
     ashr e (zext 64 (LLVM.and (ashr e_1 (const? 32 2)) (const? 32 (-536870897))) { «nneg» := true }) := by
     simp_alive_undef

--- a/SSA/Projects/InstCombine/tests/proofs/gselecthdivrem_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gselecthdivrem_proof.lean
@@ -112,7 +112,7 @@ theorem urem_common_dividend_defined_cond_thm (e e_1 e_2 : IntW 5) (e_3 : IntW 1
 
 
 theorem rem_euclid_1_thm (e : IntW 32) :
-  select (icmp IntPredicate.slt (LLVM.srem e (const? 32 8)) (const? 32 0))
+  select (icmp IntPred.slt (LLVM.srem e (const? 32 8)) (const? 32 0))
       (add (LLVM.srem e (const? 32 8)) (const? 32 8)) (LLVM.srem e (const? 32 8)) ⊑
     LLVM.and e (const? 32 7) := by
     simp_alive_undef
@@ -124,7 +124,7 @@ theorem rem_euclid_1_thm (e : IntW 32) :
 
 
 theorem rem_euclid_2_thm (e : IntW 32) :
-  select (icmp IntPredicate.sgt (LLVM.srem e (const? 32 8)) (const? 32 (-1))) (LLVM.srem e (const? 32 8))
+  select (icmp IntPred.sgt (LLVM.srem e (const? 32 8)) (const? 32 (-1))) (LLVM.srem e (const? 32 8))
       (add (LLVM.srem e (const? 32 8)) (const? 32 8)) ⊑
     LLVM.and e (const? 32 7) := by
     simp_alive_undef
@@ -136,9 +136,9 @@ theorem rem_euclid_2_thm (e : IntW 32) :
 
 
 theorem rem_euclid_wrong_sign_test_thm (e : IntW 32) :
-  select (icmp IntPredicate.sgt (LLVM.srem e (const? 32 8)) (const? 32 0))
+  select (icmp IntPred.sgt (LLVM.srem e (const? 32 8)) (const? 32 0))
       (add (LLVM.srem e (const? 32 8)) (const? 32 8)) (LLVM.srem e (const? 32 8)) ⊑
-    select (icmp IntPredicate.sgt (LLVM.srem e (const? 32 8)) (const? 32 0))
+    select (icmp IntPred.sgt (LLVM.srem e (const? 32 8)) (const? 32 0))
       (add (LLVM.srem e (const? 32 8)) (const? 32 8) { «nsw» := true, «nuw» := false })
       (LLVM.srem e (const? 32 8)) := by
     simp_alive_undef
@@ -150,9 +150,9 @@ theorem rem_euclid_wrong_sign_test_thm (e : IntW 32) :
 
 
 theorem rem_euclid_add_different_const_thm (e : IntW 32) :
-  select (icmp IntPredicate.slt (LLVM.srem e (const? 32 8)) (const? 32 0))
+  select (icmp IntPred.slt (LLVM.srem e (const? 32 8)) (const? 32 0))
       (add (LLVM.srem e (const? 32 8)) (const? 32 9)) (LLVM.srem e (const? 32 8)) ⊑
-    select (icmp IntPredicate.slt (LLVM.srem e (const? 32 8)) (const? 32 0))
+    select (icmp IntPred.slt (LLVM.srem e (const? 32 8)) (const? 32 0))
       (add (LLVM.srem e (const? 32 8)) (const? 32 9) { «nsw» := true, «nuw» := false })
       (LLVM.srem e (const? 32 8)) := by
     simp_alive_undef
@@ -164,9 +164,9 @@ theorem rem_euclid_add_different_const_thm (e : IntW 32) :
 
 
 theorem rem_euclid_wrong_operands_select_thm (e : IntW 32) :
-  select (icmp IntPredicate.slt (LLVM.srem e (const? 32 8)) (const? 32 0)) (LLVM.srem e (const? 32 8))
+  select (icmp IntPred.slt (LLVM.srem e (const? 32 8)) (const? 32 0)) (LLVM.srem e (const? 32 8))
       (add (LLVM.srem e (const? 32 8)) (const? 32 8)) ⊑
-    select (icmp IntPredicate.slt (LLVM.srem e (const? 32 8)) (const? 32 0)) (LLVM.srem e (const? 32 8))
+    select (icmp IntPred.slt (LLVM.srem e (const? 32 8)) (const? 32 0)) (LLVM.srem e (const? 32 8))
       (add (LLVM.srem e (const? 32 8)) (const? 32 8) { «nsw» := true, «nuw» := false }) := by
     simp_alive_undef
     simp_alive_ops
@@ -177,7 +177,7 @@ theorem rem_euclid_wrong_operands_select_thm (e : IntW 32) :
 
 
 theorem rem_euclid_i128_thm (e : IntW 128) :
-  select (icmp IntPredicate.slt (LLVM.srem e (const? 128 8)) (const? 128 0))
+  select (icmp IntPred.slt (LLVM.srem e (const? 128 8)) (const? 128 0))
       (add (LLVM.srem e (const? 128 8)) (const? 128 8)) (LLVM.srem e (const? 128 8)) ⊑
     LLVM.and e (const? 128 7) := by
     simp_alive_undef
@@ -189,7 +189,7 @@ theorem rem_euclid_i128_thm (e : IntW 128) :
 
 
 theorem rem_euclid_non_const_pow2_thm (e e_1 : IntW 8) :
-  select (icmp IntPredicate.slt (LLVM.srem e_1 (shl (const? 8 1) e)) (const? 8 0))
+  select (icmp IntPred.slt (LLVM.srem e_1 (shl (const? 8 1) e)) (const? 8 0))
       (add (LLVM.srem e_1 (shl (const? 8 1) e)) (shl (const? 8 1) e)) (LLVM.srem e_1 (shl (const? 8 1) e)) ⊑
     LLVM.and e_1 (LLVM.xor (shl (const? 8 (-1)) e { «nsw» := true, «nuw» := false }) (const? 8 (-1))) := by
     simp_alive_undef
@@ -201,7 +201,7 @@ theorem rem_euclid_non_const_pow2_thm (e e_1 : IntW 8) :
 
 
 theorem rem_euclid_pow2_true_arm_folded_thm (e : IntW 32) :
-  select (icmp IntPredicate.slt (LLVM.srem e (const? 32 2)) (const? 32 0)) (const? 32 1) (LLVM.srem e (const? 32 2)) ⊑
+  select (icmp IntPred.slt (LLVM.srem e (const? 32 2)) (const? 32 0)) (const? 32 1) (LLVM.srem e (const? 32 2)) ⊑
     LLVM.and e (const? 32 1) := by
     simp_alive_undef
     simp_alive_ops
@@ -212,7 +212,7 @@ theorem rem_euclid_pow2_true_arm_folded_thm (e : IntW 32) :
 
 
 theorem rem_euclid_pow2_false_arm_folded_thm (e : IntW 32) :
-  select (icmp IntPredicate.sge (LLVM.srem e (const? 32 2)) (const? 32 0)) (LLVM.srem e (const? 32 2)) (const? 32 1) ⊑
+  select (icmp IntPred.sge (LLVM.srem e (const? 32 2)) (const? 32 0)) (LLVM.srem e (const? 32 2)) (const? 32 1) ⊑
     LLVM.and e (const? 32 1) := by
     simp_alive_undef
     simp_alive_ops
@@ -223,12 +223,12 @@ theorem rem_euclid_pow2_false_arm_folded_thm (e : IntW 32) :
 
 
 theorem pr89516_thm (e e_1 : IntW 8) :
-  select (icmp IntPredicate.slt e_1 (const? 8 0))
+  select (icmp IntPred.slt e_1 (const? 8 0))
       (add (LLVM.srem (const? 8 1) (shl (const? 8 1) e { «nsw» := false, «nuw» := true }))
         (shl (const? 8 1) e { «nsw» := false, «nuw» := true }) { «nsw» := false, «nuw» := true })
       (LLVM.srem (const? 8 1) (shl (const? 8 1) e { «nsw» := false, «nuw» := true })) ⊑
     add (LLVM.srem (const? 8 1) (shl (const? 8 1) e { «nsw» := false, «nuw» := true }))
-      (select (icmp IntPredicate.slt e_1 (const? 8 0)) (shl (const? 8 1) e { «nsw» := false, «nuw» := true })
+      (select (icmp IntPred.slt e_1 (const? 8 0)) (shl (const? 8 1) e { «nsw» := false, «nuw» := true })
         (const? 8 0))
       { «nsw» := false, «nuw» := true } := by
     simp_alive_undef

--- a/SSA/Projects/InstCombine/tests/proofs/gselecthicmphand_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gselecthicmphand_proof.lean
@@ -12,7 +12,7 @@ set_option Elab.async false
 
 section gselecthicmphand_proof
 theorem test5_thm (e : IntW 41) :
-  select (icmp IntPredicate.ne (LLVM.and e (const? 41 32)) (const? 41 0)) (const? 41 32) (const? 41 0) ⊑
+  select (icmp IntPred.ne (LLVM.and e (const? 41 32)) (const? 41 0)) (const? 41 32) (const? 41 0) ⊑
     LLVM.and e (const? 41 32) := by
     simp_alive_undef
     simp_alive_ops
@@ -23,7 +23,7 @@ theorem test5_thm (e : IntW 41) :
 
 
 theorem test6_thm (e : IntW 1023) :
-  select (icmp IntPredicate.ne (LLVM.and e (const? 1023 64)) (const? 1023 0)) (const? 1023 64) (const? 1023 0) ⊑
+  select (icmp IntPred.ne (LLVM.and e (const? 1023 64)) (const? 1023 0)) (const? 1023 64) (const? 1023 0) ⊑
     LLVM.and e (const? 1023 64) := by
     simp_alive_undef
     simp_alive_ops
@@ -34,8 +34,8 @@ theorem test6_thm (e : IntW 1023) :
 
 
 theorem test35_thm (e : IntW 32) :
-  select (icmp IntPredicate.sge e (const? 32 0)) (const? 32 60) (const? 32 100) ⊑
-    select (icmp IntPredicate.sgt e (const? 32 (-1))) (const? 32 60) (const? 32 100) := by
+  select (icmp IntPred.sge e (const? 32 0)) (const? 32 60) (const? 32 100) ⊑
+    select (icmp IntPred.sgt e (const? 32 (-1))) (const? 32 60) (const? 32 100) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -45,8 +45,8 @@ theorem test35_thm (e : IntW 32) :
 
 
 theorem test35_with_trunc_thm (e : IntW 64) :
-  select (icmp IntPredicate.sge (trunc 32 e) (const? 32 0)) (const? 32 60) (const? 32 100) ⊑
-    select (icmp IntPredicate.eq (LLVM.and e (const? 64 2147483648)) (const? 64 0)) (const? 32 60)
+  select (icmp IntPred.sge (trunc 32 e) (const? 32 0)) (const? 32 60) (const? 32 100) ⊑
+    select (icmp IntPred.eq (LLVM.and e (const? 64 2147483648)) (const? 64 0)) (const? 32 60)
       (const? 32 100) := by
     simp_alive_undef
     simp_alive_ops
@@ -57,8 +57,8 @@ theorem test35_with_trunc_thm (e : IntW 64) :
 
 
 theorem test65_thm (e : IntW 64) :
-  select (icmp IntPredicate.ne (LLVM.and e (const? 64 16)) (const? 64 0)) (const? 32 40) (const? 32 42) ⊑
-    select (icmp IntPredicate.eq (LLVM.and e (const? 64 16)) (const? 64 0)) (const? 32 42) (const? 32 40) := by
+  select (icmp IntPred.ne (LLVM.and e (const? 64 16)) (const? 64 0)) (const? 32 40) (const? 32 42) ⊑
+    select (icmp IntPred.eq (LLVM.and e (const? 64 16)) (const? 64 0)) (const? 32 42) (const? 32 40) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -68,8 +68,8 @@ theorem test65_thm (e : IntW 64) :
 
 
 theorem test66_thm (e : IntW 64) :
-  select (icmp IntPredicate.ne (LLVM.and e (const? 64 4294967296)) (const? 64 0)) (const? 32 40) (const? 32 42) ⊑
-    select (icmp IntPredicate.eq (LLVM.and e (const? 64 4294967296)) (const? 64 0)) (const? 32 42)
+  select (icmp IntPred.ne (LLVM.and e (const? 64 4294967296)) (const? 64 0)) (const? 32 40) (const? 32 42) ⊑
+    select (icmp IntPred.eq (LLVM.and e (const? 64 4294967296)) (const? 64 0)) (const? 32 42)
       (const? 32 40) := by
     simp_alive_undef
     simp_alive_ops
@@ -80,8 +80,8 @@ theorem test66_thm (e : IntW 64) :
 
 
 theorem test67_thm (e : IntW 16) :
-  select (icmp IntPredicate.ne (LLVM.and e (const? 16 4)) (const? 16 0)) (const? 32 40) (const? 32 42) ⊑
-    select (icmp IntPredicate.eq (LLVM.and e (const? 16 4)) (const? 16 0)) (const? 32 42) (const? 32 40) := by
+  select (icmp IntPred.ne (LLVM.and e (const? 16 4)) (const? 16 0)) (const? 32 40) (const? 32 42) ⊑
+    select (icmp IntPred.eq (LLVM.and e (const? 16 4)) (const? 16 0)) (const? 32 42) (const? 32 40) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -91,8 +91,8 @@ theorem test67_thm (e : IntW 16) :
 
 
 theorem test71_thm (e : IntW 32) :
-  select (icmp IntPredicate.ne (LLVM.and e (const? 32 128)) (const? 32 0)) (const? 32 40) (const? 32 42) ⊑
-    select (icmp IntPredicate.eq (LLVM.and e (const? 32 128)) (const? 32 0)) (const? 32 42) (const? 32 40) := by
+  select (icmp IntPred.ne (LLVM.and e (const? 32 128)) (const? 32 0)) (const? 32 40) (const? 32 42) ⊑
+    select (icmp IntPred.eq (LLVM.and e (const? 32 128)) (const? 32 0)) (const? 32 42) (const? 32 40) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -102,8 +102,8 @@ theorem test71_thm (e : IntW 32) :
 
 
 theorem test73_thm (e : IntW 32) :
-  select (icmp IntPredicate.sgt (trunc 8 e) (const? 8 (-1))) (const? 32 40) (const? 32 42) ⊑
-    select (icmp IntPredicate.eq (LLVM.and e (const? 32 128)) (const? 32 0)) (const? 32 40) (const? 32 42) := by
+  select (icmp IntPred.sgt (trunc 8 e) (const? 8 (-1))) (const? 32 40) (const? 32 42) ⊑
+    select (icmp IntPred.eq (LLVM.and e (const? 32 128)) (const? 32 0)) (const? 32 40) (const? 32 42) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -113,7 +113,7 @@ theorem test73_thm (e : IntW 32) :
 
 
 theorem test15a_thm (e : IntW 32) :
-  select (icmp IntPredicate.eq (LLVM.and e (const? 32 16)) (const? 32 0)) (const? 32 0) (const? 32 16) ⊑
+  select (icmp IntPred.eq (LLVM.and e (const? 32 16)) (const? 32 0)) (const? 32 0) (const? 32 16) ⊑
     LLVM.and e (const? 32 16) := by
     simp_alive_undef
     simp_alive_ops
@@ -124,7 +124,7 @@ theorem test15a_thm (e : IntW 32) :
 
 
 theorem test15b_thm (e : IntW 32) :
-  select (icmp IntPredicate.eq (LLVM.and e (const? 32 32)) (const? 32 0)) (const? 32 32) (const? 32 0) ⊑
+  select (icmp IntPred.eq (LLVM.and e (const? 32 32)) (const? 32 0)) (const? 32 32) (const? 32 0) ⊑
     LLVM.xor (LLVM.and e (const? 32 32)) (const? 32 32) := by
     simp_alive_undef
     simp_alive_ops
@@ -135,7 +135,7 @@ theorem test15b_thm (e : IntW 32) :
 
 
 theorem test15c_thm (e : IntW 32) :
-  select (icmp IntPredicate.eq (LLVM.and e (const? 32 16)) (const? 32 16)) (const? 32 16) (const? 32 0) ⊑
+  select (icmp IntPred.eq (LLVM.and e (const? 32 16)) (const? 32 16)) (const? 32 16) (const? 32 0) ⊑
     LLVM.and e (const? 32 16) := by
     simp_alive_undef
     simp_alive_ops
@@ -146,7 +146,7 @@ theorem test15c_thm (e : IntW 32) :
 
 
 theorem test15d_thm (e : IntW 32) :
-  select (icmp IntPredicate.ne (LLVM.and e (const? 32 16)) (const? 32 0)) (const? 32 16) (const? 32 0) ⊑
+  select (icmp IntPred.ne (LLVM.and e (const? 32 16)) (const? 32 0)) (const? 32 16) (const? 32 0) ⊑
     LLVM.and e (const? 32 16) := by
     simp_alive_undef
     simp_alive_ops
@@ -157,7 +157,7 @@ theorem test15d_thm (e : IntW 32) :
 
 
 theorem test15e_thm (e : IntW 32) :
-  select (icmp IntPredicate.ne (LLVM.and e (const? 32 128)) (const? 32 0)) (const? 32 256) (const? 32 0) ⊑
+  select (icmp IntPred.ne (LLVM.and e (const? 32 128)) (const? 32 0)) (const? 32 256) (const? 32 0) ⊑
     LLVM.and (shl e (const? 32 1)) (const? 32 256) := by
     simp_alive_undef
     simp_alive_ops
@@ -168,7 +168,7 @@ theorem test15e_thm (e : IntW 32) :
 
 
 theorem test15f_thm (e : IntW 32) :
-  select (icmp IntPredicate.ne (LLVM.and e (const? 32 128)) (const? 32 0)) (const? 32 0) (const? 32 256) ⊑
+  select (icmp IntPred.ne (LLVM.and e (const? 32 128)) (const? 32 0)) (const? 32 0) (const? 32 256) ⊑
     LLVM.xor (LLVM.and (shl e (const? 32 1)) (const? 32 256)) (const? 32 256) := by
     simp_alive_undef
     simp_alive_ops
@@ -179,7 +179,7 @@ theorem test15f_thm (e : IntW 32) :
 
 
 theorem test15g_thm (e : IntW 32) :
-  select (icmp IntPredicate.ne (LLVM.and e (const? 32 8)) (const? 32 0)) (const? 32 (-1)) (const? 32 (-9)) ⊑
+  select (icmp IntPred.ne (LLVM.and e (const? 32 8)) (const? 32 0)) (const? 32 (-1)) (const? 32 (-9)) ⊑
     LLVM.or e (const? 32 (-9)) := by
     simp_alive_undef
     simp_alive_ops
@@ -190,7 +190,7 @@ theorem test15g_thm (e : IntW 32) :
 
 
 theorem test15h_thm (e : IntW 32) :
-  select (icmp IntPredicate.ne (LLVM.and e (const? 32 8)) (const? 32 0)) (const? 32 (-9)) (const? 32 (-1)) ⊑
+  select (icmp IntPred.ne (LLVM.and e (const? 32 8)) (const? 32 0)) (const? 32 (-9)) (const? 32 (-1)) ⊑
     LLVM.xor (LLVM.and e (const? 32 8)) (const? 32 (-1)) := by
     simp_alive_undef
     simp_alive_ops
@@ -201,8 +201,8 @@ theorem test15h_thm (e : IntW 32) :
 
 
 theorem test15i_thm (e : IntW 32) :
-  select (icmp IntPredicate.ne (LLVM.and e (const? 32 2)) (const? 32 0)) (const? 32 577) (const? 32 1089) ⊑
-    select (icmp IntPredicate.eq (LLVM.and e (const? 32 2)) (const? 32 0)) (const? 32 1089) (const? 32 577) := by
+  select (icmp IntPred.ne (LLVM.and e (const? 32 2)) (const? 32 0)) (const? 32 577) (const? 32 1089) ⊑
+    select (icmp IntPred.eq (LLVM.and e (const? 32 2)) (const? 32 0)) (const? 32 1089) (const? 32 577) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -212,8 +212,8 @@ theorem test15i_thm (e : IntW 32) :
 
 
 theorem test15j_thm (e : IntW 32) :
-  select (icmp IntPredicate.ne (LLVM.and e (const? 32 2)) (const? 32 0)) (const? 32 1089) (const? 32 577) ⊑
-    select (icmp IntPredicate.eq (LLVM.and e (const? 32 2)) (const? 32 0)) (const? 32 577) (const? 32 1089) := by
+  select (icmp IntPred.ne (LLVM.and e (const? 32 2)) (const? 32 0)) (const? 32 1089) (const? 32 577) ⊑
+    select (icmp IntPred.eq (LLVM.and e (const? 32 2)) (const? 32 0)) (const? 32 577) (const? 32 1089) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -223,7 +223,7 @@ theorem test15j_thm (e : IntW 32) :
 
 
 theorem clear_to_set_decomposebittest_thm (e : IntW 8) :
-  select (icmp IntPredicate.sgt e (const? 8 (-1))) (const? 8 (-125)) (const? 8 3) ⊑
+  select (icmp IntPred.sgt e (const? 8 (-1))) (const? 8 (-125)) (const? 8 3) ⊑
     LLVM.xor (LLVM.and e (const? 8 (-128))) (const? 8 (-125)) := by
     simp_alive_undef
     simp_alive_ops
@@ -234,7 +234,7 @@ theorem clear_to_set_decomposebittest_thm (e : IntW 8) :
 
 
 theorem clear_to_clear_decomposebittest_thm (e : IntW 8) :
-  select (icmp IntPredicate.sgt e (const? 8 (-1))) (const? 8 3) (const? 8 (-125)) ⊑
+  select (icmp IntPred.sgt e (const? 8 (-1))) (const? 8 3) (const? 8 (-125)) ⊑
     LLVM.or (LLVM.and e (const? 8 (-128))) (const? 8 3) { «disjoint» := true } := by
     simp_alive_undef
     simp_alive_ops
@@ -245,7 +245,7 @@ theorem clear_to_clear_decomposebittest_thm (e : IntW 8) :
 
 
 theorem set_to_set_decomposebittest_thm (e : IntW 8) :
-  select (icmp IntPredicate.slt e (const? 8 0)) (const? 8 (-125)) (const? 8 3) ⊑
+  select (icmp IntPred.slt e (const? 8 0)) (const? 8 (-125)) (const? 8 3) ⊑
     LLVM.or (LLVM.and e (const? 8 (-128))) (const? 8 3) { «disjoint» := true } := by
     simp_alive_undef
     simp_alive_ops
@@ -256,7 +256,7 @@ theorem set_to_set_decomposebittest_thm (e : IntW 8) :
 
 
 theorem set_to_clear_decomposebittest_thm (e : IntW 8) :
-  select (icmp IntPredicate.slt e (const? 8 0)) (const? 8 3) (const? 8 (-125)) ⊑
+  select (icmp IntPred.slt e (const? 8 0)) (const? 8 3) (const? 8 (-125)) ⊑
     LLVM.xor (LLVM.and e (const? 8 (-128))) (const? 8 (-125)) := by
     simp_alive_undef
     simp_alive_ops
@@ -267,7 +267,7 @@ theorem set_to_clear_decomposebittest_thm (e : IntW 8) :
 
 
 theorem select_bittest_to_add_thm (e : IntW 32) :
-  select (icmp IntPredicate.eq (LLVM.and e (const? 32 1)) (const? 32 0)) (const? 32 3) (const? 32 4) ⊑
+  select (icmp IntPred.eq (LLVM.and e (const? 32 1)) (const? 32 0)) (const? 32 3) (const? 32 4) ⊑
     add (LLVM.and e (const? 32 1)) (const? 32 3) { «nsw» := true, «nuw» := true } := by
     simp_alive_undef
     simp_alive_ops
@@ -278,7 +278,7 @@ theorem select_bittest_to_add_thm (e : IntW 32) :
 
 
 theorem select_bittest_to_sub_thm (e : IntW 32) :
-  select (icmp IntPredicate.eq (LLVM.and e (const? 32 1)) (const? 32 0)) (const? 32 4) (const? 32 3) ⊑
+  select (icmp IntPred.eq (LLVM.and e (const? 32 1)) (const? 32 0)) (const? 32 4) (const? 32 3) ⊑
     sub (const? 32 4) (LLVM.and e (const? 32 1)) { «nsw» := true, «nuw» := true } := by
     simp_alive_undef
     simp_alive_ops
@@ -289,9 +289,9 @@ theorem select_bittest_to_sub_thm (e : IntW 32) :
 
 
 theorem select_bittest_to_shl_negative_test_thm (e : IntW 32) :
-  add (select (icmp IntPredicate.eq (LLVM.and e (const? 32 1)) (const? 32 0)) (const? 32 2) (const? 32 4)) (const? 32 2)
+  add (select (icmp IntPred.eq (LLVM.and e (const? 32 1)) (const? 32 0)) (const? 32 2) (const? 32 4)) (const? 32 2)
       { «nsw» := true, «nuw» := true } ⊑
-    select (icmp IntPredicate.eq (LLVM.and e (const? 32 1)) (const? 32 0)) (const? 32 4) (const? 32 6) := by
+    select (icmp IntPred.eq (LLVM.and e (const? 32 1)) (const? 32 0)) (const? 32 4) (const? 32 6) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gselecthicmphandhzerohshl_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gselecthicmphandhzerohshl_proof.lean
@@ -12,7 +12,7 @@ set_option Elab.async false
 
 section gselecthicmphandhzerohshl_proof
 theorem test_eq_thm (e : IntW 32) :
-  select (icmp IntPredicate.eq (LLVM.and e (const? 32 1073741823)) (const? 32 0)) (const? 32 0) (shl e (const? 32 2)) ⊑
+  select (icmp IntPred.eq (LLVM.and e (const? 32 1073741823)) (const? 32 0)) (const? 32 0) (shl e (const? 32 2)) ⊑
     shl e (const? 32 2) := by
     simp_alive_undef
     simp_alive_ops
@@ -23,7 +23,7 @@ theorem test_eq_thm (e : IntW 32) :
 
 
 theorem test_ne_thm (e : IntW 32) :
-  select (icmp IntPredicate.ne (LLVM.and e (const? 32 1073741823)) (const? 32 0)) (shl e (const? 32 2)) (const? 32 0) ⊑
+  select (icmp IntPred.ne (LLVM.and e (const? 32 1073741823)) (const? 32 0)) (shl e (const? 32 2)) (const? 32 0) ⊑
     shl e (const? 32 2) := by
     simp_alive_undef
     simp_alive_ops
@@ -34,7 +34,7 @@ theorem test_ne_thm (e : IntW 32) :
 
 
 theorem test_nuw_dropped_thm (e : IntW 32) :
-  select (icmp IntPredicate.eq (LLVM.and e (const? 32 1073741823)) (const? 32 0)) (const? 32 0)
+  select (icmp IntPred.eq (LLVM.and e (const? 32 1073741823)) (const? 32 0)) (const? 32 0)
       (shl e (const? 32 2) { «nsw» := false, «nuw» := true }) ⊑
     shl e (const? 32 2) := by
     simp_alive_undef
@@ -46,7 +46,7 @@ theorem test_nuw_dropped_thm (e : IntW 32) :
 
 
 theorem test_nsw_dropped_thm (e : IntW 32) :
-  select (icmp IntPredicate.eq (LLVM.and e (const? 32 1073741823)) (const? 32 0)) (const? 32 0)
+  select (icmp IntPred.eq (LLVM.and e (const? 32 1073741823)) (const? 32 0)) (const? 32 0)
       (shl e (const? 32 2) { «nsw» := true, «nuw» := false }) ⊑
     shl e (const? 32 2) := by
     simp_alive_undef
@@ -58,7 +58,7 @@ theorem test_nsw_dropped_thm (e : IntW 32) :
 
 
 theorem neg_test_icmp_non_equality_thm (e : IntW 32) :
-  select (icmp IntPredicate.slt (LLVM.and e (const? 32 1073741823)) (const? 32 0)) (const? 32 0) (shl e (const? 32 2)) ⊑
+  select (icmp IntPred.slt (LLVM.and e (const? 32 1073741823)) (const? 32 0)) (const? 32 0) (shl e (const? 32 2)) ⊑
     shl e (const? 32 2) := by
     simp_alive_undef
     simp_alive_ops

--- a/SSA/Projects/InstCombine/tests/proofs/gselecthicmphxor_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gselecthicmphxor_proof.lean
@@ -12,7 +12,7 @@ set_option Elab.async false
 
 section gselecthicmphxor_proof
 theorem select_icmp_eq_pow2_thm (e : IntW 8) :
-  select (icmp IntPredicate.eq (LLVM.and e (const? 8 4)) (const? 8 0)) e (LLVM.xor e (const? 8 4)) ⊑
+  select (icmp IntPred.eq (LLVM.and e (const? 8 4)) (const? 8 0)) e (LLVM.xor e (const? 8 4)) ⊑
     LLVM.and e (const? 8 (-5)) := by
     simp_alive_undef
     simp_alive_ops
@@ -23,7 +23,7 @@ theorem select_icmp_eq_pow2_thm (e : IntW 8) :
 
 
 theorem select_icmp_eq_pow2_flipped_thm (e : IntW 8) :
-  select (icmp IntPredicate.eq (LLVM.and e (const? 8 4)) (const? 8 0)) (LLVM.xor e (const? 8 4)) e ⊑
+  select (icmp IntPred.eq (LLVM.and e (const? 8 4)) (const? 8 0)) (LLVM.xor e (const? 8 4)) e ⊑
     LLVM.or e (const? 8 4) := by
     simp_alive_undef
     simp_alive_ops
@@ -34,7 +34,7 @@ theorem select_icmp_eq_pow2_flipped_thm (e : IntW 8) :
 
 
 theorem select_icmp_ne_pow2_thm (e : IntW 8) :
-  select (icmp IntPredicate.ne (LLVM.and e (const? 8 4)) (const? 8 0)) (LLVM.xor e (const? 8 4)) e ⊑
+  select (icmp IntPred.ne (LLVM.and e (const? 8 4)) (const? 8 0)) (LLVM.xor e (const? 8 4)) e ⊑
     LLVM.and e (const? 8 (-5)) := by
     simp_alive_undef
     simp_alive_ops
@@ -45,7 +45,7 @@ theorem select_icmp_ne_pow2_thm (e : IntW 8) :
 
 
 theorem select_icmp_ne_pow2_flipped_thm (e : IntW 8) :
-  select (icmp IntPredicate.ne (LLVM.and e (const? 8 4)) (const? 8 0)) e (LLVM.xor e (const? 8 4)) ⊑
+  select (icmp IntPred.ne (LLVM.and e (const? 8 4)) (const? 8 0)) e (LLVM.xor e (const? 8 4)) ⊑
     LLVM.or e (const? 8 4) := by
     simp_alive_undef
     simp_alive_ops
@@ -56,8 +56,8 @@ theorem select_icmp_ne_pow2_flipped_thm (e : IntW 8) :
 
 
 theorem select_icmp_ne_not_pow2_thm (e : IntW 8) :
-  select (icmp IntPredicate.ne (LLVM.and e (const? 8 5)) (const? 8 0)) (LLVM.xor e (const? 8 5)) e ⊑
-    select (icmp IntPredicate.eq (LLVM.and e (const? 8 5)) (const? 8 0)) e (LLVM.xor e (const? 8 5)) := by
+  select (icmp IntPred.ne (LLVM.and e (const? 8 5)) (const? 8 0)) (LLVM.xor e (const? 8 5)) e ⊑
+    select (icmp IntPred.eq (LLVM.and e (const? 8 5)) (const? 8 0)) e (LLVM.xor e (const? 8 5)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -67,7 +67,7 @@ theorem select_icmp_ne_not_pow2_thm (e : IntW 8) :
 
 
 theorem select_icmp_slt_zero_smin_thm (e : IntW 8) :
-  select (icmp IntPredicate.slt e (const? 8 0)) e (LLVM.xor e (const? 8 (-128))) ⊑ LLVM.or e (const? 8 (-128)) := by
+  select (icmp IntPred.slt e (const? 8 0)) e (LLVM.xor e (const? 8 (-128))) ⊑ LLVM.or e (const? 8 (-128)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -77,7 +77,7 @@ theorem select_icmp_slt_zero_smin_thm (e : IntW 8) :
 
 
 theorem select_icmp_slt_zero_smin_flipped_thm (e : IntW 8) :
-  select (icmp IntPredicate.slt e (const? 8 0)) (LLVM.xor e (const? 8 (-128))) e ⊑ LLVM.and e (const? 8 127) := by
+  select (icmp IntPred.slt e (const? 8 0)) (LLVM.xor e (const? 8 (-128))) e ⊑ LLVM.and e (const? 8 127) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -87,7 +87,7 @@ theorem select_icmp_slt_zero_smin_flipped_thm (e : IntW 8) :
 
 
 theorem select_icmp_sgt_allones_smin_thm (e : IntW 8) :
-  select (icmp IntPredicate.sgt e (const? 8 (-1))) e (LLVM.xor e (const? 8 (-128))) ⊑ LLVM.and e (const? 8 127) := by
+  select (icmp IntPred.sgt e (const? 8 (-1))) e (LLVM.xor e (const? 8 (-128))) ⊑ LLVM.and e (const? 8 127) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -97,7 +97,7 @@ theorem select_icmp_sgt_allones_smin_thm (e : IntW 8) :
 
 
 theorem select_icmp_sgt_allones_smin_flipped_thm (e : IntW 8) :
-  select (icmp IntPredicate.sgt e (const? 8 (-1))) (LLVM.xor e (const? 8 (-128))) e ⊑
+  select (icmp IntPred.sgt e (const? 8 (-1))) (LLVM.xor e (const? 8 (-128))) e ⊑
     LLVM.or e (const? 8 (-128)) := by
     simp_alive_undef
     simp_alive_ops
@@ -108,8 +108,8 @@ theorem select_icmp_sgt_allones_smin_flipped_thm (e : IntW 8) :
 
 
 theorem select_icmp_sgt_not_smin_thm (e : IntW 8) :
-  select (icmp IntPredicate.sgt e (const? 8 (-1))) e (LLVM.xor e (const? 8 (-127))) ⊑
-    select (icmp IntPredicate.slt e (const? 8 0)) (LLVM.xor e (const? 8 (-127))) e := by
+  select (icmp IntPred.sgt e (const? 8 (-1))) e (LLVM.xor e (const? 8 (-127))) ⊑
+    select (icmp IntPred.slt e (const? 8 0)) (LLVM.xor e (const? 8 (-127))) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gselecthimmhcanon_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gselecthimmhcanon_proof.lean
@@ -12,8 +12,8 @@ set_option Elab.async false
 
 section gselecthimmhcanon_proof
 theorem thisdoesnotloop_thm (e e_1 : IntW 32) :
-  trunc 8 (select (icmp IntPredicate.slt e_1 (const? 32 (-128))) (const? 32 128) e) ⊑
-    select (icmp IntPredicate.slt e_1 (const? 32 (-128))) (const? 8 (-128)) (trunc 8 e) := by
+  trunc 8 (select (icmp IntPred.slt e_1 (const? 32 (-128))) (const? 32 128) e) ⊑
+    select (icmp IntPred.slt e_1 (const? 32 (-128))) (const? 8 (-128)) (trunc 8 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gselecthobohpeohops_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gselecthobohpeohops_proof.lean
@@ -12,7 +12,7 @@ set_option Elab.async false
 
 section gselecthobohpeohops_proof
 theorem test_shl_nuw_nsw__all_are_safe_thm (e : IntW 64) (e_1 : IntW 32) :
-  select (icmp IntPredicate.eq (LLVM.and e_1 (const? 32 15)) (const? 32 0)) e
+  select (icmp IntPred.eq (LLVM.and e_1 (const? 32 15)) (const? 32 0)) e
       (ashr e (zext 64 (shl (LLVM.and e_1 (const? 32 15)) (const? 32 2) { «nsw» := true, «nuw» := true }))) ⊑
     ashr e (zext 64 (LLVM.and (shl e_1 (const? 32 2)) (const? 32 60)) { «nneg» := true }) := by
     simp_alive_undef
@@ -24,7 +24,7 @@ theorem test_shl_nuw_nsw__all_are_safe_thm (e : IntW 64) (e_1 : IntW 32) :
 
 
 theorem test_shl_nuw__all_are_safe_thm (e : IntW 64) (e_1 : IntW 32) :
-  select (icmp IntPredicate.eq (LLVM.and e_1 (const? 32 15)) (const? 32 0)) e
+  select (icmp IntPred.eq (LLVM.and e_1 (const? 32 15)) (const? 32 0)) e
       (ashr e (zext 64 (shl (LLVM.and e_1 (const? 32 15)) (const? 32 2) { «nsw» := false, «nuw» := true }))) ⊑
     ashr e (zext 64 (LLVM.and (shl e_1 (const? 32 2)) (const? 32 60)) { «nneg» := true }) := by
     simp_alive_undef
@@ -36,7 +36,7 @@ theorem test_shl_nuw__all_are_safe_thm (e : IntW 64) (e_1 : IntW 32) :
 
 
 theorem test_shl_nsw__all_are_safe_thm (e : IntW 64) (e_1 : IntW 32) :
-  select (icmp IntPredicate.eq (LLVM.and e_1 (const? 32 15)) (const? 32 0)) e
+  select (icmp IntPred.eq (LLVM.and e_1 (const? 32 15)) (const? 32 0)) e
       (ashr e (zext 64 (shl (LLVM.and e_1 (const? 32 15)) (const? 32 2) { «nsw» := true, «nuw» := false }))) ⊑
     ashr e (zext 64 (LLVM.and (shl e_1 (const? 32 2)) (const? 32 60)) { «nneg» := true }) := by
     simp_alive_undef
@@ -48,7 +48,7 @@ theorem test_shl_nsw__all_are_safe_thm (e : IntW 64) (e_1 : IntW 32) :
 
 
 theorem test_shl__all_are_safe_thm (e : IntW 64) (e_1 : IntW 32) :
-  select (icmp IntPredicate.eq (LLVM.and e_1 (const? 32 15)) (const? 32 0)) e
+  select (icmp IntPred.eq (LLVM.and e_1 (const? 32 15)) (const? 32 0)) e
       (ashr e (zext 64 (shl (LLVM.and e_1 (const? 32 15)) (const? 32 2)))) ⊑
     ashr e (zext 64 (LLVM.and (shl e_1 (const? 32 2)) (const? 32 60)) { «nneg» := true }) := by
     simp_alive_undef
@@ -60,7 +60,7 @@ theorem test_shl__all_are_safe_thm (e : IntW 64) (e_1 : IntW 32) :
 
 
 theorem test_shl_nuw_nsw__nuw_is_safe_thm (e : IntW 64) (e_1 : IntW 32) :
-  select (icmp IntPredicate.eq (LLVM.and e_1 (const? 32 1073741822)) (const? 32 0)) e
+  select (icmp IntPred.eq (LLVM.and e_1 (const? 32 1073741822)) (const? 32 0)) e
       (ashr e (zext 64 (shl (LLVM.and e_1 (const? 32 1073741822)) (const? 32 2) { «nsw» := true, «nuw» := true }))) ⊑
     ashr e (zext 64 (LLVM.and (shl e_1 (const? 32 2)) (const? 32 (-8))) { «nneg» := true }) := by
     simp_alive_undef
@@ -72,7 +72,7 @@ theorem test_shl_nuw_nsw__nuw_is_safe_thm (e : IntW 64) (e_1 : IntW 32) :
 
 
 theorem test_shl_nuw__nuw_is_safe_thm (e : IntW 64) (e_1 : IntW 32) :
-  select (icmp IntPredicate.eq (LLVM.and e_1 (const? 32 1073741822)) (const? 32 0)) e
+  select (icmp IntPred.eq (LLVM.and e_1 (const? 32 1073741822)) (const? 32 0)) e
       (ashr e (zext 64 (shl (LLVM.and e_1 (const? 32 1073741822)) (const? 32 2) { «nsw» := false, «nuw» := true }))) ⊑
     ashr e (zext 64 (LLVM.and (shl e_1 (const? 32 2)) (const? 32 (-8))) { «nneg» := true }) := by
     simp_alive_undef
@@ -84,7 +84,7 @@ theorem test_shl_nuw__nuw_is_safe_thm (e : IntW 64) (e_1 : IntW 32) :
 
 
 theorem test_shl_nsw__nuw_is_safe_thm (e : IntW 64) (e_1 : IntW 32) :
-  select (icmp IntPredicate.eq (LLVM.and e_1 (const? 32 1073741822)) (const? 32 0)) e
+  select (icmp IntPred.eq (LLVM.and e_1 (const? 32 1073741822)) (const? 32 0)) e
       (ashr e (zext 64 (shl (LLVM.and e_1 (const? 32 1073741822)) (const? 32 2) { «nsw» := true, «nuw» := false }))) ⊑
     ashr e (zext 64 (LLVM.and (shl e_1 (const? 32 2)) (const? 32 (-8))) { «nneg» := true }) := by
     simp_alive_undef
@@ -96,7 +96,7 @@ theorem test_shl_nsw__nuw_is_safe_thm (e : IntW 64) (e_1 : IntW 32) :
 
 
 theorem test_shl__nuw_is_safe_thm (e : IntW 64) (e_1 : IntW 32) :
-  select (icmp IntPredicate.eq (LLVM.and e_1 (const? 32 1073741822)) (const? 32 0)) e
+  select (icmp IntPred.eq (LLVM.and e_1 (const? 32 1073741822)) (const? 32 0)) e
       (ashr e (zext 64 (shl (LLVM.and e_1 (const? 32 1073741822)) (const? 32 2)))) ⊑
     ashr e (zext 64 (LLVM.and (shl e_1 (const? 32 2)) (const? 32 (-8))) { «nneg» := true }) := by
     simp_alive_undef
@@ -110,7 +110,7 @@ theorem test_shl__nuw_is_safe_thm (e : IntW 64) (e_1 : IntW 32) :
 theorem test_shl_nuw_nsw__nsw_is_safe_thm (e : IntW 32) :
   mul
       (mul
-        (select (icmp IntPredicate.eq (LLVM.or e (const? 32 (-83886080))) (const? 32 (-83886079)))
+        (select (icmp IntPred.eq (LLVM.or e (const? 32 (-83886080))) (const? 32 (-83886079)))
           (const? 32 (-335544316))
           (shl (LLVM.or e (const? 32 (-83886080))) (const? 32 2) { «nsw» := true, «nuw» := true }))
         (LLVM.or e (const? 32 (-83886080))))
@@ -127,7 +127,7 @@ theorem test_shl_nuw_nsw__nsw_is_safe_thm (e : IntW 32) :
 theorem test_shl_nuw__nsw_is_safe_thm (e : IntW 32) :
   mul
       (mul
-        (select (icmp IntPredicate.eq (LLVM.or e (const? 32 (-83886080))) (const? 32 (-83886079)))
+        (select (icmp IntPred.eq (LLVM.or e (const? 32 (-83886080))) (const? 32 (-83886079)))
           (const? 32 (-335544316))
           (shl (LLVM.or e (const? 32 (-83886080))) (const? 32 2) { «nsw» := false, «nuw» := true }))
         (LLVM.or e (const? 32 (-83886080))))
@@ -144,7 +144,7 @@ theorem test_shl_nuw__nsw_is_safe_thm (e : IntW 32) :
 theorem test_shl_nsw__nsw_is_safe_thm (e : IntW 32) :
   mul
       (mul
-        (select (icmp IntPredicate.eq (LLVM.or e (const? 32 (-83886080))) (const? 32 (-83886079)))
+        (select (icmp IntPred.eq (LLVM.or e (const? 32 (-83886080))) (const? 32 (-83886079)))
           (const? 32 (-335544316))
           (shl (LLVM.or e (const? 32 (-83886080))) (const? 32 2) { «nsw» := true, «nuw» := false }))
         (LLVM.or e (const? 32 (-83886080))))
@@ -164,7 +164,7 @@ theorem test_shl_nsw__nsw_is_safe_thm (e : IntW 32) :
 theorem test_shl__nsw_is_safe_thm (e : IntW 32) :
   mul
       (mul
-        (select (icmp IntPredicate.eq (LLVM.or e (const? 32 (-83886080))) (const? 32 (-83886079)))
+        (select (icmp IntPred.eq (LLVM.or e (const? 32 (-83886080))) (const? 32 (-83886079)))
           (const? 32 (-335544316)) (shl (LLVM.or e (const? 32 (-83886080))) (const? 32 2)))
         (LLVM.or e (const? 32 (-83886080))))
       (shl (LLVM.or e (const? 32 (-83886080))) (const? 32 2)) ⊑
@@ -181,7 +181,7 @@ theorem test_shl__nsw_is_safe_thm (e : IntW 32) :
 
 
 theorem test_shl_nuw_nsw__none_are_safe_thm (e : IntW 64) (e_1 : IntW 32) :
-  select (icmp IntPredicate.eq (LLVM.and e_1 (const? 32 (-2))) (const? 32 0)) e
+  select (icmp IntPred.eq (LLVM.and e_1 (const? 32 (-2))) (const? 32 0)) e
       (ashr e (zext 64 (shl (LLVM.and e_1 (const? 32 (-2))) (const? 32 2) { «nsw» := true, «nuw» := true }))) ⊑
     ashr e (zext 64 (LLVM.and (shl e_1 (const? 32 2)) (const? 32 (-8))) { «nneg» := true }) := by
     simp_alive_undef
@@ -193,7 +193,7 @@ theorem test_shl_nuw_nsw__none_are_safe_thm (e : IntW 64) (e_1 : IntW 32) :
 
 
 theorem test_shl_nuw__none_are_safe_thm (e : IntW 64) (e_1 : IntW 32) :
-  select (icmp IntPredicate.eq (LLVM.and e_1 (const? 32 (-2))) (const? 32 0)) e
+  select (icmp IntPred.eq (LLVM.and e_1 (const? 32 (-2))) (const? 32 0)) e
       (ashr e (zext 64 (shl (LLVM.and e_1 (const? 32 (-2))) (const? 32 2) { «nsw» := false, «nuw» := true }))) ⊑
     ashr e (zext 64 (LLVM.and (shl e_1 (const? 32 2)) (const? 32 (-8))) { «nneg» := true }) := by
     simp_alive_undef
@@ -205,7 +205,7 @@ theorem test_shl_nuw__none_are_safe_thm (e : IntW 64) (e_1 : IntW 32) :
 
 
 theorem test_shl_nsw__none_are_safe_thm (e : IntW 64) (e_1 : IntW 32) :
-  select (icmp IntPredicate.eq (LLVM.and e_1 (const? 32 (-2))) (const? 32 0)) e
+  select (icmp IntPred.eq (LLVM.and e_1 (const? 32 (-2))) (const? 32 0)) e
       (ashr e (zext 64 (shl (LLVM.and e_1 (const? 32 (-2))) (const? 32 2) { «nsw» := true, «nuw» := false }))) ⊑
     ashr e (zext 64 (LLVM.and (shl e_1 (const? 32 2)) (const? 32 (-8))) { «nneg» := true }) := by
     simp_alive_undef
@@ -217,7 +217,7 @@ theorem test_shl_nsw__none_are_safe_thm (e : IntW 64) (e_1 : IntW 32) :
 
 
 theorem test_shl__none_are_safe_thm (e : IntW 64) (e_1 : IntW 32) :
-  select (icmp IntPredicate.eq (LLVM.and e_1 (const? 32 (-2))) (const? 32 0)) e
+  select (icmp IntPred.eq (LLVM.and e_1 (const? 32 (-2))) (const? 32 0)) e
       (ashr e (zext 64 (shl (LLVM.and e_1 (const? 32 (-2))) (const? 32 2)))) ⊑
     ashr e (zext 64 (LLVM.and (shl e_1 (const? 32 2)) (const? 32 (-8))) { «nneg» := true }) := by
     simp_alive_undef
@@ -229,7 +229,7 @@ theorem test_shl__none_are_safe_thm (e : IntW 64) (e_1 : IntW 32) :
 
 
 theorem test_lshr_exact__exact_is_safe_thm (e : IntW 64) (e_1 : IntW 32) :
-  select (icmp IntPredicate.eq (LLVM.and e_1 (const? 32 60)) (const? 32 0)) e
+  select (icmp IntPred.eq (LLVM.and e_1 (const? 32 60)) (const? 32 0)) e
       (ashr e (zext 64 (lshr (LLVM.and e_1 (const? 32 60)) (const? 32 2) { «exact» := true }))) ⊑
     ashr e (zext 64 (LLVM.and (lshr e_1 (const? 32 2)) (const? 32 15)) { «nneg» := true }) := by
     simp_alive_undef
@@ -241,7 +241,7 @@ theorem test_lshr_exact__exact_is_safe_thm (e : IntW 64) (e_1 : IntW 32) :
 
 
 theorem test_lshr__exact_is_safe_thm (e : IntW 64) (e_1 : IntW 32) :
-  select (icmp IntPredicate.eq (LLVM.and e_1 (const? 32 60)) (const? 32 0)) e
+  select (icmp IntPred.eq (LLVM.and e_1 (const? 32 60)) (const? 32 0)) e
       (ashr e (zext 64 (lshr (LLVM.and e_1 (const? 32 60)) (const? 32 2)))) ⊑
     ashr e (zext 64 (LLVM.and (lshr e_1 (const? 32 2)) (const? 32 15)) { «nneg» := true }) := by
     simp_alive_undef
@@ -253,7 +253,7 @@ theorem test_lshr__exact_is_safe_thm (e : IntW 64) (e_1 : IntW 32) :
 
 
 theorem test_lshr_exact__exact_is_unsafe_thm (e : IntW 64) (e_1 : IntW 32) :
-  select (icmp IntPredicate.eq (LLVM.and e_1 (const? 32 63)) (const? 32 0)) e
+  select (icmp IntPred.eq (LLVM.and e_1 (const? 32 63)) (const? 32 0)) e
       (ashr e (zext 64 (lshr (LLVM.and e_1 (const? 32 63)) (const? 32 2) { «exact» := true }))) ⊑
     ashr e (zext 64 (LLVM.and (lshr e_1 (const? 32 2)) (const? 32 15)) { «nneg» := true }) := by
     simp_alive_undef
@@ -265,7 +265,7 @@ theorem test_lshr_exact__exact_is_unsafe_thm (e : IntW 64) (e_1 : IntW 32) :
 
 
 theorem test_lshr__exact_is_unsafe_thm (e : IntW 64) (e_1 : IntW 32) :
-  select (icmp IntPredicate.eq (LLVM.and e_1 (const? 32 63)) (const? 32 0)) e
+  select (icmp IntPred.eq (LLVM.and e_1 (const? 32 63)) (const? 32 0)) e
       (ashr e (zext 64 (lshr (LLVM.and e_1 (const? 32 63)) (const? 32 2)))) ⊑
     ashr e (zext 64 (LLVM.and (lshr e_1 (const? 32 2)) (const? 32 15)) { «nneg» := true }) := by
     simp_alive_undef
@@ -277,7 +277,7 @@ theorem test_lshr__exact_is_unsafe_thm (e : IntW 64) (e_1 : IntW 32) :
 
 
 theorem test_ashr_exact__exact_is_safe_thm (e : IntW 64) (e_1 : IntW 32) :
-  select (icmp IntPredicate.eq (LLVM.and e_1 (const? 32 (-2147483588))) (const? 32 0)) e
+  select (icmp IntPred.eq (LLVM.and e_1 (const? 32 (-2147483588))) (const? 32 0)) e
       (ashr e (zext 64 (ashr (LLVM.and e_1 (const? 32 (-2147483588))) (const? 32 2) { «exact» := true }))) ⊑
     ashr e (zext 64 (LLVM.and (ashr e_1 (const? 32 2)) (const? 32 (-536870897))) { «nneg» := true }) := by
     simp_alive_undef
@@ -289,7 +289,7 @@ theorem test_ashr_exact__exact_is_safe_thm (e : IntW 64) (e_1 : IntW 32) :
 
 
 theorem test_ashr__exact_is_safe_thm (e : IntW 64) (e_1 : IntW 32) :
-  select (icmp IntPredicate.eq (LLVM.and e_1 (const? 32 (-2147483588))) (const? 32 0)) e
+  select (icmp IntPred.eq (LLVM.and e_1 (const? 32 (-2147483588))) (const? 32 0)) e
       (ashr e (zext 64 (ashr (LLVM.and e_1 (const? 32 (-2147483588))) (const? 32 2)))) ⊑
     ashr e (zext 64 (LLVM.and (ashr e_1 (const? 32 2)) (const? 32 (-536870897))) { «nneg» := true }) := by
     simp_alive_undef
@@ -301,7 +301,7 @@ theorem test_ashr__exact_is_safe_thm (e : IntW 64) (e_1 : IntW 32) :
 
 
 theorem test_ashr_exact__exact_is_unsafe_thm (e : IntW 64) (e_1 : IntW 32) :
-  select (icmp IntPredicate.eq (LLVM.and e_1 (const? 32 (-2147483585))) (const? 32 0)) e
+  select (icmp IntPred.eq (LLVM.and e_1 (const? 32 (-2147483585))) (const? 32 0)) e
       (ashr e (zext 64 (ashr (LLVM.and e_1 (const? 32 (-2147483585))) (const? 32 2) { «exact» := true }))) ⊑
     ashr e (zext 64 (LLVM.and (ashr e_1 (const? 32 2)) (const? 32 (-536870897))) { «nneg» := true }) := by
     simp_alive_undef
@@ -313,7 +313,7 @@ theorem test_ashr_exact__exact_is_unsafe_thm (e : IntW 64) (e_1 : IntW 32) :
 
 
 theorem test_ashr__exact_is_unsafe_thm (e : IntW 64) (e_1 : IntW 32) :
-  select (icmp IntPredicate.eq (LLVM.and e_1 (const? 32 (-2147483585))) (const? 32 0)) e
+  select (icmp IntPred.eq (LLVM.and e_1 (const? 32 (-2147483585))) (const? 32 0)) e
       (ashr e (zext 64 (ashr (LLVM.and e_1 (const? 32 (-2147483585))) (const? 32 2)))) ⊑
     ashr e (zext 64 (LLVM.and (ashr e_1 (const? 32 2)) (const? 32 (-536870897))) { «nneg» := true }) := by
     simp_alive_undef
@@ -325,7 +325,7 @@ theorem test_ashr__exact_is_unsafe_thm (e : IntW 64) (e_1 : IntW 32) :
 
 
 theorem test_add_nuw_nsw__all_are_safe_thm (e : IntW 32) :
-  select (icmp IntPredicate.eq (LLVM.and e (const? 32 1073741823)) (const? 32 3)) (const? 32 4)
+  select (icmp IntPred.eq (LLVM.and e (const? 32 1073741823)) (const? 32 3)) (const? 32 4)
       (add (LLVM.and e (const? 32 1073741823)) (const? 32 1) { «nsw» := true, «nuw» := true }) ⊑
     add (LLVM.and e (const? 32 1073741823)) (const? 32 1) { «nsw» := true, «nuw» := true } := by
     simp_alive_undef
@@ -337,7 +337,7 @@ theorem test_add_nuw_nsw__all_are_safe_thm (e : IntW 32) :
 
 
 theorem test_add_nuw__all_are_safe_thm (e : IntW 32) :
-  select (icmp IntPredicate.eq (LLVM.and e (const? 32 1073741823)) (const? 32 3)) (const? 32 4)
+  select (icmp IntPred.eq (LLVM.and e (const? 32 1073741823)) (const? 32 3)) (const? 32 4)
       (add (LLVM.and e (const? 32 1073741823)) (const? 32 1) { «nsw» := false, «nuw» := true }) ⊑
     add (LLVM.and e (const? 32 1073741823)) (const? 32 1) { «nsw» := true, «nuw» := true } := by
     simp_alive_undef
@@ -349,7 +349,7 @@ theorem test_add_nuw__all_are_safe_thm (e : IntW 32) :
 
 
 theorem test_add_nsw__all_are_safe_thm (e : IntW 32) :
-  select (icmp IntPredicate.eq (LLVM.and e (const? 32 1073741823)) (const? 32 3)) (const? 32 4)
+  select (icmp IntPred.eq (LLVM.and e (const? 32 1073741823)) (const? 32 3)) (const? 32 4)
       (add (LLVM.and e (const? 32 1073741823)) (const? 32 1) { «nsw» := true, «nuw» := false }) ⊑
     add (LLVM.and e (const? 32 1073741823)) (const? 32 1) { «nsw» := true, «nuw» := true } := by
     simp_alive_undef
@@ -361,7 +361,7 @@ theorem test_add_nsw__all_are_safe_thm (e : IntW 32) :
 
 
 theorem test_add__all_are_safe_thm (e : IntW 32) :
-  select (icmp IntPredicate.eq (LLVM.and e (const? 32 1073741823)) (const? 32 3)) (const? 32 4)
+  select (icmp IntPred.eq (LLVM.and e (const? 32 1073741823)) (const? 32 3)) (const? 32 4)
       (add (LLVM.and e (const? 32 1073741823)) (const? 32 1)) ⊑
     add (LLVM.and e (const? 32 1073741823)) (const? 32 1) { «nsw» := true, «nuw» := true } := by
     simp_alive_undef
@@ -373,7 +373,7 @@ theorem test_add__all_are_safe_thm (e : IntW 32) :
 
 
 theorem test_add_nuw_nsw__nuw_is_safe_thm (e : IntW 32) :
-  select (icmp IntPredicate.eq (LLVM.and e (const? 32 2147483647)) (const? 32 2147483647)) (const? 32 (-2147483648))
+  select (icmp IntPred.eq (LLVM.and e (const? 32 2147483647)) (const? 32 2147483647)) (const? 32 (-2147483648))
       (add (LLVM.and e (const? 32 2147483647)) (const? 32 1) { «nsw» := true, «nuw» := true }) ⊑
     add (LLVM.and e (const? 32 2147483647)) (const? 32 1) { «nsw» := false, «nuw» := true } := by
     simp_alive_undef
@@ -385,7 +385,7 @@ theorem test_add_nuw_nsw__nuw_is_safe_thm (e : IntW 32) :
 
 
 theorem test_add_nuw__nuw_is_safe_thm (e : IntW 32) :
-  select (icmp IntPredicate.eq (LLVM.and e (const? 32 2147483647)) (const? 32 2147483647)) (const? 32 (-2147483648))
+  select (icmp IntPred.eq (LLVM.and e (const? 32 2147483647)) (const? 32 2147483647)) (const? 32 (-2147483648))
       (add (LLVM.and e (const? 32 2147483647)) (const? 32 1) { «nsw» := false, «nuw» := true }) ⊑
     add (LLVM.and e (const? 32 2147483647)) (const? 32 1) { «nsw» := false, «nuw» := true } := by
     simp_alive_undef
@@ -397,7 +397,7 @@ theorem test_add_nuw__nuw_is_safe_thm (e : IntW 32) :
 
 
 theorem test_add_nsw__nuw_is_safe_thm (e : IntW 32) :
-  select (icmp IntPredicate.eq (LLVM.and e (const? 32 2147483647)) (const? 32 2147483647)) (const? 32 (-2147483648))
+  select (icmp IntPred.eq (LLVM.and e (const? 32 2147483647)) (const? 32 2147483647)) (const? 32 (-2147483648))
       (add (LLVM.and e (const? 32 2147483647)) (const? 32 1) { «nsw» := true, «nuw» := false }) ⊑
     add (LLVM.and e (const? 32 2147483647)) (const? 32 1) { «nsw» := false, «nuw» := true } := by
     simp_alive_undef
@@ -409,7 +409,7 @@ theorem test_add_nsw__nuw_is_safe_thm (e : IntW 32) :
 
 
 theorem test_add__nuw_is_safe_thm (e : IntW 32) :
-  select (icmp IntPredicate.eq (LLVM.and e (const? 32 2147483647)) (const? 32 2147483647)) (const? 32 (-2147483648))
+  select (icmp IntPred.eq (LLVM.and e (const? 32 2147483647)) (const? 32 2147483647)) (const? 32 (-2147483648))
       (add (LLVM.and e (const? 32 2147483647)) (const? 32 1)) ⊑
     add (LLVM.and e (const? 32 2147483647)) (const? 32 1) { «nsw» := false, «nuw» := true } := by
     simp_alive_undef
@@ -421,7 +421,7 @@ theorem test_add__nuw_is_safe_thm (e : IntW 32) :
 
 
 theorem test_add_nuw_nsw__nsw_is_safe_thm (e : IntW 32) :
-  select (icmp IntPredicate.eq (LLVM.or e (const? 32 (-2147483648))) (const? 32 (-1))) (const? 32 0)
+  select (icmp IntPred.eq (LLVM.or e (const? 32 (-2147483648))) (const? 32 (-1))) (const? 32 0)
       (add (LLVM.or e (const? 32 (-2147483648))) (const? 32 1) { «nsw» := true, «nuw» := true }) ⊑
     add (LLVM.or e (const? 32 (-2147483648))) (const? 32 1) { «nsw» := true, «nuw» := false } := by
     simp_alive_undef
@@ -433,7 +433,7 @@ theorem test_add_nuw_nsw__nsw_is_safe_thm (e : IntW 32) :
 
 
 theorem test_add_nuw__nsw_is_safe_thm (e : IntW 32) :
-  select (icmp IntPredicate.eq (LLVM.or e (const? 32 (-2147483648))) (const? 32 (-1))) (const? 32 0)
+  select (icmp IntPred.eq (LLVM.or e (const? 32 (-2147483648))) (const? 32 (-1))) (const? 32 0)
       (add (LLVM.or e (const? 32 (-2147483648))) (const? 32 1) { «nsw» := false, «nuw» := true }) ⊑
     add (LLVM.or e (const? 32 (-2147483648))) (const? 32 1) { «nsw» := true, «nuw» := false } := by
     simp_alive_undef
@@ -445,7 +445,7 @@ theorem test_add_nuw__nsw_is_safe_thm (e : IntW 32) :
 
 
 theorem test_add_nsw__nsw_is_safe_thm (e : IntW 32) :
-  select (icmp IntPredicate.eq (LLVM.or e (const? 32 (-2147483648))) (const? 32 (-1))) (const? 32 0)
+  select (icmp IntPred.eq (LLVM.or e (const? 32 (-2147483648))) (const? 32 (-1))) (const? 32 0)
       (add (LLVM.or e (const? 32 (-2147483648))) (const? 32 1) { «nsw» := true, «nuw» := false }) ⊑
     add (LLVM.or e (const? 32 (-2147483648))) (const? 32 1) { «nsw» := true, «nuw» := false } := by
     simp_alive_undef
@@ -457,7 +457,7 @@ theorem test_add_nsw__nsw_is_safe_thm (e : IntW 32) :
 
 
 theorem test_add__nsw_is_safe_thm (e : IntW 32) :
-  select (icmp IntPredicate.eq (LLVM.or e (const? 32 (-2147483648))) (const? 32 (-1))) (const? 32 0)
+  select (icmp IntPred.eq (LLVM.or e (const? 32 (-2147483648))) (const? 32 (-1))) (const? 32 0)
       (add (LLVM.or e (const? 32 (-2147483648))) (const? 32 1)) ⊑
     add (LLVM.or e (const? 32 (-2147483648))) (const? 32 1) { «nsw» := true, «nuw» := false } := by
     simp_alive_undef
@@ -469,7 +469,7 @@ theorem test_add__nsw_is_safe_thm (e : IntW 32) :
 
 
 theorem test_add_nuw_nsw__none_are_safe_thm (e : IntW 32) :
-  select (icmp IntPredicate.eq e (const? 32 3)) (const? 32 4) (add e (const? 32 1) { «nsw» := true, «nuw» := true }) ⊑
+  select (icmp IntPred.eq e (const? 32 3)) (const? 32 4) (add e (const? 32 1) { «nsw» := true, «nuw» := true }) ⊑
     add e (const? 32 1) := by
     simp_alive_undef
     simp_alive_ops
@@ -480,7 +480,7 @@ theorem test_add_nuw_nsw__none_are_safe_thm (e : IntW 32) :
 
 
 theorem test_add_nuw__none_are_safe_thm (e : IntW 32) :
-  select (icmp IntPredicate.eq e (const? 32 3)) (const? 32 4) (add e (const? 32 1) { «nsw» := false, «nuw» := true }) ⊑
+  select (icmp IntPred.eq e (const? 32 3)) (const? 32 4) (add e (const? 32 1) { «nsw» := false, «nuw» := true }) ⊑
     add e (const? 32 1) := by
     simp_alive_undef
     simp_alive_ops
@@ -491,7 +491,7 @@ theorem test_add_nuw__none_are_safe_thm (e : IntW 32) :
 
 
 theorem test_add_nsw__none_are_safe_thm (e : IntW 32) :
-  select (icmp IntPredicate.eq e (const? 32 3)) (const? 32 4) (add e (const? 32 1) { «nsw» := true, «nuw» := false }) ⊑
+  select (icmp IntPred.eq e (const? 32 3)) (const? 32 4) (add e (const? 32 1) { «nsw» := true, «nuw» := false }) ⊑
     add e (const? 32 1) := by
     simp_alive_undef
     simp_alive_ops
@@ -502,7 +502,7 @@ theorem test_add_nsw__none_are_safe_thm (e : IntW 32) :
 
 
 theorem test_add__none_are_safe_thm (e : IntW 32) :
-  select (icmp IntPredicate.eq e (const? 32 3)) (const? 32 4) (add e (const? 32 1)) ⊑ add e (const? 32 1) := by
+  select (icmp IntPred.eq e (const? 32 3)) (const? 32 4) (add e (const? 32 1)) ⊑ add e (const? 32 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -512,7 +512,7 @@ theorem test_add__none_are_safe_thm (e : IntW 32) :
 
 
 theorem test_sub_nuw_nsw__all_are_safe_thm (e : IntW 32) :
-  select (icmp IntPredicate.eq (LLVM.and e (const? 32 255)) (const? 32 6)) (const? 32 (-260))
+  select (icmp IntPred.eq (LLVM.and e (const? 32 255)) (const? 32 6)) (const? 32 (-260))
       (sub (const? 32 (-254)) (LLVM.and e (const? 32 255)) { «nsw» := true, «nuw» := true }) ⊑
     sub (const? 32 (-254)) (LLVM.and e (const? 32 255)) { «nsw» := true, «nuw» := true } := by
     simp_alive_undef
@@ -524,7 +524,7 @@ theorem test_sub_nuw_nsw__all_are_safe_thm (e : IntW 32) :
 
 
 theorem test_sub_nuw__all_are_safe_thm (e : IntW 32) :
-  select (icmp IntPredicate.eq (LLVM.and e (const? 32 255)) (const? 32 6)) (const? 32 (-260))
+  select (icmp IntPred.eq (LLVM.and e (const? 32 255)) (const? 32 6)) (const? 32 (-260))
       (sub (const? 32 (-254)) (LLVM.and e (const? 32 255)) { «nsw» := false, «nuw» := true }) ⊑
     sub (const? 32 (-254)) (LLVM.and e (const? 32 255)) { «nsw» := true, «nuw» := true } := by
     simp_alive_undef
@@ -536,7 +536,7 @@ theorem test_sub_nuw__all_are_safe_thm (e : IntW 32) :
 
 
 theorem test_sub_nsw__all_are_safe_thm (e : IntW 32) :
-  select (icmp IntPredicate.eq (LLVM.and e (const? 32 255)) (const? 32 6)) (const? 32 (-260))
+  select (icmp IntPred.eq (LLVM.and e (const? 32 255)) (const? 32 6)) (const? 32 (-260))
       (sub (const? 32 (-254)) (LLVM.and e (const? 32 255)) { «nsw» := true, «nuw» := false }) ⊑
     sub (const? 32 (-254)) (LLVM.and e (const? 32 255)) { «nsw» := true, «nuw» := true } := by
     simp_alive_undef
@@ -548,7 +548,7 @@ theorem test_sub_nsw__all_are_safe_thm (e : IntW 32) :
 
 
 theorem test_sub__all_are_safe_thm (e : IntW 32) :
-  select (icmp IntPredicate.eq (LLVM.and e (const? 32 255)) (const? 32 6)) (const? 32 (-260))
+  select (icmp IntPred.eq (LLVM.and e (const? 32 255)) (const? 32 6)) (const? 32 (-260))
       (sub (const? 32 (-254)) (LLVM.and e (const? 32 255))) ⊑
     sub (const? 32 (-254)) (LLVM.and e (const? 32 255)) { «nsw» := true, «nuw» := true } := by
     simp_alive_undef
@@ -560,7 +560,7 @@ theorem test_sub__all_are_safe_thm (e : IntW 32) :
 
 
 theorem test_sub_nuw_nsw__nuw_is_safe_thm (e : IntW 32) :
-  select (icmp IntPredicate.eq (LLVM.and e (const? 32 2147483647)) (const? 32 1073741824)) (const? 32 1073741824)
+  select (icmp IntPred.eq (LLVM.and e (const? 32 2147483647)) (const? 32 1073741824)) (const? 32 1073741824)
       (sub (const? 32 (-2147483648)) (LLVM.and e (const? 32 2147483647)) { «nsw» := true, «nuw» := true }) ⊑
     sub (const? 32 (-2147483648)) (LLVM.and e (const? 32 2147483647)) { «nsw» := false, «nuw» := true } := by
     simp_alive_undef
@@ -572,7 +572,7 @@ theorem test_sub_nuw_nsw__nuw_is_safe_thm (e : IntW 32) :
 
 
 theorem test_sub_nuw__nuw_is_safe_thm (e : IntW 32) :
-  select (icmp IntPredicate.eq (LLVM.and e (const? 32 2147483647)) (const? 32 1073741824)) (const? 32 1073741824)
+  select (icmp IntPred.eq (LLVM.and e (const? 32 2147483647)) (const? 32 1073741824)) (const? 32 1073741824)
       (sub (const? 32 (-2147483648)) (LLVM.and e (const? 32 2147483647)) { «nsw» := false, «nuw» := true }) ⊑
     sub (const? 32 (-2147483648)) (LLVM.and e (const? 32 2147483647)) { «nsw» := false, «nuw» := true } := by
     simp_alive_undef
@@ -584,7 +584,7 @@ theorem test_sub_nuw__nuw_is_safe_thm (e : IntW 32) :
 
 
 theorem test_sub_nsw__nuw_is_safe_thm (e : IntW 32) :
-  select (icmp IntPredicate.eq (LLVM.and e (const? 32 2147483647)) (const? 32 1073741824)) (const? 32 1073741824)
+  select (icmp IntPred.eq (LLVM.and e (const? 32 2147483647)) (const? 32 1073741824)) (const? 32 1073741824)
       (sub (const? 32 (-2147483648)) (LLVM.and e (const? 32 2147483647)) { «nsw» := true, «nuw» := false }) ⊑
     sub (const? 32 (-2147483648)) (LLVM.and e (const? 32 2147483647)) { «nsw» := false, «nuw» := true } := by
     simp_alive_undef
@@ -596,7 +596,7 @@ theorem test_sub_nsw__nuw_is_safe_thm (e : IntW 32) :
 
 
 theorem test_sub__nuw_is_safe_thm (e : IntW 32) :
-  select (icmp IntPredicate.eq (LLVM.and e (const? 32 2147483647)) (const? 32 1073741824)) (const? 32 1073741824)
+  select (icmp IntPred.eq (LLVM.and e (const? 32 2147483647)) (const? 32 1073741824)) (const? 32 1073741824)
       (sub (const? 32 (-2147483648)) (LLVM.and e (const? 32 2147483647))) ⊑
     sub (const? 32 (-2147483648)) (LLVM.and e (const? 32 2147483647)) { «nsw» := false, «nuw» := true } := by
     simp_alive_undef
@@ -608,7 +608,7 @@ theorem test_sub__nuw_is_safe_thm (e : IntW 32) :
 
 
 theorem test_sub_nuw_nsw__nsw_is_safe_thm (e : IntW 32) :
-  select (icmp IntPredicate.eq (LLVM.or e (const? 32 (-2147483648))) (const? 32 (-2147483647))) (const? 32 (-1))
+  select (icmp IntPred.eq (LLVM.or e (const? 32 (-2147483648))) (const? 32 (-2147483647))) (const? 32 (-1))
       (sub (const? 32 (-2147483648)) (LLVM.or e (const? 32 (-2147483648))) { «nsw» := true, «nuw» := true }) ⊑
     sub (const? 32 (-2147483648)) (LLVM.or e (const? 32 (-2147483648))) { «nsw» := true, «nuw» := false } := by
     simp_alive_undef
@@ -620,7 +620,7 @@ theorem test_sub_nuw_nsw__nsw_is_safe_thm (e : IntW 32) :
 
 
 theorem test_sub_nuw__nsw_is_safe_thm (e : IntW 32) :
-  select (icmp IntPredicate.eq (LLVM.or e (const? 32 (-2147483648))) (const? 32 (-2147483647))) (const? 32 (-1))
+  select (icmp IntPred.eq (LLVM.or e (const? 32 (-2147483648))) (const? 32 (-2147483647))) (const? 32 (-1))
       (sub (const? 32 (-2147483648)) (LLVM.or e (const? 32 (-2147483648))) { «nsw» := false, «nuw» := true }) ⊑
     sub (const? 32 (-2147483648)) (LLVM.or e (const? 32 (-2147483648))) { «nsw» := true, «nuw» := false } := by
     simp_alive_undef
@@ -632,7 +632,7 @@ theorem test_sub_nuw__nsw_is_safe_thm (e : IntW 32) :
 
 
 theorem test_sub_nsw__nsw_is_safe_thm (e : IntW 32) :
-  select (icmp IntPredicate.eq (LLVM.or e (const? 32 (-2147483648))) (const? 32 (-2147483647))) (const? 32 (-1))
+  select (icmp IntPred.eq (LLVM.or e (const? 32 (-2147483648))) (const? 32 (-2147483647))) (const? 32 (-1))
       (sub (const? 32 (-2147483648)) (LLVM.or e (const? 32 (-2147483648))) { «nsw» := true, «nuw» := false }) ⊑
     sub (const? 32 (-2147483648)) (LLVM.or e (const? 32 (-2147483648))) { «nsw» := true, «nuw» := false } := by
     simp_alive_undef
@@ -644,7 +644,7 @@ theorem test_sub_nsw__nsw_is_safe_thm (e : IntW 32) :
 
 
 theorem test_sub__nsw_is_safe_thm (e : IntW 32) :
-  select (icmp IntPredicate.eq (LLVM.or e (const? 32 (-2147483648))) (const? 32 (-2147483647))) (const? 32 (-1))
+  select (icmp IntPred.eq (LLVM.or e (const? 32 (-2147483648))) (const? 32 (-2147483647))) (const? 32 (-1))
       (sub (const? 32 (-2147483648)) (LLVM.or e (const? 32 (-2147483648)))) ⊑
     sub (const? 32 (-2147483648)) (LLVM.or e (const? 32 (-2147483648))) { «nsw» := true, «nuw» := false } := by
     simp_alive_undef
@@ -656,7 +656,7 @@ theorem test_sub__nsw_is_safe_thm (e : IntW 32) :
 
 
 theorem test_sub_nuw_nsw__none_are_safe_thm (e : IntW 32) :
-  select (icmp IntPredicate.eq e (const? 32 1)) (const? 32 2147483647)
+  select (icmp IntPred.eq e (const? 32 1)) (const? 32 2147483647)
       (sub (const? 32 (-2147483648)) e { «nsw» := true, «nuw» := true }) ⊑
     sub (const? 32 (-2147483648)) e := by
     simp_alive_undef
@@ -668,7 +668,7 @@ theorem test_sub_nuw_nsw__none_are_safe_thm (e : IntW 32) :
 
 
 theorem test_sub_nuw__none_are_safe_thm (e : IntW 32) :
-  select (icmp IntPredicate.eq e (const? 32 1)) (const? 32 2147483647)
+  select (icmp IntPred.eq e (const? 32 1)) (const? 32 2147483647)
       (sub (const? 32 (-2147483648)) e { «nsw» := false, «nuw» := true }) ⊑
     sub (const? 32 (-2147483648)) e := by
     simp_alive_undef
@@ -680,7 +680,7 @@ theorem test_sub_nuw__none_are_safe_thm (e : IntW 32) :
 
 
 theorem test_sub_nsw__none_are_safe_thm (e : IntW 32) :
-  select (icmp IntPredicate.eq e (const? 32 1)) (const? 32 2147483647)
+  select (icmp IntPred.eq e (const? 32 1)) (const? 32 2147483647)
       (sub (const? 32 (-2147483648)) e { «nsw» := true, «nuw» := false }) ⊑
     sub (const? 32 (-2147483648)) e := by
     simp_alive_undef
@@ -692,7 +692,7 @@ theorem test_sub_nsw__none_are_safe_thm (e : IntW 32) :
 
 
 theorem test_sub__none_are_safe_thm (e : IntW 32) :
-  select (icmp IntPredicate.eq e (const? 32 1)) (const? 32 2147483647) (sub (const? 32 (-2147483648)) e) ⊑
+  select (icmp IntPred.eq e (const? 32 1)) (const? 32 2147483647) (sub (const? 32 (-2147483648)) e) ⊑
     sub (const? 32 (-2147483648)) e := by
     simp_alive_undef
     simp_alive_ops
@@ -703,7 +703,7 @@ theorem test_sub__none_are_safe_thm (e : IntW 32) :
 
 
 theorem test_mul_nuw_nsw__all_are_safe_thm (e : IntW 32) :
-  select (icmp IntPredicate.eq (LLVM.and e (const? 32 255)) (const? 32 17)) (const? 32 153)
+  select (icmp IntPred.eq (LLVM.and e (const? 32 255)) (const? 32 17)) (const? 32 153)
       (mul (LLVM.and e (const? 32 255)) (const? 32 9) { «nsw» := true, «nuw» := true }) ⊑
     mul (LLVM.and e (const? 32 255)) (const? 32 9) { «nsw» := true, «nuw» := true } := by
     simp_alive_undef
@@ -715,7 +715,7 @@ theorem test_mul_nuw_nsw__all_are_safe_thm (e : IntW 32) :
 
 
 theorem test_mul_nuw__all_are_safe_thm (e : IntW 32) :
-  select (icmp IntPredicate.eq (LLVM.and e (const? 32 255)) (const? 32 17)) (const? 32 153)
+  select (icmp IntPred.eq (LLVM.and e (const? 32 255)) (const? 32 17)) (const? 32 153)
       (mul (LLVM.and e (const? 32 255)) (const? 32 9) { «nsw» := false, «nuw» := true }) ⊑
     mul (LLVM.and e (const? 32 255)) (const? 32 9) { «nsw» := true, «nuw» := true } := by
     simp_alive_undef
@@ -727,7 +727,7 @@ theorem test_mul_nuw__all_are_safe_thm (e : IntW 32) :
 
 
 theorem test_mul_nsw__all_are_safe_thm (e : IntW 32) :
-  select (icmp IntPredicate.eq (LLVM.and e (const? 32 255)) (const? 32 17)) (const? 32 153)
+  select (icmp IntPred.eq (LLVM.and e (const? 32 255)) (const? 32 17)) (const? 32 153)
       (mul (LLVM.and e (const? 32 255)) (const? 32 9) { «nsw» := true, «nuw» := false }) ⊑
     mul (LLVM.and e (const? 32 255)) (const? 32 9) { «nsw» := true, «nuw» := true } := by
     simp_alive_undef
@@ -739,7 +739,7 @@ theorem test_mul_nsw__all_are_safe_thm (e : IntW 32) :
 
 
 theorem test_mul__all_are_safe_thm (e : IntW 32) :
-  select (icmp IntPredicate.eq (LLVM.and e (const? 32 255)) (const? 32 17)) (const? 32 153)
+  select (icmp IntPred.eq (LLVM.and e (const? 32 255)) (const? 32 17)) (const? 32 153)
       (mul (LLVM.and e (const? 32 255)) (const? 32 9)) ⊑
     mul (LLVM.and e (const? 32 255)) (const? 32 9) { «nsw» := true, «nuw» := true } := by
     simp_alive_undef
@@ -751,7 +751,7 @@ theorem test_mul__all_are_safe_thm (e : IntW 32) :
 
 
 theorem test_mul_nuw_nsw__nuw_is_safe_thm (e : IntW 32) :
-  select (icmp IntPredicate.eq (LLVM.and e (const? 32 268435457)) (const? 32 268435456)) (const? 32 (-1879048192))
+  select (icmp IntPred.eq (LLVM.and e (const? 32 268435457)) (const? 32 268435456)) (const? 32 (-1879048192))
       (mul (LLVM.and e (const? 32 268435457)) (const? 32 9) { «nsw» := true, «nuw» := true }) ⊑
     mul (LLVM.and e (const? 32 268435457)) (const? 32 9) { «nsw» := false, «nuw» := true } := by
     simp_alive_undef
@@ -763,7 +763,7 @@ theorem test_mul_nuw_nsw__nuw_is_safe_thm (e : IntW 32) :
 
 
 theorem test_mul_nuw__nuw_is_safe_thm (e : IntW 32) :
-  select (icmp IntPredicate.eq (LLVM.and e (const? 32 268435457)) (const? 32 268435456)) (const? 32 (-1879048192))
+  select (icmp IntPred.eq (LLVM.and e (const? 32 268435457)) (const? 32 268435456)) (const? 32 (-1879048192))
       (mul (LLVM.and e (const? 32 268435457)) (const? 32 9) { «nsw» := false, «nuw» := true }) ⊑
     mul (LLVM.and e (const? 32 268435457)) (const? 32 9) { «nsw» := false, «nuw» := true } := by
     simp_alive_undef
@@ -775,7 +775,7 @@ theorem test_mul_nuw__nuw_is_safe_thm (e : IntW 32) :
 
 
 theorem test_mul_nsw__nuw_is_safe_thm (e : IntW 32) :
-  select (icmp IntPredicate.eq (LLVM.and e (const? 32 268435457)) (const? 32 268435456)) (const? 32 (-1879048192))
+  select (icmp IntPred.eq (LLVM.and e (const? 32 268435457)) (const? 32 268435456)) (const? 32 (-1879048192))
       (mul (LLVM.and e (const? 32 268435457)) (const? 32 9) { «nsw» := true, «nuw» := false }) ⊑
     mul (LLVM.and e (const? 32 268435457)) (const? 32 9) { «nsw» := false, «nuw» := true } := by
     simp_alive_undef
@@ -787,7 +787,7 @@ theorem test_mul_nsw__nuw_is_safe_thm (e : IntW 32) :
 
 
 theorem test_mul__nuw_is_safe_thm (e : IntW 32) :
-  select (icmp IntPredicate.eq (LLVM.and e (const? 32 268435457)) (const? 32 268435456)) (const? 32 (-1879048192))
+  select (icmp IntPred.eq (LLVM.and e (const? 32 268435457)) (const? 32 268435456)) (const? 32 (-1879048192))
       (mul (LLVM.and e (const? 32 268435457)) (const? 32 9)) ⊑
     mul (LLVM.and e (const? 32 268435457)) (const? 32 9) { «nsw» := false, «nuw» := true } := by
     simp_alive_undef
@@ -799,7 +799,7 @@ theorem test_mul__nuw_is_safe_thm (e : IntW 32) :
 
 
 theorem test_mul_nuw_nsw__nsw_is_safe_thm (e : IntW 32) :
-  select (icmp IntPredicate.eq (LLVM.or e (const? 32 (-83886080))) (const? 32 (-83886079))) (const? 32 (-754974711))
+  select (icmp IntPred.eq (LLVM.or e (const? 32 (-83886080))) (const? 32 (-83886079))) (const? 32 (-754974711))
       (mul (LLVM.or e (const? 32 (-83886080))) (const? 32 9) { «nsw» := true, «nuw» := true }) ⊑
     mul (LLVM.or e (const? 32 (-83886080))) (const? 32 9) { «nsw» := true, «nuw» := false } := by
     simp_alive_undef
@@ -811,7 +811,7 @@ theorem test_mul_nuw_nsw__nsw_is_safe_thm (e : IntW 32) :
 
 
 theorem test_mul_nuw__nsw_is_safe_thm (e : IntW 32) :
-  select (icmp IntPredicate.eq (LLVM.or e (const? 32 (-83886080))) (const? 32 (-83886079))) (const? 32 (-754974711))
+  select (icmp IntPred.eq (LLVM.or e (const? 32 (-83886080))) (const? 32 (-83886079))) (const? 32 (-754974711))
       (mul (LLVM.or e (const? 32 (-83886080))) (const? 32 9) { «nsw» := false, «nuw» := true }) ⊑
     mul (LLVM.or e (const? 32 (-83886080))) (const? 32 9) { «nsw» := true, «nuw» := false } := by
     simp_alive_undef
@@ -823,7 +823,7 @@ theorem test_mul_nuw__nsw_is_safe_thm (e : IntW 32) :
 
 
 theorem test_mul_nsw__nsw_is_safe_thm (e : IntW 32) :
-  select (icmp IntPredicate.eq (LLVM.or e (const? 32 (-83886080))) (const? 32 (-83886079))) (const? 32 (-754974711))
+  select (icmp IntPred.eq (LLVM.or e (const? 32 (-83886080))) (const? 32 (-83886079))) (const? 32 (-754974711))
       (mul (LLVM.or e (const? 32 (-83886080))) (const? 32 9) { «nsw» := true, «nuw» := false }) ⊑
     mul (LLVM.or e (const? 32 (-83886080))) (const? 32 9) { «nsw» := true, «nuw» := false } := by
     simp_alive_undef
@@ -835,7 +835,7 @@ theorem test_mul_nsw__nsw_is_safe_thm (e : IntW 32) :
 
 
 theorem test_mul__nsw_is_safe_thm (e : IntW 32) :
-  select (icmp IntPredicate.eq (LLVM.or e (const? 32 (-83886080))) (const? 32 (-83886079))) (const? 32 (-754974711))
+  select (icmp IntPred.eq (LLVM.or e (const? 32 (-83886080))) (const? 32 (-83886079))) (const? 32 (-754974711))
       (mul (LLVM.or e (const? 32 (-83886080))) (const? 32 9)) ⊑
     mul (LLVM.or e (const? 32 (-83886080))) (const? 32 9) { «nsw» := true, «nuw» := false } := by
     simp_alive_undef
@@ -847,7 +847,7 @@ theorem test_mul__nsw_is_safe_thm (e : IntW 32) :
 
 
 theorem test_mul_nuw_nsw__none_are_safe_thm (e : IntW 32) :
-  select (icmp IntPredicate.eq e (const? 32 805306368)) (const? 32 (-1342177280))
+  select (icmp IntPred.eq e (const? 32 805306368)) (const? 32 (-1342177280))
       (mul e (const? 32 9) { «nsw» := true, «nuw» := true }) ⊑
     mul e (const? 32 9) := by
     simp_alive_undef
@@ -859,7 +859,7 @@ theorem test_mul_nuw_nsw__none_are_safe_thm (e : IntW 32) :
 
 
 theorem test_mul_nuw__none_are_safe_thm (e : IntW 32) :
-  select (icmp IntPredicate.eq e (const? 32 805306368)) (const? 32 (-1342177280))
+  select (icmp IntPred.eq e (const? 32 805306368)) (const? 32 (-1342177280))
       (mul e (const? 32 9) { «nsw» := false, «nuw» := true }) ⊑
     mul e (const? 32 9) := by
     simp_alive_undef
@@ -871,7 +871,7 @@ theorem test_mul_nuw__none_are_safe_thm (e : IntW 32) :
 
 
 theorem test_mul_nsw__none_are_safe_thm (e : IntW 32) :
-  select (icmp IntPredicate.eq e (const? 32 805306368)) (const? 32 (-1342177280))
+  select (icmp IntPred.eq e (const? 32 805306368)) (const? 32 (-1342177280))
       (mul e (const? 32 9) { «nsw» := true, «nuw» := false }) ⊑
     mul e (const? 32 9) := by
     simp_alive_undef
@@ -883,7 +883,7 @@ theorem test_mul_nsw__none_are_safe_thm (e : IntW 32) :
 
 
 theorem test_mul__none_are_safe_thm (e : IntW 32) :
-  select (icmp IntPredicate.eq e (const? 32 805306368)) (const? 32 (-1342177280)) (mul e (const? 32 9)) ⊑
+  select (icmp IntPred.eq e (const? 32 805306368)) (const? 32 (-1342177280)) (mul e (const? 32 9)) ⊑
     mul e (const? 32 9) := by
     simp_alive_undef
     simp_alive_ops

--- a/SSA/Projects/InstCombine/tests/proofs/gselecthofhbittest_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gselecthofhbittest_proof.lean
@@ -12,9 +12,9 @@ set_option Elab.async false
 
 section gselecthofhbittest_proof
 theorem and_lshr_and_thm (e : IntW 32) :
-  select (icmp IntPredicate.eq (LLVM.and e (const? 32 1)) (const? 32 0)) (LLVM.and (lshr e (const? 32 1)) (const? 32 1))
+  select (icmp IntPred.eq (LLVM.and e (const? 32 1)) (const? 32 0)) (LLVM.and (lshr e (const? 32 1)) (const? 32 1))
       (const? 32 1) ⊑
-    zext 32 (icmp IntPredicate.ne (LLVM.and e (const? 32 3)) (const? 32 0)) := by
+    zext 32 (icmp IntPred.ne (LLVM.and e (const? 32 3)) (const? 32 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -24,8 +24,8 @@ theorem and_lshr_and_thm (e : IntW 32) :
 
 
 theorem and_and_thm (e : IntW 32) :
-  select (icmp IntPredicate.eq (LLVM.and e (const? 32 2)) (const? 32 0)) (LLVM.and e (const? 32 1)) (const? 32 1) ⊑
-    zext 32 (icmp IntPredicate.ne (LLVM.and e (const? 32 3)) (const? 32 0)) := by
+  select (icmp IntPred.eq (LLVM.and e (const? 32 2)) (const? 32 0)) (LLVM.and e (const? 32 1)) (const? 32 1) ⊑
+    zext 32 (icmp IntPred.ne (LLVM.and e (const? 32 3)) (const? 32 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -35,9 +35,9 @@ theorem and_and_thm (e : IntW 32) :
 
 
 theorem f_var0_thm (e e_1 : IntW 32) :
-  select (icmp IntPredicate.eq (LLVM.and e_1 e) (const? 32 0)) (LLVM.and (lshr e_1 (const? 32 1)) (const? 32 1))
+  select (icmp IntPred.eq (LLVM.and e_1 e) (const? 32 0)) (LLVM.and (lshr e_1 (const? 32 1)) (const? 32 1))
       (const? 32 1) ⊑
-    zext 32 (icmp IntPredicate.ne (LLVM.and e_1 (LLVM.or e (const? 32 2))) (const? 32 0)) := by
+    zext 32 (icmp IntPred.ne (LLVM.and e_1 (LLVM.or e (const? 32 2))) (const? 32 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -47,9 +47,9 @@ theorem f_var0_thm (e e_1 : IntW 32) :
 
 
 theorem f_var0_commutative_and_thm (e e_1 : IntW 32) :
-  select (icmp IntPredicate.eq (LLVM.and e_1 e) (const? 32 0)) (LLVM.and (lshr e (const? 32 1)) (const? 32 1))
+  select (icmp IntPred.eq (LLVM.and e_1 e) (const? 32 0)) (LLVM.and (lshr e (const? 32 1)) (const? 32 1))
       (const? 32 1) ⊑
-    zext 32 (icmp IntPredicate.ne (LLVM.and e (LLVM.or e_1 (const? 32 2))) (const? 32 0)) := by
+    zext 32 (icmp IntPred.ne (LLVM.and e (LLVM.or e_1 (const? 32 2))) (const? 32 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -59,8 +59,8 @@ theorem f_var0_commutative_and_thm (e e_1 : IntW 32) :
 
 
 theorem f_var1_thm (e e_1 : IntW 32) :
-  select (icmp IntPredicate.eq (LLVM.and e_1 e) (const? 32 0)) (LLVM.and e_1 (const? 32 1)) (const? 32 1) ⊑
-    zext 32 (icmp IntPredicate.ne (LLVM.and e_1 (LLVM.or e (const? 32 1))) (const? 32 0)) := by
+  select (icmp IntPred.eq (LLVM.and e_1 e) (const? 32 0)) (LLVM.and e_1 (const? 32 1)) (const? 32 1) ⊑
+    zext 32 (icmp IntPred.ne (LLVM.and e_1 (LLVM.or e (const? 32 1))) (const? 32 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -70,8 +70,8 @@ theorem f_var1_thm (e e_1 : IntW 32) :
 
 
 theorem f_var1_commutative_and_thm (e e_1 : IntW 32) :
-  select (icmp IntPredicate.eq (LLVM.and e_1 e) (const? 32 0)) (LLVM.and e (const? 32 1)) (const? 32 1) ⊑
-    zext 32 (icmp IntPredicate.ne (LLVM.and e (LLVM.or e_1 (const? 32 1))) (const? 32 0)) := by
+  select (icmp IntPred.eq (LLVM.and e_1 e) (const? 32 0)) (LLVM.and e (const? 32 1)) (const? 32 1) ⊑
+    zext 32 (icmp IntPred.ne (LLVM.and e (LLVM.or e_1 (const? 32 1))) (const? 32 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -81,7 +81,7 @@ theorem f_var1_commutative_and_thm (e e_1 : IntW 32) :
 
 
 theorem n5_thm (e : IntW 32) :
-  select (icmp IntPredicate.eq (LLVM.and e (const? 32 2)) (const? 32 0)) (LLVM.and e (const? 32 2)) (const? 32 1) ⊑
+  select (icmp IntPred.eq (LLVM.and e (const? 32 2)) (const? 32 0)) (LLVM.and e (const? 32 2)) (const? 32 1) ⊑
     LLVM.and (lshr e (const? 32 1)) (const? 32 1) := by
     simp_alive_undef
     simp_alive_ops
@@ -92,9 +92,9 @@ theorem n5_thm (e : IntW 32) :
 
 
 theorem n6_thm (e : IntW 32) :
-  select (icmp IntPredicate.ne (LLVM.and e (const? 32 1)) (const? 32 0)) (LLVM.and (lshr e (const? 32 2)) (const? 32 1))
+  select (icmp IntPred.ne (LLVM.and e (const? 32 1)) (const? 32 0)) (LLVM.and (lshr e (const? 32 2)) (const? 32 1))
       (const? 32 1) ⊑
-    select (icmp IntPredicate.eq (LLVM.and e (const? 32 1)) (const? 32 0)) (const? 32 1)
+    select (icmp IntPred.eq (LLVM.and e (const? 32 1)) (const? 32 0)) (const? 32 1)
       (LLVM.and (lshr e (const? 32 2)) (const? 32 1)) := by
     simp_alive_undef
     simp_alive_ops
@@ -105,8 +105,8 @@ theorem n6_thm (e : IntW 32) :
 
 
 theorem n7_thm (e : IntW 32) :
-  select (icmp IntPredicate.ne (LLVM.and e (const? 32 2)) (const? 32 0)) (LLVM.and e (const? 32 1)) (const? 32 1) ⊑
-    select (icmp IntPredicate.eq (LLVM.and e (const? 32 2)) (const? 32 0)) (const? 32 1)
+  select (icmp IntPred.ne (LLVM.and e (const? 32 2)) (const? 32 0)) (LLVM.and e (const? 32 1)) (const? 32 1) ⊑
+    select (icmp IntPred.eq (LLVM.and e (const? 32 2)) (const? 32 0)) (const? 32 1)
       (LLVM.and e (const? 32 1)) := by
     simp_alive_undef
     simp_alive_ops
@@ -117,9 +117,9 @@ theorem n7_thm (e : IntW 32) :
 
 
 theorem n8_thm (e : IntW 32) :
-  select (icmp IntPredicate.eq (LLVM.and e (const? 32 1)) (const? 32 1)) (LLVM.and (lshr e (const? 32 2)) (const? 32 1))
+  select (icmp IntPred.eq (LLVM.and e (const? 32 1)) (const? 32 1)) (LLVM.and (lshr e (const? 32 2)) (const? 32 1))
       (const? 32 1) ⊑
-    select (icmp IntPredicate.eq (LLVM.and e (const? 32 1)) (const? 32 0)) (const? 32 1)
+    select (icmp IntPred.eq (LLVM.and e (const? 32 1)) (const? 32 0)) (const? 32 1)
       (LLVM.and (lshr e (const? 32 2)) (const? 32 1)) := by
     simp_alive_undef
     simp_alive_ops

--- a/SSA/Projects/InstCombine/tests/proofs/gselecthsafehimpliedcondhtransforms_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gselecthsafehimpliedcondhtransforms_proof.lean
@@ -12,9 +12,9 @@ set_option Elab.async false
 
 section gselecthsafehimpliedcondhtransforms_proof
 theorem a_true_implies_b_true_thm (e e_1 : IntW 1) (e_2 : IntW 8) :
-  select (icmp IntPredicate.ugt e_2 (const? 8 20)) (select (icmp IntPredicate.ugt e_2 (const? 8 10)) e_1 e)
+  select (icmp IntPred.ugt e_2 (const? 8 20)) (select (icmp IntPred.ugt e_2 (const? 8 10)) e_1 e)
       (const? 1 0) ⊑
-    select (icmp IntPredicate.ugt e_2 (const? 8 20)) e_1 (const? 1 0) := by
+    select (icmp IntPred.ugt e_2 (const? 8 20)) e_1 (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -24,8 +24,8 @@ theorem a_true_implies_b_true_thm (e e_1 : IntW 1) (e_2 : IntW 8) :
 
 
 theorem a_true_implies_b_true2_thm (e e_1 : IntW 1) (e_2 : IntW 8) :
-  LLVM.and (icmp IntPredicate.ugt e_2 (const? 8 20)) (select (icmp IntPredicate.ugt e_2 (const? 8 10)) e_1 e) ⊑
-    select (icmp IntPredicate.ugt e_2 (const? 8 20)) e_1 (const? 1 0) := by
+  LLVM.and (icmp IntPred.ugt e_2 (const? 8 20)) (select (icmp IntPred.ugt e_2 (const? 8 10)) e_1 e) ⊑
+    select (icmp IntPred.ugt e_2 (const? 8 20)) e_1 (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -35,8 +35,8 @@ theorem a_true_implies_b_true2_thm (e e_1 : IntW 1) (e_2 : IntW 8) :
 
 
 theorem a_true_implies_b_true2_comm_thm (e e_1 : IntW 1) (e_2 : IntW 8) :
-  LLVM.and (select (icmp IntPredicate.ugt e_2 (const? 8 10)) e_1 e) (icmp IntPredicate.ugt e_2 (const? 8 20)) ⊑
-    select (icmp IntPredicate.ugt e_2 (const? 8 20)) e_1 (const? 1 0) := by
+  LLVM.and (select (icmp IntPred.ugt e_2 (const? 8 10)) e_1 e) (icmp IntPred.ugt e_2 (const? 8 20)) ⊑
+    select (icmp IntPred.ugt e_2 (const? 8 20)) e_1 (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -46,9 +46,9 @@ theorem a_true_implies_b_true2_comm_thm (e e_1 : IntW 1) (e_2 : IntW 8) :
 
 
 theorem a_true_implies_b_false_thm (e e_1 : IntW 1) (e_2 : IntW 8) :
-  select (icmp IntPredicate.ugt e_2 (const? 8 20)) (select (icmp IntPredicate.ult e_2 (const? 8 10)) e_1 e)
+  select (icmp IntPred.ugt e_2 (const? 8 20)) (select (icmp IntPred.ult e_2 (const? 8 10)) e_1 e)
       (const? 1 0) ⊑
-    select (icmp IntPredicate.ugt e_2 (const? 8 20)) e (const? 1 0) := by
+    select (icmp IntPred.ugt e_2 (const? 8 20)) e (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -58,8 +58,8 @@ theorem a_true_implies_b_false_thm (e e_1 : IntW 1) (e_2 : IntW 8) :
 
 
 theorem a_true_implies_b_false2_thm (e e_1 : IntW 1) (e_2 : IntW 8) :
-  LLVM.and (icmp IntPredicate.ugt e_2 (const? 8 20)) (select (icmp IntPredicate.eq e_2 (const? 8 10)) e_1 e) ⊑
-    select (icmp IntPredicate.ugt e_2 (const? 8 20)) e (const? 1 0) := by
+  LLVM.and (icmp IntPred.ugt e_2 (const? 8 20)) (select (icmp IntPred.eq e_2 (const? 8 10)) e_1 e) ⊑
+    select (icmp IntPred.ugt e_2 (const? 8 20)) e (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -69,8 +69,8 @@ theorem a_true_implies_b_false2_thm (e e_1 : IntW 1) (e_2 : IntW 8) :
 
 
 theorem a_true_implies_b_false2_comm_thm (e e_1 : IntW 1) (e_2 : IntW 8) :
-  LLVM.and (select (icmp IntPredicate.eq e_2 (const? 8 10)) e_1 e) (icmp IntPredicate.ugt e_2 (const? 8 20)) ⊑
-    select (icmp IntPredicate.ugt e_2 (const? 8 20)) e (const? 1 0) := by
+  LLVM.and (select (icmp IntPred.eq e_2 (const? 8 10)) e_1 e) (icmp IntPred.ugt e_2 (const? 8 20)) ⊑
+    select (icmp IntPred.ugt e_2 (const? 8 20)) e (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -80,9 +80,9 @@ theorem a_true_implies_b_false2_comm_thm (e e_1 : IntW 1) (e_2 : IntW 8) :
 
 
 theorem a_false_implies_b_true_thm (e e_1 : IntW 1) (e_2 : IntW 8) :
-  select (icmp IntPredicate.ugt e_2 (const? 8 10)) (const? 1 1)
-      (select (icmp IntPredicate.ult e_2 (const? 8 20)) e_1 e) ⊑
-    select (icmp IntPredicate.ugt e_2 (const? 8 10)) (const? 1 1) e_1 := by
+  select (icmp IntPred.ugt e_2 (const? 8 10)) (const? 1 1)
+      (select (icmp IntPred.ult e_2 (const? 8 20)) e_1 e) ⊑
+    select (icmp IntPred.ugt e_2 (const? 8 10)) (const? 1 1) e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -92,8 +92,8 @@ theorem a_false_implies_b_true_thm (e e_1 : IntW 1) (e_2 : IntW 8) :
 
 
 theorem a_false_implies_b_true2_thm (e e_1 : IntW 1) (e_2 : IntW 8) :
-  LLVM.or (icmp IntPredicate.ugt e_2 (const? 8 10)) (select (icmp IntPredicate.ult e_2 (const? 8 20)) e_1 e) ⊑
-    select (icmp IntPredicate.ugt e_2 (const? 8 10)) (const? 1 1) e_1 := by
+  LLVM.or (icmp IntPred.ugt e_2 (const? 8 10)) (select (icmp IntPred.ult e_2 (const? 8 20)) e_1 e) ⊑
+    select (icmp IntPred.ugt e_2 (const? 8 10)) (const? 1 1) e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -103,8 +103,8 @@ theorem a_false_implies_b_true2_thm (e e_1 : IntW 1) (e_2 : IntW 8) :
 
 
 theorem a_false_implies_b_true2_comm_thm (e e_1 : IntW 1) (e_2 : IntW 8) :
-  LLVM.or (select (icmp IntPredicate.ult e_2 (const? 8 20)) e_1 e) (icmp IntPredicate.ugt e_2 (const? 8 10)) ⊑
-    select (icmp IntPredicate.ugt e_2 (const? 8 10)) (const? 1 1) e_1 := by
+  LLVM.or (select (icmp IntPred.ult e_2 (const? 8 20)) e_1 e) (icmp IntPred.ugt e_2 (const? 8 10)) ⊑
+    select (icmp IntPred.ugt e_2 (const? 8 10)) (const? 1 1) e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -114,9 +114,9 @@ theorem a_false_implies_b_true2_comm_thm (e e_1 : IntW 1) (e_2 : IntW 8) :
 
 
 theorem a_false_implies_b_false_thm (e e_1 : IntW 1) (e_2 : IntW 8) :
-  select (icmp IntPredicate.ugt e_2 (const? 8 10)) (const? 1 1)
-      (select (icmp IntPredicate.ugt e_2 (const? 8 20)) e_1 e) ⊑
-    select (icmp IntPredicate.ugt e_2 (const? 8 10)) (const? 1 1) e := by
+  select (icmp IntPred.ugt e_2 (const? 8 10)) (const? 1 1)
+      (select (icmp IntPred.ugt e_2 (const? 8 20)) e_1 e) ⊑
+    select (icmp IntPred.ugt e_2 (const? 8 10)) (const? 1 1) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -126,8 +126,8 @@ theorem a_false_implies_b_false_thm (e e_1 : IntW 1) (e_2 : IntW 8) :
 
 
 theorem a_false_implies_b_false2_thm (e e_1 : IntW 1) (e_2 : IntW 8) :
-  LLVM.or (icmp IntPredicate.ugt e_2 (const? 8 10)) (select (icmp IntPredicate.ugt e_2 (const? 8 20)) e_1 e) ⊑
-    select (icmp IntPredicate.ugt e_2 (const? 8 10)) (const? 1 1) e := by
+  LLVM.or (icmp IntPred.ugt e_2 (const? 8 10)) (select (icmp IntPred.ugt e_2 (const? 8 20)) e_1 e) ⊑
+    select (icmp IntPred.ugt e_2 (const? 8 10)) (const? 1 1) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -137,8 +137,8 @@ theorem a_false_implies_b_false2_thm (e e_1 : IntW 1) (e_2 : IntW 8) :
 
 
 theorem a_false_implies_b_false2_comm_thm (e e_1 : IntW 1) (e_2 : IntW 8) :
-  LLVM.or (select (icmp IntPredicate.ugt e_2 (const? 8 20)) e_1 e) (icmp IntPredicate.ugt e_2 (const? 8 10)) ⊑
-    select (icmp IntPredicate.ugt e_2 (const? 8 10)) (const? 1 1) e := by
+  LLVM.or (select (icmp IntPred.ugt e_2 (const? 8 20)) e_1 e) (icmp IntPred.ugt e_2 (const? 8 10)) ⊑
+    select (icmp IntPred.ugt e_2 (const? 8 10)) (const? 1 1) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gselecthsafehtransforms_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gselecthsafehtransforms_proof.lean
@@ -12,8 +12,8 @@ set_option Elab.async false
 
 section gselecthsafehtransforms_proof
 theorem cond_eq_and_const_thm (e e_1 : IntW 8) :
-  select (icmp IntPredicate.eq e_1 (const? 8 10)) (icmp IntPredicate.ult e_1 e) (const? 1 0) ⊑
-    select (icmp IntPredicate.eq e_1 (const? 8 10)) (icmp IntPredicate.ugt e (const? 8 10)) (const? 1 0) := by
+  select (icmp IntPred.eq e_1 (const? 8 10)) (icmp IntPred.ult e_1 e) (const? 1 0) ⊑
+    select (icmp IntPred.eq e_1 (const? 8 10)) (icmp IntPred.ugt e (const? 8 10)) (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -23,8 +23,8 @@ theorem cond_eq_and_const_thm (e e_1 : IntW 8) :
 
 
 theorem cond_eq_or_const_thm (e e_1 : IntW 8) :
-  select (icmp IntPredicate.ne e_1 (const? 8 10)) (const? 1 1) (icmp IntPredicate.ult e_1 e) ⊑
-    select (icmp IntPredicate.ne e_1 (const? 8 10)) (const? 1 1) (icmp IntPredicate.ugt e (const? 8 10)) := by
+  select (icmp IntPred.ne e_1 (const? 8 10)) (const? 1 1) (icmp IntPred.ult e_1 e) ⊑
+    select (icmp IntPred.ne e_1 (const? 8 10)) (const? 1 1) (icmp IntPred.ugt e (const? 8 10)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -34,8 +34,8 @@ theorem cond_eq_or_const_thm (e e_1 : IntW 8) :
 
 
 theorem xor_and_thm (e e_1 : IntW 32) (e_2 : IntW 1) :
-  LLVM.xor (select e_2 (icmp IntPredicate.ult e_1 e) (const? 1 0)) (const? 1 1) ⊑
-    select (LLVM.xor e_2 (const? 1 1)) (const? 1 1) (icmp IntPredicate.uge e_1 e) := by
+  LLVM.xor (select e_2 (icmp IntPred.ult e_1 e) (const? 1 0)) (const? 1 1) ⊑
+    select (LLVM.xor e_2 (const? 1 1)) (const? 1 1) (icmp IntPred.uge e_1 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -45,8 +45,8 @@ theorem xor_and_thm (e e_1 : IntW 32) (e_2 : IntW 1) :
 
 
 theorem xor_or_thm (e e_1 : IntW 32) (e_2 : IntW 1) :
-  LLVM.xor (select e_2 (const? 1 1) (icmp IntPredicate.ult e_1 e)) (const? 1 1) ⊑
-    select (LLVM.xor e_2 (const? 1 1)) (icmp IntPredicate.uge e_1 e) (const? 1 0) := by
+  LLVM.xor (select e_2 (const? 1 1) (icmp IntPred.ult e_1 e)) (const? 1 1) ⊑
+    select (LLVM.xor e_2 (const? 1 1)) (icmp IntPred.uge e_1 e) (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -56,8 +56,8 @@ theorem xor_or_thm (e e_1 : IntW 32) (e_2 : IntW 1) :
 
 
 theorem and_orn_cmp_1_logical_thm (e : IntW 1) (e_1 e_2 : IntW 32) :
-  select (icmp IntPredicate.sgt e_2 e_1) (select e (const? 1 1) (icmp IntPredicate.sle e_2 e_1)) (const? 1 0) ⊑
-    select (icmp IntPredicate.sgt e_2 e_1) e (const? 1 0) := by
+  select (icmp IntPred.sgt e_2 e_1) (select e (const? 1 1) (icmp IntPred.sle e_2 e_1)) (const? 1 0) ⊑
+    select (icmp IntPred.sgt e_2 e_1) e (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -67,8 +67,8 @@ theorem and_orn_cmp_1_logical_thm (e : IntW 1) (e_1 e_2 : IntW 32) :
 
 
 theorem andn_or_cmp_2_logical_thm (e e_1 : IntW 16) (e_2 : IntW 1) :
-  select (select e_2 (const? 1 1) (icmp IntPredicate.sge e_1 e)) (icmp IntPredicate.slt e_1 e) (const? 1 0) ⊑
-    select e_2 (icmp IntPredicate.slt e_1 e) (const? 1 0) := by
+  select (select e_2 (const? 1 1) (icmp IntPred.sge e_1 e)) (icmp IntPred.slt e_1 e) (const? 1 0) ⊑
+    select e_2 (icmp IntPred.slt e_1 e) (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -78,8 +78,8 @@ theorem andn_or_cmp_2_logical_thm (e e_1 : IntW 16) (e_2 : IntW 1) :
 
 
 theorem andn_or_cmp_2_partial_logical_thm (e : IntW 1) (e_1 e_2 : IntW 16) :
-  select (LLVM.or (icmp IntPredicate.sge e_2 e_1) e) (icmp IntPredicate.slt e_2 e_1) (const? 1 0) ⊑
-    LLVM.and e (icmp IntPredicate.slt e_2 e_1) := by
+  select (LLVM.or (icmp IntPred.sge e_2 e_1) e) (icmp IntPred.slt e_2 e_1) (const? 1 0) ⊑
+    LLVM.and e (icmp IntPred.slt e_2 e_1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -274,8 +274,8 @@ theorem bools2_logical_commute3_and1_thm (e e_1 e_2 : IntW 1) :
 
 
 theorem orn_and_cmp_1_logical_thm (e : IntW 1) (e_1 e_2 : IntW 37) :
-  select (icmp IntPredicate.sle e_2 e_1) (const? 1 1) (select e (icmp IntPredicate.sgt e_2 e_1) (const? 1 0)) ⊑
-    select (icmp IntPredicate.sle e_2 e_1) (const? 1 1) e := by
+  select (icmp IntPred.sle e_2 e_1) (const? 1 1) (select e (icmp IntPred.sgt e_2 e_1) (const? 1 0)) ⊑
+    select (icmp IntPred.sle e_2 e_1) (const? 1 1) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -285,8 +285,8 @@ theorem orn_and_cmp_1_logical_thm (e : IntW 1) (e_1 e_2 : IntW 37) :
 
 
 theorem orn_and_cmp_2_logical_thm (e e_1 : IntW 16) (e_2 : IntW 1) :
-  select (select e_2 (icmp IntPredicate.sge e_1 e) (const? 1 0)) (const? 1 1) (icmp IntPredicate.slt e_1 e) ⊑
-    select e_2 (const? 1 1) (icmp IntPredicate.slt e_1 e) := by
+  select (select e_2 (icmp IntPred.sge e_1 e) (const? 1 0)) (const? 1 1) (icmp IntPred.slt e_1 e) ⊑
+    select e_2 (const? 1 1) (icmp IntPred.slt e_1 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -296,8 +296,8 @@ theorem orn_and_cmp_2_logical_thm (e e_1 : IntW 16) (e_2 : IntW 1) :
 
 
 theorem orn_and_cmp_2_partial_logical_thm (e : IntW 1) (e_1 e_2 : IntW 16) :
-  select (LLVM.and (icmp IntPredicate.sge e_2 e_1) e) (const? 1 1) (icmp IntPredicate.slt e_2 e_1) ⊑
-    LLVM.or e (icmp IntPredicate.slt e_2 e_1) := by
+  select (LLVM.and (icmp IntPred.sge e_2 e_1) e) (const? 1 1) (icmp IntPred.slt e_2 e_1) ⊑
+    LLVM.or e (icmp IntPred.slt e_2 e_1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gselecthwithhbitwisehops_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gselecthwithhbitwisehops_proof.lean
@@ -12,7 +12,7 @@ set_option Elab.async false
 
 section gselecthwithhbitwisehops_proof
 theorem select_icmp_eq_and_1_0_or_2_thm (e e_1 : IntW 32) :
-  select (icmp IntPredicate.eq (LLVM.and e_1 (const? 32 1)) (const? 32 0)) e (LLVM.or e (const? 32 2)) ⊑
+  select (icmp IntPred.eq (LLVM.and e_1 (const? 32 1)) (const? 32 0)) e (LLVM.or e (const? 32 2)) ⊑
     LLVM.or e (LLVM.and (shl e_1 (const? 32 1)) (const? 32 2)) := by
     simp_alive_undef
     simp_alive_ops
@@ -23,7 +23,7 @@ theorem select_icmp_eq_and_1_0_or_2_thm (e e_1 : IntW 32) :
 
 
 theorem select_icmp_eq_and_1_0_xor_2_thm (e e_1 : IntW 32) :
-  select (icmp IntPredicate.eq (LLVM.and e_1 (const? 32 1)) (const? 32 0)) e (LLVM.xor e (const? 32 2)) ⊑
+  select (icmp IntPred.eq (LLVM.and e_1 (const? 32 1)) (const? 32 0)) e (LLVM.xor e (const? 32 2)) ⊑
     LLVM.xor e (LLVM.and (shl e_1 (const? 32 1)) (const? 32 2)) := by
     simp_alive_undef
     simp_alive_ops
@@ -34,7 +34,7 @@ theorem select_icmp_eq_and_1_0_xor_2_thm (e e_1 : IntW 32) :
 
 
 theorem select_icmp_eq_and_32_0_or_8_thm (e e_1 : IntW 32) :
-  select (icmp IntPredicate.eq (LLVM.and e_1 (const? 32 32)) (const? 32 0)) e (LLVM.or e (const? 32 8)) ⊑
+  select (icmp IntPred.eq (LLVM.and e_1 (const? 32 32)) (const? 32 0)) e (LLVM.or e (const? 32 8)) ⊑
     LLVM.or e (LLVM.and (lshr e_1 (const? 32 2)) (const? 32 8)) := by
     simp_alive_undef
     simp_alive_ops
@@ -45,7 +45,7 @@ theorem select_icmp_eq_and_32_0_or_8_thm (e e_1 : IntW 32) :
 
 
 theorem select_icmp_eq_and_32_0_xor_8_thm (e e_1 : IntW 32) :
-  select (icmp IntPredicate.eq (LLVM.and e_1 (const? 32 32)) (const? 32 0)) e (LLVM.xor e (const? 32 8)) ⊑
+  select (icmp IntPred.eq (LLVM.and e_1 (const? 32 32)) (const? 32 0)) e (LLVM.xor e (const? 32 8)) ⊑
     LLVM.xor e (LLVM.and (lshr e_1 (const? 32 2)) (const? 32 8)) := by
     simp_alive_undef
     simp_alive_ops
@@ -56,7 +56,7 @@ theorem select_icmp_eq_and_32_0_xor_8_thm (e e_1 : IntW 32) :
 
 
 theorem select_icmp_ne_0_and_4096_or_4096_thm (e e_1 : IntW 32) :
-  select (icmp IntPredicate.ne (const? 32 0) (LLVM.and e_1 (const? 32 4096))) e (LLVM.or e (const? 32 4096)) ⊑
+  select (icmp IntPred.ne (const? 32 0) (LLVM.and e_1 (const? 32 4096))) e (LLVM.or e (const? 32 4096)) ⊑
     LLVM.or e (LLVM.xor (LLVM.and e_1 (const? 32 4096)) (const? 32 4096)) := by
     simp_alive_undef
     simp_alive_ops
@@ -67,7 +67,7 @@ theorem select_icmp_ne_0_and_4096_or_4096_thm (e e_1 : IntW 32) :
 
 
 theorem select_icmp_ne_0_and_4096_xor_4096_thm (e e_1 : IntW 32) :
-  select (icmp IntPredicate.ne (const? 32 0) (LLVM.and e_1 (const? 32 4096))) e (LLVM.xor e (const? 32 4096)) ⊑
+  select (icmp IntPred.ne (const? 32 0) (LLVM.and e_1 (const? 32 4096))) e (LLVM.xor e (const? 32 4096)) ⊑
     LLVM.xor (LLVM.xor (LLVM.and e_1 (const? 32 4096)) e) (const? 32 4096) := by
     simp_alive_undef
     simp_alive_ops
@@ -78,8 +78,8 @@ theorem select_icmp_ne_0_and_4096_xor_4096_thm (e e_1 : IntW 32) :
 
 
 theorem select_icmp_ne_0_and_4096_and_not_4096_thm (e e_1 : IntW 32) :
-  select (icmp IntPredicate.ne (const? 32 0) (LLVM.and e_1 (const? 32 4096))) e (LLVM.and e (const? 32 (-4097))) ⊑
-    select (icmp IntPredicate.eq (LLVM.and e_1 (const? 32 4096)) (const? 32 0)) (LLVM.and e (const? 32 (-4097)))
+  select (icmp IntPred.ne (const? 32 0) (LLVM.and e_1 (const? 32 4096))) e (LLVM.and e (const? 32 (-4097))) ⊑
+    select (icmp IntPred.eq (LLVM.and e_1 (const? 32 4096)) (const? 32 0)) (LLVM.and e (const? 32 (-4097)))
       e := by
     simp_alive_undef
     simp_alive_ops
@@ -90,7 +90,7 @@ theorem select_icmp_ne_0_and_4096_and_not_4096_thm (e e_1 : IntW 32) :
 
 
 theorem select_icmp_eq_and_4096_0_or_4096_thm (e e_1 : IntW 32) :
-  select (icmp IntPredicate.eq (LLVM.and e_1 (const? 32 4096)) (const? 32 0)) e (LLVM.or e (const? 32 4096)) ⊑
+  select (icmp IntPred.eq (LLVM.and e_1 (const? 32 4096)) (const? 32 0)) e (LLVM.or e (const? 32 4096)) ⊑
     LLVM.or e (LLVM.and e_1 (const? 32 4096)) := by
     simp_alive_undef
     simp_alive_ops
@@ -101,7 +101,7 @@ theorem select_icmp_eq_and_4096_0_or_4096_thm (e e_1 : IntW 32) :
 
 
 theorem select_icmp_eq_and_4096_0_xor_4096_thm (e e_1 : IntW 32) :
-  select (icmp IntPredicate.eq (LLVM.and e_1 (const? 32 4096)) (const? 32 0)) e (LLVM.xor e (const? 32 4096)) ⊑
+  select (icmp IntPred.eq (LLVM.and e_1 (const? 32 4096)) (const? 32 0)) e (LLVM.xor e (const? 32 4096)) ⊑
     LLVM.xor e (LLVM.and e_1 (const? 32 4096)) := by
     simp_alive_undef
     simp_alive_ops
@@ -112,7 +112,7 @@ theorem select_icmp_eq_and_4096_0_xor_4096_thm (e e_1 : IntW 32) :
 
 
 theorem select_icmp_eq_0_and_1_or_1_thm (e : IntW 32) (e_1 : IntW 64) :
-  select (icmp IntPredicate.eq (LLVM.and e_1 (const? 64 1)) (const? 64 0)) e (LLVM.or e (const? 32 1)) ⊑
+  select (icmp IntPred.eq (LLVM.and e_1 (const? 64 1)) (const? 64 0)) e (LLVM.or e (const? 32 1)) ⊑
     LLVM.or e (LLVM.and (trunc 32 e_1) (const? 32 1)) := by
     simp_alive_undef
     simp_alive_ops
@@ -123,7 +123,7 @@ theorem select_icmp_eq_0_and_1_or_1_thm (e : IntW 32) (e_1 : IntW 64) :
 
 
 theorem select_icmp_eq_0_and_1_xor_1_thm (e : IntW 32) (e_1 : IntW 64) :
-  select (icmp IntPredicate.eq (LLVM.and e_1 (const? 64 1)) (const? 64 0)) e (LLVM.xor e (const? 32 1)) ⊑
+  select (icmp IntPred.eq (LLVM.and e_1 (const? 64 1)) (const? 64 0)) e (LLVM.xor e (const? 32 1)) ⊑
     LLVM.xor e (LLVM.and (trunc 32 e_1) (const? 32 1)) := by
     simp_alive_undef
     simp_alive_ops
@@ -134,7 +134,7 @@ theorem select_icmp_eq_0_and_1_xor_1_thm (e : IntW 32) (e_1 : IntW 64) :
 
 
 theorem select_icmp_ne_0_and_4096_or_32_thm (e e_1 : IntW 32) :
-  select (icmp IntPredicate.ne (const? 32 0) (LLVM.and e_1 (const? 32 4096))) e (LLVM.or e (const? 32 32)) ⊑
+  select (icmp IntPred.ne (const? 32 0) (LLVM.and e_1 (const? 32 4096))) e (LLVM.or e (const? 32 32)) ⊑
     LLVM.or e (LLVM.xor (LLVM.and (lshr e_1 (const? 32 7)) (const? 32 32)) (const? 32 32)) := by
     simp_alive_undef
     simp_alive_ops
@@ -145,7 +145,7 @@ theorem select_icmp_ne_0_and_4096_or_32_thm (e e_1 : IntW 32) :
 
 
 theorem select_icmp_ne_0_and_4096_xor_32_thm (e e_1 : IntW 32) :
-  select (icmp IntPredicate.ne (const? 32 0) (LLVM.and e_1 (const? 32 4096))) e (LLVM.xor e (const? 32 32)) ⊑
+  select (icmp IntPred.ne (const? 32 0) (LLVM.and e_1 (const? 32 4096))) e (LLVM.xor e (const? 32 32)) ⊑
     LLVM.xor (LLVM.xor (LLVM.and (lshr e_1 (const? 32 7)) (const? 32 32)) e) (const? 32 32) := by
     simp_alive_undef
     simp_alive_ops
@@ -156,8 +156,8 @@ theorem select_icmp_ne_0_and_4096_xor_32_thm (e e_1 : IntW 32) :
 
 
 theorem select_icmp_ne_0_and_4096_and_not_32_thm (e e_1 : IntW 32) :
-  select (icmp IntPredicate.ne (const? 32 0) (LLVM.and e_1 (const? 32 4096))) e (LLVM.and e (const? 32 (-33))) ⊑
-    select (icmp IntPredicate.eq (LLVM.and e_1 (const? 32 4096)) (const? 32 0)) (LLVM.and e (const? 32 (-33)))
+  select (icmp IntPred.ne (const? 32 0) (LLVM.and e_1 (const? 32 4096))) e (LLVM.and e (const? 32 (-33))) ⊑
+    select (icmp IntPred.eq (LLVM.and e_1 (const? 32 4096)) (const? 32 0)) (LLVM.and e (const? 32 (-33)))
       e := by
     simp_alive_undef
     simp_alive_ops
@@ -168,7 +168,7 @@ theorem select_icmp_ne_0_and_4096_and_not_32_thm (e e_1 : IntW 32) :
 
 
 theorem select_icmp_ne_0_and_32_or_4096_thm (e e_1 : IntW 32) :
-  select (icmp IntPredicate.ne (const? 32 0) (LLVM.and e_1 (const? 32 32))) e (LLVM.or e (const? 32 4096)) ⊑
+  select (icmp IntPred.ne (const? 32 0) (LLVM.and e_1 (const? 32 32))) e (LLVM.or e (const? 32 4096)) ⊑
     LLVM.or e (LLVM.xor (LLVM.and (shl e_1 (const? 32 7)) (const? 32 4096)) (const? 32 4096)) := by
     simp_alive_undef
     simp_alive_ops
@@ -179,7 +179,7 @@ theorem select_icmp_ne_0_and_32_or_4096_thm (e e_1 : IntW 32) :
 
 
 theorem select_icmp_ne_0_and_32_xor_4096_thm (e e_1 : IntW 32) :
-  select (icmp IntPredicate.ne (const? 32 0) (LLVM.and e_1 (const? 32 32))) e (LLVM.xor e (const? 32 4096)) ⊑
+  select (icmp IntPred.ne (const? 32 0) (LLVM.and e_1 (const? 32 32))) e (LLVM.xor e (const? 32 4096)) ⊑
     LLVM.xor (LLVM.xor (LLVM.and (shl e_1 (const? 32 7)) (const? 32 4096)) e) (const? 32 4096) := by
     simp_alive_undef
     simp_alive_ops
@@ -190,8 +190,8 @@ theorem select_icmp_ne_0_and_32_xor_4096_thm (e e_1 : IntW 32) :
 
 
 theorem select_icmp_ne_0_and_32_and_not_4096_thm (e e_1 : IntW 32) :
-  select (icmp IntPredicate.ne (const? 32 0) (LLVM.and e_1 (const? 32 32))) e (LLVM.and e (const? 32 (-4097))) ⊑
-    select (icmp IntPredicate.eq (LLVM.and e_1 (const? 32 32)) (const? 32 0)) (LLVM.and e (const? 32 (-4097)))
+  select (icmp IntPred.ne (const? 32 0) (LLVM.and e_1 (const? 32 32))) e (LLVM.and e (const? 32 (-4097))) ⊑
+    select (icmp IntPred.eq (LLVM.and e_1 (const? 32 32)) (const? 32 0)) (LLVM.and e (const? 32 (-4097)))
       e := by
     simp_alive_undef
     simp_alive_ops
@@ -202,8 +202,8 @@ theorem select_icmp_ne_0_and_32_and_not_4096_thm (e e_1 : IntW 32) :
 
 
 theorem select_icmp_ne_0_and_1073741824_or_8_thm (e : IntW 8) (e_1 : IntW 32) :
-  select (icmp IntPredicate.ne (const? 32 0) (LLVM.and e_1 (const? 32 1073741824))) e (LLVM.or e (const? 8 8)) ⊑
-    select (icmp IntPredicate.eq (LLVM.and e_1 (const? 32 1073741824)) (const? 32 0)) (LLVM.or e (const? 8 8))
+  select (icmp IntPred.ne (const? 32 0) (LLVM.and e_1 (const? 32 1073741824))) e (LLVM.or e (const? 8 8)) ⊑
+    select (icmp IntPred.eq (LLVM.and e_1 (const? 32 1073741824)) (const? 32 0)) (LLVM.or e (const? 8 8))
       e := by
     simp_alive_undef
     simp_alive_ops
@@ -214,8 +214,8 @@ theorem select_icmp_ne_0_and_1073741824_or_8_thm (e : IntW 8) (e_1 : IntW 32) :
 
 
 theorem select_icmp_ne_0_and_1073741824_xor_8_thm (e : IntW 8) (e_1 : IntW 32) :
-  select (icmp IntPredicate.ne (const? 32 0) (LLVM.and e_1 (const? 32 1073741824))) e (LLVM.xor e (const? 8 8)) ⊑
-    select (icmp IntPredicate.eq (LLVM.and e_1 (const? 32 1073741824)) (const? 32 0)) (LLVM.xor e (const? 8 8))
+  select (icmp IntPred.ne (const? 32 0) (LLVM.and e_1 (const? 32 1073741824))) e (LLVM.xor e (const? 8 8)) ⊑
+    select (icmp IntPred.eq (LLVM.and e_1 (const? 32 1073741824)) (const? 32 0)) (LLVM.xor e (const? 8 8))
       e := by
     simp_alive_undef
     simp_alive_ops
@@ -226,8 +226,8 @@ theorem select_icmp_ne_0_and_1073741824_xor_8_thm (e : IntW 8) (e_1 : IntW 32) :
 
 
 theorem select_icmp_ne_0_and_1073741824_and_not_8_thm (e : IntW 8) (e_1 : IntW 32) :
-  select (icmp IntPredicate.ne (const? 32 0) (LLVM.and e_1 (const? 32 1073741824))) e (LLVM.and e (const? 8 (-9))) ⊑
-    select (icmp IntPredicate.eq (LLVM.and e_1 (const? 32 1073741824)) (const? 32 0)) (LLVM.and e (const? 8 (-9)))
+  select (icmp IntPred.ne (const? 32 0) (LLVM.and e_1 (const? 32 1073741824))) e (LLVM.and e (const? 8 (-9))) ⊑
+    select (icmp IntPred.eq (LLVM.and e_1 (const? 32 1073741824)) (const? 32 0)) (LLVM.and e (const? 8 (-9)))
       e := by
     simp_alive_undef
     simp_alive_ops
@@ -238,8 +238,8 @@ theorem select_icmp_ne_0_and_1073741824_and_not_8_thm (e : IntW 8) (e_1 : IntW 3
 
 
 theorem select_icmp_ne_0_and_8_or_1073741824_thm (e : IntW 32) (e_1 : IntW 8) :
-  select (icmp IntPredicate.ne (const? 8 0) (LLVM.and e_1 (const? 8 8))) e (LLVM.or e (const? 32 1073741824)) ⊑
-    select (icmp IntPredicate.eq (LLVM.and e_1 (const? 8 8)) (const? 8 0)) (LLVM.or e (const? 32 1073741824)) e := by
+  select (icmp IntPred.ne (const? 8 0) (LLVM.and e_1 (const? 8 8))) e (LLVM.or e (const? 32 1073741824)) ⊑
+    select (icmp IntPred.eq (LLVM.and e_1 (const? 8 8)) (const? 8 0)) (LLVM.or e (const? 32 1073741824)) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -249,8 +249,8 @@ theorem select_icmp_ne_0_and_8_or_1073741824_thm (e : IntW 32) (e_1 : IntW 8) :
 
 
 theorem select_icmp_ne_0_and_8_xor_1073741824_thm (e : IntW 32) (e_1 : IntW 8) :
-  select (icmp IntPredicate.ne (const? 8 0) (LLVM.and e_1 (const? 8 8))) e (LLVM.xor e (const? 32 1073741824)) ⊑
-    select (icmp IntPredicate.eq (LLVM.and e_1 (const? 8 8)) (const? 8 0)) (LLVM.xor e (const? 32 1073741824))
+  select (icmp IntPred.ne (const? 8 0) (LLVM.and e_1 (const? 8 8))) e (LLVM.xor e (const? 32 1073741824)) ⊑
+    select (icmp IntPred.eq (LLVM.and e_1 (const? 8 8)) (const? 8 0)) (LLVM.xor e (const? 32 1073741824))
       e := by
     simp_alive_undef
     simp_alive_ops
@@ -261,8 +261,8 @@ theorem select_icmp_ne_0_and_8_xor_1073741824_thm (e : IntW 32) (e_1 : IntW 8) :
 
 
 theorem select_icmp_ne_0_and_8_and_not_1073741824_thm (e : IntW 32) (e_1 : IntW 8) :
-  select (icmp IntPredicate.ne (const? 8 0) (LLVM.and e_1 (const? 8 8))) e (LLVM.and e (const? 32 (-1073741825))) ⊑
-    select (icmp IntPredicate.eq (LLVM.and e_1 (const? 8 8)) (const? 8 0)) (LLVM.and e (const? 32 (-1073741825)))
+  select (icmp IntPred.ne (const? 8 0) (LLVM.and e_1 (const? 8 8))) e (LLVM.and e (const? 32 (-1073741825))) ⊑
+    select (icmp IntPred.eq (LLVM.and e_1 (const? 8 8)) (const? 8 0)) (LLVM.and e (const? 32 (-1073741825)))
       e := by
     simp_alive_undef
     simp_alive_ops
@@ -273,7 +273,7 @@ theorem select_icmp_ne_0_and_8_and_not_1073741824_thm (e : IntW 32) (e_1 : IntW 
 
 
 theorem select_icmp_and_8_ne_0_xor_8_thm (e : IntW 32) :
-  select (icmp IntPredicate.eq (LLVM.and e (const? 32 8)) (const? 32 0)) e (LLVM.xor e (const? 32 8)) ⊑
+  select (icmp IntPred.eq (LLVM.and e (const? 32 8)) (const? 32 0)) e (LLVM.xor e (const? 32 8)) ⊑
     LLVM.and e (const? 32 (-9)) := by
     simp_alive_undef
     simp_alive_ops
@@ -284,7 +284,7 @@ theorem select_icmp_and_8_ne_0_xor_8_thm (e : IntW 32) :
 
 
 theorem select_icmp_and_8_eq_0_xor_8_thm (e : IntW 32) :
-  select (icmp IntPredicate.eq (LLVM.and e (const? 32 8)) (const? 32 0)) (LLVM.xor e (const? 32 8)) e ⊑
+  select (icmp IntPred.eq (LLVM.and e (const? 32 8)) (const? 32 0)) (LLVM.xor e (const? 32 8)) e ⊑
     LLVM.or e (const? 32 8) := by
     simp_alive_undef
     simp_alive_ops
@@ -295,7 +295,7 @@ theorem select_icmp_and_8_eq_0_xor_8_thm (e : IntW 32) :
 
 
 theorem select_icmp_x_and_8_eq_0_y_xor_8_thm (e : IntW 64) (e_1 : IntW 32) :
-  select (icmp IntPredicate.eq (LLVM.and e_1 (const? 32 8)) (const? 32 0)) e (LLVM.xor e (const? 64 8)) ⊑
+  select (icmp IntPred.eq (LLVM.and e_1 (const? 32 8)) (const? 32 0)) e (LLVM.xor e (const? 64 8)) ⊑
     LLVM.xor e (zext 64 (LLVM.and e_1 (const? 32 8)) { «nneg» := true }) := by
     simp_alive_undef
     simp_alive_ops
@@ -306,7 +306,7 @@ theorem select_icmp_x_and_8_eq_0_y_xor_8_thm (e : IntW 64) (e_1 : IntW 32) :
 
 
 theorem select_icmp_x_and_8_ne_0_y_xor_8_thm (e : IntW 64) (e_1 : IntW 32) :
-  select (icmp IntPredicate.eq (LLVM.and e_1 (const? 32 8)) (const? 32 0)) (LLVM.xor e (const? 64 8)) e ⊑
+  select (icmp IntPred.eq (LLVM.and e_1 (const? 32 8)) (const? 32 0)) (LLVM.xor e (const? 64 8)) e ⊑
     LLVM.xor e (zext 64 (LLVM.xor (LLVM.and e_1 (const? 32 8)) (const? 32 8)) { «nneg» := true }) := by
     simp_alive_undef
     simp_alive_ops
@@ -317,7 +317,7 @@ theorem select_icmp_x_and_8_ne_0_y_xor_8_thm (e : IntW 64) (e_1 : IntW 32) :
 
 
 theorem select_icmp_x_and_8_ne_0_y_or_8_thm (e : IntW 64) (e_1 : IntW 32) :
-  select (icmp IntPredicate.eq (LLVM.and e_1 (const? 32 8)) (const? 32 0)) (LLVM.or e (const? 64 8)) e ⊑
+  select (icmp IntPred.eq (LLVM.and e_1 (const? 32 8)) (const? 32 0)) (LLVM.or e (const? 64 8)) e ⊑
     LLVM.or e (zext 64 (LLVM.xor (LLVM.and e_1 (const? 32 8)) (const? 32 8)) { «nneg» := true }) := by
     simp_alive_undef
     simp_alive_ops
@@ -328,7 +328,7 @@ theorem select_icmp_x_and_8_ne_0_y_or_8_thm (e : IntW 64) (e_1 : IntW 32) :
 
 
 theorem select_icmp_and_2147483648_ne_0_xor_2147483648_thm (e : IntW 32) :
-  select (icmp IntPredicate.eq (LLVM.and e (const? 32 (-2147483648))) (const? 32 0)) e
+  select (icmp IntPred.eq (LLVM.and e (const? 32 (-2147483648))) (const? 32 0)) e
       (LLVM.xor e (const? 32 (-2147483648))) ⊑
     LLVM.and e (const? 32 2147483647) := by
     simp_alive_undef
@@ -340,7 +340,7 @@ theorem select_icmp_and_2147483648_ne_0_xor_2147483648_thm (e : IntW 32) :
 
 
 theorem select_icmp_and_2147483648_eq_0_xor_2147483648_thm (e : IntW 32) :
-  select (icmp IntPredicate.eq (LLVM.and e (const? 32 (-2147483648))) (const? 32 0))
+  select (icmp IntPred.eq (LLVM.and e (const? 32 (-2147483648))) (const? 32 0))
       (LLVM.xor e (const? 32 (-2147483648))) e ⊑
     LLVM.or e (const? 32 (-2147483648)) := by
     simp_alive_undef
@@ -352,7 +352,7 @@ theorem select_icmp_and_2147483648_eq_0_xor_2147483648_thm (e : IntW 32) :
 
 
 theorem select_icmp_x_and_2147483648_ne_0_or_2147483648_thm (e : IntW 32) :
-  select (icmp IntPredicate.eq (LLVM.and e (const? 32 (-2147483648))) (const? 32 0))
+  select (icmp IntPred.eq (LLVM.and e (const? 32 (-2147483648))) (const? 32 0))
       (LLVM.or e (const? 32 (-2147483648))) e ⊑
     LLVM.or e (const? 32 (-2147483648)) := by
     simp_alive_undef
@@ -364,7 +364,7 @@ theorem select_icmp_x_and_2147483648_ne_0_or_2147483648_thm (e : IntW 32) :
 
 
 theorem test68_thm (e e_1 : IntW 32) :
-  select (icmp IntPredicate.eq (LLVM.and e_1 (const? 32 128)) (const? 32 0)) e (LLVM.or e (const? 32 2)) ⊑
+  select (icmp IntPred.eq (LLVM.and e_1 (const? 32 128)) (const? 32 0)) e (LLVM.or e (const? 32 2)) ⊑
     LLVM.or e (LLVM.and (lshr e_1 (const? 32 6)) (const? 32 2)) := by
     simp_alive_undef
     simp_alive_ops
@@ -375,7 +375,7 @@ theorem test68_thm (e e_1 : IntW 32) :
 
 
 theorem test68_xor_thm (e e_1 : IntW 32) :
-  select (icmp IntPredicate.eq (LLVM.and e_1 (const? 32 128)) (const? 32 0)) e (LLVM.xor e (const? 32 2)) ⊑
+  select (icmp IntPred.eq (LLVM.and e_1 (const? 32 128)) (const? 32 0)) e (LLVM.xor e (const? 32 2)) ⊑
     LLVM.xor e (LLVM.and (lshr e_1 (const? 32 6)) (const? 32 2)) := by
     simp_alive_undef
     simp_alive_ops
@@ -386,7 +386,7 @@ theorem test68_xor_thm (e e_1 : IntW 32) :
 
 
 theorem test69_thm (e e_1 : IntW 32) :
-  select (icmp IntPredicate.ne (LLVM.and e_1 (const? 32 128)) (const? 32 0)) e (LLVM.or e (const? 32 2)) ⊑
+  select (icmp IntPred.ne (LLVM.and e_1 (const? 32 128)) (const? 32 0)) e (LLVM.or e (const? 32 2)) ⊑
     LLVM.or e (LLVM.xor (LLVM.and (lshr e_1 (const? 32 6)) (const? 32 2)) (const? 32 2)) := by
     simp_alive_undef
     simp_alive_ops
@@ -397,7 +397,7 @@ theorem test69_thm (e e_1 : IntW 32) :
 
 
 theorem test69_xor_thm (e e_1 : IntW 32) :
-  select (icmp IntPredicate.ne (LLVM.and e_1 (const? 32 128)) (const? 32 0)) e (LLVM.xor e (const? 32 2)) ⊑
+  select (icmp IntPred.ne (LLVM.and e_1 (const? 32 128)) (const? 32 0)) e (LLVM.xor e (const? 32 2)) ⊑
     LLVM.xor (LLVM.xor (LLVM.and (lshr e_1 (const? 32 6)) (const? 32 2)) e) (const? 32 2) := by
     simp_alive_undef
     simp_alive_ops
@@ -408,8 +408,8 @@ theorem test69_xor_thm (e e_1 : IntW 32) :
 
 
 theorem test69_and_thm (e e_1 : IntW 32) :
-  select (icmp IntPredicate.ne (LLVM.and e_1 (const? 32 128)) (const? 32 0)) e (LLVM.and e (const? 32 2)) ⊑
-    select (icmp IntPredicate.eq (LLVM.and e_1 (const? 32 128)) (const? 32 0)) (LLVM.and e (const? 32 2)) e := by
+  select (icmp IntPred.ne (LLVM.and e_1 (const? 32 128)) (const? 32 0)) e (LLVM.and e (const? 32 2)) ⊑
+    select (icmp IntPred.eq (LLVM.and e_1 (const? 32 128)) (const? 32 0)) (LLVM.and e (const? 32 2)) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -419,7 +419,7 @@ theorem test69_and_thm (e e_1 : IntW 32) :
 
 
 theorem test70_thm (e e_1 : IntW 8) :
-  select (icmp IntPredicate.slt e_1 (const? 8 0)) (LLVM.or e (const? 8 2)) e ⊑
+  select (icmp IntPred.slt e_1 (const? 8 0)) (LLVM.or e (const? 8 2)) e ⊑
     LLVM.or e (LLVM.and (lshr e_1 (const? 8 6)) (const? 8 2)) := by
     simp_alive_undef
     simp_alive_ops
@@ -430,7 +430,7 @@ theorem test70_thm (e e_1 : IntW 8) :
 
 
 theorem shift_no_xor_multiuse_or_thm (e e_1 : IntW 32) :
-  mul (select (icmp IntPredicate.eq (LLVM.and e_1 (const? 32 1)) (const? 32 0)) e (LLVM.or e (const? 32 2)))
+  mul (select (icmp IntPred.eq (LLVM.and e_1 (const? 32 1)) (const? 32 0)) e (LLVM.or e (const? 32 2)))
       (LLVM.or e (const? 32 2)) ⊑
     mul (LLVM.or e (LLVM.and (shl e_1 (const? 32 1)) (const? 32 2))) (LLVM.or e (const? 32 2)) := by
     simp_alive_undef
@@ -442,7 +442,7 @@ theorem shift_no_xor_multiuse_or_thm (e e_1 : IntW 32) :
 
 
 theorem shift_no_xor_multiuse_xor_thm (e e_1 : IntW 32) :
-  mul (select (icmp IntPredicate.eq (LLVM.and e_1 (const? 32 1)) (const? 32 0)) e (LLVM.xor e (const? 32 2)))
+  mul (select (icmp IntPred.eq (LLVM.and e_1 (const? 32 1)) (const? 32 0)) e (LLVM.xor e (const? 32 2)))
       (LLVM.xor e (const? 32 2)) ⊑
     mul (LLVM.xor e (LLVM.and (shl e_1 (const? 32 1)) (const? 32 2))) (LLVM.xor e (const? 32 2)) := by
     simp_alive_undef
@@ -454,7 +454,7 @@ theorem shift_no_xor_multiuse_xor_thm (e e_1 : IntW 32) :
 
 
 theorem no_shift_no_xor_multiuse_or_thm (e e_1 : IntW 32) :
-  mul (select (icmp IntPredicate.eq (LLVM.and e_1 (const? 32 4096)) (const? 32 0)) e (LLVM.or e (const? 32 4096)))
+  mul (select (icmp IntPred.eq (LLVM.and e_1 (const? 32 4096)) (const? 32 0)) e (LLVM.or e (const? 32 4096)))
       (LLVM.or e (const? 32 4096)) ⊑
     mul (LLVM.or e (LLVM.and e_1 (const? 32 4096))) (LLVM.or e (const? 32 4096)) := by
     simp_alive_undef
@@ -466,7 +466,7 @@ theorem no_shift_no_xor_multiuse_or_thm (e e_1 : IntW 32) :
 
 
 theorem no_shift_no_xor_multiuse_xor_thm (e e_1 : IntW 32) :
-  mul (select (icmp IntPredicate.eq (LLVM.and e_1 (const? 32 4096)) (const? 32 0)) e (LLVM.xor e (const? 32 4096)))
+  mul (select (icmp IntPred.eq (LLVM.and e_1 (const? 32 4096)) (const? 32 0)) e (LLVM.xor e (const? 32 4096)))
       (LLVM.xor e (const? 32 4096)) ⊑
     mul (LLVM.xor e (LLVM.and e_1 (const? 32 4096))) (LLVM.xor e (const? 32 4096)) := by
     simp_alive_undef
@@ -478,7 +478,7 @@ theorem no_shift_no_xor_multiuse_xor_thm (e e_1 : IntW 32) :
 
 
 theorem no_shift_xor_multiuse_or_thm (e e_1 : IntW 32) :
-  mul (select (icmp IntPredicate.ne (const? 32 0) (LLVM.and e_1 (const? 32 4096))) e (LLVM.or e (const? 32 4096)))
+  mul (select (icmp IntPred.ne (const? 32 0) (LLVM.and e_1 (const? 32 4096))) e (LLVM.or e (const? 32 4096)))
       (LLVM.or e (const? 32 4096)) ⊑
     mul (LLVM.or e (LLVM.xor (LLVM.and e_1 (const? 32 4096)) (const? 32 4096))) (LLVM.or e (const? 32 4096)) := by
     simp_alive_undef
@@ -490,7 +490,7 @@ theorem no_shift_xor_multiuse_or_thm (e e_1 : IntW 32) :
 
 
 theorem no_shift_xor_multiuse_xor_thm (e e_1 : IntW 32) :
-  mul (select (icmp IntPredicate.ne (const? 32 0) (LLVM.and e_1 (const? 32 4096))) e (LLVM.xor e (const? 32 4096)))
+  mul (select (icmp IntPred.ne (const? 32 0) (LLVM.and e_1 (const? 32 4096))) e (LLVM.xor e (const? 32 4096)))
       (LLVM.xor e (const? 32 4096)) ⊑
     mul (LLVM.xor (LLVM.xor (LLVM.and e_1 (const? 32 4096)) e) (const? 32 4096)) (LLVM.xor e (const? 32 4096)) := by
     simp_alive_undef
@@ -502,9 +502,9 @@ theorem no_shift_xor_multiuse_xor_thm (e e_1 : IntW 32) :
 
 
 theorem no_shift_xor_multiuse_and_thm (e e_1 : IntW 32) :
-  mul (select (icmp IntPredicate.ne (const? 32 0) (LLVM.and e_1 (const? 32 4096))) e (LLVM.and e (const? 32 (-4097))))
+  mul (select (icmp IntPred.ne (const? 32 0) (LLVM.and e_1 (const? 32 4096))) e (LLVM.and e (const? 32 (-4097))))
       (LLVM.and e (const? 32 (-4097))) ⊑
-    mul (select (icmp IntPredicate.eq (LLVM.and e_1 (const? 32 4096)) (const? 32 0)) (LLVM.and e (const? 32 (-4097))) e)
+    mul (select (icmp IntPred.eq (LLVM.and e_1 (const? 32 4096)) (const? 32 0)) (LLVM.and e (const? 32 (-4097))) e)
       (LLVM.and e (const? 32 (-4097))) := by
     simp_alive_undef
     simp_alive_ops
@@ -515,9 +515,9 @@ theorem no_shift_xor_multiuse_and_thm (e e_1 : IntW 32) :
 
 
 theorem shift_xor_multiuse_or_thm (e e_1 : IntW 32) :
-  mul (select (icmp IntPredicate.ne (const? 32 0) (LLVM.and e_1 (const? 32 4096))) e (LLVM.or e (const? 32 2048)))
+  mul (select (icmp IntPred.ne (const? 32 0) (LLVM.and e_1 (const? 32 4096))) e (LLVM.or e (const? 32 2048)))
       (LLVM.or e (const? 32 2048)) ⊑
-    mul (select (icmp IntPredicate.eq (LLVM.and e_1 (const? 32 4096)) (const? 32 0)) (LLVM.or e (const? 32 2048)) e)
+    mul (select (icmp IntPred.eq (LLVM.and e_1 (const? 32 4096)) (const? 32 0)) (LLVM.or e (const? 32 2048)) e)
       (LLVM.or e (const? 32 2048)) := by
     simp_alive_undef
     simp_alive_ops
@@ -528,9 +528,9 @@ theorem shift_xor_multiuse_or_thm (e e_1 : IntW 32) :
 
 
 theorem shift_xor_multiuse_xor_thm (e e_1 : IntW 32) :
-  mul (select (icmp IntPredicate.ne (const? 32 0) (LLVM.and e_1 (const? 32 4096))) e (LLVM.xor e (const? 32 2048)))
+  mul (select (icmp IntPred.ne (const? 32 0) (LLVM.and e_1 (const? 32 4096))) e (LLVM.xor e (const? 32 2048)))
       (LLVM.xor e (const? 32 2048)) ⊑
-    mul (select (icmp IntPredicate.eq (LLVM.and e_1 (const? 32 4096)) (const? 32 0)) (LLVM.xor e (const? 32 2048)) e)
+    mul (select (icmp IntPred.eq (LLVM.and e_1 (const? 32 4096)) (const? 32 0)) (LLVM.xor e (const? 32 2048)) e)
       (LLVM.xor e (const? 32 2048)) := by
     simp_alive_undef
     simp_alive_ops
@@ -541,9 +541,9 @@ theorem shift_xor_multiuse_xor_thm (e e_1 : IntW 32) :
 
 
 theorem shift_xor_multiuse_and_thm (e e_1 : IntW 32) :
-  mul (select (icmp IntPredicate.ne (const? 32 0) (LLVM.and e_1 (const? 32 4096))) e (LLVM.and e (const? 32 (-2049))))
+  mul (select (icmp IntPred.ne (const? 32 0) (LLVM.and e_1 (const? 32 4096))) e (LLVM.and e (const? 32 (-2049))))
       (LLVM.and e (const? 32 (-2049))) ⊑
-    mul (select (icmp IntPredicate.eq (LLVM.and e_1 (const? 32 4096)) (const? 32 0)) (LLVM.and e (const? 32 (-2049))) e)
+    mul (select (icmp IntPred.eq (LLVM.and e_1 (const? 32 4096)) (const? 32 0)) (LLVM.and e (const? 32 (-2049))) e)
       (LLVM.and e (const? 32 (-2049))) := by
     simp_alive_undef
     simp_alive_ops
@@ -554,10 +554,10 @@ theorem shift_xor_multiuse_and_thm (e e_1 : IntW 32) :
 
 
 theorem shift_no_xor_multiuse_cmp_thm (e e_1 e_2 e_3 : IntW 32) :
-  mul (select (icmp IntPredicate.eq (LLVM.and e_3 (const? 32 1)) (const? 32 0)) e_2 (LLVM.or e_2 (const? 32 2)))
-      (select (icmp IntPredicate.eq (LLVM.and e_3 (const? 32 1)) (const? 32 0)) e_1 e) ⊑
+  mul (select (icmp IntPred.eq (LLVM.and e_3 (const? 32 1)) (const? 32 0)) e_2 (LLVM.or e_2 (const? 32 2)))
+      (select (icmp IntPred.eq (LLVM.and e_3 (const? 32 1)) (const? 32 0)) e_1 e) ⊑
     mul (LLVM.or e_2 (shl (LLVM.and e_3 (const? 32 1)) (const? 32 1) { «nsw» := true, «nuw» := true }))
-      (select (icmp IntPredicate.eq (LLVM.and e_3 (const? 32 1)) (const? 32 0)) e_1 e) := by
+      (select (icmp IntPred.eq (LLVM.and e_3 (const? 32 1)) (const? 32 0)) e_1 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -567,10 +567,10 @@ theorem shift_no_xor_multiuse_cmp_thm (e e_1 e_2 e_3 : IntW 32) :
 
 
 theorem shift_no_xor_multiuse_cmp_with_xor_thm (e e_1 e_2 e_3 : IntW 32) :
-  mul (select (icmp IntPredicate.eq (LLVM.and e_3 (const? 32 1)) (const? 32 0)) e_2 (LLVM.xor e_2 (const? 32 2)))
-      (select (icmp IntPredicate.eq (LLVM.and e_3 (const? 32 1)) (const? 32 0)) e_1 e) ⊑
+  mul (select (icmp IntPred.eq (LLVM.and e_3 (const? 32 1)) (const? 32 0)) e_2 (LLVM.xor e_2 (const? 32 2)))
+      (select (icmp IntPred.eq (LLVM.and e_3 (const? 32 1)) (const? 32 0)) e_1 e) ⊑
     mul (LLVM.xor e_2 (shl (LLVM.and e_3 (const? 32 1)) (const? 32 1) { «nsw» := true, «nuw» := true }))
-      (select (icmp IntPredicate.eq (LLVM.and e_3 (const? 32 1)) (const? 32 0)) e_1 e) := by
+      (select (icmp IntPred.eq (LLVM.and e_3 (const? 32 1)) (const? 32 0)) e_1 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -580,10 +580,10 @@ theorem shift_no_xor_multiuse_cmp_with_xor_thm (e e_1 e_2 e_3 : IntW 32) :
 
 
 theorem no_shift_no_xor_multiuse_cmp_thm (e e_1 e_2 e_3 : IntW 32) :
-  mul (select (icmp IntPredicate.eq (LLVM.and e_3 (const? 32 4096)) (const? 32 0)) e_2 (LLVM.or e_2 (const? 32 4096)))
-      (select (icmp IntPredicate.eq (LLVM.and e_3 (const? 32 4096)) (const? 32 0)) e_1 e) ⊑
+  mul (select (icmp IntPred.eq (LLVM.and e_3 (const? 32 4096)) (const? 32 0)) e_2 (LLVM.or e_2 (const? 32 4096)))
+      (select (icmp IntPred.eq (LLVM.and e_3 (const? 32 4096)) (const? 32 0)) e_1 e) ⊑
     mul (LLVM.or e_2 (LLVM.and e_3 (const? 32 4096)))
-      (select (icmp IntPredicate.eq (LLVM.and e_3 (const? 32 4096)) (const? 32 0)) e_1 e) := by
+      (select (icmp IntPred.eq (LLVM.and e_3 (const? 32 4096)) (const? 32 0)) e_1 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -593,10 +593,10 @@ theorem no_shift_no_xor_multiuse_cmp_thm (e e_1 e_2 e_3 : IntW 32) :
 
 
 theorem no_shift_no_xor_multiuse_cmp_with_xor_thm (e e_1 e_2 e_3 : IntW 32) :
-  mul (select (icmp IntPredicate.eq (LLVM.and e_3 (const? 32 4096)) (const? 32 0)) e_2 (LLVM.xor e_2 (const? 32 4096)))
-      (select (icmp IntPredicate.eq (LLVM.and e_3 (const? 32 4096)) (const? 32 0)) e_1 e) ⊑
+  mul (select (icmp IntPred.eq (LLVM.and e_3 (const? 32 4096)) (const? 32 0)) e_2 (LLVM.xor e_2 (const? 32 4096)))
+      (select (icmp IntPred.eq (LLVM.and e_3 (const? 32 4096)) (const? 32 0)) e_1 e) ⊑
     mul (LLVM.xor e_2 (LLVM.and e_3 (const? 32 4096)))
-      (select (icmp IntPredicate.eq (LLVM.and e_3 (const? 32 4096)) (const? 32 0)) e_1 e) := by
+      (select (icmp IntPred.eq (LLVM.and e_3 (const? 32 4096)) (const? 32 0)) e_1 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -606,10 +606,10 @@ theorem no_shift_no_xor_multiuse_cmp_with_xor_thm (e e_1 e_2 e_3 : IntW 32) :
 
 
 theorem no_shift_xor_multiuse_cmp_thm (e e_1 e_2 e_3 : IntW 32) :
-  mul (select (icmp IntPredicate.ne (const? 32 0) (LLVM.and e_3 (const? 32 4096))) e_2 (LLVM.or e_2 (const? 32 4096)))
-      (select (icmp IntPredicate.ne (const? 32 0) (LLVM.and e_3 (const? 32 4096))) e_1 e) ⊑
+  mul (select (icmp IntPred.ne (const? 32 0) (LLVM.and e_3 (const? 32 4096))) e_2 (LLVM.or e_2 (const? 32 4096)))
+      (select (icmp IntPred.ne (const? 32 0) (LLVM.and e_3 (const? 32 4096))) e_1 e) ⊑
     mul (LLVM.or e_2 (LLVM.xor (LLVM.and e_3 (const? 32 4096)) (const? 32 4096)))
-      (select (icmp IntPredicate.eq (LLVM.and e_3 (const? 32 4096)) (const? 32 0)) e e_1) := by
+      (select (icmp IntPred.eq (LLVM.and e_3 (const? 32 4096)) (const? 32 0)) e e_1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -619,10 +619,10 @@ theorem no_shift_xor_multiuse_cmp_thm (e e_1 e_2 e_3 : IntW 32) :
 
 
 theorem no_shift_xor_multiuse_cmp_with_xor_thm (e e_1 e_2 e_3 : IntW 32) :
-  mul (select (icmp IntPredicate.ne (const? 32 0) (LLVM.and e_3 (const? 32 4096))) e_2 (LLVM.xor e_2 (const? 32 4096)))
-      (select (icmp IntPredicate.ne (const? 32 0) (LLVM.and e_3 (const? 32 4096))) e_1 e) ⊑
+  mul (select (icmp IntPred.ne (const? 32 0) (LLVM.and e_3 (const? 32 4096))) e_2 (LLVM.xor e_2 (const? 32 4096)))
+      (select (icmp IntPred.ne (const? 32 0) (LLVM.and e_3 (const? 32 4096))) e_1 e) ⊑
     mul (LLVM.xor (LLVM.xor (LLVM.and e_3 (const? 32 4096)) e_2) (const? 32 4096))
-      (select (icmp IntPredicate.eq (LLVM.and e_3 (const? 32 4096)) (const? 32 0)) e e_1) := by
+      (select (icmp IntPred.eq (LLVM.and e_3 (const? 32 4096)) (const? 32 0)) e e_1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -633,13 +633,13 @@ theorem no_shift_xor_multiuse_cmp_with_xor_thm (e e_1 e_2 e_3 : IntW 32) :
 
 theorem no_shift_xor_multiuse_cmp_with_and_thm (e e_1 e_2 e_3 : IntW 32) :
   mul
-      (select (icmp IntPredicate.ne (const? 32 0) (LLVM.and e_3 (const? 32 4096))) e_2
+      (select (icmp IntPred.ne (const? 32 0) (LLVM.and e_3 (const? 32 4096))) e_2
         (LLVM.and e_2 (const? 32 (-4097))))
-      (select (icmp IntPredicate.ne (const? 32 0) (LLVM.and e_3 (const? 32 4096))) e_1 e) ⊑
+      (select (icmp IntPred.ne (const? 32 0) (LLVM.and e_3 (const? 32 4096))) e_1 e) ⊑
     mul
-      (select (icmp IntPredicate.eq (LLVM.and e_3 (const? 32 4096)) (const? 32 0)) (LLVM.and e_2 (const? 32 (-4097)))
+      (select (icmp IntPred.eq (LLVM.and e_3 (const? 32 4096)) (const? 32 0)) (LLVM.and e_2 (const? 32 (-4097)))
         e_2)
-      (select (icmp IntPredicate.eq (LLVM.and e_3 (const? 32 4096)) (const? 32 0)) e e_1) := by
+      (select (icmp IntPred.eq (LLVM.and e_3 (const? 32 4096)) (const? 32 0)) e e_1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -649,10 +649,10 @@ theorem no_shift_xor_multiuse_cmp_with_and_thm (e e_1 e_2 e_3 : IntW 32) :
 
 
 theorem shift_xor_multiuse_cmp_thm (e e_1 e_2 e_3 : IntW 32) :
-  mul (select (icmp IntPredicate.ne (const? 32 0) (LLVM.and e_3 (const? 32 4096))) e_2 (LLVM.or e_2 (const? 32 2048)))
-      (select (icmp IntPredicate.ne (const? 32 0) (LLVM.and e_3 (const? 32 4096))) e_1 e) ⊑
-    mul (select (icmp IntPredicate.eq (LLVM.and e_3 (const? 32 4096)) (const? 32 0)) (LLVM.or e_2 (const? 32 2048)) e_2)
-      (select (icmp IntPredicate.eq (LLVM.and e_3 (const? 32 4096)) (const? 32 0)) e e_1) := by
+  mul (select (icmp IntPred.ne (const? 32 0) (LLVM.and e_3 (const? 32 4096))) e_2 (LLVM.or e_2 (const? 32 2048)))
+      (select (icmp IntPred.ne (const? 32 0) (LLVM.and e_3 (const? 32 4096))) e_1 e) ⊑
+    mul (select (icmp IntPred.eq (LLVM.and e_3 (const? 32 4096)) (const? 32 0)) (LLVM.or e_2 (const? 32 2048)) e_2)
+      (select (icmp IntPred.eq (LLVM.and e_3 (const? 32 4096)) (const? 32 0)) e e_1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -662,11 +662,11 @@ theorem shift_xor_multiuse_cmp_thm (e e_1 e_2 e_3 : IntW 32) :
 
 
 theorem shift_xor_multiuse_cmp_with_xor_thm (e e_1 e_2 e_3 : IntW 32) :
-  mul (select (icmp IntPredicate.ne (const? 32 0) (LLVM.and e_3 (const? 32 4096))) e_2 (LLVM.xor e_2 (const? 32 2048)))
-      (select (icmp IntPredicate.ne (const? 32 0) (LLVM.and e_3 (const? 32 4096))) e_1 e) ⊑
+  mul (select (icmp IntPred.ne (const? 32 0) (LLVM.and e_3 (const? 32 4096))) e_2 (LLVM.xor e_2 (const? 32 2048)))
+      (select (icmp IntPred.ne (const? 32 0) (LLVM.and e_3 (const? 32 4096))) e_1 e) ⊑
     mul
-      (select (icmp IntPredicate.eq (LLVM.and e_3 (const? 32 4096)) (const? 32 0)) (LLVM.xor e_2 (const? 32 2048)) e_2)
-      (select (icmp IntPredicate.eq (LLVM.and e_3 (const? 32 4096)) (const? 32 0)) e e_1) := by
+      (select (icmp IntPred.eq (LLVM.and e_3 (const? 32 4096)) (const? 32 0)) (LLVM.xor e_2 (const? 32 2048)) e_2)
+      (select (icmp IntPred.eq (LLVM.and e_3 (const? 32 4096)) (const? 32 0)) e e_1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -677,13 +677,13 @@ theorem shift_xor_multiuse_cmp_with_xor_thm (e e_1 e_2 e_3 : IntW 32) :
 
 theorem shift_xor_multiuse_cmp_with_and_thm (e e_1 e_2 e_3 : IntW 32) :
   mul
-      (select (icmp IntPredicate.ne (const? 32 0) (LLVM.and e_3 (const? 32 4096))) e_2
+      (select (icmp IntPred.ne (const? 32 0) (LLVM.and e_3 (const? 32 4096))) e_2
         (LLVM.and e_2 (const? 32 (-2049))))
-      (select (icmp IntPredicate.ne (const? 32 0) (LLVM.and e_3 (const? 32 4096))) e_1 e) ⊑
+      (select (icmp IntPred.ne (const? 32 0) (LLVM.and e_3 (const? 32 4096))) e_1 e) ⊑
     mul
-      (select (icmp IntPredicate.eq (LLVM.and e_3 (const? 32 4096)) (const? 32 0)) (LLVM.and e_2 (const? 32 (-2049)))
+      (select (icmp IntPred.eq (LLVM.and e_3 (const? 32 4096)) (const? 32 0)) (LLVM.and e_2 (const? 32 (-2049)))
         e_2)
-      (select (icmp IntPredicate.eq (LLVM.and e_3 (const? 32 4096)) (const? 32 0)) e e_1) := by
+      (select (icmp IntPred.eq (LLVM.and e_3 (const? 32 4096)) (const? 32 0)) e e_1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -695,12 +695,12 @@ theorem shift_xor_multiuse_cmp_with_and_thm (e e_1 e_2 e_3 : IntW 32) :
 theorem no_shift_no_xor_multiuse_cmp_or_thm (e e_1 e_2 e_3 : IntW 32) :
   mul
       (mul
-        (select (icmp IntPredicate.eq (LLVM.and e_3 (const? 32 4096)) (const? 32 0)) e_2 (LLVM.or e_2 (const? 32 4096)))
-        (select (icmp IntPredicate.eq (LLVM.and e_3 (const? 32 4096)) (const? 32 0)) e_1 e))
+        (select (icmp IntPred.eq (LLVM.and e_3 (const? 32 4096)) (const? 32 0)) e_2 (LLVM.or e_2 (const? 32 4096)))
+        (select (icmp IntPred.eq (LLVM.and e_3 (const? 32 4096)) (const? 32 0)) e_1 e))
       (LLVM.or e_2 (const? 32 4096)) ⊑
     mul
       (mul (LLVM.or e_2 (LLVM.and e_3 (const? 32 4096)))
-        (select (icmp IntPredicate.eq (LLVM.and e_3 (const? 32 4096)) (const? 32 0)) e_1 e))
+        (select (icmp IntPred.eq (LLVM.and e_3 (const? 32 4096)) (const? 32 0)) e_1 e))
       (LLVM.or e_2 (const? 32 4096)) := by
     simp_alive_undef
     simp_alive_ops
@@ -713,13 +713,13 @@ theorem no_shift_no_xor_multiuse_cmp_or_thm (e e_1 e_2 e_3 : IntW 32) :
 theorem no_shift_no_xor_multiuse_cmp_xor_thm (e e_1 e_2 e_3 : IntW 32) :
   mul
       (mul
-        (select (icmp IntPredicate.eq (LLVM.and e_3 (const? 32 4096)) (const? 32 0)) e_2
+        (select (icmp IntPred.eq (LLVM.and e_3 (const? 32 4096)) (const? 32 0)) e_2
           (LLVM.xor e_2 (const? 32 4096)))
-        (select (icmp IntPredicate.eq (LLVM.and e_3 (const? 32 4096)) (const? 32 0)) e_1 e))
+        (select (icmp IntPred.eq (LLVM.and e_3 (const? 32 4096)) (const? 32 0)) e_1 e))
       (LLVM.xor e_2 (const? 32 4096)) ⊑
     mul
       (mul (LLVM.xor e_2 (LLVM.and e_3 (const? 32 4096)))
-        (select (icmp IntPredicate.eq (LLVM.and e_3 (const? 32 4096)) (const? 32 0)) e_1 e))
+        (select (icmp IntPred.eq (LLVM.and e_3 (const? 32 4096)) (const? 32 0)) e_1 e))
       (LLVM.xor e_2 (const? 32 4096)) := by
     simp_alive_undef
     simp_alive_ops
@@ -732,13 +732,13 @@ theorem no_shift_no_xor_multiuse_cmp_xor_thm (e e_1 e_2 e_3 : IntW 32) :
 theorem no_shift_xor_multiuse_cmp_or_thm (e e_1 e_2 e_3 : IntW 32) :
   mul
       (mul
-        (select (icmp IntPredicate.ne (const? 32 0) (LLVM.and e_3 (const? 32 4096))) e_2 (LLVM.or e_2 (const? 32 4096)))
-        (select (icmp IntPredicate.ne (const? 32 0) (LLVM.and e_3 (const? 32 4096))) e_1 e))
+        (select (icmp IntPred.ne (const? 32 0) (LLVM.and e_3 (const? 32 4096))) e_2 (LLVM.or e_2 (const? 32 4096)))
+        (select (icmp IntPred.ne (const? 32 0) (LLVM.and e_3 (const? 32 4096))) e_1 e))
       (LLVM.or e_2 (const? 32 4096)) ⊑
     mul
       (mul
-        (select (icmp IntPredicate.eq (LLVM.and e_3 (const? 32 4096)) (const? 32 0)) (LLVM.or e_2 (const? 32 4096)) e_2)
-        (select (icmp IntPredicate.eq (LLVM.and e_3 (const? 32 4096)) (const? 32 0)) e e_1))
+        (select (icmp IntPred.eq (LLVM.and e_3 (const? 32 4096)) (const? 32 0)) (LLVM.or e_2 (const? 32 4096)) e_2)
+        (select (icmp IntPred.eq (LLVM.and e_3 (const? 32 4096)) (const? 32 0)) e e_1))
       (LLVM.or e_2 (const? 32 4096)) := by
     simp_alive_undef
     simp_alive_ops
@@ -751,15 +751,15 @@ theorem no_shift_xor_multiuse_cmp_or_thm (e e_1 e_2 e_3 : IntW 32) :
 theorem no_shift_xor_multiuse_cmp_xor_thm (e e_1 e_2 e_3 : IntW 32) :
   mul
       (mul
-        (select (icmp IntPredicate.ne (const? 32 0) (LLVM.and e_3 (const? 32 4096))) e_2
+        (select (icmp IntPred.ne (const? 32 0) (LLVM.and e_3 (const? 32 4096))) e_2
           (LLVM.xor e_2 (const? 32 4096)))
-        (select (icmp IntPredicate.ne (const? 32 0) (LLVM.and e_3 (const? 32 4096))) e_1 e))
+        (select (icmp IntPred.ne (const? 32 0) (LLVM.and e_3 (const? 32 4096))) e_1 e))
       (LLVM.xor e_2 (const? 32 4096)) ⊑
     mul
       (mul
-        (select (icmp IntPredicate.eq (LLVM.and e_3 (const? 32 4096)) (const? 32 0)) (LLVM.xor e_2 (const? 32 4096))
+        (select (icmp IntPred.eq (LLVM.and e_3 (const? 32 4096)) (const? 32 0)) (LLVM.xor e_2 (const? 32 4096))
           e_2)
-        (select (icmp IntPredicate.eq (LLVM.and e_3 (const? 32 4096)) (const? 32 0)) e e_1))
+        (select (icmp IntPred.eq (LLVM.and e_3 (const? 32 4096)) (const? 32 0)) e e_1))
       (LLVM.xor e_2 (const? 32 4096)) := by
     simp_alive_undef
     simp_alive_ops
@@ -772,15 +772,15 @@ theorem no_shift_xor_multiuse_cmp_xor_thm (e e_1 e_2 e_3 : IntW 32) :
 theorem no_shift_xor_multiuse_cmp_and_thm (e e_1 e_2 e_3 : IntW 32) :
   mul
       (mul
-        (select (icmp IntPredicate.ne (const? 32 0) (LLVM.and e_3 (const? 32 4096))) e_2
+        (select (icmp IntPred.ne (const? 32 0) (LLVM.and e_3 (const? 32 4096))) e_2
           (LLVM.and e_2 (const? 32 (-4097))))
-        (select (icmp IntPredicate.ne (const? 32 0) (LLVM.and e_3 (const? 32 4096))) e_1 e))
+        (select (icmp IntPred.ne (const? 32 0) (LLVM.and e_3 (const? 32 4096))) e_1 e))
       (LLVM.and e_2 (const? 32 (-4097))) ⊑
     mul
       (mul
-        (select (icmp IntPredicate.eq (LLVM.and e_3 (const? 32 4096)) (const? 32 0)) (LLVM.and e_2 (const? 32 (-4097)))
+        (select (icmp IntPred.eq (LLVM.and e_3 (const? 32 4096)) (const? 32 0)) (LLVM.and e_2 (const? 32 (-4097)))
           e_2)
-        (select (icmp IntPredicate.eq (LLVM.and e_3 (const? 32 4096)) (const? 32 0)) e e_1))
+        (select (icmp IntPred.eq (LLVM.and e_3 (const? 32 4096)) (const? 32 0)) e e_1))
       (LLVM.and e_2 (const? 32 (-4097))) := by
     simp_alive_undef
     simp_alive_ops
@@ -793,13 +793,13 @@ theorem no_shift_xor_multiuse_cmp_and_thm (e e_1 e_2 e_3 : IntW 32) :
 theorem shift_xor_multiuse_cmp_or_thm (e e_1 e_2 e_3 : IntW 32) :
   mul
       (mul
-        (select (icmp IntPredicate.ne (const? 32 0) (LLVM.and e_3 (const? 32 4096))) e_2 (LLVM.or e_2 (const? 32 2048)))
-        (select (icmp IntPredicate.ne (const? 32 0) (LLVM.and e_3 (const? 32 4096))) e_1 e))
+        (select (icmp IntPred.ne (const? 32 0) (LLVM.and e_3 (const? 32 4096))) e_2 (LLVM.or e_2 (const? 32 2048)))
+        (select (icmp IntPred.ne (const? 32 0) (LLVM.and e_3 (const? 32 4096))) e_1 e))
       (LLVM.or e_2 (const? 32 2048)) ⊑
     mul
       (mul
-        (select (icmp IntPredicate.eq (LLVM.and e_3 (const? 32 4096)) (const? 32 0)) (LLVM.or e_2 (const? 32 2048)) e_2)
-        (select (icmp IntPredicate.eq (LLVM.and e_3 (const? 32 4096)) (const? 32 0)) e e_1))
+        (select (icmp IntPred.eq (LLVM.and e_3 (const? 32 4096)) (const? 32 0)) (LLVM.or e_2 (const? 32 2048)) e_2)
+        (select (icmp IntPred.eq (LLVM.and e_3 (const? 32 4096)) (const? 32 0)) e e_1))
       (LLVM.or e_2 (const? 32 2048)) := by
     simp_alive_undef
     simp_alive_ops
@@ -812,15 +812,15 @@ theorem shift_xor_multiuse_cmp_or_thm (e e_1 e_2 e_3 : IntW 32) :
 theorem shift_xor_multiuse_cmp_xor_thm (e e_1 e_2 e_3 : IntW 32) :
   mul
       (mul
-        (select (icmp IntPredicate.ne (const? 32 0) (LLVM.and e_3 (const? 32 4096))) e_2
+        (select (icmp IntPred.ne (const? 32 0) (LLVM.and e_3 (const? 32 4096))) e_2
           (LLVM.xor e_2 (const? 32 2048)))
-        (select (icmp IntPredicate.ne (const? 32 0) (LLVM.and e_3 (const? 32 4096))) e_1 e))
+        (select (icmp IntPred.ne (const? 32 0) (LLVM.and e_3 (const? 32 4096))) e_1 e))
       (LLVM.xor e_2 (const? 32 2048)) ⊑
     mul
       (mul
-        (select (icmp IntPredicate.eq (LLVM.and e_3 (const? 32 4096)) (const? 32 0)) (LLVM.xor e_2 (const? 32 2048))
+        (select (icmp IntPred.eq (LLVM.and e_3 (const? 32 4096)) (const? 32 0)) (LLVM.xor e_2 (const? 32 2048))
           e_2)
-        (select (icmp IntPredicate.eq (LLVM.and e_3 (const? 32 4096)) (const? 32 0)) e e_1))
+        (select (icmp IntPred.eq (LLVM.and e_3 (const? 32 4096)) (const? 32 0)) e e_1))
       (LLVM.xor e_2 (const? 32 2048)) := by
     simp_alive_undef
     simp_alive_ops
@@ -833,15 +833,15 @@ theorem shift_xor_multiuse_cmp_xor_thm (e e_1 e_2 e_3 : IntW 32) :
 theorem shift_xor_multiuse_cmp_and_thm (e e_1 e_2 e_3 : IntW 32) :
   mul
       (mul
-        (select (icmp IntPredicate.ne (const? 32 0) (LLVM.and e_3 (const? 32 4096))) e_2
+        (select (icmp IntPred.ne (const? 32 0) (LLVM.and e_3 (const? 32 4096))) e_2
           (LLVM.and e_2 (const? 32 2048)))
-        (select (icmp IntPredicate.ne (const? 32 0) (LLVM.and e_3 (const? 32 4096))) e_1 e))
+        (select (icmp IntPred.ne (const? 32 0) (LLVM.and e_3 (const? 32 4096))) e_1 e))
       (LLVM.and e_2 (const? 32 2048)) ⊑
     mul
       (mul
-        (select (icmp IntPredicate.eq (LLVM.and e_3 (const? 32 4096)) (const? 32 0)) (LLVM.and e_2 (const? 32 2048))
+        (select (icmp IntPred.eq (LLVM.and e_3 (const? 32 4096)) (const? 32 0)) (LLVM.and e_2 (const? 32 2048))
           e_2)
-        (select (icmp IntPredicate.eq (LLVM.and e_3 (const? 32 4096)) (const? 32 0)) e e_1))
+        (select (icmp IntPred.eq (LLVM.and e_3 (const? 32 4096)) (const? 32 0)) e e_1))
       (LLVM.and e_2 (const? 32 2048)) := by
     simp_alive_undef
     simp_alive_ops
@@ -863,7 +863,7 @@ theorem set_bits_thm (e : IntW 8) (e_1 : IntW 1) :
 
 
 theorem xor_i8_to_i64_shl_save_and_ne_thm (e : IntW 64) (e_1 : IntW 8) :
-  select (icmp IntPredicate.ne (LLVM.and e_1 (const? 8 1)) (const? 8 0)) (LLVM.xor e (const? 64 (-9223372036854775808)))
+  select (icmp IntPred.ne (LLVM.and e_1 (const? 8 1)) (const? 8 0)) (LLVM.xor e (const? 64 (-9223372036854775808)))
       e ⊑
     LLVM.xor e (shl (zext 64 e_1) (const? 64 63)) := by
     simp_alive_undef
@@ -875,7 +875,7 @@ theorem xor_i8_to_i64_shl_save_and_ne_thm (e : IntW 64) (e_1 : IntW 8) :
 
 
 theorem select_icmp_eq_and_1_0_lshr_fv_thm (e e_1 : IntW 8) :
-  select (icmp IntPredicate.eq (LLVM.and e_1 (const? 8 1)) (const? 8 0)) e (lshr e (const? 8 2)) ⊑
+  select (icmp IntPred.eq (LLVM.and e_1 (const? 8 1)) (const? 8 0)) e (lshr e (const? 8 2)) ⊑
     lshr e (LLVM.and (shl e_1 (const? 8 1)) (const? 8 2)) := by
     simp_alive_undef
     simp_alive_ops
@@ -886,7 +886,7 @@ theorem select_icmp_eq_and_1_0_lshr_fv_thm (e e_1 : IntW 8) :
 
 
 theorem select_icmp_eq_and_1_0_lshr_tv_thm (e e_1 : IntW 8) :
-  select (icmp IntPredicate.ne (LLVM.and e_1 (const? 8 1)) (const? 8 0)) (lshr e (const? 8 2)) e ⊑
+  select (icmp IntPred.ne (LLVM.and e_1 (const? 8 1)) (const? 8 0)) (lshr e (const? 8 2)) e ⊑
     lshr e (LLVM.and (shl e_1 (const? 8 1)) (const? 8 2)) := by
     simp_alive_undef
     simp_alive_ops

--- a/SSA/Projects/InstCombine/tests/proofs/gset_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gset_proof.lean
@@ -11,7 +11,7 @@ set_option maxRecDepth 1000000
 set_option Elab.async false
 
 section gset_proof
-theorem test3_thm (e : IntW 32) : icmp IntPredicate.slt e e ⊑ const? 1 0 := by
+theorem test3_thm (e : IntW 32) : icmp IntPred.slt e e ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -20,7 +20,7 @@ theorem test3_thm (e : IntW 32) : icmp IntPredicate.slt e e ⊑ const? 1 0 := by
     all_goals sorry
 
 
-theorem test4_thm (e : IntW 32) : icmp IntPredicate.sgt e e ⊑ const? 1 0 := by
+theorem test4_thm (e : IntW 32) : icmp IntPred.sgt e e ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -29,7 +29,7 @@ theorem test4_thm (e : IntW 32) : icmp IntPredicate.sgt e e ⊑ const? 1 0 := by
     all_goals sorry
 
 
-theorem test5_thm (e : IntW 32) : icmp IntPredicate.sle e e ⊑ const? 1 1 := by
+theorem test5_thm (e : IntW 32) : icmp IntPred.sle e e ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -38,7 +38,7 @@ theorem test5_thm (e : IntW 32) : icmp IntPredicate.sle e e ⊑ const? 1 1 := by
     all_goals sorry
 
 
-theorem test6_thm (e : IntW 32) : icmp IntPredicate.sge e e ⊑ const? 1 1 := by
+theorem test6_thm (e : IntW 32) : icmp IntPred.sge e e ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -47,7 +47,7 @@ theorem test6_thm (e : IntW 32) : icmp IntPredicate.sge e e ⊑ const? 1 1 := by
     all_goals sorry
 
 
-theorem test7_thm (e : IntW 32) : icmp IntPredicate.uge e (const? 32 0) ⊑ const? 1 1 := by
+theorem test7_thm (e : IntW 32) : icmp IntPred.uge e (const? 32 0) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -56,7 +56,7 @@ theorem test7_thm (e : IntW 32) : icmp IntPredicate.uge e (const? 32 0) ⊑ cons
     all_goals sorry
 
 
-theorem test8_thm (e : IntW 32) : icmp IntPredicate.ult e (const? 32 0) ⊑ const? 1 0 := by
+theorem test8_thm (e : IntW 32) : icmp IntPred.ult e (const? 32 0) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -65,7 +65,7 @@ theorem test8_thm (e : IntW 32) : icmp IntPredicate.ult e (const? 32 0) ⊑ cons
     all_goals sorry
 
 
-theorem test9_thm (e : IntW 1) : icmp IntPredicate.ult e (const? 1 0) ⊑ const? 1 0 := by
+theorem test9_thm (e : IntW 1) : icmp IntPred.ult e (const? 1 0) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -74,7 +74,7 @@ theorem test9_thm (e : IntW 1) : icmp IntPredicate.ult e (const? 1 0) ⊑ const?
     all_goals sorry
 
 
-theorem test10_thm (e : IntW 1) : icmp IntPredicate.ugt e (const? 1 1) ⊑ const? 1 0 := by
+theorem test10_thm (e : IntW 1) : icmp IntPred.ugt e (const? 1 1) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -83,7 +83,7 @@ theorem test10_thm (e : IntW 1) : icmp IntPredicate.ugt e (const? 1 1) ⊑ const
     all_goals sorry
 
 
-theorem test11_thm (e : IntW 1) : icmp IntPredicate.ule e (const? 1 1) ⊑ const? 1 1 := by
+theorem test11_thm (e : IntW 1) : icmp IntPred.ule e (const? 1 1) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -92,7 +92,7 @@ theorem test11_thm (e : IntW 1) : icmp IntPredicate.ule e (const? 1 1) ⊑ const
     all_goals sorry
 
 
-theorem test12_thm (e : IntW 1) : icmp IntPredicate.uge e (const? 1 0) ⊑ const? 1 1 := by
+theorem test12_thm (e : IntW 1) : icmp IntPred.uge e (const? 1 0) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -101,7 +101,7 @@ theorem test12_thm (e : IntW 1) : icmp IntPredicate.uge e (const? 1 0) ⊑ const
     all_goals sorry
 
 
-theorem test13_thm (e e_1 : IntW 1) : icmp IntPredicate.uge e_1 e ⊑ LLVM.or e_1 (LLVM.xor e (const? 1 1)) := by
+theorem test13_thm (e e_1 : IntW 1) : icmp IntPred.uge e_1 e ⊑ LLVM.or e_1 (LLVM.xor e (const? 1 1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -110,7 +110,7 @@ theorem test13_thm (e e_1 : IntW 1) : icmp IntPredicate.uge e_1 e ⊑ LLVM.or e_
     all_goals sorry
 
 
-theorem test14_thm (e e_1 : IntW 1) : icmp IntPredicate.eq e_1 e ⊑ LLVM.xor (LLVM.xor e_1 e) (const? 1 1) := by
+theorem test14_thm (e e_1 : IntW 1) : icmp IntPred.eq e_1 e ⊑ LLVM.xor (LLVM.xor e_1 e) (const? 1 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -120,9 +120,9 @@ theorem test14_thm (e e_1 : IntW 1) : icmp IntPredicate.eq e_1 e ⊑ LLVM.xor (L
 
 
 theorem bool_eq0_thm (e : IntW 64) :
-  LLVM.and (icmp IntPredicate.sgt e (const? 64 0))
-      (icmp IntPredicate.eq (icmp IntPredicate.eq e (const? 64 1)) (const? 1 0)) ⊑
-    icmp IntPredicate.sgt e (const? 64 1) := by
+  LLVM.and (icmp IntPred.sgt e (const? 64 0))
+      (icmp IntPred.eq (icmp IntPred.eq e (const? 64 1)) (const? 1 0)) ⊑
+    icmp IntPred.sgt e (const? 64 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -132,9 +132,9 @@ theorem bool_eq0_thm (e : IntW 64) :
 
 
 theorem bool_eq0_logical_thm (e : IntW 64) :
-  select (icmp IntPredicate.sgt e (const? 64 0))
-      (icmp IntPredicate.eq (icmp IntPredicate.eq e (const? 64 1)) (const? 1 0)) (const? 1 0) ⊑
-    icmp IntPredicate.sgt e (const? 64 1) := by
+  select (icmp IntPred.sgt e (const? 64 0))
+      (icmp IntPred.eq (icmp IntPred.eq e (const? 64 1)) (const? 1 0)) (const? 1 0) ⊑
+    icmp IntPred.sgt e (const? 64 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -144,8 +144,8 @@ theorem bool_eq0_logical_thm (e : IntW 64) :
 
 
 theorem xor_of_icmps_thm (e : IntW 64) :
-  LLVM.xor (icmp IntPredicate.eq e (const? 64 1)) (icmp IntPredicate.sgt e (const? 64 0)) ⊑
-    icmp IntPredicate.sgt e (const? 64 1) := by
+  LLVM.xor (icmp IntPred.eq e (const? 64 1)) (icmp IntPred.sgt e (const? 64 0)) ⊑
+    icmp IntPred.sgt e (const? 64 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -155,8 +155,8 @@ theorem xor_of_icmps_thm (e : IntW 64) :
 
 
 theorem xor_of_icmps_commute_thm (e : IntW 64) :
-  LLVM.xor (icmp IntPredicate.sgt e (const? 64 0)) (icmp IntPredicate.eq e (const? 64 1)) ⊑
-    icmp IntPredicate.sgt e (const? 64 1) := by
+  LLVM.xor (icmp IntPred.sgt e (const? 64 0)) (icmp IntPred.eq e (const? 64 1)) ⊑
+    icmp IntPred.sgt e (const? 64 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -166,8 +166,8 @@ theorem xor_of_icmps_commute_thm (e : IntW 64) :
 
 
 theorem xor_of_icmps_to_ne_thm (e : IntW 64) :
-  LLVM.xor (icmp IntPredicate.sgt e (const? 64 4)) (icmp IntPredicate.slt e (const? 64 6)) ⊑
-    icmp IntPredicate.ne e (const? 64 5) := by
+  LLVM.xor (icmp IntPred.sgt e (const? 64 4)) (icmp IntPred.slt e (const? 64 6)) ⊑
+    icmp IntPred.ne e (const? 64 5) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -177,8 +177,8 @@ theorem xor_of_icmps_to_ne_thm (e : IntW 64) :
 
 
 theorem xor_of_icmps_to_ne_commute_thm (e : IntW 64) :
-  LLVM.xor (icmp IntPredicate.slt e (const? 64 6)) (icmp IntPredicate.sgt e (const? 64 4)) ⊑
-    icmp IntPredicate.ne e (const? 64 5) := by
+  LLVM.xor (icmp IntPred.slt e (const? 64 6)) (icmp IntPred.sgt e (const? 64 4)) ⊑
+    icmp IntPred.ne e (const? 64 5) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -188,8 +188,8 @@ theorem xor_of_icmps_to_ne_commute_thm (e : IntW 64) :
 
 
 theorem xor_of_icmps_neg_to_ne_thm (e : IntW 64) :
-  LLVM.xor (icmp IntPredicate.sgt e (const? 64 (-6))) (icmp IntPredicate.slt e (const? 64 (-4))) ⊑
-    icmp IntPredicate.ne e (const? 64 (-5)) := by
+  LLVM.xor (icmp IntPred.sgt e (const? 64 (-6))) (icmp IntPred.slt e (const? 64 (-4))) ⊑
+    icmp IntPred.ne e (const? 64 (-5)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -199,8 +199,8 @@ theorem xor_of_icmps_neg_to_ne_thm (e : IntW 64) :
 
 
 theorem xor_of_icmps_to_eq_thm (e : IntW 8) :
-  LLVM.xor (icmp IntPredicate.slt e (const? 8 (-128))) (icmp IntPredicate.sgt e (const? 8 126)) ⊑
-    icmp IntPredicate.eq e (const? 8 127) := by
+  LLVM.xor (icmp IntPred.slt e (const? 8 (-128))) (icmp IntPred.sgt e (const? 8 126)) ⊑
+    icmp IntPred.eq e (const? 8 127) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -210,10 +210,10 @@ theorem xor_of_icmps_to_eq_thm (e : IntW 8) :
 
 
 theorem PR2844_thm (e : IntW 32) :
-  select (LLVM.or (icmp IntPredicate.eq e (const? 32 0)) (icmp IntPredicate.slt e (const? 32 (-638208501))))
+  select (LLVM.or (icmp IntPred.eq e (const? 32 0)) (icmp IntPred.slt e (const? 32 (-638208501))))
       (const? 32 0) (const? 32 1) ⊑
     zext 32
-      (LLVM.and (icmp IntPredicate.ne e (const? 32 0)) (icmp IntPredicate.sgt e (const? 32 (-638208502)))) := by
+      (LLVM.and (icmp IntPred.ne e (const? 32 0)) (icmp IntPred.sgt e (const? 32 (-638208502)))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -223,10 +223,10 @@ theorem PR2844_thm (e : IntW 32) :
 
 
 theorem PR2844_logical_thm (e : IntW 32) :
-  select (select (icmp IntPredicate.eq e (const? 32 0)) (const? 1 1) (icmp IntPredicate.slt e (const? 32 (-638208501))))
+  select (select (icmp IntPred.eq e (const? 32 0)) (const? 1 1) (icmp IntPred.slt e (const? 32 (-638208501))))
       (const? 32 0) (const? 32 1) ⊑
     zext 32
-      (LLVM.and (icmp IntPredicate.ne e (const? 32 0)) (icmp IntPredicate.sgt e (const? 32 (-638208502)))) := by
+      (LLVM.and (icmp IntPred.ne e (const? 32 0)) (icmp IntPred.sgt e (const? 32 (-638208502)))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -235,7 +235,7 @@ theorem PR2844_logical_thm (e : IntW 32) :
     all_goals sorry
 
 
-theorem test16_thm (e : IntW 32) : icmp IntPredicate.eq (LLVM.and e (const? 32 5)) (const? 32 8) ⊑ const? 1 0 := by
+theorem test16_thm (e : IntW 32) : icmp IntPred.eq (LLVM.and e (const? 32 5)) (const? 32 8) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -244,7 +244,7 @@ theorem test16_thm (e : IntW 32) : icmp IntPredicate.eq (LLVM.and e (const? 32 5
     all_goals sorry
 
 
-theorem test17_thm (e : IntW 8) : icmp IntPredicate.eq (LLVM.or e (const? 8 1)) (const? 8 2) ⊑ const? 1 0 := by
+theorem test17_thm (e : IntW 8) : icmp IntPred.eq (LLVM.or e (const? 8 1)) (const? 8 2) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -254,7 +254,7 @@ theorem test17_thm (e : IntW 8) : icmp IntPredicate.eq (LLVM.or e (const? 8 1)) 
 
 
 theorem test19_thm (e e_1 : IntW 1) :
-  icmp IntPredicate.eq (zext 32 e_1) (zext 32 e) ⊑ LLVM.xor (LLVM.xor e_1 e) (const? 1 1) := by
+  icmp IntPred.eq (zext 32 e_1) (zext 32 e) ⊑ LLVM.xor (LLVM.xor e_1 e) (const? 1 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -264,7 +264,7 @@ theorem test19_thm (e e_1 : IntW 1) :
 
 
 theorem test20_thm (e : IntW 32) :
-  zext 32 (icmp IntPredicate.ne (LLVM.and e (const? 32 1)) (const? 32 0)) ⊑ LLVM.and e (const? 32 1) := by
+  zext 32 (icmp IntPred.ne (LLVM.and e (const? 32 1)) (const? 32 0)) ⊑ LLVM.and e (const? 32 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -274,7 +274,7 @@ theorem test20_thm (e : IntW 32) :
 
 
 theorem test21_thm (e : IntW 32) :
-  zext 32 (icmp IntPredicate.ne (LLVM.and e (const? 32 4)) (const? 32 0)) ⊑
+  zext 32 (icmp IntPred.ne (LLVM.and e (const? 32 4)) (const? 32 0)) ⊑
     LLVM.and (lshr e (const? 32 2)) (const? 32 1) := by
     simp_alive_undef
     simp_alive_ops
@@ -285,8 +285,8 @@ theorem test21_thm (e : IntW 32) :
 
 
 theorem test22_thm (e e_1 : IntW 32) :
-  LLVM.or (icmp IntPredicate.ult (LLVM.and e_1 (const? 32 100663295)) (const? 32 268435456))
-      (icmp IntPredicate.sgt (LLVM.and e (const? 32 7)) (const? 32 (-1))) ⊑
+  LLVM.or (icmp IntPred.ult (LLVM.and e_1 (const? 32 100663295)) (const? 32 268435456))
+      (icmp IntPred.sgt (LLVM.and e (const? 32 7)) (const? 32 (-1))) ⊑
     const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
@@ -297,8 +297,8 @@ theorem test22_thm (e e_1 : IntW 32) :
 
 
 theorem test22_logical_thm (e e_1 : IntW 32) :
-  select (icmp IntPredicate.ult (LLVM.and e_1 (const? 32 100663295)) (const? 32 268435456)) (const? 1 1)
-      (icmp IntPredicate.sgt (LLVM.and e (const? 32 7)) (const? 32 (-1))) ⊑
+  select (icmp IntPred.ult (LLVM.and e_1 (const? 32 100663295)) (const? 32 268435456)) (const? 1 1)
+      (icmp IntPred.sgt (LLVM.and e (const? 32 7)) (const? 32 (-1))) ⊑
     const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
@@ -309,7 +309,7 @@ theorem test22_logical_thm (e e_1 : IntW 32) :
 
 
 theorem test23_thm (e : IntW 32) :
-  zext 32 (icmp IntPredicate.eq (LLVM.and e (const? 32 1)) (const? 32 0)) ⊑
+  zext 32 (icmp IntPred.eq (LLVM.and e (const? 32 1)) (const? 32 0)) ⊑
     LLVM.xor (LLVM.and e (const? 32 1)) (const? 32 1) := by
     simp_alive_undef
     simp_alive_ops
@@ -320,7 +320,7 @@ theorem test23_thm (e : IntW 32) :
 
 
 theorem test24_thm (e : IntW 32) :
-  zext 32 (icmp IntPredicate.eq (lshr (LLVM.and e (const? 32 4)) (const? 32 2)) (const? 32 0)) ⊑
+  zext 32 (icmp IntPred.eq (lshr (LLVM.and e (const? 32 4)) (const? 32 2)) (const? 32 0)) ⊑
     LLVM.xor (LLVM.and (lshr e (const? 32 2)) (const? 32 1)) (const? 32 1) := by
     simp_alive_undef
     simp_alive_ops
@@ -330,7 +330,7 @@ theorem test24_thm (e : IntW 32) :
     all_goals sorry
 
 
-theorem test25_thm (e : IntW 32) : icmp IntPredicate.ugt (LLVM.and e (const? 32 2)) (const? 32 2) ⊑ const? 1 0 := by
+theorem test25_thm (e : IntW 32) : icmp IntPred.ugt (LLVM.and e (const? 32 2)) (const? 32 2) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gsetcchstrengthhreduce_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gsetcchstrengthhreduce_proof.lean
@@ -12,7 +12,7 @@ set_option Elab.async false
 
 section gsetcchstrengthhreduce_proof
 theorem test1_thm (e : IntW 32) :
-  icmp IntPredicate.uge e (const? 32 1) ⊑ icmp IntPredicate.ne e (const? 32 0) := by
+  icmp IntPred.uge e (const? 32 1) ⊑ icmp IntPred.ne e (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -22,7 +22,7 @@ theorem test1_thm (e : IntW 32) :
 
 
 theorem test2_thm (e : IntW 32) :
-  icmp IntPredicate.ugt e (const? 32 0) ⊑ icmp IntPredicate.ne e (const? 32 0) := by
+  icmp IntPred.ugt e (const? 32 0) ⊑ icmp IntPred.ne e (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -32,7 +32,7 @@ theorem test2_thm (e : IntW 32) :
 
 
 theorem test3_thm (e : IntW 8) :
-  icmp IntPredicate.sge e (const? 8 (-127)) ⊑ icmp IntPredicate.ne e (const? 8 (-128)) := by
+  icmp IntPred.sge e (const? 8 (-127)) ⊑ icmp IntPred.ne e (const? 8 (-128)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -42,7 +42,7 @@ theorem test3_thm (e : IntW 8) :
 
 
 theorem test4_thm (e : IntW 8) :
-  icmp IntPredicate.sle e (const? 8 126) ⊑ icmp IntPredicate.ne e (const? 8 127) := by
+  icmp IntPred.sle e (const? 8 126) ⊑ icmp IntPred.ne e (const? 8 127) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -52,7 +52,7 @@ theorem test4_thm (e : IntW 8) :
 
 
 theorem test5_thm (e : IntW 8) :
-  icmp IntPredicate.slt e (const? 8 127) ⊑ icmp IntPredicate.ne e (const? 8 127) := by
+  icmp IntPred.slt e (const? 8 127) ⊑ icmp IntPred.ne e (const? 8 127) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gsext_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gsext_proof.lean
@@ -66,7 +66,7 @@ theorem test10_thm (e : IntW 32) :
 
 
 theorem test13_thm (e : IntW 32) :
-  sext 32 (icmp IntPredicate.eq (LLVM.and e (const? 32 8)) (const? 32 0)) ⊑
+  sext 32 (icmp IntPred.eq (LLVM.and e (const? 32 8)) (const? 32 0)) ⊑
     add (LLVM.and (lshr e (const? 32 3)) (const? 32 1)) (const? 32 (-1)) { «nsw» := true, «nuw» := false } := by
     simp_alive_undef
     simp_alive_ops
@@ -77,7 +77,7 @@ theorem test13_thm (e : IntW 32) :
 
 
 theorem test14_thm (e : IntW 16) :
-  sext 32 (icmp IntPredicate.ne (LLVM.and e (const? 16 16)) (const? 16 16)) ⊑
+  sext 32 (icmp IntPred.ne (LLVM.and e (const? 16 16)) (const? 16 16)) ⊑
     sext 32
       (add (LLVM.and (lshr e (const? 16 4)) (const? 16 1)) (const? 16 (-1)) { «nsw» := true, «nuw» := false }) := by
     simp_alive_undef
@@ -89,7 +89,7 @@ theorem test14_thm (e : IntW 16) :
 
 
 theorem test15_thm (e : IntW 32) :
-  sext 32 (icmp IntPredicate.ne (LLVM.and e (const? 32 16)) (const? 32 0)) ⊑
+  sext 32 (icmp IntPred.ne (LLVM.and e (const? 32 16)) (const? 32 0)) ⊑
     ashr (shl e (const? 32 27)) (const? 32 31) := by
     simp_alive_undef
     simp_alive_ops
@@ -100,7 +100,7 @@ theorem test15_thm (e : IntW 32) :
 
 
 theorem test16_thm (e : IntW 16) :
-  sext 32 (icmp IntPredicate.eq (LLVM.and e (const? 16 8)) (const? 16 8)) ⊑
+  sext 32 (icmp IntPred.eq (LLVM.and e (const? 16 8)) (const? 16 8)) ⊑
     sext 32 (ashr (shl e (const? 16 12)) (const? 16 15)) := by
     simp_alive_undef
     simp_alive_ops

--- a/SSA/Projects/InstCombine/tests/proofs/gsexthand_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gsexthand_proof.lean
@@ -12,8 +12,8 @@ set_option Elab.async false
 
 section gsexthand_proof
 theorem fold_sext_to_and_thm (e : IntW 8) :
-  icmp IntPredicate.eq (LLVM.and (sext 32 e) (const? 32 (-2147483647))) (const? 32 1) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 8 (-127))) (const? 8 1) := by
+  icmp IntPred.eq (LLVM.and (sext 32 e) (const? 32 (-2147483647))) (const? 32 1) ⊑
+    icmp IntPred.eq (LLVM.and e (const? 8 (-127))) (const? 8 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -23,8 +23,8 @@ theorem fold_sext_to_and_thm (e : IntW 8) :
 
 
 theorem fold_sext_to_and1_thm (e : IntW 8) :
-  icmp IntPredicate.ne (LLVM.and (sext 32 e) (const? 32 (-2147483647))) (const? 32 1) ⊑
-    icmp IntPredicate.ne (LLVM.and e (const? 8 (-127))) (const? 8 1) := by
+  icmp IntPred.ne (LLVM.and (sext 32 e) (const? 32 (-2147483647))) (const? 32 1) ⊑
+    icmp IntPred.ne (LLVM.and e (const? 8 (-127))) (const? 8 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -34,8 +34,8 @@ theorem fold_sext_to_and1_thm (e : IntW 8) :
 
 
 theorem fold_sext_to_and2_thm (e : IntW 8) :
-  icmp IntPredicate.eq (LLVM.and (sext 32 e) (const? 32 1073741826)) (const? 32 2) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 8 (-126))) (const? 8 2) := by
+  icmp IntPred.eq (LLVM.and (sext 32 e) (const? 32 1073741826)) (const? 32 2) ⊑
+    icmp IntPred.eq (LLVM.and e (const? 8 (-126))) (const? 8 2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -45,8 +45,8 @@ theorem fold_sext_to_and2_thm (e : IntW 8) :
 
 
 theorem fold_sext_to_and3_thm (e : IntW 8) :
-  icmp IntPredicate.ne (LLVM.and (sext 32 e) (const? 32 1073741826)) (const? 32 2) ⊑
-    icmp IntPredicate.ne (LLVM.and e (const? 8 (-126))) (const? 8 2) := by
+  icmp IntPred.ne (LLVM.and (sext 32 e) (const? 32 1073741826)) (const? 32 2) ⊑
+    icmp IntPred.ne (LLVM.and e (const? 8 (-126))) (const? 8 2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -56,7 +56,7 @@ theorem fold_sext_to_and3_thm (e : IntW 8) :
 
 
 theorem fold_sext_to_and_wrong_thm (e : IntW 8) :
-  icmp IntPredicate.eq (LLVM.and (sext 32 e) (const? 32 (-2147483647))) (const? 32 (-1)) ⊑ const? 1 0 := by
+  icmp IntPred.eq (LLVM.and (sext 32 e) (const? 32 (-2147483647))) (const? 32 (-1)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -66,7 +66,7 @@ theorem fold_sext_to_and_wrong_thm (e : IntW 8) :
 
 
 theorem fold_sext_to_and_wrong2_thm (e : IntW 8) :
-  icmp IntPredicate.eq (LLVM.and (sext 32 e) (const? 32 (-2147483647))) (const? 32 128) ⊑ const? 1 0 := by
+  icmp IntPred.eq (LLVM.and (sext 32 e) (const? 32 (-2147483647))) (const? 32 128) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -76,7 +76,7 @@ theorem fold_sext_to_and_wrong2_thm (e : IntW 8) :
 
 
 theorem fold_sext_to_and_wrong3_thm (e : IntW 8) :
-  icmp IntPredicate.eq (LLVM.and (sext 32 e) (const? 32 128)) (const? 32 (-2147483648)) ⊑ const? 1 0 := by
+  icmp IntPred.eq (LLVM.and (sext 32 e) (const? 32 128)) (const? 32 (-2147483648)) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -86,7 +86,7 @@ theorem fold_sext_to_and_wrong3_thm (e : IntW 8) :
 
 
 theorem fold_sext_to_and_wrong4_thm (e : IntW 8) :
-  icmp IntPredicate.eq (LLVM.and (sext 32 e) (const? 32 128)) (const? 32 1) ⊑ const? 1 0 := by
+  icmp IntPred.eq (LLVM.and (sext 32 e) (const? 32 128)) (const? 32 1) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -96,7 +96,7 @@ theorem fold_sext_to_and_wrong4_thm (e : IntW 8) :
 
 
 theorem fold_sext_to_and_wrong5_thm (e : IntW 8) :
-  icmp IntPredicate.eq (LLVM.and (sext 32 e) (const? 32 (-256))) (const? 32 1) ⊑ const? 1 0 := by
+  icmp IntPred.eq (LLVM.and (sext 32 e) (const? 32 (-256))) (const? 32 1) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -106,7 +106,7 @@ theorem fold_sext_to_and_wrong5_thm (e : IntW 8) :
 
 
 theorem fold_sext_to_and_wrong6_thm (e : IntW 8) :
-  icmp IntPredicate.ne (LLVM.and (sext 32 e) (const? 32 (-2147483647))) (const? 32 (-1)) ⊑ const? 1 1 := by
+  icmp IntPred.ne (LLVM.and (sext 32 e) (const? 32 (-2147483647))) (const? 32 (-1)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -116,7 +116,7 @@ theorem fold_sext_to_and_wrong6_thm (e : IntW 8) :
 
 
 theorem fold_sext_to_and_wrong7_thm (e : IntW 8) :
-  icmp IntPredicate.ne (LLVM.and (sext 32 e) (const? 32 (-2147483647))) (const? 32 128) ⊑ const? 1 1 := by
+  icmp IntPred.ne (LLVM.and (sext 32 e) (const? 32 (-2147483647))) (const? 32 128) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -126,7 +126,7 @@ theorem fold_sext_to_and_wrong7_thm (e : IntW 8) :
 
 
 theorem fold_sext_to_and_wrong8_thm (e : IntW 8) :
-  icmp IntPredicate.ne (LLVM.and (sext 32 e) (const? 32 128)) (const? 32 (-2147483648)) ⊑ const? 1 1 := by
+  icmp IntPred.ne (LLVM.and (sext 32 e) (const? 32 128)) (const? 32 (-2147483648)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -136,7 +136,7 @@ theorem fold_sext_to_and_wrong8_thm (e : IntW 8) :
 
 
 theorem fold_sext_to_and_wrong9_thm (e : IntW 8) :
-  icmp IntPredicate.ne (LLVM.and (sext 32 e) (const? 32 128)) (const? 32 1) ⊑ const? 1 1 := by
+  icmp IntPred.ne (LLVM.and (sext 32 e) (const? 32 128)) (const? 32 1) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -146,7 +146,7 @@ theorem fold_sext_to_and_wrong9_thm (e : IntW 8) :
 
 
 theorem fold_sext_to_and_wrong10_thm (e : IntW 8) :
-  icmp IntPredicate.ne (LLVM.and (sext 32 e) (const? 32 (-256))) (const? 32 1) ⊑ const? 1 1 := by
+  icmp IntPred.ne (LLVM.and (sext 32 e) (const? 32 (-256))) (const? 32 1) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gshifthadd_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gshifthadd_proof.lean
@@ -162,7 +162,7 @@ theorem ashr_2_add_zext_basic_thm (e e_1 : IntW 1) :
 
 theorem lshr_16_add_zext_basic_thm (e e_1 : IntW 16) :
   lshr (add (zext 32 e_1) (zext 32 e)) (const? 32 16) ⊑
-    zext 32 (icmp IntPredicate.ugt e (LLVM.xor e_1 (const? 16 (-1)))) := by
+    zext 32 (icmp IntPred.ugt e (LLVM.xor e_1 (const? 16 (-1)))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -209,7 +209,7 @@ theorem lshr_16_add_not_known_16_leading_zeroes_thm (e e_1 : IntW 32) :
 
 theorem lshr_32_add_zext_basic_thm (e e_1 : IntW 32) :
   lshr (add (zext 64 e_1) (zext 64 e)) (const? 64 32) ⊑
-    zext 64 (icmp IntPredicate.ugt e (LLVM.xor e_1 (const? 32 (-1)))) := by
+    zext 64 (icmp IntPred.ugt e (LLVM.xor e_1 (const? 32 (-1)))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -251,7 +251,7 @@ theorem lshr_33_i32_add_zext_basic_thm (e e_1 : IntW 32) : lshr (add (zext 64 e_
 
 theorem lshr_16_to_64_add_zext_basic_thm (e e_1 : IntW 16) :
   lshr (add (zext 64 e_1) (zext 64 e)) (const? 64 16) ⊑
-    zext 64 (icmp IntPredicate.ugt e (LLVM.xor e_1 (const? 16 (-1)))) := by
+    zext 64 (icmp IntPred.ugt e (LLVM.xor e_1 (const? 16 (-1)))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -288,7 +288,7 @@ theorem lshr_32_add_not_known_32_leading_zeroes_thm (e e_1 : IntW 64) :
 
 theorem ashr_16_add_zext_basic_thm (e e_1 : IntW 16) :
   lshr (add (zext 32 e_1) (zext 32 e)) (const? 32 16) ⊑
-    zext 32 (icmp IntPredicate.ugt e (LLVM.xor e_1 (const? 16 (-1)))) := by
+    zext 32 (icmp IntPred.ugt e (LLVM.xor e_1 (const? 16 (-1)))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -299,7 +299,7 @@ theorem ashr_16_add_zext_basic_thm (e e_1 : IntW 16) :
 
 theorem ashr_32_add_zext_basic_thm (e e_1 : IntW 32) :
   ashr (add (zext 64 e_1) (zext 64 e)) (const? 64 32) ⊑
-    zext 64 (icmp IntPredicate.ugt e (LLVM.xor e_1 (const? 32 (-1)))) := by
+    zext 64 (icmp IntPred.ugt e (LLVM.xor e_1 (const? 32 (-1)))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -310,7 +310,7 @@ theorem ashr_32_add_zext_basic_thm (e e_1 : IntW 32) :
 
 theorem ashr_16_to_64_add_zext_basic_thm (e e_1 : IntW 16) :
   ashr (add (zext 64 e_1) (zext 64 e)) (const? 64 16) ⊑
-    zext 64 (icmp IntPredicate.ugt e (LLVM.xor e_1 (const? 16 (-1)))) := by
+    zext 64 (icmp IntPred.ugt e (LLVM.xor e_1 (const? 16 (-1)))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -321,7 +321,7 @@ theorem ashr_16_to_64_add_zext_basic_thm (e e_1 : IntW 16) :
 
 theorem lshr_32_add_zext_trunc_thm (e e_1 : IntW 32) :
   add (trunc 32 (add (zext 64 e_1) (zext 64 e))) (trunc 32 (lshr (add (zext 64 e_1) (zext 64 e)) (const? 64 32))) ⊑
-    add (add e_1 e) (zext 32 (icmp IntPredicate.ult (add e_1 e) e_1)) := by
+    add (add e_1 e) (zext 32 (icmp IntPred.ult (add e_1 e) e_1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gshifthamounthreassociationhinhbittest_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gshifthamounthreassociationhinhbittest_proof.lean
@@ -12,8 +12,8 @@ set_option Elab.async false
 
 section gshifthamounthreassociationhinhbittest_proof
 theorem t0_const_lshr_shl_ne_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.ne (LLVM.and (shl e_1 (const? 32 1)) (lshr e (const? 32 1))) (const? 32 0) ⊑
-    icmp IntPredicate.ne (LLVM.and (lshr e (const? 32 2)) e_1) (const? 32 0) := by
+  icmp IntPred.ne (LLVM.and (shl e_1 (const? 32 1)) (lshr e (const? 32 1))) (const? 32 0) ⊑
+    icmp IntPred.ne (LLVM.and (lshr e (const? 32 2)) e_1) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -23,8 +23,8 @@ theorem t0_const_lshr_shl_ne_thm (e e_1 : IntW 32) :
 
 
 theorem t1_const_shl_lshr_ne_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.ne (LLVM.and (lshr e_1 (const? 32 1)) (shl e (const? 32 1))) (const? 32 0) ⊑
-    icmp IntPredicate.ne (LLVM.and (lshr e_1 (const? 32 2)) e) (const? 32 0) := by
+  icmp IntPred.ne (LLVM.and (lshr e_1 (const? 32 1)) (shl e (const? 32 1))) (const? 32 0) ⊑
+    icmp IntPred.ne (LLVM.and (lshr e_1 (const? 32 2)) e) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -34,8 +34,8 @@ theorem t1_const_shl_lshr_ne_thm (e e_1 : IntW 32) :
 
 
 theorem t2_const_lshr_shl_eq_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.eq (LLVM.and (shl e_1 (const? 32 1)) (lshr e (const? 32 1))) (const? 32 0) ⊑
-    icmp IntPredicate.eq (LLVM.and (lshr e (const? 32 2)) e_1) (const? 32 0) := by
+  icmp IntPred.eq (LLVM.and (shl e_1 (const? 32 1)) (lshr e (const? 32 1))) (const? 32 0) ⊑
+    icmp IntPred.eq (LLVM.and (lshr e (const? 32 2)) e_1) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -45,8 +45,8 @@ theorem t2_const_lshr_shl_eq_thm (e e_1 : IntW 32) :
 
 
 theorem t3_const_after_fold_lshr_shl_ne_thm (e e_1 e_2 : IntW 32) :
-  icmp IntPredicate.ne (LLVM.and (lshr e_2 (sub (const? 32 32) e_1)) (shl e (add e_1 (const? 32 (-1))))) (const? 32 0) ⊑
-    icmp IntPredicate.ne (LLVM.and (lshr e_2 (const? 32 31)) e) (const? 32 0) := by
+  icmp IntPred.ne (LLVM.and (lshr e_2 (sub (const? 32 32) e_1)) (shl e (add e_1 (const? 32 (-1))))) (const? 32 0) ⊑
+    icmp IntPred.ne (LLVM.and (lshr e_2 (const? 32 31)) e) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -56,8 +56,8 @@ theorem t3_const_after_fold_lshr_shl_ne_thm (e e_1 e_2 : IntW 32) :
 
 
 theorem t4_const_after_fold_lshr_shl_ne_thm (e e_1 e_2 : IntW 32) :
-  icmp IntPredicate.ne (LLVM.and (shl e_2 (sub (const? 32 32) e_1)) (lshr e (add e_1 (const? 32 (-1))))) (const? 32 0) ⊑
-    icmp IntPredicate.ne (LLVM.and (lshr e (const? 32 31)) e_2) (const? 32 0) := by
+  icmp IntPred.ne (LLVM.and (shl e_2 (sub (const? 32 32) e_1)) (lshr e (add e_1 (const? 32 (-1))))) (const? 32 0) ⊑
+    icmp IntPred.ne (LLVM.and (lshr e (const? 32 31)) e_2) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gshifthamounthreassociationhinhbittesthwithhtruncationhlshr_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gshifthamounthreassociationhinhbittesthwithhtruncationhlshr_proof.lean
@@ -12,10 +12,10 @@ set_option Elab.async false
 
 section gshifthamounthreassociationhinhbittesthwithhtruncationhlshr_proof
 theorem n0_thm (e : IntW 64) (e_1 e_2 : IntW 32) :
-  icmp IntPredicate.ne
+  icmp IntPred.ne
       (LLVM.and (shl e_2 (sub (const? 32 32) e_1)) (trunc 32 (lshr e (zext 64 (add e_1 (const? 32 (-16)))))))
       (const? 32 0) ⊑
-    icmp IntPredicate.ne
+    icmp IntPred.ne
       (LLVM.and (shl e_2 (sub (const? 32 32) e_1))
         (trunc 32 (lshr e (zext 64 (add e_1 (const? 32 (-16))) { «nneg» := true }))))
       (const? 32 0) := by
@@ -28,11 +28,11 @@ theorem n0_thm (e : IntW 64) (e_1 e_2 : IntW 32) :
 
 
 theorem t1_thm (e : IntW 64) (e_1 : IntW 32) :
-  icmp IntPredicate.ne
+  icmp IntPred.ne
       (LLVM.and (shl (const? 32 65535) (sub (const? 32 32) e_1))
         (trunc 32 (lshr e (zext 64 (add e_1 (const? 32 (-16)))))))
       (const? 32 0) ⊑
-    icmp IntPredicate.ne (LLVM.and e (const? 64 4294901760)) (const? 64 0) := by
+    icmp IntPred.ne (LLVM.and e (const? 64 4294901760)) (const? 64 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -42,11 +42,11 @@ theorem t1_thm (e : IntW 64) (e_1 : IntW 32) :
 
 
 theorem t1_single_bit_thm (e : IntW 64) (e_1 : IntW 32) :
-  icmp IntPredicate.ne
+  icmp IntPred.ne
       (LLVM.and (shl (const? 32 32768) (sub (const? 32 32) e_1))
         (trunc 32 (lshr e (zext 64 (add e_1 (const? 32 (-16)))))))
       (const? 32 0) ⊑
-    icmp IntPredicate.ne (LLVM.and e (const? 64 2147483648)) (const? 64 0) := by
+    icmp IntPred.ne (LLVM.and e (const? 64 2147483648)) (const? 64 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -56,11 +56,11 @@ theorem t1_single_bit_thm (e : IntW 64) (e_1 : IntW 32) :
 
 
 theorem n2_thm (e : IntW 64) (e_1 : IntW 32) :
-  icmp IntPredicate.ne
+  icmp IntPred.ne
       (LLVM.and (shl (const? 32 131071) (sub (const? 32 32) e_1))
         (trunc 32 (lshr e (zext 64 (add e_1 (const? 32 (-16)))))))
       (const? 32 0) ⊑
-    icmp IntPredicate.ne
+    icmp IntPred.ne
       (LLVM.and (shl (const? 32 131071) (sub (const? 32 32) e_1))
         (trunc 32 (lshr e (zext 64 (add e_1 (const? 32 (-16))) { «nneg» := true }))))
       (const? 32 0) := by
@@ -73,11 +73,11 @@ theorem n2_thm (e : IntW 64) (e_1 : IntW 32) :
 
 
 theorem t3_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.ne
+  icmp IntPred.ne
       (LLVM.and (shl e_1 (sub (const? 32 32) e))
         (trunc 32 (lshr (const? 64 131071) (zext 64 (add e (const? 32 (-16)))))))
       (const? 32 0) ⊑
-    icmp IntPredicate.ne (LLVM.and e_1 (const? 32 1)) (const? 32 0) := by
+    icmp IntPred.ne (LLVM.and e_1 (const? 32 1)) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -87,11 +87,11 @@ theorem t3_thm (e e_1 : IntW 32) :
 
 
 theorem t3_singlebit_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.ne
+  icmp IntPred.ne
       (LLVM.and (shl e_1 (sub (const? 32 32) e))
         (trunc 32 (lshr (const? 64 65536) (zext 64 (add e (const? 32 (-16)))))))
       (const? 32 0) ⊑
-    icmp IntPredicate.ne (LLVM.and e_1 (const? 32 1)) (const? 32 0) := by
+    icmp IntPred.ne (LLVM.and e_1 (const? 32 1)) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -101,11 +101,11 @@ theorem t3_singlebit_thm (e e_1 : IntW 32) :
 
 
 theorem n4_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.ne
+  icmp IntPred.ne
       (LLVM.and (shl e_1 (sub (const? 32 32) e))
         (trunc 32 (lshr (const? 64 262143) (zext 64 (add e (const? 32 (-16)))))))
       (const? 32 0) ⊑
-    icmp IntPredicate.ne
+    icmp IntPred.ne
       (LLVM.and (shl e_1 (sub (const? 32 32) e))
         (trunc 32 (lshr (const? 64 262143) (zext 64 (add e (const? 32 (-16))) { «nneg» := true }))
           { «nsw» := true, «nuw» := true }))
@@ -119,10 +119,10 @@ theorem n4_thm (e e_1 : IntW 32) :
 
 
 theorem t9_highest_bit_thm (e : IntW 64) (e_1 e_2 : IntW 32) :
-  icmp IntPredicate.ne
+  icmp IntPred.ne
       (LLVM.and (shl e_2 (sub (const? 32 64) e_1)) (trunc 32 (lshr e (zext 64 (add e_1 (const? 32 (-1)))))))
       (const? 32 0) ⊑
-    icmp IntPredicate.ne (LLVM.and (lshr e (const? 64 63)) (zext 64 e_2)) (const? 64 0) := by
+    icmp IntPred.ne (LLVM.and (lshr e (const? 64 63)) (zext 64 e_2)) (const? 64 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -132,10 +132,10 @@ theorem t9_highest_bit_thm (e : IntW 64) (e_1 e_2 : IntW 32) :
 
 
 theorem t10_almost_highest_bit_thm (e : IntW 64) (e_1 e_2 : IntW 32) :
-  icmp IntPredicate.ne
+  icmp IntPred.ne
       (LLVM.and (shl e_2 (sub (const? 32 64) e_1)) (trunc 32 (lshr e (zext 64 (add e_1 (const? 32 (-2)))))))
       (const? 32 0) ⊑
-    icmp IntPredicate.ne
+    icmp IntPred.ne
       (LLVM.and (shl e_2 (sub (const? 32 64) e_1))
         (trunc 32 (lshr e (zext 64 (add e_1 (const? 32 (-2))) { «nneg» := true }))))
       (const? 32 0) := by
@@ -148,10 +148,10 @@ theorem t10_almost_highest_bit_thm (e : IntW 64) (e_1 e_2 : IntW 32) :
 
 
 theorem t11_no_shift_thm (e : IntW 64) (e_1 e_2 : IntW 32) :
-  icmp IntPredicate.ne
+  icmp IntPred.ne
       (LLVM.and (shl e_2 (sub (const? 32 64) e_1)) (trunc 32 (lshr e (zext 64 (add e_1 (const? 32 (-64)))))))
       (const? 32 0) ⊑
-    icmp IntPredicate.ne (LLVM.and e (zext 64 e_2)) (const? 64 0) := by
+    icmp IntPred.ne (LLVM.and e (zext 64 e_2)) (const? 64 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -161,10 +161,10 @@ theorem t11_no_shift_thm (e : IntW 64) (e_1 e_2 : IntW 32) :
 
 
 theorem t10_shift_by_one_thm (e : IntW 64) (e_1 e_2 : IntW 32) :
-  icmp IntPredicate.ne
+  icmp IntPred.ne
       (LLVM.and (shl e_2 (sub (const? 32 64) e_1)) (trunc 32 (lshr e (zext 64 (add e_1 (const? 32 (-63)))))))
       (const? 32 0) ⊑
-    icmp IntPredicate.ne
+    icmp IntPred.ne
       (LLVM.and (shl e_2 (sub (const? 32 64) e_1))
         (trunc 32 (lshr e (zext 64 (add e_1 (const? 32 (-63))) { «nneg» := true }))))
       (const? 32 0) := by
@@ -177,10 +177,10 @@ theorem t10_shift_by_one_thm (e : IntW 64) (e_1 e_2 : IntW 32) :
 
 
 theorem t13_x_is_one_thm (e : IntW 64) (e_1 : IntW 32) :
-  icmp IntPredicate.ne
+  icmp IntPred.ne
       (LLVM.and (shl (const? 32 1) (sub (const? 32 32) e_1)) (trunc 32 (lshr e (zext 64 (add e_1 (const? 32 (-16)))))))
       (const? 32 0) ⊑
-    icmp IntPredicate.ne (LLVM.and e (const? 64 65536)) (const? 64 0) := by
+    icmp IntPred.ne (LLVM.and e (const? 64 65536)) (const? 64 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -190,7 +190,7 @@ theorem t13_x_is_one_thm (e : IntW 64) (e_1 : IntW 32) :
 
 
 theorem t14_x_is_one_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.ne
+  icmp IntPred.ne
       (LLVM.and (shl e_1 (sub (const? 32 32) e)) (trunc 32 (lshr (const? 64 1) (zext 64 (add e (const? 32 (-16)))))))
       (const? 32 0) ⊑
     const? 1 0 := by
@@ -203,11 +203,11 @@ theorem t14_x_is_one_thm (e e_1 : IntW 32) :
 
 
 theorem rawspeed_signbit_thm (e : IntW 64) (e_1 : IntW 32) :
-  icmp IntPredicate.eq
+  icmp IntPred.eq
       (LLVM.and (shl (const? 32 1) (add e_1 (const? 32 (-1)) { «nsw» := true, «nuw» := false }))
         (trunc 32 (lshr e (zext 64 (sub (const? 32 64) e_1 { «nsw» := true, «nuw» := false })))))
       (const? 32 0) ⊑
-    icmp IntPredicate.sgt e (const? 64 (-1)) := by
+    icmp IntPred.sgt e (const? 64 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gshifthamounthreassociationhinhbittesthwithhtruncationhshl_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gshifthamounthreassociationhinhbittesthwithhtruncationhshl_proof.lean
@@ -12,10 +12,10 @@ set_option Elab.async false
 
 section gshifthamounthreassociationhinhbittesthwithhtruncationhshl_proof
 theorem t0_const_after_fold_lshr_shl_ne_thm (e : IntW 64) (e_1 e_2 : IntW 32) :
-  icmp IntPredicate.ne
+  icmp IntPred.ne
       (LLVM.and (lshr e_2 (sub (const? 32 32) e_1)) (trunc 32 (shl e (zext 64 (add e_1 (const? 32 (-1)))))))
       (const? 32 0) ⊑
-    icmp IntPredicate.ne (LLVM.and e (zext 64 (lshr e_2 (const? 32 31)) { «nneg» := true })) (const? 64 0) := by
+    icmp IntPred.ne (LLVM.and e (zext 64 (lshr e_2 (const? 32 31)) { «nneg» := true })) (const? 64 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -25,8 +25,8 @@ theorem t0_const_after_fold_lshr_shl_ne_thm (e : IntW 64) (e_1 e_2 : IntW 32) :
 
 
 theorem t10_constants_thm (e : IntW 64) (e_1 : IntW 32) :
-  icmp IntPredicate.ne (LLVM.and (lshr e_1 (const? 32 12)) (trunc 32 (shl e (const? 64 14)))) (const? 32 0) ⊑
-    icmp IntPredicate.ne (LLVM.and (lshr e_1 (const? 32 26)) (trunc 32 e)) (const? 32 0) := by
+  icmp IntPred.ne (LLVM.and (lshr e_1 (const? 32 12)) (trunc 32 (shl e (const? 64 14)))) (const? 32 0) ⊑
+    icmp IntPred.ne (LLVM.and (lshr e_1 (const? 32 26)) (trunc 32 e)) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -36,10 +36,10 @@ theorem t10_constants_thm (e : IntW 64) (e_1 : IntW 32) :
 
 
 theorem n13_overshift_thm (e : IntW 64) (e_1 e_2 : IntW 32) :
-  icmp IntPredicate.ne
+  icmp IntPred.ne
       (LLVM.and (lshr e_2 (sub (const? 32 32) e_1)) (trunc 32 (shl e (zext 64 (add e_1 (const? 32 32))))))
       (const? 32 0) ⊑
-    icmp IntPredicate.ne
+    icmp IntPred.ne
       (LLVM.and (lshr e_2 (sub (const? 32 32) e_1))
         (trunc 32 (shl e (zext 64 (add e_1 (const? 32 32)) { «nneg» := true }))))
       (const? 32 0) := by
@@ -52,10 +52,10 @@ theorem n13_overshift_thm (e : IntW 64) (e_1 e_2 : IntW 32) :
 
 
 theorem n14_trunc_of_lshr_thm (e e_1 : IntW 32) (e_2 : IntW 64) :
-  icmp IntPredicate.ne
+  icmp IntPred.ne
       (LLVM.and (trunc 32 (lshr e_2 (zext 64 (sub (const? 32 32) e_1)))) (shl e (add e_1 (const? 32 (-1)))))
       (const? 32 0) ⊑
-    icmp IntPredicate.ne
+    icmp IntPred.ne
       (LLVM.and (shl e (add e_1 (const? 32 (-1))))
         (trunc 32 (lshr e_2 (zext 64 (sub (const? 32 32) e_1) { «nneg» := true }))))
       (const? 32 0) := by
@@ -68,8 +68,8 @@ theorem n14_trunc_of_lshr_thm (e e_1 : IntW 32) (e_2 : IntW 64) :
 
 
 theorem n15_variable_shamts_thm (e e_1 : IntW 32) (e_2 e_3 : IntW 64) :
-  icmp IntPredicate.ne (LLVM.and (trunc 32 (shl e_3 e_2)) (lshr e_1 e)) (const? 32 0) ⊑
-    icmp IntPredicate.ne (LLVM.and (lshr e_1 e) (trunc 32 (shl e_3 e_2))) (const? 32 0) := by
+  icmp IntPred.ne (LLVM.and (trunc 32 (shl e_3 e_2)) (lshr e_1 e)) (const? 32 0) ⊑
+    icmp IntPred.ne (LLVM.and (lshr e_1 e) (trunc 32 (shl e_3 e_2))) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gshifthdirectionhinhbithtest_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gshifthdirectionhinhbithtest_proof.lean
@@ -12,8 +12,8 @@ set_option Elab.async false
 
 section gshifthdirectionhinhbithtest_proof
 theorem t7_twoshifts2_thm (e e_1 e_2 : IntW 32) :
-  icmp IntPredicate.eq (LLVM.and (shl e_2 e_1) (shl (const? 32 1) e)) (const? 32 0) ⊑
-    icmp IntPredicate.eq (LLVM.and (shl e_2 e_1) (shl (const? 32 1) e { «nsw» := false, «nuw» := true }))
+  icmp IntPred.eq (LLVM.and (shl e_2 e_1) (shl (const? 32 1) e)) (const? 32 0) ⊑
+    icmp IntPred.eq (LLVM.and (shl e_2 e_1) (shl (const? 32 1) e { «nsw» := false, «nuw» := true }))
       (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
@@ -24,8 +24,8 @@ theorem t7_twoshifts2_thm (e e_1 e_2 : IntW 32) :
 
 
 theorem t8_twoshifts3_thm (e e_1 e_2 : IntW 32) :
-  icmp IntPredicate.eq (LLVM.and (shl (const? 32 1) e_2) (shl e_1 e)) (const? 32 0) ⊑
-    icmp IntPredicate.eq (LLVM.and (shl (const? 32 1) e_2 { «nsw» := false, «nuw» := true }) (shl e_1 e))
+  icmp IntPred.eq (LLVM.and (shl (const? 32 1) e_2) (shl e_1 e)) (const? 32 0) ⊑
+    icmp IntPred.eq (LLVM.and (shl (const? 32 1) e_2 { «nsw» := false, «nuw» := true }) (shl e_1 e))
       (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
@@ -36,8 +36,8 @@ theorem t8_twoshifts3_thm (e e_1 e_2 : IntW 32) :
 
 
 theorem t12_shift_of_const0_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.eq (LLVM.and (shl (const? 32 1) e_1) e) (const? 32 0) ⊑
-    icmp IntPredicate.eq (LLVM.and (shl (const? 32 1) e_1 { «nsw» := false, «nuw» := true }) e) (const? 32 0) := by
+  icmp IntPred.eq (LLVM.and (shl (const? 32 1) e_1) e) (const? 32 0) ⊑
+    icmp IntPred.eq (LLVM.and (shl (const? 32 1) e_1 { «nsw» := false, «nuw» := true }) e) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -47,8 +47,8 @@ theorem t12_shift_of_const0_thm (e e_1 : IntW 32) :
 
 
 theorem t14_and_with_const0_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.eq (LLVM.and (shl e_1 e) (const? 32 1)) (const? 32 0) ⊑
-    icmp IntPredicate.eq (LLVM.and e_1 (lshr (const? 32 1) e)) (const? 32 0) := by
+  icmp IntPred.eq (LLVM.and (shl e_1 e) (const? 32 1)) (const? 32 0) ⊑
+    icmp IntPred.eq (LLVM.and e_1 (lshr (const? 32 1) e)) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -58,8 +58,8 @@ theorem t14_and_with_const0_thm (e e_1 : IntW 32) :
 
 
 theorem t15_and_with_const1_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.eq (LLVM.and (lshr e_1 e) (const? 32 1)) (const? 32 0) ⊑
-    icmp IntPredicate.eq (LLVM.and e_1 (shl (const? 32 1) e { «nsw» := false, «nuw» := true })) (const? 32 0) := by
+  icmp IntPred.eq (LLVM.and (lshr e_1 e) (const? 32 1)) (const? 32 0) ⊑
+    icmp IntPred.eq (LLVM.and e_1 (shl (const? 32 1) e { «nsw» := false, «nuw» := true })) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gshlhandhnegChicmpeqhzero_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gshlhandhnegChicmpeqhzero_proof.lean
@@ -12,8 +12,8 @@ set_option Elab.async false
 
 section gshlhandhnegChicmpeqhzero_proof
 theorem scalar_i8_shl_and_negC_eq_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.eq (LLVM.and (shl e_1 e) (const? 8 (-4))) (const? 8 0) ⊑
-    icmp IntPredicate.ult (shl e_1 e) (const? 8 4) := by
+  icmp IntPred.eq (LLVM.and (shl e_1 e) (const? 8 (-4))) (const? 8 0) ⊑
+    icmp IntPred.ult (shl e_1 e) (const? 8 4) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -23,8 +23,8 @@ theorem scalar_i8_shl_and_negC_eq_thm (e e_1 : IntW 8) :
 
 
 theorem scalar_i16_shl_and_negC_eq_thm (e e_1 : IntW 16) :
-  icmp IntPredicate.eq (LLVM.and (shl e_1 e) (const? 16 (-128))) (const? 16 0) ⊑
-    icmp IntPredicate.ult (shl e_1 e) (const? 16 128) := by
+  icmp IntPred.eq (LLVM.and (shl e_1 e) (const? 16 (-128))) (const? 16 0) ⊑
+    icmp IntPred.ult (shl e_1 e) (const? 16 128) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -34,8 +34,8 @@ theorem scalar_i16_shl_and_negC_eq_thm (e e_1 : IntW 16) :
 
 
 theorem scalar_i32_shl_and_negC_eq_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.eq (LLVM.and (shl e_1 e) (const? 32 (-262144))) (const? 32 0) ⊑
-    icmp IntPredicate.ult (shl e_1 e) (const? 32 262144) := by
+  icmp IntPred.eq (LLVM.and (shl e_1 e) (const? 32 (-262144))) (const? 32 0) ⊑
+    icmp IntPred.ult (shl e_1 e) (const? 32 262144) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -45,8 +45,8 @@ theorem scalar_i32_shl_and_negC_eq_thm (e e_1 : IntW 32) :
 
 
 theorem scalar_i64_shl_and_negC_eq_thm (e e_1 : IntW 64) :
-  icmp IntPredicate.eq (LLVM.and (shl e_1 e) (const? 64 (-8589934592))) (const? 64 0) ⊑
-    icmp IntPredicate.ult (shl e_1 e) (const? 64 8589934592) := by
+  icmp IntPred.eq (LLVM.and (shl e_1 e) (const? 64 (-8589934592))) (const? 64 0) ⊑
+    icmp IntPred.ult (shl e_1 e) (const? 64 8589934592) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -56,8 +56,8 @@ theorem scalar_i64_shl_and_negC_eq_thm (e e_1 : IntW 64) :
 
 
 theorem scalar_i32_shl_and_negC_ne_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.ne (LLVM.and (shl e_1 e) (const? 32 (-262144))) (const? 32 0) ⊑
-    icmp IntPredicate.ugt (shl e_1 e) (const? 32 262143) := by
+  icmp IntPred.ne (LLVM.and (shl e_1 e) (const? 32 (-262144))) (const? 32 0) ⊑
+    icmp IntPred.ugt (shl e_1 e) (const? 32 262143) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -67,8 +67,8 @@ theorem scalar_i32_shl_and_negC_ne_thm (e e_1 : IntW 32) :
 
 
 theorem scalar_i32_shl_and_negC_eq_X_is_constant1_thm (e : IntW 32) :
-  icmp IntPredicate.eq (LLVM.and (shl (const? 32 12345) e) (const? 32 (-8))) (const? 32 0) ⊑
-    icmp IntPredicate.ult (shl (const? 32 12345) e) (const? 32 8) := by
+  icmp IntPred.eq (LLVM.and (shl (const? 32 12345) e) (const? 32 (-8))) (const? 32 0) ⊑
+    icmp IntPred.ult (shl (const? 32 12345) e) (const? 32 8) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -78,8 +78,8 @@ theorem scalar_i32_shl_and_negC_eq_X_is_constant1_thm (e : IntW 32) :
 
 
 theorem scalar_i32_shl_and_negC_eq_X_is_constant2_thm (e : IntW 32) :
-  icmp IntPredicate.eq (LLVM.and (shl (const? 32 1) e) (const? 32 (-8))) (const? 32 0) ⊑
-    icmp IntPredicate.ult e (const? 32 3) := by
+  icmp IntPred.eq (LLVM.and (shl (const? 32 1) e) (const? 32 (-8))) (const? 32 0) ⊑
+    icmp IntPred.ult e (const? 32 3) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -89,8 +89,8 @@ theorem scalar_i32_shl_and_negC_eq_X_is_constant2_thm (e : IntW 32) :
 
 
 theorem scalar_i32_shl_and_negC_slt_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.slt (LLVM.and (shl e_1 e) (const? 32 (-8))) (const? 32 0) ⊑
-    icmp IntPredicate.slt (shl e_1 e) (const? 32 0) := by
+  icmp IntPred.slt (LLVM.and (shl e_1 e) (const? 32 (-8))) (const? 32 0) ⊑
+    icmp IntPred.slt (shl e_1 e) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -100,7 +100,7 @@ theorem scalar_i32_shl_and_negC_slt_thm (e e_1 : IntW 32) :
 
 
 theorem scalar_i32_shl_and_negC_eq_nonzero_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.eq (LLVM.and (shl e_1 e) (const? 32 (-8))) (const? 32 1) ⊑ const? 1 0 := by
+  icmp IntPred.eq (LLVM.and (shl e_1 e) (const? 32 (-8))) (const? 32 1) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gshlhandhsignbithicmpeqhzero_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gshlhandhsignbithicmpeqhzero_proof.lean
@@ -12,8 +12,8 @@ set_option Elab.async false
 
 section gshlhandhsignbithicmpeqhzero_proof
 theorem scalar_i8_shl_and_signbit_eq_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.eq (LLVM.and (shl e_1 e) (const? 8 (-128))) (const? 8 0) ⊑
-    icmp IntPredicate.sgt (shl e_1 e) (const? 8 (-1)) := by
+  icmp IntPred.eq (LLVM.and (shl e_1 e) (const? 8 (-128))) (const? 8 0) ⊑
+    icmp IntPred.sgt (shl e_1 e) (const? 8 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -23,8 +23,8 @@ theorem scalar_i8_shl_and_signbit_eq_thm (e e_1 : IntW 8) :
 
 
 theorem scalar_i16_shl_and_signbit_eq_thm (e e_1 : IntW 16) :
-  icmp IntPredicate.eq (LLVM.and (shl e_1 e) (const? 16 (-32768))) (const? 16 0) ⊑
-    icmp IntPredicate.sgt (shl e_1 e) (const? 16 (-1)) := by
+  icmp IntPred.eq (LLVM.and (shl e_1 e) (const? 16 (-32768))) (const? 16 0) ⊑
+    icmp IntPred.sgt (shl e_1 e) (const? 16 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -34,8 +34,8 @@ theorem scalar_i16_shl_and_signbit_eq_thm (e e_1 : IntW 16) :
 
 
 theorem scalar_i32_shl_and_signbit_eq_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.eq (LLVM.and (shl e_1 e) (const? 32 (-2147483648))) (const? 32 0) ⊑
-    icmp IntPredicate.sgt (shl e_1 e) (const? 32 (-1)) := by
+  icmp IntPred.eq (LLVM.and (shl e_1 e) (const? 32 (-2147483648))) (const? 32 0) ⊑
+    icmp IntPred.sgt (shl e_1 e) (const? 32 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -45,8 +45,8 @@ theorem scalar_i32_shl_and_signbit_eq_thm (e e_1 : IntW 32) :
 
 
 theorem scalar_i64_shl_and_signbit_eq_thm (e e_1 : IntW 64) :
-  icmp IntPredicate.eq (LLVM.and (shl e_1 e) (const? 64 (-9223372036854775808))) (const? 64 0) ⊑
-    icmp IntPredicate.sgt (shl e_1 e) (const? 64 (-1)) := by
+  icmp IntPred.eq (LLVM.and (shl e_1 e) (const? 64 (-9223372036854775808))) (const? 64 0) ⊑
+    icmp IntPred.sgt (shl e_1 e) (const? 64 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -56,8 +56,8 @@ theorem scalar_i64_shl_and_signbit_eq_thm (e e_1 : IntW 64) :
 
 
 theorem scalar_i32_shl_and_signbit_ne_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.ne (LLVM.and (shl e_1 e) (const? 32 (-2147483648))) (const? 32 0) ⊑
-    icmp IntPredicate.slt (shl e_1 e) (const? 32 0) := by
+  icmp IntPred.ne (LLVM.and (shl e_1 e) (const? 32 (-2147483648))) (const? 32 0) ⊑
+    icmp IntPred.slt (shl e_1 e) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -67,8 +67,8 @@ theorem scalar_i32_shl_and_signbit_ne_thm (e e_1 : IntW 32) :
 
 
 theorem scalar_i32_shl_and_signbit_eq_X_is_constant1_thm (e : IntW 32) :
-  icmp IntPredicate.eq (LLVM.and (shl (const? 32 12345) e) (const? 32 (-2147483648))) (const? 32 0) ⊑
-    icmp IntPredicate.sgt (shl (const? 32 12345) e) (const? 32 (-1)) := by
+  icmp IntPred.eq (LLVM.and (shl (const? 32 12345) e) (const? 32 (-2147483648))) (const? 32 0) ⊑
+    icmp IntPred.sgt (shl (const? 32 12345) e) (const? 32 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -78,8 +78,8 @@ theorem scalar_i32_shl_and_signbit_eq_X_is_constant1_thm (e : IntW 32) :
 
 
 theorem scalar_i32_shl_and_signbit_eq_X_is_constant2_thm (e : IntW 32) :
-  icmp IntPredicate.eq (LLVM.and (shl (const? 32 1) e) (const? 32 (-2147483648))) (const? 32 0) ⊑
-    icmp IntPredicate.ne e (const? 32 31) := by
+  icmp IntPred.eq (LLVM.and (shl (const? 32 1) e) (const? 32 (-2147483648))) (const? 32 0) ⊑
+    icmp IntPred.ne e (const? 32 31) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -89,8 +89,8 @@ theorem scalar_i32_shl_and_signbit_eq_X_is_constant2_thm (e : IntW 32) :
 
 
 theorem scalar_i32_shl_and_signbit_slt_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.slt (LLVM.and (shl e_1 e) (const? 32 (-2147483648))) (const? 32 0) ⊑
-    icmp IntPredicate.slt (shl e_1 e) (const? 32 0) := by
+  icmp IntPred.slt (LLVM.and (shl e_1 e) (const? 32 (-2147483648))) (const? 32 0) ⊑
+    icmp IntPred.slt (shl e_1 e) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -100,7 +100,7 @@ theorem scalar_i32_shl_and_signbit_slt_thm (e e_1 : IntW 32) :
 
 
 theorem scalar_i32_shl_and_signbit_eq_nonzero_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.eq (LLVM.and (shl e_1 e) (const? 32 (-2147483648))) (const? 32 1) ⊑ const? 1 0 := by
+  icmp IntPred.eq (LLVM.and (shl e_1 e) (const? 32 (-2147483648))) (const? 32 1) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gshlhunsignedhcmphconst_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gshlhunsignedhcmphconst_proof.lean
@@ -12,8 +12,8 @@ set_option Elab.async false
 
 section gshlhunsignedhcmphconst_proof
 theorem scalar_i8_shl_ult_const_1_thm (e : IntW 8) :
-  icmp IntPredicate.ult (shl e (const? 8 5)) (const? 8 64) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 8 6)) (const? 8 0) := by
+  icmp IntPred.ult (shl e (const? 8 5)) (const? 8 64) ⊑
+    icmp IntPred.eq (LLVM.and e (const? 8 6)) (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -23,8 +23,8 @@ theorem scalar_i8_shl_ult_const_1_thm (e : IntW 8) :
 
 
 theorem scalar_i8_shl_ult_const_2_thm (e : IntW 8) :
-  icmp IntPredicate.ult (shl e (const? 8 6)) (const? 8 64) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 8 3)) (const? 8 0) := by
+  icmp IntPred.ult (shl e (const? 8 6)) (const? 8 64) ⊑
+    icmp IntPred.eq (LLVM.and e (const? 8 3)) (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -34,8 +34,8 @@ theorem scalar_i8_shl_ult_const_2_thm (e : IntW 8) :
 
 
 theorem scalar_i8_shl_ult_const_3_thm (e : IntW 8) :
-  icmp IntPredicate.ult (shl e (const? 8 7)) (const? 8 64) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 8 1)) (const? 8 0) := by
+  icmp IntPred.ult (shl e (const? 8 7)) (const? 8 64) ⊑
+    icmp IntPred.eq (LLVM.and e (const? 8 1)) (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -45,8 +45,8 @@ theorem scalar_i8_shl_ult_const_3_thm (e : IntW 8) :
 
 
 theorem scalar_i16_shl_ult_const_thm (e : IntW 16) :
-  icmp IntPredicate.ult (shl e (const? 16 8)) (const? 16 1024) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 16 252)) (const? 16 0) := by
+  icmp IntPred.ult (shl e (const? 16 8)) (const? 16 1024) ⊑
+    icmp IntPred.eq (LLVM.and e (const? 16 252)) (const? 16 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -56,8 +56,8 @@ theorem scalar_i16_shl_ult_const_thm (e : IntW 16) :
 
 
 theorem scalar_i32_shl_ult_const_thm (e : IntW 32) :
-  icmp IntPredicate.ult (shl e (const? 32 11)) (const? 32 131072) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 32 2097088)) (const? 32 0) := by
+  icmp IntPred.ult (shl e (const? 32 11)) (const? 32 131072) ⊑
+    icmp IntPred.eq (LLVM.and e (const? 32 2097088)) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -67,8 +67,8 @@ theorem scalar_i32_shl_ult_const_thm (e : IntW 32) :
 
 
 theorem scalar_i64_shl_ult_const_thm (e : IntW 64) :
-  icmp IntPredicate.ult (shl e (const? 64 25)) (const? 64 8589934592) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 64 549755813632)) (const? 64 0) := by
+  icmp IntPred.ult (shl e (const? 64 25)) (const? 64 8589934592) ⊑
+    icmp IntPred.eq (LLVM.and e (const? 64 549755813632)) (const? 64 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -78,8 +78,8 @@ theorem scalar_i64_shl_ult_const_thm (e : IntW 64) :
 
 
 theorem scalar_i8_shl_uge_const_thm (e : IntW 8) :
-  icmp IntPredicate.uge (shl e (const? 8 5)) (const? 8 64) ⊑
-    icmp IntPredicate.ne (LLVM.and e (const? 8 6)) (const? 8 0) := by
+  icmp IntPred.uge (shl e (const? 8 5)) (const? 8 64) ⊑
+    icmp IntPred.ne (LLVM.and e (const? 8 6)) (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -89,8 +89,8 @@ theorem scalar_i8_shl_uge_const_thm (e : IntW 8) :
 
 
 theorem scalar_i8_shl_ule_const_thm (e : IntW 8) :
-  icmp IntPredicate.ule (shl e (const? 8 5)) (const? 8 63) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 8 6)) (const? 8 0) := by
+  icmp IntPred.ule (shl e (const? 8 5)) (const? 8 63) ⊑
+    icmp IntPred.eq (LLVM.and e (const? 8 6)) (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -100,8 +100,8 @@ theorem scalar_i8_shl_ule_const_thm (e : IntW 8) :
 
 
 theorem scalar_i8_shl_ugt_const_thm (e : IntW 8) :
-  icmp IntPredicate.ugt (shl e (const? 8 5)) (const? 8 63) ⊑
-    icmp IntPredicate.ne (LLVM.and e (const? 8 6)) (const? 8 0) := by
+  icmp IntPred.ugt (shl e (const? 8 5)) (const? 8 63) ⊑
+    icmp IntPred.ne (LLVM.and e (const? 8 6)) (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gsignbithlshrhandhicmpeqhzero_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gsignbithlshrhandhicmpeqhzero_proof.lean
@@ -12,8 +12,8 @@ set_option Elab.async false
 
 section gsignbithlshrhandhicmpeqhzero_proof
 theorem scalar_i8_signbit_lshr_and_eq_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.eq (LLVM.and (lshr (const? 8 (-128)) e_1) e) (const? 8 0) ⊑
-    icmp IntPredicate.eq (LLVM.and (lshr (const? 8 (-128)) e_1 { «exact» := true }) e) (const? 8 0) := by
+  icmp IntPred.eq (LLVM.and (lshr (const? 8 (-128)) e_1) e) (const? 8 0) ⊑
+    icmp IntPred.eq (LLVM.and (lshr (const? 8 (-128)) e_1 { «exact» := true }) e) (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -23,8 +23,8 @@ theorem scalar_i8_signbit_lshr_and_eq_thm (e e_1 : IntW 8) :
 
 
 theorem scalar_i16_signbit_lshr_and_eq_thm (e e_1 : IntW 16) :
-  icmp IntPredicate.eq (LLVM.and (lshr (const? 16 (-32768)) e_1) e) (const? 16 0) ⊑
-    icmp IntPredicate.eq (LLVM.and (lshr (const? 16 (-32768)) e_1 { «exact» := true }) e) (const? 16 0) := by
+  icmp IntPred.eq (LLVM.and (lshr (const? 16 (-32768)) e_1) e) (const? 16 0) ⊑
+    icmp IntPred.eq (LLVM.and (lshr (const? 16 (-32768)) e_1 { «exact» := true }) e) (const? 16 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -34,8 +34,8 @@ theorem scalar_i16_signbit_lshr_and_eq_thm (e e_1 : IntW 16) :
 
 
 theorem scalar_i32_signbit_lshr_and_eq_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.eq (LLVM.and (lshr (const? 32 (-2147483648)) e_1) e) (const? 32 0) ⊑
-    icmp IntPredicate.eq (LLVM.and (lshr (const? 32 (-2147483648)) e_1 { «exact» := true }) e) (const? 32 0) := by
+  icmp IntPred.eq (LLVM.and (lshr (const? 32 (-2147483648)) e_1) e) (const? 32 0) ⊑
+    icmp IntPred.eq (LLVM.and (lshr (const? 32 (-2147483648)) e_1 { «exact» := true }) e) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -45,8 +45,8 @@ theorem scalar_i32_signbit_lshr_and_eq_thm (e e_1 : IntW 32) :
 
 
 theorem scalar_i64_signbit_lshr_and_eq_thm (e e_1 : IntW 64) :
-  icmp IntPredicate.eq (LLVM.and (lshr (const? 64 (-9223372036854775808)) e_1) e) (const? 64 0) ⊑
-    icmp IntPredicate.eq (LLVM.and (lshr (const? 64 (-9223372036854775808)) e_1 { «exact» := true }) e)
+  icmp IntPred.eq (LLVM.and (lshr (const? 64 (-9223372036854775808)) e_1) e) (const? 64 0) ⊑
+    icmp IntPred.eq (LLVM.and (lshr (const? 64 (-9223372036854775808)) e_1 { «exact» := true }) e)
       (const? 64 0) := by
     simp_alive_undef
     simp_alive_ops
@@ -57,8 +57,8 @@ theorem scalar_i64_signbit_lshr_and_eq_thm (e e_1 : IntW 64) :
 
 
 theorem scalar_i32_signbit_lshr_and_ne_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.ne (LLVM.and (lshr (const? 32 (-2147483648)) e_1) e) (const? 32 0) ⊑
-    icmp IntPredicate.ne (LLVM.and (lshr (const? 32 (-2147483648)) e_1 { «exact» := true }) e) (const? 32 0) := by
+  icmp IntPred.ne (LLVM.and (lshr (const? 32 (-2147483648)) e_1) e) (const? 32 0) ⊑
+    icmp IntPred.ne (LLVM.and (lshr (const? 32 (-2147483648)) e_1 { «exact» := true }) e) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -68,8 +68,8 @@ theorem scalar_i32_signbit_lshr_and_ne_thm (e e_1 : IntW 32) :
 
 
 theorem scalar_i32_signbit_lshr_and_eq_X_is_constant1_thm (e : IntW 32) :
-  icmp IntPredicate.eq (LLVM.and (lshr (const? 32 (-2147483648)) e) (const? 32 12345)) (const? 32 0) ⊑
-    icmp IntPredicate.eq (LLVM.and (lshr (const? 32 (-2147483648)) e { «exact» := true }) (const? 32 12345))
+  icmp IntPred.eq (LLVM.and (lshr (const? 32 (-2147483648)) e) (const? 32 12345)) (const? 32 0) ⊑
+    icmp IntPred.eq (LLVM.and (lshr (const? 32 (-2147483648)) e { «exact» := true }) (const? 32 12345))
       (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
@@ -80,8 +80,8 @@ theorem scalar_i32_signbit_lshr_and_eq_X_is_constant1_thm (e : IntW 32) :
 
 
 theorem scalar_i32_signbit_lshr_and_eq_X_is_constant2_thm (e : IntW 32) :
-  icmp IntPredicate.eq (LLVM.and (lshr (const? 32 (-2147483648)) e) (const? 32 1)) (const? 32 0) ⊑
-    icmp IntPredicate.ne e (const? 32 31) := by
+  icmp IntPred.eq (LLVM.and (lshr (const? 32 (-2147483648)) e) (const? 32 1)) (const? 32 0) ⊑
+    icmp IntPred.ne e (const? 32 31) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -91,8 +91,8 @@ theorem scalar_i32_signbit_lshr_and_eq_X_is_constant2_thm (e : IntW 32) :
 
 
 theorem scalar_i32_signbit_lshr_and_slt_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.slt (LLVM.and (lshr (const? 32 (-2147483648)) e_1) e) (const? 32 0) ⊑
-    icmp IntPredicate.slt (LLVM.and (lshr (const? 32 (-2147483648)) e_1 { «exact» := true }) e) (const? 32 0) := by
+  icmp IntPred.slt (LLVM.and (lshr (const? 32 (-2147483648)) e_1) e) (const? 32 0) ⊑
+    icmp IntPred.slt (LLVM.and (lshr (const? 32 (-2147483648)) e_1 { «exact» := true }) e) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -102,8 +102,8 @@ theorem scalar_i32_signbit_lshr_and_slt_thm (e e_1 : IntW 32) :
 
 
 theorem scalar_i32_signbit_lshr_and_eq_nonzero_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.eq (LLVM.and (lshr (const? 32 (-2147483648)) e_1) e) (const? 32 1) ⊑
-    icmp IntPredicate.eq (LLVM.and (lshr (const? 32 (-2147483648)) e_1 { «exact» := true }) e) (const? 32 1) := by
+  icmp IntPred.eq (LLVM.and (lshr (const? 32 (-2147483648)) e_1) e) (const? 32 1) ⊑
+    icmp IntPred.eq (LLVM.and (lshr (const? 32 (-2147483648)) e_1 { «exact» := true }) e) (const? 32 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gsignbithshlhandhicmpeqhzero_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gsignbithshlhandhicmpeqhzero_proof.lean
@@ -12,7 +12,7 @@ set_option Elab.async false
 
 section gsignbithshlhandhicmpeqhzero_proof
 theorem scalar_i32_signbit_shl_and_eq_X_is_constant1_thm (e : IntW 32) :
-  icmp IntPredicate.eq (LLVM.and (shl (const? 32 (-2147483648)) e) (const? 32 12345)) (const? 32 0) ⊑
+  icmp IntPred.eq (LLVM.and (shl (const? 32 (-2147483648)) e) (const? 32 12345)) (const? 32 0) ⊑
     const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
@@ -23,7 +23,7 @@ theorem scalar_i32_signbit_shl_and_eq_X_is_constant1_thm (e : IntW 32) :
 
 
 theorem scalar_i32_signbit_shl_and_eq_X_is_constant2_thm (e : IntW 32) :
-  icmp IntPredicate.eq (LLVM.and (shl (const? 32 (-2147483648)) e) (const? 32 1)) (const? 32 0) ⊑ const? 1 1 := by
+  icmp IntPred.eq (LLVM.and (shl (const? 32 (-2147483648)) e) (const? 32 1)) (const? 32 0) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -33,8 +33,8 @@ theorem scalar_i32_signbit_shl_and_eq_X_is_constant2_thm (e : IntW 32) :
 
 
 theorem scalar_i32_signbit_shl_and_slt_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.slt (LLVM.and (shl (const? 32 (-2147483648)) e_1) e) (const? 32 0) ⊑
-    icmp IntPredicate.ne (LLVM.and (shl (const? 32 (-2147483648)) e_1) e) (const? 32 0) := by
+  icmp IntPred.slt (LLVM.and (shl (const? 32 (-2147483648)) e_1) e) (const? 32 0) ⊑
+    icmp IntPred.ne (LLVM.and (shl (const? 32 (-2147483648)) e_1) e) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -44,7 +44,7 @@ theorem scalar_i32_signbit_shl_and_slt_thm (e e_1 : IntW 32) :
 
 
 theorem scalar_i32_signbit_shl_and_eq_nonzero_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.eq (LLVM.and (shl (const? 32 (-2147483648)) e_1) e) (const? 32 1) ⊑ const? 1 0 := by
+  icmp IntPred.eq (LLVM.and (shl (const? 32 (-2147483648)) e_1) e) (const? 32 1) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gsignedhcomparison_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gsignedhcomparison_proof.lean
@@ -12,7 +12,7 @@ set_option Elab.async false
 
 section gsignedhcomparison_proof
 theorem scalar_zext_slt_thm (e : IntW 16) :
-  icmp IntPredicate.slt (zext 32 e) (const? 32 500) ⊑ icmp IntPredicate.ult e (const? 16 500) := by
+  icmp IntPred.slt (zext 32 e) (const? 32 500) ⊑ icmp IntPred.ult e (const? 16 500) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gsignedhtruncationhcheck_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gsignedhtruncationhcheck_proof.lean
@@ -12,8 +12,8 @@ set_option Elab.async false
 
 section gsignedhtruncationhcheck_proof
 theorem positive_with_signbit_thm (e : IntW 32) :
-  LLVM.and (icmp IntPredicate.sgt e (const? 32 (-1))) (icmp IntPredicate.ult (add e (const? 32 128)) (const? 32 256)) ⊑
-    icmp IntPredicate.ult e (const? 32 128) := by
+  LLVM.and (icmp IntPred.sgt e (const? 32 (-1))) (icmp IntPred.ult (add e (const? 32 128)) (const? 32 256)) ⊑
+    icmp IntPred.ult e (const? 32 128) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -23,9 +23,9 @@ theorem positive_with_signbit_thm (e : IntW 32) :
 
 
 theorem positive_with_signbit_logical_thm (e : IntW 32) :
-  select (icmp IntPredicate.sgt e (const? 32 (-1))) (icmp IntPredicate.ult (add e (const? 32 128)) (const? 32 256))
+  select (icmp IntPred.sgt e (const? 32 (-1))) (icmp IntPred.ult (add e (const? 32 128)) (const? 32 256))
       (const? 1 0) ⊑
-    icmp IntPredicate.ult e (const? 32 128) := by
+    icmp IntPred.ult e (const? 32 128) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -35,9 +35,9 @@ theorem positive_with_signbit_logical_thm (e : IntW 32) :
 
 
 theorem positive_with_mask_thm (e : IntW 32) :
-  LLVM.and (icmp IntPredicate.eq (LLVM.and e (const? 32 1107296256)) (const? 32 0))
-      (icmp IntPredicate.ult (add e (const? 32 128)) (const? 32 256)) ⊑
-    icmp IntPredicate.ult e (const? 32 128) := by
+  LLVM.and (icmp IntPred.eq (LLVM.and e (const? 32 1107296256)) (const? 32 0))
+      (icmp IntPred.ult (add e (const? 32 128)) (const? 32 256)) ⊑
+    icmp IntPred.ult e (const? 32 128) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -47,9 +47,9 @@ theorem positive_with_mask_thm (e : IntW 32) :
 
 
 theorem positive_with_mask_logical_thm (e : IntW 32) :
-  select (icmp IntPredicate.eq (LLVM.and e (const? 32 1107296256)) (const? 32 0))
-      (icmp IntPredicate.ult (add e (const? 32 128)) (const? 32 256)) (const? 1 0) ⊑
-    icmp IntPredicate.ult e (const? 32 128) := by
+  select (icmp IntPred.eq (LLVM.and e (const? 32 1107296256)) (const? 32 0))
+      (icmp IntPred.ult (add e (const? 32 128)) (const? 32 256)) (const? 1 0) ⊑
+    icmp IntPred.ult e (const? 32 128) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -59,8 +59,8 @@ theorem positive_with_mask_logical_thm (e : IntW 32) :
 
 
 theorem positive_with_icmp_thm (e : IntW 32) :
-  LLVM.and (icmp IntPredicate.ult e (const? 32 512)) (icmp IntPredicate.ult (add e (const? 32 128)) (const? 32 256)) ⊑
-    icmp IntPredicate.ult e (const? 32 128) := by
+  LLVM.and (icmp IntPred.ult e (const? 32 512)) (icmp IntPred.ult (add e (const? 32 128)) (const? 32 256)) ⊑
+    icmp IntPred.ult e (const? 32 128) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -70,9 +70,9 @@ theorem positive_with_icmp_thm (e : IntW 32) :
 
 
 theorem positive_with_icmp_logical_thm (e : IntW 32) :
-  select (icmp IntPredicate.ult e (const? 32 512)) (icmp IntPredicate.ult (add e (const? 32 128)) (const? 32 256))
+  select (icmp IntPred.ult e (const? 32 512)) (icmp IntPred.ult (add e (const? 32 128)) (const? 32 256))
       (const? 1 0) ⊑
-    icmp IntPredicate.ult e (const? 32 128) := by
+    icmp IntPred.ult e (const? 32 128) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -82,8 +82,8 @@ theorem positive_with_icmp_logical_thm (e : IntW 32) :
 
 
 theorem positive_with_aggressive_icmp_thm (e : IntW 32) :
-  LLVM.and (icmp IntPredicate.ult e (const? 32 128)) (icmp IntPredicate.ult (add e (const? 32 256)) (const? 32 512)) ⊑
-    icmp IntPredicate.ult e (const? 32 128) := by
+  LLVM.and (icmp IntPred.ult e (const? 32 128)) (icmp IntPred.ult (add e (const? 32 256)) (const? 32 512)) ⊑
+    icmp IntPred.ult e (const? 32 128) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -93,9 +93,9 @@ theorem positive_with_aggressive_icmp_thm (e : IntW 32) :
 
 
 theorem positive_with_aggressive_icmp_logical_thm (e : IntW 32) :
-  select (icmp IntPredicate.ult e (const? 32 128)) (icmp IntPredicate.ult (add e (const? 32 256)) (const? 32 512))
+  select (icmp IntPred.ult e (const? 32 128)) (icmp IntPred.ult (add e (const? 32 256)) (const? 32 512))
       (const? 1 0) ⊑
-    icmp IntPredicate.ult e (const? 32 128) := by
+    icmp IntPred.ult e (const? 32 128) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -105,9 +105,9 @@ theorem positive_with_aggressive_icmp_logical_thm (e : IntW 32) :
 
 
 theorem positive_with_extra_and_thm (e : IntW 1) (e_1 : IntW 32) :
-  LLVM.and (icmp IntPredicate.ult (add e_1 (const? 32 128)) (const? 32 256))
-      (LLVM.and (icmp IntPredicate.sgt e_1 (const? 32 (-1))) e) ⊑
-    LLVM.and (icmp IntPredicate.ult e_1 (const? 32 128)) e := by
+  LLVM.and (icmp IntPred.ult (add e_1 (const? 32 128)) (const? 32 256))
+      (LLVM.and (icmp IntPred.sgt e_1 (const? 32 (-1))) e) ⊑
+    LLVM.and (icmp IntPred.ult e_1 (const? 32 128)) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -117,9 +117,9 @@ theorem positive_with_extra_and_thm (e : IntW 1) (e_1 : IntW 32) :
 
 
 theorem positive_with_extra_and_logical_thm (e : IntW 1) (e_1 : IntW 32) :
-  select (icmp IntPredicate.ult (add e_1 (const? 32 128)) (const? 32 256))
-      (select (icmp IntPredicate.sgt e_1 (const? 32 (-1))) e (const? 1 0)) (const? 1 0) ⊑
-    select (icmp IntPredicate.ult e_1 (const? 32 128)) e (const? 1 0) := by
+  select (icmp IntPred.ult (add e_1 (const? 32 128)) (const? 32 256))
+      (select (icmp IntPred.sgt e_1 (const? 32 (-1))) e (const? 1 0)) (const? 1 0) ⊑
+    select (icmp IntPred.ult e_1 (const? 32 128)) e (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -129,9 +129,9 @@ theorem positive_with_extra_and_logical_thm (e : IntW 1) (e_1 : IntW 32) :
 
 
 theorem positive_trunc_signbit_thm (e : IntW 32) :
-  LLVM.and (icmp IntPredicate.sgt (trunc 8 e) (const? 8 (-1)))
-      (icmp IntPredicate.ult (add e (const? 32 128)) (const? 32 256)) ⊑
-    icmp IntPredicate.ult e (const? 32 128) := by
+  LLVM.and (icmp IntPred.sgt (trunc 8 e) (const? 8 (-1)))
+      (icmp IntPred.ult (add e (const? 32 128)) (const? 32 256)) ⊑
+    icmp IntPred.ult e (const? 32 128) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -141,9 +141,9 @@ theorem positive_trunc_signbit_thm (e : IntW 32) :
 
 
 theorem positive_trunc_signbit_logical_thm (e : IntW 32) :
-  select (icmp IntPredicate.sgt (trunc 8 e) (const? 8 (-1)))
-      (icmp IntPredicate.ult (add e (const? 32 128)) (const? 32 256)) (const? 1 0) ⊑
-    icmp IntPredicate.ult e (const? 32 128) := by
+  select (icmp IntPred.sgt (trunc 8 e) (const? 8 (-1)))
+      (icmp IntPred.ult (add e (const? 32 128)) (const? 32 256)) (const? 1 0) ⊑
+    icmp IntPred.ult e (const? 32 128) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -153,9 +153,9 @@ theorem positive_trunc_signbit_logical_thm (e : IntW 32) :
 
 
 theorem positive_trunc_base_thm (e : IntW 32) :
-  LLVM.and (icmp IntPredicate.sgt (trunc 16 e) (const? 16 (-1)))
-      (icmp IntPredicate.ult (add (trunc 16 e) (const? 16 128)) (const? 16 256)) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 32 65408)) (const? 32 0) := by
+  LLVM.and (icmp IntPred.sgt (trunc 16 e) (const? 16 (-1)))
+      (icmp IntPred.ult (add (trunc 16 e) (const? 16 128)) (const? 16 256)) ⊑
+    icmp IntPred.eq (LLVM.and e (const? 32 65408)) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -165,9 +165,9 @@ theorem positive_trunc_base_thm (e : IntW 32) :
 
 
 theorem positive_trunc_base_logical_thm (e : IntW 32) :
-  select (icmp IntPredicate.sgt (trunc 16 e) (const? 16 (-1)))
-      (icmp IntPredicate.ult (add (trunc 16 e) (const? 16 128)) (const? 16 256)) (const? 1 0) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 32 65408)) (const? 32 0) := by
+  select (icmp IntPred.sgt (trunc 16 e) (const? 16 (-1)))
+      (icmp IntPred.ult (add (trunc 16 e) (const? 16 128)) (const? 16 256)) (const? 1 0) ⊑
+    icmp IntPred.eq (LLVM.and e (const? 32 65408)) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -177,10 +177,10 @@ theorem positive_trunc_base_logical_thm (e : IntW 32) :
 
 
 theorem positive_different_trunc_both_thm (e : IntW 32) :
-  LLVM.and (icmp IntPredicate.sgt (trunc 15 e) (const? 15 (-1)))
-      (icmp IntPredicate.ult (add (trunc 16 e) (const? 16 128)) (const? 16 256)) ⊑
-    LLVM.and (icmp IntPredicate.eq (LLVM.and e (const? 32 16384)) (const? 32 0))
-      (icmp IntPredicate.ult (add (trunc 16 e) (const? 16 128)) (const? 16 256)) := by
+  LLVM.and (icmp IntPred.sgt (trunc 15 e) (const? 15 (-1)))
+      (icmp IntPred.ult (add (trunc 16 e) (const? 16 128)) (const? 16 256)) ⊑
+    LLVM.and (icmp IntPred.eq (LLVM.and e (const? 32 16384)) (const? 32 0))
+      (icmp IntPred.ult (add (trunc 16 e) (const? 16 128)) (const? 16 256)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -190,10 +190,10 @@ theorem positive_different_trunc_both_thm (e : IntW 32) :
 
 
 theorem positive_different_trunc_both_logical_thm (e : IntW 32) :
-  select (icmp IntPredicate.sgt (trunc 15 e) (const? 15 (-1)))
-      (icmp IntPredicate.ult (add (trunc 16 e) (const? 16 128)) (const? 16 256)) (const? 1 0) ⊑
-    select (icmp IntPredicate.eq (LLVM.and e (const? 32 16384)) (const? 32 0))
-      (icmp IntPredicate.ult (add (trunc 16 e) (const? 16 128)) (const? 16 256)) (const? 1 0) := by
+  select (icmp IntPred.sgt (trunc 15 e) (const? 15 (-1)))
+      (icmp IntPred.ult (add (trunc 16 e) (const? 16 128)) (const? 16 256)) (const? 1 0) ⊑
+    select (icmp IntPred.eq (LLVM.and e (const? 32 16384)) (const? 32 0))
+      (icmp IntPred.ult (add (trunc 16 e) (const? 16 128)) (const? 16 256)) (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -203,10 +203,10 @@ theorem positive_different_trunc_both_logical_thm (e : IntW 32) :
 
 
 theorem negative_trunc_not_arg_thm (e e_1 : IntW 32) :
-  LLVM.and (icmp IntPredicate.sgt (trunc 8 e_1) (const? 8 (-1)))
-      (icmp IntPredicate.ult (add e (const? 32 128)) (const? 32 256)) ⊑
-    LLVM.and (icmp IntPredicate.eq (LLVM.and e_1 (const? 32 128)) (const? 32 0))
-      (icmp IntPredicate.ult (add e (const? 32 128)) (const? 32 256)) := by
+  LLVM.and (icmp IntPred.sgt (trunc 8 e_1) (const? 8 (-1)))
+      (icmp IntPred.ult (add e (const? 32 128)) (const? 32 256)) ⊑
+    LLVM.and (icmp IntPred.eq (LLVM.and e_1 (const? 32 128)) (const? 32 0))
+      (icmp IntPred.ult (add e (const? 32 128)) (const? 32 256)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -216,10 +216,10 @@ theorem negative_trunc_not_arg_thm (e e_1 : IntW 32) :
 
 
 theorem negative_trunc_not_arg_logical_thm (e e_1 : IntW 32) :
-  select (icmp IntPredicate.sgt (trunc 8 e_1) (const? 8 (-1)))
-      (icmp IntPredicate.ult (add e (const? 32 128)) (const? 32 256)) (const? 1 0) ⊑
-    select (icmp IntPredicate.eq (LLVM.and e_1 (const? 32 128)) (const? 32 0))
-      (icmp IntPredicate.ult (add e (const? 32 128)) (const? 32 256)) (const? 1 0) := by
+  select (icmp IntPred.sgt (trunc 8 e_1) (const? 8 (-1)))
+      (icmp IntPred.ult (add e (const? 32 128)) (const? 32 256)) (const? 1 0) ⊑
+    select (icmp IntPred.eq (LLVM.and e_1 (const? 32 128)) (const? 32 0))
+      (icmp IntPred.ult (add e (const? 32 128)) (const? 32 256)) (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -229,10 +229,10 @@ theorem negative_trunc_not_arg_logical_thm (e e_1 : IntW 32) :
 
 
 theorem negative_with_nonuniform_bad_mask_logical_thm (e : IntW 32) :
-  select (icmp IntPredicate.eq (LLVM.and e (const? 32 1711276033)) (const? 32 0))
-      (icmp IntPredicate.ult (add e (const? 32 128)) (const? 32 256)) (const? 1 0) ⊑
-    LLVM.and (icmp IntPredicate.eq (LLVM.and e (const? 32 1711276033)) (const? 32 0))
-      (icmp IntPredicate.ult (add e (const? 32 128)) (const? 32 256)) := by
+  select (icmp IntPred.eq (LLVM.and e (const? 32 1711276033)) (const? 32 0))
+      (icmp IntPred.ult (add e (const? 32 128)) (const? 32 256)) (const? 1 0) ⊑
+    LLVM.and (icmp IntPred.eq (LLVM.and e (const? 32 1711276033)) (const? 32 0))
+      (icmp IntPred.ult (add e (const? 32 128)) (const? 32 256)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -242,10 +242,10 @@ theorem negative_with_nonuniform_bad_mask_logical_thm (e : IntW 32) :
 
 
 theorem negative_with_uniform_bad_mask_logical_thm (e : IntW 32) :
-  select (icmp IntPredicate.eq (LLVM.and e (const? 32 (-16777152))) (const? 32 0))
-      (icmp IntPredicate.ult (add e (const? 32 128)) (const? 32 256)) (const? 1 0) ⊑
-    LLVM.and (icmp IntPredicate.eq (LLVM.and e (const? 32 (-16777152))) (const? 32 0))
-      (icmp IntPredicate.ult (add e (const? 32 128)) (const? 32 256)) := by
+  select (icmp IntPred.eq (LLVM.and e (const? 32 (-16777152))) (const? 32 0))
+      (icmp IntPred.ult (add e (const? 32 128)) (const? 32 256)) (const? 1 0) ⊑
+    LLVM.and (icmp IntPred.eq (LLVM.and e (const? 32 (-16777152))) (const? 32 0))
+      (icmp IntPred.ult (add e (const? 32 128)) (const? 32 256)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -255,10 +255,10 @@ theorem negative_with_uniform_bad_mask_logical_thm (e : IntW 32) :
 
 
 theorem negative_with_wrong_mask_logical_thm (e : IntW 32) :
-  select (icmp IntPredicate.eq (LLVM.and e (const? 32 1)) (const? 32 0))
-      (icmp IntPredicate.ult (add e (const? 32 128)) (const? 32 256)) (const? 1 0) ⊑
-    LLVM.and (icmp IntPredicate.eq (LLVM.and e (const? 32 1)) (const? 32 0))
-      (icmp IntPredicate.ult (add e (const? 32 128)) (const? 32 256)) := by
+  select (icmp IntPred.eq (LLVM.and e (const? 32 1)) (const? 32 0))
+      (icmp IntPred.ult (add e (const? 32 128)) (const? 32 256)) (const? 1 0) ⊑
+    LLVM.and (icmp IntPred.eq (LLVM.and e (const? 32 1)) (const? 32 0))
+      (icmp IntPred.ult (add e (const? 32 128)) (const? 32 256)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -268,7 +268,7 @@ theorem negative_with_wrong_mask_logical_thm (e : IntW 32) :
 
 
 theorem negative_not_less_than_thm (e : IntW 32) :
-  LLVM.and (icmp IntPredicate.sgt e (const? 32 (-1))) (icmp IntPredicate.ult (add e (const? 32 256)) (const? 32 256)) ⊑
+  LLVM.and (icmp IntPred.sgt e (const? 32 (-1))) (icmp IntPred.ult (add e (const? 32 256)) (const? 32 256)) ⊑
     const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
@@ -279,7 +279,7 @@ theorem negative_not_less_than_thm (e : IntW 32) :
 
 
 theorem negative_not_less_than_logical_thm (e : IntW 32) :
-  select (icmp IntPredicate.sgt e (const? 32 (-1))) (icmp IntPredicate.ult (add e (const? 32 256)) (const? 32 256))
+  select (icmp IntPred.sgt e (const? 32 (-1))) (icmp IntPred.ult (add e (const? 32 256)) (const? 32 256))
       (const? 1 0) ⊑
     const? 1 0 := by
     simp_alive_undef
@@ -291,8 +291,8 @@ theorem negative_not_less_than_logical_thm (e : IntW 32) :
 
 
 theorem negative_not_power_of_two_thm (e : IntW 32) :
-  LLVM.and (icmp IntPredicate.sgt e (const? 32 (-1))) (icmp IntPredicate.ult (add e (const? 32 255)) (const? 32 256)) ⊑
-    icmp IntPredicate.eq e (const? 32 0) := by
+  LLVM.and (icmp IntPred.sgt e (const? 32 (-1))) (icmp IntPred.ult (add e (const? 32 255)) (const? 32 256)) ⊑
+    icmp IntPred.eq e (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -302,9 +302,9 @@ theorem negative_not_power_of_two_thm (e : IntW 32) :
 
 
 theorem negative_not_power_of_two_logical_thm (e : IntW 32) :
-  select (icmp IntPredicate.sgt e (const? 32 (-1))) (icmp IntPredicate.ult (add e (const? 32 255)) (const? 32 256))
+  select (icmp IntPred.sgt e (const? 32 (-1))) (icmp IntPred.ult (add e (const? 32 255)) (const? 32 256))
       (const? 1 0) ⊑
-    icmp IntPredicate.eq e (const? 32 0) := by
+    icmp IntPred.eq e (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -314,8 +314,8 @@ theorem negative_not_power_of_two_logical_thm (e : IntW 32) :
 
 
 theorem negative_not_next_power_of_two_thm (e : IntW 32) :
-  LLVM.and (icmp IntPredicate.sgt e (const? 32 (-1))) (icmp IntPredicate.ult (add e (const? 32 64)) (const? 32 256)) ⊑
-    icmp IntPredicate.ult e (const? 32 192) := by
+  LLVM.and (icmp IntPred.sgt e (const? 32 (-1))) (icmp IntPred.ult (add e (const? 32 64)) (const? 32 256)) ⊑
+    icmp IntPred.ult e (const? 32 192) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -325,9 +325,9 @@ theorem negative_not_next_power_of_two_thm (e : IntW 32) :
 
 
 theorem negative_not_next_power_of_two_logical_thm (e : IntW 32) :
-  select (icmp IntPredicate.sgt e (const? 32 (-1))) (icmp IntPredicate.ult (add e (const? 32 64)) (const? 32 256))
+  select (icmp IntPred.sgt e (const? 32 (-1))) (icmp IntPred.ult (add e (const? 32 64)) (const? 32 256))
       (const? 1 0) ⊑
-    icmp IntPredicate.ult e (const? 32 192) := by
+    icmp IntPred.ult e (const? 32 192) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -337,9 +337,9 @@ theorem negative_not_next_power_of_two_logical_thm (e : IntW 32) :
 
 
 theorem two_signed_truncation_checks_thm (e : IntW 32) :
-  LLVM.and (icmp IntPredicate.ult (add e (const? 32 512)) (const? 32 1024))
-      (icmp IntPredicate.ult (add e (const? 32 128)) (const? 32 256)) ⊑
-    icmp IntPredicate.ult (add e (const? 32 128)) (const? 32 256) := by
+  LLVM.and (icmp IntPred.ult (add e (const? 32 512)) (const? 32 1024))
+      (icmp IntPred.ult (add e (const? 32 128)) (const? 32 256)) ⊑
+    icmp IntPred.ult (add e (const? 32 128)) (const? 32 256) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -349,9 +349,9 @@ theorem two_signed_truncation_checks_thm (e : IntW 32) :
 
 
 theorem two_signed_truncation_checks_logical_thm (e : IntW 32) :
-  select (icmp IntPredicate.ult (add e (const? 32 512)) (const? 32 1024))
-      (icmp IntPredicate.ult (add e (const? 32 128)) (const? 32 256)) (const? 1 0) ⊑
-    icmp IntPredicate.ult (add e (const? 32 128)) (const? 32 256) := by
+  select (icmp IntPred.ult (add e (const? 32 512)) (const? 32 1024))
+      (icmp IntPred.ult (add e (const? 32 128)) (const? 32 256)) (const? 1 0) ⊑
+    icmp IntPred.ult (add e (const? 32 128)) (const? 32 256) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gsignhbithtesthviahrighthshiftinghallhotherhbits_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gsignhbithtesthviahrighthshiftinghallhotherhbits_proof.lean
@@ -12,7 +12,7 @@ set_option Elab.async false
 
 section gsignhbithtesthviahrighthshiftinghallhotherhbits_proof
 theorem unsigned_sign_bit_extract_thm (e : IntW 32) :
-  icmp IntPredicate.ne (lshr e (const? 32 31)) (const? 32 0) ⊑ icmp IntPredicate.slt e (const? 32 0) := by
+  icmp IntPred.ne (lshr e (const? 32 31)) (const? 32 0) ⊑ icmp IntPred.slt e (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -22,7 +22,7 @@ theorem unsigned_sign_bit_extract_thm (e : IntW 32) :
 
 
 theorem signed_sign_bit_extract_thm (e : IntW 32) :
-  icmp IntPredicate.ne (ashr e (const? 32 31)) (const? 32 0) ⊑ icmp IntPredicate.slt e (const? 32 0) := by
+  icmp IntPred.ne (ashr e (const? 32 31)) (const? 32 0) ⊑ icmp IntPred.slt e (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -32,7 +32,7 @@ theorem signed_sign_bit_extract_thm (e : IntW 32) :
 
 
 theorem unsigned_sign_bit_extract_with_trunc_thm (e : IntW 64) :
-  icmp IntPredicate.ne (trunc 32 (lshr e (const? 64 63))) (const? 32 0) ⊑ icmp IntPredicate.slt e (const? 64 0) := by
+  icmp IntPred.ne (trunc 32 (lshr e (const? 64 63))) (const? 32 0) ⊑ icmp IntPred.slt e (const? 64 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -42,7 +42,7 @@ theorem unsigned_sign_bit_extract_with_trunc_thm (e : IntW 64) :
 
 
 theorem signed_sign_bit_extract_trunc_thm (e : IntW 64) :
-  icmp IntPredicate.ne (trunc 32 (ashr e (const? 64 63))) (const? 32 0) ⊑ icmp IntPredicate.slt e (const? 64 0) := by
+  icmp IntPred.ne (trunc 32 (ashr e (const? 64 63))) (const? 32 0) ⊑ icmp IntPred.slt e (const? 64 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gsignhtesthandhor_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gsignhtesthandhor_proof.lean
@@ -12,8 +12,8 @@ set_option Elab.async false
 
 section gsignhtesthandhor_proof
 theorem test1_thm (e e_1 : IntW 32) :
-  LLVM.or (icmp IntPredicate.slt e_1 (const? 32 0)) (icmp IntPredicate.slt e (const? 32 0)) ⊑
-    icmp IntPredicate.slt (LLVM.or e_1 e) (const? 32 0) := by
+  LLVM.or (icmp IntPred.slt e_1 (const? 32 0)) (icmp IntPred.slt e (const? 32 0)) ⊑
+    icmp IntPred.slt (LLVM.or e_1 e) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -23,8 +23,8 @@ theorem test1_thm (e e_1 : IntW 32) :
 
 
 theorem test2_thm (e e_1 : IntW 32) :
-  LLVM.or (icmp IntPredicate.sgt e_1 (const? 32 (-1))) (icmp IntPredicate.sgt e (const? 32 (-1))) ⊑
-    icmp IntPredicate.sgt (LLVM.and e_1 e) (const? 32 (-1)) := by
+  LLVM.or (icmp IntPred.sgt e_1 (const? 32 (-1))) (icmp IntPred.sgt e (const? 32 (-1))) ⊑
+    icmp IntPred.sgt (LLVM.and e_1 e) (const? 32 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -34,8 +34,8 @@ theorem test2_thm (e e_1 : IntW 32) :
 
 
 theorem test3_thm (e e_1 : IntW 32) :
-  LLVM.and (icmp IntPredicate.slt e_1 (const? 32 0)) (icmp IntPredicate.slt e (const? 32 0)) ⊑
-    icmp IntPredicate.slt (LLVM.and e_1 e) (const? 32 0) := by
+  LLVM.and (icmp IntPred.slt e_1 (const? 32 0)) (icmp IntPred.slt e (const? 32 0)) ⊑
+    icmp IntPred.slt (LLVM.and e_1 e) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -45,8 +45,8 @@ theorem test3_thm (e e_1 : IntW 32) :
 
 
 theorem test4_thm (e e_1 : IntW 32) :
-  LLVM.and (icmp IntPredicate.sgt e_1 (const? 32 (-1))) (icmp IntPredicate.sgt e (const? 32 (-1))) ⊑
-    icmp IntPredicate.sgt (LLVM.or e_1 e) (const? 32 (-1)) := by
+  LLVM.and (icmp IntPred.sgt e_1 (const? 32 (-1))) (icmp IntPred.sgt e (const? 32 (-1))) ⊑
+    icmp IntPred.sgt (LLVM.or e_1 e) (const? 32 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -56,9 +56,9 @@ theorem test4_thm (e e_1 : IntW 32) :
 
 
 theorem test9_thm (e : IntW 32) :
-  LLVM.and (icmp IntPredicate.ne (LLVM.and e (const? 32 1073741824)) (const? 32 0))
-      (icmp IntPredicate.sgt e (const? 32 (-1))) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 32 (-1073741824))) (const? 32 1073741824) := by
+  LLVM.and (icmp IntPred.ne (LLVM.and e (const? 32 1073741824)) (const? 32 0))
+      (icmp IntPred.sgt e (const? 32 (-1))) ⊑
+    icmp IntPred.eq (LLVM.and e (const? 32 (-1073741824))) (const? 32 1073741824) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -68,9 +68,9 @@ theorem test9_thm (e : IntW 32) :
 
 
 theorem test9_logical_thm (e : IntW 32) :
-  select (icmp IntPredicate.ne (LLVM.and e (const? 32 1073741824)) (const? 32 0))
-      (icmp IntPredicate.sgt e (const? 32 (-1))) (const? 1 0) ⊑
-    icmp IntPredicate.eq (LLVM.and e (const? 32 (-1073741824))) (const? 32 1073741824) := by
+  select (icmp IntPred.ne (LLVM.and e (const? 32 1073741824)) (const? 32 0))
+      (icmp IntPred.sgt e (const? 32 (-1))) (const? 1 0) ⊑
+    icmp IntPred.eq (LLVM.and e (const? 32 (-1073741824))) (const? 32 1073741824) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -80,8 +80,8 @@ theorem test9_logical_thm (e : IntW 32) :
 
 
 theorem test10_thm (e : IntW 32) :
-  LLVM.and (icmp IntPredicate.eq (LLVM.and e (const? 32 2)) (const? 32 0)) (icmp IntPredicate.ult e (const? 32 4)) ⊑
-    icmp IntPredicate.ult e (const? 32 2) := by
+  LLVM.and (icmp IntPred.eq (LLVM.and e (const? 32 2)) (const? 32 0)) (icmp IntPred.ult e (const? 32 4)) ⊑
+    icmp IntPred.ult e (const? 32 2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -91,9 +91,9 @@ theorem test10_thm (e : IntW 32) :
 
 
 theorem test10_logical_thm (e : IntW 32) :
-  select (icmp IntPredicate.eq (LLVM.and e (const? 32 2)) (const? 32 0)) (icmp IntPredicate.ult e (const? 32 4))
+  select (icmp IntPred.eq (LLVM.and e (const? 32 2)) (const? 32 0)) (icmp IntPred.ult e (const? 32 4))
       (const? 1 0) ⊑
-    icmp IntPredicate.ult e (const? 32 2) := by
+    icmp IntPred.ult e (const? 32 2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -103,8 +103,8 @@ theorem test10_logical_thm (e : IntW 32) :
 
 
 theorem test11_thm (e : IntW 32) :
-  LLVM.or (icmp IntPredicate.ne (LLVM.and e (const? 32 2)) (const? 32 0)) (icmp IntPredicate.ugt e (const? 32 3)) ⊑
-    icmp IntPredicate.ugt e (const? 32 1) := by
+  LLVM.or (icmp IntPred.ne (LLVM.and e (const? 32 2)) (const? 32 0)) (icmp IntPred.ugt e (const? 32 3)) ⊑
+    icmp IntPred.ugt e (const? 32 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -114,9 +114,9 @@ theorem test11_thm (e : IntW 32) :
 
 
 theorem test11_logical_thm (e : IntW 32) :
-  select (icmp IntPredicate.ne (LLVM.and e (const? 32 2)) (const? 32 0)) (const? 1 1)
-      (icmp IntPredicate.ugt e (const? 32 3)) ⊑
-    icmp IntPredicate.ugt e (const? 32 1) := by
+  select (icmp IntPred.ne (LLVM.and e (const? 32 2)) (const? 32 0)) (const? 1 1)
+      (icmp IntPred.ugt e (const? 32 3)) ⊑
+    icmp IntPred.ugt e (const? 32 1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gsinkhnothintohand_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gsinkhnothintohand_proof.lean
@@ -12,8 +12,8 @@ set_option Elab.async false
 
 section gsinkhnothintohand_proof
 theorem t0_thm (e e_1 e_2 e_3 : IntW 32) :
-  LLVM.xor (LLVM.and (icmp IntPredicate.eq e_3 e_2) (icmp IntPredicate.eq e_1 e)) (const? 1 1) ⊑
-    LLVM.or (icmp IntPredicate.ne e_3 e_2) (icmp IntPredicate.ne e_1 e) := by
+  LLVM.xor (LLVM.and (icmp IntPred.eq e_3 e_2) (icmp IntPred.eq e_1 e)) (const? 1 1) ⊑
+    LLVM.or (icmp IntPred.ne e_3 e_2) (icmp IntPred.ne e_1 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gsinkhnothintohanotherhhandhofhand_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gsinkhnothintohanotherhhandhofhand_proof.lean
@@ -12,8 +12,8 @@ set_option Elab.async false
 
 section gsinkhnothintohanotherhhandhofhand_proof
 theorem t0_thm (e e_1 e_2 e_3 : IntW 8) (e_4 : IntW 1) :
-  select (LLVM.and (LLVM.xor e_4 (const? 1 1)) (icmp IntPredicate.eq e_3 e_2)) e_1 e ⊑
-    select (LLVM.or (icmp IntPredicate.ne e_3 e_2) e_4) e e_1 := by
+  select (LLVM.and (LLVM.xor e_4 (const? 1 1)) (icmp IntPred.eq e_3 e_2)) e_1 e ⊑
+    select (LLVM.or (icmp IntPred.ne e_3 e_2) e_4) e e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -23,8 +23,8 @@ theorem t0_thm (e e_1 e_2 e_3 : IntW 8) (e_4 : IntW 1) :
 
 
 theorem n2_thm (e e_1 : IntW 8) (e_2 : IntW 1) :
-  LLVM.and (LLVM.xor e_2 (const? 1 1)) (icmp IntPredicate.eq e_1 e) ⊑
-    LLVM.and (icmp IntPredicate.eq e_1 e) (LLVM.xor e_2 (const? 1 1)) := by
+  LLVM.and (LLVM.xor e_2 (const? 1 1)) (icmp IntPred.eq e_1 e) ⊑
+    LLVM.and (icmp IntPred.eq e_1 e) (LLVM.xor e_2 (const? 1 1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gsinkhnothintohanotherhhandhofhlogicalhand_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gsinkhnothintohanotherhhandhofhlogicalhand_proof.lean
@@ -12,8 +12,8 @@ set_option Elab.async false
 
 section gsinkhnothintohanotherhhandhofhlogicalhand_proof
 theorem t0_thm (e e_1 e_2 e_3 : IntW 8) (e_4 : IntW 1) :
-  select (select (LLVM.xor e_4 (const? 1 1)) (icmp IntPredicate.eq e_3 e_2) (const? 1 0)) e_1 e ⊑
-    select (select e_4 (const? 1 1) (icmp IntPredicate.ne e_3 e_2)) e e_1 := by
+  select (select (LLVM.xor e_4 (const? 1 1)) (icmp IntPred.eq e_3 e_2) (const? 1 0)) e_1 e ⊑
+    select (select e_4 (const? 1 1) (icmp IntPred.ne e_3 e_2)) e e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -23,8 +23,8 @@ theorem t0_thm (e e_1 e_2 e_3 : IntW 8) (e_4 : IntW 1) :
 
 
 theorem t0_commutative_thm (e e_1 : IntW 8) (e_2 : IntW 1) (e_3 e_4 : IntW 8) :
-  select (select (icmp IntPredicate.eq e_4 e_3) (LLVM.xor e_2 (const? 1 1)) (const? 1 0)) e_1 e ⊑
-    select (select (icmp IntPredicate.ne e_4 e_3) (const? 1 1) e_2) e e_1 := by
+  select (select (icmp IntPred.eq e_4 e_3) (LLVM.xor e_2 (const? 1 1)) (const? 1 0)) e_1 e ⊑
+    select (select (icmp IntPred.ne e_4 e_3) (const? 1 1) e_2) e e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gsinkhnothintohanotherhhandhofhlogicalhor_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gsinkhnothintohanotherhhandhofhlogicalhor_proof.lean
@@ -12,8 +12,8 @@ set_option Elab.async false
 
 section gsinkhnothintohanotherhhandhofhlogicalhor_proof
 theorem t0_thm (e e_1 e_2 e_3 : IntW 8) (e_4 : IntW 1) :
-  select (select (LLVM.xor e_4 (const? 1 1)) (const? 1 1) (icmp IntPredicate.eq e_3 e_2)) e_1 e ⊑
-    select (select e_4 (icmp IntPredicate.ne e_3 e_2) (const? 1 0)) e e_1 := by
+  select (select (LLVM.xor e_4 (const? 1 1)) (const? 1 1) (icmp IntPred.eq e_3 e_2)) e_1 e ⊑
+    select (select e_4 (icmp IntPred.ne e_3 e_2) (const? 1 0)) e e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -23,8 +23,8 @@ theorem t0_thm (e e_1 e_2 e_3 : IntW 8) (e_4 : IntW 1) :
 
 
 theorem t0_commutative_thm (e e_1 : IntW 8) (e_2 : IntW 1) (e_3 e_4 : IntW 8) :
-  select (select (icmp IntPredicate.eq e_4 e_3) (const? 1 1) (LLVM.xor e_2 (const? 1 1))) e_1 e ⊑
-    select (select (icmp IntPredicate.ne e_4 e_3) e_2 (const? 1 0)) e e_1 := by
+  select (select (icmp IntPred.eq e_4 e_3) (const? 1 1) (LLVM.xor e_2 (const? 1 1))) e_1 e ⊑
+    select (select (icmp IntPred.ne e_4 e_3) e_2 (const? 1 0)) e e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gsinkhnothintohanotherhhandhofhor_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gsinkhnothintohanotherhhandhofhor_proof.lean
@@ -12,8 +12,8 @@ set_option Elab.async false
 
 section gsinkhnothintohanotherhhandhofhor_proof
 theorem t0_thm (e e_1 e_2 e_3 : IntW 8) (e_4 : IntW 1) :
-  select (LLVM.or (LLVM.xor e_4 (const? 1 1)) (icmp IntPredicate.eq e_3 e_2)) e_1 e ⊑
-    select (LLVM.and (icmp IntPredicate.ne e_3 e_2) e_4) e e_1 := by
+  select (LLVM.or (LLVM.xor e_4 (const? 1 1)) (icmp IntPred.eq e_3 e_2)) e_1 e ⊑
+    select (LLVM.and (icmp IntPred.ne e_3 e_2) e_4) e e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -23,8 +23,8 @@ theorem t0_thm (e e_1 e_2 e_3 : IntW 8) (e_4 : IntW 1) :
 
 
 theorem n2_thm (e e_1 : IntW 8) (e_2 : IntW 1) :
-  LLVM.or (LLVM.xor e_2 (const? 1 1)) (icmp IntPredicate.eq e_1 e) ⊑
-    LLVM.or (icmp IntPredicate.eq e_1 e) (LLVM.xor e_2 (const? 1 1)) := by
+  LLVM.or (LLVM.xor e_2 (const? 1 1)) (icmp IntPred.eq e_1 e) ⊑
+    LLVM.or (icmp IntPred.eq e_1 e) (LLVM.xor e_2 (const? 1 1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gsinkhnothintohlogicalhand_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gsinkhnothintohlogicalhand_proof.lean
@@ -12,8 +12,8 @@ set_option Elab.async false
 
 section gsinkhnothintohlogicalhand_proof
 theorem t0_thm (e e_1 e_2 e_3 : IntW 32) :
-  LLVM.xor (select (icmp IntPredicate.eq e_3 e_2) (icmp IntPredicate.eq e_1 e) (const? 1 0)) (const? 1 1) ⊑
-    select (icmp IntPredicate.ne e_3 e_2) (const? 1 1) (icmp IntPredicate.ne e_1 e) := by
+  LLVM.xor (select (icmp IntPred.eq e_3 e_2) (icmp IntPred.eq e_1 e) (const? 1 0)) (const? 1 1) ⊑
+    select (icmp IntPred.ne e_3 e_2) (const? 1 1) (icmp IntPred.ne e_1 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -23,8 +23,8 @@ theorem t0_thm (e e_1 e_2 e_3 : IntW 32) :
 
 
 theorem n2_thm (e e_1 : IntW 32) (e_2 : IntW 1) :
-  LLVM.xor (select e_2 (icmp IntPredicate.eq e_1 e) (const? 1 0)) (const? 1 1) ⊑
-    select (LLVM.xor e_2 (const? 1 1)) (const? 1 1) (icmp IntPredicate.ne e_1 e) := by
+  LLVM.xor (select e_2 (icmp IntPred.eq e_1 e) (const? 1 0)) (const? 1 1) ⊑
+    select (LLVM.xor e_2 (const? 1 1)) (const? 1 1) (icmp IntPred.ne e_1 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gsinkhnothintohlogicalhor_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gsinkhnothintohlogicalhor_proof.lean
@@ -12,8 +12,8 @@ set_option Elab.async false
 
 section gsinkhnothintohlogicalhor_proof
 theorem t0_thm (e e_1 e_2 e_3 : IntW 32) :
-  LLVM.xor (select (icmp IntPredicate.eq e_3 e_2) (const? 1 1) (icmp IntPredicate.eq e_1 e)) (const? 1 1) ⊑
-    select (icmp IntPredicate.ne e_3 e_2) (icmp IntPredicate.ne e_1 e) (const? 1 0) := by
+  LLVM.xor (select (icmp IntPred.eq e_3 e_2) (const? 1 1) (icmp IntPred.eq e_1 e)) (const? 1 1) ⊑
+    select (icmp IntPred.ne e_3 e_2) (icmp IntPred.ne e_1 e) (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -23,8 +23,8 @@ theorem t0_thm (e e_1 e_2 e_3 : IntW 32) :
 
 
 theorem n2_thm (e e_1 : IntW 32) (e_2 : IntW 1) :
-  LLVM.xor (select e_2 (const? 1 1) (icmp IntPredicate.eq e_1 e)) (const? 1 1) ⊑
-    select (LLVM.xor e_2 (const? 1 1)) (icmp IntPredicate.ne e_1 e) (const? 1 0) := by
+  LLVM.xor (select e_2 (const? 1 1) (icmp IntPred.eq e_1 e)) (const? 1 1) ⊑
+    select (LLVM.xor e_2 (const? 1 1)) (icmp IntPred.ne e_1 e) (const? 1 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gsinkhnothintohor_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gsinkhnothintohor_proof.lean
@@ -12,8 +12,8 @@ set_option Elab.async false
 
 section gsinkhnothintohor_proof
 theorem t0_thm (e e_1 e_2 e_3 : IntW 32) :
-  LLVM.xor (LLVM.or (icmp IntPredicate.eq e_3 e_2) (icmp IntPredicate.eq e_1 e)) (const? 1 1) ⊑
-    LLVM.and (icmp IntPredicate.ne e_3 e_2) (icmp IntPredicate.ne e_1 e) := by
+  LLVM.xor (LLVM.or (icmp IntPred.eq e_3 e_2) (icmp IntPred.eq e_1 e)) (const? 1 1) ⊑
+    LLVM.and (icmp IntPred.ne e_3 e_2) (icmp IntPred.ne e_1 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gsmaxhicmp_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gsmaxhicmp_proof.lean
@@ -12,7 +12,7 @@ set_option Elab.async false
 
 section gsmaxhicmp_proof
 theorem eq_smax1_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.eq (select (icmp IntPredicate.sgt e_1 e) e_1 e) e_1 ⊑ icmp IntPredicate.sge e_1 e := by
+  icmp IntPred.eq (select (icmp IntPred.sgt e_1 e) e_1 e) e_1 ⊑ icmp IntPred.sge e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -22,7 +22,7 @@ theorem eq_smax1_thm (e e_1 : IntW 32) :
 
 
 theorem eq_smax2_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.eq (select (icmp IntPredicate.sgt e_1 e) e_1 e) e ⊑ icmp IntPredicate.sge e e_1 := by
+  icmp IntPred.eq (select (icmp IntPred.sgt e_1 e) e_1 e) e ⊑ icmp IntPred.sge e e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -32,9 +32,9 @@ theorem eq_smax2_thm (e e_1 : IntW 32) :
 
 
 theorem eq_smax3_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.eq (add e_1 (const? 32 3))
-      (select (icmp IntPredicate.sgt (add e_1 (const? 32 3)) e) (add e_1 (const? 32 3)) e) ⊑
-    icmp IntPredicate.sge (add e_1 (const? 32 3)) e := by
+  icmp IntPred.eq (add e_1 (const? 32 3))
+      (select (icmp IntPred.sgt (add e_1 (const? 32 3)) e) (add e_1 (const? 32 3)) e) ⊑
+    icmp IntPred.sge (add e_1 (const? 32 3)) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -44,9 +44,9 @@ theorem eq_smax3_thm (e e_1 : IntW 32) :
 
 
 theorem eq_smax4_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.eq (add e_1 (const? 32 3))
-      (select (icmp IntPredicate.sgt e (add e_1 (const? 32 3))) e (add e_1 (const? 32 3))) ⊑
-    icmp IntPredicate.sge (add e_1 (const? 32 3)) e := by
+  icmp IntPred.eq (add e_1 (const? 32 3))
+      (select (icmp IntPred.sgt e (add e_1 (const? 32 3))) e (add e_1 (const? 32 3))) ⊑
+    icmp IntPred.sge (add e_1 (const? 32 3)) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -56,7 +56,7 @@ theorem eq_smax4_thm (e e_1 : IntW 32) :
 
 
 theorem sle_smax1_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.sle (select (icmp IntPredicate.sgt e_1 e) e_1 e) e_1 ⊑ icmp IntPredicate.sle e e_1 := by
+  icmp IntPred.sle (select (icmp IntPred.sgt e_1 e) e_1 e) e_1 ⊑ icmp IntPred.sle e e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -66,7 +66,7 @@ theorem sle_smax1_thm (e e_1 : IntW 32) :
 
 
 theorem sle_smax2_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.sle (select (icmp IntPredicate.sgt e_1 e) e_1 e) e ⊑ icmp IntPredicate.sle e_1 e := by
+  icmp IntPred.sle (select (icmp IntPred.sgt e_1 e) e_1 e) e ⊑ icmp IntPred.sle e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -76,9 +76,9 @@ theorem sle_smax2_thm (e e_1 : IntW 32) :
 
 
 theorem sle_smax3_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.sge (add e_1 (const? 32 3))
-      (select (icmp IntPredicate.sgt (add e_1 (const? 32 3)) e) (add e_1 (const? 32 3)) e) ⊑
-    icmp IntPredicate.sle e (add e_1 (const? 32 3)) := by
+  icmp IntPred.sge (add e_1 (const? 32 3))
+      (select (icmp IntPred.sgt (add e_1 (const? 32 3)) e) (add e_1 (const? 32 3)) e) ⊑
+    icmp IntPred.sle e (add e_1 (const? 32 3)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -88,9 +88,9 @@ theorem sle_smax3_thm (e e_1 : IntW 32) :
 
 
 theorem sle_smax4_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.sge (add e_1 (const? 32 3))
-      (select (icmp IntPredicate.sgt e (add e_1 (const? 32 3))) e (add e_1 (const? 32 3))) ⊑
-    icmp IntPredicate.sle e (add e_1 (const? 32 3)) := by
+  icmp IntPred.sge (add e_1 (const? 32 3))
+      (select (icmp IntPred.sgt e (add e_1 (const? 32 3))) e (add e_1 (const? 32 3))) ⊑
+    icmp IntPred.sle e (add e_1 (const? 32 3)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -100,7 +100,7 @@ theorem sle_smax4_thm (e e_1 : IntW 32) :
 
 
 theorem ne_smax1_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.ne (select (icmp IntPredicate.sgt e_1 e) e_1 e) e_1 ⊑ icmp IntPredicate.slt e_1 e := by
+  icmp IntPred.ne (select (icmp IntPred.sgt e_1 e) e_1 e) e_1 ⊑ icmp IntPred.slt e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -110,7 +110,7 @@ theorem ne_smax1_thm (e e_1 : IntW 32) :
 
 
 theorem ne_smax2_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.ne (select (icmp IntPredicate.sgt e_1 e) e_1 e) e ⊑ icmp IntPredicate.slt e e_1 := by
+  icmp IntPred.ne (select (icmp IntPred.sgt e_1 e) e_1 e) e ⊑ icmp IntPred.slt e e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -120,9 +120,9 @@ theorem ne_smax2_thm (e e_1 : IntW 32) :
 
 
 theorem ne_smax3_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.ne (add e_1 (const? 32 3))
-      (select (icmp IntPredicate.sgt (add e_1 (const? 32 3)) e) (add e_1 (const? 32 3)) e) ⊑
-    icmp IntPredicate.slt (add e_1 (const? 32 3)) e := by
+  icmp IntPred.ne (add e_1 (const? 32 3))
+      (select (icmp IntPred.sgt (add e_1 (const? 32 3)) e) (add e_1 (const? 32 3)) e) ⊑
+    icmp IntPred.slt (add e_1 (const? 32 3)) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -132,9 +132,9 @@ theorem ne_smax3_thm (e e_1 : IntW 32) :
 
 
 theorem ne_smax4_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.ne (add e_1 (const? 32 3))
-      (select (icmp IntPredicate.sgt e (add e_1 (const? 32 3))) e (add e_1 (const? 32 3))) ⊑
-    icmp IntPredicate.slt (add e_1 (const? 32 3)) e := by
+  icmp IntPred.ne (add e_1 (const? 32 3))
+      (select (icmp IntPred.sgt e (add e_1 (const? 32 3))) e (add e_1 (const? 32 3))) ⊑
+    icmp IntPred.slt (add e_1 (const? 32 3)) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -144,7 +144,7 @@ theorem ne_smax4_thm (e e_1 : IntW 32) :
 
 
 theorem sgt_smax1_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.sgt (select (icmp IntPredicate.sgt e_1 e) e_1 e) e_1 ⊑ icmp IntPredicate.sgt e e_1 := by
+  icmp IntPred.sgt (select (icmp IntPred.sgt e_1 e) e_1 e) e_1 ⊑ icmp IntPred.sgt e e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -154,7 +154,7 @@ theorem sgt_smax1_thm (e e_1 : IntW 32) :
 
 
 theorem sgt_smax2_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.sgt (select (icmp IntPredicate.sgt e_1 e) e_1 e) e ⊑ icmp IntPredicate.sgt e_1 e := by
+  icmp IntPred.sgt (select (icmp IntPred.sgt e_1 e) e_1 e) e ⊑ icmp IntPred.sgt e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -164,9 +164,9 @@ theorem sgt_smax2_thm (e e_1 : IntW 32) :
 
 
 theorem sgt_smax3_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.slt (add e_1 (const? 32 3))
-      (select (icmp IntPredicate.sgt (add e_1 (const? 32 3)) e) (add e_1 (const? 32 3)) e) ⊑
-    icmp IntPredicate.sgt e (add e_1 (const? 32 3)) := by
+  icmp IntPred.slt (add e_1 (const? 32 3))
+      (select (icmp IntPred.sgt (add e_1 (const? 32 3)) e) (add e_1 (const? 32 3)) e) ⊑
+    icmp IntPred.sgt e (add e_1 (const? 32 3)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -176,9 +176,9 @@ theorem sgt_smax3_thm (e e_1 : IntW 32) :
 
 
 theorem sgt_smax4_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.slt (add e_1 (const? 32 3))
-      (select (icmp IntPredicate.sgt e (add e_1 (const? 32 3))) e (add e_1 (const? 32 3))) ⊑
-    icmp IntPredicate.sgt e (add e_1 (const? 32 3)) := by
+  icmp IntPred.slt (add e_1 (const? 32 3))
+      (select (icmp IntPred.sgt e (add e_1 (const? 32 3))) e (add e_1 (const? 32 3))) ⊑
+    icmp IntPred.sgt e (add e_1 (const? 32 3)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gsminhicmp_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gsminhicmp_proof.lean
@@ -12,7 +12,7 @@ set_option Elab.async false
 
 section gsminhicmp_proof
 theorem eq_smin1_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.eq (select (icmp IntPredicate.slt e_1 e) e_1 e) e_1 ⊑ icmp IntPredicate.sle e_1 e := by
+  icmp IntPred.eq (select (icmp IntPred.slt e_1 e) e_1 e) e_1 ⊑ icmp IntPred.sle e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -22,7 +22,7 @@ theorem eq_smin1_thm (e e_1 : IntW 32) :
 
 
 theorem eq_smin2_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.eq (select (icmp IntPredicate.slt e_1 e) e_1 e) e ⊑ icmp IntPredicate.sle e e_1 := by
+  icmp IntPred.eq (select (icmp IntPred.slt e_1 e) e_1 e) e ⊑ icmp IntPred.sle e e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -32,9 +32,9 @@ theorem eq_smin2_thm (e e_1 : IntW 32) :
 
 
 theorem eq_smin3_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.eq (add e_1 (const? 32 3))
-      (select (icmp IntPredicate.slt (add e_1 (const? 32 3)) e) (add e_1 (const? 32 3)) e) ⊑
-    icmp IntPredicate.sle (add e_1 (const? 32 3)) e := by
+  icmp IntPred.eq (add e_1 (const? 32 3))
+      (select (icmp IntPred.slt (add e_1 (const? 32 3)) e) (add e_1 (const? 32 3)) e) ⊑
+    icmp IntPred.sle (add e_1 (const? 32 3)) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -44,9 +44,9 @@ theorem eq_smin3_thm (e e_1 : IntW 32) :
 
 
 theorem eq_smin4_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.eq (add e_1 (const? 32 3))
-      (select (icmp IntPredicate.slt e (add e_1 (const? 32 3))) e (add e_1 (const? 32 3))) ⊑
-    icmp IntPredicate.sle (add e_1 (const? 32 3)) e := by
+  icmp IntPred.eq (add e_1 (const? 32 3))
+      (select (icmp IntPred.slt e (add e_1 (const? 32 3))) e (add e_1 (const? 32 3))) ⊑
+    icmp IntPred.sle (add e_1 (const? 32 3)) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -56,7 +56,7 @@ theorem eq_smin4_thm (e e_1 : IntW 32) :
 
 
 theorem sge_smin1_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.sge (select (icmp IntPredicate.slt e_1 e) e_1 e) e_1 ⊑ icmp IntPredicate.sge e e_1 := by
+  icmp IntPred.sge (select (icmp IntPred.slt e_1 e) e_1 e) e_1 ⊑ icmp IntPred.sge e e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -66,7 +66,7 @@ theorem sge_smin1_thm (e e_1 : IntW 32) :
 
 
 theorem sge_smin2_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.sge (select (icmp IntPredicate.slt e_1 e) e_1 e) e ⊑ icmp IntPredicate.sge e_1 e := by
+  icmp IntPred.sge (select (icmp IntPred.slt e_1 e) e_1 e) e ⊑ icmp IntPred.sge e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -76,9 +76,9 @@ theorem sge_smin2_thm (e e_1 : IntW 32) :
 
 
 theorem sge_smin3_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.sle (add e_1 (const? 32 3))
-      (select (icmp IntPredicate.slt (add e_1 (const? 32 3)) e) (add e_1 (const? 32 3)) e) ⊑
-    icmp IntPredicate.sge e (add e_1 (const? 32 3)) := by
+  icmp IntPred.sle (add e_1 (const? 32 3))
+      (select (icmp IntPred.slt (add e_1 (const? 32 3)) e) (add e_1 (const? 32 3)) e) ⊑
+    icmp IntPred.sge e (add e_1 (const? 32 3)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -88,9 +88,9 @@ theorem sge_smin3_thm (e e_1 : IntW 32) :
 
 
 theorem sge_smin4_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.sle (add e_1 (const? 32 3))
-      (select (icmp IntPredicate.slt e (add e_1 (const? 32 3))) e (add e_1 (const? 32 3))) ⊑
-    icmp IntPredicate.sge e (add e_1 (const? 32 3)) := by
+  icmp IntPred.sle (add e_1 (const? 32 3))
+      (select (icmp IntPred.slt e (add e_1 (const? 32 3))) e (add e_1 (const? 32 3))) ⊑
+    icmp IntPred.sge e (add e_1 (const? 32 3)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -100,7 +100,7 @@ theorem sge_smin4_thm (e e_1 : IntW 32) :
 
 
 theorem ne_smin1_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.ne (select (icmp IntPredicate.slt e_1 e) e_1 e) e_1 ⊑ icmp IntPredicate.sgt e_1 e := by
+  icmp IntPred.ne (select (icmp IntPred.slt e_1 e) e_1 e) e_1 ⊑ icmp IntPred.sgt e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -110,7 +110,7 @@ theorem ne_smin1_thm (e e_1 : IntW 32) :
 
 
 theorem ne_smin2_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.ne (select (icmp IntPredicate.slt e_1 e) e_1 e) e ⊑ icmp IntPredicate.sgt e e_1 := by
+  icmp IntPred.ne (select (icmp IntPred.slt e_1 e) e_1 e) e ⊑ icmp IntPred.sgt e e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -120,9 +120,9 @@ theorem ne_smin2_thm (e e_1 : IntW 32) :
 
 
 theorem ne_smin3_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.ne (add e_1 (const? 32 3))
-      (select (icmp IntPredicate.slt (add e_1 (const? 32 3)) e) (add e_1 (const? 32 3)) e) ⊑
-    icmp IntPredicate.sgt (add e_1 (const? 32 3)) e := by
+  icmp IntPred.ne (add e_1 (const? 32 3))
+      (select (icmp IntPred.slt (add e_1 (const? 32 3)) e) (add e_1 (const? 32 3)) e) ⊑
+    icmp IntPred.sgt (add e_1 (const? 32 3)) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -132,9 +132,9 @@ theorem ne_smin3_thm (e e_1 : IntW 32) :
 
 
 theorem ne_smin4_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.ne (add e_1 (const? 32 3))
-      (select (icmp IntPredicate.slt e (add e_1 (const? 32 3))) e (add e_1 (const? 32 3))) ⊑
-    icmp IntPredicate.sgt (add e_1 (const? 32 3)) e := by
+  icmp IntPred.ne (add e_1 (const? 32 3))
+      (select (icmp IntPred.slt e (add e_1 (const? 32 3))) e (add e_1 (const? 32 3))) ⊑
+    icmp IntPred.sgt (add e_1 (const? 32 3)) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -144,7 +144,7 @@ theorem ne_smin4_thm (e e_1 : IntW 32) :
 
 
 theorem slt_smin1_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.slt (select (icmp IntPredicate.slt e_1 e) e_1 e) e_1 ⊑ icmp IntPredicate.slt e e_1 := by
+  icmp IntPred.slt (select (icmp IntPred.slt e_1 e) e_1 e) e_1 ⊑ icmp IntPred.slt e e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -154,7 +154,7 @@ theorem slt_smin1_thm (e e_1 : IntW 32) :
 
 
 theorem slt_smin2_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.slt (select (icmp IntPredicate.slt e_1 e) e_1 e) e ⊑ icmp IntPredicate.slt e_1 e := by
+  icmp IntPred.slt (select (icmp IntPred.slt e_1 e) e_1 e) e ⊑ icmp IntPred.slt e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -164,9 +164,9 @@ theorem slt_smin2_thm (e e_1 : IntW 32) :
 
 
 theorem slt_smin3_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.sgt (add e_1 (const? 32 3))
-      (select (icmp IntPredicate.slt (add e_1 (const? 32 3)) e) (add e_1 (const? 32 3)) e) ⊑
-    icmp IntPredicate.slt e (add e_1 (const? 32 3)) := by
+  icmp IntPred.sgt (add e_1 (const? 32 3))
+      (select (icmp IntPred.slt (add e_1 (const? 32 3)) e) (add e_1 (const? 32 3)) e) ⊑
+    icmp IntPred.slt e (add e_1 (const? 32 3)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -176,9 +176,9 @@ theorem slt_smin3_thm (e e_1 : IntW 32) :
 
 
 theorem slt_smin4_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.sgt (add e_1 (const? 32 3))
-      (select (icmp IntPredicate.slt e (add e_1 (const? 32 3))) e (add e_1 (const? 32 3))) ⊑
-    icmp IntPredicate.slt e (add e_1 (const? 32 3)) := by
+  icmp IntPred.sgt (add e_1 (const? 32 3))
+      (select (icmp IntPred.slt e (add e_1 (const? 32 3))) e (add e_1 (const? 32 3))) ⊑
+    icmp IntPred.slt e (add e_1 (const? 32 3)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -188,7 +188,7 @@ theorem slt_smin4_thm (e e_1 : IntW 32) :
 
 
 theorem sle_smin1_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.sle (select (icmp IntPredicate.slt e_1 e) e_1 e) e_1 ⊑ const? 1 1 := by
+  icmp IntPred.sle (select (icmp IntPred.slt e_1 e) e_1 e) e_1 ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -198,7 +198,7 @@ theorem sle_smin1_thm (e e_1 : IntW 32) :
 
 
 theorem sle_smin2_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.sle (select (icmp IntPredicate.slt e_1 e) e_1 e) e ⊑ const? 1 1 := by
+  icmp IntPred.sle (select (icmp IntPred.slt e_1 e) e_1 e) e ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -208,8 +208,8 @@ theorem sle_smin2_thm (e e_1 : IntW 32) :
 
 
 theorem sle_smin3_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.sge (add e_1 (const? 32 3))
-      (select (icmp IntPredicate.slt (add e_1 (const? 32 3)) e) (add e_1 (const? 32 3)) e) ⊑
+  icmp IntPred.sge (add e_1 (const? 32 3))
+      (select (icmp IntPred.slt (add e_1 (const? 32 3)) e) (add e_1 (const? 32 3)) e) ⊑
     const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
@@ -220,8 +220,8 @@ theorem sle_smin3_thm (e e_1 : IntW 32) :
 
 
 theorem sle_smin4_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.sge (add e_1 (const? 32 3))
-      (select (icmp IntPredicate.slt e (add e_1 (const? 32 3))) e (add e_1 (const? 32 3))) ⊑
+  icmp IntPred.sge (add e_1 (const? 32 3))
+      (select (icmp IntPred.slt e (add e_1 (const? 32 3))) e (add e_1 (const? 32 3))) ⊑
     const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
@@ -232,7 +232,7 @@ theorem sle_smin4_thm (e e_1 : IntW 32) :
 
 
 theorem sgt_smin1_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.sgt (select (icmp IntPredicate.slt e_1 e) e_1 e) e_1 ⊑ const? 1 0 := by
+  icmp IntPred.sgt (select (icmp IntPred.slt e_1 e) e_1 e) e_1 ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -242,7 +242,7 @@ theorem sgt_smin1_thm (e e_1 : IntW 32) :
 
 
 theorem sgt_smin2_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.sgt (select (icmp IntPredicate.slt e_1 e) e_1 e) e ⊑ const? 1 0 := by
+  icmp IntPred.sgt (select (icmp IntPred.slt e_1 e) e_1 e) e ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -252,8 +252,8 @@ theorem sgt_smin2_thm (e e_1 : IntW 32) :
 
 
 theorem sgt_smin3_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.slt (add e_1 (const? 32 3))
-      (select (icmp IntPredicate.slt (add e_1 (const? 32 3)) e) (add e_1 (const? 32 3)) e) ⊑
+  icmp IntPred.slt (add e_1 (const? 32 3))
+      (select (icmp IntPred.slt (add e_1 (const? 32 3)) e) (add e_1 (const? 32 3)) e) ⊑
     const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
@@ -264,8 +264,8 @@ theorem sgt_smin3_thm (e e_1 : IntW 32) :
 
 
 theorem sgt_smin4_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.slt (add e_1 (const? 32 3))
-      (select (icmp IntPredicate.slt e (add e_1 (const? 32 3))) e (add e_1 (const? 32 3))) ⊑
+  icmp IntPred.slt (add e_1 (const? 32 3))
+      (select (icmp IntPred.slt e (add e_1 (const? 32 3))) e (add e_1 (const? 32 3))) ⊑
     const? 1 0 := by
     simp_alive_undef
     simp_alive_ops

--- a/SSA/Projects/InstCombine/tests/proofs/gsremhsimplifyhbug_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gsremhsimplifyhbug_proof.lean
@@ -12,7 +12,7 @@ set_option Elab.async false
 
 section gsremhsimplifyhbug_proof
 theorem f_thm (e : IntW 32) :
-  icmp IntPredicate.ne (LLVM.srem (LLVM.or e (const? 32 1)) (const? 32 1)) (const? 32 0) ⊑ const? 1 0 := by
+  icmp IntPred.ne (LLVM.srem (LLVM.or e (const? 32 1)) (const? 32 1)) (const? 32 0) ⊑ const? 1 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gsubhashrhandhtohicmphselect_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gsubhashrhandhtohicmphselect_proof.lean
@@ -13,7 +13,7 @@ set_option Elab.async false
 section gsubhashrhandhtohicmphselect_proof
 theorem sub_ashr_and_i8_thm (e e_1 : IntW 8) :
   LLVM.and (ashr (sub e_1 e { «nsw» := true, «nuw» := false }) (const? 8 7)) e ⊑
-    select (icmp IntPredicate.slt e_1 e) e (const? 8 0) := by
+    select (icmp IntPred.slt e_1 e) e (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -24,7 +24,7 @@ theorem sub_ashr_and_i8_thm (e e_1 : IntW 8) :
 
 theorem sub_ashr_and_i16_thm (e e_1 : IntW 16) :
   LLVM.and (ashr (sub e_1 e { «nsw» := true, «nuw» := false }) (const? 16 15)) e ⊑
-    select (icmp IntPredicate.slt e_1 e) e (const? 16 0) := by
+    select (icmp IntPred.slt e_1 e) e (const? 16 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -35,7 +35,7 @@ theorem sub_ashr_and_i16_thm (e e_1 : IntW 16) :
 
 theorem sub_ashr_and_i32_thm (e e_1 : IntW 32) :
   LLVM.and (ashr (sub e_1 e { «nsw» := true, «nuw» := false }) (const? 32 31)) e ⊑
-    select (icmp IntPredicate.slt e_1 e) e (const? 32 0) := by
+    select (icmp IntPred.slt e_1 e) e (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -46,7 +46,7 @@ theorem sub_ashr_and_i32_thm (e e_1 : IntW 32) :
 
 theorem sub_ashr_and_i64_thm (e e_1 : IntW 64) :
   LLVM.and (ashr (sub e_1 e { «nsw» := true, «nuw» := false }) (const? 64 63)) e ⊑
-    select (icmp IntPredicate.slt e_1 e) e (const? 64 0) := by
+    select (icmp IntPred.slt e_1 e) e (const? 64 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -57,7 +57,7 @@ theorem sub_ashr_and_i64_thm (e e_1 : IntW 64) :
 
 theorem sub_ashr_and_i32_nuw_nsw_thm (e e_1 : IntW 32) :
   LLVM.and (ashr (sub e_1 e { «nsw» := true, «nuw» := true }) (const? 32 31)) e ⊑
-    select (icmp IntPredicate.slt e_1 e) e (const? 32 0) := by
+    select (icmp IntPred.slt e_1 e) e (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -68,7 +68,7 @@ theorem sub_ashr_and_i32_nuw_nsw_thm (e e_1 : IntW 32) :
 
 theorem sub_ashr_and_i32_commute_thm (e e_1 : IntW 32) :
   LLVM.and e_1 (ashr (sub e e_1 { «nsw» := true, «nuw» := false }) (const? 32 31)) ⊑
-    select (icmp IntPredicate.slt e e_1) e_1 (const? 32 0) := by
+    select (icmp IntPred.slt e e_1) e_1 (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gsubhashrhorhtohicmphselect_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gsubhashrhorhtohicmphselect_proof.lean
@@ -13,7 +13,7 @@ set_option Elab.async false
 section gsubhashrhorhtohicmphselect_proof
 theorem sub_ashr_or_i8_thm (e e_1 : IntW 8) :
   LLVM.or (ashr (sub e_1 e { «nsw» := true, «nuw» := false }) (const? 8 7)) e ⊑
-    select (icmp IntPredicate.slt e_1 e) (const? 8 (-1)) e := by
+    select (icmp IntPred.slt e_1 e) (const? 8 (-1)) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -24,7 +24,7 @@ theorem sub_ashr_or_i8_thm (e e_1 : IntW 8) :
 
 theorem sub_ashr_or_i16_thm (e e_1 : IntW 16) :
   LLVM.or (ashr (sub e_1 e { «nsw» := true, «nuw» := false }) (const? 16 15)) e ⊑
-    select (icmp IntPredicate.slt e_1 e) (const? 16 (-1)) e := by
+    select (icmp IntPred.slt e_1 e) (const? 16 (-1)) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -35,7 +35,7 @@ theorem sub_ashr_or_i16_thm (e e_1 : IntW 16) :
 
 theorem sub_ashr_or_i32_thm (e e_1 : IntW 32) :
   LLVM.or (ashr (sub e_1 e { «nsw» := true, «nuw» := false }) (const? 32 31)) e ⊑
-    select (icmp IntPredicate.slt e_1 e) (const? 32 (-1)) e := by
+    select (icmp IntPred.slt e_1 e) (const? 32 (-1)) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -46,7 +46,7 @@ theorem sub_ashr_or_i32_thm (e e_1 : IntW 32) :
 
 theorem sub_ashr_or_i64_thm (e e_1 : IntW 64) :
   LLVM.or (ashr (sub e_1 e { «nsw» := true, «nuw» := false }) (const? 64 63)) e ⊑
-    select (icmp IntPredicate.slt e_1 e) (const? 64 (-1)) e := by
+    select (icmp IntPred.slt e_1 e) (const? 64 (-1)) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -56,7 +56,7 @@ theorem sub_ashr_or_i64_thm (e e_1 : IntW 64) :
 
 
 theorem neg_or_ashr_i32_thm (e : IntW 32) :
-  ashr (LLVM.or (sub (const? 32 0) e) e) (const? 32 31) ⊑ sext 32 (icmp IntPredicate.ne e (const? 32 0)) := by
+  ashr (LLVM.or (sub (const? 32 0) e) e) (const? 32 31) ⊑ sext 32 (icmp IntPred.ne e (const? 32 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -67,7 +67,7 @@ theorem neg_or_ashr_i32_thm (e : IntW 32) :
 
 theorem sub_ashr_or_i32_nuw_nsw_thm (e e_1 : IntW 32) :
   LLVM.or (ashr (sub e_1 e { «nsw» := true, «nuw» := true }) (const? 32 31)) e ⊑
-    select (icmp IntPredicate.slt e_1 e) (const? 32 (-1)) e := by
+    select (icmp IntPred.slt e_1 e) (const? 32 (-1)) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -78,7 +78,7 @@ theorem sub_ashr_or_i32_nuw_nsw_thm (e e_1 : IntW 32) :
 
 theorem sub_ashr_or_i32_commute_thm (e e_1 : IntW 32) :
   LLVM.or e_1 (ashr (sub e e_1 { «nsw» := true, «nuw» := false }) (const? 32 31)) ⊑
-    select (icmp IntPredicate.slt e e_1) (const? 32 (-1)) e_1 := by
+    select (icmp IntPred.slt e e_1) (const? 32 (-1)) e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -89,7 +89,7 @@ theorem sub_ashr_or_i32_commute_thm (e e_1 : IntW 32) :
 
 theorem neg_or_ashr_i32_commute_thm (e : IntW 32) :
   ashr (LLVM.or (LLVM.sdiv (const? 32 42) e) (sub (const? 32 0) (LLVM.sdiv (const? 32 42) e))) (const? 32 31) ⊑
-    sext 32 (icmp IntPredicate.ne (LLVM.sdiv (const? 32 42) e) (const? 32 0)) := by
+    sext 32 (icmp IntPred.ne (LLVM.sdiv (const? 32 42) e) (const? 32 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gsubhlshrhorhtohicmphselect_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gsubhlshrhorhtohicmphselect_proof.lean
@@ -12,7 +12,7 @@ set_option Elab.async false
 
 section gsubhlshrhorhtohicmphselect_proof
 theorem neg_or_lshr_i32_thm (e : IntW 32) :
-  lshr (LLVM.or (sub (const? 32 0) e) e) (const? 32 31) ⊑ zext 32 (icmp IntPredicate.ne e (const? 32 0)) := by
+  lshr (LLVM.or (sub (const? 32 0) e) e) (const? 32 31) ⊑ zext 32 (icmp IntPred.ne e (const? 32 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -23,7 +23,7 @@ theorem neg_or_lshr_i32_thm (e : IntW 32) :
 
 theorem neg_or_lshr_i32_commute_thm (e : IntW 32) :
   lshr (LLVM.or (LLVM.sdiv (const? 32 42) e) (sub (const? 32 0) (LLVM.sdiv (const? 32 42) e))) (const? 32 31) ⊑
-    zext 32 (icmp IntPredicate.ne (LLVM.sdiv (const? 32 42) e) (const? 32 0)) := by
+    zext 32 (icmp IntPred.ne (LLVM.sdiv (const? 32 42) e) (const? 32 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gsubhxorhcmp_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gsubhxorhcmp_proof.lean
@@ -93,8 +93,8 @@ theorem sext_multi_uses_thm (e : IntW 64) (e_1 : IntW 1) (e_2 : IntW 64) :
 
 
 theorem absdiff_thm (e e_1 : IntW 64) :
-  sub (LLVM.xor (sext 64 (icmp IntPredicate.ult e_1 e)) (sub e_1 e)) (sext 64 (icmp IntPredicate.ult e_1 e)) ⊑
-    select (icmp IntPredicate.ult e_1 e) (sub (const? 64 0) (sub e_1 e)) (sub e_1 e) := by
+  sub (LLVM.xor (sext 64 (icmp IntPred.ult e_1 e)) (sub e_1 e)) (sext 64 (icmp IntPred.ult e_1 e)) ⊑
+    select (icmp IntPred.ult e_1 e) (sub (const? 64 0) (sub e_1 e)) (sub e_1 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -104,8 +104,8 @@ theorem absdiff_thm (e e_1 : IntW 64) :
 
 
 theorem absdiff1_thm (e e_1 : IntW 64) :
-  sub (LLVM.xor (sub e_1 e) (sext 64 (icmp IntPredicate.ult e_1 e))) (sext 64 (icmp IntPredicate.ult e_1 e)) ⊑
-    select (icmp IntPredicate.ult e_1 e) (sub (const? 64 0) (sub e_1 e)) (sub e_1 e) := by
+  sub (LLVM.xor (sub e_1 e) (sext 64 (icmp IntPred.ult e_1 e))) (sext 64 (icmp IntPred.ult e_1 e)) ⊑
+    select (icmp IntPred.ult e_1 e) (sub (const? 64 0) (sub e_1 e)) (sub e_1 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -115,8 +115,8 @@ theorem absdiff1_thm (e e_1 : IntW 64) :
 
 
 theorem absdiff2_thm (e e_1 : IntW 64) :
-  sub (LLVM.xor (sub e_1 e) (sext 64 (icmp IntPredicate.ugt e e_1))) (sext 64 (icmp IntPredicate.ugt e e_1)) ⊑
-    select (icmp IntPredicate.ugt e e_1) (sub (const? 64 0) (sub e_1 e)) (sub e_1 e) := by
+  sub (LLVM.xor (sub e_1 e) (sext 64 (icmp IntPred.ugt e e_1))) (sext 64 (icmp IntPred.ugt e e_1)) ⊑
+    select (icmp IntPred.ugt e e_1) (sub (const? 64 0) (sub e_1 e)) (sub e_1 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gtrunc_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gtrunc_proof.lean
@@ -295,10 +295,10 @@ theorem trunc_shl_shl_var_thm (e e_1 : IntW 64) :
 theorem PR44545_thm (e e_1 : IntW 32) :
   add
       (trunc 16
-        (select (icmp IntPredicate.eq e_1 (const? 32 0)) (const? 32 0)
+        (select (icmp IntPred.eq e_1 (const? 32 0)) (const? 32 0)
           (add e (const? 32 1) { «nsw» := true, «nuw» := true })))
       (const? 16 (-1)) { «nsw» := true, «nuw» := false } ⊑
-    select (icmp IntPredicate.eq e_1 (const? 32 0)) (const? 16 (-1)) (trunc 16 e) := by
+    select (icmp IntPred.eq e_1 (const? 32 0)) (const? 16 (-1)) (trunc 16 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -341,7 +341,7 @@ theorem drop_both_trunc_thm (e e_1 : IntW 16) :
 
 
 theorem trunc_nuw_xor_thm (e e_1 : IntW 8) :
-  trunc 1 (LLVM.xor e_1 e) { «nsw» := false, «nuw» := true } ⊑ icmp IntPredicate.ne e_1 e := by
+  trunc 1 (LLVM.xor e_1 e) { «nsw» := false, «nuw» := true } ⊑ icmp IntPred.ne e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -351,7 +351,7 @@ theorem trunc_nuw_xor_thm (e e_1 : IntW 8) :
 
 
 theorem trunc_nsw_xor_thm (e e_1 : IntW 8) :
-  trunc 1 (LLVM.xor e_1 e) { «nsw» := true, «nuw» := false } ⊑ icmp IntPredicate.ne e_1 e := by
+  trunc 1 (LLVM.xor e_1 e) { «nsw» := true, «nuw» := false } ⊑ icmp IntPred.ne e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gtruncatinghsaturate_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gtruncatinghsaturate_proof.lean
@@ -12,10 +12,10 @@ set_option Elab.async false
 
 section gtruncatinghsaturate_proof
 theorem testtrunclowhigh_thm (e e_1 : IntW 16) (e_2 : IntW 32) :
-  select (icmp IntPredicate.ult (add e_2 (const? 32 128)) (const? 32 256)) (trunc 16 e_2)
-      (select (icmp IntPredicate.sgt e_2 (const? 32 (-1))) e_1 e) ⊑
-    select (icmp IntPredicate.ult (add e_2 (const? 32 128)) (const? 32 256)) (trunc 16 e_2)
-      (select (icmp IntPredicate.slt e_2 (const? 32 0)) e e_1) := by
+  select (icmp IntPred.ult (add e_2 (const? 32 128)) (const? 32 256)) (trunc 16 e_2)
+      (select (icmp IntPred.sgt e_2 (const? 32 (-1))) e_1 e) ⊑
+    select (icmp IntPred.ult (add e_2 (const? 32 128)) (const? 32 256)) (trunc 16 e_2)
+      (select (icmp IntPred.slt e_2 (const? 32 0)) e e_1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -25,9 +25,9 @@ theorem testtrunclowhigh_thm (e e_1 : IntW 16) (e_2 : IntW 32) :
 
 
 theorem testi32i8_thm (e : IntW 32) :
-  select (icmp IntPredicate.eq (ashr (trunc 8 e) (const? 8 7)) (trunc 8 (lshr e (const? 32 8)))) (trunc 8 e)
+  select (icmp IntPred.eq (ashr (trunc 8 e) (const? 8 7)) (trunc 8 (lshr e (const? 32 8)))) (trunc 8 e)
       (LLVM.xor (trunc 8 (ashr e (const? 32 15))) (const? 8 127)) ⊑
-    select (icmp IntPredicate.eq (ashr (trunc 8 e) (const? 8 7)) (trunc 8 (lshr e (const? 32 8)))) (trunc 8 e)
+    select (icmp IntPred.eq (ashr (trunc 8 e) (const? 8 7)) (trunc 8 (lshr e (const? 32 8)))) (trunc 8 e)
       (LLVM.xor (trunc 8 (lshr e (const? 32 15))) (const? 8 127)) := by
     simp_alive_undef
     simp_alive_ops
@@ -38,10 +38,10 @@ theorem testi32i8_thm (e : IntW 32) :
 
 
 theorem differentconsts_thm (e : IntW 32) :
-  select (icmp IntPredicate.ult (add e (const? 32 16)) (const? 32 144)) (trunc 16 e)
-      (select (icmp IntPredicate.slt e (const? 32 128)) (const? 16 256) (const? 16 (-1))) ⊑
-    select (icmp IntPredicate.sgt e (const? 32 127)) (const? 16 (-1))
-      (select (icmp IntPredicate.slt e (const? 32 (-16))) (const? 16 256) (trunc 16 e)) := by
+  select (icmp IntPred.ult (add e (const? 32 16)) (const? 32 144)) (trunc 16 e)
+      (select (icmp IntPred.slt e (const? 32 128)) (const? 16 256) (const? 16 (-1))) ⊑
+    select (icmp IntPred.sgt e (const? 32 127)) (const? 16 (-1))
+      (select (icmp IntPred.slt e (const? 32 (-16))) (const? 16 256) (trunc 16 e)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -51,12 +51,12 @@ theorem differentconsts_thm (e : IntW 32) :
 
 
 theorem badimm1_thm (e : IntW 16) :
-  select (icmp IntPredicate.eq (ashr (trunc 8 e) (const? 8 7)) (trunc 8 (lshr e (const? 16 9)))) (trunc 8 e)
+  select (icmp IntPred.eq (ashr (trunc 8 e) (const? 8 7)) (trunc 8 (lshr e (const? 16 9)))) (trunc 8 e)
       (LLVM.xor (trunc 8 (ashr e (const? 16 15))) (const? 8 127)) ⊑
     select
-      (icmp IntPredicate.eq (ashr (trunc 8 e) (const? 8 7))
+      (icmp IntPred.eq (ashr (trunc 8 e) (const? 8 7))
         (trunc 8 (lshr e (const? 16 9)) { «nsw» := true, «nuw» := true }))
-      (trunc 8 e) (select (icmp IntPredicate.sgt e (const? 16 (-1))) (const? 8 127) (const? 8 (-128))) := by
+      (trunc 8 e) (select (icmp IntPred.sgt e (const? 16 (-1))) (const? 8 127) (const? 8 (-128))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -66,12 +66,12 @@ theorem badimm1_thm (e : IntW 16) :
 
 
 theorem badimm2_thm (e : IntW 16) :
-  select (icmp IntPredicate.eq (ashr (trunc 8 e) (const? 8 6)) (trunc 8 (lshr e (const? 16 8)))) (trunc 8 e)
+  select (icmp IntPred.eq (ashr (trunc 8 e) (const? 8 6)) (trunc 8 (lshr e (const? 16 8)))) (trunc 8 e)
       (LLVM.xor (trunc 8 (ashr e (const? 16 15))) (const? 8 127)) ⊑
     select
-      (icmp IntPredicate.eq (ashr (trunc 8 e) (const? 8 6))
+      (icmp IntPred.eq (ashr (trunc 8 e) (const? 8 6))
         (trunc 8 (lshr e (const? 16 8)) { «nsw» := false, «nuw» := true }))
-      (trunc 8 e) (select (icmp IntPredicate.sgt e (const? 16 (-1))) (const? 8 127) (const? 8 (-128))) := by
+      (trunc 8 e) (select (icmp IntPred.sgt e (const? 16 (-1))) (const? 8 127) (const? 8 (-128))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -81,9 +81,9 @@ theorem badimm2_thm (e : IntW 16) :
 
 
 theorem badimm3_thm (e : IntW 16) :
-  select (icmp IntPredicate.eq (ashr (trunc 8 e) (const? 8 7)) (trunc 8 (lshr e (const? 16 8)))) (trunc 8 e)
+  select (icmp IntPred.eq (ashr (trunc 8 e) (const? 8 7)) (trunc 8 (lshr e (const? 16 8)))) (trunc 8 e)
       (LLVM.xor (trunc 8 (ashr e (const? 16 14))) (const? 8 127)) ⊑
-    select (icmp IntPredicate.ult (add e (const? 16 128)) (const? 16 256)) (trunc 8 e)
+    select (icmp IntPred.ult (add e (const? 16 128)) (const? 16 256)) (trunc 8 e)
       (LLVM.xor (trunc 8 (ashr e (const? 16 14)) { «nsw» := true, «nuw» := false }) (const? 8 127)) := by
     simp_alive_undef
     simp_alive_ops
@@ -94,10 +94,10 @@ theorem badimm3_thm (e : IntW 16) :
 
 
 theorem badimm4_thm (e : IntW 16) :
-  select (icmp IntPredicate.eq (ashr (trunc 8 e) (const? 8 7)) (trunc 8 (lshr e (const? 16 8)))) (trunc 8 e)
+  select (icmp IntPred.eq (ashr (trunc 8 e) (const? 8 7)) (trunc 8 (lshr e (const? 16 8)))) (trunc 8 e)
       (LLVM.xor (trunc 8 (ashr e (const? 16 15))) (const? 8 126)) ⊑
-    select (icmp IntPredicate.sgt e (const? 16 127)) (const? 8 126)
-      (select (icmp IntPredicate.slt e (const? 16 (-128))) (const? 8 (-127)) (trunc 8 e)) := by
+    select (icmp IntPred.sgt e (const? 16 127)) (const? 8 126)
+      (select (icmp IntPred.slt e (const? 16 (-128))) (const? 8 (-127)) (trunc 8 e)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -107,9 +107,9 @@ theorem badimm4_thm (e : IntW 16) :
 
 
 theorem C0zero_thm (e e_1 e_2 : IntW 8) :
-  select (icmp IntPredicate.ult (add e_2 (const? 8 10)) (const? 8 0)) e_2
-      (select (icmp IntPredicate.slt e_2 (const? 8 (-10))) e_1 e) ⊑
-    select (icmp IntPredicate.slt e_2 (const? 8 (-10))) e_1 e := by
+  select (icmp IntPred.ult (add e_2 (const? 8 10)) (const? 8 0)) e_2
+      (select (icmp IntPred.slt e_2 (const? 8 (-10))) e_1 e) ⊑
+    select (icmp IntPred.slt e_2 (const? 8 (-10))) e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gtrunchinseltpoison_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gtrunchinseltpoison_proof.lean
@@ -295,10 +295,10 @@ theorem trunc_shl_shl_var_thm (e e_1 : IntW 64) :
 theorem PR44545_thm (e e_1 : IntW 32) :
   add
       (trunc 16
-        (select (icmp IntPredicate.eq e_1 (const? 32 0)) (const? 32 0)
+        (select (icmp IntPred.eq e_1 (const? 32 0)) (const? 32 0)
           (add e (const? 32 1) { «nsw» := true, «nuw» := true })))
       (const? 16 (-1)) { «nsw» := true, «nuw» := false } ⊑
-    select (icmp IntPredicate.eq e_1 (const? 32 0)) (const? 16 (-1)) (trunc 16 e) := by
+    select (icmp IntPred.eq e_1 (const? 32 0)) (const? 16 (-1)) (trunc 16 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/guaddo_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/guaddo_proof.lean
@@ -12,8 +12,8 @@ set_option Elab.async false
 
 section guaddo_proof
 theorem uaddo_commute3_thm (e e_1 e_2 : IntW 32) :
-  select (icmp IntPredicate.ult (LLVM.xor e_2 (const? 32 (-1))) e_1) e (add e_1 e_2) ⊑
-    select (icmp IntPredicate.ugt e_1 (LLVM.xor e_2 (const? 32 (-1)))) e (add e_1 e_2) := by
+  select (icmp IntPred.ult (LLVM.xor e_2 (const? 32 (-1))) e_1) e (add e_1 e_2) ⊑
+    select (icmp IntPred.ugt e_1 (LLVM.xor e_2 (const? 32 (-1)))) e (add e_1 e_2) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -23,8 +23,8 @@ theorem uaddo_commute3_thm (e e_1 e_2 : IntW 32) :
 
 
 theorem uaddo_commute4_thm (e e_1 e_2 : IntW 32) :
-  select (icmp IntPredicate.ult (LLVM.xor e_2 (const? 32 (-1))) e_1) e (add e_2 e_1) ⊑
-    select (icmp IntPredicate.ugt e_1 (LLVM.xor e_2 (const? 32 (-1)))) e (add e_2 e_1) := by
+  select (icmp IntPred.ult (LLVM.xor e_2 (const? 32 (-1))) e_1) e (add e_2 e_1) ⊑
+    select (icmp IntPred.ugt e_1 (LLVM.xor e_2 (const? 32 (-1)))) e (add e_2 e_1) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -34,8 +34,8 @@ theorem uaddo_commute4_thm (e e_1 e_2 : IntW 32) :
 
 
 theorem uaddo_commute7_thm (e e_1 e_2 : IntW 32) :
-  select (icmp IntPredicate.ult (LLVM.xor e_2 (const? 32 (-1))) e_1) (add e_1 e_2) e ⊑
-    select (icmp IntPredicate.ugt e_1 (LLVM.xor e_2 (const? 32 (-1)))) (add e_1 e_2) e := by
+  select (icmp IntPred.ult (LLVM.xor e_2 (const? 32 (-1))) e_1) (add e_1 e_2) e ⊑
+    select (icmp IntPred.ugt e_1 (LLVM.xor e_2 (const? 32 (-1)))) (add e_1 e_2) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -45,8 +45,8 @@ theorem uaddo_commute7_thm (e e_1 e_2 : IntW 32) :
 
 
 theorem uaddo_commute8_thm (e e_1 e_2 : IntW 32) :
-  select (icmp IntPredicate.ult (LLVM.xor e_2 (const? 32 (-1))) e_1) (add e_2 e_1) e ⊑
-    select (icmp IntPredicate.ugt e_1 (LLVM.xor e_2 (const? 32 (-1)))) (add e_2 e_1) e := by
+  select (icmp IntPred.ult (LLVM.xor e_2 (const? 32 (-1))) e_1) (add e_2 e_1) e ⊑
+    select (icmp IntPred.ugt e_1 (LLVM.xor e_2 (const? 32 (-1)))) (add e_2 e_1) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -56,8 +56,8 @@ theorem uaddo_commute8_thm (e e_1 e_2 : IntW 32) :
 
 
 theorem uaddo_wrong_pred2_thm (e e_1 e_2 : IntW 32) :
-  select (icmp IntPredicate.uge e_2 (LLVM.xor e_1 (const? 32 (-1)))) e (add e_2 e_1) ⊑
-    select (icmp IntPredicate.ult e_2 (LLVM.xor e_1 (const? 32 (-1)))) (add e_2 e_1) e := by
+  select (icmp IntPred.uge e_2 (LLVM.xor e_1 (const? 32 (-1)))) e (add e_2 e_1) ⊑
+    select (icmp IntPred.ult e_2 (LLVM.xor e_1 (const? 32 (-1)))) (add e_2 e_1) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gumaxhicmp_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gumaxhicmp_proof.lean
@@ -12,7 +12,7 @@ set_option Elab.async false
 
 section gumaxhicmp_proof
 theorem eq_umax1_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.eq (select (icmp IntPredicate.ugt e_1 e) e_1 e) e_1 ⊑ icmp IntPredicate.uge e_1 e := by
+  icmp IntPred.eq (select (icmp IntPred.ugt e_1 e) e_1 e) e_1 ⊑ icmp IntPred.uge e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -22,7 +22,7 @@ theorem eq_umax1_thm (e e_1 : IntW 32) :
 
 
 theorem eq_umax2_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.eq (select (icmp IntPredicate.ugt e_1 e) e_1 e) e ⊑ icmp IntPredicate.uge e e_1 := by
+  icmp IntPred.eq (select (icmp IntPred.ugt e_1 e) e_1 e) e ⊑ icmp IntPred.uge e e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -32,9 +32,9 @@ theorem eq_umax2_thm (e e_1 : IntW 32) :
 
 
 theorem eq_umax3_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.eq (add e_1 (const? 32 3))
-      (select (icmp IntPredicate.ugt (add e_1 (const? 32 3)) e) (add e_1 (const? 32 3)) e) ⊑
-    icmp IntPredicate.uge (add e_1 (const? 32 3)) e := by
+  icmp IntPred.eq (add e_1 (const? 32 3))
+      (select (icmp IntPred.ugt (add e_1 (const? 32 3)) e) (add e_1 (const? 32 3)) e) ⊑
+    icmp IntPred.uge (add e_1 (const? 32 3)) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -44,9 +44,9 @@ theorem eq_umax3_thm (e e_1 : IntW 32) :
 
 
 theorem eq_umax4_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.eq (add e_1 (const? 32 3))
-      (select (icmp IntPredicate.ugt e (add e_1 (const? 32 3))) e (add e_1 (const? 32 3))) ⊑
-    icmp IntPredicate.uge (add e_1 (const? 32 3)) e := by
+  icmp IntPred.eq (add e_1 (const? 32 3))
+      (select (icmp IntPred.ugt e (add e_1 (const? 32 3))) e (add e_1 (const? 32 3))) ⊑
+    icmp IntPred.uge (add e_1 (const? 32 3)) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -56,7 +56,7 @@ theorem eq_umax4_thm (e e_1 : IntW 32) :
 
 
 theorem ule_umax1_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.ule (select (icmp IntPredicate.ugt e_1 e) e_1 e) e_1 ⊑ icmp IntPredicate.ule e e_1 := by
+  icmp IntPred.ule (select (icmp IntPred.ugt e_1 e) e_1 e) e_1 ⊑ icmp IntPred.ule e e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -66,7 +66,7 @@ theorem ule_umax1_thm (e e_1 : IntW 32) :
 
 
 theorem ule_umax2_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.ule (select (icmp IntPredicate.ugt e_1 e) e_1 e) e ⊑ icmp IntPredicate.ule e_1 e := by
+  icmp IntPred.ule (select (icmp IntPred.ugt e_1 e) e_1 e) e ⊑ icmp IntPred.ule e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -76,9 +76,9 @@ theorem ule_umax2_thm (e e_1 : IntW 32) :
 
 
 theorem ule_umax3_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.uge (add e_1 (const? 32 3))
-      (select (icmp IntPredicate.ugt (add e_1 (const? 32 3)) e) (add e_1 (const? 32 3)) e) ⊑
-    icmp IntPredicate.ule e (add e_1 (const? 32 3)) := by
+  icmp IntPred.uge (add e_1 (const? 32 3))
+      (select (icmp IntPred.ugt (add e_1 (const? 32 3)) e) (add e_1 (const? 32 3)) e) ⊑
+    icmp IntPred.ule e (add e_1 (const? 32 3)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -88,9 +88,9 @@ theorem ule_umax3_thm (e e_1 : IntW 32) :
 
 
 theorem ule_umax4_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.uge (add e_1 (const? 32 3))
-      (select (icmp IntPredicate.ugt e (add e_1 (const? 32 3))) e (add e_1 (const? 32 3))) ⊑
-    icmp IntPredicate.ule e (add e_1 (const? 32 3)) := by
+  icmp IntPred.uge (add e_1 (const? 32 3))
+      (select (icmp IntPred.ugt e (add e_1 (const? 32 3))) e (add e_1 (const? 32 3))) ⊑
+    icmp IntPred.ule e (add e_1 (const? 32 3)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -100,7 +100,7 @@ theorem ule_umax4_thm (e e_1 : IntW 32) :
 
 
 theorem ne_umax1_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.ne (select (icmp IntPredicate.ugt e_1 e) e_1 e) e_1 ⊑ icmp IntPredicate.ult e_1 e := by
+  icmp IntPred.ne (select (icmp IntPred.ugt e_1 e) e_1 e) e_1 ⊑ icmp IntPred.ult e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -110,7 +110,7 @@ theorem ne_umax1_thm (e e_1 : IntW 32) :
 
 
 theorem ne_umax2_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.ne (select (icmp IntPredicate.ugt e_1 e) e_1 e) e ⊑ icmp IntPredicate.ult e e_1 := by
+  icmp IntPred.ne (select (icmp IntPred.ugt e_1 e) e_1 e) e ⊑ icmp IntPred.ult e e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -120,9 +120,9 @@ theorem ne_umax2_thm (e e_1 : IntW 32) :
 
 
 theorem ne_umax3_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.ne (add e_1 (const? 32 3))
-      (select (icmp IntPredicate.ugt (add e_1 (const? 32 3)) e) (add e_1 (const? 32 3)) e) ⊑
-    icmp IntPredicate.ult (add e_1 (const? 32 3)) e := by
+  icmp IntPred.ne (add e_1 (const? 32 3))
+      (select (icmp IntPred.ugt (add e_1 (const? 32 3)) e) (add e_1 (const? 32 3)) e) ⊑
+    icmp IntPred.ult (add e_1 (const? 32 3)) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -132,9 +132,9 @@ theorem ne_umax3_thm (e e_1 : IntW 32) :
 
 
 theorem ne_umax4_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.ne (add e_1 (const? 32 3))
-      (select (icmp IntPredicate.ugt e (add e_1 (const? 32 3))) e (add e_1 (const? 32 3))) ⊑
-    icmp IntPredicate.ult (add e_1 (const? 32 3)) e := by
+  icmp IntPred.ne (add e_1 (const? 32 3))
+      (select (icmp IntPred.ugt e (add e_1 (const? 32 3))) e (add e_1 (const? 32 3))) ⊑
+    icmp IntPred.ult (add e_1 (const? 32 3)) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -144,7 +144,7 @@ theorem ne_umax4_thm (e e_1 : IntW 32) :
 
 
 theorem ugt_umax1_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.ugt (select (icmp IntPredicate.ugt e_1 e) e_1 e) e_1 ⊑ icmp IntPredicate.ugt e e_1 := by
+  icmp IntPred.ugt (select (icmp IntPred.ugt e_1 e) e_1 e) e_1 ⊑ icmp IntPred.ugt e e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -154,7 +154,7 @@ theorem ugt_umax1_thm (e e_1 : IntW 32) :
 
 
 theorem ugt_umax2_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.ugt (select (icmp IntPredicate.ugt e_1 e) e_1 e) e ⊑ icmp IntPredicate.ugt e_1 e := by
+  icmp IntPred.ugt (select (icmp IntPred.ugt e_1 e) e_1 e) e ⊑ icmp IntPred.ugt e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -164,9 +164,9 @@ theorem ugt_umax2_thm (e e_1 : IntW 32) :
 
 
 theorem ugt_umax3_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.ult (add e_1 (const? 32 3))
-      (select (icmp IntPredicate.ugt (add e_1 (const? 32 3)) e) (add e_1 (const? 32 3)) e) ⊑
-    icmp IntPredicate.ugt e (add e_1 (const? 32 3)) := by
+  icmp IntPred.ult (add e_1 (const? 32 3))
+      (select (icmp IntPred.ugt (add e_1 (const? 32 3)) e) (add e_1 (const? 32 3)) e) ⊑
+    icmp IntPred.ugt e (add e_1 (const? 32 3)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -176,9 +176,9 @@ theorem ugt_umax3_thm (e e_1 : IntW 32) :
 
 
 theorem ugt_umax4_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.ult (add e_1 (const? 32 3))
-      (select (icmp IntPredicate.ugt e (add e_1 (const? 32 3))) e (add e_1 (const? 32 3))) ⊑
-    icmp IntPredicate.ugt e (add e_1 (const? 32 3)) := by
+  icmp IntPred.ult (add e_1 (const? 32 3))
+      (select (icmp IntPred.ugt e (add e_1 (const? 32 3))) e (add e_1 (const? 32 3))) ⊑
+    icmp IntPred.ugt e (add e_1 (const? 32 3)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/guminhicmp_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/guminhicmp_proof.lean
@@ -12,7 +12,7 @@ set_option Elab.async false
 
 section guminhicmp_proof
 theorem eq_umin1_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.eq (select (icmp IntPredicate.ult e_1 e) e_1 e) e_1 ⊑ icmp IntPredicate.ule e_1 e := by
+  icmp IntPred.eq (select (icmp IntPred.ult e_1 e) e_1 e) e_1 ⊑ icmp IntPred.ule e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -22,7 +22,7 @@ theorem eq_umin1_thm (e e_1 : IntW 32) :
 
 
 theorem eq_umin2_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.eq (select (icmp IntPredicate.ult e_1 e) e_1 e) e ⊑ icmp IntPredicate.ule e e_1 := by
+  icmp IntPred.eq (select (icmp IntPred.ult e_1 e) e_1 e) e ⊑ icmp IntPred.ule e e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -32,9 +32,9 @@ theorem eq_umin2_thm (e e_1 : IntW 32) :
 
 
 theorem eq_umin3_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.eq (add e_1 (const? 32 3))
-      (select (icmp IntPredicate.ult (add e_1 (const? 32 3)) e) (add e_1 (const? 32 3)) e) ⊑
-    icmp IntPredicate.ule (add e_1 (const? 32 3)) e := by
+  icmp IntPred.eq (add e_1 (const? 32 3))
+      (select (icmp IntPred.ult (add e_1 (const? 32 3)) e) (add e_1 (const? 32 3)) e) ⊑
+    icmp IntPred.ule (add e_1 (const? 32 3)) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -44,9 +44,9 @@ theorem eq_umin3_thm (e e_1 : IntW 32) :
 
 
 theorem eq_umin4_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.eq (add e_1 (const? 32 3))
-      (select (icmp IntPredicate.ult e (add e_1 (const? 32 3))) e (add e_1 (const? 32 3))) ⊑
-    icmp IntPredicate.ule (add e_1 (const? 32 3)) e := by
+  icmp IntPred.eq (add e_1 (const? 32 3))
+      (select (icmp IntPred.ult e (add e_1 (const? 32 3))) e (add e_1 (const? 32 3))) ⊑
+    icmp IntPred.ule (add e_1 (const? 32 3)) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -56,7 +56,7 @@ theorem eq_umin4_thm (e e_1 : IntW 32) :
 
 
 theorem uge_umin1_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.uge (select (icmp IntPredicate.ult e_1 e) e_1 e) e_1 ⊑ icmp IntPredicate.uge e e_1 := by
+  icmp IntPred.uge (select (icmp IntPred.ult e_1 e) e_1 e) e_1 ⊑ icmp IntPred.uge e e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -66,7 +66,7 @@ theorem uge_umin1_thm (e e_1 : IntW 32) :
 
 
 theorem uge_umin2_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.uge (select (icmp IntPredicate.ult e_1 e) e_1 e) e ⊑ icmp IntPredicate.uge e_1 e := by
+  icmp IntPred.uge (select (icmp IntPred.ult e_1 e) e_1 e) e ⊑ icmp IntPred.uge e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -76,9 +76,9 @@ theorem uge_umin2_thm (e e_1 : IntW 32) :
 
 
 theorem uge_umin3_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.ule (add e_1 (const? 32 3))
-      (select (icmp IntPredicate.ult (add e_1 (const? 32 3)) e) (add e_1 (const? 32 3)) e) ⊑
-    icmp IntPredicate.uge e (add e_1 (const? 32 3)) := by
+  icmp IntPred.ule (add e_1 (const? 32 3))
+      (select (icmp IntPred.ult (add e_1 (const? 32 3)) e) (add e_1 (const? 32 3)) e) ⊑
+    icmp IntPred.uge e (add e_1 (const? 32 3)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -88,9 +88,9 @@ theorem uge_umin3_thm (e e_1 : IntW 32) :
 
 
 theorem uge_umin4_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.ule (add e_1 (const? 32 3))
-      (select (icmp IntPredicate.ult e (add e_1 (const? 32 3))) e (add e_1 (const? 32 3))) ⊑
-    icmp IntPredicate.uge e (add e_1 (const? 32 3)) := by
+  icmp IntPred.ule (add e_1 (const? 32 3))
+      (select (icmp IntPred.ult e (add e_1 (const? 32 3))) e (add e_1 (const? 32 3))) ⊑
+    icmp IntPred.uge e (add e_1 (const? 32 3)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -100,7 +100,7 @@ theorem uge_umin4_thm (e e_1 : IntW 32) :
 
 
 theorem ne_umin1_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.ne (select (icmp IntPredicate.ult e_1 e) e_1 e) e_1 ⊑ icmp IntPredicate.ugt e_1 e := by
+  icmp IntPred.ne (select (icmp IntPred.ult e_1 e) e_1 e) e_1 ⊑ icmp IntPred.ugt e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -110,7 +110,7 @@ theorem ne_umin1_thm (e e_1 : IntW 32) :
 
 
 theorem ne_umin2_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.ne (select (icmp IntPredicate.ult e_1 e) e_1 e) e ⊑ icmp IntPredicate.ugt e e_1 := by
+  icmp IntPred.ne (select (icmp IntPred.ult e_1 e) e_1 e) e ⊑ icmp IntPred.ugt e e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -120,9 +120,9 @@ theorem ne_umin2_thm (e e_1 : IntW 32) :
 
 
 theorem ne_umin3_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.ne (add e_1 (const? 32 3))
-      (select (icmp IntPredicate.ult (add e_1 (const? 32 3)) e) (add e_1 (const? 32 3)) e) ⊑
-    icmp IntPredicate.ugt (add e_1 (const? 32 3)) e := by
+  icmp IntPred.ne (add e_1 (const? 32 3))
+      (select (icmp IntPred.ult (add e_1 (const? 32 3)) e) (add e_1 (const? 32 3)) e) ⊑
+    icmp IntPred.ugt (add e_1 (const? 32 3)) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -132,9 +132,9 @@ theorem ne_umin3_thm (e e_1 : IntW 32) :
 
 
 theorem ne_umin4_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.ne (add e_1 (const? 32 3))
-      (select (icmp IntPredicate.ult e (add e_1 (const? 32 3))) e (add e_1 (const? 32 3))) ⊑
-    icmp IntPredicate.ugt (add e_1 (const? 32 3)) e := by
+  icmp IntPred.ne (add e_1 (const? 32 3))
+      (select (icmp IntPred.ult e (add e_1 (const? 32 3))) e (add e_1 (const? 32 3))) ⊑
+    icmp IntPred.ugt (add e_1 (const? 32 3)) e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -144,7 +144,7 @@ theorem ne_umin4_thm (e e_1 : IntW 32) :
 
 
 theorem ult_umin1_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.ult (select (icmp IntPredicate.ult e_1 e) e_1 e) e_1 ⊑ icmp IntPredicate.ult e e_1 := by
+  icmp IntPred.ult (select (icmp IntPred.ult e_1 e) e_1 e) e_1 ⊑ icmp IntPred.ult e e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -154,7 +154,7 @@ theorem ult_umin1_thm (e e_1 : IntW 32) :
 
 
 theorem ult_umin2_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.ult (select (icmp IntPredicate.ult e_1 e) e_1 e) e ⊑ icmp IntPredicate.ult e_1 e := by
+  icmp IntPred.ult (select (icmp IntPred.ult e_1 e) e_1 e) e ⊑ icmp IntPred.ult e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -164,9 +164,9 @@ theorem ult_umin2_thm (e e_1 : IntW 32) :
 
 
 theorem ult_umin3_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.ugt (add e_1 (const? 32 3))
-      (select (icmp IntPredicate.ult (add e_1 (const? 32 3)) e) (add e_1 (const? 32 3)) e) ⊑
-    icmp IntPredicate.ult e (add e_1 (const? 32 3)) := by
+  icmp IntPred.ugt (add e_1 (const? 32 3))
+      (select (icmp IntPred.ult (add e_1 (const? 32 3)) e) (add e_1 (const? 32 3)) e) ⊑
+    icmp IntPred.ult e (add e_1 (const? 32 3)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -176,9 +176,9 @@ theorem ult_umin3_thm (e e_1 : IntW 32) :
 
 
 theorem ult_umin4_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.ugt (add e_1 (const? 32 3))
-      (select (icmp IntPredicate.ult e (add e_1 (const? 32 3))) e (add e_1 (const? 32 3))) ⊑
-    icmp IntPredicate.ult e (add e_1 (const? 32 3)) := by
+  icmp IntPred.ugt (add e_1 (const? 32 3))
+      (select (icmp IntPred.ult e (add e_1 (const? 32 3))) e (add e_1 (const? 32 3))) ⊑
+    icmp IntPred.ult e (add e_1 (const? 32 3)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gunsigned_saturated_sub_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gunsigned_saturated_sub_proof.lean
@@ -12,7 +12,7 @@ set_option Elab.async false
 
 section gunsigned_saturated_sub_proof
 theorem max_sub_ugt_c0_thm (e : IntW 32) :
-  select (icmp IntPredicate.ugt e (const? 32 (-1))) (add e (const? 32 0)) (const? 32 0) ⊑ const? 32 0 := by
+  select (icmp IntPred.ugt e (const? 32 (-1))) (add e (const? 32 0)) (const? 32 0) ⊑ const? 32 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -22,8 +22,8 @@ theorem max_sub_ugt_c0_thm (e : IntW 32) :
 
 
 theorem max_sub_ult_c1_thm (e : IntW 32) :
-  select (icmp IntPredicate.ult e (const? 32 1)) (add e (const? 32 (-1))) (const? 32 0) ⊑
-    sext 32 (icmp IntPredicate.eq e (const? 32 0)) := by
+  select (icmp IntPred.ult e (const? 32 1)) (add e (const? 32 (-1))) (const? 32 0) ⊑
+    sext 32 (icmp IntPred.eq e (const? 32 0)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -33,8 +33,8 @@ theorem max_sub_ult_c1_thm (e : IntW 32) :
 
 
 theorem max_sub_ugt_c32_thm (e : IntW 32) :
-  select (icmp IntPredicate.ugt (const? 32 3) e) (add e (const? 32 (-2))) (const? 32 0) ⊑
-    select (icmp IntPredicate.ult e (const? 32 3)) (add e (const? 32 (-2))) (const? 32 0) := by
+  select (icmp IntPred.ugt (const? 32 3) e) (add e (const? 32 (-2))) (const? 32 0) ⊑
+    select (icmp IntPred.ult e (const? 32 3)) (add e (const? 32 (-2))) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -44,8 +44,8 @@ theorem max_sub_ugt_c32_thm (e : IntW 32) :
 
 
 theorem max_sub_uge_c32_thm (e : IntW 32) :
-  select (icmp IntPredicate.uge (const? 32 2) e) (add e (const? 32 (-2))) (const? 32 0) ⊑
-    select (icmp IntPredicate.ult e (const? 32 3)) (add e (const? 32 (-2))) (const? 32 0) := by
+  select (icmp IntPred.uge (const? 32 2) e) (add e (const? 32 (-2))) (const? 32 0) ⊑
+    select (icmp IntPred.ult e (const? 32 3)) (add e (const? 32 (-2))) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -55,8 +55,8 @@ theorem max_sub_uge_c32_thm (e : IntW 32) :
 
 
 theorem max_sub_ult_c12_thm (e : IntW 32) :
-  select (icmp IntPredicate.ult e (const? 32 1)) (add e (const? 32 (-2))) (const? 32 0) ⊑
-    select (icmp IntPredicate.eq e (const? 32 0)) (const? 32 (-2)) (const? 32 0) := by
+  select (icmp IntPred.ult e (const? 32 1)) (add e (const? 32 (-2))) (const? 32 0) ⊑
+    select (icmp IntPred.eq e (const? 32 0)) (const? 32 (-2)) (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -66,7 +66,7 @@ theorem max_sub_ult_c12_thm (e : IntW 32) :
 
 
 theorem max_sub_ult_c0_thm (e : IntW 32) :
-  select (icmp IntPredicate.ult e (const? 32 0)) (add e (const? 32 (-1))) (const? 32 0) ⊑ const? 32 0 := by
+  select (icmp IntPred.ult e (const? 32 0)) (add e (const? 32 (-1))) (const? 32 0) ⊑ const? 32 0 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gunsignedhaddhlackhofhoverflowhcheck_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gunsignedhaddhlackhofhoverflowhcheck_proof.lean
@@ -12,7 +12,7 @@ set_option Elab.async false
 
 section gunsignedhaddhlackhofhoverflowhcheck_proof
 theorem t0_basic_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.uge (add e_1 e) e ⊑ icmp IntPredicate.ule e_1 (LLVM.xor e (const? 8 (-1))) := by
+  icmp IntPred.uge (add e_1 e) e ⊑ icmp IntPred.ule e_1 (LLVM.xor e (const? 8 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -22,7 +22,7 @@ theorem t0_basic_thm (e e_1 : IntW 8) :
 
 
 theorem t2_symmetry_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.uge (add e_1 e) e_1 ⊑ icmp IntPredicate.ule e (LLVM.xor e_1 (const? 8 (-1))) := by
+  icmp IntPred.uge (add e_1 e) e_1 ⊑ icmp IntPred.ule e (LLVM.xor e_1 (const? 8 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -32,7 +32,7 @@ theorem t2_symmetry_thm (e e_1 : IntW 8) :
 
 
 theorem t4_commutative_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.ule e_1 (add e e_1) ⊑ icmp IntPredicate.ule e (LLVM.xor e_1 (const? 8 (-1))) := by
+  icmp IntPred.ule e_1 (add e e_1) ⊑ icmp IntPred.ule e (LLVM.xor e_1 (const? 8 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -42,7 +42,7 @@ theorem t4_commutative_thm (e e_1 : IntW 8) :
 
 
 theorem n10_wrong_pred2_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.eq (add e_1 e) e ⊑ icmp IntPredicate.eq e_1 (const? 8 0) := by
+  icmp IntPred.eq (add e_1 e) e ⊑ icmp IntPred.eq e_1 (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -52,7 +52,7 @@ theorem n10_wrong_pred2_thm (e e_1 : IntW 8) :
 
 
 theorem n11_wrong_pred3_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.ne (add e_1 e) e ⊑ icmp IntPredicate.ne e_1 (const? 8 0) := by
+  icmp IntPred.ne (add e_1 e) e ⊑ icmp IntPred.ne e_1 (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -62,7 +62,7 @@ theorem n11_wrong_pred3_thm (e e_1 : IntW 8) :
 
 
 theorem low_bitmask_ult_thm (e : IntW 8) :
-  icmp IntPredicate.ult (LLVM.and (add e (const? 8 31)) (const? 8 31)) e ⊑ icmp IntPredicate.ne e (const? 8 0) := by
+  icmp IntPred.ult (LLVM.and (add e (const? 8 31)) (const? 8 31)) e ⊑ icmp IntPred.ne e (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -72,8 +72,8 @@ theorem low_bitmask_ult_thm (e : IntW 8) :
 
 
 theorem low_bitmask_ugt_thm (e : IntW 8) :
-  icmp IntPredicate.ugt (mul e e) (LLVM.and (add (mul e e) (const? 8 127)) (const? 8 127)) ⊑
-    icmp IntPredicate.ne (mul e e) (const? 8 0) := by
+  icmp IntPred.ugt (mul e e) (LLVM.and (add (mul e e) (const? 8 127)) (const? 8 127)) ⊑
+    icmp IntPred.ne (mul e e) (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gunsignedhaddhlackhofhoverflowhcheckhviahadd_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gunsignedhaddhlackhofhoverflowhcheckhviahadd_proof.lean
@@ -12,7 +12,7 @@ set_option Elab.async false
 
 section gunsignedhaddhlackhofhoverflowhcheckhviahadd_proof
 theorem t6_no_extrause_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.uge (add e_1 e) e ⊑ icmp IntPredicate.ule e_1 (LLVM.xor e (const? 8 (-1))) := by
+  icmp IntPred.uge (add e_1 e) e ⊑ icmp IntPred.ule e_1 (LLVM.xor e (const? 8 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gunsignedhaddhlackhofhoverflowhcheckhviahxor_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gunsignedhaddhlackhofhoverflowhcheckhviahxor_proof.lean
@@ -12,8 +12,8 @@ set_option Elab.async false
 
 section gunsignedhaddhlackhofhoverflowhcheckhviahxor_proof
 theorem t3_no_extrause_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.uge (LLVM.xor e_1 (const? 8 (-1))) e ⊑
-    icmp IntPredicate.ule e (LLVM.xor e_1 (const? 8 (-1))) := by
+  icmp IntPred.uge (LLVM.xor e_1 (const? 8 (-1))) e ⊑
+    icmp IntPred.ule e (LLVM.xor e_1 (const? 8 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gunsignedhaddhoverflowhcheck_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gunsignedhaddhoverflowhcheck_proof.lean
@@ -12,7 +12,7 @@ set_option Elab.async false
 
 section gunsignedhaddhoverflowhcheck_proof
 theorem t0_basic_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.ult (add e_1 e) e ⊑ icmp IntPredicate.ugt e_1 (LLVM.xor e (const? 8 (-1))) := by
+  icmp IntPred.ult (add e_1 e) e ⊑ icmp IntPred.ugt e_1 (LLVM.xor e (const? 8 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -22,7 +22,7 @@ theorem t0_basic_thm (e e_1 : IntW 8) :
 
 
 theorem t2_symmetry_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.ult (add e_1 e) e_1 ⊑ icmp IntPredicate.ugt e (LLVM.xor e_1 (const? 8 (-1))) := by
+  icmp IntPred.ult (add e_1 e) e_1 ⊑ icmp IntPred.ugt e (LLVM.xor e_1 (const? 8 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -32,7 +32,7 @@ theorem t2_symmetry_thm (e e_1 : IntW 8) :
 
 
 theorem t4_commutative_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.ugt e_1 (add e e_1) ⊑ icmp IntPredicate.ugt e (LLVM.xor e_1 (const? 8 (-1))) := by
+  icmp IntPred.ugt e_1 (add e e_1) ⊑ icmp IntPred.ugt e (LLVM.xor e_1 (const? 8 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -42,7 +42,7 @@ theorem t4_commutative_thm (e e_1 : IntW 8) :
 
 
 theorem n10_wrong_pred2_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.eq (add e_1 e) e ⊑ icmp IntPredicate.eq e_1 (const? 8 0) := by
+  icmp IntPred.eq (add e_1 e) e ⊑ icmp IntPred.eq e_1 (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -52,7 +52,7 @@ theorem n10_wrong_pred2_thm (e e_1 : IntW 8) :
 
 
 theorem n11_wrong_pred3_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.ne (add e_1 e) e ⊑ icmp IntPredicate.ne e_1 (const? 8 0) := by
+  icmp IntPred.ne (add e_1 e) e ⊑ icmp IntPred.ne e_1 (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gunsignedhaddhoverflowhcheckhviahadd_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gunsignedhaddhoverflowhcheckhviahadd_proof.lean
@@ -12,7 +12,7 @@ set_option Elab.async false
 
 section gunsignedhaddhoverflowhcheckhviahadd_proof
 theorem t6_no_extrause_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.ult (add e_1 e) e ⊑ icmp IntPredicate.ugt e_1 (LLVM.xor e (const? 8 (-1))) := by
+  icmp IntPred.ult (add e_1 e) e ⊑ icmp IntPred.ugt e_1 (LLVM.xor e (const? 8 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gunsignedhaddhoverflowhcheckhviahxor_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gunsignedhaddhoverflowhcheckhviahxor_proof.lean
@@ -12,8 +12,8 @@ set_option Elab.async false
 
 section gunsignedhaddhoverflowhcheckhviahxor_proof
 theorem t3_no_extrause_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.ult (LLVM.xor e_1 (const? 8 (-1))) e ⊑
-    icmp IntPredicate.ugt e (LLVM.xor e_1 (const? 8 (-1))) := by
+  icmp IntPred.ult (LLVM.xor e_1 (const? 8 (-1))) e ⊑
+    icmp IntPred.ugt e (LLVM.xor e_1 (const? 8 (-1))) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gunsignedhsubhlackhofhoverflowhcheck_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gunsignedhsubhlackhofhoverflowhcheck_proof.lean
@@ -11,7 +11,7 @@ set_option maxRecDepth 1000000
 set_option Elab.async false
 
 section gunsignedhsubhlackhofhoverflowhcheck_proof
-theorem t0_basic_thm (e e_1 : IntW 8) : icmp IntPredicate.ule (sub e_1 e) e_1 ⊑ icmp IntPredicate.ule e e_1 := by
+theorem t0_basic_thm (e e_1 : IntW 8) : icmp IntPred.ule (sub e_1 e) e_1 ⊑ icmp IntPred.ule e e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -20,7 +20,7 @@ theorem t0_basic_thm (e e_1 : IntW 8) : icmp IntPredicate.ule (sub e_1 e) e_1 �
     all_goals sorry
 
 
-theorem t2_commutative_thm (e e_1 : IntW 8) : icmp IntPredicate.uge e_1 (sub e_1 e) ⊑ icmp IntPredicate.uge e_1 e := by
+theorem t2_commutative_thm (e e_1 : IntW 8) : icmp IntPred.uge e_1 (sub e_1 e) ⊑ icmp IntPred.uge e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -30,7 +30,7 @@ theorem t2_commutative_thm (e e_1 : IntW 8) : icmp IntPredicate.uge e_1 (sub e_1
 
 
 theorem n7_wrong_pred2_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.eq (sub e_1 e) e_1 ⊑ icmp IntPredicate.eq e (const? 8 0) := by
+  icmp IntPred.eq (sub e_1 e) e_1 ⊑ icmp IntPred.eq e (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -40,7 +40,7 @@ theorem n7_wrong_pred2_thm (e e_1 : IntW 8) :
 
 
 theorem n8_wrong_pred3_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.ne (sub e_1 e) e_1 ⊑ icmp IntPredicate.ne e (const? 8 0) := by
+  icmp IntPred.ne (sub e_1 e) e_1 ⊑ icmp IntPred.ne e (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gunsignedhsubhoverflowhcheck_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gunsignedhsubhoverflowhcheck_proof.lean
@@ -11,7 +11,7 @@ set_option maxRecDepth 1000000
 set_option Elab.async false
 
 section gunsignedhsubhoverflowhcheck_proof
-theorem t0_basic_thm (e e_1 : IntW 8) : icmp IntPredicate.ugt (sub e_1 e) e_1 ⊑ icmp IntPredicate.ugt e e_1 := by
+theorem t0_basic_thm (e e_1 : IntW 8) : icmp IntPred.ugt (sub e_1 e) e_1 ⊑ icmp IntPred.ugt e e_1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -20,7 +20,7 @@ theorem t0_basic_thm (e e_1 : IntW 8) : icmp IntPredicate.ugt (sub e_1 e) e_1 �
     all_goals sorry
 
 
-theorem t2_commutative_thm (e e_1 : IntW 8) : icmp IntPredicate.ult e_1 (sub e_1 e) ⊑ icmp IntPredicate.ult e_1 e := by
+theorem t2_commutative_thm (e e_1 : IntW 8) : icmp IntPred.ult e_1 (sub e_1 e) ⊑ icmp IntPred.ult e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -30,7 +30,7 @@ theorem t2_commutative_thm (e e_1 : IntW 8) : icmp IntPredicate.ult e_1 (sub e_1
 
 
 theorem n7_wrong_pred2_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.eq (sub e_1 e) e_1 ⊑ icmp IntPredicate.eq e (const? 8 0) := by
+  icmp IntPred.eq (sub e_1 e) e_1 ⊑ icmp IntPred.eq e (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -40,7 +40,7 @@ theorem n7_wrong_pred2_thm (e e_1 : IntW 8) :
 
 
 theorem n8_wrong_pred3_thm (e e_1 : IntW 8) :
-  icmp IntPredicate.ne (sub e_1 e) e_1 ⊑ icmp IntPredicate.ne e (const? 8 0) := by
+  icmp IntPred.ne (sub e_1 e) e_1 ⊑ icmp IntPred.ne e (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gxor2_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gxor2_proof.lean
@@ -12,8 +12,8 @@ set_option Elab.async false
 
 section gxor2_proof
 theorem test0_thm (e : IntW 32) :
-  icmp IntPredicate.sgt (LLVM.xor e (const? 32 (-2147483648))) (const? 32 (-1)) ⊑
-    icmp IntPredicate.slt e (const? 32 0) := by
+  icmp IntPred.sgt (LLVM.xor e (const? 32 (-2147483648))) (const? 32 (-1)) ⊑
+    icmp IntPred.slt e (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -23,7 +23,7 @@ theorem test0_thm (e : IntW 32) :
 
 
 theorem test1_thm (e : IntW 32) :
-  icmp IntPredicate.slt (LLVM.xor e (const? 32 12345)) (const? 32 0) ⊑ icmp IntPredicate.slt e (const? 32 0) := by
+  icmp IntPred.slt (LLVM.xor e (const? 32 12345)) (const? 32 0) ⊑ icmp IntPred.slt e (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gxor_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gxor_proof.lean
@@ -87,7 +87,7 @@ theorem test7_thm (e e_1 : IntW 32) :
 
 
 theorem test9_thm (e : IntW 8) :
-  icmp IntPredicate.eq (LLVM.xor e (const? 8 123)) (const? 8 34) ⊑ icmp IntPredicate.eq e (const? 8 89) := by
+  icmp IntPred.eq (LLVM.xor e (const? 8 123)) (const? 8 34) ⊑ icmp IntPred.eq e (const? 8 89) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -119,7 +119,7 @@ theorem test11_thm (e : IntW 8) :
 
 
 theorem test12_thm (e : IntW 8) :
-  icmp IntPredicate.ne (LLVM.xor e (const? 8 4)) (const? 8 0) ⊑ icmp IntPredicate.ne e (const? 8 4) := by
+  icmp IntPred.ne (LLVM.xor e (const? 8 4)) (const? 8 0) ⊑ icmp IntPred.ne e (const? 8 4) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -166,7 +166,7 @@ theorem fold_zext_xor_sandwich_thm (e : IntW 1) :
 
 
 theorem test23_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.eq (LLVM.xor e_1 e) e ⊑ icmp IntPredicate.eq e_1 (const? 32 0) := by
+  icmp IntPred.eq (LLVM.xor e_1 e) e ⊑ icmp IntPred.eq e_1 (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -176,7 +176,7 @@ theorem test23_thm (e e_1 : IntW 32) :
 
 
 theorem test24_thm (e e_1 : IntW 32) :
-  icmp IntPredicate.ne (LLVM.xor e_1 e) e ⊑ icmp IntPredicate.ne e_1 (const? 32 0) := by
+  icmp IntPred.ne (LLVM.xor e_1 e) e ⊑ icmp IntPred.ne e_1 (const? 32 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -196,7 +196,7 @@ theorem test25_thm (e e_1 : IntW 32) :
 
 
 theorem test27_thm (e e_1 e_2 : IntW 32) :
-  zext 32 (icmp IntPredicate.eq (LLVM.xor e_2 e_1) (LLVM.xor e_2 e)) ⊑ zext 32 (icmp IntPredicate.eq e_1 e) := by
+  zext 32 (icmp IntPred.eq (LLVM.xor e_2 e_1) (LLVM.xor e_2 e)) ⊑ zext 32 (icmp IntPred.eq e_1 e) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gxorhashr_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gxorhashr_proof.lean
@@ -13,7 +13,7 @@ set_option Elab.async false
 section gxorhashr_proof
 theorem testi8i8_thm (e : IntW 8) :
   LLVM.xor (ashr e (const? 8 7)) (const? 8 127) ⊑
-    select (icmp IntPredicate.sgt e (const? 8 (-1))) (const? 8 127) (const? 8 (-128)) := by
+    select (icmp IntPred.sgt e (const? 8 (-1))) (const? 8 127) (const? 8 (-128)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -24,7 +24,7 @@ theorem testi8i8_thm (e : IntW 8) :
 
 theorem testi16i8_thm (e : IntW 16) :
   LLVM.xor (trunc 8 (ashr e (const? 16 15))) (const? 8 27) ⊑
-    select (icmp IntPredicate.sgt e (const? 16 (-1))) (const? 8 27) (const? 8 (-28)) := by
+    select (icmp IntPred.sgt e (const? 16 (-1))) (const? 8 27) (const? 8 (-28)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -35,7 +35,7 @@ theorem testi16i8_thm (e : IntW 16) :
 
 theorem testi64i32_thm (e : IntW 64) :
   LLVM.xor (trunc 32 (ashr e (const? 64 63))) (const? 32 127) ⊑
-    select (icmp IntPredicate.sgt e (const? 64 (-1))) (const? 32 127) (const? 32 (-128)) := by
+    select (icmp IntPred.sgt e (const? 64 (-1))) (const? 32 127) (const? 32 (-128)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -46,7 +46,7 @@ theorem testi64i32_thm (e : IntW 64) :
 
 theorem testi128i128_thm (e : IntW 128) :
   LLVM.xor (ashr e (const? 128 127)) (const? 128 27) ⊑
-    select (icmp IntPredicate.sgt e (const? 128 (-1))) (const? 128 27) (const? 128 (-28)) := by
+    select (icmp IntPred.sgt e (const? 128 (-1))) (const? 128 27) (const? 128 (-28)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gxorhicmps_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gxorhicmps_proof.lean
@@ -12,8 +12,8 @@ set_option Elab.async false
 
 section gxorhicmps_proof
 theorem slt_zero_thm (e e_1 : IntW 4) :
-  LLVM.xor (icmp IntPredicate.slt e_1 (const? 4 0)) (icmp IntPredicate.slt e (const? 4 0)) ⊑
-    icmp IntPredicate.slt (LLVM.xor e_1 e) (const? 4 0) := by
+  LLVM.xor (icmp IntPred.slt e_1 (const? 4 0)) (icmp IntPred.slt e (const? 4 0)) ⊑
+    icmp IntPred.slt (LLVM.xor e_1 e) (const? 4 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -23,8 +23,8 @@ theorem slt_zero_thm (e e_1 : IntW 4) :
 
 
 theorem sgt_minus1_thm (e e_1 : IntW 4) :
-  LLVM.xor (icmp IntPredicate.sgt e_1 (const? 4 (-1))) (icmp IntPredicate.sgt e (const? 4 (-1))) ⊑
-    icmp IntPredicate.slt (LLVM.xor e_1 e) (const? 4 0) := by
+  LLVM.xor (icmp IntPred.sgt e_1 (const? 4 (-1))) (icmp IntPred.sgt e (const? 4 (-1))) ⊑
+    icmp IntPred.slt (LLVM.xor e_1 e) (const? 4 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -34,8 +34,8 @@ theorem sgt_minus1_thm (e e_1 : IntW 4) :
 
 
 theorem slt_zero_sgt_minus1_thm (e e_1 : IntW 4) :
-  LLVM.xor (icmp IntPredicate.slt e_1 (const? 4 0)) (icmp IntPredicate.sgt e (const? 4 (-1))) ⊑
-    icmp IntPredicate.sgt (LLVM.xor e_1 e) (const? 4 (-1)) := by
+  LLVM.xor (icmp IntPred.slt e_1 (const? 4 0)) (icmp IntPred.sgt e (const? 4 (-1))) ⊑
+    icmp IntPred.sgt (LLVM.xor e_1 e) (const? 4 (-1)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -45,7 +45,7 @@ theorem slt_zero_sgt_minus1_thm (e e_1 : IntW 4) :
 
 
 theorem test13_thm (e e_1 : IntW 8) :
-  LLVM.xor (icmp IntPredicate.ult e_1 e) (icmp IntPredicate.ugt e_1 e) ⊑ icmp IntPredicate.ne e_1 e := by
+  LLVM.xor (icmp IntPred.ult e_1 e) (icmp IntPred.ugt e_1 e) ⊑ icmp IntPred.ne e_1 e := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -55,7 +55,7 @@ theorem test13_thm (e e_1 : IntW 8) :
 
 
 theorem test14_thm (e e_1 : IntW 8) :
-  LLVM.xor (icmp IntPredicate.eq e_1 e) (icmp IntPredicate.ne e e_1) ⊑ const? 1 1 := by
+  LLVM.xor (icmp IntPred.eq e_1 e) (icmp IntPred.ne e e_1) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -65,7 +65,7 @@ theorem test14_thm (e e_1 : IntW 8) :
 
 
 theorem xor_icmp_true_signed_thm (e : IntW 32) :
-  LLVM.xor (icmp IntPredicate.sgt e (const? 32 5)) (icmp IntPredicate.slt e (const? 32 6)) ⊑ const? 1 1 := by
+  LLVM.xor (icmp IntPred.sgt e (const? 32 5)) (icmp IntPred.slt e (const? 32 6)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -75,7 +75,7 @@ theorem xor_icmp_true_signed_thm (e : IntW 32) :
 
 
 theorem xor_icmp_true_signed_commuted_thm (e : IntW 32) :
-  LLVM.xor (icmp IntPredicate.slt e (const? 32 6)) (icmp IntPredicate.sgt e (const? 32 5)) ⊑ const? 1 1 := by
+  LLVM.xor (icmp IntPred.slt e (const? 32 6)) (icmp IntPred.sgt e (const? 32 5)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -85,7 +85,7 @@ theorem xor_icmp_true_signed_commuted_thm (e : IntW 32) :
 
 
 theorem xor_icmp_true_unsigned_thm (e : IntW 32) :
-  LLVM.xor (icmp IntPredicate.ugt e (const? 32 5)) (icmp IntPredicate.ult e (const? 32 6)) ⊑ const? 1 1 := by
+  LLVM.xor (icmp IntPred.ugt e (const? 32 5)) (icmp IntPred.ult e (const? 32 6)) ⊑ const? 1 1 := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -95,8 +95,8 @@ theorem xor_icmp_true_unsigned_thm (e : IntW 32) :
 
 
 theorem xor_icmp_to_ne_thm (e : IntW 32) :
-  LLVM.xor (icmp IntPredicate.sgt e (const? 32 4)) (icmp IntPredicate.slt e (const? 32 6)) ⊑
-    icmp IntPredicate.ne e (const? 32 5) := by
+  LLVM.xor (icmp IntPred.sgt e (const? 32 4)) (icmp IntPred.slt e (const? 32 6)) ⊑
+    icmp IntPred.ne e (const? 32 5) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -106,8 +106,8 @@ theorem xor_icmp_to_ne_thm (e : IntW 32) :
 
 
 theorem xor_icmp_to_icmp_add_thm (e : IntW 32) :
-  LLVM.xor (icmp IntPredicate.sgt e (const? 32 3)) (icmp IntPredicate.slt e (const? 32 6)) ⊑
-    icmp IntPredicate.ult (add e (const? 32 (-6))) (const? 32 (-2)) := by
+  LLVM.xor (icmp IntPred.sgt e (const? 32 3)) (icmp IntPred.slt e (const? 32 6)) ⊑
+    icmp IntPred.ult (add e (const? 32 (-6))) (const? 32 (-2)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -117,8 +117,8 @@ theorem xor_icmp_to_icmp_add_thm (e : IntW 32) :
 
 
 theorem xor_icmp_invalid_range_thm (e : IntW 8) :
-  LLVM.xor (icmp IntPredicate.eq e (const? 8 0)) (icmp IntPredicate.ne e (const? 8 4)) ⊑
-    icmp IntPredicate.ne (LLVM.and e (const? 8 (-5))) (const? 8 0) := by
+  LLVM.xor (icmp IntPred.eq e (const? 8 0)) (icmp IntPred.ne e (const? 8 4)) ⊑
+    icmp IntPred.ne (LLVM.and e (const? 8 (-5))) (const? 8 0) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash

--- a/SSA/Projects/InstCombine/tests/proofs/gzext_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gzext_proof.lean
@@ -31,8 +31,8 @@ theorem fold_xor_zext_sandwich_thm (e : IntW 1) :
 
 
 theorem fold_and_zext_icmp_thm (e e_1 e_2 : IntW 64) :
-  LLVM.and (zext 8 (icmp IntPredicate.sgt e_2 e_1)) (zext 8 (icmp IntPredicate.slt e_2 e)) ⊑
-    zext 8 (LLVM.and (icmp IntPredicate.sgt e_2 e_1) (icmp IntPredicate.slt e_2 e)) := by
+  LLVM.and (zext 8 (icmp IntPred.sgt e_2 e_1)) (zext 8 (icmp IntPred.slt e_2 e)) ⊑
+    zext 8 (LLVM.and (icmp IntPred.sgt e_2 e_1) (icmp IntPred.slt e_2 e)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -42,8 +42,8 @@ theorem fold_and_zext_icmp_thm (e e_1 e_2 : IntW 64) :
 
 
 theorem fold_or_zext_icmp_thm (e e_1 e_2 : IntW 64) :
-  LLVM.or (zext 8 (icmp IntPredicate.sgt e_2 e_1)) (zext 8 (icmp IntPredicate.slt e_2 e)) ⊑
-    zext 8 (LLVM.or (icmp IntPredicate.sgt e_2 e_1) (icmp IntPredicate.slt e_2 e)) := by
+  LLVM.or (zext 8 (icmp IntPred.sgt e_2 e_1)) (zext 8 (icmp IntPred.slt e_2 e)) ⊑
+    zext 8 (LLVM.or (icmp IntPred.sgt e_2 e_1) (icmp IntPred.slt e_2 e)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -53,8 +53,8 @@ theorem fold_or_zext_icmp_thm (e e_1 e_2 : IntW 64) :
 
 
 theorem fold_xor_zext_icmp_thm (e e_1 e_2 : IntW 64) :
-  LLVM.xor (zext 8 (icmp IntPredicate.sgt e_2 e_1)) (zext 8 (icmp IntPredicate.slt e_2 e)) ⊑
-    zext 8 (LLVM.xor (icmp IntPredicate.sgt e_2 e_1) (icmp IntPredicate.slt e_2 e)) := by
+  LLVM.xor (zext 8 (icmp IntPred.sgt e_2 e_1)) (zext 8 (icmp IntPred.slt e_2 e)) ⊑
+    zext 8 (LLVM.xor (icmp IntPred.sgt e_2 e_1) (icmp IntPred.slt e_2 e)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -64,11 +64,11 @@ theorem fold_xor_zext_icmp_thm (e e_1 e_2 : IntW 64) :
 
 
 theorem fold_nested_logic_zext_icmp_thm (e e_1 e_2 e_3 : IntW 64) :
-  LLVM.or (LLVM.and (zext 8 (icmp IntPredicate.sgt e_3 e_2)) (zext 8 (icmp IntPredicate.slt e_3 e_1)))
-      (zext 8 (icmp IntPredicate.eq e_3 e)) ⊑
+  LLVM.or (LLVM.and (zext 8 (icmp IntPred.sgt e_3 e_2)) (zext 8 (icmp IntPred.slt e_3 e_1)))
+      (zext 8 (icmp IntPred.eq e_3 e)) ⊑
     zext 8
-      (LLVM.or (LLVM.and (icmp IntPredicate.sgt e_3 e_2) (icmp IntPredicate.slt e_3 e_1))
-        (icmp IntPredicate.eq e_3 e)) := by
+      (LLVM.or (LLVM.and (icmp IntPred.sgt e_3 e_2) (icmp IntPred.slt e_3 e_1))
+        (icmp IntPred.eq e_3 e)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -96,7 +96,7 @@ theorem sext_zext_apint2_thm (e : IntW 11) : sext 47 (zext 39 e) ⊑ zext 47 e :
 
 
 theorem masked_bit_set_thm (e e_1 : IntW 32) :
-  zext 32 (icmp IntPredicate.ne (LLVM.and (shl (const? 32 1) e_1) e) (const? 32 0)) ⊑
+  zext 32 (icmp IntPred.ne (LLVM.and (shl (const? 32 1) e_1) e) (const? 32 0)) ⊑
     LLVM.and (lshr e e_1) (const? 32 1) := by
     simp_alive_undef
     simp_alive_ops
@@ -107,7 +107,7 @@ theorem masked_bit_set_thm (e e_1 : IntW 32) :
 
 
 theorem masked_bit_clear_commute_thm (e e_1 : IntW 32) :
-  zext 32 (icmp IntPredicate.eq (LLVM.and (LLVM.srem (const? 32 42) e_1) (shl (const? 32 1) e)) (const? 32 0)) ⊑
+  zext 32 (icmp IntPred.eq (LLVM.and (LLVM.srem (const? 32 42) e_1) (shl (const? 32 1) e)) (const? 32 0)) ⊑
     LLVM.and (lshr (LLVM.xor (LLVM.srem (const? 32 42) e_1) (const? 32 (-1))) e) (const? 32 1) := by
     simp_alive_undef
     simp_alive_ops
@@ -118,9 +118,9 @@ theorem masked_bit_clear_commute_thm (e e_1 : IntW 32) :
 
 
 theorem div_bit_set_thm (e e_1 : IntW 32) :
-  zext 32 (icmp IntPredicate.ne (LLVM.sdiv (shl (const? 32 1) e_1) e) (const? 32 0)) ⊑
+  zext 32 (icmp IntPred.ne (LLVM.sdiv (shl (const? 32 1) e_1) e) (const? 32 0)) ⊑
     zext 32
-      (icmp IntPredicate.ne (LLVM.sdiv (shl (const? 32 1) e_1 { «nsw» := false, «nuw» := true }) e)
+      (icmp IntPred.ne (LLVM.sdiv (shl (const? 32 1) e_1 { «nsw» := false, «nuw» := true }) e)
         (const? 32 0)) := by
     simp_alive_undef
     simp_alive_ops
@@ -131,9 +131,9 @@ theorem div_bit_set_thm (e e_1 : IntW 32) :
 
 
 theorem masked_bit_set_nonzero_cmp_thm (e e_1 : IntW 32) :
-  zext 32 (icmp IntPredicate.ne (LLVM.and (shl (const? 32 1) e_1) e) (const? 32 1)) ⊑
+  zext 32 (icmp IntPred.ne (LLVM.and (shl (const? 32 1) e_1) e) (const? 32 1)) ⊑
     zext 32
-      (icmp IntPredicate.ne (LLVM.and (shl (const? 32 1) e_1 { «nsw» := false, «nuw» := true }) e)
+      (icmp IntPred.ne (LLVM.and (shl (const? 32 1) e_1 { «nsw» := false, «nuw» := true }) e)
         (const? 32 1)) := by
     simp_alive_undef
     simp_alive_ops
@@ -144,9 +144,9 @@ theorem masked_bit_set_nonzero_cmp_thm (e e_1 : IntW 32) :
 
 
 theorem masked_bit_wrong_pred_thm (e e_1 : IntW 32) :
-  zext 32 (icmp IntPredicate.sgt (LLVM.and (shl (const? 32 1) e_1) e) (const? 32 0)) ⊑
+  zext 32 (icmp IntPred.sgt (LLVM.and (shl (const? 32 1) e_1) e) (const? 32 0)) ⊑
     zext 32
-      (icmp IntPredicate.sgt (LLVM.and (shl (const? 32 1) e_1 { «nsw» := false, «nuw» := true }) e)
+      (icmp IntPred.sgt (LLVM.and (shl (const? 32 1) e_1 { «nsw» := false, «nuw» := true }) e)
         (const? 32 0)) := by
     simp_alive_undef
     simp_alive_ops
@@ -158,12 +158,12 @@ theorem masked_bit_wrong_pred_thm (e e_1 : IntW 32) :
 
 theorem zext_or_masked_bit_test_thm (e e_1 e_2 : IntW 32) :
   zext 32
-      (LLVM.or (icmp IntPredicate.ne (LLVM.and (shl (const? 32 1) e_2) e_1) (const? 32 0))
-        (icmp IntPredicate.eq e e_2)) ⊑
+      (LLVM.or (icmp IntPred.ne (LLVM.and (shl (const? 32 1) e_2) e_1) (const? 32 0))
+        (icmp IntPred.eq e e_2)) ⊑
     zext 32
       (LLVM.or
-        (icmp IntPredicate.ne (LLVM.and (shl (const? 32 1) e_2 { «nsw» := false, «nuw» := true }) e_1) (const? 32 0))
-        (icmp IntPredicate.eq e e_2)) := by
+        (icmp IntPred.ne (LLVM.and (shl (const? 32 1) e_2 { «nsw» := false, «nuw» := true }) e_1) (const? 32 0))
+        (icmp IntPred.eq e e_2)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -173,7 +173,7 @@ theorem zext_or_masked_bit_test_thm (e e_1 e_2 : IntW 32) :
 
 
 theorem zext_masked_bit_zero_to_smaller_bitwidth_thm (e e_1 : IntW 32) :
-  zext 16 (icmp IntPredicate.eq (LLVM.and (shl (const? 32 1) e_1) e) (const? 32 0)) ⊑
+  zext 16 (icmp IntPred.eq (LLVM.and (shl (const? 32 1) e_1) e) (const? 32 0)) ⊑
     LLVM.and (trunc 16 (lshr (LLVM.xor e (const? 32 (-1))) e_1)) (const? 16 1) := by
     simp_alive_undef
     simp_alive_ops
@@ -184,7 +184,7 @@ theorem zext_masked_bit_zero_to_smaller_bitwidth_thm (e e_1 : IntW 32) :
 
 
 theorem zext_masked_bit_nonzero_to_smaller_bitwidth_thm (e e_1 : IntW 32) :
-  zext 16 (icmp IntPredicate.ne (LLVM.and (shl (const? 32 1) e_1) e) (const? 32 0)) ⊑
+  zext 16 (icmp IntPred.ne (LLVM.and (shl (const? 32 1) e_1) e) (const? 32 0)) ⊑
     LLVM.and (trunc 16 (lshr e e_1)) (const? 16 1) := by
     simp_alive_undef
     simp_alive_ops
@@ -195,7 +195,7 @@ theorem zext_masked_bit_nonzero_to_smaller_bitwidth_thm (e e_1 : IntW 32) :
 
 
 theorem zext_masked_bit_zero_to_larger_bitwidth_thm (e e_1 : IntW 32) :
-  zext 64 (icmp IntPredicate.eq (LLVM.and (shl (const? 32 1) e_1) e) (const? 32 0)) ⊑
+  zext 64 (icmp IntPred.eq (LLVM.and (shl (const? 32 1) e_1) e) (const? 32 0)) ⊑
     zext 64 (LLVM.and (lshr (LLVM.xor e (const? 32 (-1))) e_1) (const? 32 1)) { «nneg» := true } := by
     simp_alive_undef
     simp_alive_ops

--- a/SSA/Projects/InstCombine/tests/proofs/gzexthorhicmp_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gzexthorhicmp_proof.lean
@@ -13,8 +13,8 @@ set_option Elab.async false
 section gzexthorhicmp_proof
 theorem zext_or_eq_ult_add_thm (e : IntW 32) :
   zext 32
-      (LLVM.or (icmp IntPredicate.ult (add e (const? 32 (-3))) (const? 32 3)) (icmp IntPredicate.eq e (const? 32 5))) ⊑
-    zext 32 (icmp IntPredicate.ult (add e (const? 32 (-3))) (const? 32 3)) := by
+      (LLVM.or (icmp IntPred.ult (add e (const? 32 (-3))) (const? 32 3)) (icmp IntPred.eq e (const? 32 5))) ⊑
+    zext 32 (icmp IntPred.ult (add e (const? 32 (-3))) (const? 32 3)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash
@@ -24,9 +24,9 @@ theorem zext_or_eq_ult_add_thm (e : IntW 32) :
 
 
 theorem select_zext_or_eq_ult_add_thm (e : IntW 32) :
-  select (icmp IntPredicate.ult (add e (const? 32 (-3))) (const? 32 2)) (const? 32 1)
-      (zext 32 (icmp IntPredicate.eq e (const? 32 5))) ⊑
-    zext 32 (icmp IntPredicate.ult (add e (const? 32 (-3))) (const? 32 3)) := by
+  select (icmp IntPred.ult (add e (const? 32 (-3))) (const? 32 2)) (const? 32 1)
+      (zext 32 (icmp IntPred.eq e (const? 32 5))) ⊑
+    zext 32 (icmp IntPred.ult (add e (const? 32 (-3))) (const? 32 3)) := by
     simp_alive_undef
     simp_alive_ops
     simp_alive_case_bash


### PR DESCRIPTION
These tests were forgotten during a previous refactoring. This PR works towards unbreaking them.