### PR TITLE
feat: weekly GH action to gc toolchains

### DIFF
--- a/.github/workflows/elan-gc.yml
+++ b/.github/workflows/elan-gc.yml
@@ -1,0 +1,10 @@
+name: Garbage collect elan toolchains
+on:
+  schedule:
+    - cron: '0 9 * * 1' # Run weekly, at 09:00 on Monday
+
+jobs:
+  elan-gc:
+    runs-on: self-hosted
+    steps:
+      - run: elan toolchain gc --delete


### PR DESCRIPTION
This PR adds a Github action which will run `elan toolchain gc --delete` weekly on the self-hosted evaluation VM, in an effort to reclaim disk space.

NOTE: I'm not super familiar with the GH action syntax, so please do check my work carefully to make sure I haven't missed anything significant :sweat_smile: 