### PR TITLE
chore: refactor `Comb` parser and remove unnecessary types

### DIFF
--- a/SSA/Projects/CIRCT/Comb/Comb.lean
+++ b/SSA/Projects/CIRCT/Comb/Comb.lean
@@ -161,36 +161,36 @@ def mkExpr (Γ : Ctxt _) (opStx : MLIR.AST.Op 0) :
     let mkExprOf := opStx.mkExprOf (args? := args) Γ
     match (opStx.name).splitOn "_" with
     -- 1-ary
-    | [".parity"] => mkExprOf <| .parity (← unW)
-    | [".extract", ns] =>
+    | ["Comb.parity"] => mkExprOf <| .parity (← unW)
+    | ["Comb.extract", ns] =>
       match ns.toNat? with
       | some n =>  mkExprOf <| .extract (← unW) n
       | _ => throw <| .generic s!" an integer attribute should be provided for {repr opStx.args}"
-    | [".replicate", ns] =>
+    | ["Comb.replicate", ns] =>
       match ns.toNat? with
       | some n =>  mkExprOf <| .replicate (← unW) n
       | _ => throw <| .generic s!" an integer attribute should be provided for {repr opStx.args}"
     -- 2-ary
-    | [".divs"] => mkExprOf <| .divs (← binW)
-    | [".divu"] => mkExprOf <| .divu (← binW)
-    | [".icmp", ps] =>
+    | ["Comb.divs"] => mkExprOf <| .divs (← binW)
+    | ["Comb.divu"] => mkExprOf <| .divu (← binW)
+    | ["Comb.icmp", ps] =>
       match (ofString? ps) with
       -- we avoid passing p as an IcmpPred type to avoid denoting the type
       | some p => mkExprOf <| .icmp ps (← binW)
       | _ => throw <| .generic s!" invalid attribute provided for {repr opStx.args}"
-    | [".mods"] => mkExprOf <| .mods (← binW)
-    | [".modu"] => mkExprOf <| .modu (← binW)
-    | [".mux"] => mkExprOf <| .mux (← binW)
-    | [".shl"] => mkExprOf <| .shl (← binW)
-    | [".shrs"] => mkExprOf <| .shrs (← binW)
-    | [".shru"] => mkExprOf <| .shru (← binW)
-    | [".sub "] => mkExprOf <| .sub (← binW)
+    | ["Comb.mods"] => mkExprOf <| .mods (← binW)
+    | ["Comb.modu"] => mkExprOf <| .modu (← binW)
+    | ["Comb.mux"] => mkExprOf <| .mux (← binW)
+    | ["Comb.shl"] => mkExprOf <| .shl (← binW)
+    | ["Comb.shrs"] => mkExprOf <| .shrs (← binW)
+    | ["Comb.shru"] => mkExprOf <| .shru (← binW)
+    | ["Comb.sub "] => mkExprOf <| .sub (← binW)
     -- n-ary (variadic)
-    | [".add"] => mkExprOf <| .add (← nnW) args'.length
-    | [".and"] => mkExprOf <| .and (← nnW) args'.length
-    | [".mul"] => mkExprOf <| .mul (← nnW) args'.length
-    | [".or"] => mkExprOf <| .or (← nnW) args'.length
-    | [".xor"] => mkExprOf <| .xor (← nnW) args'.length
+    | ["Comb.add"] => mkExprOf <| .add (← nnW) args'.length
+    | ["Comb.and"] => mkExprOf <| .and (← nnW) args'.length
+    | ["Comb.mul"] => mkExprOf <| .mul (← nnW) args'.length
+    | ["Comb.or"] => mkExprOf <| .or (← nnW) args'.length
+    | ["Comb.xor"] => mkExprOf <| .xor (← nnW) args'.length
     | _ => throw <| .unsupportedOp s!"{repr opStx}"
 
 def mkReturn (Γ : Ctxt Comb.Ty) (opStx : MLIR.AST.Op 0) :

--- a/SSA/Projects/CIRCT/Comb/Comb.lean
+++ b/SSA/Projects/CIRCT/Comb/Comb.lean
@@ -154,13 +154,12 @@ def mkExpr (Γ : Ctxt _) (opStx : MLIR.AST.Op 0) :
     let args ← args.assumeArity 3
     return getVarWidth args[0]
   -- n-ary ops
