### PR TITLE
fix: add python dependencies to shell.nix

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -3,6 +3,8 @@ with pkgs;let
   xdsl = ps: ps.callPackage ./xdsl.nix {};
   my-python-packages = ps: with ps; [
     (xdsl ps)
+    matplotlib
+    pandas
   ];
   my-python = pkgs.python3.withPackages my-python-packages;
 in
@@ -14,16 +16,6 @@ mkShell {
     pkgs.llvmPackages_19.mlir
     pkgs.llvmPackages_19.bintools-unwrapped
     pkgs.bitwuzla
-    pkgs.vscode
-    (vscode-with-extensions.override {
-      vscodeExtensions = pkgs.vscode-utils.extensionsFromVscodeMarketplace [
-        {
-          name = "lean4";
-          publisher = "leanprover";
-          version = "latest";
-          sha256 = "sha256-EA/m4l4TRnq002e6DZerXJhnOnyF628mqBjm+kiiElA=";
-        }
-    ];})
   ];
 shellHook = ''
 # lake exe cache get!


### PR DESCRIPTION
This PR adds matplotlib and pandas to shell.nix, as these are required to run the bv-evaluation scripts, but were not being installed yet.

Also, we remove the vscode package, as it doesn't track a specific version, meaning it continually triggers SHA mismatches. Furthermore, I would prefer to just use my own vscode, that is globally installed, so I don't think vscode ought to be part of the shell.nix file.