### PR TITLE
fix: add instance of bit vector refinement to peephole refine

### DIFF
--- a/SSA/Projects/LLVMRiscV/PeepholeRefine.lean
+++ b/SSA/Projects/LLVMRiscV/PeepholeRefine.lean
@@ -17,14 +17,16 @@ a `sorry`. To still leverage the rewrite functionality, we wrap
 our rewrites into a form accepted by the Peephole Rewriter.
  -/
 
+instance : Refinement (BitVec w) := .ofEq
+@[simp] theorem bv_isRefinedBy_iff (x y : BitVec w) : x ⊑ y ↔ x = y := by rfl
 
 /-- `LLVMPeepholeRewriteRefine` defines the `PeepholeRewrite`
 structure for LLVM `Com`s. The refinement is based on the
 dedicated refinement relation for the `PoisonOr` type, where
 a poison value can be refined by any concrete value. -/
 structure LLVMPeepholeRewriteRefine (w : Nat) (Γ : Ctxt Ty) where
-  lhs : Com LLVMPlusRiscV Γ .pure (Ty.llvm (.bitvec w.toConcrete))
-  rhs : Com LLVMPlusRiscV Γ .pure (Ty.llvm (.bitvec w.toConcrete))
+  lhs : Com LLVMPlusRiscV Γ .pure (Ty.llvm (.bitvec w))
+  rhs : Com LLVMPlusRiscV Γ .pure (Ty.llvm (.bitvec w))
   correct : ∀ V,
     PoisonOr.IsRefinedBy (lhs.denote V) (rhs.denote V)
 
@@ -43,7 +45,7 @@ provided until the Peephole Rewriter accepts refinements.
  -/
 def LLVMToRiscvPeepholeRewriteRefine.toPeepholeUNSOUND
   (self : LLVMPeepholeRewriteRefine w Γ) :
-   PeepholeRewrite LLVMPlusRiscV Γ (Ty.llvm (.bitvec w.toConcrete))  :=
+   PeepholeRewrite LLVMPlusRiscV Γ (Ty.llvm (.bitvec w))  :=
   {
     lhs := self.lhs
     rhs := self.rhs


### PR DESCRIPTION
This PR makes the bit vector refinement accessible to the peephole refinement.