### PR TITLE
feat: make (fixed-width) evaluation return a non-zero exitcode on mismatch

### DIFF
--- a/bv-evaluation/collect-data-llvm.py
+++ b/bv-evaluation/collect-data-llvm.py
@@ -257,7 +257,11 @@ print("leanSAT succeeded and Bitwuzla failed on "+str(bw_only_failed)+" theorems
 print("There were "+str(inconsistencies)+" inconsistencies")
 print("Errors raised: "+str(errTot))
 
+shell_command_mismatch = False
+
 # Double Checking Against Grep Output
+# This function sets the global `shell_command_mismatch` to True if the output
+# does not match the expected value.
 def run_shell_command_and_assert_output_eq_int(cwd : str, cmd : str, expected_val : int) -> int:
     response = subprocess.check_output(cmd, shell=True, cwd=cwd, text=True)
     val = int(response)
@@ -305,3 +309,7 @@ df_ceg = pd.DataFrame({'bitwuzla':counter_bitwuzla, 'leanSAT':counter_leanSAT,
 df.to_csv(raw_data_dir+'llvm-proved-data.csv')
 df_ceg.to_csv(raw_data_dir+'llvm-ceg-data.csv')
 
+# If any of the shell commands were not as expected, set a non-zero exit code
+# to signal this failure (in particular, making CI fail).
+if shell_command_mismatch:
+    exit(1)

--- a/bv-evaluation/collect-data-llvm.py
+++ b/bv-evaluation/collect-data-llvm.py
@@ -263,10 +263,14 @@ shell_command_mismatch = False
 # This function sets the global `shell_command_mismatch` to True if the output
 # does not match the expected value.
 def run_shell_command_and_assert_output_eq_int(cwd : str, cmd : str, expected_val : int) -> int:
+    global shell_command_mismatch
+
     response = subprocess.check_output(cmd, shell=True, cwd=cwd, text=True)
     val = int(response)
     failed =  val != expected_val
     failed_str = "FAIL" if failed else "SUCCESS"
+    if failed:
+        shell_command_mismatch = True
     print(f"ran {cmd}, expected {expected_val}, found {val}, {failed_str}")
 
 run_shell_command_and_assert_output_eq_int("results/InstCombine/", "rg 'Bitwuzla failed' | wc -l", both_failed+bw_only_failed)


### PR DESCRIPTION
This PR changes the evaluation script to return a non-zero exitcode whenever the ripgrep checks find a mismatched number (i.e., whenever it currently prints FAIL to the log). This exitcode should cause the CI to fail, meaning we no longer have to manually check the logs to confirm the evaluation actually got the right numbers.

It does mean that now whenever we do expect the numbers to change, we have to change the expected numbers in the script before CI can pass, but forcing us to keep these numbers in sync with reality seems more like a feature than a bug.