### PR TITLE
feat: add scripts and Dockerfile commands to run SMT-LIB benchmarks

### DIFF
--- a/.github/workflows/evaluation.yml
+++ b/.github/workflows/evaluation.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Install Python Modules
         run: |
           sudo apt update
-          sudo apt install -y python3-matplotlib python3-pandas python3-num2words ripgrep
+          sudo apt install -y python3-matplotlib python3-pandas python3-num2words python3-psutil ripgrep
 
       - name: Get Cache
         continue-on-error: true

--- a/artifacts/oopsla25-bv-decide/Dockerfile
+++ b/artifacts/oopsla25-bv-decide/Dockerfile
@@ -28,34 +28,98 @@ RUN apt-get update && \
 RUN useradd -m -s /bin/bash user && \
     adduser user sudo && \
     echo "user ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
-RUN mkdir -p /code && chown user:user /code # Create /code as root before switching
-
 USER user
+
+# HACK around Lean-MLIR self-reference incompatibility with docker cache:
+# Do all the work in the home directory for now and move it to the lean-mlir directory later
+RUN mkdir -p /home/user/lean-mlir
+WORKDIR /home/user/lean-mlir
 
 # Install elan and update environment
 RUN curl https://elan.lean-lang.org/elan-init.sh -sSf | sh -s -- -y --default-toolchain none
 ENV PATH=/home/user/.elan/bin:$PATH
 
+# Download and unzip SMT-LIB QF_BV benchmarks
+RUN mkdir -p bv-evaluation/SMT-LIB
+RUN curl -L -o QF_BV.tar.zst https://zenodo.org/records/15493090/files/QF_BV.tar.zst?download=1 && \
+    tar -xf QF_BV.tar.zst -C bv-evaluation/SMT-LIB && \
+    rm QF_BV.tar.zst
+
+# Create Solvers directory
+RUN mkdir -p bv-evaluation/solvers
 
 # Install Bitwuzla (commit: 22.6.25)
-RUN cd /home/user && git clone https://github.com/bitwuzla/bitwuzla
-# && git checkout 0dca38d0f62fa9002ad6278ca6374838a69ade19
-WORKDIR /home/user/bitwuzla
-RUN ./configure.py && cd build && ninja && sudo ninja install
+RUN cd bv-evaluation/solvers && git clone https://github.com/bitwuzla/bitwuzla && cd bitwuzla && git checkout 0dca38d0f62fa9002ad6278ca6374838a69ade19
+RUN cd bv-evaluation/solvers/bitwuzla && ./configure.py && cd build && ninja && sudo ninja install
 
+# Install CoqQFBV (commit: 09.04.23)
+RUN cd bv-evaluation/solvers && git clone https://github.com/fmlab-iis/coq-qfbv && cd coq-qfbv && git checkout bb055f7b05dd81a5ddf89c734bde140a9feecf70
+WORKDIR bv-evaluation/solvers/coq-qfbv
+RUN yes "/usr/local/bin" | bash -c "sh <(curl -fsSL https://opam.ocaml.org/install.sh)" && \
+    opam init --disable-sandboxing --bare
+RUN opam switch create ocaml-base-compiler.4.14.0
+RUN eval $(opam env) && \
+    opam repo add coq-released https://coq.inria.fr/opam/released && \
+    opam pin --yes coq 8.15.2 && \
+    opam pin --yes coq-mathcomp-ssreflect 1.14.0 && \
+    opam install --yes coq-mathcomp-algebra
+RUN git submodule init && \
+    git submodule update && \
+    eval $(opam env) && \
+    make -C lib/coq-nbits && \
+    make -C lib/coq-ssrlib && \
+    make
+RUN cd src/ocaml && eval $(opam env) && dune build
+RUN mkdir bin
+RUN cp src/ocaml/_build/default/coqQFBV.exe bin/coqQFBV.exe
+# Install Kissat (version: 4.0.1)
+RUN cd bin && \
+    curl -L -o kissat-4.0.1-linux-amd64.zip https://github.com/arminbiere/kissat/releases/download/rel-4.0.1/kissat-4.0.1-linux-amd64.zip && \
+    unzip -j kissat-4.0.1-linux-amd64.zip && \
+    mv kissat-4.0.1-linux-amd64 kissat && \
+    rm kissat-4.0.1-linux-amd64.zip
+# Install GRATgen (version: 1.3.2)
+RUN cd lib && \
+    curl -L -o gratgen.tgz https://www21.in.tum.de/~lammich/grat/archive/v1.3.2/gratgen.tgz && \
+    tar -xzf gratgen.tgz && \
+    rm gratgen.tgz && \
+    cd gratgen && \
+    sed -i '16a add_definitions(-DBOOST_TIMER_ENABLE_DEPRECATED)' CMakeLists.txt && \
+    mkdir build && cd build && \
+    cmake -DCMAKE_BUILD_TYPE=Release .. && \
+    make && \
+    cp gratgen ../../../bin
+# Install GRATchk (version: 1.3.2)
+RUN cd lib && \
+    curl -L -o gratchk-sml.tgz https://www21.in.tum.de/~lammich/grat/archive/v1.3.2/gratchk-sml.tgz && \
+    tar -xzf gratchk-sml.tgz && \
+    rm gratchk-sml.tgz && \
+    cd gratchk-sml && make && \
+    cp gratchk ../../bin
+WORKDIR /home/user/lean-mlir
+
+# Install Leanwuzla (commit: 25.06.25)
+# This is a fork of Leanwuzla with modifications to support the evaluation
+RUN cd bv-evaluation/solvers && git clone https://github.com/abdoo8080/Leanwuzla && \
+    cd Leanwuzla && git checkout 3ec8c974eed8f4d142a5d3422feb8220d0661089 && \
+    lake build
+
+# Install Lean-MLIR (commit: 26.06.25)
+# Note: copying contents of lean-mlir-temp to lean-mlir is much faster than doing the opposite
 RUN echo "v2"
