### PR TITLE
feat: new LLVM dialect with proper UB (for division)

### DIFF
--- a/SSA/Core/Util/Poison.lean
+++ b/SSA/Core/Util/Poison.lean
@@ -17,6 +17,7 @@ when specifying poison semantics in dialects, as it's more self-documenting.
 -/
 structure PoisonOr (α : Type) where
   ofOption :: toOption : Option α
+  deriving DecidableEq
 
 namespace PoisonOr
 

--- a/SSA/Projects/InstCombine/LLVM/Semantics.lean
+++ b/SSA/Projects/InstCombine/LLVM/Semantics.lean
@@ -20,6 +20,7 @@ def IntW w := PoisonOr <| BitVec w
 namespace IntW
 
 instance : Inhabited (IntW w) := by unfold IntW; infer_instance
+instance : DecidableEq (IntW w) := by unfold IntW; infer_instance
 
 instance : Refinement (LLVM.IntW w) := inferInstanceAs (Refinement <| PoisonOr _)
 

--- a/SSA/Projects/SLLVM/Dialect.lean
+++ b/SSA/Projects/SLLVM/Dialect.lean
@@ -1,0 +1,1 @@
+import SSA.Projects.SLLVM.Dialect.Base

--- a/SSA/Projects/SLLVM/Dialect/Base.lean
+++ b/SSA/Projects/SLLVM/Dialect/Base.lean
@@ -1,0 +1,56 @@
+/-
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+
+import SSA.Core.Framework.Macro
+
+import SSA.Projects.InstCombine.Base
+import SSA.Projects.SLLVM.Dialect.UB
+import SSA.Projects.SLLVM.Dialect.Semantics
+
+namespace LeanMLIR
+open InstCombine (LLVM)
+
+/-!
+## SLLVM Dialect
+SLLVM stands for "Structured LLVM"; eventually this dialect will become a
+formalization of the `ptr + arith + scf` MLIR dialects.
+This IR is conceptually similar to LLVM IR, except it uses only *structured*
+control flow, hence the name.
+
+Note that in the formalization, we assume a 64-bit architecture!
+Nothing in the formalization itself should depend on the exact pointer-width,
+but this assumption does affect which optimizations are admitted.
+
+For now, though, this dialect just models only arithmetic, just like our
+existing LLVM dialect, *but* it refines the semantics to include a proper model
+of (side-effecting) UB.
+-/
+
+def SLLVM : Dialect where
+  Op := LLVM.Op
+  Ty := LLVM.Ty
+  m := UBOr
+
+open InstCombine.LLVM.Op in
+/-- The signature of each operation is the same as in LLVM. -/
+instance : DialectSignature SLLVM where
+  signature op :=
+    { DialectSignature.signature (d := LLVM) op with
+        effectKind := match op with
+          | udiv .. | sdiv .. => .impure
+          | _ => .pure
+    }
+
+instance : TyDenote SLLVM.Ty := inferInstanceAs (TyDenote LLVM.Ty)
+instance : Monad (SLLVM.m) := inferInstanceAs (Monad PoisonOr)
+
+open InstCombine.LLVM.Op in
+instance : DialectDenote SLLVM where
+  denote
+  | udiv _ flag => fun (x ::ₕ (y ::ₕ .nil)) _ => LeanMLIR.SLLVM.udiv x y flag
+  | sdiv _ flag => fun (x ::ₕ (y ::ₕ .nil)) _ => LeanMLIR.SLLVM.udiv x y flag
+  | op => fun args .nil =>
+    EffectKind.liftEffect (EffectKind.pure_le _) <|
+      DialectDenote.denote (d := LLVM) op args .nil
+  -- ^^ For all other ops, just refer to the pure LLVM semantics

--- a/SSA/Projects/SLLVM/Dialect/Semantics.lean
+++ b/SSA/Projects/SLLVM/Dialect/Semantics.lean
@@ -1,0 +1,37 @@
+/-
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+
+import SSA.Projects.InstCombine.LLVM.Semantics
+import SSA.Projects.SLLVM.Dialect.UB
+
+/-- `x.canBe y` returns true when `x` can be refined into a bitvector value `y`.
+That is, when `x` is poison or `x` is equal to `value y`. -/
+def LLVM.IntW.canBe (x : LLVM.IntW w) (y : BitVec w) : Bool :=
+  x = .poison ∨ x = .value y
+
+namespace LeanMLIR.SLLVM
+
+def udiv (x y : LLVM.IntW w) (flag : LLVM.ExactFlag) : UBOr (LLVM.IntW w) := do
+  if y.canBe 0#w then
+    .ub
+  else
+    .value <| LLVM.udiv x y flag
+
+def sdiv (x y : LLVM.IntW w) (flag : LLVM.ExactFlag) : UBOr (LLVM.IntW w) := do
+  if y.canBe 0#w then
+    .ub
+  else
+    .value <| LLVM.sdiv x y flag
+
+def urem (x y : LLVM.IntW w) : UBOr (LLVM.IntW w) := do
+  if y.canBe 0#w then
+    .ub
+  else
+    .value <| LLVM.urem x y
+
+def srem (x y : LLVM.IntW w) : UBOr (LLVM.IntW w) := do
+  if y.canBe 0#w then
+    .ub
+  else
+    .value <| LLVM.srem x y

--- a/SSA/Projects/SLLVM/Dialect/UB.lean
+++ b/SSA/Projects/SLLVM/Dialect/UB.lean
@@ -1,0 +1,22 @@
+/-
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+
+import SSA.Core.Util.Poison
+
+namespace LeanMLIR
+
+def UBOr := PoisonOr
+
+namespace UBOr
+
+/-! ## Constructors -/
+
+def ub : UBOr α := PoisonOr.poison
+def value : α → UBOr α := PoisonOr.value
+
+/-! ## Monad -/
+
+instance : Monad UBOr := inferInstanceAs (Monad PoisonOr)
+
+end UBOr


### PR DESCRIPTION
This PR adds SLLVM, a new dialect which will eventually model memory, structured-control flow and UB, but for now is just a wrapper around the existing LLVM arithmetic operations, with proper UB-as-a-side-effect semantics.

For now, the operations that may throw immediate UB are udiv, sdiv, urem and srem, all when the divisor is either poison or `0`.

Follow up PRs will adapt (a copy of) AliveAutoGenerated to use these UB semantics, and build up the tactic infrastructure to decide refinement.