### PR TITLE
fix: tweak `hide_constants` to avoid exponentiation threshold

### DIFF
--- a/SSA/Projects/InstCombine/AliveHandwrittenLargeExamples.lean
+++ b/SSA/Projects/InstCombine/AliveHandwrittenLargeExamples.lean
@@ -504,7 +504,9 @@ def alive_simplifySelect764 (w : Nat) :
   simp_alive_ops
   simp_alive_case_bash
   intro A
-  simp only [BitVec.slt, ofBool_eq_one, toInt_zero, decide_eq_true_eq, BitVec.zero_sub]
+  simp only [BitVec.slt, ofInt_ofNat, toInt_zero, ofBool_eq_one, decide_eq_true_eq, BitVec.zero_sub,
+    PoisonOr.ite_value_value, PoisonOr.value_bind, PoisonOr.value_isRefinedBy_value,
+    InstCombine.bv_isRefinedBy_iff]
   split
   next => simp
   next A_ge_zero =>

--- a/SSA/Projects/InstCombine/Tactic/SimpLLVM.lean
+++ b/SSA/Projects/InstCombine/Tactic/SimpLLVM.lean
@@ -230,6 +230,6 @@ macro "simp_alive_ops" : tactic =>
       -- We need to use `BitVec.ofInt_ofNat` again, as it may have been
       -- previously blocked by a `hide`
       simp -failIfUnchanged only [
-        (BitVec.ofInt_ofNat)
+        (BitVec.ofInt_ofNat), BitVec.ofInt_neg
       ]
     ))

--- a/SSA/Projects/InstCombine/Tactic/SimpLLVM.lean
+++ b/SSA/Projects/InstCombine/Tactic/SimpLLVM.lean
@@ -227,4 +227,9 @@ macro "simp_alive_ops" : tactic =>
           (BitVec.ofInt_ofNat)
         ]
       unhide_constants
+      -- We need to use `BitVec.ofInt_ofNat` again, as it may have been
+      -- previously blocked by a `hide`
+      simp -failIfUnchanged only [
+        (BitVec.ofInt_ofNat)
+      ]
     ))

--- a/SSA/Projects/InstCombine/Tactic/SimpLLVM.lean
+++ b/SSA/Projects/InstCombine/Tactic/SimpLLVM.lean
@@ -193,7 +193,8 @@ open HideConstants (cast_self_hide_eq)
 macro "unhide_constants" : tactic => `(tactic|
   all_goals simp -failIfUnchanged only [hide_eq, cast_self_hide_eq,
     cast_self_hide_eq (fun w x => PoisonOr.value (BitVec.ofInt w x)),
-    cast_self_hide_eq (fun w x => PoisonOr.value (BitVec.ofNat w x))]
+    cast_self_hide_eq (fun w x => PoisonOr.value (BitVec.ofNat w x)),
+    cast_self_hide_eq (fun w x => PoisonOr.value (-BitVec.ofNat w x))]
   -- ----------------- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   -- We specify these anually as inference usually won't manage to
   -- instantiate `cast_self_hide_eq` like this without assistance.


### PR DESCRIPTION
This PR tweaks the hide_constants so that `LLVM.const? w x` is now rewritten to `hide (LLVM.const? (hide w) x`, instead of `hide (LLVM.const? _ _)`. This was not necessary to avoid the original deep recursion errors, but, in some examples it seems that `2 ^ w` was still being evaluated, leading to errors talking about the exponentiation threshold. (NOTE: these did not seem to be kernel errors, rather this seemed to be happening in the elaborator). By explicitly hiding the `w` value, the problematic expression becomes `2 ^ (hide w)`, which Lean will not attempt to evaluate, silencing the aforementioned exponentation threshold error.

We did have to insert a cast, as the return type now changed from `IntW w` to `IntW (hide w)`, so we had to tweak unhide_constants as well to properly eliminate this cast. Furthermore, this PR removes the check whether `x` is a "constant", instead choosing to hide any expression. There is no real cost to doing the rewrite, so this isConstant check was unneccessary complexity, which would've been even more complex to maintain after this change.
