### PR TITLE
feat: modify toString instance of LLVMAndRiscv

### DIFF
--- a/SSA/Projects/LLVMRiscV/LLVMAndRiscv.lean
+++ b/SSA/Projects/LLVMRiscV/LLVMAndRiscv.lean
@@ -68,8 +68,11 @@ instance LLVMPlusRiscVSignature : DialectSignature LLVMPlusRiscV where
   | .castLLVM =>
       {sig := [Ty.llvm (.bitvec 64)], outTy := (Ty.riscv .bv), regSig := []}
 
-instance : ToString LLVMPlusRiscV.Ty  where
-  toString t := repr t |>.pretty
+instance : ToString LLVMPlusRiscV.Op  where
+  toString := fun
+  | .llvm llvm    => toString llvm
+  | .riscv riscv  => toString riscv
+  | _  => "builtin.unrealized_conversion_cast"
 
 @[simp_denote]
 def llvmArgsFromHybrid : {tys : List LLVM.Ty} →

--- a/SSA/Projects/LLVMRiscV/LLVMAndRiscv.lean
+++ b/SSA/Projects/LLVMRiscV/LLVMAndRiscv.lean
@@ -72,7 +72,8 @@ instance : ToString LLVMPlusRiscV.Op  where
   toString := fun
   | .llvm llvm    => toString llvm
   | .riscv riscv  => toString riscv
-  | _  => "builtin.unrealized_conversion_cast"
+  | .castLLVM => "builtin.unrealized_conversion_cast"
+  | .castRiscv => "builtin.unrealized_conversion_cast"
 
 @[simp_denote]
 def llvmArgsFromHybrid : {tys : List LLVM.Ty} →


### PR DESCRIPTION
This PR modifies the existing toString instance of the LLVMAndRiscV dialect to no longer use the Repr instance internally. This allows toString to differ from Repr.