-RUN cd /code && git clone https://github.com/opencompl/lean-mlir && cd lean-mlir
-WORKDIR /code/lean-mlir
+RUN cd .. && git clone https://github.com/opencompl/lean-mlir lean-mlir-temp && \
+    cp -r lean-mlir-temp/. lean-mlir && \
+    rm -rf lean-mlir-temp
 
 # Ensure the .lake/packages directory is clean before running lake update
 RUN rm -rf .lake/packages/mathlib && lake update && lake build
 
-# Install dependencies
+# Install Python dependencies
 RUN python3 -m venv .venv && \
     .venv/bin/pip install -r requirements.txt
 
-# Setup python env
+# Setup Python env
 ENV VIRTUAL_ENV=/opt/venv
 ENV PATH="/opt/venv/bin:$PATH"
 
-USER root
+USER user

--- a/bv-evaluation/plot.py
+++ b/bv-evaluation/plot.py
@@ -9,7 +9,7 @@ import numpy as np
 
 instCombineDataDir = "raw-data/InstCombine/"
 hackersDelightDataDir = "raw-data/HackersDelight/"
-SMTLIBDataDir = "raw-data/SMTLIB/"
+SMTLIBDataDir = "raw-data/SMT-LIB/"
 plotsdir = "plots/"
 
 
@@ -118,10 +118,16 @@ def compare_tools_same_bw(df, bm, tool1, tool2):
     fig, ax = plt.subplots()
     df_sorted = df.sort_values(by="solved_bv_decide_times_average")
     ax.plot(
-        np.arange(len(df_sorted[tool1])), df_sorted[tool1], color=col[0], label="bv_decide"
+        np.arange(len(df_sorted[tool1])),
+        df_sorted[tool1],
+        color=col[0],
+        label="bv_decide",
     )
     ax.plot(
-        np.arange(len(df_sorted[tool2])), df_sorted[tool2], color=col[3], label="bitwuzla"
+        np.arange(len(df_sorted[tool2])),
+        df_sorted[tool2],
+        color=col[3],
+        label="bitwuzla",
     )
     if np.max(df_sorted[tool2]) > max:
         max = np.max(df_sorted[tool2])
@@ -249,22 +255,42 @@ def bv_decide_tot_stacked_perc(df, bm, type):
     save(fig, plotsdir + "bv_decide_stacked_perc_" + bm.split(".")[0] + ".pdf")
 
 
-def leanSAT_smtlib_unsat_stacked_perc(df: pd.DataFrame, bm, type):
-    if type == 'h_tot':
+def bv_decide_smtlib_unsat_stacked_perc(df: pd.DataFrame, bm, type):
+    if type == "h_tot":
         matplotlib.rcParams["figure.figsize"] = 14, 5
     x = np.arange(len(df["benchmark"]))
     width = 1.0
     fig, ax = plt.subplots()
     # df_sorted = df.sort_values(by="leanSAT")
     # print(df_sorted)
-    df = df.apply(lambda x: x / 10**6 if x.name in
-      ['leanSAT-ld', 'leanSAT-rr', 'leanSAT-ac',
-       'leanSAT-af', 'leanSAT-ecs', 'leanSAT-bb',
-       'leanSAT-sat', 'leanSAT-lrat', 'leanSAT-kc'] else x)
-    tot_sum = (df["leanSAT-ld"] + df["leanSAT-rr"] + df["leanSAT-ac"] +
-               df["leanSAT-af"] + df["leanSAT-ecs"] + df["leanSAT-bb"] +
-               df["leanSAT-sat"] + df["leanSAT-lrat"] + df["leanSAT-kc"])
-    df['tot-sum'] = tot_sum
+    df = df.apply(
+        lambda x: x / 10**6
+        if x.name
+        in [
+            "leanSAT-ld",
+            "leanSAT-rr",
+            "leanSAT-ac",
+            "leanSAT-af",
+            "leanSAT-ecs",
+            "leanSAT-bb",
+            "leanSAT-sat",
+            "leanSAT-lrat",
+            "leanSAT-kc",
+        ]
+        else x
+    )
+    tot_sum = (
+        df["leanSAT-ld"]
+        + df["leanSAT-rr"]
+        + df["leanSAT-ac"]
+        + df["leanSAT-af"]
+        + df["leanSAT-ecs"]
+        + df["leanSAT-bb"]
+        + df["leanSAT-sat"]
+        + df["leanSAT-lrat"]
+        + df["leanSAT-kc"]
+    )
+    df["tot-sum"] = tot_sum
     df_sorted = df.sort_values(by="tot-sum")
     # print(df_sorted)
     ax_right = ax.twinx()
@@ -272,71 +298,118 @@ def leanSAT_smtlib_unsat_stacked_perc(df: pd.DataFrame, bm, type):
     bottom = np.zeros_like(df_sorted["leanSAT-ld"])
     ax.bar(
         x,
-        np.divide(df_sorted["leanSAT-ld"] + df_sorted["leanSAT-rr"] +
-                  df_sorted["leanSAT-ac"] + df_sorted["leanSAT-af"] +
-                  df_sorted["leanSAT-ecs"] + df_sorted["leanSAT-kc"], df_sorted['tot-sum'])*100,
+        np.divide(
+            df_sorted["leanSAT-ld"]
+            + df_sorted["leanSAT-rr"]
+            + df_sorted["leanSAT-ac"]
+            + df_sorted["leanSAT-af"]
+            + df_sorted["leanSAT-ecs"]
+            + df_sorted["leanSAT-kc"],
+            df_sorted["tot-sum"],
+        )
+        * 100,
         width,
         label="rewriting + kernel checking",
         bottom=bottom,
-        color=dark_blue, 
-        edgecolor = dark_blue
+        color=dark_blue,
+        edgecolor=dark_blue,
     )
