### PR TITLE
chore: don't pass the (I think incorrectly) built induction circuit for K-induction

### DIFF
--- a/SSA/Experimental/Bits/Fast/Tests.lean
+++ b/SSA/Experimental/Bits/Fast/Tests.lean
@@ -71,7 +71,8 @@ example (w : Nat) (a b : BitVec w) : (a + b = b + a)  := by
 
 example (w : Nat) (a : BitVec w) : (a = a + 0#w) ∨ (a = a - a)  := by
   fail_if_success bv_automata_gen (config := {backend := .circuit_cadical_verified 20 } )
-  bv_automata_gen (config := {backend := .circuit_cadical_unverified 20 } )
+  fail_if_success bv_automata_gen (config := {backend := .circuit_cadical_unverified 20 } )
+  sorry
 
 example (w : Nat) (a : BitVec w) :  (a = a + 0#w)  := by
   bv_automata_gen (config := {backend := .circuit_cadical_verified 20 } )
@@ -222,7 +223,8 @@ Note that this is pretty expensive.
 -/
 example (w : Nat) (a : BitVec w) : (1#w + 1#w = 0#w) → (a = 0#w ∨ a = 1#w) := by
   fail_if_success bv_automata_gen (config := {backend := .circuit_cadical_verified} )
-  bv_automata_gen (config := {backend := .circuit_cadical_unverified} )
+  fail_if_success bv_automata_gen (config := {backend := .circuit_cadical_unverified} )
+  sorry
 
 example (w : Nat) (a b : BitVec w) : (a + b = 0#w) → a = - b := by
   bv_automata_gen (config := {backend := .circuit_cadical_verified} )
@@ -352,7 +354,8 @@ example : ∀ (w : Nat) , (BitVec.ofNat w 1) &&& (BitVec.ofNat w 3) = BitVec.ofN
 example : ∀ (w : Nat) (x : BitVec w), -1#w &&& x = x := by
   intros
   fail_if_success bv_automata_gen (config := {backend := .circuit_cadical_verified} )
-  bv_automata_gen (config := {backend := .circuit_cadical_unverified} )
+  fail_if_success bv_automata_gen (config := {backend := .circuit_cadical_unverified} )
+  sorry
 
 example : ∀ (w : Nat) (x : BitVec w), x <<< (0 : Nat) = x := by
   intros
@@ -466,7 +469,8 @@ theorem e_331 (x y : BitVec w):
      - 6 *  ~~~x + 2 * (x |||  ~~~y) - 3 * x + 2 * (x ||| y) - 10 *  ~~~(x ||| y) - 10 *  ~~~(x |||  ~~~y) - 4 * (x &&&  ~~~y) - 15 * (x &&& y) + 3 *  ~~~(x &&&  ~~~x) + 11 *  ~~~(x &&&  ~~~y) = 0#w := by
   -- bv_automata_gen (config := {genSizeThreshold := 2000, stateSpaceSizeThreshold := 100})
   fail_if_success bv_automata_gen (config := {backend := .circuit_cadical_verified 5 } )
-  bv_automata_gen (config := {backend := .circuit_cadical_unverified 5 } )
+  -- fail_if_success bv_automata_gen (config := {backend := .circuit_cadical_unverified 5 } )
+  sorry
 
 #exit
 


### PR DESCRIPTION
Fix another difference that I just spotted between the unverified and verified implementations. If this is the right fix, then this should eliminate all mismatches between the unverified and verified implementations, and make both of them equally slow for K-induction.