### PR TITLE
fix: adapt PeepholeRefine for hybrid dialect to support generic width.

### DIFF
--- a/SSA/Projects/LLVMRiscV/LLVMAndRiscv.lean
+++ b/SSA/Projects/LLVMRiscV/LLVMAndRiscv.lean
@@ -33,11 +33,7 @@ inductive Op where
   | riscv : RISCV64.RV64.Op -> Op
   | castRiscv : Nat → Op
   | castLLVM : Nat → Op
-<<<<<<< HEAD
-  deriving DecidableEq, Repr
-=======
   deriving DecidableEq, Repr, Lean.ToExpr
->>>>>>> origin/main
 
 /-- Semantics of an unrealized conversion cast from RISC-V 64 to LLVM.
 We wrap `BitVec 64`in `Option (BitVec 64)` -/

--- a/SSA/Projects/LLVMRiscV/PeepholeRefine.lean
+++ b/SSA/Projects/LLVMRiscV/PeepholeRefine.lean
@@ -22,7 +22,7 @@ our rewrites into a form accepted by the Peephole Rewriter.
 structure for LLVM `Com`s. The refinement is based on the
 dedicated refinement relation for the `PoisonOr` type, where
 a poison value can be refined by any concrete value. -/
-structure LLVMPeepholeRewriteRefine (w : InstCombine.Width 0) (Γ : Ctxt Ty) where
+structure LLVMPeepholeRewriteRefine (w : Nat) (Γ : Ctxt Ty) where
   lhs : Com LLVMPlusRiscV Γ .pure (Ty.llvm (.bitvec w.toConcrete))
   rhs : Com LLVMPlusRiscV Γ .pure (Ty.llvm (.bitvec w.toConcrete))
   correct : ∀ V,


### PR DESCRIPTION
This PR changes the PeepholeRefine structure of the LLVMAndRiscV dialect to support Refinement for generic width and not fixed to 64-bit width. 