-    bottom += np.divide(df_sorted["leanSAT-ld"] + df_sorted["leanSAT-rr"] +
-                        df_sorted["leanSAT-ac"] + df_sorted["leanSAT-af"] +
-                        df_sorted["leanSAT-ecs"] + df_sorted["leanSAT-kc"], df_sorted['tot-sum'])*100
+    bottom += (
+        np.divide(
+            df_sorted["leanSAT-ld"]
+            + df_sorted["leanSAT-rr"]
+            + df_sorted["leanSAT-ac"]
+            + df_sorted["leanSAT-af"]
+            + df_sorted["leanSAT-ecs"]
+            + df_sorted["leanSAT-kc"],
+            df_sorted["tot-sum"],
+        )
+        * 100
+    )
     ax.bar(
         x,
-        np.divide(df_sorted["leanSAT-bb"] + df_sorted["leanSAT-sat"],
-                  df_sorted['tot-sum'])*100,
+        np.divide(
+            df_sorted["leanSAT-bb"] + df_sorted["leanSAT-sat"], df_sorted["tot-sum"]
+        )
+        * 100,
         width,
         label="bit-blasting and SAT solving",
         bottom=bottom,
         color=light_gray,
-        edgecolor=light_gray
+        edgecolor=light_gray,
     )
-    bottom += np.divide(df_sorted["leanSAT-bb"] + df_sorted["leanSAT-sat"], df_sorted['tot-sum'])*100
+    bottom += (
+        np.divide(
+            df_sorted["leanSAT-bb"] + df_sorted["leanSAT-sat"], df_sorted["tot-sum"]
+        )
+        * 100
+    )
     ax.bar(
         x,
-        np.divide(df_sorted["leanSAT-lrat"], df_sorted['tot-sum'])*100,
+        np.divide(df_sorted["leanSAT-lrat"], df_sorted["tot-sum"]) * 100,
         width,
         label="LRAT",
         bottom=bottom,
         color=dark_green,
-        edgecolor=dark_green
+        edgecolor=dark_green,
     )
     ax_right.plot(
         x,
-        df_sorted['tot-sum'],
+        df_sorted["tot-sum"],
         width,
         label="total time",
-        color=black, 
+        color=black,
     )
     ax_right.set_yscale("log")
-    ax.set_xticks(np.arange(0,len(df_sorted), 10**np.floor(np.log10(len(df_sorted)))))
+    ax.set_xticks(
+        np.arange(0, len(df_sorted), 10 ** np.floor(np.log10(len(df_sorted))))
+    )
     # ax.set_title("Time to solve theorems from "+bm, pad=20)
-    ax.set_ylabel("Distribution [%]", rotation="horizontal", horizontalalignment="left", y=1.05)
-    ax_right.set_ylabel("Time [ms]", rotation="horizontal", horizontalalignment="right", y=1.08)
-    ax.legend(ncols=4, frameon=False, bbox_to_anchor= [0.5, 1], loc='lower center')
-    plt.gca().spines['right'].set_visible(True) 
-    save(fig, "leanSAT_stacked_smtlib_" + bm.split(".")[0] + ".pdf")
+    ax.set_ylabel(
+        "Distribution [%]", rotation="horizontal", horizontalalignment="left", y=1.05
+    )
+    ax_right.set_ylabel(
+        "Time [ms]", rotation="horizontal", horizontalalignment="right", y=1.08
+    )
+    ax.legend(ncols=4, frameon=False, bbox_to_anchor=[0.5, 1], loc="lower center")
+    plt.gca().spines["right"].set_visible(True)
+    save(fig, plotsdir + "leanSAT_stacked_smtlib_" + bm.split(".")[0] + ".pdf")
 
 
-def leanSAT_smtlib_sat_stacked_perc(df: pd.DataFrame, bm, type):
-    if type == 'h_tot':
+def bv_decide_smtlib_sat_stacked_perc(df: pd.DataFrame, bm, type):
+    if type == "h_tot":
         matplotlib.rcParams["figure.figsize"] = 14, 5
     x = np.arange(len(df["benchmark"]))
     width = 1.0
     fig, ax = plt.subplots()
     # df_sorted = df.sort_values(by="leanSAT")
     # print(df_sorted)
-    df = df.apply(lambda x: x / 10**6 if x.name in
-      ['leanSAT-ld', 'leanSAT-rr', 'leanSAT-ac',
-       'leanSAT-af', 'leanSAT-ecs', 'leanSAT-bb',
-       'leanSAT-sat', 'leanSAT-lrat'] else x)
-    tot_sum = (df["leanSAT-ld"] + df["leanSAT-rr"] + df["leanSAT-ac"] +
-               df["leanSAT-af"] + df["leanSAT-ecs"] + df["leanSAT-bb"] +
-               df["leanSAT-sat"] + df["leanSAT-lrat"])
-    df['tot-sum'] = tot_sum
+    df = df.apply(
+        lambda x: x / 10**6
+        if x.name
+        in [
+            "leanSAT-ld",
+            "leanSAT-rr",
+            "leanSAT-ac",
+            "leanSAT-af",
+            "leanSAT-ecs",
+            "leanSAT-bb",
+            "leanSAT-sat",
+            "leanSAT-lrat",
+        ]
+        else x
+    )
+    tot_sum = (
+        df["leanSAT-ld"]
+        + df["leanSAT-rr"]
+        + df["leanSAT-ac"]
+        + df["leanSAT-af"]
+        + df["leanSAT-ecs"]
+        + df["leanSAT-bb"]
+        + df["leanSAT-sat"]
+        + df["leanSAT-lrat"]
+    )
+    df["tot-sum"] = tot_sum
     df_sorted = df.sort_values(by="tot-sum")
     # print(df_sorted)
     ax_right = ax.twinx()
@@ -344,43 +417,66 @@ def leanSAT_smtlib_sat_stacked_perc(df: pd.DataFrame, bm, type):
     bottom = np.zeros_like(df_sorted["leanSAT-ld"])
     ax.bar(
         x,
-        np.divide(df_sorted["leanSAT-ld"] + df_sorted["leanSAT-rr"] +
-                  df_sorted["leanSAT-ac"] + df_sorted["leanSAT-af"] +
-                  df_sorted["leanSAT-ecs"], df_sorted['tot-sum'])*100,
+        np.divide(
+            df_sorted["leanSAT-ld"]
+            + df_sorted["leanSAT-rr"]
+            + df_sorted["leanSAT-ac"]
+            + df_sorted["leanSAT-af"]
+            + df_sorted["leanSAT-ecs"],
+            df_sorted["tot-sum"],
+        )
+        * 100,
         width,
         label="rewriting",
         bottom=bottom,
-        color=dark_blue, 
-        edgecolor = dark_blue
+        color=dark_blue,
+        edgecolor=dark_blue,
     )
