### PR TITLE
chore: frontload date in CI nightly update script

### DIFF
--- a/.github/workflows/update-mathlib-version.yml
+++ b/.github/workflows/update-mathlib-version.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v7
         with:
-          title: "chore: update to lean nightly ${{steps.mldate.outputs.date}}"
+          title: "${{steps.mldate.outputs.date}} lean nightly update"
           branch: "auto-mathlib-update-${{steps.mldate.outputs.date}}"
           body: "automatic update of mathlib + lean via GitHub action."
           token: ${{secrets.PAT}}


### PR DESCRIPTION
This increases the signal if one looks at the git history on a narrow screen.