### PR TITLE
[Generalizer] Prettify results

### DIFF
--- a/SSA/Experimental/Bits/Fast/Generalize.lean
+++ b/SSA/Experimental/Bits/Fast/Generalize.lean
@@ -1515,6 +1515,4 @@ elab "#generalize" expr:term: command =>
 variable {x y : BitVec 8}
 #generalize (0#8 - x ||| y) + y = (y ||| 0#8 - x) + y
 
-#eval BitVec.ult (BitVec.ofInt 4 (0)) (BitVec.ofInt 4 9)
-
 end Generalize

--- a/SSA/Experimental/Bits/Fast/Generalize.lean
+++ b/SSA/Experimental/Bits/Fast/Generalize.lean
@@ -1370,6 +1370,8 @@ def checkForPreconditions (constantAssignments : List (Std.HashMap Nat BVExpr.Pa
 def prettifyBVExpr (bvExpr : BVExpr w) (variableDisplayNames: Std.HashMap Nat String) : String :=
     match bvExpr with
     | .var idx => variableDisplayNames[idx]!
+    | .const bv =>
+       toString bv.toInt
     | .bin _ BVBinOp.add (BVExpr.un BVUnOp.not operand)  =>
        s! "(-{prettifyBVExpr operand variableDisplayNames})"
     | .bin lhs BVBinOp.add (.bin _ BVBinOp.add (BVExpr.un BVUnOp.not rhs)) => -- A subtraction

--- a/SSA/Experimental/Bits/Fast/Generalize.lean
+++ b/SSA/Experimental/Bits/Fast/Generalize.lean
@@ -1373,12 +1373,12 @@ def prettifyBVExpr (bvExpr : BVExpr w) (displayNames: Std.HashMap Nat String) : 
     | .const bv =>
        toString bv.toInt
     | .bin (BVExpr.const bv) BVBinOp.add (BVExpr.un BVUnOp.not rhs)  =>
-       if bv == (BitVec.ofInt w (-1)) then
+       if bv.toInt == 1 then
         s! "(-{prettifyBVExpr rhs displayNames})"
       else
         s! "({prettifyBVExpr (BVExpr.const bv) displayNames} + {prettifyBVExpr (BVExpr.un BVUnOp.not rhs) displayNames})"
     | .bin lhs BVBinOp.add (.bin  (BVExpr.const bv) BVBinOp.add (BVExpr.un BVUnOp.not rhs)) =>
-      if bv == (BitVec.ofInt w (-1)) then -- A subtraction
+      if bv.toInt == 1 then -- A subtraction
         s! "({prettifyBVExpr lhs displayNames} - {prettifyBVExpr rhs displayNames})"
       else
         s! "({prettifyBVExpr lhs displayNames} + ({prettifyBVExpr (BVExpr.const bv) displayNames} + {prettifyBVExpr (BVExpr.un BVUnOp.not rhs) displayNames}))"
@@ -1394,7 +1394,7 @@ def prettifyBVExpr (bvExpr : BVExpr w) (displayNames: Std.HashMap Nat String) : 
         s! "({prettifyBVExpr lhs displayNames} >>a {prettifyBVExpr rhs displayNames})"
     | _ => bvExpr.toString
 
-   
+
 def prettify (generalization: BVLogicalExpr) (displayNames: Std.HashMap Nat String) : String :=
   match generalization with
   | .literal (BVPred.bin lhs op rhs) => s! "({prettifyBVExpr lhs displayNames} {op.toString} {prettifyBVExpr rhs displayNames})"

--- a/SSA/Experimental/Bits/Fast/Generalize.lean
+++ b/SSA/Experimental/Bits/Fast/Generalize.lean
@@ -1394,11 +1394,11 @@ def prettifyBVExpr (bvExpr : BVExpr w) (variableDisplayNames: Std.HashMap Nat St
 
 def prettify (generalization: BVLogicalExpr) (variableDisplayNames: Std.HashMap Nat String) : String :=
   match generalization with
-  | .literal (BVPred.bin lhs op rhs) => s! "{prettifyBVExpr lhs variableDisplayNames} {op.toString} {prettifyBVExpr rhs variableDisplayNames}"
+  | .literal (BVPred.bin lhs op rhs) => s! "({prettifyBVExpr lhs variableDisplayNames} {op.toString} {prettifyBVExpr rhs variableDisplayNames})"
   | .not boolExpr =>
-      s! "!{prettify boolExpr variableDisplayNames}"
+      s! "!({prettify boolExpr variableDisplayNames})"
   | .gate op lhs rhs =>
-      s! "{prettify lhs variableDisplayNames} {op.toString} {prettify rhs variableDisplayNames}"
+      s! "({prettify lhs variableDisplayNames}) {op.toString} ({prettify rhs variableDisplayNames})"
   | .ite cond positive _ =>
       s! "if {prettify cond variableDisplayNames} then {prettify positive variableDisplayNames} "
   | _ => generalization.toString
@@ -1446,8 +1446,6 @@ elab "#generalize" expr:term: command =>
             let mut bvLogicalExpr := parsedBVLogicalExpr.bvLogicalExpr
             let parsedBVState := parsedBVLogicalExpr.state
             let originalWidth := parsedBVState.originalWidth
-
-           -- TODO: Verify correctness in the original width
 
             let mut constantAssignments := []
             --- Synthesize constants in a lower width if needed

--- a/SSA/Experimental/Bits/Fast/Generalize.lean
+++ b/SSA/Experimental/Bits/Fast/Generalize.lean
@@ -1365,16 +1365,12 @@ def checkForPreconditions (constantAssignments : List (Std.HashMap Nat BVExpr.Pa
             throwError m! "Synthesis Timeout Failure: Exceeded timeout of {state.timeout/1000}s"
   return none
 
+
 def prettifyBVExpr (bvExpr : BVExpr w) (displayNames: Std.HashMap Nat String) : String :=
     match bvExpr with
     | .var idx => displayNames[idx]!
     | .const bv =>
        toString bv.toInt
-    | .bin (BVExpr.const bv) BVBinOp.add (BVExpr.un BVUnOp.not rhs)  =>
-       if bv.toInt == 1 then
-        s! "(-{prettifyBVExpr rhs displayNames})"
-      else
-        s! "({prettifyBVExpr (BVExpr.const bv) displayNames} + {prettifyBVExpr (BVExpr.un BVUnOp.not rhs) displayNames})"
     | .bin lhs BVBinOp.add (.bin  (BVExpr.const bv) BVBinOp.add (BVExpr.un BVUnOp.not rhs)) =>
       if bv.toInt == 1 then -- A subtraction
         s! "({prettifyBVExpr lhs displayNames} - {prettifyBVExpr rhs displayNames})"

--- a/SSA/Experimental/Bits/Fast/Generalize.lean
+++ b/SSA/Experimental/Bits/Fast/Generalize.lean
@@ -1370,6 +1370,10 @@ def checkForPreconditions (constantAssignments : List (Std.HashMap Nat BVExpr.Pa
 def prettifyBVExpr (bvExpr : BVExpr w) (variableDisplayNames: Std.HashMap Nat String) : String :=
     match bvExpr with
     | .var idx => variableDisplayNames[idx]!
+    | .bin _ BVBinOp.add (BVExpr.un BVUnOp.not operand)  =>
+       s! "(-{prettifyBVExpr operand variableDisplayNames})"
+    | .bin lhs BVBinOp.add (.bin _ BVBinOp.add (BVExpr.un BVUnOp.not rhs)) => -- A subtraction
+       s! "({prettifyBVExpr lhs variableDisplayNames} - {prettifyBVExpr rhs variableDisplayNames})"
     | .bin lhs op rhs =>
        s! "({prettifyBVExpr lhs variableDisplayNames} {op.toString} {prettifyBVExpr rhs variableDisplayNames})"
     | .un op operand =>

--- a/SSA/Experimental/Bits/Fast/Generalize.lean
+++ b/SSA/Experimental/Bits/Fast/Generalize.lean
@@ -42,7 +42,7 @@ structure ParsedBVExprState where
   BVExprIdToFreeVar : Std.HashMap Nat Name
   originalWidth : Nat
   symVarToVal : Std.HashMap Nat BVExpr.PackedBitVec
-  symVarToDisplayName : Std.HashMap Nat Name
+  symVarToDisplayName : Std.HashMap Nat String
   valToSymVar : Std.HashMap BVExpr.PackedBitVec Nat
 
 
@@ -415,14 +415,16 @@ partial def toBVExpr (expr : Expr) (targetWidth: Nat) : ParseBVExprM (Option (BV
     let existingVal :=  currState.valToSymVar[pbv]?
     match existingVal with
     | none =>
-      let newId := 1001 + currState.numSymVars
+      let numSymVars := currState.numSymVars
+      let newId := 1001 + numSymVars
       let newExpr : BVExpr targetWidth := BVExpr.var newId
 
       let updatedState : ParsedBVExprState := { currState with
-                                              numSymVars := currState.numSymVars + 1
+                                              numSymVars := numSymVars + 1
                                               , originalWidth := pbv.w
                                               , symVarToVal := currState.symVarToVal.insert newId pbv
-                                              , valToSymVar := currState.valToSymVar.insert pbv newId}
+                                              , valToSymVar := currState.valToSymVar.insert pbv newId
+                                              , symVarToDisplayName := currState.symVarToDisplayName.insert newId s!"C{numSymVars + 1}"}
       set updatedState
       return some {bvExpr := newExpr, width := targetWidth}
     | some var => let newExpr : BVExpr targetWidth := BVExpr.var var

--- a/SSA/Experimental/Bits/Fast/Generalize.lean
+++ b/SSA/Experimental/Bits/Fast/Generalize.lean
@@ -920,13 +920,11 @@ def eqToZero (expr: BVExpr w) : BVLogicalExpr :=
 
 def positive (expr: BVExpr w) (widthId : Nat) : BVLogicalExpr :=
   let shiftDistance : BVExpr w := BVExpr.bin (BVExpr.var widthId) BVBinOp.add (negate (one w))
-  let mask := BVExpr.shiftLeft (one w) shiftDistance
-  let maskAndExpr := BVExpr.bin expr BVBinOp.and mask  -- It's positive if (expr && (1 << width -1) == 0)
-
-  eqToZero maskAndExpr
+  let signVal := BVExpr.shiftLeft (one w) shiftDistance
+  BoolExpr.literal (BVPred.bin expr BVBinPred.ult signVal) --- It's positive if `expr <u 2 ^ (w - 1)`
 
 def strictlyGTZero  (expr: BVExpr w) (widthId : Nat)  : BVLogicalExpr :=
-  BoolExpr.gate  Gate.and (BoolExpr.not (eqToZero expr)) (positive expr widthId)
+  BoolExpr.gate  Gate.and (BoolExpr.literal (BVPred.bin (zero w) BVBinPred.ult expr)) (positive expr widthId)
 
 def gteZero (expr: BVExpr w) (widthId : Nat)  : BVLogicalExpr :=
   positive expr widthId
@@ -1493,5 +1491,7 @@ elab "#generalize" expr:term: command =>
 
 variable {x y : BitVec 8}
 #generalize (0#8 - x ||| y) + y = (y ||| 0#8 - x) + y
+
+#eval BitVec.ult (BitVec.ofInt 4 (0)) (BitVec.ofInt 4 9)
 
 end Generalize

--- a/SSA/Experimental/Bits/Fast/GeneralizeTest.lean
+++ b/SSA/Experimental/Bits/Fast/GeneralizeTest.lean
@@ -39,11 +39,11 @@ variable {x y z: BitVec 32}
 #generalize (42#32 - x) <<< 3#32 = 336#32 - x <<< 3#32 -- PASSED gshlhsub_proof/shl_const_op1_sub_const_op0_thm; #11
 #generalize ((x >>> 4#32 &&& 8#32) + y) <<< 4#32 = (x &&& 128#32) + y <<< 4#32 --#PASSED gshlhbo_proof/shl_add_and_lshr_thm; #12
 #generalize (x + (y >>> 5#32 &&& 127#32)) <<< 5#32 = (y &&& 4064#32) + x <<< 5#32 --- PASSED gshlhbo_proof/lshr_add_and_shl_thm; #14
+#generalize x + (x ||| (0 - x )) = x &&& (x + BitVec.ofInt 32 (-1)) -- #19
 #generalize x <<< 6#32 <<< 28#32 = 0#32   -- PASSED ; shl_shl_thm #10
 #generalize 8#32 - x &&& 7#32 = 0#32 - x &&& 7#32 -- PASSED g2008h07h08hSubAnd_proof#a_thm #16
 #generalize x &&& 1#32 ||| 1#32 = 1#32 -- PASSED gandhorand_proof/or_test1_thm
 #generalize (x ||| y <<< 1#32) &&& 1#32 = x &&& 1#32 --- PASSED gandhorand_proof/test3_thm; #30
-#generalize x + (x ||| (0 - x )) = x &&& (x + BitVec.ofInt 32 (-1)) -- #19
 #generalize (x + 5) - (y + 1)  =  x - y + 4
 #generalize (x + 5) + (y + 1)  =  x + y + 6
 #generalize (x <<< 10) <<< 14 = x <<< 24 --- #42


### PR DESCRIPTION
Updated the output so we can generalize 

```
x << 1 ^ (y << 1#8 ^ -68) = (y ^ x) << 1#8 ^ (-68)
```
as 
```
(x << C1) ^ ((y << C1 ) ^ C2) = (y ^ x) << C1 ^ C2
```
instead of
```
(var1 << var1001) ^ ((var2 << var1001) ^ var1002) = (var2 ^ var1) << var1001 ^ var1002
```