-    bottom += np.divide(df_sorted["leanSAT-ld"] + df_sorted["leanSAT-rr"] +
-                        df_sorted["leanSAT-ac"] + df_sorted["leanSAT-af"] +
-                        df_sorted["leanSAT-ecs"], df_sorted['tot-sum'])*100
+    bottom += (
+        np.divide(
+            df_sorted["leanSAT-ld"]
+            + df_sorted["leanSAT-rr"]
+            + df_sorted["leanSAT-ac"]
+            + df_sorted["leanSAT-af"]
+            + df_sorted["leanSAT-ecs"],
+            df_sorted["tot-sum"],
+        )
+        * 100
+    )
     ax.bar(
         x,
-        np.divide(df_sorted["leanSAT-bb"] + df_sorted["leanSAT-sat"],
-                  df_sorted['tot-sum'])*100,
+        np.divide(
+            df_sorted["leanSAT-bb"] + df_sorted["leanSAT-sat"], df_sorted["tot-sum"]
+        )
+        * 100,
         width,
         label="bit-blasting and SAT solving",
         bottom=bottom,
         color=light_gray,
-        edgecolor=light_gray
+        edgecolor=light_gray,
     )
     ax_right.plot(
         x,
-        df_sorted['tot-sum'],
+        df_sorted["tot-sum"],
         width,
         label="total time",
-        color=black, 
+        color=black,
     )
     ax_right.set_yscale("log")
-    ax.set_xticks(np.arange(0,len(df_sorted), 10**np.floor(np.log10(len(df_sorted)))))
+    ax.set_xticks(
+        np.arange(0, len(df_sorted), 10 ** np.floor(np.log10(len(df_sorted))))
+    )
     # ax.set_title("Time to solve theorems from "+bm, pad=20)
-    ax.set_ylabel("Distribution [%]", rotation="horizontal", horizontalalignment="left", y=1.05)
-    ax_right.set_ylabel("Time [ms]", rotation="horizontal", horizontalalignment="right", y=1.08)
-    ax.legend(ncols=4, frameon=False, bbox_to_anchor= [0.5, 1], loc='lower center')
-    plt.gca().spines['right'].set_visible(True) 
-    save(fig, "leanSAT_stacked_smtlib_" + bm.split(".")[0] + ".pdf")
+    ax.set_ylabel(
+        "Distribution [%]", rotation="horizontal", horizontalalignment="left", y=1.05
+    )
+    ax_right.set_ylabel(
+        "Time [ms]", rotation="horizontal", horizontalalignment="right", y=1.08
+    )
+    ax.legend(ncols=4, frameon=False, bbox_to_anchor=[0.5, 1], loc="lower center")
+    plt.gca().spines["right"].set_visible(True)
+    save(fig, plotsdir + "leanSAT_stacked_smtlib_" + bm.split(".")[0] + ".pdf")
+
 
 def bv_decide_tot_stacked(df, bm):
     x = np.arange(len(df["solved_bv_decide_times_average"]))
@@ -547,10 +643,10 @@ def cumul_solving_time_smtlib(df, name):
     fig, ax = plt.subplots(figsize=(14, 3))
     plt.rcParams["path.simplify_threshold"] = 1
     # only consider rows where the problem was actually sat/unsat
-    sorted1 = np.sort(df['time_cpu_bw'])
-    sorted2 = np.sort(df['time_cpu_lwt'])
-    sorted3 = np.sort(df['time_cpu_lw'])
-    sorted4 = np.sort(df['time_cpu_coq'])
+    sorted1 = np.sort(df["total_bw"])
+    sorted2 = np.sort(df["total_lwt"])
+    sorted3 = np.sort(df["total_lw"])
+    sorted4 = np.sort(df["total_coq"])
     cumtime1 = [0]
     cumtime1.extend(np.cumsum(sorted1))
     cumtime2 = [0]
@@ -561,116 +657,141 @@ def cumul_solving_time_smtlib(df, name):
     cumtime4.extend(np.cumsum(sorted4))
     ax.plot(
         cumtime1,
-        np.arange(0, len(df['time_cpu_bw']) + 1),
+        np.arange(0, len(df["total_bw"]) + 1),
         marker="o",
         color=dark_green,
-        label='bitwuzla',
+        label="bitwuzla",
     )
     ax.plot(
         cumtime2,
-        np.arange(0, len(df['time_cpu_lwt']) + 1),
+        np.arange(0, len(df["total_lwt"]) + 1),
         marker="x",
         color=light_blue,
-        label='bv_decide (no kernel)',
+        label="bv_decide (no kernel)",
     )
     ax.plot(
         cumtime3,
-        np.arange(0, len(df['time_cpu_lw']) + 1),
+        np.arange(0, len(df["total_lw"]) + 1),
         marker="x",
         color=dark_blue,
-        label='bv_decide (+ kernel)',
+        label="bv_decide (+ kernel)",
     )
     ax.plot(
         cumtime4,
-        np.arange(0, len(df['time_cpu_coq']) + 1),
+        np.arange(0, len(df["total_coq"]) + 1),
         marker="*",
         color=dark_red,
-        label='CoqQFBV',
+        label="CoqQFBV",
     )
-    ax.set_xscale('log')
-    ax.set_xlabel("Time [s] - "+name.upper()+" results")
+    ax.set_xscale("log")
+    ax.set_xlabel("Time [s] - " + name.upper() + " results")
     ax.set_ylabel("Problems solved", rotation="horizontal", ha="left", y=1)
     # add a line to highlight the difference in #solved problems between the tools
