### PR TITLE
fix: implement workaround for kernel deep recursion issue

### DIFF
--- a/SSA/Core/Util/Poison.lean
+++ b/SSA/Core/Util/Poison.lean
@@ -15,26 +15,15 @@ Elements of type `PoisonOr α` are either `poison`, or values of type `α`.
 `PoisonOr α` is simply a wrapper around `Option α`, but we generally prefer `PoisonOr`
 when specifying poison semantics in dialects, as it's more self-documenting.
 -/
--- structure PoisonOr (α : Type) where
---   ofOption :: toOption : Option α
---   deriving DecidableEq
-def PoisonOr := Option.{0}
-
-/-!
-FIXME: for some reason, having `PoisonOr` be a structure triggers kernel deep
-recursion errors in the bitvector evaluation.
--/
-
-instance [DecidableEq α] : DecidableEq (PoisonOr α) := inferInstanceAs (DecidableEq (Option α))
-
-def PoisonOr.ofOption : Option α → PoisonOr α := id
-def PoisonOr.toOption : PoisonOr α → Option α := id
+structure PoisonOr (α : Type) where
+  ofOption :: toOption : Option α
+  deriving DecidableEq
 
 namespace PoisonOr
 
 /-! ### Constructors-/
-@[match_pattern] def poison : PoisonOr α := ofOption none
-@[match_pattern] def value : α → PoisonOr α := (ofOption <| some ·)
+@[match_pattern] def poison : PoisonOr α := ⟨none⟩
+@[match_pattern] def value : α → PoisonOr α := (⟨some ·⟩)
 
 /--
 `casesOn'` is a custom eliminator. By tagging it with `cases_eliminator`, we can
@@ -148,8 +137,8 @@ variable {a : α}
 @[simp] theorem getValue_value [Inhabited α] : (value a).getValue = a := rfl
 @[simp] theorem getValue_poison [Inhabited α] : (@poison α).getValue = default := rfl
 
-@[simp] theorem mk_some (x : α) : (ofOption <| some x) = PoisonOr.value x := rfl
-@[simp] theorem mk_none : (ofOption <| none (α := α) ) = PoisonOr.poison := rfl
+@[simp] theorem mk_some (x : α) : { toOption := some x } = PoisonOr.value x := rfl
+@[simp] theorem mk_none : { toOption := none (α := α) } = PoisonOr.poison := rfl
 
 @[simp_denote, simp]
 theorem toOption_getSome : (PoisonOr.value x).toOption.getD y = x := by rfl

--- a/SSA/Core/Util/Poison.lean
+++ b/SSA/Core/Util/Poison.lean
@@ -15,15 +15,26 @@ Elements of type `PoisonOr α` are either `poison`, or values of type `α`.
 `PoisonOr α` is simply a wrapper around `Option α`, but we generally prefer `PoisonOr`
 when specifying poison semantics in dialects, as it's more self-documenting.
 -/
-structure PoisonOr (α : Type) where
-  ofOption :: toOption : Option α
-  deriving DecidableEq
+-- structure PoisonOr (α : Type) where
+--   ofOption :: toOption : Option α
+--   deriving DecidableEq
+def PoisonOr := Option.{0}
+
+/-!
+FIXME: for some reason, having `PoisonOr` be a structure triggers kernel deep
+recursion errors in the bitvector evaluation.
+-/
+
+instance [DecidableEq α] : DecidableEq (PoisonOr α) := inferInstanceAs (DecidableEq (Option α))
+
+def PoisonOr.ofOption : Option α → PoisonOr α := id
+def PoisonOr.toOption : PoisonOr α → Option α := id
 
 namespace PoisonOr
 
 /-! ### Constructors-/
-@[match_pattern] def poison : PoisonOr α := ⟨none⟩
-@[match_pattern] def value : α → PoisonOr α := (⟨some ·⟩)
+@[match_pattern] def poison : PoisonOr α := ofOption none
+@[match_pattern] def value : α → PoisonOr α := (ofOption <| some ·)
 
 /--
 `casesOn'` is a custom eliminator. By tagging it with `cases_eliminator`, we can
@@ -137,8 +148,8 @@ variable {a : α}
 @[simp] theorem getValue_value [Inhabited α] : (value a).getValue = a := rfl
 @[simp] theorem getValue_poison [Inhabited α] : (@poison α).getValue = default := rfl
 
-@[simp] theorem mk_some (x : α) : { toOption := some x } = PoisonOr.value x := rfl
-@[simp] theorem mk_none : { toOption := none (α := α) } = PoisonOr.poison := rfl
+@[simp] theorem mk_some (x : α) : (ofOption <| some x) = PoisonOr.value x := rfl
+@[simp] theorem mk_none : (ofOption <| none (α := α) ) = PoisonOr.poison := rfl
 
 @[simp_denote, simp]
 theorem toOption_getSome : (PoisonOr.value x).toOption.getD y = x := by rfl

--- a/SSA/Projects/InstCombine/Tactic/SimpLLVM.lean
+++ b/SSA/Projects/InstCombine/Tactic/SimpLLVM.lean
@@ -130,7 +130,7 @@ a def-eq, since we made `hide` opaque. -/
 theorem hide_eq {a : α} : hide a = a := by
   rw [hide, hide_def.2]; rfl
 
