### PR TITLE
feat: add instruction lowering 64-bit & according PoisonOr lemmas 

### DIFF
--- a/SSA/Core/Util/Poison.lean
+++ b/SSA/Core/Util/Poison.lean
@@ -129,6 +129,11 @@ variable {a : α}
 @[simp] theorem mk_some (x : α) : { toOption := some x } = PoisonOr.value x := rfl
 @[simp] theorem mk_none : { toOption := none (α := α) } = PoisonOr.poison := rfl
 
+@[simp_denote, simp]
+theorem toOption_getSome : (PoisonOr.value x).toOption.getD y = x := by rfl
+@[simp_denote, simp]
+theorem toOption_getNone : (PoisonOr.poison).toOption.getD y = y := by rfl
+
 end Lemmas
 
 /-! ### Refinement -/
@@ -166,6 +171,9 @@ theorem isRefinedBy_iff [Inhabited α] [Inhabited β] :
     ↔ (b?.isPoison → a?.isPoison)
       ∧ (a?.isPoison = false → a?.getValue ⊑ b?.getValue) := by
   cases a? <;> cases b? <;> simp
+
+@[simp, simp_denote]
+theorem PoisonOr.eq_squb [HRefinement α α] (a b : PoisonOr α) : PoisonOr.IsRefinedBy a b ↔ a ⊑ b := by rfl
 
 section PreOrder
 

--- a/SSA/Projects/LLVMRiscV/LLVMAndRiscv.lean
+++ b/SSA/Projects/LLVMRiscV/LLVMAndRiscv.lean
@@ -37,6 +37,7 @@ inductive Op where
 
 /-- Semantics of an unrealized conversion cast from RISC-V 64 to LLVM.
 We wrap `BitVec 64`in `Option (BitVec 64)` -/
+@[simp_riscv]
 def castriscvToLLVM (toCast : BitVec 64) : PoisonOr (BitVec w) :=
   .value (BitVec.signExtend w toCast)
 
