### PR TITLE
feat: produce UNSAT cert for k-induction, and use the no-axiomatized-proof to produce an end-to-end sorry free proof

### DIFF
--- a/SSA/Experimental/Bits/Fast/Tests.lean
+++ b/SSA/Experimental/Bits/Fast/Tests.lean
@@ -11,9 +11,6 @@ import SSA.Experimental.Bits.Frontend.Tactic
 import SSA.Experimental.Bits.Fast.MBA
 import SSA.Projects.InstCombine.TacticAuto
 
-
-
-
 open Lean Meta Elab Tactic in
 #eval show TermElabM Unit from do
   let fsm : FSM (Fin 1) := FSM.mk (α := Unit)
@@ -46,9 +43,7 @@ open NNF in
 theorem eq3 (w : Nat) (a b : BitVec w) : a = a ||| 0 := by
   bv_automata_gen (config := {backend := .circuit_cadical_verified } )
 
-/--
-info: 'eq3' depends on axioms: [propext, Quot.sound, ReflectVerif.BvDecide.decideIfZerosByKInductionCycleBreakingAx]
--/
+/-- info: 'eq3' depends on axioms: [propext, Classical.choice, Lean.ofReduceBool, Quot.sound] -/
 #guard_msgs in #print axioms eq3
 
 example (w : Nat) (a b : BitVec w) : a = a + 0 := by
@@ -59,7 +54,7 @@ theorem check_axioms (w : Nat) (a b : BitVec w) : a + b = b + a := by
   bv_automata_gen (config := {backend := .circuit_cadical_verified} )
 
 /--
-info: 'check_axioms' depends on axioms: [propext, Quot.sound, ReflectVerif.BvDecide.decideIfZerosByKInductionCycleBreakingAx]
+info: 'check_axioms' depends on axioms: [propext, Classical.choice, Lean.ofReduceBool, Quot.sound]
 -/
 #guard_msgs in #print axioms check_axioms
 
@@ -453,10 +448,7 @@ def width_1_char_2_add_four (x : BitVec w) (hw : w = 1) : x + x + x + x = 0#w :=
   bv_automata_gen (config := {backend := .circuit_cadical_verified} )
 
 /--
-info: 'width_1_char_2_add_four' depends on axioms: [propext,
- Classical.choice,
- Quot.sound,
- ReflectVerif.BvDecide.decideIfZerosByKInductionCycleBreakingAx]
+info: 'width_1_char_2_add_four' depends on axioms: [propext, Classical.choice, Lean.ofReduceBool, Quot.sound]
 -/
 #guard_msgs in #print axioms width_1_char_2_add_four
 

--- a/SSA/Experimental/Bits/Fast/Tests.lean
+++ b/SSA/Experimental/Bits/Fast/Tests.lean
@@ -317,9 +317,7 @@ def test2_gen (x y : BitVec w) : (~~~(x ^^^ y)) = ((x &&& y) + ~~~(x ||| y)) := 
 def test24 (x y : BitVec w) : (x ||| y) = (( x &&& (~~~y)) + y) := by
   bv_automata_gen (config := {backend := .circuit_cadical_verified} )
 
-/--
-info: 'test24' depends on axioms: [propext, Quot.sound, ReflectVerif.BvDecide.decideIfZerosByKInductionCycleBreakingAx]
--/
+/-- info: 'test24' depends on axioms: [propext, Classical.choice, Lean.ofReduceBool, Quot.sound] -/
 #guard_msgs in #print axioms test24
 
 def test25 (x y : BitVec w) : (x &&& y) = (((~~~x) ||| y) - ~~~x) := by


### PR DESCRIPTION
This revives code from https://raw.githubusercontent.com/opencompl/lean-mlir/3e0ff379b5e92427747f8dc84c6f77609bda7e67/SSA/Experimental/Bits/Fast/ReflectVerif.lean, which will now complete the end-to-end trust story and will produce UNSAT certs. 

Stacked on top of  #1376 