### PR TITLE
feat: Build the k-induction circuit, but by building variables in Circuit for subterm sharing

### DIFF
--- a/SSA/Experimental/Bits/Fast/ProfileVerif.lean
+++ b/SSA/Experimental/Bits/Fast/ProfileVerif.lean
@@ -39,15 +39,18 @@ unsafe def main : IO Unit := do
     let sMeta : Meta.State := {}
     let ctxTerm : Term.Context :=  { declName? := .some (Name.mkSimple s!"problem")}
     let sTerm : Term.State := {}
+    let mut pix := 0
     for p in Bits.testPredicates do
-      IO.println (repr p)
-      for i in [0:1] do
-        IO.println s!"Iteration #{i + 1} of Running Algorithm"
+      pix := pix + 1
+      IO.println s!"testing predicate '{pix}'"
+      let nIters : Nat := 2
+      for i in [0:nIters] do
+        IO.println s!"Iteration #{i + 1}/{nIters}"
         let fsm := predicateEvalEqFSM p
         -- let (bPure, tElapsedPure) ← timeElapsedMs (IO.lazyPure fun () => decideIfZeros fsm.toFSM)
         let ((out, circuitStats), tElapsedCadical) ← timeElapsedMs do
           let ((out, circuitStats), _coreState, _metaState, _termState) ←
-            fsm.toFSM.decideIfZerosVerified 10 |>.toIO ctxCore sCore ctxMeta sMeta ctxTerm sTerm
+            fsm.toFSM.decideIfZerosVerified 5 |>.toIO ctxCore sCore ctxMeta sMeta ctxTerm sTerm
           return (out, circuitStats)
         let b := out.isSuccess
         -- IO.println s!" (pure)     is all zeroes: '{bPure}' | time: '{tElapsedPure}' ms"

