### PR TITLE
chore: add cycle breaking heuristic for k-induction

### DIFF
--- a/SSA/Experimental/Bits/Fast/Dataset2/plotter.py
+++ b/SSA/Experimental/Bits/Fast/Dataset2/plotter.py
@@ -215,7 +215,7 @@ def plot(args):
 
     solver_colors = {
         "mba": material_red,
-        "kinduction_verifked": material_yellow,
+        "kinduction_verified": material_yellow,
         "kinduction_unverified": material_blue,
         "bv_automata_classic": material_green,
         "bv_decide": material_purple
@@ -223,7 +223,7 @@ def plot(args):
 
     solver_latex_names = {
         "mba": "MBA",
-        "kinduction_verifked": "KInductionVerified",
+        "kinduction_verified": "KInductionVerified",
         "kinduction_unverified": "KInductionUnverified",
         "bv_automata_classic": "Presburger",
         "bv_decide": "BvDecide"

--- a/SSA/Experimental/Bits/Fast/Dataset2/runner.py
+++ b/SSA/Experimental/Bits/Fast/Dataset2/runner.py
@@ -21,7 +21,7 @@ def parse_args():
     nproc = os.cpu_count()
     parser.add_argument('--db', default=f'run-{current_time}.sqlite3', help='path to sqlite3 database')
     parser.add_argument('--prod-run', default=False, action='store_true', help='run a production run of the whole thing.')
-    parser.add_argument('-j', type=int, default=((nproc + 2) // 3), help='number of parallel jobs.')
+    parser.add_argument('-j', type=int, default=5, help='number of parallel jobs.')
     parser.add_argument('--timeout', type=int, default=60, help='number of seconds for timeout of test.')
     return parser.parse_args()
 
@@ -205,11 +205,10 @@ class UnitTest:
     solver : str
 
     solver_mba = "mba"
-    solver_kinduction_unverified = "kinduction_unverified"
-    solver_kinduction_verified = "kinduction_verifked"
+    solver_kinduction_verified = "kinduction_verified"
     solver_bv_automata_classic = "bv_automata_classic"
     solver_bv_decide = "bv_decide"
-    solvers = [solver_mba, solver_kinduction_unverified, solver_kinduction_verified, solver_bv_automata_classic, solver_bv_decide]
+    solvers = [solver_mba, solver_kinduction_verified, solver_bv_automata_classic, solver_bv_decide]
 
     def __init__(self, ix, test, solver):
         self.ix = ix
@@ -222,10 +221,8 @@ class UnitTest:
         interpolant = """by tac_bench (config := {{ outputType := .csv }}) ["{solver}" : {call}]; sorry"""
         if solver == UnitTest.solver_mba:
             return interpolant.format(solver=solver, call="bv_mba")
-        elif solver == UnitTest.solver_kinduction_unverified:
-            return interpolant.format(solver=solver, call="bv_automata_gen (config := {backend := .circuit_cadical_unverified 5 })")
         elif solver == UnitTest.solver_kinduction_verified:
-            return interpolant.format(solver=solver, call="bv_automata_gen (config := {backend := .circuit_cadical_verified 5 })")
+            return interpolant.format(solver=solver, call="bv_automata_gen (config := {backend := .circuit_cadical_verified 100 })")
         elif solver == UnitTest.solver_bv_automata_classic:
             return interpolant.format(solver=solver, call="bv_automata_gen (config := {backend := .automata })")
         elif solver == UnitTest.solver_bv_decide:

--- a/SSA/Experimental/Bits/Fast/Dataset2/runner.py
+++ b/SSA/Experimental/Bits/Fast/Dataset2/runner.py
@@ -260,8 +260,8 @@ def load_tests(args) -> List[UnitTest]:
     if not args.prod_run:
         logging.info(f"--prod_run not enabled, pruning files to small batch")
         NTESTS_TO_RETURN = 1
-        return out[-NTESTS_TO_RETURN*len(UnitTest.solvers):]
-        # return out[:NTESTS_TO_RETURN*len(UnitTest.solvers)]
+        # return out[-NTESTS_TO_RETURN*len(UnitTest.solvers):]
+        return out[:NTESTS_TO_RETURN*len(UnitTest.solvers)]
     else:
         return out
 

--- a/SSA/Experimental/Bits/Fast/Dataset2/runner.py
+++ b/SSA/Experimental/Bits/Fast/Dataset2/runner.py
@@ -208,7 +208,7 @@ class UnitTest:
     solver_kinduction_verified = "kinduction_verified"
     solver_bv_automata_classic = "bv_automata_classic"
     solver_bv_decide = "bv_decide"
-    solvers = [solver_mba, solver_kinduction_verified, solver_bv_automata_classic, solver_bv_decide]
+    solvers = [solver_kinduction_verified] # [solver_mba, solver_kinduction_verified, solver_bv_automata_classic, solver_bv_decide]
 
     def __init__(self, ix, test, solver):
         self.ix = ix

--- a/SSA/Experimental/Bits/Fast/FiniteStateMachine.lean
+++ b/SSA/Experimental/Bits/Fast/FiniteStateMachine.lean
@@ -78,7 +78,7 @@ instance : Std.Associative Nat.add where
   assoc := fun a b => by simp only [Nat.add_eq]; omega
 
 /-- The size of the state space of the finite state machine. -/
-def stateSpaceSize : Nat := @Finset.univ p.α inferInstance |>.card
+def stateSpaceSize : Nat := @Finset.univ (p.α → Bool) inferInstance |>.card
 
 
 /--

--- a/SSA/Experimental/Bits/Fast/ReflectVerif.lean
+++ b/SSA/Experimental/Bits/Fast/ReflectVerif.lean
@@ -2286,7 +2286,8 @@ def _root_.FSM.decideIfZerosVerified {arity : Type _}
     TermElabM (DecideIfZerosOutput × CircuitStats) :=
   -- decideIfZerosM Circuit.impliesCadical fsm
   withTraceNode `trace.Bits.Fast (fun _ => return "k-induction") (collapsed := false) do
-    trace[Bits.FastVerif] s!"FSM state space size: ({fsm.stateSpaceSize})"
+    logInfo m!"FSM state space size: {fsm.stateSpaceSize}"
+    logInfo m!"FSM transition circuit size: {fsm.circuitSize}"
     decideIfZerosAuxVerified' 0 maxIter fsm (KInductionCircuits.mkZero fsm)
 
 

--- a/SSA/Experimental/Bits/Fast/ReflectVerif.lean
+++ b/SSA/Experimental/Bits/Fast/ReflectVerif.lean
@@ -2251,6 +2251,7 @@ def _root_.FSM.decideIfZerosVerified {arity : Type _}
     TermElabM (DecideIfZerosOutput × CircuitStats) :=
   -- decideIfZerosM Circuit.impliesCadical fsm
   withTraceNode `trace.Bits.Fast (fun _ => return "k-induction") (collapsed := false) do
+    trace[Bits.FastVerif] s!"FSM state space size: (Nat.pow 2 {Fintype.card arity})"
     decideIfZerosAuxVerified' 0 maxIter fsm (KInductionCircuits.mkZero fsm)
 
 

--- a/SSA/Experimental/Bits/Fast/ReflectVerif.lean
+++ b/SSA/Experimental/Bits/Fast/ReflectVerif.lean
@@ -2215,9 +2215,8 @@ partial def decideIfZerosAuxVerified' {arity : Type _}
       trace[Bits.FastVerif] s!"Safety property failed on initial state."
       return (.safetyFailure iter, circs.stats)
     | .some safetyCert =>
-      let stateSpaceSize := Nat.pow 2 (Fintype.card arity)
-      if iter ≥ 1 + stateSpaceSize then
-        trace[Bits.FastVerif] s!"Proved safety for the entire state space (state space size: {stateSpaceSize}). No need to build induction circuit."
+      if iter ≥ 1 + fsm.stateSpaceSize then
+        trace[Bits.FastVerif] s!"Proved safety for the entire state space (state space size: {fsm.stateSpaceSize}). No need to build induction circuit."
         return (.provenByExhaustion iter safetyCert, circs.stats)
 
       trace[Bits.FastVerif] s!"Safety property succeeded on initial state. Building induction circuit..."
@@ -2251,7 +2250,7 @@ def _root_.FSM.decideIfZerosVerified {arity : Type _}
     TermElabM (DecideIfZerosOutput × CircuitStats) :=
   -- decideIfZerosM Circuit.impliesCadical fsm
   withTraceNode `trace.Bits.Fast (fun _ => return "k-induction") (collapsed := false) do
-    trace[Bits.FastVerif] s!"FSM state space size: (Nat.pow 2 {Fintype.card arity})"
+    trace[Bits.FastVerif] s!"FSM state space size: ({fsm.stateSpaceSize})"
     decideIfZerosAuxVerified' 0 maxIter fsm (KInductionCircuits.mkZero fsm)
 
 

--- a/SSA/Experimental/Bits/Fast/ReflectVerif.lean
+++ b/SSA/Experimental/Bits/Fast/ReflectVerif.lean
@@ -1675,7 +1675,7 @@ theorem mkAllPairsUniqueStatesCircuit_eq_false_iff {arity : Type _}
   (p : FSM arity) (i : Nat) :
   (∀ (envBool : Vars p.α arity (i + 1) → Bool), (mkAllPairsUniqueStatesCircuit p i).eval envBool = false) ↔
   (∀ (envBitstream : arity → BitStream) (state : p.α → Bool)
-      (k l : Nat) (hkl : k < l) (hl : l ≤ i),
+      (k l : Nat) (_hkl : k < l) (_hl : l ≤ i),
     ¬ (p.carryWith state envBitstream (k + 1) = p.carryWith state envBitstream (l + 1))) := by
   constructor
   · intros h envBitstream state k l hk hl
@@ -1686,23 +1686,48 @@ theorem mkAllPairsUniqueStatesCircuit_eq_false_iff {arity : Type _}
     simp [Circuit.eval_map] at h
     obtain ⟨a, ha⟩ := h
     intros hContra
+    simp [envBool] at ha
     have := congr_fun hContra a
     rw [eval_mkCarryWithCircuit_eq_carryWith (envBitstream := envBitstream)] at ha
     · rw [eval_mkCarryWithCircuit_eq_carryWith (envBitstream := envBitstream)] at ha
       · simp at ha
-      · sorry
-    · sorry
-    -- rw [mkAllPairsUniqueStatesCircuit_eq_false_iff_of_EnvOutRelated
-    --   (envBitstream := envBitstream)] at h
-    -- · simp only [Vars.castLe_state, envBool_of_envBitstream_of_state_eq₁, envBool] at h
-    --   apply h k l hk hl
-    -- · constructor
-    --   intros x j hj
-    --   apply hEnvBitstream.envBool_inputs_mk_eq_envBitStream
-
-  · sorry
-
-
+        apply ha
+        simp [show (fun s => state s) = state by rfl]
+        apply this
+      · constructor
+        intros x j hj
+        rfl
+    · constructor
+      intros x j hj
+      rfl
+  · intros h
+    intros envBool
+    let envBitstream := Bitstream_of_envBool envBool
+    let state := fun s => envBool (.state s)
+    simp [mkAllPairsUniqueStatesCircuit]
+    intros c k l hkl hc 
+    subst hc
+    simp
+    specialize h envBitstream state k l (by omega) (by omega)
+    obtain ⟨a, ha⟩ := Function.ne_iff.mp h
+    clear h
+    exists a
+    intros hContra
+    simp [Circuit.eval_map] at hContra
+    rw [eval_mkCarryWithCircuit_eq_carryWith (envBitstream := envBitstream)] at hContra
+    · rw [eval_mkCarryWithCircuit_eq_carryWith (envBitstream := envBitstream)] at hContra
+      · simp at hContra
+        apply ha
+        exact hContra
+      · simp [envBitstream]
+        constructor
+        intros x j hj
+        simp [Bitstream_of_envBool, envBitstream, show j < i + 1 by omega]
+        rfl
+    · constructor
+      intros x j hj
+      simp [Bitstream_of_envBool, envBitstream, show j < i + 1 by omega]
+      rfl
 
 /-- induction hyp circuit. -/
 theorem eval_mkIndHypCircuit_eq_false_iff_ {arity : Type _}

--- a/SSA/Experimental/Bits/Fast/ReflectVerif.lean
+++ b/SSA/Experimental/Bits/Fast/ReflectVerif.lean
@@ -2093,6 +2093,27 @@ def mkSafetyCircuit {arity : Type _}
     rw [circs.hEvalWithN]
   ⟩
 
+/-#
+
+## Cycle Breaking
+
+Considere a state space where 'sgood' is the initial state, with transitions 'sgood->sgood'
+where 's0' is a good state, and unreachable states 'tgood, tbad' with transitions
+'tgood->tgood' and 'tgood->tbad'.
+
+
+Now, the reachable states are only `sgood^n = sgood`, so the automata is safe.
+
+Howver, when we do k-induction, we will explore paths of the form `tgood^n → tbad`,
+which will end in a bad state for *any* n > 0, regardless of how much we increase 'n'.
+
+To rule out such cases, we only prove the IH on paths where all states are unique.
+In the previous example, we will at `k = 2`, we will decide to not explore the path `tgood^2 → tbad`,
+which then establishes the invariant that all reachable states are unique.
+This gets us "unstuck" from cycles of bad states.
+-/
+
+
 /-- Make the induction hypothesis circuit, incrementally. -/
 def mkIndHypCircuit {arity : Type _}
     [DecidableEq arity] [Fintype arity] [Hashable arity]
@@ -2231,6 +2252,12 @@ def _root_.FSM.decideIfZerosVerified {arity : Type _}
   -- decideIfZerosM Circuit.impliesCadical fsm
   withTraceNode `trace.Bits.Fast (fun _ => return "k-induction") (collapsed := false) do
     decideIfZerosAuxVerified' 0 maxIter fsm (KInductionCircuits.mkZero fsm)
+
+
+/--
+An axiom tracking that the safety has been proven by exhaustion of the state space.
+-/
+axiom decideIfZerosByExhaustion {p : Prop}  : p
 
 end BvDecide
 

--- a/SSA/Experimental/Bits/Fast/Tests.lean
+++ b/SSA/Experimental/Bits/Fast/Tests.lean
@@ -466,11 +466,10 @@ theorem e_1 (x y : BitVec w) :
   bv_automata_gen (config := {backend := .circuit_cadical_verified 6 } )
 
 set_option trace.Bits.FastVerif true in
-set_option maxHeartbeats 999999999 in
 theorem e_331 (x y : BitVec w):
      - 6 *  ~~~x + 2 * (x |||  ~~~y) - 3 * x + 2 * (x ||| y) - 10 *  ~~~(x ||| y) - 10 *  ~~~(x |||  ~~~y) - 4 * (x &&&  ~~~y) - 15 * (x &&& y) + 3 *  ~~~(x &&&  ~~~x) + 11 *  ~~~(x &&&  ~~~y) = 0#w := by
   -- bv_automata_gen (config := {backend := .dryrun 6 } )
-  bv_automata_gen (config := {backend := .circuit_cadical_verified 4 } )
+  -- bv_automata_gen (config := {backend := .circuit_cadical_verified 4 } )
   -- bv_automata_gen (config := {genSizeThreshold := 2000, stateSpaceSizeThreshold := 100})
   -- fail_if_success bv_automata_gen (config := {backend := .circuit_cadical_unverified 5 } )
   sorry

--- a/SSA/Experimental/Bits/Fast/Tests.lean
+++ b/SSA/Experimental/Bits/Fast/Tests.lean
@@ -458,14 +458,14 @@ info: 'width_1_char_2_add_four' depends on axioms: [propext,
 
 theorem e_1 (x y : BitVec w) :
      - 1 *  ~~~(x ^^^ y) - 2 * y + 1 *  ~~~x =  - 1 *  ~~~(x |||  ~~~y) - 3 * (x &&& y) := by
-  bv_automata_gen (config := {backend := .circuit_cadical_verified 5 } )
+  bv_automata_gen (config := {backend := .circuit_cadical_verified 6 } )
 
 set_option trace.Bits.FastVerif true in
 set_option maxHeartbeats 999999999 in
 theorem e_331 (x y : BitVec w):
      - 6 *  ~~~x + 2 * (x |||  ~~~y) - 3 * x + 2 * (x ||| y) - 10 *  ~~~(x ||| y) - 10 *  ~~~(x |||  ~~~y) - 4 * (x &&&  ~~~y) - 15 * (x &&& y) + 3 *  ~~~(x &&&  ~~~x) + 11 *  ~~~(x &&&  ~~~y) = 0#w := by
   -- bv_automata_gen (config := {genSizeThreshold := 2000, stateSpaceSizeThreshold := 100})
-  fail_if_success bv_automata_gen (config := {backend := .circuit_cadical_verified 5 } )
+  -- fail_if_success bv_automata_gen (config := {backend := .circuit_cadical_verified 5 } )
   -- fail_if_success bv_automata_gen (config := {backend := .circuit_cadical_unverified 5 } )
   sorry
 
@@ -474,6 +474,6 @@ theorem e_331 (x y : BitVec w):
 set_option maxHeartbeats 0 in
 theorem e_2500 (a b c d e f g h i j k l m n o p q r s t u v x y z : BitVec w):
     7 * ( ~~~f ||| (d ^^^ e)) - 6 * ( ~~~(d &&&  ~~~e) &&& (e ^^^ f)) - 11 * ( ~~~(d &&&  ~~~e) &&& (d ^^^ (e ^^^ f))) - 1 * (f ^^^  ~~~( ~~~d &&& (e ||| f))) + 3 * ((e &&&  ~~~f) |||  ~~~(d ||| ( ~~~e &&& f))) - 3 * (f |||  ~~~(d |||  ~~~e)) + 1 *  ~~~(e ^^^ f) + 1 *  ~~~(d &&& (e ||| f)) + 5 * ( ~~~(d |||  ~~~e) ||| (d ^^^ (e ^^^ f))) + 1 * (e ^^^  ~~~(d ||| (e &&& f))) + 1 *  ~~~(d ||| ( ~~~e &&& f)) - 1 * ( ~~~d ||| (e ^^^ f)) + 4 * (e ^^^  ~~~( ~~~d &&& (e ||| f))) + 3 * ((d &&&  ~~~e) |||  ~~~(e ^^^ f)) + 4 * (f ^^^ ( ~~~d ||| ( ~~~e ||| f))) + 4 * ((e &&&  ~~~f) ^^^ (d ||| (e ^^^ f))) + 7 * ((d &&&  ~~~e) ||| (e ^^^ f)) + 2 * ((d ||| e) &&& (e ^^^ f)) + 3 * (e ^^^  ~~~( ~~~d ||| (e ^^^ f))) - 6 * (e ^^^  ~~~(d &&& f)) - 1 * (e ^^^ ( ~~~d ||| (e ||| f))) + 5 * (f ^^^ (d &&& (e ||| f))) + 4 * ((d &&& f) ^^^ (e ||| f)) + 1 * (e &&& (d |||  ~~~f)) - 2 *  ~~~(d &&&  ~~~e) + 7 * (f ^^^  ~~~( ~~~d &&& ( ~~~e ||| f))) - 3 * ((d &&& e) |||  ~~~(e ^^^ f)) - 1 *  ~~~( ~~~d &&& ( ~~~e ||| f)) - 5 * (f ^^^ ( ~~~d ||| (e &&& f))) - 1 * (d ||| (e ||| f)) + 5 * (d &&&  ~~~f) + 7 * (f ||| (d &&& e)) - 1 * ( ~~~d &&& (e ||| f)) + 1 * ( ~~~(d ||| e) ||| (d ^^^ (e ^^^ f))) + 7 * (e ^^^  ~~~( ~~~d &&& (e ^^^ f))) + 1 * ((d |||  ~~~e) &&& (d ^^^ (e ^^^ f))) + 11 *  ~~~(d ||| (e ^^^ f)) + 4 * (e ^^^ (d &&& (e ^^^ f))) - 1 * ( ~~~d ||| ( ~~~e ||| f)) + 5 * ((d &&&  ~~~e) |||  ~~~(d ^^^ (e ^^^ f))) - 11 * (e ^^^ ( ~~~d ||| (e ^^^ f))) - 1 * (d &&& (e ||| f)) - 1 * (f ^^^  ~~~( ~~~d ||| ( ~~~e &&& f))) + 3 * (e ^^^ ( ~~~d &&& (e ||| f))) + 7 * (e ^^^ (d &&&  ~~~f)) + 1 *  ~~~( ~~~d &&& ( ~~~e &&& f)) - 1 * (e ^^^ (d ||| (e &&& f))) + 1 * (e ^^^ (d &&& ( ~~~e ||| f))) - 1 * (f ^^^ ( ~~~d &&& ( ~~~e ||| f))) - 1 * (d ||| ( ~~~e &&& f)) - 6 * (e ^^^  ~~~(d |||  ~~~f)) + 3 *  ~~~(d ||| f) + 4 * (e |||  ~~~(d ^^^ f)) - 2 *  ~~~(d &&& ( ~~~e ||| f)) - 6 * f - 1 * (e |||  ~~~(d |||  ~~~f)) + 5 * ((d ^^^ e) |||  ~~~(d ^^^ f)) - 2 * (f ^^^ ( ~~~d ||| (e ||| f))) + 5 * (f ^^^  ~~~(d |||  ~~~e)) - 11 * (e ||| (d &&&  ~~~f)) + 11 *  ~~~(d &&& (e &&& f)) - 3 * (e ^^^  ~~~( ~~~d &&& ( ~~~e ||| f))) - 5 * ((d &&& e) ||| (e ^^^ f)) + 1 * ((e &&&  ~~~f) ^^^ ( ~~~d ||| (e ^^^ f))) - 3 * (f ^^^  ~~~(d &&& ( ~~~e &&& f))) - 1 *  ~~~(d &&& ( ~~~e &&& f)) + 4 *  ~~~( ~~~d &&& (e &&& f)) - 6 * ((d ||| e) &&&  ~~~(e ^^^ f)) - 11 * ( ~~~e &&& (d ^^^ f)) - 7 * (f &&& (d |||  ~~~e)) + 5 * (d &&& ( ~~~e ||| f)) + 11 *  ~~~(e ||| f) - 7 * (f ^^^  ~~~(d &&& e)) + 1 * ((d ^^^ e) &&& (d ^^^ f)) - 39 *  ~~~(d ||| (e ||| f)) - 29 *  ~~~(d ||| ( ~~~e ||| f)) - 54 *  ~~~( ~~~d ||| (e ||| f)) - 32 *  ~~~( ~~~d ||| ( ~~~e ||| f)) + 19 * ( ~~~d &&& ( ~~~e &&& f)) - 60 * ( ~~~d &&& (e &&& f)) - 31 * (d &&& ( ~~~e &&& f)) + 33 * (d &&& (e &&& f)) =  - 1 * (e ^^^  ~~~( ~~~d ||| ( ~~~e &&& f))) + 3 *  ~~~(d ^^^ f) := by
-  bv_automata_gen (config := {backend := .circuit_cadical_verified 5 } )
+  bv_automata_gen (config := {backend := .circuit_cadical_verified 6 } )
 
 end BvAutomataTests

--- a/SSA/Experimental/Bits/Fast/Tests.lean
+++ b/SSA/Experimental/Bits/Fast/Tests.lean
@@ -12,7 +12,6 @@ import SSA.Experimental.Bits.Fast.MBA
 import SSA.Projects.InstCombine.TacticAuto
 
 
-set_option trace.Bits.Fast true
 
 open Lean Meta Elab Tactic in
 #eval show TermElabM Unit from do
@@ -69,10 +68,9 @@ info: 'check_axioms' depends on axioms: [propext,
 example (w : Nat) (a b : BitVec w) : (a + b = b + a)  := by
   bv_automata_gen (config := {backend := .circuit_cadical_verified} )
 
+set_option trace.Bits.FastVerif true in
 example (w : Nat) (a : BitVec w) : (a = a + 0#w) ∨ (a = a - a)  := by
   bv_automata_gen (config := {backend := .circuit_cadical_verified 20 } )
-  fail_if_success bv_automata_gen (config := {backend := .circuit_cadical_unverified 20 } )
-  sorry
 
 example (w : Nat) (a : BitVec w) :  (a = a + 0#w)  := by
   bv_automata_gen (config := {backend := .circuit_cadical_verified 20 } )
@@ -222,9 +220,7 @@ When we have this, we then explicitly enumerate the different values that a can 
 Note that this is pretty expensive.
 -/
 example (w : Nat) (a : BitVec w) : (1#w + 1#w = 0#w) → (a = 0#w ∨ a = 1#w) := by
-  fail_if_success bv_automata_gen (config := {backend := .circuit_cadical_verified} )
-  fail_if_success bv_automata_gen (config := {backend := .circuit_cadical_unverified} )
-  sorry
+  bv_automata_gen (config := {backend := .circuit_cadical_verified} )
 
 example (w : Nat) (a b : BitVec w) : (a + b = 0#w) → a = - b := by
   bv_automata_gen (config := {backend := .circuit_cadical_verified} )
@@ -351,11 +347,10 @@ example : ∀ (w : Nat) , (BitVec.ofNat w 1) &&& (BitVec.ofNat w 3) = BitVec.ofN
   intros
   bv_automata_gen (config := {backend := .circuit_cadical_verified} )
 
+set_option trace.Bits.FastVerif true in
 example : ∀ (w : Nat) (x : BitVec w), -1#w &&& x = x := by
   intros
-  fail_if_success bv_automata_gen (config := {backend := .circuit_cadical_verified} )
-  fail_if_success bv_automata_gen (config := {backend := .circuit_cadical_unverified} )
-  sorry
+  bv_automata_gen (config := {backend := .circuit_cadical_verified} )
 
 example : ∀ (w : Nat) (x : BitVec w), x <<< (0 : Nat) = x := by
   intros
@@ -465,6 +460,8 @@ theorem e_1 (x y : BitVec w) :
      - 1 *  ~~~(x ^^^ y) - 2 * y + 1 *  ~~~x =  - 1 *  ~~~(x |||  ~~~y) - 3 * (x &&& y) := by
   bv_automata_gen (config := {backend := .circuit_cadical_verified 5 } )
 
+set_option trace.Bits.FastVerif true in
+set_option maxHeartbeats 999999999 in
 theorem e_331 (x y : BitVec w):
      - 6 *  ~~~x + 2 * (x |||  ~~~y) - 3 * x + 2 * (x ||| y) - 10 *  ~~~(x ||| y) - 10 *  ~~~(x |||  ~~~y) - 4 * (x &&&  ~~~y) - 15 * (x &&& y) + 3 *  ~~~(x &&&  ~~~x) + 11 *  ~~~(x &&&  ~~~y) = 0#w := by
   -- bv_automata_gen (config := {genSizeThreshold := 2000, stateSpaceSizeThreshold := 100})

--- a/SSA/Experimental/Bits/Fast/Tests.lean
+++ b/SSA/Experimental/Bits/Fast/Tests.lean
@@ -70,7 +70,7 @@ example (w : Nat) (a b : BitVec w) : (a + b = b + a)  := by
   bv_automata_gen (config := {backend := .circuit_cadical_verified} )
 
 example (w : Nat) (a : BitVec w) : (a = a + 0#w) ∨ (a = a - a)  := by
-  fail_if_success bv_automata_gen (config := {backend := .circuit_cadical_verified 20 } )
+  bv_automata_gen (config := {backend := .circuit_cadical_verified 20 } )
   fail_if_success bv_automata_gen (config := {backend := .circuit_cadical_unverified 20 } )
   sorry
 

--- a/SSA/Experimental/Bits/Fast/Tests.lean
+++ b/SSA/Experimental/Bits/Fast/Tests.lean
@@ -13,6 +13,7 @@ import SSA.Projects.InstCombine.TacticAuto
 
 
 
+
 open Lean Meta Elab Tactic in
 #eval show TermElabM Unit from do
   let fsm : FSM (Fin 1) := FSM.mk (α := Unit)
@@ -46,22 +47,19 @@ theorem eq3 (w : Nat) (a b : BitVec w) : a = a ||| 0 := by
   bv_automata_gen (config := {backend := .circuit_cadical_verified } )
 
 /--
-info: 'eq3' depends on axioms: [propext, Circuit.denote_toAIGAux_eq_eval, Classical.choice, Lean.ofReduceBool, Quot.sound]
+info: 'eq3' depends on axioms: [propext, Quot.sound, ReflectVerif.BvDecide.decideIfZerosByKInductionCycleBreakingAx]
 -/
 #guard_msgs in #print axioms eq3
 
 example (w : Nat) (a b : BitVec w) : a = a + 0 := by
   bv_automata_gen (config := {backend := .circuit_cadical_verified} )
 
+set_option trace.Bits.FastVerif true in
 theorem check_axioms (w : Nat) (a b : BitVec w) : a + b = b + a := by
   bv_automata_gen (config := {backend := .circuit_cadical_verified} )
 
 /--
-info: 'check_axioms' depends on axioms: [propext,
- Circuit.denote_toAIGAux_eq_eval,
- Classical.choice,
- Lean.ofReduceBool,
- Quot.sound]
+info: 'check_axioms' depends on axioms: [propext, Quot.sound, ReflectVerif.BvDecide.decideIfZerosByKInductionCycleBreakingAx]
 -/
 #guard_msgs in #print axioms check_axioms
 
@@ -326,7 +324,7 @@ def test24 (x y : BitVec w) : (x ||| y) = (( x &&& (~~~y)) + y) := by
   bv_automata_gen (config := {backend := .circuit_cadical_verified} )
 
 /--
-info: 'test24' depends on axioms: [propext, Circuit.denote_toAIGAux_eq_eval, Classical.choice, Lean.ofReduceBool, Quot.sound]
+info: 'test24' depends on axioms: [propext, Quot.sound, ReflectVerif.BvDecide.decideIfZerosByKInductionCycleBreakingAx]
 -/
 #guard_msgs in #print axioms test24
 
@@ -392,10 +390,17 @@ theorem add_eq_xor_add_mul_and_nt (x y : BitVec w) :
 theorem mul_four (x : BitVec w) : 4 * x = x + x + x + x := by
   bv_automata_gen
 
+theorem add_eq (x : BitVec w) : x = x + 0 := by
+  bv_automata_gen (config := {backend := .circuit_cadical_verified 6 } )
+
+theorem add_five (x : BitVec w) : (x + x) + (x + x) + x = x + x + x + x + x := by
+  bv_automata_gen (config := {backend := .circuit_cadical_verified 6 } )
+
 /-- Check that we correctly process an odd numeral multiplication. -/
 theorem mul_five (x : BitVec w) : 5 * x = x + x + x + x + x := by
   bv_automata_gen (config := {backend := .circuit_cadical_verified 6 } )
 
+set_option maxHeartbeats 999999999 in
 /-- Check that we correctly process an odd numeral multiplication. -/
 theorem mul_eleven (x : BitVec w) : 11 * x =
   (x + x + x + x + x +
@@ -403,6 +408,7 @@ theorem mul_eleven (x : BitVec w) : 11 * x =
    x) := by
   bv_automata_gen (config := {backend := .circuit_cadical_verified 6 } )
 
+set_option maxHeartbeats 999999999 in
 theorem mul_eleven' (x : BitVec w) : 11 * x =
   (x + x + x + x + x +
    x + x + x + x + x +
@@ -449,10 +455,9 @@ def width_1_char_2_add_four (x : BitVec w) (hw : w = 1) : x + x + x + x = 0#w :=
 
 /--
 info: 'width_1_char_2_add_four' depends on axioms: [propext,
- Circuit.denote_toAIGAux_eq_eval,
  Classical.choice,
- Lean.ofReduceBool,
- Quot.sound]
+ Quot.sound,
+ ReflectVerif.BvDecide.decideIfZerosByKInductionCycleBreakingAx]
 -/
 #guard_msgs in #print axioms width_1_char_2_add_four
 
@@ -464,8 +469,9 @@ set_option trace.Bits.FastVerif true in
 set_option maxHeartbeats 999999999 in
 theorem e_331 (x y : BitVec w):
      - 6 *  ~~~x + 2 * (x |||  ~~~y) - 3 * x + 2 * (x ||| y) - 10 *  ~~~(x ||| y) - 10 *  ~~~(x |||  ~~~y) - 4 * (x &&&  ~~~y) - 15 * (x &&& y) + 3 *  ~~~(x &&&  ~~~x) + 11 *  ~~~(x &&&  ~~~y) = 0#w := by
+  -- bv_automata_gen (config := {backend := .dryrun 6 } )
+  bv_automata_gen (config := {backend := .circuit_cadical_verified 4 } )
   -- bv_automata_gen (config := {genSizeThreshold := 2000, stateSpaceSizeThreshold := 100})
-  -- fail_if_success bv_automata_gen (config := {backend := .circuit_cadical_verified 5 } )
   -- fail_if_success bv_automata_gen (config := {backend := .circuit_cadical_unverified 5 } )
   sorry
 

--- a/SSA/Experimental/Bits/Frontend/Tactic.lean
+++ b/SSA/Experimental/Bits/Frontend/Tactic.lean
@@ -618,7 +618,13 @@ def reflectUniversalWidthBVs (g : MVarId) (cfg : Config) : TermElabM (List MVarI
       trace[Bits.Frontend] f!"{fsm.format}'"
       let (cert?, _circuitStats) ← fsm.decideIfZerosVerified maxIter
       match cert? with
-      | .proven niter safetyCert indCert =>
+      | .provenByExhaustion niter safetyCert =>
+        let gs ← g.apply (mkConst ``ReflectVerif.BvDecide.decideIfZerosByExhaustion [])
+        if gs.isEmpty
+          then return gs
+        else
+          throwError m!"Expected application of 'decideIfZerosMAx' to close goal, but failed. {indentD g}"
+      | .provenByKInd niter safetyCert indCert =>
         let safetyCertExpr := Lean.mkStrLit safetyCert
         let indCertExpr := Lean.mkStrLit indCert
         let prf ← g.withContext do

--- a/SSA/Experimental/Bits/Frontend/Tactic.lean
+++ b/SSA/Experimental/Bits/Frontend/Tactic.lean
@@ -620,9 +620,9 @@ def reflectUniversalWidthBVs (g : MVarId) (cfg : Config) : TermElabM (List MVarI
       return [g]
     | .circuit_cadical_verified maxIter checkTypes? =>
       let fsm := predicateEvalEqFSM predicate.e |>.toFSM
-      logInfo m!"built FSM."
-      logInfo m!"FSM state space size: {fsm.stateSpaceSize}"
-      logInfo m!"FSM transition circuit size: {fsm.circuitSize}"
+      -- logInfo m!"built FSM."
+      -- logInfo m!"FSM state space size: {fsm.stateSpaceSize}"
+      -- logInfo m!"FSM transition circuit size: {fsm.circuitSize}"
       let (cert?, _circuitStats) ← fsm.decideIfZerosVerified maxIter
       match cert? with
       | .provenByExhaustion niter safetyCert =>

--- a/SSA/Experimental/Bits/Frontend/Tactic.lean
+++ b/SSA/Experimental/Bits/Frontend/Tactic.lean
@@ -585,6 +585,11 @@ def reflectUniversalWidthBVs (g : MVarId) (cfg : Config) : TermElabM (List MVarI
 
     match cfg.backend with
     | .dryrun =>
+        logInfo m!"Reflected predicate: {repr <| predicate.e}. Converting to FSM..."
+        let fsm := predicateEvalEqFSM predicate.e |>.toFSM
+        logInfo m!"built FSM."
+        logInfo m!"FSM state space size: {fsm.stateSpaceSize}"
+        logInfo m!"FSM transition circuit size: {fsm.circuitSize}"
         g.assign (← mkSorry (← g.getType) (synthetic := false))
         trace[Bits.Frontend] "Closing goal with 'sorry' for dry-run"
         return []
@@ -615,16 +620,24 @@ def reflectUniversalWidthBVs (g : MVarId) (cfg : Config) : TermElabM (List MVarI
       return [g]
     | .circuit_cadical_verified maxIter checkTypes? =>
       let fsm := predicateEvalEqFSM predicate.e |>.toFSM
-      trace[Bits.Frontend] f!"{fsm.format}'"
+      logInfo m!"built FSM."
+      logInfo m!"FSM state space size: {fsm.stateSpaceSize}"
+      logInfo m!"FSM transition circuit size: {fsm.circuitSize}"
       let (cert?, _circuitStats) ← fsm.decideIfZerosVerified maxIter
       match cert? with
       | .provenByExhaustion niter safetyCert =>
-        let gs ← g.apply (mkConst ``ReflectVerif.BvDecide.decideIfZerosByExhaustion [])
+        let gs ← g.apply (mkConst ``ReflectVerif.BvDecide.decideIfZerosByExhaustionAx [])
         if gs.isEmpty
           then return gs
         else
           throwError m!"Expected application of 'decideIfZerosMAx' to close goal, but failed. {indentD g}"
-      | .provenByKInd niter safetyCert indCert =>
+      | .provenByKIndCycleBreaking niter safetyCert indCert =>
+        let gs ← g.apply (mkConst ``ReflectVerif.BvDecide.decideIfZerosByKInductionCycleBreakingAx [])
+        if gs.isEmpty
+          then return gs
+        else
+          throwError m!"Expected application of 'decideIfZerosMAx' to close goal, but failed. {indentD g}"
+      | .provenByKIndNoCycleBreaking niter safetyCert indCert =>
         let safetyCertExpr := Lean.mkStrLit safetyCert
         let indCertExpr := Lean.mkStrLit indCert
         let prf ← g.withContext do
@@ -676,7 +689,7 @@ def reflectUniversalWidthBVs (g : MVarId) (cfg : Config) : TermElabM (List MVarI
         throwError m!"Failed to prove goal in '{niter}' iterations: Try increasing number of iterations."
     | .circuit_cadical_unverified maxIter =>
       let fsm := predicateEvalEqFSM predicate.e |>.toFSM
-      trace[Bits.Frontend] f!"{fsm.format}'"
+      -- trace[Bits.Frontend] f!"{fsm.format}'"
       let (isTrueForall, _circuitState) ← fsm.decideIfZerosMUnverified maxIter
       if isTrueForall
       then do
@@ -690,7 +703,7 @@ def reflectUniversalWidthBVs (g : MVarId) (cfg : Config) : TermElabM (List MVarI
         return [g]
     | .circuit_lean =>
       let fsm := predicateEvalEqFSM predicate.e |>.toFSM
-      trace[Bits.Frontend] f!"{fsm.format}'"
+      -- trace[Bits.Frontend] f!"{fsm.format}'"
       if fsm.circuitSize > cfg.circuitSizeThreshold && cfg.circuitSizeThreshold != 0 then
         throwError m!"Not running on goal: since circuit size ('{fsm.circuitSize}') is larger than threshold ('circuitSizeThreshold:{cfg.circuitSizeThreshold}')"
       if fsm.stateSpaceSize > cfg.stateSpaceSizeThreshold && cfg.stateSpaceSizeThreshold != 0 then

--- a/SSA/Projects/InstCombine/TacticAuto.lean
+++ b/SSA/Projects/InstCombine/TacticAuto.lean
@@ -245,3 +245,8 @@ macro "bv_bench_automata": tactic =>
         )
       )
    )
+
+example : ∀ (x : BitVec w), x * 2 = x + x := by
+    intros w
+    bv_bench_automata
+    sorry

--- a/SSA/Projects/InstCombine/TacticAuto.lean
+++ b/SSA/Projects/InstCombine/TacticAuto.lean
@@ -231,15 +231,15 @@ macro "bv_bench_automata": tactic =>
         all_goals (
           tac_bench (config := { outputType := .csv }) [
             "bv_normalize" : (bv_normalize; done),
-            "presburger" : (bv_automata_gen (config := { backend := .presburger }); done),
+            -- "presburger" : (bv_automata_gen (config := { backend := .presburger }); done),
             "normPresburger" : ((try (solve | bv_normalize)); (try bv_automata_gen (config := { backend := .presburger })); done),
-            "circuitUnverified" : (bv_automata_gen (config := { backend := .circuit_cadical_unverified /- maxIter -/ 4 }); done),
-            "circuitVerified" : (bv_automata_gen (config := { backend := .circuit_cadical_verified /- maxIter -/ 4 }); done),
-            "normCircuitUnverified" : ((try (solve | bv_normalize)); (try bv_automata_gen (config := { backend := .circuit_cadical_unverified /- maxIter -/ 4 })); done),
+           --  "circuitUnverified" : (bv_automata_gen (config := { backend := .circuit_cadical_unverified /- maxIter -/ 4 }); done),
+            -- "circuitVerified" : (bv_automata_gen (config := { backend := .circuit_cadical_verified /- maxIter -/ 4 }); done),
+            -- "normCircuitUnverified" : ((try (solve | bv_normalize)); (try bv_automata_gen (config := { backend := .circuit_cadical_unverified /- maxIter -/ 4 })); done),
             "normCircuitVerified" : ((try (solve | bv_normalize)); (try bv_automata_gen (config := { backend := .circuit_cadical_verified /- maxIter -/ 4 })); done),
-            "no_uninterpreted" : (bv_automata_fragment_no_uninterpreted),
-            "width_ok" : (bv_automata_fragment_width_legal),
-            "reflect_ok" : (bv_automata_fragment_reflect),
+            -- "no_uninterpreted" : (bv_automata_fragment_no_uninterpreted),
+            -- "width_ok" : (bv_automata_fragment_width_legal),
+            -- "reflect_ok" : (bv_automata_fragment_reflect),
             "bv_decide" : (bv_decide; done),
           ]
         )

--- a/bv-evaluation/compare-automata-automata-circuit.py
+++ b/bv-evaluation/compare-automata-automata-circuit.py
@@ -261,7 +261,7 @@ if __name__ == "__main__":
   parser = argparse.ArgumentParser(prog='compare-automata-automata-circuit')
   default_db = f'automata-circuit-{current_time}.sqlite3'
   parser.add_argument('--db', default=default_db, help='path to sqlite3 database')
-  parser.add_argument('-j', '--jobs', type=int, default=((nproc + 2)// 3))
+  parser.add_argument('-j', '--jobs', type=int, default=5) # ((nproc + 2)// 3))
   parser.add_argument('--run', action='store_true', help="run evaluation")
   parser.add_argument('--prodrun', action='store_true', help="run production run of evaluation")
   parser.add_argument('--analyze', action='store_true', help="analyze the data of the db")

--- a/bv-evaluation/plot-automata-automata-circuit.py
+++ b/bv-evaluation/plot-automata-automata-circuit.py
@@ -251,7 +251,7 @@ def plot(args):
     solver_latex_names : dict[str, str] = {
         "normCircuitVerified": "NormCircuitVerified",
         "normCircuitUnverified": "NormCircuitUnverified",
-        "normCircuit": "NormCircuit",
+        # "normCircuit": "NormCircuit",
         "normPresburger": "NormPresburger",
         "bv_decide": "BvDecide",
         "bv_normalize": "BvNormalize",


### PR DESCRIPTION
This allows k-induction to bail out faster in the case of proving safety properties on cycles in the FSM.

Supercedes #1293 