### PR TITLE
feat: check in CI that nix-shell has the right python depencies

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,0 +1,22 @@
+name: Nix ci
+on:
+  push:
+    branches:
+      - "main"
+  pull_request:
+  merge_group:
+
+jobs:
+  nix:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: cachix/install-nix-action@v31
+        with:
+          nix_path: nixpkgs-unstable=channel:nixpkgs-unstable:nixpkgs=channel:nixpkgs-unstable
+      - name: "⚙️ Confirm nix-shell is functional"
+        run: nix-shell
+      - name: "🐍 Check Python dependencies are available"
+        run: nix-shell --run './bv-evaluation/check-imports.sh'
+
+

--- a/bv-evaluation/check-imports.sh
+++ b/bv-evaluation/check-imports.sh
@@ -3,7 +3,7 @@
 # Check that the dependencies of all bv-evaluation python scripts are installed
 # 
 
-shopt -x
+shopt x
 cd $(dirname "$(realpath "$0")")
 
 FILE=$(mktemp)
@@ -13,4 +13,10 @@ rm "$FILE"          # Unlink tmpfile
 #       the tmpfile gets automatically cleaned up when the script exits
 
 cat *.py | rg '^import' | sed -E 's/\s*(as \w+)?\s*$//' | sort -u | tee /proc/self/fd/3
-python3 /proc/self/fd/3
+
+python3 /proc/self/fd/3 || (
+    echo
+    echo "To fix, please add the missing dependency to shell.nix"
+    echo
+    exit 1
+)

--- a/bv-evaluation/check-imports.sh
+++ b/bv-evaluation/check-imports.sh
@@ -3,7 +3,6 @@
 # Check that the dependencies of all bv-evaluation python scripts are installed
 # 
 
-shopt x
 cd $(dirname "$(realpath "$0")")
 
 FILE=$(mktemp)

--- a/bv-evaluation/check-imports.sh
+++ b/bv-evaluation/check-imports.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+#
+# Check that the dependencies of all bv-evaluation python scripts are installed
+# 
+
+shopt -x
+cd $(dirname "$(realpath "$0")")
+
+FILE=$(mktemp)
+exec 3<> "$FILE"    # Open tmpfile on file descriptor 3
+rm "$FILE"          # Unlink tmpfile
+# NOTE: we can still read and write to the file on the file descriptor, this way
+#       the tmpfile gets automatically cleaned up when the script exits
+
+cat *.py | rg '^import' | sed -E 's/\s*(as \w+)?\s*$//' | sort -u | tee /proc/self/fd/3
+python3 /proc/self/fd/3

--- a/shell.nix
+++ b/shell.nix
@@ -16,6 +16,7 @@ mkShell {
     pkgs.llvmPackages_19.mlir
     pkgs.llvmPackages_19.bintools-unwrapped
     pkgs.bitwuzla
+    pkgs.ripgrep
   ];
 shellHook = ''
 # lake exe cache get!

--- a/shell.nix
+++ b/shell.nix
@@ -5,6 +5,7 @@ with pkgs;let
     (xdsl ps)
     matplotlib
     pandas
+    polars
   ];
   my-python = pkgs.python3.withPackages my-python-packages;
 in


### PR DESCRIPTION
This PR adds a new action to CI which will confirm that (a) nix-shell is functional (guarding against any SHAs going out of date, as has happened previously), and (b) that shell.nix has all python dependencies required to run the bv-evaluation scripts.

Furthermore, despite #1363 shell.nix wasn't quite up to date yet. So this PR also adds `pandas` and `ripgrep` to `shell.nix`.