### PR TITLE
chore: rerun width-generic eval

### DIFF
--- a/SSA/Projects/InstCombine/TacticAuto.lean
+++ b/SSA/Projects/InstCombine/TacticAuto.lean
@@ -230,7 +230,7 @@ macro "bv_bench_automata": tactic =>
            BitVec.ofNat_eq_ofNat, BitVec.two_mul]
         all_goals (
           tac_bench (config := { outputType := .csv }) [
-            "bv_normalize" : (bv_normalize; done),
+            -- "bv_normalize" : (bv_normalize; done),
             -- "presburger" : (bv_automata_gen (config := { backend := .presburger }); done),
             "normPresburger" : ((try (solve | bv_normalize)); (try bv_automata_gen (config := { backend := .presburger })); done),
            --  "circuitUnverified" : (bv_automata_gen (config := { backend := .circuit_cadical_unverified /- maxIter -/ 4 }); done),
@@ -238,7 +238,7 @@ macro "bv_bench_automata": tactic =>
             -- "normCircuitUnverified" : ((try (solve | bv_normalize)); (try bv_automata_gen (config := { backend := .circuit_cadical_unverified /- maxIter -/ 4 })); done),
             "normCircuitVerified" : ((try (solve | bv_normalize)); (try bv_automata_gen (config := { backend := .circuit_cadical_verified /- maxIter -/ 4 })); done),
             -- "no_uninterpreted" : (bv_automata_fragment_no_uninterpreted),
-            -- "width_ok" : (bv_automata_fragment_width_legal),
+            "width_ok" : (bv_automata_fragment_width_legal),
             -- "reflect_ok" : (bv_automata_fragment_reflect),
             "bv_decide" : (bv_decide; done),
           ]

--- a/SSA/Projects/InstCombine/TacticAuto.lean
+++ b/SSA/Projects/InstCombine/TacticAuto.lean
@@ -246,7 +246,7 @@ macro "bv_bench_automata": tactic =>
       )
    )
 
-example : ∀ (x : BitVec w), x * 2 = x + x := by
-    intros w
-    bv_bench_automata
-    sorry
+-- example : ∀ (x : BitVec w), x * 2 = x + x := by
+--     intros w
+--     bv_bench_automata
+--     sorry

--- a/bv-evaluation/compare-automata-automata-circuit-jsonl.py
+++ b/bv-evaluation/compare-automata-automata-circuit-jsonl.py
@@ -50,11 +50,9 @@ def run_file(db : str, file: str, file_num : int):
     logging.info(f"{fileTitle}({file_num}): done.")
     logging.info(out)
     if p.returncode != 0:
-        logging.info(f"ERROR: Expected return code of 0, found {p.returncode}")
-        logging.info(f"{fileTitle}({file_num}) stderr: {err}")
+        logging.error(f"{fileTitle}({file_num}): Expected return code of 0, found {p.returncode}")
         assert p.returncode == 0
 
-    logging.info(f"{fileTitle}({file_num}) output:\n{out}")
     records = []
     for line in out.strip().split("\n"):
         TACBENCH_PREAMBLE = "TACBENCHCSV|"

--- a/bv-evaluation/compare-automata-automata-circuit-jsonl.py
+++ b/bv-evaluation/compare-automata-automata-circuit-jsonl.py
@@ -3,7 +3,6 @@ import subprocess
 import datetime
 import os
 import platform
-import concurrent.futures
 import argparse
 import shutil
 import pandas as pd
@@ -12,15 +11,15 @@ import re
 import sqlite3
 import logging
 import random
-from tabulate import tabulate
+import json
 
 ROOT_DIR = subprocess.check_output(['git', 'rev-parse', '--show-toplevel']).decode('utf-8').strip()
 BENCHMARK_DIR = ROOT_DIR + '/SSA/Projects/InstCombine/tests/proofs/'
 TIMEOUT = 1800 # timeout
 
-STATUS_FAIL = "❌",
-STATUS_GREEN_CHECK = "✅",
-STATUS_SUCCESS = "🎉",
+STATUS_FAIL = "❌"
+STATUS_GREEN_CHECK = "✅"
+STATUS_SUCCESS = "🎉"
 STATUS_PROCESSING = "⌛️"
 
 def sed():
