### PR TITLE
chore: set default number of jobs in eval to be ceiling(nproc / 3).

### DIFF
--- a/SSA/Experimental/Bits/Fast/Dataset2/runner.py
+++ b/SSA/Experimental/Bits/Fast/Dataset2/runner.py
@@ -21,7 +21,7 @@ def parse_args():
     nproc = os.cpu_count()
     parser.add_argument('--db', default=f'run-{current_time}.sqlite3', help='path to sqlite3 database')
     parser.add_argument('--prod-run', default=False, action='store_true', help='run a production run of the whole thing.')
-    parser.add_argument('-j', type=int, default=nproc, help='number of parallel jobs.')
+    parser.add_argument('-j', type=int, default=((nproc + 2) // 3), help='number of parallel jobs.')
     parser.add_argument('--timeout', type=int, default=60, help='number of seconds for timeout of test.')
     return parser.parse_args()
 

--- a/SSA/Experimental/Bits/Fast/Profile.lean
+++ b/SSA/Experimental/Bits/Fast/Profile.lean
@@ -43,11 +43,11 @@ unsafe def main : IO Unit := do
         IO.println s!"Iteration #{i + 1} of Running Algorithm"
         let fsm := predicateEvalEqFSM p
         -- let (bPure, tElapsedPure) ← timeElapsedMs (IO.lazyPure fun () => decideIfZeros fsm.toFSM)
-        let (bCadical, tElapsedCadical) ← timeElapsedMs do
-          let (b, _coreState, _metaState, _termState) ←
+        let ((bCadical, circuitStats), tElapsedCadical) ← timeElapsedMs do
+          let ((b, circuitStats), _coreState, _metaState, _termState) ←
             fsm.toFSM.decideIfZerosMUnverified 10 |>.toIO ctxCore sCore ctxMeta sMeta ctxTerm sTerm
-          return b
+          return (b, circuitStats)
         -- IO.println s!" (pure)     is all zeroes: '{bPure}' | time: '{tElapsedPure}' ms"
-        IO.println s!" (cadical)  is all zeroes: '{bCadical}' | time: '{tElapsedCadical}' ms"
+        IO.println s!" (cadical) is all zeroes: '{bCadical}' | stats: {repr circuitStats} | time: '{tElapsedCadical}' ms"
         IO.println "--"
   return ()

--- a/SSA/Experimental/Bits/Fast/ProfileVerif.lean
+++ b/SSA/Experimental/Bits/Fast/ProfileVerif.lean
@@ -45,12 +45,12 @@ unsafe def main : IO Unit := do
         IO.println s!"Iteration #{i + 1} of Running Algorithm"
         let fsm := predicateEvalEqFSM p
         -- let (bPure, tElapsedPure) ← timeElapsedMs (IO.lazyPure fun () => decideIfZeros fsm.toFSM)
-        let (out, tElapsedCadical) ← timeElapsedMs do
-          let (out, _coreState, _metaState, _termState) ←
+        let ((out, circuitStats), tElapsedCadical) ← timeElapsedMs do
+          let ((out, circuitStats), _coreState, _metaState, _termState) ←
             fsm.toFSM.decideIfZerosVerified 10 |>.toIO ctxCore sCore ctxMeta sMeta ctxTerm sTerm
-          return out
+          return (out, circuitStats)
         let b := out.isSuccess
         -- IO.println s!" (pure)     is all zeroes: '{bPure}' | time: '{tElapsedPure}' ms"
-        IO.println s!" (cadical)  is all zeroes: '{b}' | time: '{tElapsedCadical}' ms"
+        IO.println s!" (cadical)  is all zeroes: '{b}' | stats: '{repr circuitStats}' | time: '{tElapsedCadical}' ms"
         IO.println "--"
   return ()

--- a/SSA/Experimental/Bits/Fast/Reflect.lean
+++ b/SSA/Experimental/Bits/Fast/Reflect.lean
@@ -257,6 +257,11 @@ def Vars.format (fσ : σ → Format) (fι : ι → Format) {n : Nat} (v : Vars 
   | .state s => fσ s
   | .inputs is => is.format fι
 
+structure CircuitStats where
+  safetySize : Nat := 0
+  indSize : Nat := 0
+deriving Repr, Inhabited, DecidableEq, Hashable
+
 @[nospecialize]
 partial def decideIfZerosAuxTermElabM {arity : Type _}
     [DecidableEq arity] [Fintype arity] [Hashable arity]
@@ -266,10 +271,10 @@ partial def decideIfZerosAuxTermElabM {arity : Type _}
     (c0K : Circuit (Vars p.α arity iter))
     -- cK = 0 <-> ∀ p.eval env iter = 0
     (cK : Circuit (Vars p.α arity iter))
-    -- (safetyProperty = 1) <->
+    -- (indCircuit = 1) <->
     --   (∃ k < K,
     --      (∀ i < k, p.eval env i = 0) → (∀ j ≤ K, p.eval env j = 0))
-    (safetyProperty : Circuit (Vars p.α arity iter)) : TermElabM Bool := do
+    (indCircuit : Circuit (Vars p.α arity iter)) : TermElabM (Bool × CircuitStats) := do
   trace[Bits.Fast] s!"### K-induction (iter {iter}) ###"
   let formatα : p.α → Format := fun s => "s" ++ formatDecEqFinset s
   let formatEmpty : Empty → Format := fun e => e.elim
@@ -278,7 +283,7 @@ partial def decideIfZerosAuxTermElabM {arity : Type _}
   trace[Bits.Fast] m!"cK: {formatCircuit (Vars.format formatα formatArity) cK}"
   if iter ≥ maxIter && maxIter != 0 then
     throwError s!"ran out of iterations, quitting"
-    return false
+    return (false, {indSize := indCircuit.size })
   let cKSucc : Circuit (Vars p.α arity (iter + 1)) :=
     cK.bind fun v =>
       match v with
@@ -309,7 +314,7 @@ partial def decideIfZerosAuxTermElabM {arity : Type _}
   if ← checkCircuitSatAux c0KSuccWithInit
   then
     trace[Bits.Fast] s!"Safety property failed on initial state."
-    return false
+    return (false, { safetySize := c0KSuccWithInit.size })
   else
     trace[Bits.Fast] s!"Safety property succeeded on initial state. Building next state circuit..."
     let tStart ← IO.monoMsNow
@@ -319,11 +324,11 @@ partial def decideIfZerosAuxTermElabM {arity : Type _}
     trace[Bits.Fast] s!"C0KAdapted: {formatCircuit (Vars.format formatα formatArity) c0KAdapted}"
     trace[Bits.Fast] s!"CKSucc: {formatCircuit (Vars.format formatα formatArity) cKSucc}"
     let impliesCircuit : Circuit (Vars p.α arity (iter + 1)) := c0KAdapted ||| ~~~ c0KSucc
-    let safetyProperty := safetyProperty.map fun v =>
+    let indCircuit := indCircuit.map fun v =>
        match v with
        | .state a => .state a
        | .inputs i => .inputs (i.castLe (by omega))
-    let safetyProperty := safetyProperty ||| impliesCircuit
+    let indCircuit := indCircuit ||| impliesCircuit
     -- let formatαβarity : p.α ⊕ (β ⊕ arity) → Format := sorry
     trace[Bits.Fast] m!"induction hyp circuit: {formatCircuit (Vars.format formatα formatArity) impliesCircuit}"
     let tEnd ← IO.monoMsNow
@@ -332,20 +337,20 @@ partial def decideIfZerosAuxTermElabM {arity : Type _}
     trace[Bits.Fast] s!"Establishing inductive invariant with cadical..."
     let tStart ← IO.monoMsNow
     -- let le : Bool := sorry
-    let le ← checkCircuitTautoAux safetyProperty
+    let le ← checkCircuitTautoAux indCircuit
     let tEnd ← IO.monoMsNow
     let tElapsedSec := (tEnd - tStart) / 1000
     if le then
       trace[Bits.Fast] s!"Inductive invariant established! (time={tElapsedSec}s)"
-      return true
+      return (true, { indSize := indCircuit.size, safetySize := c0KSuccWithInit.size })
     else
       trace[Bits.Fast] s!"Unable to establish inductive invariant (time={tElapsedSec}s). Recursing..."
-      decideIfZerosAuxTermElabM (iter + 1) maxIter p c0KSucc cKSucc safetyProperty
+      decideIfZerosAuxTermElabM (iter + 1) maxIter p c0KSucc cKSucc indCircuit
 
 
 @[nospecialize]
 def _root_.FSM.decideIfZerosMUnverified  {arity : Type _} [DecidableEq arity]  [Fintype arity] [Hashable arity]
-   (fsm : FSM arity) (maxIter : Nat) : TermElabM Bool :=
+   (fsm : FSM arity) (maxIter : Nat) : TermElabM (Bool × CircuitStats) :=
   -- decideIfZerosM Circuit.impliesCadical fsm
   withTraceNode `Bits.Fast (fun _ => return "k-induction") (collapsed := false) do
     let c : Circuit (Vars fsm.α arity 0) := (fsm.nextBitCirc none).fst.map Vars.state

--- a/SSA/Experimental/Bits/Frontend/Tactic.lean
+++ b/SSA/Experimental/Bits/Frontend/Tactic.lean
@@ -616,7 +616,7 @@ def reflectUniversalWidthBVs (g : MVarId) (cfg : Config) : TermElabM (List MVarI
     | .circuit_cadical_verified maxIter checkTypes? =>
       let fsm := predicateEvalEqFSM predicate.e |>.toFSM
       trace[Bits.Frontend] f!"{fsm.format}'"
-      let cert? ← fsm.decideIfZerosVerified maxIter
+      let (cert?, _circuitStats) ← fsm.decideIfZerosVerified maxIter
       match cert? with
       | .proven niter safetyCert indCert =>
         let safetyCertExpr := Lean.mkStrLit safetyCert
@@ -671,7 +671,7 @@ def reflectUniversalWidthBVs (g : MVarId) (cfg : Config) : TermElabM (List MVarI
     | .circuit_cadical_unverified maxIter =>
       let fsm := predicateEvalEqFSM predicate.e |>.toFSM
       trace[Bits.Frontend] f!"{fsm.format}'"
-      let isTrueForall ← fsm.decideIfZerosMUnverified maxIter
+      let (isTrueForall, _circuitState) ← fsm.decideIfZerosMUnverified maxIter
       if isTrueForall
       then do
         let gs ← g.apply (mkConst ``Reflect.BvDecide.decideIfZerosMAx [])

--- a/bv-evaluation/compare-automata-automata-circuit.py
+++ b/bv-evaluation/compare-automata-automata-circuit.py
@@ -261,7 +261,7 @@ if __name__ == "__main__":
   parser = argparse.ArgumentParser(prog='compare-automata-automata-circuit')
   default_db = f'automata-circuit-{current_time}.sqlite3'
   parser.add_argument('--db', default=default_db, help='path to sqlite3 database')
-  parser.add_argument('-j', '--jobs', type=int, default=nproc // 3)
+  parser.add_argument('-j', '--jobs', type=int, default=((nproc + 2)// 3))
   parser.add_argument('--run', action='store_true', help="run evaluation")
   parser.add_argument('--prodrun', action='store_true', help="run production run of evaluation")
   parser.add_argument('--analyze', action='store_true', help="analyze the data of the db")


### PR DESCRIPTION
This ensures that we don't accidentally kill the evaluation machine.