-    # x_start = cumtime1[len([x for x in np.array(df['time_cpu_lw']) if x > 0])-10]
-    # x_end = np.sum(df['time_cpu_lw'])
-    # y_value = len([x for x in np.array(df['time_cpu_lw']) if x > 0])
-    # ax.plot([x_start, x_end], [len([x for x in np.array(df['time_cpu_lw']) if x > 0]), len([x for x in np.array(df['time_cpu_lw']) if x > 0])], color='black', linestyle='--', linewidth=1)
-    # ax.annotate(f"10^{int(np.round(np.log10(x_end - x_start)))} s", 
-    #         xy=(x_start+(x_end-x_start)/2, y_value), 
+    # x_start = cumtime1[len([x for x in np.array(df['total_lw']) if x > 0])-10]
+    # x_end = np.sum(df['total_lw'])
+    # y_value = len([x for x in np.array(df['total_lw']) if x > 0])
+    # ax.plot([x_start, x_end], [len([x for x in np.array(df['total_lw']) if x > 0]), len([x for x in np.array(df['total_lw']) if x > 0])], color='black', linestyle='--', linewidth=1)
+    # ax.annotate(f"10^{int(np.round(np.log10(x_end - x_start)))} s",
+    #         xy=(x_start+(x_end-x_start)/2, y_value),
     #         xytext=((x_end-x_start)/2, y_value * 1.01),
     #         fontsize=12, color='black')
-    
-    # x_start_c = cumtime1[len([x for x in np.array(df['time_cpu_coq']) if x > 0])-10]
-    # x_end_c = np.sum(df['time_cpu_coq'])
-    # y_value_c = len([x for x in np.array(df['time_cpu_coq']) if x > 0])
-    # ax.plot([x_start_c, x_end_c], [len([x for x in np.array(df['time_cpu_coq']) if x > 0]), len([x for x in np.array(df['time_cpu_coq']) if x > 0])], color='black', linestyle='--', linewidth=1)
-    # ax.annotate(f"10^{int(np.round(np.log10(x_end_c - x_start_c)))} s", 
-    #         xy=(x_start_c, y_value_c), 
-    #         xytext=((x_end_c-x_start_c)/2, y_value_c * 1.01),
-    #         fontsize=12, color='black')
-    
-    # y_start = next((i for i, x in enumerate(cumtime2) if x > np.sum(df['time_cpu_bw'])), -1)
-    # y_end = len(df['time_cpu_bw'])
-    # print(cumtime1[-1])
-    # x_value = np.sum(df['time_cpu_bw'])
-    # ax.plot([x_value, x_value], [y_start, y_end], color='black', linestyle='dashed', linewidth=1)
-    # y_end = next((i for i, x in enumerate(cumtime2) if x > np.sum(df['time_cpu_bw'])), -1)
-    # y_start = 0
-    # print(cumtime1[-1])
-    # x_value = np.sum(df['time_cpu_bw'])
-    # ax.plot([x_value, x_value], [y_start, y_end], color='black', linestyle='solid', linewidth=2)
-    # ax.annotate(f"{int(y_end)} problems", 
-    #         xy=(x_start, y_value), 
-    #         xytext=(x_value*1.1, y_end * 0.95),
-    #         fontsize=12, color='black')
-    
-    # x_start_c = cumtime1[len([x for x in np.array(df['time_cpu_coq']) if x > 0])-10]
-    # x_end_c = np.sum(df['time_cpu_coq'])
-    # y_value_c = len([x for x in np.array(df['time_cpu_coq']) if x > 0])
-    # ax.plot([x_start_c, x_end_c], [len([x for x in np.array(df['time_cpu_coq']) if x > 0]), len([x for x in np.array(df['time_cpu_coq']) if x > 0])], color='black', linestyle='--', linewidth=1)
-    # ax.annotate(f"10^{int(np.round(np.log10(x_end_c - x_start_c)))} s", 
-    #         xy=(x_start_c, y_value_c), 
+
+    # x_start_c = cumtime1[len([x for x in np.array(df['total_coq']) if x > 0])-10]
+    # x_end_c = np.sum(df['total_coq'])
+    # y_value_c = len([x for x in np.array(df['total_coq']) if x > 0])
+    # ax.plot([x_start_c, x_end_c], [len([x for x in np.array(df['total_coq']) if x > 0]), len([x for x in np.array(df['total_coq']) if x > 0])], color='black', linestyle='--', linewidth=1)
+    # ax.annotate(f"10^{int(np.round(np.log10(x_end_c - x_start_c)))} s",
+    #         xy=(x_start_c, y_value_c),
     #         xytext=((x_end_c-x_start_c)/2, y_value_c * 1.01),
     #         fontsize=12, color='black')
 
-    # ax.axvline(np.sum(df['time_cpu_bw']), color = black, linestyle = '--')
+    # y_start = next((i for i, x in enumerate(cumtime2) if x > np.sum(df['total_bw'])), -1)
+    # y_end = len(df['total_bw'])
+    # print(cumtime1[-1])
+    # x_value = np.sum(df['total_bw'])
+    # ax.plot([x_value, x_value], [y_start, y_end], color='black', linestyle='dashed', linewidth=1)
+    # y_end = next((i for i, x in enumerate(cumtime2) if x > np.sum(df['total_bw'])), -1)
+    # y_start = 0
+    # print(cumtime1[-1])
+    # x_value = np.sum(df['total_bw'])
+    # ax.plot([x_value, x_value], [y_start, y_end], color='black', linestyle='solid', linewidth=2)
+    # ax.annotate(f"{int(y_end)} problems",
+    #         xy=(x_start, y_value),
+    #         xytext=(x_value*1.1, y_end * 0.95),
+    #         fontsize=12, color='black')
+
+    # x_start_c = cumtime1[len([x for x in np.array(df['total_coq']) if x > 0])-10]
+    # x_end_c = np.sum(df['total_coq'])
+    # y_value_c = len([x for x in np.array(df['total_coq']) if x > 0])
+    # ax.plot([x_start_c, x_end_c], [len([x for x in np.array(df['total_coq']) if x > 0]), len([x for x in np.array(df['total_coq']) if x > 0])], color='black', linestyle='--', linewidth=1)
+    # ax.annotate(f"10^{int(np.round(np.log10(x_end_c - x_start_c)))} s",
+    #         xy=(x_start_c, y_value_c),
+    #         xytext=((x_end_c-x_start_c)/2, y_value_c * 1.01),
+    #         fontsize=12, color='black')
+
+    # ax.axvline(np.sum(df['total_bw']), color = black, linestyle = '--')
     # ax.set_xscale("log")
     # ax.set_yscale("log")
     # ax.legend(loc="center right", ncols=1, frameon=False, bbox_to_anchor=(1.2, 0.5))
     ax.legend(loc="upper left", ncols=1, frameon=False)