@@ -75,7 +74,7 @@ def run_file(db : str, file: str, file_num : int):
 
 def process(db : str, jobs: int, prod_run : bool):
     tactic_auto_path = f'{ROOT_DIR}/SSA/Projects/InstCombine/TacticAuto.lean'
-    os.mkdir(db, exist_ok=True)
+    os.makedirs(os.path.dirname(db), exist_ok=True)
 
     if os.path.exists(db):
         os.remove(db)
@@ -105,11 +104,10 @@ def process(db : str, jobs: int, prod_run : bool):
 
     total = len(files)
     logging.info(f"total #files to process: {total}")
-    futures = []
-    future_to_file ={}
+    num_completed = 0
     for ix, file in enumerate(files):
         future = run_file(db, file, ix+1)
-        percentage = ((idx + 1) / total) * 100
+        percentage = ((ix + 1) / total) * 100
         logging.info(f'completed {file} ({percentage:.1f}%)')
         num_completed += 1
         logging.info(f"total #files processed: {num_completed}")

--- a/bv-evaluation/compare-automata-automata-circuit-jsonl.py
+++ b/bv-evaluation/compare-automata-automata-circuit-jsonl.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+import subprocess
+import datetime
+import os
+import platform
+import concurrent.futures
+import argparse
+import shutil
+import pandas as pd
+import os
+import re
+import sqlite3
+import logging
+import random
+from tabulate import tabulate
+
+ROOT_DIR = subprocess.check_output(['git', 'rev-parse', '--show-toplevel']).decode('utf-8').strip()
+BENCHMARK_DIR = ROOT_DIR + '/SSA/Projects/InstCombine/tests/proofs/'
+TIMEOUT = 1800 # timeout
+
+STATUS_FAIL = "❌",
+STATUS_GREEN_CHECK = "✅",
+STATUS_SUCCESS = "🎉",
+STATUS_PROCESSING = "⌛️"
+
+def sed():
+    if platform.system() == "Darwin":
+        return "gsed"
+    return "sed"
+
+def run_file(db : str, file: str, file_num : int):
+    assert 0 < file_num, "file_num must be greater than 0"
+    file_path = BENCHMARK_DIR + file
+    fileTitle = file.split('.')[0]
+    logging.info(f"{fileTitle}: writing 'bv_bench_automata' tactic into file #{file_num}.")
+    subprocess.Popen(f'{sed()} -i -E \'s,simp_alive_benchmark,bv_bench_automata,g\' ' + file_path, cwd=ROOT_DIR, shell=True).wait()
+    logging.info(f"{fileTitle}: {STATUS_PROCESSING}")
+
+    cmd = 'lake lean ' + file_path
+    logging.info(f"{fileTitle}({file_num}): running '{cmd}'")
+
+    # TODO: can check that file exists to skip.
+    p = subprocess.Popen(cmd, cwd=ROOT_DIR, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True, universal_newlines=True)
+    logging.info(f"{fileTitle}({file_num}): running...")
+    try:
+        out, err = p.communicate(timeout=TIMEOUT)
+    except subprocess.TimeoutExpired as e:
+        logging.info(f"{file_path} - time out of {TIMEOUT} seconds reached")
+        p.kill()
+        return None
+
+    logging.info(f"{fileTitle}({file_num}): done.")
+    logging.info(out)
+    if p.returncode != 0:
+        logging.info(f"ERROR: Expected return code of 0, found {p.returncode}")
+        logging.info(f"{fileTitle}({file_num}) stderr: {err}")
+        assert p.returncode == 0
+
+    logging.info(f"{fileTitle}({file_num}) output:\n{out}")
+    records = []
+    for line in out.strip().split("\n"):
+        TACBENCH_PREAMBLE = "TACBENCHCSV|"
+        COLS = ["thmName", "goalStr", "tactic", "status", "errmsg", "timeElapsed"]
+        if line.startswith(TACBENCH_PREAMBLE):
+            line = line.removeprefix(TACBENCH_PREAMBLE)
+            row = line.split(", ")
+            assert len(row) == len(COLS)
+            record = dict(zip(COLS, row))
+            record["fileTitle"] = fileTitle
+            records.append(record)
+
+    with open(f"{db}", "a") as f:
+        for record in records:
+            f.write(json.dumps(record) + "\n")
+
+def process(db : str, jobs: int, prod_run : bool):
+    tactic_auto_path = f'{ROOT_DIR}/SSA/Projects/InstCombine/TacticAuto.lean'
+    os.mkdir(db, exist_ok=True)
+
+    if os.path.exists(db):
+        os.remove(db)
+
+
+
+    logging.info(f"Clearing git state of '{BENCHMARK_DIR}' with 'git checkout --'")
+    gco = subprocess.Popen(f'git checkout -- {BENCHMARK_DIR}', cwd=ROOT_DIR, shell=True)
+    gco.wait()
+    assert gco.returncode == 0, f"git checkout -- {BENCHMARK_DIR} should succeed."
+
+
+    logging.info(f"Running a 'lake exe cache get && lake build'.")
+    lake = subprocess.Popen(f'lake exe cache get && lake build', cwd=ROOT_DIR, shell=True)
+    lake.wait()
+    assert lake.returncode == 0, f"lake build should succeed before running evaluation."
+
+    raw_files = list(os.listdir(BENCHMARK_DIR))
+
+    files = []
+    for ix, file in enumerate(raw_files):
+        if "_proof" in file and "gandhorhicmps_proof" not in file: # currently discard broken chapter
+            files.append(file)
+            N_TEST_RUN_FILES = 5
+            if len(files) == N_TEST_RUN_FILES and not prod_run:
+                break # quit if we are not doing a production run after 5 files.
+
+    total = len(files)
+    logging.info(f"total #files to process: {total}")
+    futures = []
+    future_to_file ={}
+    for ix, file in enumerate(files):
+        future = run_file(db, file, ix+1)
+        percentage = ((idx + 1) / total) * 100
+        logging.info(f'completed {file} ({percentage:.1f}%)')
+        num_completed += 1
+        logging.info(f"total #files processed: {num_completed}")
+
+    if num_completed != total:
+        logging.error(f"Expected {total} files to be processed, but got {num_completed} completed futures.")
+
+def setup_logging(db_name : str):
+    # Set up the logging configuration
+    logging.basicConfig(level=logging.DEBUG,
+        format='%(asctime)s - %(levelname)s - %(message)s',
+        handlers=[logging.FileHandler(f'{db_name}.log', mode='a'), logging.StreamHandler()])
+
+if __name__ == "__main__":
+  current_time = datetime.datetime.now().strftime('%Y-%m-%d-%H:%M:%S')
+  nproc = os.cpu_count()
+  parser = argparse.ArgumentParser(prog='compare-automata-automata-circuit')
+  default_db = f'automata-circuit-{current_time}.sqlite3'
+  parser.add_argument('--db', default=default_db, help='path to sqlite3 database')
+  parser.add_argument('-j', '--jobs', type=int, default=1)
+  parser.add_argument('--run', action='store_true', help="run evaluation")
+  parser.add_argument('--prodrun', action='store_true', help="run production run of evaluation")
+  args = parser.parse_args()
+  setup_logging(args.db)
+  logging.info(args)
+  if args.run:
+    process(args.db, args.jobs, prod_run=False)
+  elif args.prodrun:
+    process(args.db, args.jobs, prod_run=True)
+  else:
+    logging.error("expected --run or --prodrun.")
+

