### PR TITLE
feat: generalize PoisonOr refinement to build on top of a refinement relation of underlying values

### DIFF
--- a/SSA/Core/Framework/Refinement.lean
+++ b/SSA/Core/Framework/Refinement.lean
@@ -43,12 +43,28 @@ NOTE: This typeclass is not intended for dialect implementors. Please implement
 class Refinement (α : Type) where
   IsRefinedBy : α → α → Prop
 
-instance [Refinement α] : HRefinement α α where
+instance instHRefinementOfRefinement [Refinement α] : HRefinement α α where
   IsRefinedBy := Refinement.IsRefinedBy
+
+/-! #### Trivial Refinement -/
+
+section OfEq
 
 /-- Equality induces a trivial (homogenous) refinement relation on any type `α`. -/
 def Refinement.ofEq : Refinement α where
   IsRefinedBy := Eq
+
+instance (priority := low) :
+    Std.Refl (HRefinement.IsRefinedBy (self := @instHRefinementOfRefinement α .ofEq)) where
+  refl _ := rfl
+instance (priority := low) :
+    IsTrans α (HRefinement.IsRefinedBy (self := @instHRefinementOfRefinement α .ofEq)) where
+  trans _ _ _ := Eq.trans
+instance (priority := low) [DecidableEq α] :
+    Decidable (HRefinement.IsRefinedBy (self := @instHRefinementOfRefinement α .ofEq) x y) :=
+  decidable_of_iff (x = y) (by rfl)
+
+end OfEq
 
 /-! ### Dialect Refinement -/
 

--- a/SSA/Core/Util/Poison.lean
+++ b/SSA/Core/Util/Poison.lean
@@ -128,15 +128,14 @@ variable {a : α}
 end Lemmas
 
 /-! ### Refinement -/
-inductive IsRefinedBy : PoisonOr α → PoisonOr α → Prop
+inductive IsRefinedBy [HRefinement α α] : PoisonOr α → PoisonOr α → Prop
   /-- `poison` is refined by anything -/
   | poisonLeft : IsRefinedBy poison b?
-  /-- `value a` is only refined by a `value b` s.t. `a = b`. -/
-  -- TODO: this should be `a ⊑ b` once generic refinement is merged
-  | bothValues : a = b → IsRefinedBy (value a) (value b)
+  /-- `value a` is only refined by a `value b` s.t. `a ⊑ b` -/
+  | bothValues : a ⊑ b → IsRefinedBy (value a) (value b)
 
 section Refinement
-variable (a? b? : PoisonOr α)
+variable [HRefinement α α] (a? b? : PoisonOr α)
 
 instance : Refinement (PoisonOr α) where
   IsRefinedBy := IsRefinedBy
@@ -145,7 +144,7 @@ instance : Refinement (PoisonOr α) where
   IsRefinedBy.poisonLeft
 
 @[simp] theorem value_isRefinedBy_value (a b : α) :
-    value a ⊑ value b ↔ a = b := by
+    value a ⊑ value b ↔ a ⊑ b := by
   constructor
   · rintro ⟨⟩; assumption
   · exact IsRefinedBy.bothValues
@@ -158,48 +157,48 @@ theorem isRefinedBy_poison_iff : a? ⊑ (@poison α) ↔ a? = poison := by
   · simp
   · simp only [not_value_isRefinedBy_poison, false_iff]; rintro ⟨⟩
 
-theorem value_isRefinedBy_iff : value a ⊑ b? ↔ b? = value a := by
-  cases b? <;> (
-    simp only [value_isRefinedBy_value, value_inj, isRefinedBy_poison_iff]
-    constructor <;> exact Eq.symm
-  )
-
 theorem isRefinedBy_iff [Inhabited α] [Inhabited β] :
     a? ⊑ b?
     ↔ (b?.isPoison → a?.isPoison)
-      ∧ (a?.isPoison = false → a?.getValue = b?.getValue) := by
+      ∧ (a?.isPoison = false → a?.getValue ⊑ b?.getValue) := by
   cases a? <;> cases b? <;> simp
 
 section PreOrder
-variable {α : Type} {a? : PoisonOr α}
 
 /--
-Refinement on poison values is reflexive
+Refinement on poison values is reflexive, when the underlying refinement is reflexive
 -/