-  let args' ← opStx.args.mapM (MLIR.AST.TypedSSAVal.mkVal Γ) -- will need to find a better way to do this
-  if h : args'.length = 0 then
+  if h : args.toList.length = 0 then
     throw <| .generic s!" empty list of argument provided for the variadic op {repr opStx.args}"
   else
     -- exclude empty list of args
     let nnW : AST.ReaderM (Comb) (Nat) := do
-      let args ← args.assumeArity args'.length
+      let args ← args.assumeArity args.toList.length
       return getVarWidth args[0]
     let mkExprOf := opStx.mkExprOf (args? := args) Γ
     match (opStx.name).splitOn "_" with

--- a/SSA/Projects/CIRCT/Comb/Comb.lean
+++ b/SSA/Projects/CIRCT/Comb/Comb.lean
@@ -190,11 +190,11 @@ def mkExpr (Γ : Ctxt _) (opStx : MLIR.AST.Op 0) :
     -- 3-ary
     | ["Comb.mux"] => mkExprOf <| .mux (← terW)
     -- n-ary (variadic)
-    | ["Comb.add"] => mkExprOf <| .add (← nnW) args'.length
-    | ["Comb.and"] => mkExprOf <| .and (← nnW) args'.length
-    | ["Comb.mul"] => mkExprOf <| .mul (← nnW) args'.length
-    | ["Comb.or"] => mkExprOf <| .or (← nnW) args'.length
-    | ["Comb.xor"] => mkExprOf <| .xor (← nnW) args'.length
+    | ["Comb.add"] => mkExprOf <| .add (← nnW) args.toList.length
+    | ["Comb.and"] => mkExprOf <| .and (← nnW) args.toList.length
+    | ["Comb.mul"] => mkExprOf <| .mul (← nnW) args.toList.length
+    | ["Comb.or"] => mkExprOf <| .or (← nnW) args.toList.length
+    | ["Comb.xor"] => mkExprOf <| .xor (← nnW) args.toList.length
     | _ => throw <| .unsupportedOp s!"{repr opStx}"
 
 def mkReturn (Γ : Ctxt Comb.Ty) (opStx : MLIR.AST.Op 0) :

--- a/SSA/Projects/CIRCT/Comb/Comb.lean
+++ b/SSA/Projects/CIRCT/Comb/Comb.lean
@@ -120,7 +120,7 @@ def mkTy : MLIR.AST.MLIRType 0 → MLIR.AST.ExceptM Comb (Comb.Ty)
   | MLIR.AST.MLIRType.int _ w =>
     match w with
     | .concrete w' => return .bitvec w'
-    | .mvar _ => throw <| .generic s!" bitVec size can't be an mvar!"
+    | .mvar _ => throw <| .generic s!" BitVec size can't be an mvar!"
   | _ => throw .unsupportedType
 
 -- borrowed from the LLVM/EDSL infra

--- a/SSA/Projects/CIRCT/Comb/Comb.lean
+++ b/SSA/Projects/CIRCT/Comb/Comb.lean
@@ -149,6 +149,10 @@ def mkExpr (Γ : Ctxt _) (opStx : MLIR.AST.Op 0) :
   let binW : AST.ReaderM (Comb) (Nat) := do
     let args ← args.assumeArity 2
     return getVarWidth args[0]
+  -- 3-ary ops
+  let terW : AST.ReaderM (Comb) (Nat) := do
+    let args ← args.assumeArity 3
+    return getVarWidth args[0]
   -- n-ary ops
   let args' ← opStx.args.mapM (MLIR.AST.TypedSSAVal.mkVal Γ) -- will need to find a better way to do this
   if h : args'.length = 0 then
@@ -180,11 +184,12 @@ def mkExpr (Γ : Ctxt _) (opStx : MLIR.AST.Op 0) :
       | _ => throw <| .generic s!" invalid attribute provided for {repr opStx.args}"
     | ["Comb.mods"] => mkExprOf <| .mods (← binW)
     | ["Comb.modu"] => mkExprOf <| .modu (← binW)
-    | ["Comb.mux"] => mkExprOf <| .mux (← binW)
     | ["Comb.shl"] => mkExprOf <| .shl (← binW)
     | ["Comb.shrs"] => mkExprOf <| .shrs (← binW)
     | ["Comb.shru"] => mkExprOf <| .shru (← binW)
     | ["Comb.sub "] => mkExprOf <| .sub (← binW)
+    -- 3-ary
+    | ["Comb.mux"] => mkExprOf <| .mux (← terW)
     -- n-ary (variadic)
     | ["Comb.add"] => mkExprOf <| .add (← nnW) args'.length
     | ["Comb.and"] => mkExprOf <| .and (← nnW) args'.length