--- a/bv-evaluation/compare-automata-automata-circuit-jsonl.py
+++ b/bv-evaluation/compare-automata-automata-circuit-jsonl.py
@@ -8,7 +8,6 @@ import shutil
 import pandas as pd
 import os
 import re
-import sqlite3
 import logging
 import random
 import json
@@ -74,7 +73,7 @@ def run_file(db : str, file: str, file_num : int):
 
 def process(db : str, jobs: int, prod_run : bool):
     tactic_auto_path = f'{ROOT_DIR}/SSA/Projects/InstCombine/TacticAuto.lean'
-    os.makedirs(os.path.dirname(db), exist_ok=True)
+    # os.makedirs(os.path.dirname(db), exist_ok=True)
 
     if os.path.exists(db):
         os.remove(db)
@@ -125,8 +124,8 @@ if __name__ == "__main__":
   current_time = datetime.datetime.now().strftime('%Y-%m-%d-%H:%M:%S')
   nproc = os.cpu_count()
   parser = argparse.ArgumentParser(prog='compare-automata-automata-circuit')
-  default_db = f'automata-circuit-{current_time}.sqlite3'
-  parser.add_argument('--db', default=default_db, help='path to sqlite3 database')
+  default_db = f'automata-circuit-{current_time}.jsonl'
+  parser.add_argument('--db', default=default_db, help='path to jsonl database')
   parser.add_argument('-j', '--jobs', type=int, default=1)
   parser.add_argument('--run', action='store_true', help="run evaluation")
   parser.add_argument('--prodrun', action='store_true', help="run production run of evaluation")