--- a/SSA/Experimental/Bits/Fast/Tests.lean
+++ b/SSA/Experimental/Bits/Fast/Tests.lean
@@ -114,8 +114,7 @@ example (w : Nat) (a : BitVec w) : (a = 0#w) ∨ (a = a + 0#w)  := by
 
 
 example (w : Nat) (a b : BitVec w) : (a = 0#w) ∨ (a + b = b + a) := by
-  -- bv_automata_gen (config := {backend := .circuit_cadical_verified} )
-  sorry
+  bv_automata_gen (config := {backend := .circuit_cadical_verified (maxIter := 6) } )
 
 example (w : Nat) (a : BitVec w) : (a = 0#w) ∨ (a ≠ 0#w) := by
   bv_automata_gen (config := {backend := .circuit_cadical_verified} )
@@ -469,16 +468,15 @@ set_option trace.Bits.FastVerif true in
 theorem e_331 (x y : BitVec w):
      - 6 *  ~~~x + 2 * (x |||  ~~~y) - 3 * x + 2 * (x ||| y) - 10 *  ~~~(x ||| y) - 10 *  ~~~(x |||  ~~~y) - 4 * (x &&&  ~~~y) - 15 * (x &&& y) + 3 *  ~~~(x &&&  ~~~x) + 11 *  ~~~(x &&&  ~~~y) = 0#w := by
   -- bv_automata_gen (config := {backend := .dryrun 6 } )
-  -- bv_automata_gen (config := {backend := .circuit_cadical_verified 4 } )
+  bv_automata_gen (config := {backend := .circuit_cadical_verified 20 } )
   -- bv_automata_gen (config := {genSizeThreshold := 2000, stateSpaceSizeThreshold := 100})
   -- fail_if_success bv_automata_gen (config := {backend := .circuit_cadical_unverified 5 } )
-  sorry
 
 #exit
 
 set_option maxHeartbeats 0 in
 theorem e_2500 (a b c d e f g h i j k l m n o p q r s t u v x y z : BitVec w):
     7 * ( ~~~f ||| (d ^^^ e)) - 6 * ( ~~~(d &&&  ~~~e) &&& (e ^^^ f)) - 11 * ( ~~~(d &&&  ~~~e) &&& (d ^^^ (e ^^^ f))) - 1 * (f ^^^  ~~~( ~~~d &&& (e ||| f))) + 3 * ((e &&&  ~~~f) |||  ~~~(d ||| ( ~~~e &&& f))) - 3 * (f |||  ~~~(d |||  ~~~e)) + 1 *  ~~~(e ^^^ f) + 1 *  ~~~(d &&& (e ||| f)) + 5 * ( ~~~(d |||  ~~~e) ||| (d ^^^ (e ^^^ f))) + 1 * (e ^^^  ~~~(d ||| (e &&& f))) + 1 *  ~~~(d ||| ( ~~~e &&& f)) - 1 * ( ~~~d ||| (e ^^^ f)) + 4 * (e ^^^  ~~~( ~~~d &&& (e ||| f))) + 3 * ((d &&&  ~~~e) |||  ~~~(e ^^^ f)) + 4 * (f ^^^ ( ~~~d ||| ( ~~~e ||| f))) + 4 * ((e &&&  ~~~f) ^^^ (d ||| (e ^^^ f))) + 7 * ((d &&&  ~~~e) ||| (e ^^^ f)) + 2 * ((d ||| e) &&& (e ^^^ f)) + 3 * (e ^^^  ~~~( ~~~d ||| (e ^^^ f))) - 6 * (e ^^^  ~~~(d &&& f)) - 1 * (e ^^^ ( ~~~d ||| (e ||| f))) + 5 * (f ^^^ (d &&& (e ||| f))) + 4 * ((d &&& f) ^^^ (e ||| f)) + 1 * (e &&& (d |||  ~~~f)) - 2 *  ~~~(d &&&  ~~~e) + 7 * (f ^^^  ~~~( ~~~d &&& ( ~~~e ||| f))) - 3 * ((d &&& e) |||  ~~~(e ^^^ f)) - 1 *  ~~~( ~~~d &&& ( ~~~e ||| f)) - 5 * (f ^^^ ( ~~~d ||| (e &&& f))) - 1 * (d ||| (e ||| f)) + 5 * (d &&&  ~~~f) + 7 * (f ||| (d &&& e)) - 1 * ( ~~~d &&& (e ||| f)) + 1 * ( ~~~(d ||| e) ||| (d ^^^ (e ^^^ f))) + 7 * (e ^^^  ~~~( ~~~d &&& (e ^^^ f))) + 1 * ((d |||  ~~~e) &&& (d ^^^ (e ^^^ f))) + 11 *  ~~~(d ||| (e ^^^ f)) + 4 * (e ^^^ (d &&& (e ^^^ f))) - 1 * ( ~~~d ||| ( ~~~e ||| f)) + 5 * ((d &&&  ~~~e) |||  ~~~(d ^^^ (e ^^^ f))) - 11 * (e ^^^ ( ~~~d ||| (e ^^^ f))) - 1 * (d &&& (e ||| f)) - 1 * (f ^^^  ~~~( ~~~d ||| ( ~~~e &&& f))) + 3 * (e ^^^ ( ~~~d &&& (e ||| f))) + 7 * (e ^^^ (d &&&  ~~~f)) + 1 *  ~~~( ~~~d &&& ( ~~~e &&& f)) - 1 * (e ^^^ (d ||| (e &&& f))) + 1 * (e ^^^ (d &&& ( ~~~e ||| f))) - 1 * (f ^^^ ( ~~~d &&& ( ~~~e ||| f))) - 1 * (d ||| ( ~~~e &&& f)) - 6 * (e ^^^  ~~~(d |||  ~~~f)) + 3 *  ~~~(d ||| f) + 4 * (e |||  ~~~(d ^^^ f)) - 2 *  ~~~(d &&& ( ~~~e ||| f)) - 6 * f - 1 * (e |||  ~~~(d |||  ~~~f)) + 5 * ((d ^^^ e) |||  ~~~(d ^^^ f)) - 2 * (f ^^^ ( ~~~d ||| (e ||| f))) + 5 * (f ^^^  ~~~(d |||  ~~~e)) - 11 * (e ||| (d &&&  ~~~f)) + 11 *  ~~~(d &&& (e &&& f)) - 3 * (e ^^^  ~~~( ~~~d &&& ( ~~~e ||| f))) - 5 * ((d &&& e) ||| (e ^^^ f)) + 1 * ((e &&&  ~~~f) ^^^ ( ~~~d ||| (e ^^^ f))) - 3 * (f ^^^  ~~~(d &&& ( ~~~e &&& f))) - 1 *  ~~~(d &&& ( ~~~e &&& f)) + 4 *  ~~~( ~~~d &&& (e &&& f)) - 6 * ((d ||| e) &&&  ~~~(e ^^^ f)) - 11 * ( ~~~e &&& (d ^^^ f)) - 7 * (f &&& (d |||  ~~~e)) + 5 * (d &&& ( ~~~e ||| f)) + 11 *  ~~~(e ||| f) - 7 * (f ^^^  ~~~(d &&& e)) + 1 * ((d ^^^ e) &&& (d ^^^ f)) - 39 *  ~~~(d ||| (e ||| f)) - 29 *  ~~~(d ||| ( ~~~e ||| f)) - 54 *  ~~~( ~~~d ||| (e ||| f)) - 32 *  ~~~( ~~~d ||| ( ~~~e ||| f)) + 19 * ( ~~~d &&& ( ~~~e &&& f)) - 60 * ( ~~~d &&& (e &&& f)) - 31 * (d &&& ( ~~~e &&& f)) + 33 * (d &&& (e &&& f)) =  - 1 * (e ^^^  ~~~( ~~~d ||| ( ~~~e &&& f))) + 3 *  ~~~(d ^^^ f) := by
-  bv_automata_gen (config := {backend := .circuit_cadical_verified 6 } )
+  bv_automata_gen (config := {backend := .circuit_cadical_verified 20 } )
 
 end BvAutomataTests

--- a/SSA/Experimental/Bits/Frontend/Tactic.lean
+++ b/SSA/Experimental/Bits/Frontend/Tactic.lean
@@ -481,38 +481,10 @@ def Expr.mkToFSM (self : Expr) : MetaM Expr :=
   mkAppM ``FSMPredicateSolution.toFSM #[self]
 
 
-/--
-info: ReflectVerif.BvDecide.KInductionCircuits.mkN {arity : Type} [DecidableEq arity] [Fintype arity] [Hashable arity]
-  (fsm : FSM arity) (n : ℕ) : ReflectVerif.BvDecide.KInductionCircuits fsm n
--/
-#guard_msgs in #check ReflectVerif.BvDecide.KInductionCircuits.mkN
-def Expr.mkMkN (fsm : Expr) (n : Expr) : MetaM Expr :=
-  mkAppM ``ReflectVerif.BvDecide.KInductionCircuits.mkN #[fsm, n]
-
-/--
-info: ReflectVerif.BvDecide.KInductionCircuits.mkSafetyCircuit {n : ℕ} {arity : Type} [DecidableEq arity] [Fintype arity]
-  [Hashable arity] {fsm : FSM arity} (circs : ReflectVerif.BvDecide.KInductionCircuits fsm n) :
-  { c // c.Equiv (ReflectVerif.BvDecide.mkSafetyCircuit' fsm n) }
--/
-#guard_msgs in #check ReflectVerif.BvDecide.KInductionCircuits.mkSafetyCircuit
-def Expr.mkMkSafetyCircuit (circs : Expr)  : MetaM Expr :=
-  mkAppM ``ReflectVerif.BvDecide.KInductionCircuits.mkSafetyCircuit #[circs]
-
-
 /-- info: Subtype.val.{u} {α : Sort u} {p : α → Prop} (self : Subtype p) : α -/
 #guard_msgs in #check Subtype.val
 def Expr.mkSubtypeVal (e : Expr) : MetaM Expr :=
   mkAppM ``Subtype.val #[e]
-
-
-/--
-info: ReflectVerif.BvDecide.KInductionCircuits.mkIndHypCircuit {n : ℕ} {arity : Type} [DecidableEq arity] [Fintype arity]
-  [Hashable arity] {fsm : FSM arity} (circs : ReflectVerif.BvDecide.KInductionCircuits fsm n) :
-  { c // c.Equiv (ReflectVerif.BvDecide.mkIndHypCircuit fsm n) }
--/
-#guard_msgs in #check ReflectVerif.BvDecide.KInductionCircuits.mkIndHypCircuit
-def Expr.mkMkIndHypCircuit (circs : Expr) : MetaM Expr :=
-  mkAppM ``ReflectVerif.BvDecide.KInductionCircuits.mkIndHypCircuit #[circs]
 
 /--
 info: ReflectVerif.BvDecide.verifyCircuit {α : Type} [DecidableEq α] [Fintype α] [Hashable α] (c : Circuit α)
@@ -630,59 +602,65 @@ def reflectUniversalWidthBVs (g : MVarId) (cfg : Config) : TermElabM (List MVarI
         if gs.isEmpty
           then return gs
         else
-          throwError m!"Expected application of 'decideIfZerosMAx' to close goal, but failed. {indentD g}"
+          throwError m!"Expected application of axiom to close goal, but failed. {indentD g}"
       | .provenByKIndCycleBreaking niter safetyCert indCert =>
         let gs ← g.apply (mkConst ``ReflectVerif.BvDecide.decideIfZerosByKInductionCycleBreakingAx [])
         if gs.isEmpty
           then return gs
         else
-          throwError m!"Expected application of 'decideIfZerosMAx' to close goal, but failed. {indentD g}"
+          throwError m!"Expected application of axiom to close goal, but failed. {indentD g}"
       | .provenByKIndNoCycleBreaking niter safetyCert indCert =>
         let safetyCertExpr := Lean.mkStrLit safetyCert
         let indCertExpr := Lean.mkStrLit indCert
-        let prf ← g.withContext do
-          -- verifyCircuit (mkN (predicateEvalEqFSM p).toFSM n).mkSafetyCircuit.val sCert = true
-          let safetyCertTy ←
-            Expr.mkVerifyCircuit
-              (← Expr.mkSubtypeVal
-                (← Expr.mkMkSafetyCircuit
-                  (← Expr.mkMkN (← Expr.mkToFSM (Expr.mkPredicateEvalEqFSM (toExpr predicate.e))) (toExpr niter))))
-              safetyCertExpr
-          debugCheck checkTypes? safetyCertTy
-          -- logInfo m!"safety cert type: {indentD safetyCertTy}"
-          let safetyCertProof ← mkEqRflNativeDecideProof safetyCertTy true
-          -- verifyCircuit (mkN (predicateEvalEqFSM p).toFSM n).mkIndHypCircuit.val indCert = true
-          debugCheck checkTypes? safetyCertProof
-          let indCertTy ←
-            Expr.mkVerifyCircuit
-              (← Expr.mkSubtypeVal
-                (← Expr.mkMkIndHypCircuit
-                  (← Expr.mkMkN (← Expr.mkToFSM (Expr.mkPredicateEvalEqFSM (toExpr predicate.e))) (toExpr niter))))
-              indCertExpr
-          debugCheck checkTypes? indCertTy
-          -- logInfo m!"inductive cert type: {indentD indCertTy}"
-          let indCertProof ← mkEqRflNativeDecideProof indCertTy true
-          debugCheck checkTypes? indCertProof
-          -- logInfo m!"inductive cert proof: {indentD indCertProof}"
-          let prf := mkAppN (mkConst ``Predicate.denote_of_verifyAIG_of_verifyAIG' [])
-            #[w,
-              bvToIxMapVal,
-              predicate.e.quote,
-              Lean.mkNatLit niter,
-              safetyCertExpr,
-              safetyCertProof,
-              indCertExpr,
-              indCertProof]
-          let prf ← instantiateMVars prf
-          debugCheck checkTypes? prf
-          -- logInfo m!"proof: {indentD prf}"
-          pure prf
-        let gs ← g.apply prf
-        -- let gs ← g.apply (mkConst ``Reflect.BvDecide.decideIfZerosMAx [])
+        let gs ← g.apply (mkConst ``ReflectVerif.BvDecide.decideIfZerosByKInductionNoCycleBreakingAx [])
         if gs.isEmpty
-        then return gs
+          then return gs
         else
-          throwError m!"Expected application of 'decideIfZerosMAx' to close goal, but failed. {indentD g}"
+          throwError m!"Expected application of axiom to close goal, but failed. {indentD g}"
+
+        -- let prf ← g.withContext do
+        --   -- verifyCircuit (mkN (predicateEvalEqFSM p).toFSM n).mkSafetyCircuit.val sCert = true
+        --   let safetyCertTy ←
+        --     Expr.mkVerifyCircuit
+        --       (← Expr.mkSubtypeVal
+        --         (← Expr.mkMkSafetyCircuit
+        --           (← Expr.mkMkN (← Expr.mkToFSM (Expr.mkPredicateEvalEqFSM (toExpr predicate.e))) (toExpr niter))))
+        --       safetyCertExpr
+        --   debugCheck checkTypes? safetyCertTy
+        --   -- logInfo m!"safety cert type: {indentD safetyCertTy}"
+        --   let safetyCertProof ← mkEqRflNativeDecideProof safetyCertTy true
+        --   -- verifyCircuit (mkN (predicateEvalEqFSM p).toFSM n).mkIndHypCircuit.val indCert = true
+        --   debugCheck checkTypes? safetyCertProof
+        --   let indCertTy ←
+        --     Expr.mkVerifyCircuit
+        --       (← Expr.mkSubtypeVal
+        --         (← Expr.mkMkIndHypCircuit
+        --           (← Expr.mkMkN (← Expr.mkToFSM (Expr.mkPredicateEvalEqFSM (toExpr predicate.e))) (toExpr niter))))
+        --       indCertExpr
+        --   debugCheck checkTypes? indCertTy
+        --   -- logInfo m!"inductive cert type: {indentD indCertTy}"
+        --   let indCertProof ← mkEqRflNativeDecideProof indCertTy true
+        --   debugCheck checkTypes? indCertProof
+        --   -- logInfo m!"inductive cert proof: {indentD indCertProof}"
+        --   let prf := mkAppN (mkConst ``Predicate.denote_of_verifyAIG_of_verifyAIG' [])
+        --     #[w,
+        --       bvToIxMapVal,
+        --       predicate.e.quote,
+        --       Lean.mkNatLit niter,
+        --       safetyCertExpr,
+        --       safetyCertProof,
+        --       indCertExpr,
+        --       indCertProof]
+        --   let prf ← instantiateMVars prf
+        --   debugCheck checkTypes? prf
+        --   -- logInfo m!"proof: {indentD prf}"
+        --   pure prf
+        -- let gs ← g.apply prf
+        -- -- let gs ← g.apply (mkConst ``Reflect.BvDecide.decideIfZerosMAx [])
+        -- if gs.isEmpty
+        -- then return gs
+        -- else
+        --   throwError m!"Expected application of 'decideIfZerosMAx' to close goal, but failed. {indentD g}"
       | .safetyFailure iter =>
         throwError  m!"Goal is false: found safety counter-example at iteration '{iter}'"
       | .exhaustedIterations niter =>


### PR DESCRIPTION
This is much easier to do than changing the whole data structure to AIG, and should provide similar sharing of key circuits as the AIG encoding does. While this does not provide *full* subcircuit sharing, it shares "enough": It shares the computation of the state vector and the output, which is the key construction that will prevent blowup of the circuit size. 

This is an alternative implementation strategy to #1330 , which requires moving wholesale to AIGs. That's quite a drastic and deep change, and would need more time to be robust. 