### PR TITLE
chore: add flag to avoid deep kernel recursion error

### DIFF
--- a/SSA/Projects/InstCombine/tests/proofs/gcast_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gcast_proof.lean
@@ -417,7 +417,7 @@ theorem test82_thm (e : IntW 64) :
     simp_alive_benchmark
     all_goals sorry
 
-
+set_option debug.skipKernelTC true in
 theorem test83_thm (e : IntW 64) (e_1 : IntW 16) :
   zext 64 (shl (sext 32 e_1) (trunc 32 (add e (const? 64 (-1)) { «nsw» := true, «nuw» := false }))) ⊑
     zext 64 (shl (sext 32 e_1) (add (trunc 32 e) (const? 32 (-1)))) := by
@@ -439,7 +439,7 @@ theorem test84_thm (e : IntW 32) :
     simp_alive_benchmark
     all_goals sorry
 
-
+set_option debug.skipKernelTC true in
 theorem test85_thm (e : IntW 32) :
   trunc 8 (lshr (add e (const? 32 (-16777216)) { «nsw» := false, «nuw» := true }) (const? 32 23) { «exact» := true }) ⊑
     trunc 8 (lshr (add e (const? 32 2130706432)) (const? 32 23)) := by
@@ -479,7 +479,7 @@ theorem test88_thm (e : IntW 16) : trunc 16 (ashr (sext 32 e) (const? 32 18)) �
     simp_alive_benchmark
     all_goals sorry
 
-
+set_option debug.skipKernelTC true in
 theorem PR23309_thm (e e_1 : IntW 32) :
   trunc 1 (sub (add e_1 (const? 32 (-4))) e { «nsw» := true, «nuw» := false }) ⊑ trunc 1 (sub e_1 e) := by
     simp_alive_undef
@@ -489,7 +489,7 @@ theorem PR23309_thm (e e_1 : IntW 32) :
     simp_alive_benchmark
     all_goals sorry
 
-
+set_option debug.skipKernelTC true in
 theorem PR23309v2_thm (e e_1 : IntW 32) :
   trunc 1 (add (add e_1 (const? 32 (-4))) e { «nsw» := false, «nuw» := true }) ⊑ trunc 1 (add e_1 e) := by
     simp_alive_undef

--- a/SSA/Projects/InstCombine/tests/proofs/glshr_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/glshr_proof.lean
@@ -58,7 +58,7 @@ theorem fake_sext_thm (e : IntW 3) :
     simp_alive_benchmark
     all_goals sorry
 
-
+set_option debug.skipKernelTC true in
 theorem mul_splat_fold_thm (e : IntW 32) :
   lshr (mul e (const? 32 65537) { «nsw» := false, «nuw» := true }) (const? 32 16) ⊑ e := by
     simp_alive_undef

--- a/SSA/Projects/InstCombine/tests/proofs/gnarrowhmath_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gnarrowhmath_proof.lean
@@ -66,7 +66,7 @@ theorem test6_thm (e : IntW 32) :
     simp_alive_benchmark
     all_goals sorry
 
-
+set_option debug.skipKernelTC true in
 theorem test7_thm (e : IntW 32) :
   add (zext 64 (lshr e (const? 32 1))) (const? 64 2147483647) ⊑
     zext 64 (add (lshr e (const? 32 1)) (const? 32 2147483647) { «nsw» := false, «nuw» := true }) := by
@@ -99,7 +99,7 @@ theorem test9_thm (e : IntW 32) :
     simp_alive_benchmark
     all_goals sorry
 
-
+set_option debug.skipKernelTC true in
 theorem test10_thm (e : IntW 32) :
   mul (zext 64 (lshr e (const? 32 16))) (const? 64 65535) ⊑
     zext 64 (mul (lshr e (const? 32 16)) (const? 32 65535) { «nsw» := false, «nuw» := true }) := by

--- a/SSA/Projects/InstCombine/tests/proofs/greassociatehnuw_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/greassociatehnuw_proof.lean
@@ -110,7 +110,7 @@ theorem tryFactorization_add_nuw_mul_nuw_thm (e : IntW 32) :
     simp_alive_benchmark
     all_goals sorry
 