--- a/bv-evaluation/compare-automata-automata-circuit.py
+++ b/bv-evaluation/compare-automata-automata-circuit.py
@@ -28,44 +28,45 @@ def sed():
         return "gsed"
     return "sed"
 
-def run_file(db : str, file: str):
+def run_file(db : str, file: str, file_num : int):
+    assert 0 < file_num, "file_num must be greater than 0"
     file_path = BENCHMARK_DIR + file
     fileTitle = file.split('.')[0]
 
-    logging.info(f"{fileTitle}: Cache lookup, Opening connection...")
-    con = sqlite3.connect(db)
-    cur = con.cursor()
-    # Check if there is a row with the given fileTitle and timeout
-    logging.info(f"{fileTitle}: Cache lookup, SELECTING for existing data...")
-    cur.execute("""
-        SELECT 1 FROM completedFiles WHERE fileTitle = ? LIMIT 1
-    """, (fileTitle, ))
-    # Fetch the result, if no rows exist, the result will be an empty list
-    result = cur.fetchone()
-    con.close()
-    if result is not None:
-        logging.info(f"{fileTitle}: cache hit, skipping ⏭️")
-        return
-    else:
-        logging.info(f"{fileTitle}: cache miss, processing ▶️")
+    # logging.info(f"{fileTitle}: Cache lookup, Opening connection...")
+    # con = sqlite3.connect(db)
+    # cur = con.cursor()
+    # # Check if there is a row with the given fileTitle and timeout
+    # logging.info(f"{fileTitle}: Cache lookup, SELECTING for existing data...")
+    # cur.execute("""
+    #     SELECT 1 FROM completedFiles WHERE fileTitle = ? LIMIT 1
+    # """, (fileTitle, ))
+    # # Fetch the result, if no rows exist, the result will be an empty list
+    # result = cur.fetchone()
+    # con.close()
+    # if result is not None:
+    #     logging.info(f"{fileTitle}: cache hit, skipping ⏭️")
+    #     return
+    # else:
+    #     logging.info(f"{fileTitle}: cache miss, processing ▶️")
 
-    logging.info(f"{fileTitle}: writing 'bv_bench_automata' tactic into file.")
+    logging.info(f"{fileTitle}: writing 'bv_bench_automata' tactic into file #{file_num}.")
     subprocess.Popen(f'{sed()} -i -E \'s,simp_alive_benchmark,bv_bench_automata,g\' ' + file_path, cwd=ROOT_DIR, shell=True).wait()
     logging.info(f"{fileTitle}: {STATUS_PROCESSING}")
 
     cmd = 'lake lean ' + file_path
-    logging.info(f"{fileTitle}: running '{cmd}'")
+    logging.info(f"{fileTitle}({file_num}): running '{cmd}'")
     try:
         p = subprocess.Popen(cmd, cwd=ROOT_DIR, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True, universal_newlines=True)
-        logging.info(f"{fileTitle}: running...")
+        logging.info(f"{fileTitle}({file_num}): running...")
         out, err = p.communicate(timeout=TIMEOUT)
-        logging.info(f"{fileTitle}: done.")
+        logging.info(f"{fileTitle}({file_num}): done.")
         logging.info(out)
         if p.returncode != 0:
             logging.info(f"ERROR: Expected return code of 0, found {p.returncode}")
-            logging.info(f"{fileTitle} stderr: {err}")
+            logging.info(f"{fileTitle}({file_num}) stderr: {err}")
             assert p.returncode == 0