-@[simp] theorem isRefinedBy_self : a? ⊑ a? := by
-  cases a? <;> simp
+instance [Std.Refl (· ⊑ · : α → α → _)] : Std.Refl (· ⊑ · : PoisonOr α → PoisonOr α → _) where
+  refl a? := by cases a? <;> simp [Std.Refl.refl]
+
+@[simp] theorem isRefinedBy_self [Std.Refl (· ⊑ · : α → α → _)] : a? ⊑ a? := Std.Refl.refl _
+
+/--
+Refinement on poison values is transitive, when the underlying refinement is transitive
+-/
+instance [IsTrans α (· ⊑ ·)] : IsTrans (PoisonOr α) (· ⊑ ·) where
+  trans a? b? c? := by
+    cases a?; simp
+    cases b?; simp
+    cases c?; simp
+    simpa using IsTrans.trans _ _ _
 
 /--
 Refinement on poison values is transitive
 -/
-theorem isRefinedBy_trans (a? b? c? : PoisonOr α) :
-    a? ⊑ b? → b? ⊑ c? → a? ⊑ c? := by
-  cases a?
-  · simp
-  · simp only [value_isRefinedBy_iff]
-    rintro rfl
-    simp [value_isRefinedBy_iff]
+theorem isRefinedBy_trans [IsTrans α (· ⊑ ·)] (a? b? c? : PoisonOr α) :
+    a? ⊑ b? → b? ⊑ c? → a? ⊑ c? := IsTrans.trans _ _ _
 
 end PreOrder
 
 /--
 Refinement on poison values is decidable if equality of the underlying values is decidable.
 -/
-instance {α : Type} [DecidableEq α] :
+instance [DecidableRel (· ⊑ · : α → α → _)] :
     DecidableRel (· ⊑ · : PoisonOr α → PoisonOr α → _)
   | .poison, _ => .isTrue <| by simp
   | .value _, .poison => .isFalse <| by simp
-  | .value a, .value b => decidable_of_decidable_of_iff (p := a = b) <| by simp
+  | .value a, .value b => decidable_of_decidable_of_iff (p := a ⊑ b) <| by simp
 
 end Refinement
 

--- a/SSA/Projects/InstCombine/AliveHandwrittenLargeExamples.lean
+++ b/SSA/Projects/InstCombine/AliveHandwrittenLargeExamples.lean
@@ -130,7 +130,7 @@ def alive_simplifyMulDivRem805 (w : Nat) :
     case pos =>
       subst hx
       rw [LLVM.sdiv?_denom_zero_eq_poison]
-      apply PoisonOr.poison_isRefinedBy
+      simp
     case neg =>
       rw [BitVec.ult_toNat]
       rw [BitVec.toNat_ofNat]
@@ -231,8 +231,8 @@ def alive_simplifyMulDivRem805' (w : Nat) :
   simp only [ofBool_1_iff_true]
   by_cases w_0 : w = 0; subst w_0; simp [BitVec.eq_nil a]
   split_ifs with c
-  · apply PoisonOr.poison_isRefinedBy
-  · apply PoisonOr.poison_isRefinedBy
+  · simp
+  · simp
   · by_cases h : 3#w >ᵤ 1#w + a
     · simp only [h, ofBool_true, ofNat_eq_ofNat, PoisonOr.value_isRefinedBy_value]
       by_cases a_0 : a = 0; subst a_0; simp at c
@@ -305,7 +305,7 @@ def alive_simplifyMulDivRem805' (w : Nat) :
         Nat.add_comm, Nat.sub_add_cancel, Nat.mod_self] at h
       norm_num at h
       omega
-    rw [one_sdiv a_ne_zero a_ne_one a_ne_allOnes]
+    simp [one_sdiv a_ne_zero a_ne_one a_ne_allOnes]
 
 
 /--info: 'AliveHandwritten.MulDivRem.alive_simplifyMulDivRem805'' depends on axioms:

--- a/SSA/Projects/InstCombine/LLVM/Semantics.lean
+++ b/SSA/Projects/InstCombine/LLVM/Semantics.lean
@@ -21,6 +21,10 @@ namespace IntW
 
 instance : Inhabited (IntW w) := by unfold IntW; infer_instance
 
+scoped instance : Refinement (BitVec w) := .ofEq
+@[simp, simp_llvm_split] theorem bv_isRefinedBy_iff (x y : BitVec w) : x ⊑ y ↔ x = y := by rfl
+-- ^^ declare that for pure bitvectors, refinement is just equality
+
 instance : Refinement (LLVM.IntW w) := inferInstanceAs (Refinement <| PoisonOr _)
 
 /--