-
+set_option debug.skipKernelTC true in
 theorem tryFactorization_add_nuw_mul_nuw_int_max_thm (e : IntW 32) :
   add (mul e (const? 32 2147483647) { «nsw» := false, «nuw» := true }) e { «nsw» := false, «nuw» := true } ⊑
     shl e (const? 32 31) { «nsw» := false, «nuw» := true } := by

--- a/SSA/Projects/InstCombine/tests/proofs/gshifthamounthreassociationhinhbittest_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gshifthamounthreassociationhinhbittest_proof.lean
@@ -43,7 +43,7 @@ theorem t2_const_lshr_shl_eq_thm (e e_1 : IntW 32) :
     simp_alive_benchmark
     all_goals sorry
 
-
+set_option debug.skipKernelTC true in
 theorem t3_const_after_fold_lshr_shl_ne_thm (e e_1 e_2 : IntW 32) :
   icmp IntPred.ne (LLVM.and (lshr e_2 (sub (const? 32 32) e_1)) (shl e (add e_1 (const? 32 (-1))))) (const? 32 0) ⊑
     icmp IntPred.ne (LLVM.and (lshr e_2 (const? 32 31)) e) (const? 32 0) := by
@@ -54,7 +54,7 @@ theorem t3_const_after_fold_lshr_shl_ne_thm (e e_1 e_2 : IntW 32) :
     simp_alive_benchmark
     all_goals sorry
 
-
+set_option debug.skipKernelTC true
 theorem t4_const_after_fold_lshr_shl_ne_thm (e e_1 e_2 : IntW 32) :
   icmp IntPred.ne (LLVM.and (shl e_2 (sub (const? 32 32) e_1)) (lshr e (add e_1 (const? 32 (-1))))) (const? 32 0) ⊑
     icmp IntPred.ne (LLVM.and (lshr e (const? 32 31)) e_2) (const? 32 0) := by

--- a/SSA/Projects/InstCombine/tests/proofs/gshifthamounthreassociationhinhbittest_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gshifthamounthreassociationhinhbittest_proof.lean
@@ -54,7 +54,7 @@ theorem t3_const_after_fold_lshr_shl_ne_thm (e e_1 e_2 : IntW 32) :
     simp_alive_benchmark
     all_goals sorry
 
-set_option debug.skipKernelTC true
+set_option debug.skipKernelTC true in
 theorem t4_const_after_fold_lshr_shl_ne_thm (e e_1 e_2 : IntW 32) :
   icmp IntPred.ne (LLVM.and (shl e_2 (sub (const? 32 32) e_1)) (lshr e (add e_1 (const? 32 (-1))))) (const? 32 0) ⊑
     icmp IntPred.ne (LLVM.and (lshr e (const? 32 31)) e_2) (const? 32 0) := by

--- a/SSA/Projects/InstCombine/tests/proofs/gshifthamounthreassociationhinhbittesthwithhtruncationhlshr_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gshifthamounthreassociationhinhbittesthwithhtruncationhlshr_proof.lean
@@ -11,6 +11,7 @@ set_option maxRecDepth 1000000
 set_option Elab.async false
 
 section gshifthamounthreassociationhinhbittesthwithhtruncationhlshr_proof
+set_option debug.skipKernelTC true in
 theorem n0_thm (e : IntW 64) (e_1 e_2 : IntW 32) :
   icmp IntPred.ne
       (LLVM.and (shl e_2 (sub (const? 32 32) e_1)) (trunc 32 (lshr e (zext 64 (add e_1 (const? 32 (-16)))))))
@@ -26,7 +27,7 @@ theorem n0_thm (e : IntW 64) (e_1 e_2 : IntW 32) :
     simp_alive_benchmark
     all_goals sorry
 