--- a/SSA/Projects/CIRCT/Comb/Comb.lean
+++ b/SSA/Projects/CIRCT/Comb/Comb.lean
@@ -11,8 +11,6 @@ section Dialect
 
 inductive Ty
 | bv (w : Nat) : Ty -- A bitvector of width `w`.
--- | hList (l : List Nat) : Ty -- List of bitvecs whose length are defined in l
--- | icmpPred : Ty
 deriving DecidableEq, Repr, Lean.ToExpr
 
 inductive Op

--- a/SSA/Projects/CIRCT/Comb/Comb.lean
+++ b/SSA/Projects/CIRCT/Comb/Comb.lean
@@ -11,17 +11,14 @@ section Dialect
 
 inductive Ty
 | bv (w : Nat) : Ty -- A bitvector of width `w`.
-| typeSum (w₁ w₂ : Nat) : Ty
-| bool : Ty
-| nat : Ty
-| hList (l : List Nat) : Ty -- List of bitvecs whose length are defined in l
-| icmpPred : Ty
+-- | hList (l : List Nat) : Ty -- List of bitvecs whose length are defined in l
+-- | icmpPred : Ty
 deriving DecidableEq, Repr, Lean.ToExpr
 
 inductive Op
 | add (w : Nat) (arity : Nat)
 | and (w : Nat) (arity : Nat)
-| concat (w : List Nat) -- len(w) = #args, wi is the width of the i-th arg
+-- | concat (w : List Nat) -- len(w) = #args, wi is the width of the i-th arg
 | divs (w : Nat)
 | divu (w : Nat)
 | extract (w : Nat) (n : Nat)
@@ -29,7 +26,7 @@ inductive Op
 | mods (w : Nat)
 | modu (w : Nat)
 | mul (w : Nat) (arity : Nat)
-| mux (w₁ : Nat) (w₂ : Nat)
+| mux (w : Nat)
 | or (w : Nat) (arity : Nat)
 | parity (w : Nat)
 | replicate (w : Nat) (n : Nat)
@@ -44,23 +41,20 @@ abbrev Comb : Dialect where
   Op := Op
   Ty := Ty
 
-instance : ToString Ty where
-  toString t := repr t |>.pretty
-  
 def_signature for Comb where
   | .add w n => ${List.replicate n (Ty.bv w)} → (Ty.bv w)
   | .and w n => ${List.replicate n (Ty.bv w)} → (Ty.bv w)
-  | .concat l => (Ty.hList l) → (Ty.bv l.sum)
+  -- | .concat l => (Ty.hList l) → (Ty.bv l.sum)
   | .divs w => (Ty.bv w, Ty.bv w) → (Ty.bv w)
   | .divu w => (Ty.bv w, Ty.bv w) → (Ty.bv w)
   | .extract w n => (Ty.bv w) → (Ty.bv (w - n))
-  | .icmp _ w => (Ty.bv w, Ty.bv w) → (Ty.bool)
+  | .icmp _ w => (Ty.bv w, Ty.bv w) → (Ty.bv 1)
   | .mods w => (Ty.bv w, Ty.bv w) → (Ty.bv w)
   | .modu w => (Ty.bv w, Ty.bv w) → (Ty.bv w)
   | .mul w n => ${List.replicate n (Ty.bv w)} → (Ty.bv w)
-  | .mux w₁ w₂ => (Ty.bv w₁, Ty.bv w₂, Ty.bool) → (Ty.typeSum w₁ w₂)
+  | .mux w => (Ty.bv w, Ty.bv w, Ty.bv 1) → (Ty.bv w)
   | .or w n => ${List.replicate n (Ty.bv w)} → (Ty.bv w)
-  | .parity w => (Ty.bv w) → (Ty.bool)
+  | .parity w => (Ty.bv w) → (Ty.bv 1)
   | .replicate w n => (Ty.bv w) → (Ty.bv (w * n))
   | .shl w => (Ty.bv w, Ty.bv w) → (Ty.bv w)
   | .shrs w => (Ty.bv w, Ty.bv w) → (Ty.bv w)
@@ -71,11 +65,9 @@ def_signature for Comb where
 instance : TyDenote (Dialect.Ty Comb) where
   toType := fun
   | .bv w => BitVec w