-        logging.info(f"{fileTitle} output:\n{out}")
+        logging.info(f"{fileTitle}({file_num}) output:\n{out}")
         for line in out.strip().split("\n"):
             TACBENCH_PREAMBLE = "TACBENCHCSV|"
             COLS = ["thmName", "goalStr", "tactic", "status", "errmsg", "timeElapsed"]
@@ -76,9 +77,9 @@ def run_file(db : str, file: str):
                 record = dict(zip(COLS, row))
                 record["fileTitle"] = fileTitle
                 # TODO: invoke sqlite here to store
-                logging.info(f"{fileTitle}: Opening connection to write test record.")
+                logging.info(f"{fileTitle}({file_num}): Opening connection to write test record.")
                 con = sqlite3.connect(args.db)
-                logging.info(f"{fileTitle}: Executing INSERT of record...")
+                logging.info(f"{fileTitle}({file_num}): Executing INSERT of record...")
                 cur = con.cursor()
                 cur.execute("""
                     INSERT INTO tests (
@@ -92,20 +93,20 @@ def run_file(db : str, file: str):
                     VALUES (?, ?, ?, ?, ?, ?, ?)
                 """, (record["fileTitle"], record["thmName"], record["goalStr"], record["tactic"], record["status"], record["errmsg"], record["timeElapsed"]))
                 con.commit()
-                logging.info(f"{fileTitle}: Done executing INSERT of record...")
+                logging.info(f"{fileTitle}({file_num}): Done executing INSERT of record...")
                 con.close()
 
         # write that we are done with the file
-        logging.info(f"{fileTitle}: Opening connection to write successful completion.")
-        con = sqlite3.connect(args.db)
-        logging.info(f"{fileTitle}: Executing INSERT of successful completion...")
-        cur = con.cursor()
-        cur.execute("""
-            INSERT INTO completedFiles (fileTitle) VALUES (?)
-        """, (record["fileTitle"], ))
-        con.commit()
-        logging.info(f"{fileTitle}: Done executing INSERT of successful completion...")
-        con.close()
+        # logging.info(f"{fileTitle}: Opening connection to write successful completion.")
+        # con = sqlite3.connect(args.db)
+        # logging.info(f"{fileTitle}: Executing INSERT of successful completion...")
+        # cur = con.cursor()
+        # cur.execute("""
+        #     INSERT INTO completedFiles (fileTitle) VALUES (?)
+        # """, (record["fileTitle"], ))
+        # con.commit()
+        # logging.info(f"{fileTitle}: Done executing INSERT of successful completion...")
+        # con.close()
 
     except subprocess.TimeoutExpired as e:
         logging.info(f"{file_path} - time out of {TIMEOUT} seconds reached")
@@ -130,11 +131,11 @@ def process(db : str, jobs: int, prod_run : bool):
             PRIMARY KEY (fileTitle, thmName, goalStr, tactic)
             )
     """)
-    cur.execute("""
-        CREATE TABLE IF NOT EXISTS completedFiles (
-            fileTitle text
-            )
-    """)
+    # cur.execute("""
+    #     CREATE TABLE IF NOT EXISTS completedFiles (
+    #         fileTitle text
+    #         )
+    # """)
 
     con.commit()
     con.close()
@@ -150,26 +151,42 @@ def process(db : str, jobs: int, prod_run : bool):
     lake.wait()
     assert lake.returncode == 0, f"lake build should succeed before running evaluation."
 
+    raw_files = list(os.listdir(BENCHMARK_DIR))
+
+    files = []
+    for ix, file in enumerate(raw_files):
+        if "_proof" in file and "gandhorhicmps_proof" not in file: # currently discard broken chapter
+            files.append(file)
+            N_TEST_RUN_FILES = 5
+            if len(files) == N_TEST_RUN_FILES and not prod_run:
+                break # quit if we are not doing a production run after 5 files.
+
+
+    total = len(files)
+    logging.info(f"total #files to process: {total}")
+    futures = []
+    future_to_file ={}
     with concurrent.futures.ThreadPoolExecutor(max_workers=jobs) as executor:
-        futures = {}
-        files = os.listdir(BENCHMARK_DIR)
+        for ix, file in enumerate(files):
+            future = executor.submit(run_file, db, file, ix+1)
+            futures.append(future)
+            future_to_file[future] = file
 