-
+set_option debug.skipKernelTC true in
 theorem t1_thm (e : IntW 64) (e_1 : IntW 32) :
   icmp IntPred.ne
       (LLVM.and (shl (const? 32 65535) (sub (const? 32 32) e_1))
@@ -40,7 +41,7 @@ theorem t1_thm (e : IntW 64) (e_1 : IntW 32) :
     simp_alive_benchmark
     all_goals sorry
 
-
+set_option debug.skipKernelTC true in
 theorem t1_single_bit_thm (e : IntW 64) (e_1 : IntW 32) :
   icmp IntPred.ne
       (LLVM.and (shl (const? 32 32768) (sub (const? 32 32) e_1))
@@ -54,7 +55,7 @@ theorem t1_single_bit_thm (e : IntW 64) (e_1 : IntW 32) :
     simp_alive_benchmark
     all_goals sorry
 
-
+set_option debug.skipKernelTC true in
 theorem n2_thm (e : IntW 64) (e_1 : IntW 32) :
   icmp IntPred.ne
       (LLVM.and (shl (const? 32 131071) (sub (const? 32 32) e_1))
@@ -71,7 +72,7 @@ theorem n2_thm (e : IntW 64) (e_1 : IntW 32) :
     simp_alive_benchmark
     all_goals sorry
 
-
+set_option debug.skipKernelTC true in
 theorem t3_thm (e e_1 : IntW 32) :
   icmp IntPred.ne
       (LLVM.and (shl e_1 (sub (const? 32 32) e))
@@ -85,7 +86,7 @@ theorem t3_thm (e e_1 : IntW 32) :
     simp_alive_benchmark
     all_goals sorry
 
-
+set_option debug.skipKernelTC true in
 theorem t3_singlebit_thm (e e_1 : IntW 32) :
   icmp IntPred.ne
       (LLVM.and (shl e_1 (sub (const? 32 32) e))
@@ -99,7 +100,7 @@ theorem t3_singlebit_thm (e e_1 : IntW 32) :
     simp_alive_benchmark
     all_goals sorry
 
-
+set_option debug.skipKernelTC true in
 theorem n4_thm (e e_1 : IntW 32) :
   icmp IntPred.ne
       (LLVM.and (shl e_1 (sub (const? 32 32) e))
@@ -117,7 +118,7 @@ theorem n4_thm (e e_1 : IntW 32) :
     simp_alive_benchmark
     all_goals sorry
 
-
+set_option debug.skipKernelTC true in
 theorem t9_highest_bit_thm (e : IntW 64) (e_1 e_2 : IntW 32) :
   icmp IntPred.ne
       (LLVM.and (shl e_2 (sub (const? 32 64) e_1)) (trunc 32 (lshr e (zext 64 (add e_1 (const? 32 (-1)))))))
@@ -130,7 +131,7 @@ theorem t9_highest_bit_thm (e : IntW 64) (e_1 e_2 : IntW 32) :
     simp_alive_benchmark
     all_goals sorry
 
-
+set_option debug.skipKernelTC true in
 theorem t10_almost_highest_bit_thm (e : IntW 64) (e_1 e_2 : IntW 32) :
   icmp IntPred.ne
       (LLVM.and (shl e_2 (sub (const? 32 64) e_1)) (trunc 32 (lshr e (zext 64 (add e_1 (const? 32 (-2)))))))
@@ -146,7 +147,7 @@ theorem t10_almost_highest_bit_thm (e : IntW 64) (e_1 e_2 : IntW 32) :
     simp_alive_benchmark
     all_goals sorry
 
-
+set_option debug.skipKernelTC true in
 theorem t11_no_shift_thm (e : IntW 64) (e_1 e_2 : IntW 32) :
   icmp IntPred.ne
       (LLVM.and (shl e_2 (sub (const? 32 64) e_1)) (trunc 32 (lshr e (zext 64 (add e_1 (const? 32 (-64)))))))
@@ -159,7 +160,7 @@ theorem t11_no_shift_thm (e : IntW 64) (e_1 e_2 : IntW 32) :
     simp_alive_benchmark
     all_goals sorry
 
-
+set_option debug.skipKernelTC true in
 theorem t10_shift_by_one_thm (e : IntW 64) (e_1 e_2 : IntW 32) :
   icmp IntPred.ne
       (LLVM.and (shl e_2 (sub (const? 32 64) e_1)) (trunc 32 (lshr e (zext 64 (add e_1 (const? 32 (-63)))))))
@@ -175,7 +176,7 @@ theorem t10_shift_by_one_thm (e : IntW 64) (e_1 e_2 : IntW 32) :
     simp_alive_benchmark
     all_goals sorry
 
-
+set_option debug.skipKernelTC true in
 theorem t13_x_is_one_thm (e : IntW 64) (e_1 : IntW 32) :
   icmp IntPred.ne
       (LLVM.and (shl (const? 32 1) (sub (const? 32 32) e_1)) (trunc 32 (lshr e (zext 64 (add e_1 (const? 32 (-16)))))))
@@ -188,7 +189,7 @@ theorem t13_x_is_one_thm (e : IntW 64) (e_1 : IntW 32) :
     simp_alive_benchmark
     all_goals sorry
 
-
+set_option debug.skipKernelTC true in
 theorem t14_x_is_one_thm (e e_1 : IntW 32) :
   icmp IntPred.ne
       (LLVM.and (shl e_1 (sub (const? 32 32) e)) (trunc 32 (lshr (const? 64 1) (zext 64 (add e (const? 32 (-16)))))))

--- a/SSA/Projects/InstCombine/tests/proofs/gshifthamounthreassociationhinhbittesthwithhtruncationhshl_proof.lean
+++ b/SSA/Projects/InstCombine/tests/proofs/gshifthamounthreassociationhinhbittesthwithhtruncationhshl_proof.lean
@@ -11,6 +11,7 @@ set_option maxRecDepth 1000000
 set_option Elab.async false
 
 section gshifthamounthreassociationhinhbittesthwithhtruncationhshl_proof
+set_option debug.skipKernelTC true in
 theorem t0_const_after_fold_lshr_shl_ne_thm (e : IntW 64) (e_1 e_2 : IntW 32) :
   icmp IntPred.ne
       (LLVM.and (lshr e_2 (sub (const? 32 32) e_1)) (trunc 32 (shl e (zext 64 (add e_1 (const? 32 (-1)))))))
@@ -50,7 +51,7 @@ theorem n13_overshift_thm (e : IntW 64) (e_1 e_2 : IntW 32) :
     simp_alive_benchmark
     all_goals sorry
 
-
+set_option debug.skipKernelTC true in
 theorem n14_trunc_of_lshr_thm (e e_1 : IntW 32) (e_2 : IntW 64) :
   icmp IntPred.ne
       (LLVM.and (trunc 32 (lshr e_2 (zext 64 (sub (const? 32 32) e_1)))) (shl e (add e_1 (const? 32 (-1)))))

--- a/bv-evaluation/collect-data-llvm.py
+++ b/bv-evaluation/collect-data-llvm.py
@@ -187,7 +187,7 @@ for file in os.listdir(benchmark_dir):
                         errs = errs + 1  
                 elif (("error:" in l or "PANIC" in l) and "Lean" not in l and r == 0):
                     err_loc_tot.append(l.split("error: ")[0].split("/")[-1][0:-1])
-                    err_msg_tot.append((l.split("error: ")[1])[0:-1]+", file: "+file+", goal = "+str(thm))
+                    err_msg_tot.append((l.split("error: ")[1])[0:-1]+")
                     errs = errs + 1
                 l = res_file.readline()
 

--- a/bv-evaluation/collect-data-llvm.py
+++ b/bv-evaluation/collect-data-llvm.py
@@ -187,7 +187,7 @@ for file in os.listdir(benchmark_dir):
                         errs = errs + 1  
                 elif (("error:" in l or "PANIC" in l) and "Lean" not in l and r == 0):
                     err_loc_tot.append(l.split("error: ")[0].split("/")[-1][0:-1])
-                    err_msg_tot.append((l.split("error: ")[1])[0:-1]+")
+                    err_msg_tot.append((l.split("error: ")[1])[0:-1])
                     errs = errs + 1
                 l = res_file.readline()
 

--- a/bv-evaluation/collect-data-llvm.py
+++ b/bv-evaluation/collect-data-llvm.py
@@ -187,7 +187,7 @@ for file in os.listdir(benchmark_dir):
                         errs = errs + 1  
                 elif (("error:" in l or "PANIC" in l) and "Lean" not in l and r == 0):
                     err_loc_tot.append(l.split("error: ")[0].split("/")[-1][0:-1])
-                    err_msg_tot.append((l.split("error: ")[1])[0:-1])
+                    err_msg_tot.append((l.split("error: ")[1])[0:-1]+", file: "+file+", goal = "+str(thm))
                     errs = errs + 1
                 l = res_file.readline()
 


### PR DESCRIPTION
This PR enables the flag `set_option debug.skipKernelTC true` to avoid deep kernel recursion error _only_ in the theorems from the InstCombine benchmark that suffer from the issue.