### PR TITLE
chore: ci mathlib update - drop '-' from dates

### DIFF
--- a/.github/workflows/update-mathlib-version.yml
+++ b/.github/workflows/update-mathlib-version.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Check if lean toolchain is already newer or equally old
         shell: zsh {0}
         run: |
-           if [[ `cat lean-toolchain | sed -e 's/leanprover\/lean4:nightly-//' | sed -e '/$^/d'` -le ${{steps.mldate.outputs.date}} ]]; then echo "abort: lean-toolchain is newer than proposed date"; false ; fi
+           if [[ `cat lean-toolchain | sed -e 's/leanprover\/lean4:nightly-//' | sed -e '/$^/d' | sed -e 's/-//g' ` -le `echo ${{steps.mldate.outputs.date}} | sed -e 's/-//g'` ]]; then echo "abort: lean-toolchain is newer than proposed date"; false ; fi
 
       - name: Set Mathlib Date
         run: |


### PR DESCRIPTION
The `-le` zsh command does not support strings well, so we need to drop `-` to make it compare number, e.g., a date `2025-01-01` will then become `20250101`.