-  | .nat  => Nat
-  | .bool => Bool
-  | .typeSum w₁ w₂ => BitVec w₁ ⊕ BitVec w₂
-  | .hList l => HVector BitVec l -- het list of bitvec whose lengths are contained in l
-  | .icmpPred => CombOp.IcmpPredicate
+  -- | .bool => Bool
+  -- | .hList l => HVector BitVec l -- het list of bitvec whose lengths are contained in l
+  -- | .icmpPred => CombOp.IcmpPredicate
 
 def HVector.replicateToList {α : Type} {f : α → Type} {a : α} :
     {n : Nat} → HVector f (List.replicate n a) → List (f a)
@@ -99,7 +91,7 @@ def ofString? (s : String) : Option CombOp.IcmpPredicate :=
 def_denote for Comb where
   | .add _ _ => fun xs => CombOp.add (HVector.replicateToList (f := TyDenote.toType) xs)
   | .and _ _ => fun xs => CombOp.and (HVector.replicateToList (f := TyDenote.toType) xs)
-  | .concat _ => fun xs => CombOp.concat xs
+  -- | .concat _ => fun xs => CombOp.concat xs
   | .divs _ => BitVec.sdiv
   | .divu _ => BitVec.udiv
   | .extract _ _ => fun x => CombOp.extract x _
@@ -107,7 +99,7 @@ def_denote for Comb where
   | .mods _ => BitVec.smod
   | .modu _ => BitVec.umod
   | .mul _ _ => fun xs => CombOp.mul (HVector.replicateToList (f := TyDenote.toType) xs)
-  | .mux _ _ => fun x y => CombOp.mux x y
+  | .mux _ => fun x y => CombOp.mux x y
   | .or _ _ => fun xs => CombOp.or (HVector.replicateToList (f := TyDenote.toType) xs)
   | .parity _ => fun x => CombOp.parity x
   | .replicate _ n => fun xs => CombOp.replicate xs n
@@ -124,16 +116,10 @@ end Dialect
 def mkTy : MLIR.AST.MLIRType φ → MLIR.AST.ExceptM Comb Ty
   | MLIR.AST.MLIRType.undefined s => do
     match s.splitOn "_" with
-    | ["Bool"] =>
-      return .bool
-    | ["Nat"] =>
-      return .nat
-    | ["IcmpPred"] =>
-      return .icmpPred
-    | ["TypeSum", w₁, w₂] =>
-      match w₁.toNat?, w₂.toNat? with
-      | some w₁', some w₂' => return .typeSum w₁' w₂'
-      | _, _ => throw .unsupportedType
+    -- | ["Bool"] =>
+    --   return .bool
+    -- | ["IcmpPred"] =>
+    --   return .icmpPred
     | _ => throw .unsupportedType
   | MLIR.AST.MLIRType.int _ w =>
     match w with
@@ -161,13 +147,13 @@ def mkExpr (Γ : Ctxt _) (opStx : MLIR.AST.Op 0) :
       let ⟨ty₁, v₁⟩ ← MLIR.AST.TypedSSAVal.mkVal Γ v₁Stx
       match ty₁, op with
       | .bv w, "Comb.parity" =>
-        return ⟨_, .bool,
+        return ⟨_, .bv 1,
           (Expr.mk (op := .parity w) (ty_eq := rfl) (eff_le := by constructor)
-            (args := .cons v₁ <| .nil) (regArgs := .nil) : Expr (Comb) Γ .pure (.bool))⟩
-      | .hList l, "Comb.concat" =>
-        return ⟨_, .bv l.sum,
-          (Expr.mk (op := .concat l) (ty_eq := rfl) (eff_le := by constructor)
-            (args := .cons v₁ <| .nil) (regArgs := .nil) : Expr (Comb) Γ .pure (.bv (l.sum)))⟩
+            (args := .cons v₁ <| .nil) (regArgs := .nil) : Expr (Comb) Γ .pure (.bv 1))⟩
+      -- | .hList l, "Comb.concat" =>
+      --   return ⟨_, .bv l.sum,
+      --     (Expr.mk (op := .concat l) (ty_eq := rfl) (eff_le := by constructor)
+      --       (args := .cons v₁ <| .nil) (regArgs := .nil) : Expr (Comb) Γ .pure (.bv (l.sum)))⟩
       | _, _ => throw <| .generic s!"type mismatch for {opStx.name}"
     | _ => throw <| .generic s!"expected one operand found #'{opStx.args.length}' in '{repr opStx.args}'"
   | op@"Comb.add" | op@"Comb.and" | op@"Comb.mul" | op@"Comb.or" | op@"Comb.xor" =>