-    save(fig, "cumul_problems_smtlib_"+name+".pdf")
+    save(fig, "cumul_problems_smtlib_" + name + ".pdf")
 
-def scatter_solving_time_smtlib(df_sat, df_unsat): 
+
+def scatter_solving_time_smtlib(df_sat, df_unsat):
     fig, ax = plt.subplots(1, 2, figsize=(14, 4), sharey=True)
-
-    ax[0].scatter(df_sat['time_cpu_bw'], df_sat['time_cpu_lw'], c = "#beaed4",  label = 'SAT results', marker = ".")
-    ax[1].scatter(df_unsat['time_cpu_bw'], df_unsat['time_cpu_lw'], c = "#fdc086",  label = 'UNSAT results', marker=".")
+    ax[0].scatter(
+        df_sat["total_bw"],
+        df_sat["total_lw"],
+        c="#beaed4",
+        label="SAT results",
+        marker=".",
+    )
+    ax[1].scatter(
+        df_unsat["total_bw"],
+        df_unsat["total_lw"],
+        c="#fdc086",
+        label="UNSAT results",
+        marker=".",
+    )
 
     ax[0].set_xlabel("SAT")
     ax[1].set_xlabel("UNSAT")
 
-    time_sat_min = min(df_sat["time_cpu_bw"].min(), df_sat["time_cpu_lw"].min())
-    time_sat_max = max(df_sat["time_cpu_bw"].max(), df_sat["time_cpu_lw"].max())
+    time_sat_min = min(df_sat["total_bw"].min(), df_sat["total_lw"].min())
+    time_sat_max = max(df_sat["total_bw"].max(), df_sat["total_lw"].max())
 
-    time_unsat_min = min(df_unsat["time_cpu_bw"].min(), df_unsat["time_cpu_lw"].min())
-    time_unsat_max = max(df_unsat["time_cpu_bw"].max(), df_unsat["time_cpu_lw"].max())
+    time_unsat_min = min(df_unsat["total_bw"].min(), df_unsat["total_lw"].min())
+    time_unsat_max = max(df_unsat["total_bw"].max(), df_unsat["total_lw"].max())
 
-    time_min = min(time_sat_min, time_sat_max)
+    time_min = min(time_sat_min, time_unsat_min)
     time_max = max(time_sat_max, time_unsat_max)
 
-    ax[0].set_ylim(10**(np.floor(np.log10(time_min))), 10**(np.ceil(np.log10(time_max))))
-    ax[1].set_ylim(10**(np.floor(np.log10(time_min))), 10**(np.ceil(np.log10(time_max))))
-    ax[0].plot([df_sat["time_cpu_bw"].min(), df_sat["time_cpu_bw"].max()], [df_sat["time_cpu_bw"].min(), df_sat["time_cpu_bw"].max()], c = black)
-    ax[1].plot([df_unsat["time_cpu_bw"].min(), df_unsat["time_cpu_lw"].max()], [df_unsat["time_cpu_bw"].min(), df_unsat["time_cpu_lw"].max()], c = black)
-    ax[0].set_xscale('log')
-    ax[0].set_yscale('log')
-    ax[1].set_xscale('log')
-    ax[1].set_yscale('log')
+    ax[0].set_ylim(
+        10 ** (np.floor(np.log10(time_min))), 10 ** (np.ceil(np.log10(time_max)))
+    )
+    ax[1].set_ylim(
+        10 ** (np.floor(np.log10(time_min))), 10 ** (np.ceil(np.log10(time_max)))
+    )
+    ax[0].plot(
+        [time_sat_min, time_sat_max],
+        [time_sat_min, time_sat_max],
+        c=black,
+    )
+    ax[1].plot(
+        [time_unsat_min, time_unsat_max],
+        [time_unsat_min, time_unsat_max],
+        c=black,
+    )
+    ax[0].set_xscale("log")
+    ax[0].set_yscale("log")
+    ax[1].set_xscale("log")
+    ax[1].set_yscale("log")
     # ax[1].text(1.2, 0, "Time [ms]\nbitwuzla", transform=ax[1].transAxes, ha="right")
     fig.text(0.5, 0.04, "Time [ms] - bitwuzla", ha="center", va="center")
     ax[0].set_ylabel("Time [s] - bv_decide", rotation="horizontal", ha="left", y=1.05)
     # ax.legend(loc="lower center", ncols=2, frameon=False)
-    save(fig, "scatter_smtlib.pdf")
+    save(fig, plotsdir + "scatter_smtlib.pdf")
+
 
 def scatter_solving_time_instcombine(df):
     fig, ax = plt.subplots(figsize=(14, 3), sharey=True)
@@ -702,13 +823,18 @@ def scatter_solving_time_instcombine(df):
     ax.set_xlabel("Time [ms] - bitwuzla", ha="center", va="center", y=-0.2)
     ax.set_ylabel("Time [ms] - bv_decide", rotation="horizontal", ha="left", y=1.05)
     # ax.legend(loc="lower center", ncols=2, frameon=False)
-    save(fig, plotsdir + "scatter_smtlib_instcombine.pdf")
+    save(fig, plotsdir + "scatter_instcombine.pdf")
 
 
 def plot_hackersdelight():
     dfs = []
     for file in os.listdir(hackersDelightDataDir):
-        if "err" not in file and "ceg" not in file and "sym" and ".placeholder" not in file:
+        if (
+            "err" not in file
+            and "ceg" not in file
+            and "sym"
+            and ".placeholder" not in file
+        ):
             print(file)
             bvw = file.split("_")[2]
             df_bw = pd.read_csv(hackersDelightDataDir + file)
@@ -758,6 +884,7 @@ def plot_hackersdelight():
         bv_width,
     )
 
+
 def plot_instcombine():
     for file in os.listdir(instCombineDataDir):
         if "err" not in file and "ceg" not in file and ".placeholder" not in file:
@@ -776,37 +903,68 @@ def plot_instcombine():
 
 def plot_smtlib():
     # filter out results that are unknown for both solvers
