### PR TITLE
chore: add table to dockerfile

### DIFF
--- a/artifacts/oopsla25-bv-decide/Dockerfile
+++ b/artifacts/oopsla25-bv-decide/Dockerfile
@@ -41,9 +41,7 @@ ENV PATH=/home/user/.elan/bin:$PATH
 
 # Install bv-theorem-table-maker
 
-RUN git clone https://github.com/opencompl/bv-theorem-table-maker.git && cd bv-theorem-table-maker && git checkout 4a3b029fbcea100f54d79261ed6ed1e6e8b8bc2d && make 
-# Print the table in the terminal
-RUN python3 mk-latex-table.py
+RUN git clone https://github.com/opencompl/bv-theorem-table-maker.git && cd bv-theorem-table-maker && git checkout 4a3b029fbcea100f54d79261ed6ed1e6e8b8bc2d 
 
 # Download and unzip SMT-LIB QF_BV benchmarks
 RUN mkdir -p bv-evaluation/SMT-LIB

--- a/artifacts/oopsla25-bv-decide/Dockerfile
+++ b/artifacts/oopsla25-bv-decide/Dockerfile
@@ -39,6 +39,12 @@ WORKDIR /home/user/lean-mlir
 RUN curl https://elan.lean-lang.org/elan-init.sh -sSf | sh -s -- -y --default-toolchain none
 ENV PATH=/home/user/.elan/bin:$PATH
 
+# Install bv-theorem-table-maker
+
+RUN git clone https://github.com/opencompl/bv-theorem-table-maker.git && cd bv-theorem-table-maker && git checkout 4a3b029fbcea100f54d79261ed6ed1e6e8b8bc2d && make 
+# Print the table in the terminal
+RUN python3 mk-latex-table.py
+
 # Download and unzip SMT-LIB QF_BV benchmarks
 RUN mkdir -p bv-evaluation/SMT-LIB
 RUN curl -L -o QF_BV.tar.zst https://zenodo.org/records/15493090/files/QF_BV.tar.zst?download=1 && \

--- a/artifacts/oopsla25-bv-decide/Dockerfile
+++ b/artifacts/oopsla25-bv-decide/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get update && \
         ninja-build \
         gdb curl wget zstd unzip sudo \
         # dependencies for experiment scripts
-        python3-matplotlib python3-pandas python3-num2words \
+        python3-matplotlib python3-pandas python3-num2words python3-tabulate \
         # bitwuzla dependencies
         meson libgmp-dev libcadical-dev libsymfpu-dev pkg-config \
         # CoqQFBV dependencies

--- a/artifacts/oopsla25-bv-decide/artifact.tex
+++ b/artifacts/oopsla25-bv-decide/artifact.tex
@@ -162,6 +162,16 @@ which can be used to build the docker image that is uploaded to docker hub.
 % $ docker run --name oopsla25-bv-decide -it oopsla25-bv-decide
 % \end{script}
 
+\section{BitVec API}
+To reproduce our results concerning the converage of the BitVec API (Table 1), one can rune the following: 
+\begin{script}
+$ cd /home/user/bv-decide-table-maker
+# Parse the library and build the table
+$ make
+# Print the table in the terminal
+$ python3 mk-latex-table.py
+\end{script}
+
 \section{Experiments Reproduction}
 
 Three main scripts are involved in the reproduction of our results and plots:

--- a/artifacts/oopsla25-bv-decide/artifact.tex
+++ b/artifacts/oopsla25-bv-decide/artifact.tex
@@ -163,7 +163,7 @@ which can be used to build the docker image that is uploaded to docker hub.
 % \end{script}
 
 \section{BitVec API}
-To reproduce our results concerning the converage of the BitVec API (Table 1), one can rune the following: 
+To reproduce our results concerning the converage of the BitVec API (Table 1), one can run the following: 
 \begin{script}
 $ cd /home/user/bv-decide-table-maker
 # Parse the library and build the table


### PR DESCRIPTION
This PR adds `bv-theorem-table-maker` to the `Dockerfile` to reproduce the bitvec table in the `bv_decide` paper.