-/-- symmetric version of `hide_eq` -/
+/-- Symmetric version of `hide_eq`. -/
 theorem eq_hide {a : α} : a = hide a := by
   symm; exact hide_eq
 

--- a/SSA/Projects/InstCombine/Tactic/SimpLLVM.lean
+++ b/SSA/Projects/InstCombine/Tactic/SimpLLVM.lean
@@ -2,7 +2,6 @@
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import SSA.Core.Framework.Trace
-import SSA.Core.Framework.Trace
 import SSA.Projects.InstCombine.ForLean
 import SSA.Projects.InstCombine.LLVM.EDSL
 

--- a/SSA/Projects/InstCombine/Tactic/SimpLLVM.lean
+++ b/SSA/Projects/InstCombine/Tactic/SimpLLVM.lean
@@ -2,6 +2,7 @@
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import SSA.Core.Framework.Trace
+import SSA.Core.Framework.Trace
 import SSA.Projects.InstCombine.ForLean
 import SSA.Projects.InstCombine.LLVM.EDSL
 
@@ -105,7 +106,7 @@ macro_rules
 
 /-! ### Constant Hiding Workaround
 The following section defined two tactics `hide_constants` and `unhide_constants`.
-* `hide_constants` will rewrite all occurences of `LLVM.const?` or `BitVec.ofInt`
+* `hide_constants` will rewrite occurences of `LLVM.const?` or `BitVec.ofInt`
   into an application of a new `hide` function. This function is an *opaque*
   identity function, and serves to block kernel reduction.
 * `unhide_constants` does the reverse, and removes all `hide` applications.

--- a/SSA/Projects/InstCombine/Tactic/SimpLLVM.lean
+++ b/SSA/Projects/InstCombine/Tactic/SimpLLVM.lean
@@ -105,7 +105,7 @@ macro_rules
   )
 
 /-! ### Constant Hiding Workaround
-The following section defined two tactics `hide_constants` and `unhide_constants`.
+The following section defines two tactics, `hide_constants` and `unhide_constants`.
 * `hide_constants` will rewrite occurences of `LLVM.const?` or `BitVec.ofInt`
   into an application of a new `hide` function. This function is an *opaque*
   identity function, and serves to block kernel reduction.

--- a/bv-evaluation/.gitignore
+++ b/bv-evaluation/.gitignore
@@ -1,6 +1,7 @@
 *.xz
 *.jpeg
 *.pdf
+*.csv
 *.sqlite3
 .venv/
 *.sqlite3.log


### PR DESCRIPTION
This PR implements a workaround to avoid the kernel deep recursion issue we've been seeing in the evaluation (https://github.com/leanprover/lean4/issues/8898).

Concretely, we add simprocs which match for `BitVec.ofInt w x` or `LLVM.const? w x`, with `x` a constant (e.g.., literals like 65000 or -1), and rewrites them to `hide (BitVec.ofInt w x)` (resp, `hide (LLVM.const? w x)`). Here, `hide` is a new opaque definition which is just the identity function (and for which we have a proof that it is the identity function), but because it is opaque it prevents the kernel from trying to reduce the argument.
The workaround is encapsulated in two new tactics: `hide_constant` (which applies aforementioned simprocs), and `unhide_constants` (which eliminates all `hide` applications).

It seems that both `simp_alive_undef` and `simp_alive_ops` can trigger the deep recursion, so we call `hide_constant` at the start of the former, and `unhide_constant` at the end of the latter. This does mean that any proof which only uses the former will break---but these tactics aren't really meant to be used in isolation to begin with so it shouldn't cause too many problems.

I ran the evaluation locally, with this workaround and confirmed no more deep recursion issues, and all proofs still seem to work as expected:
```
In total we found 7978 goals.
leanSAT and Bitwuzla solved: 7920
leanSAT and Bitwuzla provided 8 counterexamples
leanSAT and Bitwuzla both failed on 25 theorems
leanSAT failed and Bitwuzla succeeded on 25 theorems
leanSAT succeeded and Bitwuzla failed on 0 theorems
There were 0 inconsistencies
Errors raised: 75
ran rg 'Bitwuzla failed' | wc -l, expected 25, found 25, SUCCESS
ran rg 'LeanSAT failed' | wc -l, expected 50, found 50, SUCCESS
ran rg 'LeanSAT provided a counter' | wc -l, expected 8, found 8, SUCCESS
ran rg 'Bitwuzla provided a counter' | wc -l, expected 8, found 8, SUCCESS
ran rg 'LeanSAT proved' | wc -l, expected 7920, found 7920, SUCCESS
ran rg 'Bitwuzla proved' | wc -l, expected 7945, found 7945, SUCCESS
error The SAT solver timed out while solving the problem. was raised 50 times
error The SMT solver timed out while solving the problem. was raised 25 times
```

Finally, I tweaked the shell.nix file to include some missing python dependencies, and remove vscode. The latter was tracking the "latest" version of the Lean extension, meaning it would trigger a SHA mismatch whenever the extension got an update. In any case, I'd much rather use my global vscode config, so it seems an anti-pattern to have vscode in shell.nix. I made these changes as the previous version broke (and I believe I'm the only one currently using nix), but I'm happy to pull this out into a separate PR if it is at all controversial.