@@ -202,7 +188,6 @@ def mkExpr (Γ : Ctxt _) (opStx : MLIR.AST.Op 0) :
             | _ => throw <| .generic s!"Unknown operation"
           else
             throw <| .generic s!"Unexpected argument types for '{repr opStx.args}'"
-        | _ => throw <| .generic s!"Unexpected argument types for '{repr opStx.args}'"
   | op@"Comb.divs" | op@"Comb.divu" | op@"Comb.mods" | op@"Comb.modu" | op@"Comb.shl" | op@"Comb.shrs" | op@"Comb.shru" | op@"Comb.sub"  =>
     match opStx.args with
     | v₁Stx::v₂Stx::[] =>
@@ -247,7 +232,6 @@ def mkExpr (Γ : Ctxt _) (opStx : MLIR.AST.Op 0) :
           | _ => throw <| .generic s!"Unknown operation"
         else
           throw <| .generic s!"bitvector sizes don't match for '{repr opStx.args}' in {opStx.name}"
-      | _, _ => throw <| .generic s!"type mismatch in {opStx.name}"
     | _ => throw <| .generic s!"expected two operands, found #'{opStx.args.length}' in '{repr opStx.args}'"
   | op@"Comb.mux" =>
     match opStx.args with
@@ -256,17 +240,19 @@ def mkExpr (Γ : Ctxt _) (opStx : MLIR.AST.Op 0) :
       let ⟨ty₂, v₂⟩ ← MLIR.AST.TypedSSAVal.mkVal Γ v₂Stx
       let ⟨ty₃, v₃⟩ ← MLIR.AST.TypedSSAVal.mkVal Γ v₃Stx
       match ty₁, ty₂, ty₃, op with
-      | .bv w₁, .bv w₂, .bool, "Comb.mux" =>
+      | .bv w₁, .bv w₂, .bv 1, "Comb.mux" =>
         /- mux currently only works if w₁ = w₂, since we need to fix the output type of the operation
           it should work even if w₁ ≠ w₂ but i need to think about how to implement that in an elegant way -/
-        return ⟨_, .typeSum w₁ w₂,
-          (Expr.mk (op := .mux w₁ w₂) (ty_eq := rfl) (eff_le := by constructor)
-            (args := .cons v₁ <| .cons v₂ <| .cons v₃ <| .nil) (regArgs := .nil) : Expr (Comb) Γ .pure (.typeSum w₁ w₂))⟩
+        if h : w₁ = w₂ then
+          return ⟨_, .bv w₁,
+            (Expr.mk (op := .mux w₁) (ty_eq := rfl) (eff_le := by constructor)
+              (args := .cons v₁ <| .cons (h ▸ v₂) <| .cons v₃ <| .nil) (regArgs := .nil) : Expr (Comb) Γ .pure (.bv w₁))⟩
+        else throw <| .generic s!"bitvec sizes do not match"
       | _, _, _, _ => throw <| .generic s!"type mismatch"
     | _ => throw <| .generic s!"expected three operands, found #'{opStx.args.length}' in '{repr opStx.args}'"
   |  _ =>
     match (opStx.name).splitOn "_" with
-    | ["Comb.replicate", n]=>
+    | ["Comb.replicate", n] =>
       match opStx.args with
       | v₁Stx::[] =>
         let ⟨ty₁, v₁⟩ ← MLIR.AST.TypedSSAVal.mkVal Γ v₁Stx