-    df_bitwuzla_46k = pd.read_csv(SMTLIBDataDir + 'bitwuzla_46k.csv')
-    df_leanwuzla_46k = pd.read_csv(SMTLIBDataDir + 'leanwuzla_46k.csv')
-    df_leanwuzla_trusted_46k = pd.read_csv(SMTLIBDataDir + 'leanwuzla_trusted_46k.csv')
-    df_coq_46k = pd.read_csv(SMTLIBDataDir + 'coq_46k.csv')
-    df_bitwuzla_46k_no_unknowns = df_bitwuzla_46k[df_bitwuzla_46k['result'] != 'unknown']
-    df_leanwuzla_46k_no_unknowns = df_leanwuzla_46k[df_leanwuzla_46k['result'] != 'unknown']
-    df_leanwuzla_trusted_46k_no_unknowns = df_leanwuzla_trusted_46k[df_leanwuzla_trusted_46k['result'] != 'unknown']
-    df_leanwuzla_trusted_46k_no_unknowns = df_leanwuzla_trusted_46k_no_unknowns.rename(columns = lambda x : x + '_lwt' if x != 'benchmark' else x)
-    df_coq_46k_no_unknowns = df_coq_46k[df_coq_46k['result'] != 'unknown']
-    df_coq_46k_no_unknowns = df_coq_46k_no_unknowns.rename(columns = lambda x : x + '_coq' if x != 'benchmark' else x)
-    merged_df = pd.merge(df_bitwuzla_46k_no_unknowns, df_leanwuzla_46k_no_unknowns, how = 'outer', on = 'benchmark', suffixes = ('_bw', '_lw'))
-    merged_df = pd.merge(merged_df, df_leanwuzla_trusted_46k_no_unknowns, how = 'outer', on = 'benchmark')
-    merged_df_tot = pd.merge(merged_df, df_coq_46k_no_unknowns, how = 'outer', on = 'benchmark')
-    df_sat = merged_df_tot.loc[lambda x: (x['result_bw'] == 'sat') | (x['result_lw'] == 'sat') | (x['result_coq'] == 'sat')]
-    df_unsat = merged_df_tot.loc[lambda x: (x['result_bw'] == 'unsat') | (x['result_lw'] == 'unsat') | (x['result_coq'] == 'unsat')]
-    # separate sat from unsat 
-    cumul_solving_time_smtlib(df_sat, 'sat')
-    cumul_solving_time_smtlib(df_unsat, 'unsat')
+    df_bitwuzla = pd.read_csv(SMTLIBDataDir + "bitwuzla_data.csv")
+    df_bv_decide = pd.read_csv(SMTLIBDataDir + "bv_decide_data.csv")
+    df_bv_decide_nokernel = pd.read_csv(SMTLIBDataDir + "bv_decide-nokernel_data.csv")
+    df_coq_qfbv = pd.read_csv(SMTLIBDataDir + "coqQFBV_data.csv")
+    df_bitwuzla["benchmark"] = df_bitwuzla["benchmark"].apply(os.path.dirname)
+    df_bv_decide["benchmark"] = df_bv_decide["benchmark"].apply(os.path.dirname)
+    df_bv_decide_nokernel["benchmark"] = df_bv_decide_nokernel["benchmark"].apply(
+        os.path.dirname
+    )
+    df_coq_qfbv["benchmark"] = df_coq_qfbv["benchmark"].apply(os.path.dirname)
+    df_bitwuzla_no_unknowns = df_bitwuzla[df_bitwuzla["result"] != "unknown"]
+    df_bv_decide_no_unknowns = df_bv_decide[df_bv_decide["result"] != "unknown"]
+    df_bv_decide_nokernel_no_unknowns = df_bv_decide_nokernel[
+        df_bv_decide_nokernel["result"] != "unknown"
+    ]
+    df_bv_decide_nokernel_no_unknowns = df_bv_decide_nokernel_no_unknowns.rename(
+        columns=lambda x: x + "_lwt" if x != "benchmark" else x
+    )
+    df_coq_qfbv_no_unknowns = df_coq_qfbv[df_coq_qfbv["result"] != "unknown"]
+    df_coq_qfbv_no_unknowns = df_coq_qfbv_no_unknowns.rename(
+        columns=lambda x: x + "_coq" if x != "benchmark" else x
+    )
+    merged_df = pd.merge(
+        df_bitwuzla_no_unknowns,
+        df_bv_decide_no_unknowns,
+        how="outer",
+        on="benchmark",
+        suffixes=("_bw", "_lw"),
+    )
+    merged_df = pd.merge(
+        merged_df, df_bv_decide_nokernel_no_unknowns, how="outer", on="benchmark"
+    )
+    merged_df_tot = pd.merge(
+        merged_df, df_coq_qfbv_no_unknowns, how="outer", on="benchmark"
+    )
+    df_sat = merged_df_tot.loc[
+        lambda x: (x["result_bw"] == "sat")
+        | (x["result_lw"] == "sat")
+        | (x["result_lwt"] == "sat")
+        | (x["result_coq"] == "sat")
+    ]
+    df_unsat = merged_df_tot.loc[
+        lambda x: (x["result_bw"] == "unsat")
+        | (x["result_lw"] == "unsat")
+        | (x["result_lwt"] == "unsat")
+        | (x["result_coq"] == "unsat")
+    ]
+    # separate sat from unsat
+    cumul_solving_time_smtlib(df_sat, "sat")
+    cumul_solving_time_smtlib(df_unsat, "unsat")
     scatter_solving_time_smtlib(df_sat, df_unsat)
     # plot stacked area plot