--- a/SSA/Projects/InstCombine/LLVM/Semantics.lean
+++ b/SSA/Projects/InstCombine/LLVM/Semantics.lean
@@ -11,8 +11,17 @@ import Mathlib.Tactic.SplitIfs
 import Mathlib.Tactic.Tauto
 import Aesop
 
+namespace InstCombine
+
+scoped instance : Refinement (BitVec w) := .ofEq
+@[simp, simp_llvm_split] theorem bv_isRefinedBy_iff (x y : BitVec w) : x ⊑ y ↔ x = y := by rfl
+-- ^^ declare that for pure bitvectors, refinement is just equality
+
+end InstCombine
+
 
 namespace LLVM
+open InstCombine
 open PoisonOr (value poison)
 
 def IntW w := PoisonOr <| BitVec w
@@ -20,10 +29,6 @@ def IntW w := PoisonOr <| BitVec w
 namespace IntW
 
 instance : Inhabited (IntW w) := by unfold IntW; infer_instance
-
-scoped instance : Refinement (BitVec w) := .ofEq
-@[simp, simp_llvm_split] theorem bv_isRefinedBy_iff (x y : BitVec w) : x ⊑ y ↔ x = y := by rfl
--- ^^ declare that for pure bitvectors, refinement is just equality
 
 instance : Refinement (LLVM.IntW w) := inferInstanceAs (Refinement <| PoisonOr _)
 

--- a/SSA/Projects/InstCombine/Tactic/SimpLLVM.lean
+++ b/SSA/Projects/InstCombine/Tactic/SimpLLVM.lean
@@ -23,8 +23,17 @@ attribute [simp_llvm_split]
    so they've been preserved to not change this existing behaviour of `simp_alive_case_bash` -/
 
 attribute [simp_llvm_option]
-  PoisonOr.value_bind PoisonOr.value_isRefinedBy_iff PoisonOr.isRefinedBy_poison_iff
+  PoisonOr.value_bind PoisonOr.isRefinedBy_poison_iff
   PoisonOr.value_ne_poison PoisonOr.poison_ne_value
+
+open PoisonOr in
+@[simp_llvm_option]
+theorem LLVM.IntW.value_isRefinedBy_iff (a : BitVec w) (b? : PoisonOr (BitVec w)) :
+    value a ⊑ b? ↔ b? = value a := by
+  cases b? <;> (
+    simp only [value_isRefinedBy_value, value_inj, isRefinedBy_poison_iff]
+    constructor <;> exact Eq.symm
+  )
 
 /-- `ensure_only_goal` succeeds, doing nothing, when there is exactly *one* goal.
 If there are multiple goals, `ensure_only_goal` fails -/

--- a/SSA/Projects/InstCombine/Tactic/SimpLLVM.lean
+++ b/SSA/Projects/InstCombine/Tactic/SimpLLVM.lean
@@ -6,6 +6,7 @@ import SSA.Projects.InstCombine.LLVM.EDSL
 
 open Lean
 open Lean.Elab.Tactic
+open InstCombine
 
 attribute [simp_llvm_case_bash]
   bind_assoc forall_const Nat.cast_one

--- a/SSA/Projects/InstCombine/Test.lean
+++ b/SSA/Projects/InstCombine/Test.lean
@@ -473,5 +473,5 @@ def constant_macro (w : Nat) :=
 def constant_macro_proof (w : Nat) :
     constant_macro w ⊑ constant_macro w := by
   unfold constant_macro
-  simp_alive_ssa
-  apply PoisonOr.isRefinedBy_self
+  simp_peephole
+  simp


### PR DESCRIPTION
This PR adapts refinement of PoisonOr values s.t. `value a` is refined by `value b` whenever `a` is refined by `b` (rather than hard-coding `a = b` as the condition), by requiring some underlying refinement relation on the wrapped values. This will become relevant when modelling UB, as then we'll have two layers of optionals (UB and poison), which we'd ideally both model as `PoisonOr`. This change thus ensures that stack gets the right poison semantics, so that `value poison` indeed is refined by `value (value 1#w)`.

To make the existing LLVM semantics work, we add a scoped instance of refinement for pure bitvectors, based on equality, so that the meaning of refinement of LLVM.IntW is the same as before. We make this instance scoped so that other dialects can still make other choices as to what refinement of bitvectors means, but it does mean that some lemmas won't apply out of the box. Instead of having to remember to open the right namespace for each proof file, I fixed this by using `simp` instead (which is able to unify against the not-in-scope instance in the proof goal, rather than trying to synthesize a new instance).