### PR TITLE
feat: add sext and zext lowering

### DIFF
--- a/SSA/Projects/LLVMRiscV/Pipeline/sext.lean
+++ b/SSA/Projects/LLVMRiscV/Pipeline/sext.lean
@@ -7,7 +7,7 @@ open LLVMRiscV
 /- # sext instruction lowering-/
 
 def sext_riscv_i1_to_i8 := [LV| {
-  ^entry (%arg: i1 ):
+  ^entry (%arg: i1):
     %0 = "builtin.unrealized_conversion_cast"(%arg) : (i1) -> (!i64)
     %1 = slli %0, 63 : !i64
     %2 = srai %1, 63 : !i64
@@ -16,7 +16,7 @@ def sext_riscv_i1_to_i8 := [LV| {
   }]
 
 def sext_llvm_i1_to_i8 := [LV| {
-  ^entry (%arg: i1 ):
+  ^entry (%arg: i1):
     %0 = llvm.sext %arg: i1 to i8
     llvm.return %0: i8
   }]
@@ -38,7 +38,7 @@ def llvm_sext_lower_riscv_i1_to_i8 : LLVMPeepholeRewriteRefine 8 [Ty.llvm (.bitv
   }
 
 def sext_riscv_i1_to_i16 := [LV| {
-  ^entry (%arg: i1 ):
+  ^entry (%arg: i1):
     %0 = "builtin.unrealized_conversion_cast"(%arg) : (i1) -> (!i64)
     %1 = slli %0, 63 : !i64
     %2 = srai %1, 63 : !i64
@@ -47,7 +47,7 @@ def sext_riscv_i1_to_i16 := [LV| {
   }]
 
 def sext_llvm_i1_to_i16 := [LV| {
-  ^entry (%arg: i1 ):
+  ^entry (%arg: i1):
     %0 = llvm.sext %arg: i1 to i16
     llvm.return %0: i16
   }]
@@ -69,7 +69,7 @@ def llvm_sext_lower_riscv_i1_to_i16 : LLVMPeepholeRewriteRefine 16 [Ty.llvm (.bi
   }
 
 def sext_riscv_i1_to_i32 := [LV| {
-  ^entry (%arg: i1 ):
+  ^entry (%arg: i1):
     %0 = "builtin.unrealized_conversion_cast"(%arg) : (i1) -> (!i64)
     %1 = slli %0, 63 : !i64
     %2 = srai %1, 63 : !i64
@@ -78,7 +78,7 @@ def sext_riscv_i1_to_i32 := [LV| {
   }]
 
 def sext_llvm_i1_to_i32 := [LV| {
-  ^entry (%arg: i1 ):
+  ^entry (%arg: i1):
     %0 = llvm.sext %arg: i1 to i32
     llvm.return %0: i32
   }]
@@ -100,7 +100,7 @@ def llvm_sext_lower_riscv_i1_to_i32 : LLVMPeepholeRewriteRefine 32 [Ty.llvm (.bi
   }
 
 def sext_riscv_i1_to_i64 := [LV| {
-  ^entry (%arg: i1 ):
+  ^entry (%arg: i1):
     %0 = "builtin.unrealized_conversion_cast"(%arg) : (i1) -> (!i64)
     %1 = slli %0, 63 : !i64
     %2 = srai %1, 63 : !i64
@@ -109,7 +109,7 @@ def sext_riscv_i1_to_i64 := [LV| {
   }]
 
 def sext_llvm_i1_to_i64 := [LV| {
-  ^entry (%arg: i1 ):
+  ^entry (%arg: i1):
     %0 = llvm.sext %arg: i1 to i64
     llvm.return %0: i64
   }]
@@ -140,7 +140,7 @@ def sext_riscv_i8_to_i64 := [LV| {
   }]
 
 def sext_llvm_i8_to_i64 := [LV| {
-  ^entry (%arg: i8 ):
+  ^entry (%arg: i8):
     %0 = llvm.sext %arg: i8 to i64
     llvm.return %0: i64
   }]

--- a/SSA/Projects/LLVMRiscV/Pipeline/sext.lean
+++ b/SSA/Projects/LLVMRiscV/Pipeline/sext.lean
@@ -22,7 +22,7 @@ def sext_llvm_i1_to_i8 := [LV| {
   }]
 
 def llvm_sext_lower_riscv_i1_to_i8 : LLVMPeepholeRewriteRefine 8 [Ty.llvm (.bitvec 1)] :=
-  {lhs:= sext_llvm_i1_to_i8 , rhs:= sext_riscv_i1_to_i8 ,
+  {lhs:= sext_llvm_i1_to_i8, rhs:= sext_riscv_i1_to_i8,
    correct := by
     unfold sext_llvm_i1_to_i8 sext_riscv_i1_to_i8
     simp_peephole
@@ -53,7 +53,7 @@ def sext_llvm_i1_to_i16 := [LV| {
   }]
 
 def llvm_sext_lower_riscv_i1_to_i16 : LLVMPeepholeRewriteRefine 16 [Ty.llvm (.bitvec 1)] :=
-  {lhs:= sext_llvm_i1_to_i16 , rhs:= sext_riscv_i1_to_i16 ,
+  {lhs:= sext_llvm_i1_to_i16, rhs:= sext_riscv_i1_to_i16,
    correct := by
     unfold sext_llvm_i1_to_i16 sext_riscv_i1_to_i16
     simp_peephole
@@ -84,7 +84,7 @@ def sext_llvm_i1_to_i32 := [LV| {
   }]
 
 def llvm_sext_lower_riscv_i1_to_i32 : LLVMPeepholeRewriteRefine 32 [Ty.llvm (.bitvec 1)] :=
-  {lhs:= sext_llvm_i1_to_i32 , rhs:= sext_riscv_i1_to_i32 ,
+  {lhs:= sext_llvm_i1_to_i32, rhs:= sext_riscv_i1_to_i32,
    correct := by
     unfold sext_llvm_i1_to_i32 sext_riscv_i1_to_i32
     simp_peephole
@@ -115,7 +115,7 @@ def sext_llvm_i1_to_i64 := [LV| {
   }]
 
 def llvm_sext_lower_riscv_i1_to_i64 : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 1)] :=
-  {lhs:= sext_llvm_i1_to_i64 , rhs:= sext_riscv_i1_to_i64 ,
+  {lhs:= sext_llvm_i1_to_i64, rhs:= sext_riscv_i1_to_i64,
    correct := by
     unfold sext_llvm_i1_to_i64 sext_riscv_i1_to_i64
     simp_peephole
@@ -146,7 +146,7 @@ def sext_llvm_i8_to_i64 := [LV| {
   }]
 
 def llvm_sext_lower_riscv_i8_to_i64 : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 8)] :=
-  {lhs:=sext_llvm_i8_to_i64 , rhs:= sext_riscv_i8_to_i64 ,
+  {lhs:=sext_llvm_i8_to_i64, rhs:= sext_riscv_i8_to_i64,
    correct := by
     unfold sext_llvm_i8_to_i64 sext_riscv_i8_to_i64
     simp_peephole
@@ -177,7 +177,7 @@ def sext_llvm_i8_to_i16 := [LV| {
   }]
 
 def llvm_sext_lower_riscv_i8_to_i16 : LLVMPeepholeRewriteRefine 16 [Ty.llvm (.bitvec 8)] :=
-  {lhs:= sext_llvm_i8_to_i16 , rhs:= sext_riscv_i8_to_i16,
+  {lhs:= sext_llvm_i8_to_i16, rhs:= sext_riscv_i8_to_i16,
    correct := by
     unfold sext_llvm_i8_to_i16 sext_riscv_i8_to_i16
     simp_peephole
@@ -208,7 +208,7 @@ def sext_llvm_i8_to_i32 := [LV| {
   }]
 
 def llvm_sext_lower_riscv_i8_to_i32 : LLVMPeepholeRewriteRefine 32 [Ty.llvm (.bitvec 8)] :=
-  {lhs:= sext_llvm_i8_to_i32 , rhs:= sext_riscv_i8_to_i32,
+  {lhs:= sext_llvm_i8_to_i32, rhs:= sext_riscv_i8_to_i32,
    correct := by
     unfold sext_llvm_i8_to_i32 sext_riscv_i8_to_i32
     simp_peephole
@@ -239,7 +239,7 @@ def sext_llvm_i16_to_i32 := [LV| {
   }]
 
 def llvm_sext_lower_riscv_i16_to_i32 : LLVMPeepholeRewriteRefine 32 [Ty.llvm (.bitvec 16)] :=
-  {lhs:= sext_llvm_i16_to_i32 , rhs:= sext_riscv_i16_to_i32,
+  {lhs:= sext_llvm_i16_to_i32, rhs:= sext_riscv_i16_to_i32,
    correct := by
     unfold sext_llvm_i16_to_i32 sext_riscv_i16_to_i32
     simp_peephole

--- a/SSA/Projects/LLVMRiscV/Pipeline/sext.lean
+++ b/SSA/Projects/LLVMRiscV/Pipeline/sext.lean
@@ -62,7 +62,9 @@ def llvm_sext_lower_riscv_i1_to_i16 : LLVMPeepholeRewriteRefine 16 [Ty.llvm (.bi
     simp_alive_case_bash
     simp_alive_split
     all_goals
-    simp [ LLVM.sext?]
+    simp only [LLVM.sext?, PoisonOr.toOption_getSome, BitVec.shiftLeft_eq', BitVec.toNat_ofNat,
+      Nat.reducePow, Nat.mod_succ, BitVec.sshiftRight_eq', PoisonOr.value_isRefinedBy_value,
+      InstCombine.bv_isRefinedBy_iff]
     bv_decide
   }
 
@@ -91,7 +93,9 @@ def llvm_sext_lower_riscv_i1_to_i32 : LLVMPeepholeRewriteRefine 32 [Ty.llvm (.bi
     simp_alive_case_bash
     simp_alive_split
     all_goals
-    simp [ LLVM.sext?]
+    simp only [LLVM.sext?, PoisonOr.toOption_getSome, BitVec.shiftLeft_eq', BitVec.toNat_ofNat,
+      Nat.reducePow, Nat.mod_succ, BitVec.sshiftRight_eq', PoisonOr.value_isRefinedBy_value,
+      InstCombine.bv_isRefinedBy_iff]
     bv_decide
   }
 
@@ -120,7 +124,9 @@ def llvm_sext_lower_riscv_i1_to_i64 : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bi
     simp_alive_case_bash
     simp_alive_split
     all_goals
-    simp [LLVM.sext?]
+    simp only [LLVM.sext?, PoisonOr.toOption_getSome, BitVec.shiftLeft_eq', BitVec.toNat_ofNat,
+      Nat.reducePow, Nat.mod_succ, BitVec.sshiftRight_eq', BitVec.signExtend_eq,
+      PoisonOr.value_isRefinedBy_value, InstCombine.bv_isRefinedBy_iff]
     bv_decide
   }
 
@@ -149,7 +155,9 @@ def llvm_sext_lower_riscv_i8_to_i64 : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bi
     simp_alive_case_bash
     simp_alive_split
     all_goals
-    simp [LLVM.sext?]
+    simp only [LLVM.sext?, PoisonOr.toOption_getSome, BitVec.shiftLeft_eq', BitVec.toNat_ofNat,
+      Nat.reducePow, Nat.reduceMod, BitVec.sshiftRight_eq', BitVec.signExtend_eq,
+      PoisonOr.value_isRefinedBy_value, InstCombine.bv_isRefinedBy_iff]
     bv_decide
   }
 
@@ -178,7 +186,9 @@ def llvm_sext_lower_riscv_i8_to_i16 : LLVMPeepholeRewriteRefine 16 [Ty.llvm (.bi
     simp_alive_case_bash
     simp_alive_split
     all_goals
-    simp [LLVM.sext?]
+    simp only [LLVM.sext?, PoisonOr.toOption_getSome, BitVec.shiftLeft_eq', BitVec.toNat_ofNat,
+      Nat.reducePow, Nat.reduceMod, BitVec.sshiftRight_eq', PoisonOr.value_isRefinedBy_value,
+      InstCombine.bv_isRefinedBy_iff]
     bv_decide
   }
 
@@ -207,7 +217,9 @@ def llvm_sext_lower_riscv_i8_to_i32 : LLVMPeepholeRewriteRefine 32 [Ty.llvm (.bi
     simp_alive_case_bash
     simp_alive_split
     all_goals
-    simp [LLVM.sext?]
+    simp only [LLVM.sext?, PoisonOr.toOption_getSome, BitVec.shiftLeft_eq', BitVec.toNat_ofNat,
+      Nat.reducePow, Nat.reduceMod, BitVec.sshiftRight_eq', PoisonOr.value_isRefinedBy_value,
+      InstCombine.bv_isRefinedBy_iff]
     bv_decide
   }
 
@@ -236,7 +248,9 @@ def llvm_sext_lower_riscv_i16_to_i32 : LLVMPeepholeRewriteRefine 32 [Ty.llvm (.b
     simp_alive_case_bash
     simp_alive_split
     all_goals
-    simp [LLVM.sext?]
+    simp only [LLVM.sext?, PoisonOr.toOption_getSome, BitVec.shiftLeft_eq', BitVec.toNat_ofNat,
+      Nat.reducePow, Nat.reduceMod, BitVec.sshiftRight_eq', PoisonOr.value_isRefinedBy_value,
+      InstCombine.bv_isRefinedBy_iff]
     bv_decide
   }
 
@@ -265,6 +279,8 @@ def llvm_sext_lower_riscv_i16_to_i64 : LLVMPeepholeRewriteRefine 32 [Ty.llvm (.b
     simp_alive_case_bash
     simp_alive_split
     all_goals
-    simp [LLVM.sext?]
+    simp only [LLVM.sext?, PoisonOr.toOption_getSome, BitVec.shiftLeft_eq', BitVec.toNat_ofNat,
+      Nat.reducePow, Nat.reduceMod, BitVec.sshiftRight_eq', PoisonOr.value_isRefinedBy_value,
+      InstCombine.bv_isRefinedBy_iff]
     bv_decide
   }

--- a/SSA/Projects/LLVMRiscV/Pipeline/sext.lean
+++ b/SSA/Projects/LLVMRiscV/Pipeline/sext.lean
@@ -1,0 +1,270 @@
+import SSA.Projects.LLVMRiscV.PeepholeRefine
+import SSA.Projects.LLVMRiscV.simpproc
+import SSA.Projects.RISCV64.Tactic.SimpRiscV
+
+open LLVMRiscV
+
+/- # sext instruction lowering-/
+
+def sext_riscv_i1_to_i8 := [LV| {
+  ^entry (%arg: i1 ):
+    %0 = "builtin.unrealized_conversion_cast"(%arg) : (i1) -> !i64
+    %1 = slli %0, 63 : !i64
+    %2 = srai %1, 63 : !i64
+    %res = "builtin.unrealized_conversion_cast"(%2) : (!i64) -> (i8)
+    llvm.return %res: i8
+  }]
+
+def sext_llvm_i1_to_i8 := [LV| {
+  ^entry (%arg: i1 ):
+    %0 = llvm.sext %arg: i1 to i8
+    llvm.return %0: i8
+  }]
+
+def llvm_sext_lower_riscv_i1_to_i8 : LLVMPeepholeRewriteRefine 8 [Ty.llvm (.bitvec 1)] :=
+  {lhs:= sext_llvm_i1_to_i8 , rhs:= sext_riscv_i1_to_i8 ,
+   correct := by
+    unfold sext_llvm_i1_to_i8 sext_riscv_i1_to_i8
+    simp_peephole
+    simp_riscv
+    simp_alive_undef
+    simp_alive_case_bash
+    simp_alive_split
+    all_goals
+    simp only [LLVM.sext?, PoisonOr.toOption_getSome, BitVec.shiftLeft_eq', BitVec.toNat_ofNat,
+      Nat.reducePow, Nat.mod_succ, BitVec.sshiftRight_eq', PoisonOr.value_isRefinedBy_value,
+      InstCombine.bv_isRefinedBy_iff]
+    bv_decide
+  }
+
+def sext_riscv_i1_to_i16 := [LV| {
+  ^entry (%arg: i1 ):
+    %0 = "builtin.unrealized_conversion_cast"(%arg) : (i1) -> !i64
+    %1 = slli %0, 63 : !i64
+    %2 = srai %1, 63 : !i64
+    %res = "builtin.unrealized_conversion_cast"(%2) : (!i64) -> (i16)
+    llvm.return %res : i16
+  }]
+
+def sext_llvm_i1_to_i16 := [LV| {
+  ^entry (%arg: i1 ):
+    %0 = llvm.sext %arg: i1 to i16
+    llvm.return %0: i16
+  }]
+
+def llvm_sext_lower_riscv_i1_to_i16 : LLVMPeepholeRewriteRefine 16 [Ty.llvm (.bitvec 1)] :=
+  {lhs:= sext_llvm_i1_to_i16 , rhs:= sext_riscv_i1_to_i16 ,
+   correct := by
+    unfold sext_llvm_i1_to_i16 sext_riscv_i1_to_i16
+    simp_peephole
+    simp_riscv
+    simp_alive_undef
+    simp_alive_case_bash
+    simp_alive_split
+    all_goals
+    simp [ LLVM.sext?]
+    bv_decide
+  }
+
+def sext_riscv_i1_to_i32 := [LV| {
+  ^entry (%arg: i1 ):
+    %0 = "builtin.unrealized_conversion_cast"(%arg) : (i1) -> !i64
+    %1 = slli %0, 63 : !i64
+    %2 = srai %1, 63 : !i64
+    %res = "builtin.unrealized_conversion_cast"(%2) : (!i64) -> (i32)
+    llvm.return %res : i32
+  }]
+
+def sext_llvm_i1_to_i32 := [LV| {
+  ^entry (%arg: i1 ):
+    %0 = llvm.sext %arg: i1 to i32
+    llvm.return %0: i32
+  }]
+
+def llvm_sext_lower_riscv_i1_to_i32 : LLVMPeepholeRewriteRefine 32 [Ty.llvm (.bitvec 1)] :=
+  {lhs:= sext_llvm_i1_to_i32 , rhs:= sext_riscv_i1_to_i32 ,
+   correct := by
+    unfold sext_llvm_i1_to_i32 sext_riscv_i1_to_i32
+    simp_peephole
+    simp_riscv
+    simp_alive_undef
+    simp_alive_case_bash
+    simp_alive_split
+    all_goals
+    simp [ LLVM.sext?]
+    bv_decide
+  }
+
+def sext_riscv_i1_to_i64 := [LV| {
+  ^entry (%arg: i1 ):
+    %0 = "builtin.unrealized_conversion_cast"(%arg) : (i1) -> !i64
+    %1 = slli %0, 63 : !i64
+    %2 = srai %1, 63 : !i64
+    %res = "builtin.unrealized_conversion_cast"(%2) : (!i64) -> (i64)
+    llvm.return %res : i64
+  }]
+
+def sext_llvm_i1_to_i64 := [LV| {
+  ^entry (%arg: i1 ):
+    %0 = llvm.sext %arg: i1 to i64
+    llvm.return %0: i64
+  }]
+
+def llvm_sext_lower_riscv_i1_to_i64 : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 1)] :=
+  {lhs:= sext_llvm_i1_to_i64 , rhs:= sext_riscv_i1_to_i64 ,
+   correct := by
+    unfold sext_llvm_i1_to_i64 sext_riscv_i1_to_i64
+    simp_peephole
+    simp_riscv
+    simp_alive_undef
+    simp_alive_case_bash
+    simp_alive_split
+    all_goals
+    simp [LLVM.sext?]
+    bv_decide
+  }
+
+def sext_riscv_i8_to_i64 := [LV| {
+  ^entry (%arg: i8):
+    %0 = "builtin.unrealized_conversion_cast"(%arg) : (i8) -> !i64
+    %1 = slli %0, 56 : !i64
+    %2 = srai %1, 56 : !i64
+    %res = "builtin.unrealized_conversion_cast"(%2) : (!i64) -> (i64)
+    llvm.return %res : i64
+  }]
+
+def sext_llvm_i8_to_i64 := [LV| {
+  ^entry (%arg: i8 ):
+    %0 = llvm.sext %arg: i8 to i64
+    llvm.return %0: i64
+  }]
+
+def llvm_sext_lower_riscv_i8_to_i64 : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 8)] :=
+  {lhs:=sext_llvm_i8_to_i64 , rhs:= sext_riscv_i8_to_i64 ,
+   correct := by
+    unfold sext_llvm_i8_to_i64 sext_riscv_i8_to_i64
+    simp_peephole
+    simp_riscv
+    simp_alive_undef
+    simp_alive_case_bash
+    simp_alive_split
+    all_goals
+    simp [LLVM.sext?]
+    bv_decide
+  }
+
+def sext_riscv_i8_to_i16 := [LV| {
+  ^entry (%arg: i8):
+    %0 = "builtin.unrealized_conversion_cast"(%arg) : (i8) -> !i64
+    %1 = slli %0, 56 : !i64
+    %2 = srai %1, 56 : !i64
+    %res = "builtin.unrealized_conversion_cast"(%2) : (!i64) -> (i16)
+    llvm.return %res : i16
+  }]
+
+def sext_llvm_i8_to_i16 := [LV| {
+  ^entry (%arg: i8):
+    %0 = llvm.sext %arg: i8 to i16
+    llvm.return %0: i16
+  }]
+
+def llvm_sext_lower_riscv_i8_to_i16 : LLVMPeepholeRewriteRefine 16 [Ty.llvm (.bitvec 8)] :=
+  {lhs:= sext_llvm_i8_to_i16 , rhs:= sext_riscv_i8_to_i16,
+   correct := by
+    unfold sext_llvm_i8_to_i16 sext_riscv_i8_to_i16
+    simp_peephole
+    simp_riscv
+    simp_alive_undef
+    simp_alive_case_bash
+    simp_alive_split
+    all_goals
+    simp [LLVM.sext?]
+    bv_decide
+  }
+
+def sext_riscv_i8_to_i32 := [LV| {
+  ^entry (%arg: i8):
+    %0 = "builtin.unrealized_conversion_cast"(%arg) : (i8) -> !i64
+    %1 = slli %0, 56 : !i64
+    %2 = srai %1, 56 : !i64
+    %res = "builtin.unrealized_conversion_cast"(%2) : (!i64) -> (i32)
+    llvm.return %res : i32
+  }]
+
+def sext_llvm_i8_to_i32 := [LV| {
+  ^entry (%arg: i8):
+    %0 = llvm.sext %arg: i8 to i32
+    llvm.return %0: i32
+  }]
+
+def llvm_sext_lower_riscv_i8_to_i32 : LLVMPeepholeRewriteRefine 32 [Ty.llvm (.bitvec 8)] :=
+  {lhs:= sext_llvm_i8_to_i32 , rhs:= sext_riscv_i8_to_i32,
+   correct := by
+    unfold sext_llvm_i8_to_i32 sext_riscv_i8_to_i32
+    simp_peephole
+    simp_riscv
+    simp_alive_undef
+    simp_alive_case_bash
+    simp_alive_split
+    all_goals
+    simp [LLVM.sext?]
+    bv_decide
+  }
+
+def sext_riscv_i16_to_i32 := [LV| {
+  ^entry (%arg: i16):
+    %0 = "builtin.unrealized_conversion_cast"(%arg) : (i16) -> !i64
+    %1 = slli %0, 48 : !i64
+    %2 = srai %1, 48 : !i64
+    %res = "builtin.unrealized_conversion_cast"(%2) : (!i64) -> (i32)
+    llvm.return %res : i32
+  }]
+
+def sext_llvm_i16_to_i32 := [LV| {
+  ^entry (%arg: i16):
+    %0 = llvm.sext %arg: i16 to i32
+    llvm.return %0: i32
+  }]
+
+def llvm_sext_lower_riscv_i16_to_i32 : LLVMPeepholeRewriteRefine 32 [Ty.llvm (.bitvec 16)] :=
+  {lhs:= sext_llvm_i16_to_i32 , rhs:= sext_riscv_i16_to_i32,
+   correct := by
+    unfold sext_llvm_i16_to_i32 sext_riscv_i16_to_i32
+    simp_peephole
+    simp_riscv
+    simp_alive_undef
+    simp_alive_case_bash
+    simp_alive_split
+    all_goals
+    simp [LLVM.sext?]
+    bv_decide
+  }
+
+def sext_riscv_i16_to_i64 := [LV| {
+  ^entry (%arg: i16):
+    %0 = "builtin.unrealized_conversion_cast"(%arg) : (i16) -> !i64
+    %1 = slli %0, 48 : !i64
+    %2 = srai %1, 48 : !i64
+    %res = "builtin.unrealized_conversion_cast"(%2) : (!i64) -> (i32)
+    llvm.return %res : i32
+  }]
+
+def sext_llvm_i16_to_i64 := [LV| {
+  ^entry (%arg: i16):
+    %0 = llvm.sext %arg: i16 to i32
+    llvm.return %0: i32
+  }]
+
+def llvm_sext_lower_riscv_i16_to_i64 : LLVMPeepholeRewriteRefine 32 [Ty.llvm (.bitvec 16)] :=
+  {lhs:= sext_llvm_i16_to_i64 , rhs:= sext_riscv_i16_to_i64,
+   correct := by
+    unfold sext_llvm_i16_to_i64 sext_riscv_i16_to_i64
+    simp_peephole
+    simp_riscv
+    simp_alive_undef
+    simp_alive_case_bash
+    simp_alive_split
+    all_goals
+    simp [LLVM.sext?]
+    bv_decide
+  }

--- a/SSA/Projects/LLVMRiscV/Pipeline/sext.lean
+++ b/SSA/Projects/LLVMRiscV/Pipeline/sext.lean
@@ -8,7 +8,7 @@ open LLVMRiscV
 
 def sext_riscv_i1_to_i8 := [LV| {
   ^entry (%arg: i1 ):
-    %0 = "builtin.unrealized_conversion_cast"(%arg) : (i1) -> !i64
+    %0 = "builtin.unrealized_conversion_cast"(%arg) : (i1) -> (!i64)
     %1 = slli %0, 63 : !i64
     %2 = srai %1, 63 : !i64
     %res = "builtin.unrealized_conversion_cast"(%2) : (!i64) -> (i8)
@@ -39,7 +39,7 @@ def llvm_sext_lower_riscv_i1_to_i8 : LLVMPeepholeRewriteRefine 8 [Ty.llvm (.bitv
 
 def sext_riscv_i1_to_i16 := [LV| {
   ^entry (%arg: i1 ):
-    %0 = "builtin.unrealized_conversion_cast"(%arg) : (i1) -> !i64
+    %0 = "builtin.unrealized_conversion_cast"(%arg) : (i1) -> (!i64)
     %1 = slli %0, 63 : !i64
     %2 = srai %1, 63 : !i64
     %res = "builtin.unrealized_conversion_cast"(%2) : (!i64) -> (i16)
@@ -70,7 +70,7 @@ def llvm_sext_lower_riscv_i1_to_i16 : LLVMPeepholeRewriteRefine 16 [Ty.llvm (.bi
 
 def sext_riscv_i1_to_i32 := [LV| {
   ^entry (%arg: i1 ):
-    %0 = "builtin.unrealized_conversion_cast"(%arg) : (i1) -> !i64
+    %0 = "builtin.unrealized_conversion_cast"(%arg) : (i1) -> (!i64)
     %1 = slli %0, 63 : !i64
     %2 = srai %1, 63 : !i64
     %res = "builtin.unrealized_conversion_cast"(%2) : (!i64) -> (i32)
@@ -101,7 +101,7 @@ def llvm_sext_lower_riscv_i1_to_i32 : LLVMPeepholeRewriteRefine 32 [Ty.llvm (.bi
 
 def sext_riscv_i1_to_i64 := [LV| {
   ^entry (%arg: i1 ):
-    %0 = "builtin.unrealized_conversion_cast"(%arg) : (i1) -> !i64
+    %0 = "builtin.unrealized_conversion_cast"(%arg) : (i1) -> (!i64)
     %1 = slli %0, 63 : !i64
     %2 = srai %1, 63 : !i64
     %res = "builtin.unrealized_conversion_cast"(%2) : (!i64) -> (i64)
@@ -132,7 +132,7 @@ def llvm_sext_lower_riscv_i1_to_i64 : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bi
 
 def sext_riscv_i8_to_i64 := [LV| {
   ^entry (%arg: i8):
-    %0 = "builtin.unrealized_conversion_cast"(%arg) : (i8) -> !i64
+    %0 = "builtin.unrealized_conversion_cast"(%arg) : (i8) -> (!i64)
     %1 = slli %0, 56 : !i64
     %2 = srai %1, 56 : !i64
     %res = "builtin.unrealized_conversion_cast"(%2) : (!i64) -> (i64)
@@ -163,7 +163,7 @@ def llvm_sext_lower_riscv_i8_to_i64 : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bi
 
 def sext_riscv_i8_to_i16 := [LV| {
   ^entry (%arg: i8):
-    %0 = "builtin.unrealized_conversion_cast"(%arg) : (i8) -> !i64
+    %0 = "builtin.unrealized_conversion_cast"(%arg) : (i8) -> (!i64)
     %1 = slli %0, 56 : !i64
     %2 = srai %1, 56 : !i64
     %res = "builtin.unrealized_conversion_cast"(%2) : (!i64) -> (i16)
@@ -194,7 +194,7 @@ def llvm_sext_lower_riscv_i8_to_i16 : LLVMPeepholeRewriteRefine 16 [Ty.llvm (.bi
 
 def sext_riscv_i8_to_i32 := [LV| {
   ^entry (%arg: i8):
-    %0 = "builtin.unrealized_conversion_cast"(%arg) : (i8) -> !i64
+    %0 = "builtin.unrealized_conversion_cast"(%arg) : (i8) -> (!i64)
     %1 = slli %0, 56 : !i64
     %2 = srai %1, 56 : !i64
     %res = "builtin.unrealized_conversion_cast"(%2) : (!i64) -> (i32)
@@ -225,7 +225,7 @@ def llvm_sext_lower_riscv_i8_to_i32 : LLVMPeepholeRewriteRefine 32 [Ty.llvm (.bi
 
 def sext_riscv_i16_to_i32 := [LV| {
   ^entry (%arg: i16):
-    %0 = "builtin.unrealized_conversion_cast"(%arg) : (i16) -> !i64
+    %0 = "builtin.unrealized_conversion_cast"(%arg) : (i16) -> (!i64)
     %1 = slli %0, 48 : !i64
     %2 = srai %1, 48 : !i64
     %res = "builtin.unrealized_conversion_cast"(%2) : (!i64) -> (i32)
@@ -256,7 +256,7 @@ def llvm_sext_lower_riscv_i16_to_i32 : LLVMPeepholeRewriteRefine 32 [Ty.llvm (.b
 
 def sext_riscv_i16_to_i64 := [LV| {
   ^entry (%arg: i16):
-    %0 = "builtin.unrealized_conversion_cast"(%arg) : (i16) -> !i64
+    %0 = "builtin.unrealized_conversion_cast"(%arg) : (i16) -> (!i64)
     %1 = slli %0, 48 : !i64
     %2 = srai %1, 48 : !i64
     %res = "builtin.unrealized_conversion_cast"(%2) : (!i64) -> (i32)
@@ -270,7 +270,7 @@ def sext_llvm_i16_to_i64 := [LV| {
   }]
 
 def llvm_sext_lower_riscv_i16_to_i64 : LLVMPeepholeRewriteRefine 32 [Ty.llvm (.bitvec 16)] :=
-  {lhs:= sext_llvm_i16_to_i64 , rhs:= sext_riscv_i16_to_i64,
+  {lhs:= sext_llvm_i16_to_i64, rhs:= sext_riscv_i16_to_i64,
    correct := by
     unfold sext_llvm_i16_to_i64 sext_riscv_i16_to_i64
     simp_peephole

--- a/SSA/Projects/LLVMRiscV/Pipeline/zext.lean
+++ b/SSA/Projects/LLVMRiscV/Pipeline/zext.lean
@@ -7,7 +7,7 @@ open LLVMRiscV
 /- # sext instruction lowering-/
 
 def zext_riscv_i1_to_i8 := [LV| {
-  ^entry (%arg: i1 ):
+  ^entry (%arg: i1):
     %0 = "builtin.unrealized_conversion_cast"(%arg) : (i1) -> !i64
     %1 = andi %0, 1 : !i64
     %res = "builtin.unrealized_conversion_cast"(%1) : (!i64) -> (i8)
@@ -15,7 +15,7 @@ def zext_riscv_i1_to_i8 := [LV| {
   }]
 
 def zext_llvm_i1_to_i8 := [LV| {
-  ^entry (%arg: i1 ):
+  ^entry (%arg: i1):
     %0 = llvm.zext %arg: i1 to i8
     llvm.return %0: i8
   }]
@@ -37,7 +37,7 @@ def llvm_sext_lower_riscv_i1_to_i8 : LLVMPeepholeRewriteRefine 8 [Ty.llvm (.bitv
   }
 
 def zext_riscv_i1_to_i16 := [LV| {
-  ^entry (%arg: i1 ):
+  ^entry (%arg: i1):
     %0 = "builtin.unrealized_conversion_cast"(%arg) : (i1) -> !i64
     %1 = andi %0, 1 : !i64
     %res = "builtin.unrealized_conversion_cast"(%1) : (!i64) -> (i16)
@@ -45,7 +45,7 @@ def zext_riscv_i1_to_i16 := [LV| {
   }]
 
 def zext_llvm_i1_to_i16 := [LV| {
-  ^entry (%arg: i1 ):
+  ^entry (%arg: i1):
     %0 = llvm.zext %arg: i1 to i16
     llvm.return %0: i16
   }]
@@ -75,7 +75,7 @@ def zext_riscv_i1_to_i32 := [LV| {
   }]
 
 def zext_llvm_i1_to_i32 := [LV| {
-  ^entry (%arg: i1 ):
+  ^entry (%arg: i1):
     %0 = llvm.zext %arg: i1 to i32
     llvm.return %0: i32
   }]
@@ -98,7 +98,7 @@ def llvm_sext_lower_riscv_i1_to_i32 : LLVMPeepholeRewriteRefine 32 [Ty.llvm (.bi
 
 def zext_riscv_i1_to_i64 := [LV| {
   ^entry (%arg: i1):
-    %0 = "builtin.unrealized_conversion_cast"(%arg) : (i1) -> !i64
+    %0 = "builtin.unrealized_conversion_cast"(%arg) : (i1) -> (!i64)
     %1 = andi %0, 1 : !i64
     %res = "builtin.unrealized_conversion_cast"(%1) : (!i64) -> (i64)
     llvm.return %res : i64
@@ -128,7 +128,7 @@ def llvm_sext_lower_riscv_i1_to_i64 : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bi
 
 def zext_riscv_i8_to_i64 := [LV| {
   ^entry (%arg: i8):
-    %0 = "builtin.unrealized_conversion_cast"(%arg) : (i8) -> !i64
+    %0 = "builtin.unrealized_conversion_cast"(%arg) : (i8) -> (!i64)
     %1 = andi %0, 255 : !i64
     %res = "builtin.unrealized_conversion_cast"(%1) : (!i64) -> (i64)
     llvm.return %res : i64
@@ -158,7 +158,7 @@ def llvm_sext_lower_riscv_i8_to_i64 : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bi
 
 def zext_riscv_i8_to_i16 := [LV| {
   ^entry (%arg: i8):
-    %0 = "builtin.unrealized_conversion_cast"(%arg) : (i8) -> !i64
+    %0 = "builtin.unrealized_conversion_cast"(%arg) : (i8) -> (!i64)
     %1 = andi %0, 255 : !i64
     %res = "builtin.unrealized_conversion_cast"(%1) : (!i64) -> (i16)
     llvm.return %res : i16
@@ -188,7 +188,7 @@ def llvm_sext_lower_riscv_i8_to_i16 : LLVMPeepholeRewriteRefine 16 [Ty.llvm (.bi
 
 def zext_riscv_i8_to_i32 := [LV| {
   ^entry (%arg: i8):
-    %0 = "builtin.unrealized_conversion_cast"(%arg) : (i8) -> !i64
+    %0 = "builtin.unrealized_conversion_cast"(%arg) : (i8) -> (!i64)
     %1 = andi %0, 255 : !i64
     %res = "builtin.unrealized_conversion_cast"(%1) : (!i64) -> (i32)
     llvm.return %res : i32
@@ -218,7 +218,7 @@ def llvm_sext_lower_riscv_i8_to_i32 : LLVMPeepholeRewriteRefine 32 [Ty.llvm (.bi
 
 def zext_riscv_i16_to_i64 := [LV| {
   ^entry (%arg: i16):
-    %0 = "builtin.unrealized_conversion_cast"(%arg) : (i16) -> !i64
+    %0 = "builtin.unrealized_conversion_cast"(%arg) : (i16) -> (!i64)
     %1 = slli %0, 48 : !i64
     %2 = srli %1, 48 : !i64
     %res = "builtin.unrealized_conversion_cast"(%2) : (!i64) -> (i64)
@@ -250,7 +250,7 @@ def llvm_zext_lower_riscv_i16_to_i64 : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.b
 
 def zext_riscv_i16_to_i32 := [LV| {
   ^entry (%arg: i16):
-    %0 = "builtin.unrealized_conversion_cast"(%arg) : (i16) -> !i64
+    %0 = "builtin.unrealized_conversion_cast"(%arg) : (i16) -> (!i64)
     %1 = slli %0, 48 : !i64
     %2 = srli %1, 48 : !i64
     %res = "builtin.unrealized_conversion_cast"(%2) : (!i64) -> (i32)

--- a/SSA/Projects/LLVMRiscV/Pipeline/zext.lean
+++ b/SSA/Projects/LLVMRiscV/Pipeline/zext.lean
@@ -30,7 +30,9 @@ def llvm_sext_lower_riscv_i1_to_i8 : LLVMPeepholeRewriteRefine 8 [Ty.llvm (.bitv
     simp_alive_case_bash
     simp_alive_split
     all_goals
-    simp [LLVM.zext?]
+    simp only [LLVM.zext?, BitVec.truncate_eq_setWidth, PoisonOr.toOption_getSome,
+      BitVec.reduceSignExtend, BitVec.and_eq, BitVec.signExtend_and,
+      PoisonOr.value_isRefinedBy_value, InstCombine.bv_isRefinedBy_iff]
     bv_decide
   }
 
@@ -58,7 +60,9 @@ def llvm_zext_lower_riscv_i1_to_i16 : LLVMPeepholeRewriteRefine 16 [Ty.llvm (.bi
     simp_alive_case_bash
     simp_alive_split
     all_goals
-    simp [LLVM.zext?]
+    simp only [LLVM.zext?, BitVec.truncate_eq_setWidth, PoisonOr.toOption_getSome,
+      BitVec.reduceSignExtend, BitVec.and_eq, BitVec.signExtend_and,
+      PoisonOr.value_isRefinedBy_value, InstCombine.bv_isRefinedBy_iff]
     bv_decide
   }
 
@@ -86,7 +90,9 @@ def llvm_sext_lower_riscv_i1_to_i32 : LLVMPeepholeRewriteRefine 32 [Ty.llvm (.bi
     simp_alive_case_bash
     simp_alive_split
     all_goals
-    simp [LLVM.zext?]
+    simp only [LLVM.zext?, BitVec.truncate_eq_setWidth, PoisonOr.toOption_getSome,
+      BitVec.reduceSignExtend, BitVec.and_eq, BitVec.signExtend_and,
+      PoisonOr.value_isRefinedBy_value, InstCombine.bv_isRefinedBy_iff]
     bv_decide
   }
 
@@ -114,7 +120,9 @@ def llvm_sext_lower_riscv_i1_to_i64 : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bi
     simp_alive_case_bash
     simp_alive_split
     all_goals
-    simp [LLVM.zext?]
+    simp only [LLVM.zext?, BitVec.truncate_eq_setWidth, PoisonOr.toOption_getSome,
+      BitVec.reduceSignExtend, BitVec.and_eq, BitVec.signExtend_eq,
+      PoisonOr.value_isRefinedBy_value, InstCombine.bv_isRefinedBy_iff]
     bv_decide
   }
 
@@ -142,7 +150,9 @@ def llvm_sext_lower_riscv_i8_to_i64 : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bi
     simp_alive_case_bash
     simp_alive_split
     all_goals
-    simp [LLVM.zext?]
+    simp only [LLVM.zext?, BitVec.truncate_eq_setWidth, PoisonOr.toOption_getSome,
+      BitVec.reduceSignExtend, BitVec.and_eq, BitVec.signExtend_eq,
+      PoisonOr.value_isRefinedBy_value, InstCombine.bv_isRefinedBy_iff]
     bv_decide
   }
 
@@ -170,7 +180,9 @@ def llvm_sext_lower_riscv_i8_to_i16 : LLVMPeepholeRewriteRefine 16 [Ty.llvm (.bi
     simp_alive_case_bash
     simp_alive_split
     all_goals
-    simp [LLVM.zext?]
+    simp only [LLVM.zext?, BitVec.truncate_eq_setWidth, PoisonOr.toOption_getSome,
+      BitVec.reduceSignExtend, BitVec.and_eq, BitVec.signExtend_and,
+      PoisonOr.value_isRefinedBy_value, InstCombine.bv_isRefinedBy_iff]
     bv_decide
   }
 
@@ -198,7 +210,9 @@ def llvm_sext_lower_riscv_i8_to_i32 : LLVMPeepholeRewriteRefine 32 [Ty.llvm (.bi
     simp_alive_case_bash
     simp_alive_split
     all_goals
-    simp [LLVM.zext?]
+    simp only [LLVM.zext?, BitVec.truncate_eq_setWidth, PoisonOr.toOption_getSome,
+      BitVec.reduceSignExtend, BitVec.and_eq, BitVec.signExtend_and,
+      PoisonOr.value_isRefinedBy_value, InstCombine.bv_isRefinedBy_iff]
     bv_decide
   }
 
@@ -227,7 +241,10 @@ def llvm_zext_lower_riscv_i16_to_i64 : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.b
     simp_alive_case_bash
     simp_alive_split
     all_goals
-    simp [LLVM.zext?]
+    simp only [LLVM.zext?, BitVec.truncate_eq_setWidth, PoisonOr.toOption_getSome,
+      BitVec.shiftLeft_eq', BitVec.toNat_ofNat, Nat.reducePow, Nat.reduceMod,
+      BitVec.ushiftRight_eq', BitVec.signExtend_eq, PoisonOr.value_isRefinedBy_value,
+      InstCombine.bv_isRefinedBy_iff]
     bv_decide
   }
 
@@ -256,6 +273,8 @@ def llvm_zext_lower_riscv_i16_to_i32 : LLVMPeepholeRewriteRefine 32 [Ty.llvm (.b
     simp_alive_case_bash
     simp_alive_split
     all_goals
-    simp [LLVM.zext?]
+    simp only [LLVM.zext?, BitVec.truncate_eq_setWidth, PoisonOr.toOption_getSome,
+      BitVec.shiftLeft_eq', BitVec.toNat_ofNat, Nat.reducePow, Nat.reduceMod,
+      BitVec.ushiftRight_eq', PoisonOr.value_isRefinedBy_value, InstCombine.bv_isRefinedBy_iff]
     bv_decide
   }

--- a/SSA/Projects/LLVMRiscV/Pipeline/zext.lean
+++ b/SSA/Projects/LLVMRiscV/Pipeline/zext.lean
@@ -21,7 +21,7 @@ def zext_llvm_i1_to_i8 := [LV| {
   }]
 
 def llvm_sext_lower_riscv_i1_to_i8 : LLVMPeepholeRewriteRefine 8 [Ty.llvm (.bitvec 1)] :=
-  {lhs:= zext_llvm_i1_to_i8, rhs:= zext_riscv_i1_to_i8 ,
+  {lhs:= zext_llvm_i1_to_i8, rhs:= zext_riscv_i1_to_i8,
    correct := by
     unfold zext_llvm_i1_to_i8  zext_riscv_i1_to_i8
     simp_peephole
@@ -51,7 +51,7 @@ def zext_llvm_i1_to_i16 := [LV| {
   }]
 
 def llvm_zext_lower_riscv_i1_to_i16 : LLVMPeepholeRewriteRefine 16 [Ty.llvm (.bitvec 1)] :=
-  {lhs:= zext_llvm_i1_to_i16 , rhs:= zext_riscv_i1_to_i16 ,
+  {lhs:= zext_llvm_i1_to_i16, rhs:= zext_riscv_i1_to_i16,
    correct := by
     unfold zext_llvm_i1_to_i16 zext_riscv_i1_to_i16
     simp_peephole
@@ -81,7 +81,7 @@ def zext_llvm_i1_to_i32 := [LV| {
   }]
 
 def llvm_sext_lower_riscv_i1_to_i32 : LLVMPeepholeRewriteRefine 32 [Ty.llvm (.bitvec 1)] :=
-  {lhs:= zext_llvm_i1_to_i32 , rhs:= zext_riscv_i1_to_i32 ,
+  {lhs:= zext_llvm_i1_to_i32, rhs:= zext_riscv_i1_to_i32,
    correct := by
     unfold zext_llvm_i1_to_i32 zext_riscv_i1_to_i32
     simp_peephole
@@ -111,7 +111,7 @@ def zext_llvm_i1_to_i64 := [LV| {
   }]
 
 def llvm_sext_lower_riscv_i1_to_i64 : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 1)] :=
-  {lhs:= zext_llvm_i1_to_i64, rhs:= zext_riscv_i1_to_i64 ,
+  {lhs:= zext_llvm_i1_to_i64, rhs:= zext_riscv_i1_to_i64,
    correct := by
     unfold zext_llvm_i1_to_i64 zext_riscv_i1_to_i64
     simp_peephole
@@ -141,7 +141,7 @@ def zext_llvm_i8_to_i64 := [LV| {
   }]
 
 def llvm_sext_lower_riscv_i8_to_i64 : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 8)] :=
-  {lhs:= zext_llvm_i8_to_i64, rhs:= zext_riscv_i8_to_i64 ,
+  {lhs:= zext_llvm_i8_to_i64, rhs:= zext_riscv_i8_to_i64,
    correct := by
     unfold zext_llvm_i8_to_i64 zext_riscv_i8_to_i64
     simp_peephole
@@ -171,7 +171,7 @@ def zext_llvm_i8_to_i16 := [LV| {
   }]
 
 def llvm_sext_lower_riscv_i8_to_i16 : LLVMPeepholeRewriteRefine 16 [Ty.llvm (.bitvec 8)] :=
-  {lhs:= zext_llvm_i8_to_i16 , rhs:= zext_riscv_i8_to_i16,
+  {lhs:= zext_llvm_i8_to_i16, rhs:= zext_riscv_i8_to_i16,
    correct := by
     unfold zext_llvm_i8_to_i16 zext_riscv_i8_to_i16
     simp_peephole
@@ -232,7 +232,7 @@ def zext_llvm_i16_to_i64 := [LV| {
   }]
 
 def llvm_zext_lower_riscv_i16_to_i64 : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 16)] :=
-  {lhs:= zext_llvm_i16_to_i64, rhs:= zext_riscv_i16_to_i64 ,
+  {lhs:= zext_llvm_i16_to_i64, rhs:= zext_riscv_i16_to_i64,
    correct := by
     unfold zext_llvm_i16_to_i64 zext_riscv_i16_to_i64
     simp_peephole

--- a/SSA/Projects/LLVMRiscV/Pipeline/zext.lean
+++ b/SSA/Projects/LLVMRiscV/Pipeline/zext.lean
@@ -1,0 +1,261 @@
+import SSA.Projects.LLVMRiscV.PeepholeRefine
+import SSA.Projects.LLVMRiscV.simpproc
+import SSA.Projects.RISCV64.Tactic.SimpRiscV
+
+open LLVMRiscV
+
+/- # sext instruction lowering-/
+
+def zext_riscv_i1_to_i8 := [LV| {
+  ^entry (%arg: i1 ):
+    %0 = "builtin.unrealized_conversion_cast"(%arg) : (i1) -> !i64
+    %1 = andi %0, 1 : !i64
+    %res = "builtin.unrealized_conversion_cast"(%1) : (!i64) -> (i8)
+    llvm.return %res: i8
+  }]
+
+def zext_llvm_i1_to_i8 := [LV| {
+  ^entry (%arg: i1 ):
+    %0 = llvm.zext %arg: i1 to i8
+    llvm.return %0: i8
+  }]
+
+def llvm_sext_lower_riscv_i1_to_i8 : LLVMPeepholeRewriteRefine 8 [Ty.llvm (.bitvec 1)] :=
+  {lhs:= zext_llvm_i1_to_i8, rhs:= zext_riscv_i1_to_i8 ,
+   correct := by
+    unfold zext_llvm_i1_to_i8  zext_riscv_i1_to_i8
+    simp_peephole
+    simp_riscv
+    simp_alive_undef
+    simp_alive_case_bash
+    simp_alive_split
+    all_goals
+    simp [LLVM.zext?]
+    bv_decide
+  }
+
+def zext_riscv_i1_to_i16 := [LV| {
+  ^entry (%arg: i1 ):
+    %0 = "builtin.unrealized_conversion_cast"(%arg) : (i1) -> !i64
+    %1 = andi %0, 1 : !i64
+    %res = "builtin.unrealized_conversion_cast"(%1) : (!i64) -> (i16)
+    llvm.return %res : i16
+  }]
+
+def zext_llvm_i1_to_i16 := [LV| {
+  ^entry (%arg: i1 ):
+    %0 = llvm.zext %arg: i1 to i16
+    llvm.return %0: i16
+  }]
+
+def llvm_zext_lower_riscv_i1_to_i16 : LLVMPeepholeRewriteRefine 16 [Ty.llvm (.bitvec 1)] :=
+  {lhs:= zext_llvm_i1_to_i16 , rhs:= zext_riscv_i1_to_i16 ,
+   correct := by
+    unfold zext_llvm_i1_to_i16 zext_riscv_i1_to_i16
+    simp_peephole
+    simp_riscv
+    simp_alive_undef
+    simp_alive_case_bash
+    simp_alive_split
+    all_goals
+    simp [LLVM.zext?]
+    bv_decide
+  }
+
+def zext_riscv_i1_to_i32 := [LV| {
+  ^entry (%arg: i1):
+    %0 = "builtin.unrealized_conversion_cast"(%arg) : (i1) -> !i64
+    %1 = andi %0, 1 : !i64
+    %res = "builtin.unrealized_conversion_cast"(%1) : (!i64) -> (i32)
+    llvm.return %res : i32
+  }]
+
+def zext_llvm_i1_to_i32 := [LV| {
+  ^entry (%arg: i1 ):
+    %0 = llvm.zext %arg: i1 to i32
+    llvm.return %0: i32
+  }]
+
+def llvm_sext_lower_riscv_i1_to_i32 : LLVMPeepholeRewriteRefine 32 [Ty.llvm (.bitvec 1)] :=
+  {lhs:= zext_llvm_i1_to_i32 , rhs:= zext_riscv_i1_to_i32 ,
+   correct := by
+    unfold zext_llvm_i1_to_i32 zext_riscv_i1_to_i32
+    simp_peephole
+    simp_riscv
+    simp_alive_undef
+    simp_alive_case_bash
+    simp_alive_split
+    all_goals
+    simp [LLVM.zext?]
+    bv_decide
+  }
+
+def zext_riscv_i1_to_i64 := [LV| {
+  ^entry (%arg: i1):
+    %0 = "builtin.unrealized_conversion_cast"(%arg) : (i1) -> !i64
+    %1 = andi %0, 1 : !i64
+    %res = "builtin.unrealized_conversion_cast"(%1) : (!i64) -> (i64)
+    llvm.return %res : i64
+  }]
+
+def zext_llvm_i1_to_i64 := [LV| {
+  ^entry (%arg: i1):
+    %0 = llvm.zext %arg: i1 to i64
+    llvm.return %0: i64
+  }]
+
+def llvm_sext_lower_riscv_i1_to_i64 : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 1)] :=
+  {lhs:= zext_llvm_i1_to_i64, rhs:= zext_riscv_i1_to_i64 ,
+   correct := by
+    unfold zext_llvm_i1_to_i64 zext_riscv_i1_to_i64
+    simp_peephole
+    simp_riscv
+    simp_alive_undef
+    simp_alive_case_bash
+    simp_alive_split
+    all_goals
+    simp [LLVM.zext?]
+    bv_decide
+  }
+
+def zext_riscv_i8_to_i64 := [LV| {
+  ^entry (%arg: i8):
+    %0 = "builtin.unrealized_conversion_cast"(%arg) : (i8) -> !i64
+    %1 = andi %0, 255 : !i64
+    %res = "builtin.unrealized_conversion_cast"(%1) : (!i64) -> (i64)
+    llvm.return %res : i64
+  }]
+
+def zext_llvm_i8_to_i64 := [LV| {
+  ^entry (%arg: i8):
+    %0 = llvm.zext %arg: i8 to i64
+    llvm.return %0: i64
+  }]
+
+def llvm_sext_lower_riscv_i8_to_i64 : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 8)] :=
+  {lhs:= zext_llvm_i8_to_i64, rhs:= zext_riscv_i8_to_i64 ,
+   correct := by
+    unfold zext_llvm_i8_to_i64 zext_riscv_i8_to_i64
+    simp_peephole
+    simp_riscv
+    simp_alive_undef
+    simp_alive_case_bash
+    simp_alive_split
+    all_goals
+    simp [LLVM.zext?]
+    bv_decide
+  }
+
+def zext_riscv_i8_to_i16 := [LV| {
+  ^entry (%arg: i8):
+    %0 = "builtin.unrealized_conversion_cast"(%arg) : (i8) -> !i64
+    %1 = andi %0, 255 : !i64
+    %res = "builtin.unrealized_conversion_cast"(%1) : (!i64) -> (i16)
+    llvm.return %res : i16
+  }]
+
+def zext_llvm_i8_to_i16 := [LV| {
+  ^entry (%arg: i8):
+    %0 = llvm.zext %arg: i8 to i16
+    llvm.return %0: i16
+  }]
+
+def llvm_sext_lower_riscv_i8_to_i16 : LLVMPeepholeRewriteRefine 16 [Ty.llvm (.bitvec 8)] :=
+  {lhs:= zext_llvm_i8_to_i16 , rhs:= zext_riscv_i8_to_i16,
+   correct := by
+    unfold zext_llvm_i8_to_i16 zext_riscv_i8_to_i16
+    simp_peephole
+    simp_riscv
+    simp_alive_undef
+    simp_alive_case_bash
+    simp_alive_split
+    all_goals
+    simp [LLVM.zext?]
+    bv_decide
+  }
+
+def zext_riscv_i8_to_i32 := [LV| {
+  ^entry (%arg: i8):
+    %0 = "builtin.unrealized_conversion_cast"(%arg) : (i8) -> !i64
+    %1 = andi %0, 255 : !i64
+    %res = "builtin.unrealized_conversion_cast"(%1) : (!i64) -> (i32)
+    llvm.return %res : i32
+  }]
+
+def zext_llvm_i8_to_i32 := [LV| {
+  ^entry (%arg: i8):
+    %0 = llvm.zext %arg: i8 to i32
+    llvm.return %0: i32
+  }]
+
+def llvm_sext_lower_riscv_i8_to_i32 : LLVMPeepholeRewriteRefine 32 [Ty.llvm (.bitvec 8)] :=
+  {lhs:= zext_llvm_i8_to_i32, rhs:= zext_riscv_i8_to_i32,
+   correct := by
+    unfold zext_llvm_i8_to_i32 zext_riscv_i8_to_i32
+    simp_peephole
+    simp_riscv
+    simp_alive_undef
+    simp_alive_case_bash
+    simp_alive_split
+    all_goals
+    simp [LLVM.zext?]
+    bv_decide
+  }
+
+def zext_riscv_i16_to_i64 := [LV| {
+  ^entry (%arg: i16):
+    %0 = "builtin.unrealized_conversion_cast"(%arg) : (i16) -> !i64
+    %1 = slli %0, 48 : !i64
+    %2 = srli %1, 48 : !i64
+    %res = "builtin.unrealized_conversion_cast"(%2) : (!i64) -> (i64)
+    llvm.return %res : i64
+  }]
+
+def zext_llvm_i16_to_i64 := [LV| {
+  ^entry (%arg: i16):
+    %0 = llvm.zext %arg: i16 to i64
+    llvm.return %0: i64
+  }]
+
+def llvm_zext_lower_riscv_i16_to_i64 : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 16)] :=
+  {lhs:= zext_llvm_i16_to_i64, rhs:= zext_riscv_i16_to_i64 ,
+   correct := by
+    unfold zext_llvm_i16_to_i64 zext_riscv_i16_to_i64
+    simp_peephole
+    simp_riscv
+    simp_alive_undef
+    simp_alive_case_bash
+    simp_alive_split
+    all_goals
+    simp [LLVM.zext?]
+    bv_decide
+  }
+
+def zext_riscv_i16_to_i32 := [LV| {
+  ^entry (%arg: i16):
+    %0 = "builtin.unrealized_conversion_cast"(%arg) : (i16) -> !i64
+    %1 = slli %0, 48 : !i64
+    %2 = srli %1, 48 : !i64
+    %res = "builtin.unrealized_conversion_cast"(%2) : (!i64) -> (i32)
+    llvm.return %res : i32
+  }]
+
+def zext_llvm_i16_to_i32 := [LV| {
+  ^entry (%arg: i16):
+    %0 = llvm.zext %arg: i16 to i32
+    llvm.return %0: i32
+  }]
+
+def llvm_zext_lower_riscv_i16_to_i32 : LLVMPeepholeRewriteRefine 32 [Ty.llvm (.bitvec 16)] :=
+  {lhs:= zext_llvm_i16_to_i32, rhs:= zext_riscv_i16_to_i32,
+   correct := by
+    unfold zext_llvm_i16_to_i32 zext_riscv_i16_to_i32
+    simp_peephole
+    simp_riscv
+    simp_alive_undef
+    simp_alive_case_bash
+    simp_alive_split
+    all_goals
+    simp [LLVM.zext?]
+    bv_decide
+  }


### PR DESCRIPTION
This PR adds the RiscV 64 bit lowering for the LLVM sext and zext instructions.