### PR TITLE
feat: intros_llvm tactic

### DIFF
--- a/SSA/Projects/InstCombine/Tactic/SimpLLVM.lean
+++ b/SSA/Projects/InstCombine/Tactic/SimpLLVM.lean
@@ -117,3 +117,22 @@ macro "simp_alive_ops" : tactic =>
           (BitVec.ofInt_ofNat)
         ]
     ))
+
+/-! ## `llvm_intros` -/
+
+/--
+`intros_llvm x` will introduce as many binders as possible without unfolding
+definitions, just like `intros` (without passing any identifiers) would.
+However, unlike `intros`, `intros_llvm x` will give the new variables
+*accessible* names, with `x` as a prefix.
+
+This tactic is intended for use with the `simp_llvm..` / `simp_alive..` family
+of tactics, hence the name.
+-/
+elab "intros_llvm" x:ident : tactic => do
+  let x := x.getId
+  let ⟨newFVars, newGoal⟩ ← (← getMainGoal).intros
+  let mut goal := newGoal
+  for fvar in newFVars do
+    goal ← goal.rename fvar (← Meta.getUnusedUserName x)
+  replaceMainGoal [goal]


### PR DESCRIPTION
This PR adds an `intros_llvm` tactic which behaves similar to `intros`, in that it introduces as many binders as it can, but it does while giving them accessible names. The tactic is not strictly speaking specific to the LLVM dialect, but it's intended for use with the other alive/llvm tactics, hence the name.