@@ -276,7 +262,6 @@ def mkExpr (Γ : Ctxt _) (opStx : MLIR.AST.Op 0) :
             (Expr.mk (op := .replicate w n') (ty_eq := rfl) (eff_le := by constructor)
               (args := .cons v₁ <| .nil) (regArgs := .nil) : Expr (Comb) Γ .pure (.bv (w * n')))⟩
         | _, none => throw <| .generic s!"invalid parameter in {repr opStx}"
-        | _, _ => throw <| .generic s!"type mismatch in {repr opStx}"
       | _ => throw <| .generic s!"type mismatch in {repr opStx}"
     | ["Comb.extract", n] =>
       match opStx.args with
@@ -288,7 +273,6 @@ def mkExpr (Γ : Ctxt _) (opStx : MLIR.AST.Op 0) :
             (Expr.mk (op := .extract w n') (ty_eq := rfl) (eff_le := by constructor)
               (args := .cons v₁ <| .nil) (regArgs := .nil) : Expr (Comb) Γ .pure (.bv (w - n')))⟩
         | _, none => throw <| .generic s!"invalid parameter in {repr opStx}"
-        | _, _ => throw <| .generic s!"type mismatch in {repr opStx}"
       | _ => throw <| .generic s!"type mismatch in {repr opStx}"
     | ["Comb.icmp", p] =>
       match opStx.args with
@@ -298,12 +282,11 @@ def mkExpr (Γ : Ctxt _) (opStx : MLIR.AST.Op 0) :
         match ty₁, ty₂, (ofString? p) with
         | .bv w₁, .bv w₂, some p' =>
           if h : w₁ = w₂ then
-            return ⟨_, .bool,
+            return ⟨_, .bv 1,
               (Expr.mk (op := .icmp p w₁)  (ty_eq := rfl)  (eff_le := by constructor)
-                (args := .cons v₁ <| .cons (h ▸ v₂) <| .nil) (regArgs := .nil): Expr (Comb) Γ .pure (.bool))⟩
+                (args := .cons v₁ <| .cons (h ▸ v₂) <| .nil) (regArgs := .nil): Expr (Comb) Γ .pure (.bv 1))⟩
           else throw <| .generic s!"bitvector sizes don't match for '{repr opStx.args}' in {opStx.name}"
         | _, _, none => throw <| .generic s!"unknown predicate in {repr opStx}"
-        | _, _, _ => throw <| .generic s!"type mismatch in {repr opStx}"
       | _ => throw <| .generic s!"expected two operands, found #'{opStx.args.length}' in '{repr opStx.args}'"
     | _ => throw <| .unsupportedOp s!"unsupported operation {repr opStx}"
 

--- a/SSA/Projects/CIRCT/Comb/Comb.lean
+++ b/SSA/Projects/CIRCT/Comb/Comb.lean
@@ -202,6 +202,9 @@ def mkReturn (Γ : Ctxt Comb.Ty) (opStx : MLIR.AST.Op 0) :
     let ⟨ty, v⟩ := args[0]
     return ⟨.pure, ty, Com.ret v⟩
 
+instance : MLIR.AST.TransformExpr (Comb) 0 where
+  mkExpr := mkExpr
+
 instance : AST.TransformReturn Comb 0 := { mkReturn }
 
 instance : DialectToExpr Comb where
@@ -209,6 +212,7 @@ instance : DialectToExpr Comb where
   toExprDialect := .const ``Comb []
 
 open Qq MLIR AST Lean Elab Term Meta in
-elab "[Comb_com| " reg:mlir_region "]" : term => do SSA.elabIntoCom' reg Comb
+elab "[Comb_com| " reg:mlir_region "]" : term => do
+  SSA.elabIntoCom' reg Comb
 
 end MLIR2Comb

--- a/SSA/Projects/CIRCT/Comb/CombExample.lean
+++ b/SSA/Projects/CIRCT/Comb/CombExample.lean
@@ -11,8 +11,8 @@ open MLIR AST in
 
 unseal String.splitOnAux in
 def CombEg1 := [Comb_com| {
-  ^entry(%0: !i1):
-    "return" (%0) : (!i1) -> ()
+  ^entry(%0: i1):
+    "return" (%0) : (i1) -> ()
   }]
 
 #check CombEg1

--- a/SSA/Projects/CIRCT/Comb/CombExample.lean
+++ b/SSA/Projects/CIRCT/Comb/CombExample.lean
@@ -11,8 +11,8 @@ open MLIR AST in
 
 unseal String.splitOnAux in
 def CombEg1 := [Comb_com| {
-  ^entry(%0: !Bool):
-    "return" (%0) : (!Bool) -> ()
+  ^entry(%0: !i1):
+    "return" (%0) : (!i1) -> ()
   }]
 
 #check CombEg1
@@ -43,8 +43,8 @@ def test2 : BitVec 4 :=
 
 def CombEg3 := [Comb_com| {
   ^entry(%0: i4, %1 : i4):
-    %2 = "Comb.icmp_slt" (%0, %1) : (i4, i4) -> !Bool
-    "return" (%2) : (!Bool) -> ()
+    %2 = "Comb.icmp_slt" (%0, %1) : (i4, i4) -> !i1
+    "return" (%2) : (!i1) -> ()
   }]
 
 #check CombEg3
@@ -63,8 +63,8 @@ def test3 : Bool :=
 
 def CombEg4 := [Comb_com| {
   ^entry(%0: i4, %1 : i4):
-    %2 = "Comb.icmp_eq" (%0, %1) : (i4, i4) -> !Bool
-    "return" (%2) : (!Bool) -> ()
+    %2 = "Comb.icmp_eq" (%0, %1) : (i4, i4) -> !i1
+    "return" (%2) : (!i1) -> ()
   }]
 
 #check CombEg4
@@ -101,8 +101,8 @@ def test5 : BitVec 3 :=
 #eval test5
 
 def CombEg6 := [Comb_com| {
-    ^entry (%0 : i2, %1 : i4, %2 : !Bool):
-      %3 = "Comb.mux" (%0, %1, %2) : (i2, i4, !Bool) -> !TypeSum_2_4
+    ^entry (%0 : i2, %1 : i4, %2 : !i1):
+      %3 = "Comb.mux" (%0, %1, %2) : (i2, i4, !i1) -> !TypeSum_2_4
       "return" (%3) : (!TypeSum_2_4) -> ()
 }]
 
@@ -118,3 +118,11 @@ def bv6c : Bool := true
 
 def test6 : BitVec 2 ⊕ BitVec 4 :=
   CombEg6.denote (Ctxt.Valuation.ofHVector (.cons bv6c <| .cons bv6₂ <| .cons bv6₁ <| .nil))
+
+
+let s:= "ciao"
+
+let test :=
+  match s.splitOn "_" with
+  | ["ciao"] => 1
+  | _ => 0

--- a/SSA/Projects/CIRCT/Comb/CombExample.lean
+++ b/SSA/Projects/CIRCT/Comb/CombExample.lean
@@ -22,9 +22,9 @@ def CombEg1 := [Comb_com| {
 #print axioms CombEg1
 
 def CombEg2 := [Comb_com| {
-    ^entry(%0: i4, %1 : i4):
-      %2 = "Comb.add" (%0, %1) : (i4, i4) -> i4
-      "return" (%2) : (i4) -> ()
+    ^entry(%0: i4, %1 : i4, %2 : i4):
+      %3 = "Comb.add" (%0, %1, %2) : (i4, i4, i4) -> i4
+      "return" (%3) : (i4) -> ()
     }]
 
 #print CombEg2
@@ -35,16 +35,17 @@ def CombEg2 := [Comb_com| {
 
 def bv1 : BitVec 4 := BitVec.ofNat 4 5 -- 0010
 def bv2 : BitVec 4 := BitVec.ofNat 4 1 -- 0011
+def bv3 : BitVec 4 := BitVec.ofNat 4 2 -- 0011
 
 def test2 : BitVec 4 :=
-  CombEg2.denote (Ctxt.Valuation.ofPair bv1 bv2)
+  CombEg2.denote (Ctxt.Valuation.ofHVector (.cons bv1 <| .cons bv2 <| .cons bv3 <| .nil))
 
-#eval test2
+#eval test2 -- 8#4
 
 def CombEg3 := [Comb_com| {
   ^entry(%0: i4, %1 : i4):
-    %2 = "Comb.icmp_slt" (%0, %1) : (i4, i4) -> !i1
-    "return" (%2) : (!i1) -> ()
+    %2 = "Comb.icmp_slt" (%0, %1) : (i4, i4) -> i1
+    "return" (%2) : (i1) -> ()
   }]
 
 #check CombEg3
@@ -56,15 +57,15 @@ def CombEg3 := [Comb_com| {
 def bv1' : BitVec 4 := BitVec.ofNat 4 1
 def bv2' : BitVec 4 := BitVec.ofNat 4 6
 
-def test3 : Bool :=
+def test3 : BitVec 1 :=
   CombEg3.denote (Ctxt.Valuation.ofPair bv2' bv1')
 
 #eval test3
 
 def CombEg4 := [Comb_com| {
   ^entry(%0: i4, %1 : i4):
-    %2 = "Comb.icmp_eq" (%0, %1) : (i4, i4) -> !i1
-    "return" (%2) : (!i1) -> ()
+    %2 = "Comb.icmp_eq" (%0, %1) : (i4, i4) -> i1
+    "return" (%2) : (i1) -> ()
   }]
 
 #check CombEg4
@@ -76,7 +77,7 @@ def CombEg4 := [Comb_com| {
 def bv1'' : BitVec 4 := BitVec.ofNat 4 3
 def bv2'' : BitVec 4 := BitVec.ofNat 4 3
 
-def test4 : Bool :=
+def test4 : BitVec 1 :=
   CombEg4.denote (Ctxt.Valuation.ofPair bv2'' bv1'')
 
 #eval test4
@@ -101,9 +102,9 @@ def test5 : BitVec 3 :=
 #eval test5
 
 def CombEg6 := [Comb_com| {
-    ^entry (%0 : i2, %1 : i4, %2 : !i1):
-      %3 = "Comb.mux" (%0, %1, %2) : (i2, i4, !i1) -> !TypeSum_2_4
-      "return" (%3) : (!TypeSum_2_4) -> ()
+    ^entry (%0 : i4, %1 : i4, %2 : i1):
+      %3 = "Comb.mux" (%0, %1, %2) : (i4, i4, i1) -> i4
+      "return" (%3) : (i4) -> ()
 }]
 
 #check CombEg6
@@ -112,17 +113,9 @@ def CombEg6 := [Comb_com| {
 #check CombEg6.denote
 #print axioms CombEg6
 
-def bv6₁ : BitVec 2 := BitVec.ofNat 2 1
+def bv6₁ : BitVec 4 := BitVec.ofNat 4 1
 def bv6₂ : BitVec 4 := BitVec.ofNat 4 3
-def bv6c : Bool := true
+def bv6c : BitVec 1 := BitVec.ofNat 1 1
 
-def test6 : BitVec 2 ⊕ BitVec 4 :=
+def test6 : BitVec 4 :=
   CombEg6.denote (Ctxt.Valuation.ofHVector (.cons bv6c <| .cons bv6₂ <| .cons bv6₁ <| .nil))
-
-
-let s:= "ciao"
-
-let test :=
-  match s.splitOn "_" with
-  | ["ciao"] => 1
-  | _ => 0

--- a/SSA/Projects/CIRCT/Comb/CombSemantics.lean
+++ b/SSA/Projects/CIRCT/Comb/CombSemantics.lean
@@ -53,34 +53,34 @@ def extract (x : BitVec w) (lb : Nat) : BitVec (w - lb) :=
   BitVec.truncate (w - lb) (BitVec.ushiftRight x lb)
 
 /-- Boolean comparison between two input BitVecs -/
-def icmp {w : Nat} (p : IcmpPredicate) (x y : BitVec w) : Bool :=
+def icmp {w : Nat} (p : IcmpPredicate) (x y : BitVec w) : BitVec 1 :=
   match p with
-  | .eq  => (x == y)
-  | .ne => (x != y)
-  | .sgt => (y.slt x)
-  | .sge => (y.sle x)
-  | .slt => (x.slt y)
-  | .sle => (x.sle y)
-  | .ugt => (x > y)
-  | .uge => (x ≥ y)
-  | .ult => (x < y)
-  | .ule => (x ≤ y)
+  | .eq  => BitVec.ofBool (x == y)
+  | .ne => BitVec.ofBool (x != y)
+  | .sgt => BitVec.ofBool (y.slt x)
+  | .sge => BitVec.ofBool (y.sle x)
+  | .slt => BitVec.ofBool (x.slt y)
+  | .sle => BitVec.ofBool (x.sle y)
+  | .ugt => BitVec.ofBool (x > y)
+  | .uge => BitVec.ofBool (x ≥ y)
+  | .ult => BitVec.ofBool (x < y)
+  | .ule => BitVec.ofBool (x ≤ y)
 
 /-- Variadic `mul` operation with a list of bitvectors with width `w` as input -/
 def mul {w : Nat} (l : List (BitVec w)) : BitVec w :=
   List.foldr BitVec.mul (1#w) l
 
 /- Generic `mux` operation for any types α, β -/
-def mux (x : BitVec w₁) (y : BitVec w₂) (cond : Bool) : BitVec w₁ ⊕ BitVec w₂ :=
-  if cond then .inl x else .inr y
+def mux (x : BitVec w) (y : BitVec w) (cond : BitVec 1) : BitVec w :=
+  if cond.msb then x else y
 
 /-- Variadic `or` operation with a list of bitvectors with width `w` as input -/
 def or {w : Nat} (l : List (BitVec w)) : BitVec w :=
   List.foldr BitVec.or (BitVec.zero w) l
 
 /-- Returns boolean parity value of BitVec `x` -/
-def parity (x : BitVec w) : Bool :=
-  (BitVec.umod x 2#w) == 1
+def parity (x : BitVec w) : BitVec 1 :=
+  BitVec.ofBool ((BitVec.umod x 2#w) == 1)
 
 /-- Replicate input BitVec `x` `n` times -/
 def replicate (x : BitVec w) (n : Nat) : BitVec (w * n) :=


### PR DESCRIPTION
This PR refactors the `Comb` parser according to #1208, removes unnecessary types (so that everything is a bitvector operation) and removes support for `concat`, since it can't be supported without `HVector`/`hList`/similar. 