### PR TITLE
chore: delete bv_normalize from bv_bench_automata

### DIFF
--- a/SSA/Projects/InstCombine/TacticAuto.lean
+++ b/SSA/Projects/InstCombine/TacticAuto.lean
@@ -230,7 +230,7 @@ macro "bv_bench_automata": tactic =>
            BitVec.ofNat_eq_ofNat, BitVec.two_mul]
         all_goals (
           tac_bench (config := { outputType := .csv }) [
-            "bv_normalize" : (bv_normalize; done),
+            -- "bv_normalize" : (bv_normalize; done),
             -- "presburger" : (bv_automata_gen (config := { backend := .presburger }); done),
             "normPresburger" : ((try (solve | bv_normalize)); (try bv_automata_gen (config := { backend := .presburger })); done),
            --  "circuitUnverified" : (bv_automata_gen (config := { backend := .circuit_cadical_unverified /- maxIter -/ 4 }); done),


### PR DESCRIPTION
This just adds overhead and confusion in reproducing our plots.