-        for file in files:
-            if "_proof" in file and "gandhorhicmps_proof" not in file: # currently discard broken chapter
-                future = executor.submit(run_file, db, file)
-                futures[future] = file
-                N_TEST_RUN_FILES = 5
-                if len(futures) == N_TEST_RUN_FILES and not prod_run:
-                    break # quit if we are not doing a production run after 5 files.
+        if len(futures) != len(files):
+            logging.error(f"Expected {len(files)} files to be processed, but got {total} futures.")
 
-        total = len(futures)
+        num_completed = 0
         for idx, future in enumerate(concurrent.futures.as_completed(futures)):
             if future.exception() is not None:
                 raise future.exception()
-            file = futures[future]
             future.result()
+            file = future_to_file[future]
             percentage = ((idx + 1) / total) * 100
-            logging.info(f'{file} completed, {percentage}%')
+            logging.info(f'completed {file} ({percentage:.1f}%)')
+            num_completed += 1
+    logging.info(f"total #files processed: {num_completed}")
+    if num_completed != total:
+        logging.error(f"Expected {total} files to be processed, but got {num_completed} completed futures.")
 
 def setup_logging(db_name : str):
     # Set up the logging configuration
@@ -226,13 +243,13 @@ def analyze_errors(cur : sqlite3.Cursor):
                 break
         if not matched:
             str2matches[KEY_UNKNOWN].append((errMsg, goalStr, thmName, fileTitle))
-            print(errMsg)
+            logging.info(errMsg)
 
     for s in str2matches:
         NEXAMPLES = 5
-        print(f"{str2explanation[s]} (#{len(str2matches[s])}):")
+        logging.info(f"{str2explanation[s]} (#{len(str2matches[s])}):")
         if not str2matches[s]: continue
-        print(tabulate(str2matches[s][:NEXAMPLES], headers=HEADERS, tablefmt="grid", maxcolwidths=HEADER_COL_WIDTHS))
+        logging.info(tabulate(str2matches[s][:NEXAMPLES], headers=HEADERS, tablefmt="grid", maxcolwidths=HEADER_COL_WIDTHS))
 
 
 def analyze_uninterpreted_functions(cur : sqlite3.Cursor):
@@ -244,8 +261,8 @@ def analyze_uninterpreted_functions(cur : sqlite3.Cursor):
     rows = list(rows)
     for row in rows:
         (fileTitle, thmName, goalStr, errMsg) = row
-        print(errMsg)
-    print(f"#problems with uninterpreted functions: {len(rows)}")
+        logging.info(errMsg)
+    logging.info(f"#problems with uninterpreted functions: {len(rows)}")
 
 # analyze the sqlite db.
 def analyze(db : str):
@@ -261,7 +278,7 @@ if __name__ == "__main__":
   parser = argparse.ArgumentParser(prog='compare-automata-automata-circuit')
   default_db = f'automata-circuit-{current_time}.sqlite3'
   parser.add_argument('--db', default=default_db, help='path to sqlite3 database')
-  parser.add_argument('-j', '--jobs', type=int, default=5) # ((nproc + 2)// 3))
+  parser.add_argument('-j', '--jobs', type=int, default=1)
   parser.add_argument('--run', action='store_true', help="run evaluation")
   parser.add_argument('--prodrun', action='store_true', help="run production run of evaluation")
   parser.add_argument('--analyze', action='store_true', help="analyze the data of the db")


### PR DESCRIPTION
We notice that our width-generic scripts return different numbers on different runs for totally unclear reasons. To remedy this, we run this with zero parallelism to ensure determinisim:

```
## solver: bv_decide ##
  #problems (total): 4718
  #problems solved : 4651
  geomean timeElapsed: 44.67723884195559
## solver: normCircuitVerified ##
  #problems (total): 4718
  #problems solved : 1574
  geomean timeElapsed: 20.892505827148902
## solver: normPresburger ##
  #problems (total): 4718
  #problems solved : 1376
  geomean timeElapsed: 11.61569256890815
written to automata-automata-circuit-cactus-plot.pdf and automata-automata-circuit-cactus-plot.jpeg
solver: bv_decide | total_time: 394809.3578069998
solver: normCircuitVerified | total_time: 118577.19034100001
solver: normPresburger | total_time: 39338.12589999999
written to automata-automata-circuit-cactus-plot-data.tex
```