### PR TITLE
feat: eliminate counter-examples

### DIFF
--- a/SSA/Projects/InstCombine/Tactic/ReduceModTwoPow.lean
+++ b/SSA/Projects/InstCombine/Tactic/ReduceModTwoPow.lean
@@ -1,0 +1,37 @@
+import Lean
+import Std.Tactic.BVDecide
+
+open Lean Meta
+
+namespace Nat
+
+/-- Auxiliary lemma for `Nat.reduceModTwoPow` simproc. -/
+theorem lt_two_pow_succ_of_lt (x y : Nat) :
+    (x / 2) < 2 ^ y → x < 2 ^ (y + 1) := by
+  omega
+
+def mkLtTwoPowProof (x y : Nat) : Option Expr :=
+  match y with
+  | 0   => none
+  | y'+1 => do
+    if x = 0 then
+      return mkApp (mkConst ``Nat.two_pow_pos) (toExpr y)
+    else
+      let h ← mkLtTwoPowProof (x / 2) y'
+      return mkApp3 (mkConst ``Nat.lt_two_pow_succ_of_lt) (toExpr x) (toExpr y') h
+
+simproc ↓ reduceModTwoPow ((_ : Nat) % 2 ^ (_ : Nat)) := fun e => do
+  let_expr HMod.hMod _α _β _γ _self x rhs := e | return .continue
+  let_expr HPow.hPow _α _β _γ _self _ y := rhs | return .continue
+  let some xVal := x.nat? | return .continue
+  let some yVal := y.nat? | return .continue
+
+  let some ltProof := mkLtTwoPowProof xVal yVal
+    | return .continue
+
+  return .done {
+    expr := x
+    proof? := mkApp3 (mkConst ``Nat.mod_eq_of_lt) x rhs ltProof
+  }
+
+attribute [bv_normalize] reduceModTwoPow

--- a/SSA/Projects/InstCombine/Tactic/SimpLLVM.lean
+++ b/SSA/Projects/InstCombine/Tactic/SimpLLVM.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 import SSA.Core.Framework.Trace
 import SSA.Projects.InstCombine.ForLean
 import SSA.Projects.InstCombine.LLVM.EDSL
+import SSA.Projects.Tactic.ReduceModTwoPow
 
 open Lean
 open Lean.Elab.Tactic

--- a/SSA/Projects/InstCombine/Tactic/SimpLLVM.lean
+++ b/SSA/Projects/InstCombine/Tactic/SimpLLVM.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 import SSA.Core.Framework.Trace
 import SSA.Projects.InstCombine.ForLean
 import SSA.Projects.InstCombine.LLVM.EDSL
-import SSA.Projects.Tactic.ReduceModTwoPow
+import SSA.Projects.InstCombine.Tactic.ReduceModTwoPow
 
 open Lean
 open Lean.Elab.Tactic


### PR DESCRIPTION
This PR adds a simproc that rewrites `n % 2 ^ w` into `n` (given that `n < 2 ^ w`). This simproc has a custom procedure to construct a proof of the inequality, hence it works smoothly even when the exponent is large (I tested it for `w = 1000`), without having to touch the exponentiation threshold. When I ran the evaluation locally, it reported 0 counterexamples :tada:.

This simproc could eventually be upstreamed to bv_decide proper, but let's first merge it here so that we have a clean artifact.