-    df_leanwuzla_46k_stats = pd.read_csv(SMTLIBDataDir + 'leanwuzla_46k_stats.csv')
-    df_sat_stats = df_leanwuzla_46k_stats[df_leanwuzla_46k_stats['leanSAT-res'] == 'sat']
-    df_unsat_stats = df_leanwuzla_46k_stats[df_leanwuzla_46k_stats['leanSAT-res'] == 'unsat']
-    leanSAT_smtlib_sat_stacked_perc(df_sat_stats, 'sat', 'i')
-    leanSAT_smtlib_unsat_stacked_perc(df_unsat_stats, 'unsat', 'i')
-    df_leanwuzla_trusted_46k_stats = pd.read_csv(SMTLIBDataDir + 'leanwuzla_trusted_46k_stats.csv')
-    df_sat_stats = df_leanwuzla_trusted_46k_stats[df_leanwuzla_trusted_46k_stats['leanSAT-res'] == 'sat']
-    df_unsat_stats = df_leanwuzla_trusted_46k_stats[df_leanwuzla_trusted_46k_stats['leanSAT-res'] == 'unsat']
-    leanSAT_smtlib_sat_stacked_perc(df_sat_stats, 'trusted_sat', 'i')
-    leanSAT_smtlib_unsat_stacked_perc(df_unsat_stats, 'trusted_unsat', 'i')
-    
+    df_sat_stats = df_bv_decide[df_bv_decide["result"] == "sat"]
+    df_unsat_stats = df_bv_decide[df_bv_decide["result"] == "unsat"]
+    bv_decide_smtlib_sat_stacked_perc(df_sat_stats, "sat", "i")
+    bv_decide_smtlib_unsat_stacked_perc(df_unsat_stats, "unsat", "i")
+    df_sat_stats = df_bv_decide_nokernel[df_bv_decide_nokernel["result"] == "sat"]
+    df_unsat_stats = df_bv_decide_nokernel[df_bv_decide_nokernel["result"] == "unsat"]
+    bv_decide_smtlib_sat_stacked_perc(df_sat_stats, "nokernel_sat", "i")
+    bv_decide_smtlib_unsat_stacked_perc(df_unsat_stats, "nokernel_unsat", "i")
+
+
 def main():
     parser = argparse.ArgumentParser(
         prog="plot",

--- a/bv-evaluation/solvers/bitwuzla.sh
+++ b/bv-evaluation/solvers/bitwuzla.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -e
+
+input_file="$1"
+
+# Measure time
+start_time=$(date +%s%N) # Start time in nanoseconds
+"$PWD/solvers/bitwuzla/build/src/main/bitwuzla" "$input_file"
+end_time=$(date +%s%N)   # End time in nanoseconds
+
+# Calculate and print the elapsed time
+time=$((end_time - start_time))
+echo "[time] total: $time"

--- a/bv-evaluation/solvers/bv_decide-nokernel.sh
+++ b/bv-evaluation/solvers/bv_decide-nokernel.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -e
+
+input_file="$1"
+
+export PATH="$HOME/.elan/toolchains/leanprover--lean4-nightly---nightly-2025-06-20/bin:$PATH"
+export LEAN_PATH="$PWD/solvers/Leanwuzla/.lake/build/lib/lean:$HOME/.elan/toolchains/leanprover--lean4-nightly---nightly-2025-06-20/lib/lean"
+
+ulimit -s unlimited
+
+# Measure time
+start_time=$(date +%s%N) # Start time in nanoseconds
+"$PWD/solvers/Leanwuzla/.lake/build/bin/leanwuzla" --disableKernel --disableEmbeddedConstraintSubst --expthreshold=32768 --acnf --timeout=1200 --maxSteps=100000000 --maxHeartbeats=200000000 --maxRecDepth=1048576 "$input_file"
+end_time=$(date +%s%N)   # End time in nanoseconds
+
+# Calculate and print the elapsed time
+time=$((end_time - start_time))
+echo "[time] total: $time"

--- a/bv-evaluation/solvers/bv_decide.sh
+++ b/bv-evaluation/solvers/bv_decide.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -e
+
+input_file="$1"
+
+export PATH="$HOME/.elan/toolchains/leanprover--lean4-nightly---nightly-2025-06-20/bin:$PATH"
+export LEAN_PATH="$PWD/solvers/Leanwuzla/.lake/build/lib/lean:$HOME/.elan/toolchains/leanprover--lean4-nightly---nightly-2025-06-20/lib/lean"
+
+ulimit -s unlimited
+
+# Measure time
+start_time=$(date +%s%N) # Start time in nanoseconds
+"$PWD/solvers/Leanwuzla/.lake/build/bin/leanwuzla" --disableEmbeddedConstraintSubst --expthreshold=32768 --acnf --timeout=1200 --maxSteps=100000000 --maxHeartbeats=200000000 --maxRecDepth=1048576 "$input_file"
+end_time=$(date +%s%N)   # End time in nanoseconds
+
+# Calculate and print the elapsed time
+time=$((end_time - start_time))
+echo "[time] total: $time"

--- a/bv-evaluation/solvers/coqQFBV.sh
+++ b/bv-evaluation/solvers/coqQFBV.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -e
+
+input_file="$1"
+
+export PATH="$PWD/solvers/coq-qfbv/bin:$PATH"
+export OCAMLRUNPARAM="s=2G"
+
+# Measure time
+start_time=$(date +%s%N) # Start time in nanoseconds
+"$PWD/solvers/coq-qfbv/bin/coqQFBV.exe" "$input_file"
+end_time=$(date +%s%N)   # End time in nanoseconds
+
+# Calculate and print the elapsed time
+time=$((end_time - start_time))
+echo "[time] total: $time"

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ packaging==24.2
 pandas==2.2.3
 pillow==11.1.0
 polars==1.24.0
+psutil==7.0.0
 pyparsing==3.2.1
 python-dateutil==2.9.0.post0
 pytz==2025.1

--- a/shell.nix
+++ b/shell.nix
@@ -7,6 +7,7 @@ with pkgs;let
     pandas
     polars
     num2words
+    psutil
   ];
   my-python = pkgs.python3.withPackages my-python-packages;
 in


### PR DESCRIPTION
This WIP PR sets up the initial SMT-LIB benchmarking framework. It installs the relevant solvers and introduces `results/run_smtlib_benchmarks.py`, which executes benchmarks in parallel and stores results under `bv-evaluation/results`. TODO:
- Develop scripts to aggregate benchmark data into CSV format.
- Integrate with plotting and statistics scripts.
- Refactor `results/run_smtlib_benchmarks.py` to:
  - Reorganize output paths for clarity.
  - Enable shared task pools across solvers when possible (low priority).