@@ -46,6 +47,7 @@ This cast attempts to lower an `(Option (BitVec 64))` to a concrete `(BitVec 64)
 If the value is `some`, we extract the underlying `BitVec`.
 If it is `none` (e.g., an LLVM poison value), we default to the zero `BitVec`.
 -/
+@[simp_riscv]
 def castLLVMToriscv (toCast : PoisonOr (BitVec w)) : BitVec 64 :=
   BitVec.setWidth 64 (toCast.toOption.getD 0#w)
 

--- a/SSA/Projects/LLVMRiscV/PeepholeRefine.lean
+++ b/SSA/Projects/LLVMRiscV/PeepholeRefine.lean
@@ -19,14 +19,15 @@ our rewrites into a form accepted by the Peephole Rewriter.
 
 instance : Refinement (BitVec w) := .ofEq
 @[simp] theorem bv_isRefinedBy_iff (x y : BitVec w) : x ⊑ y ↔ x = y := by rfl
+-- ^^ declare that for pure bitvectors, refinement is just equality
 
 /-- `LLVMPeepholeRewriteRefine` defines the `PeepholeRewrite`
 structure for LLVM `Com`s. The refinement is based on the
 dedicated refinement relation for the `PoisonOr` type, where
 a poison value can be refined by any concrete value. -/
-structure LLVMPeepholeRewriteRefine (w : Nat) (Γ : Ctxt Ty) where
-  lhs : Com LLVMPlusRiscV Γ .pure (Ty.llvm (.bitvec w))
-  rhs : Com LLVMPlusRiscV Γ .pure (Ty.llvm (.bitvec w))
+structure LLVMPeepholeRewriteRefine ( w : InstCombine.Width 0) (Γ : Ctxt Ty) where
+  lhs : Com LLVMPlusRiscV Γ .pure (Ty.llvm (.bitvec w.toConcrete))
+  rhs : Com LLVMPlusRiscV Γ .pure (Ty.llvm (.bitvec w.toConcrete))
   correct : ∀ V,
     PoisonOr.IsRefinedBy (lhs.denote V) (rhs.denote V)
 

--- a/SSA/Projects/LLVMRiscV/PeepholeRefine.lean
+++ b/SSA/Projects/LLVMRiscV/PeepholeRefine.lean
@@ -29,7 +29,7 @@ structure LLVMPeepholeRewriteRefine (w : Nat) (Γ : Ctxt Ty) where
   rhs : Com LLVMPlusRiscV Γ .pure (Ty.llvm (.bitvec w))
   correct : ∀ V,
     PoisonOr.IsRefinedBy (lhs.denote V) (rhs.denote V)
-    
+
 /-!
 ##  Wrapper for the Peephole Rewriter
 -/

--- a/SSA/Projects/LLVMRiscV/PeepholeRefine.lean
+++ b/SSA/Projects/LLVMRiscV/PeepholeRefine.lean
@@ -29,6 +29,7 @@ structure LLVMPeepholeRewriteRefine (w : Nat) (Γ : Ctxt Ty) where
   rhs : Com LLVMPlusRiscV Γ .pure (Ty.llvm (.bitvec w))
   correct : ∀ V,
     PoisonOr.IsRefinedBy (lhs.denote V) (rhs.denote V)
+    
 /-!
 ##  Wrapper for the Peephole Rewriter
 -/

--- a/SSA/Projects/LLVMRiscV/PeepholeRefine.lean
+++ b/SSA/Projects/LLVMRiscV/PeepholeRefine.lean
@@ -19,18 +19,16 @@ our rewrites into a form accepted by the Peephole Rewriter.
 
 instance : Refinement (BitVec w) := .ofEq
 @[simp] theorem bv_isRefinedBy_iff (x y : BitVec w) : x ⊑ y ↔ x = y := by rfl
--- ^^ declare that for pure bitvectors, refinement is just equality
 
 /-- `LLVMPeepholeRewriteRefine` defines the `PeepholeRewrite`
 structure for LLVM `Com`s. The refinement is based on the
 dedicated refinement relation for the `PoisonOr` type, where
 a poison value can be refined by any concrete value. -/
-structure LLVMPeepholeRewriteRefine ( w : InstCombine.Width 0) (Γ : Ctxt Ty) where
-  lhs : Com LLVMPlusRiscV Γ .pure (Ty.llvm (.bitvec w.toConcrete))
-  rhs : Com LLVMPlusRiscV Γ .pure (Ty.llvm (.bitvec w.toConcrete))
+structure LLVMPeepholeRewriteRefine (w : Nat) (Γ : Ctxt Ty) where
+  lhs : Com LLVMPlusRiscV Γ .pure (Ty.llvm (.bitvec w))
+  rhs : Com LLVMPlusRiscV Γ .pure (Ty.llvm (.bitvec w))
   correct : ∀ V,
     PoisonOr.IsRefinedBy (lhs.denote V) (rhs.denote V)
-
 /-!
 ##  Wrapper for the Peephole Rewriter
 -/

--- a/SSA/Projects/LLVMRiscV/Pipeline/add.lean
+++ b/SSA/Projects/LLVMRiscV/Pipeline/add.lean
@@ -1,0 +1,109 @@
+import SSA.Projects.LLVMRiscV.PeepholeRefine
+import SSA.Projects.LLVMRiscV.LLVMAndRiscv
+import SSA.Projects.InstCombine.Tactic
+import SSA.Projects.RISCV64.PrettyEDSL
+import SSA.Projects.InstCombine.LLVM.PrettyEDSL
+import SSA.Projects.LLVMRiscV.simpproc
+import SSA.Projects.RISCV64.Tactic.SimpRiscV
+
+import Lean
+
+open LLVMRiscV
+open RV64Semantics
+open InstCombine(LLVM)
+
+/-
+Disabled due to simproc implementation not being re-evaluated correctly
+on Lean version "4.20.0-nightly-2025-04-21" -/
+set_option Elab.async true
+
+/- # ADD, riscv -/
+def add_riscv := [LV| {
+  ^entry (%lhs: i64, %rhs: i64 ):
+    %lhsr = "builtin.unrealized_conversion_cast"(%lhs) : (i64) -> !i64
+    %rhsr = "builtin.unrealized_conversion_cast"(%rhs) : (i64) -> !i64
+    %add1 = add %lhsr, %rhsr : !i64
+    %addl = "builtin.unrealized_conversion_cast"(%add1) : (!i64) -> (i64)
+    llvm.return %addl : i64
+  }]
+
+/- # ADD, no flag  -/
+def add_llvm_no_flags : Com LLVMPlusRiscV [.llvm (.bitvec 64), .llvm (.bitvec 64)]
+  .pure (.llvm (.bitvec 64))  := [LV| {
+  ^entry (%lhs: i64, %rhs: i64 ):
+    %1 = llvm.add %lhs, %rhs  : i64
+    llvm.return %1 : i64
+  }]
+
+/- # ADD, with flags  -/
+def add_llvm_nsw_flags : Com LLVMPlusRiscV [.llvm (.bitvec 64), .llvm (.bitvec 64)]
+  .pure (.llvm (.bitvec 64))  := [LV| {
+  ^entry (%lhs: i64, %rhs: i64 ):
+    %1 = llvm.add %lhs, %rhs overflow<nsw> : i64
+    llvm.return %1 : i64
+  }]
+
+def add_llvm_nuw_flags : Com LLVMPlusRiscV [.llvm (.bitvec 64), .llvm (.bitvec 64)]
+  .pure (.llvm (.bitvec 64)) := [LV| {
+  ^entry (%lhs: i64, %rhs: i64 ):
+     %1 = llvm.add %lhs, %rhs overflow<nuw> : i64
+    llvm.return %1 : i64
+  }]
+
+def add_llvm_nsw_nuw_flags : Com LLVMPlusRiscV [.llvm (.bitvec 64), .llvm (.bitvec 64)]
+  .pure (.llvm (.bitvec 64)) := [LV| {
+   ^entry (%lhs: i64, %rhs: i64 ):
+      %1 = llvm.add %lhs, %rhs overflow<nsw,nuw> : i64
+      llvm.return %1 : i64
+  }]
+
+/- example of very manula proof ->try to extract patterns for automation-/
+def llvm_add_lower_riscv_noflags : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64),
+  Ty.llvm (.bitvec 64)] :=
+  {lhs:= add_llvm_no_flags, rhs:= add_riscv ,
+   correct := by
+    unfold add_llvm_no_flags add_riscv
+    simp_peephole
+    simp_riscv
+    simp_alive_undef
+    simp_alive_case_bash
+    simp_alive_split
+    all_goals simp
+  }
+
+def llvm_add_lower_riscv_nsw_flag : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] :=
+  {lhs:= add_llvm_nsw_flags, rhs:= add_riscv ,
+   correct := by
+    unfold add_llvm_nsw_flags add_riscv
+    simp_peephole
+    simp_riscv
+    simp_alive_undef
+    simp_alive_case_bash
+    simp_alive_split
+    all_goals simp
+  }
+
+def llvm_add_lower_riscv_nuw_flag : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64),
+  Ty.llvm (.bitvec 64)] :=
+  {lhs:= add_llvm_nuw_flags, rhs:= add_riscv ,
+   correct := by
+    unfold add_llvm_nuw_flags add_riscv
+    simp_peephole
+    simp_riscv
+    simp_alive_undef
+    simp_alive_case_bash
+    simp_alive_split
+    all_goals simp
+  }
+
+def llvm_add_lower_riscv_nuw_nsw_flag : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64) , Ty.llvm (.bitvec 64)] :=
+  {lhs:= add_llvm_nuw_flags, rhs:= add_riscv ,
+   correct := by
+    unfold add_llvm_nuw_flags add_riscv
+    simp_peephole
+    simp_riscv
+    simp_alive_undef
+    simp_alive_case_bash
+    simp_alive_split
+    all_goals simp
+  }


### PR DESCRIPTION
This PR adds the proof for 64-bit addition lowering. The proofs are structured so that each one follows the same sequence of tactics.
To support this, we added missing lemmas to the PoisonOr file and marked two cast definitions in the LLVMAndRiscV dialect with the simp_riscv attribute.