### PR TITLE
feat: add multi width definitions and ensure that they are reflectable

### DIFF
--- a/SSA.lean
+++ b/SSA.lean
@@ -34,3 +34,4 @@ import SSA.Experimental.Bits.Fast
 import SSA.Experimental.Bits.SingleWidth.Tactic
 import SSA.Experimental.Bits.KInduction.KInduction
 import SSA.Experimental.Bits.KInduction.Tests
+import SSA.Experimental.Bits.MultiWidth.Tests

--- a/SSA/Experimental/Bits/Fast/BitStream.lean
+++ b/SSA/Experimental/Bits/Fast/BitStream.lean
@@ -1107,3 +1107,17 @@ theorem toBitVec_concat(a : BitStream) :
       | 0 => 0#0
       | w + 1 => (a.toBitVec w).concat b  := by
   rcases w with rfl | w <;> simp
+
+section InverseLimit
+
+def Bitstream.ofBitvecSequence (bs : (w : ℕ) → BitVec w) : BitStream :=
+    fun i => (bs (i + 1)).getLsbD i
+
+/--
+A bitvec sequence 'bs' is good, if it produces a sequence of bitvectors b₁, b₂, ..,
+where the truncations agree with each other.
+-/
+def Bitstream.goodBitvecSequence (bs : (w : ℕ) → BitVec w) : Prop :=
+  ∀ wsmall wlarge, wsmall ≤ wlarge →
+    (bs wlarge).setWidth wsmall = bs wsmall
+end InverseLimit

--- a/SSA/Experimental/Bits/MultiWidth/Defs.lean
+++ b/SSA/Experimental/Bits/MultiWidth/Defs.lean
@@ -1,5 +1,7 @@
 import Mathlib.Algebra.Notation.Defs
 import Mathlib.Order.Notation
+import SSA.Experimental.Bits.Fast.FiniteStateMachine
+import SSA.Experimental.Bits.Vars
 
 import Std.Tactic.BVDecide
 
@@ -11,63 +13,130 @@ inductive WidthExpr (n : Nat) : Type
 def WidthExpr.Env (n : Nat) : Type :=
   Fin n → Nat
 
-def WidthExpr.eval (e : WidthExpr n) (env : Fin n → Nat) : Nat :=
+def WidthExpr.toNat (e : WidthExpr n) (env : Fin n → Nat) : Nat :=
   match e with
   | .var v => env v
 
 inductive NatPredicate (n : Nat) : Type
 | eq : WidthExpr n → WidthExpr n → NatPredicate n
 
-def NatPredicate.eval (env : Fin n → Nat) : NatPredicate n → Prop
-  | .eq e1 e2 => WidthExpr.eval e1 env = WidthExpr.eval e2 env
+def NatPredicate.toProp (env : Fin n → Nat) : NatPredicate n → Prop
+  | .eq e1 e2 => WidthExpr.toNat e1 env = WidthExpr.toNat e2 env
 
 
-abbrev Term.Ctx (widthCard : Nat) (termCard : Nat) : Type :=
-  Fin termCard → WidthExpr widthCard
+abbrev Term.Ctx (wcard : Nat) (tcard : Nat) : Type :=
+  Fin tcard → WidthExpr wcard
 
-inductive Term
-  (ctx : Term.Ctx widthCard termCard) : (WidthExpr widthCard) → Type
+inductive Term {wcard tcard : Nat}
+  (ctx : Term.Ctx wcard tcard) : (WidthExpr wcard) → Type
 /-- a variable of a given width -/
-| var (v : Fin termCard) : Term ctx (ctx v)
+| var (v : Fin tcard) : Term ctx (ctx v)
 /-- addition of two terms of the same width -/
 | add (a : Term ctx w) (b : Term ctx w) : Term ctx w
 /-- zero extend a term to a given width -/
-| zext (a : Term ctx w) (v : WidthExpr widthCard) : Term ctx v
+| zext (a : Term ctx w) (v : WidthExpr wcard) : Term ctx v
 /-- sign extend a term to a given width -/
-| sext (a : Term ctx w) (v : WidthExpr widthCard) : Term ctx v
+| sext (a : Term ctx w) (v : WidthExpr wcard) : Term ctx v
 
 /--
 Environments are for evaluation.
 -/
 abbrev Term.Env
-  (tyCtx : Term.Ctx widthCard termCard)
-  (widthEnv : Fin widthCard → Nat) :=
-  (v : Fin termCard) → BitVec ((tyCtx v).eval widthEnv)
+  (tCtx : Term.Ctx wcard tcard)
+  (wenv : Fin wcard → Nat) :=
+  (v : Fin tcard) → BitVec ((tCtx v).toNat wenv)
 
 /-- Evaluate a term to get a concrete bitvector expression. -/
-def Term.eval {widthEnv : WidthExpr.Env widthCard}
-    (bvEnv : Term.Env termCard widthEnv) :
-  Term termCard w → BitVec (w.eval widthEnv)
-| .var v => bvEnv v
-| .add a b => a.eval bvEnv + b.eval bvEnv
-| .zext a v => (a.eval bvEnv).zeroExtend (v.eval widthEnv)
-| .sext a v => (a.eval bvEnv).signExtend (v.eval widthEnv)
+def Term.toBV {wenv : WidthExpr.Env wcard}
+    (tenv : Term.Env tcard wenv) :
+  Term tcard w → BitVec (w.toNat wenv)
+| .var v => tenv v
+| .add a b => a.toBV tenv + b.toBV tenv
+| .zext a v => (a.toBV tenv).zeroExtend (v.toNat wenv)
+| .sext a v => (a.toBV tenv).signExtend (v.toNat wenv)
 
 inductive BinaryRelationKind
 | eq
 
 inductive Predicate
-  (ctx : Term.Ctx widthCard termCard) : Type
-| binRel (k : BinaryRelationKind) (a : Term ctx w) (b : Term ctx w) : Predicate ctx
+  (ctx : Term.Ctx wcard tcard) : Type
+| binRel (k : BinaryRelationKind)
+    (a : Term ctx w) (b : Term ctx w) : Predicate ctx
 | and (p1 p2 : Predicate ctx) : Predicate ctx
 | or (p1 p2 : Predicate ctx) : Predicate ctx
 | not (p : Predicate ctx) : Predicate ctx
 
-section toBV
-end toBV
+def Predicate.toProp
+    {tCtx : Term.Ctx wcard tcard}
+    (tenv : Term.Env tCtx wenv)
+    (p : Predicate tCtx) : Prop :=
+  match p with
+  | .binRel k a b =>
+    match k with
+    | .eq => a.toBV tenv = b.toBV tenv
+  | .and p1 p2 => p1.toProp tenv ∧ p2.toProp tenv
+  | .or p1 p2 => p1.toProp tenv ∨ p2.toProp tenv
+  | .not p => ¬ p.toProp tenv
 
-section toBitstream
-end toBitstream
+section ToBitstream
 
+/--
+A width expression denotes a bitstream, whose
+value is true if for all indeces larger than 'env v'.
+-/
+def WidthExpr.toBitstream
+  (e : WidthExpr n)
+  (env : WidthExpr.Env n) : BitStream :=
+  match e with
+  | .var v => fun i => decide (env v ≤ i)
+
+
+def Term.toBitstream {wcard tcard : Nat}
+    {tctx :Term.Ctx wcard tcard}
+    {w : WidthExpr wcard}
+    (t : Term tctx w)
+    {wenv : WidthExpr.Env wcard}
+    (tenv : Term.Env tctx wenv) :
+    BitStream :=
+  BitStream.ofBitVec (t.toBV tenv)
+
+def Predicate.toBitstream {tCtx : Term.Ctx wcard tcard}
+    (p : Predicate tCtx)
+    {wenv : WidthExpr.Env wcard}
+    (tenv : Term.Env tCtx wenv) :
+    BitStream :=
+  match p with
+  | .binRel k a b =>
+    match k with
+    | .eq => fun i => a.toBitstream tenv i = b.toBitstream tenv i
+  | .and p1 p2 => (p1.toBitstream tenv) &&& (p2.toBitstream tenv)
+  | .or p1 p2 => (p1.toBitstream tenv) ||| (p2.toBitstream tenv)
+  | .not p => ~~~ (p.toBitstream tenv)
+
+end ToBitstream
+
+section ToFSM
+
+inductive StateSpace (wcard tcard : Nat)
+| widthVar (v : Fin wcard)
+| termVar (v : Fin tcard)
+deriving DecidableEq, Repr
+
+/-- the FSM that corresponds to a given nat-predicate. -/
+structure NatFSM (wcard : Nat) (v : WidthExpr wcard) where
+  fsm : FSM (StateSpace wcard 0)
+
+structure TermFSM {w : WidthExpr wcard}
+  (ctx : Term.Ctx wcard tcard)
+  (t : Term tCtx w) where
+  fsm : FSM (StateSpace wcard tcard)
+
+structure PredicateFSM
+  {tCtx : Term.Ctx wcard tcard}
+  (p : Predicate tCtx) where
+  fsm : FSM (StateSpace wcard tcard)
+
+
+end ToFSM
 
 end MultiWidth

--- a/SSA/Experimental/Bits/MultiWidth/Defs.lean
+++ b/SSA/Experimental/Bits/MultiWidth/Defs.lean
@@ -2,6 +2,7 @@ import Mathlib.Algebra.Notation.Defs
 import Mathlib.Order.Notation
 import SSA.Experimental.Bits.Fast.FiniteStateMachine
 import SSA.Experimental.Bits.Vars
+import Lean
 
 import Std.Tactic.BVDecide
 

--- a/SSA/Experimental/Bits/MultiWidth/Defs.lean
+++ b/SSA/Experimental/Bits/MultiWidth/Defs.lean
@@ -123,6 +123,20 @@ inductive StateSpace (wcard tcard : Nat)
 | termVar (v : Fin tcard)
 deriving DecidableEq, Repr
 
+
+/--
+A bitstream environment.
+-/
+structure Term.Ctx.GoodBitstreamEnv {wcard tcard : Nat}
+  (bs : StateSpace wcard tcard → BitStream)
+  {wenv : WidthExpr.Env wcard}
+  {tctx : Term.Ctx wcard tcard}
+  (tenv : tctx.Env wenv) where
+  hw : ∀ (v : Fin wcard),
+    BitStream.ofNat (wenv v)  = bs (StateSpace.widthVar v)
+  ht : ∀ (v : Fin tcard),
+    BitStream.ofBitVec (tenv v) = bs (StateSpace.termVar v)
+
 /-- the FSM that corresponds to a given nat-predicate. -/
 structure NatFSM (wcard : Nat) (v : WidthExpr wcard) where
   fsm : FSM (StateSpace wcard 0)

--- a/SSA/Experimental/Bits/MultiWidth/Defs.lean
+++ b/SSA/Experimental/Bits/MultiWidth/Defs.lean
@@ -63,6 +63,11 @@ inductive Predicate
 | or (p1 p2 : Predicate ctx) : Predicate ctx
 | not (p : Predicate ctx) : Predicate ctx
 
+section toBV
+end toBV
+
+section toBitstream
+end toBitstream
+
+
 end MultiWidth
-
-

--- a/SSA/Experimental/Bits/MultiWidth/Defs.lean
+++ b/SSA/Experimental/Bits/MultiWidth/Defs.lean
@@ -92,7 +92,6 @@ def WidthExpr.toBitstream
   match e with
   | .var v => fun i => decide (env v ≤ i)
 
-
 def Term.toBitstream {wcard tcard : Nat}
     {tctx :Term.Ctx wcard tcard}
     {w : WidthExpr wcard}
@@ -177,4 +176,13 @@ structure GoodPredicateFSM
 
 end ToFSM
 
+namespace Nondep
+
+inductive WidthExpr
+| var (v : Nat) : WidthExpr
+
+inductive Term : Type
+| var (v : Nat) : Term
+
+end Nondep
 end MultiWidth

--- a/SSA/Experimental/Bits/MultiWidth/Defs.lean
+++ b/SSA/Experimental/Bits/MultiWidth/Defs.lean
@@ -1,0 +1,68 @@
+import Mathlib.Algebra.Notation.Defs
+import Mathlib.Order.Notation
+
+import Std.Tactic.BVDecide
+
+namespace MultiWidth
+
+inductive WidthExpr (n : Nat) : Type
+| var : (v : Fin n) → WidthExpr n
+
+def WidthExpr.Env (n : Nat) : Type :=
+  Fin n → Nat
+
+def WidthExpr.eval (e : WidthExpr n) (env : Fin n → Nat) : Nat :=
+  match e with
+  | .var v => env v
+
+inductive NatPredicate (n : Nat) : Type
+| eq : WidthExpr n → WidthExpr n → NatPredicate n
+
+def NatPredicate.eval (env : Fin n → Nat) : NatPredicate n → Prop
+  | .eq e1 e2 => WidthExpr.eval e1 env = WidthExpr.eval e2 env
+
+
+abbrev Term.Ctx (widthCard : Nat) (termCard : Nat) : Type :=
+  Fin termCard → WidthExpr widthCard
+
+inductive Term
+  (ctx : Term.Ctx widthCard termCard) : (WidthExpr widthCard) → Type
+/-- a variable of a given width -/
+| var (v : Fin termCard) : Term ctx (ctx v)
+/-- addition of two terms of the same width -/
+| add (a : Term ctx w) (b : Term ctx w) : Term ctx w
+/-- zero extend a term to a given width -/
+| zext (a : Term ctx w) (v : WidthExpr widthCard) : Term ctx v
+/-- sign extend a term to a given width -/
+| sext (a : Term ctx w) (v : WidthExpr widthCard) : Term ctx v
+
+/--
+Environments are for evaluation.
+-/
+abbrev Term.Env
+  (tyCtx : Term.Ctx widthCard termCard)
+  (widthEnv : Fin widthCard → Nat) :=
+  (v : Fin termCard) → BitVec ((tyCtx v).eval widthEnv)
+
+/-- Evaluate a term to get a concrete bitvector expression. -/
+def Term.eval {widthEnv : WidthExpr.Env widthCard}
+    (bvEnv : Term.Env termCard widthEnv) :
+  Term termCard w → BitVec (w.eval widthEnv)
+| .var v => bvEnv v
+| .add a b => a.eval bvEnv + b.eval bvEnv
+| .zext a v => (a.eval bvEnv).zeroExtend (v.eval widthEnv)
+| .sext a v => (a.eval bvEnv).signExtend (v.eval widthEnv)
+
+inductive BinaryRelationKind
+| eq
+
+inductive Predicate
+  (ctx : Term.Ctx widthCard termCard) : Type
+| binRel (k : BinaryRelationKind) (a : Term ctx w) (b : Term ctx w) : Predicate ctx
+| and (p1 p2 : Predicate ctx) : Predicate ctx
+| or (p1 p2 : Predicate ctx) : Predicate ctx
+| not (p : Predicate ctx) : Predicate ctx
+
+end MultiWidth
+
+

--- a/SSA/Experimental/Bits/MultiWidth/Defs.lean
+++ b/SSA/Experimental/Bits/MultiWidth/Defs.lean
@@ -38,7 +38,7 @@ abbrev Term.Ctx (wcard : Nat) (tcard : Nat) : Type :=
 def Term.Ctx.empty (wcard : Nat) : Term.Ctx wcard 0 :=
   fun x => x.elim0
 
-def Term.Ctx.cons (ctx : Term.Ctx wcard tcard)
+def Term.Ctx.cons (wcard : Nat) {tcard : Nat} (ctx : Term.Ctx wcard tcard)
   (w : WidthExpr wcard) : Term.Ctx wcard (tcard + 1) :=
   fun v =>
     v.cases w (fun v' => ctx v')

--- a/SSA/Experimental/Bits/MultiWidth/Defs.lean
+++ b/SSA/Experimental/Bits/MultiWidth/Defs.lean
@@ -98,7 +98,7 @@ inductive Predicate
 | or (p1 p2 : Predicate ctx) : Predicate ctx
 | not (p : Predicate ctx) : Predicate ctx
 
-def Predicate.toProp
+def Predicate.toProp {wcard tcard : Nat} {wenv : WidthExpr.Env wcard}
     {tctx : Term.Ctx wcard tcard}
     (tenv : tctx.Env wenv)
     (p : Predicate tctx) : Prop :=
@@ -205,6 +205,13 @@ structure GoodPredicateFSM
       fsm.eval fsmEnv = p.toBitstream tenv
 
 end ToFSM
+
+namespace Decide
+theorem Predicate.toProp_of_decide
+    {wcard tcard : Nat}
+    {tctx : Term.Ctx wcard tcard} (p : Predicate tctx) (hdecide : decide (1 = 1) = true) :
+    (∀ {wenv : WidthExpr.Env wcard} (tenv : tctx.Env wenv), p.toProp tenv) := by sorry
+end Decide
 
 namespace Nondep
 

--- a/SSA/Experimental/Bits/MultiWidth/Defs.lean
+++ b/SSA/Experimental/Bits/MultiWidth/Defs.lean
@@ -14,6 +14,13 @@ inductive WidthExpr (n : Nat) : Type
 def WidthExpr.Env (n : Nat) : Type :=
   Fin n → Nat
 
+def WidthExpr.Env.empty : WidthExpr.Env 0 :=
+  fun v => v.elim0
+
+def WidthExpr.Env.cons (env : WidthExpr.Env n) (w : Nat) :
+  WidthExpr.Env (n + 1) :=
+  fun v => v.cases w env
+
 def WidthExpr.toNat (e : WidthExpr n) (env : Fin n → Nat) : Nat :=
   match e with
   | .var v => env v
@@ -62,15 +69,12 @@ def Term.Ctx.Env.empty
 
 def Term.Ctx.Env.cons
   {wcard : Nat} {wenv : Fin wcard → Nat}
-  {ctx : Term.Ctx wcard tcard}
-  (tenv : Term.Ctx.Env ctx wenv)
+  {tctx : Term.Ctx wcard tcard}
+  (tenv : tctx.Env wenv)
   (w : WidthExpr wcard)
   (bv : BitVec (w.toNat wenv)) :
-  Term.Ctx.Env (ctx.cons w) wenv :=
-  fun v =>
-    v.cases
-      bv
-      (fun w => tenv w)
+  Term.Ctx.Env (tctx.cons w) wenv :=
+  fun v => v.cases bv (fun w => tenv w)
 
 /-- Evaluate a term to get a concrete bitvector expression. -/
 def Term.toBV {wenv : WidthExpr.Env wcard}

--- a/SSA/Experimental/Bits/MultiWidth/Defs.lean
+++ b/SSA/Experimental/Bits/MultiWidth/Defs.lean
@@ -28,6 +28,14 @@ def NatPredicate.toProp (env : Fin n → Nat) : NatPredicate n → Prop
 abbrev Term.Ctx (wcard : Nat) (tcard : Nat) : Type :=
   Fin tcard → WidthExpr wcard
 
+def Term.Ctx.empty (wcard : Nat) : Term.Ctx wcard 0 :=
+  fun x => x.elim0
+
+def Term.Ctx.cons (ctx : Term.Ctx wcard tcard)
+  (w : WidthExpr wcard) : Term.Ctx wcard (tcard + 1) :=
+  fun v =>
+    v.cases w (fun v' => ctx v')
+
 inductive Term {wcard tcard : Nat}
   (ctx : Term.Ctx wcard tcard) : (WidthExpr wcard) → Type
 /-- a variable of a given width -/
@@ -46,6 +54,23 @@ abbrev Term.Ctx.Env
   (tctx : Term.Ctx wcard tcard)
   (wenv : Fin wcard → Nat) :=
   (v : Fin tcard) → BitVec ((tctx v).toNat wenv)
+
+def Term.Ctx.Env.empty
+  {wcard : Nat} (wenv : Fin wcard → Nat) (ctx : Term.Ctx wcard 0) :
+  Term.Ctx.Env ctx wenv :=
+  fun v => v.elim0
+
+def Term.Ctx.Env.cons
+  {wcard : Nat} {wenv : Fin wcard → Nat}
+  {ctx : Term.Ctx wcard tcard}
+  (tenv : Term.Ctx.Env ctx wenv)
+  (w : WidthExpr wcard)
+  (bv : BitVec (w.toNat wenv)) :
+  Term.Ctx.Env (ctx.cons w) wenv :=
+  fun v =>
+    v.cases
+      bv
+      (fun w => tenv w)
 
 /-- Evaluate a term to get a concrete bitvector expression. -/
 def Term.toBV {wenv : WidthExpr.Env wcard}

--- a/SSA/Experimental/Bits/MultiWidth/GoodFSM.lean
+++ b/SSA/Experimental/Bits/MultiWidth/GoodFSM.lean
@@ -1,0 +1,8 @@
+/-
+This file builds the FSMs whose
+verification implies the correctness of the
+multi-width bitstream semantics.
+-/
+import SSA.Experimental.Bits.Fast.FiniteStateMachine
+import SSA.Experimental.Bits.Vars
+import SSA.Experimental.Bits.MultiWidth.Defs

--- a/SSA/Experimental/Bits/MultiWidth/OfExpr.lean
+++ b/SSA/Experimental/Bits/MultiWidth/OfExpr.lean
@@ -1,0 +1,5 @@
+/-
+This file contains functions to reflect Multi-Width defs
+from expressions.
+-/
+

--- a/SSA/Experimental/Bits/MultiWidth/Tactic.lean
+++ b/SSA/Experimental/Bits/MultiWidth/Tactic.lean
@@ -1,58 +1,46 @@
 import Mathlib.Data.Fintype.Defs
-import SSA.Experimental.Bits.SingleWidth.Defs
-import SSA.Experimental.Bits.SingleWidth.Preprocessing
-import SSA.Experimental.Bits.SingleWidth.Syntax
+import SSA.Experimental.Bits.MultiWidth.Defs
+import SSA.Experimental.Bits.MultiWidth.OfExpr
 
 import SSA.Experimental.Bits.KInduction.KInduction
 import SSA.Experimental.Bits.AutoStructs.FormulaToAuto
-import SSA.Experimental.Bits.ReflectMap
 
-initialize Lean.registerTraceClass `Bits.SingleWidth
+initialize Lean.registerTraceClass `Bits.MultiWidth
 
 namespace Tactic
 open Lean Meta Elab Tactic
 
-inductive CircuitBackend
-/-- NFA-based implementation. -/
-| automata
-/-- Pure lean implementation, verified. -/
-| circuit_lean
-/-- bv_decide based backend for k-induction. -/
-| circuit_cadical_verified (maxIter : Nat := 4) (checkTypes? : Bool := false)
-/-- Dry run, do not execute and close proof with `sorry` -/
-| dryrun
-deriving Repr, DecidableEq
-
-
 
 /-- Tactic options for bv_automata_circuit -/
 structure Config where
-  /--
-  The upper bound on the size of circuits in the FSM, beyond which the tactic will bail out on an error.
-  This is useful to prevent the tactic from taking oodles of time cruncing on goals that
-  build large state spaces, which can happen in the presence of tactics.
-  -/
-  circuitSizeThreshold : Nat := 200
-
-  /--
-  The upper bound on the state space of the FSM, beyond which the tactic will bail out on an error.
-  See also `Config.circuitSizeThreshold`.
-  -/
-  stateSpaceSizeThreshold : Nat := 200
-  /--
-  Whether the tactic should used a specialized solver for fixed-width constraints.
-  -/
-  fastFixedWidth : Bool := false
-  /--
-  Whether the tactic should use the (currently unverified) bv_decide based backend for solving constraints.
-  -/
-  backend : CircuitBackend := .circuit_lean
 
 /-- Default user configuration -/
 def Config.default : Config := {}
 
+/-- The free variables in the term that is reflected. -/
+structure ReflectMap where
+  /-- Map expressions to their index in the eventual `Reflect.Map`. -/
+  exprs : Std.HashMap Expr Nat
+
+
+instance : EmptyCollection ReflectMap where
+  emptyCollection := { exprs := ∅ }
 
 abbrev ReflectedExpr := Expr
+
+/--
+Insert expression 'e' into the reflection map. This returns the map,
+as well as the denoted term.
+-/
+def ReflectMap.findOrInsertExpr (m : ReflectMap) (e : Expr) : _root_.Term × ReflectMap :=
+  let (ix, m) := match m.exprs.get? e with
+    | some ix =>  (ix, m)
+    | none =>
+      let ix := m.exprs.size
+      (ix, { m with exprs := m.exprs.insert e ix })
+  -- let e :=  mkApp (mkConst ``Term.var) (mkNatLit ix)
+  (Term.var ix, m)
+
 
 /--
 Convert the meta-level `ReflectMap` into an object level `Reflect.Map` by
@@ -67,8 +55,45 @@ def ReflectMap.toExpr (xs : ReflectMap) (w : Expr) : MetaM ReflectedExpr := do
     out := mkAppN (mkConst ``Reflect.Map.append) #[w, e, out]
   return out
 
+instance : ToMessageData ReflectMap where
+  toMessageData exprs := Id.run do
+    -- sort in order of index.
+    let es := exprs.exprs.toArray.qsort (fun a b => a.2 < b.2)
+    let mut lines := es.map (fun (e, i) => m!"{i}→{e}")
+    return m!"[" ++ m!" ".joinSep lines.toList ++ m!"]"
+
+/--
+If we have variables in the `ReflectMap` that are not FVars,
+then we will throw a warning informing the user that this will be treated as a symbolic variable.
+-/
+def ReflectMap.throwWarningIfUninterpretedExprs (xs : ReflectMap) : MetaM Unit := do
+  let mut out? : Option MessageData := none
+  let header := m!"Tactic has not understood the following expressions, and will treat them as symbolic:"
+  -- Order the expressions so we get stable error messages.
+  let exprs := xs.exprs.toArray.qsort (fun ei ej => ei.1.lt ej.1)
+
+  for (e, _) in exprs do
+    if e.isFVar then continue
+    let eshow := indentD m!"- '{e}'"
+    out? := match out? with
+      | .none => header ++ Format.line ++ eshow
+      | .some out => .some (out ++ eshow)
+  let .some out := out? | return ()
+  logWarning out
+
+/--
+Result of reflection, where we have a collection of bitvector variables,
+along with the bitwidth and the final term.
+-/
+structure ReflectResult (α : Type) where
+  /-- Map of 'free variables' in the bitvector expression,
+  which are indexed as Term.var. This array is used to build the environment for decide.
+  -/
+  bvToIxMap : ReflectMap
+  e : α
+
 instance [ToMessageData α] : ToMessageData (ReflectResult α) where
-  toMessageData result := m!"{result.e} {result.exprToIx}"
+  toMessageData result := m!"{result.e} {result.bvToIxMap}"
 
 
 
@@ -123,7 +148,7 @@ info: ∀ {w : Nat} (a : BitVec w),
 
 def reflectAtomUnchecked (map : ReflectMap) (_w : Expr) (e : Expr) : MetaM (ReflectResult _root_.Term) := do
   let (e, map) := map.findOrInsertExpr e
-  return { exprToIx := map, e := Term.var e }
+  return { bvToIxMap := map, e := e }
 
 
 /--
@@ -135,7 +160,7 @@ Precondition: we assume that this is called on bitvectors.
 -/
 partial def reflectTermUnchecked (map : ReflectMap) (w : Expr) (e : Expr) : MetaM (ReflectResult _root_.Term) := do
   if let some (v, _bvTy) ← getOfNatValue? e ``BitVec then
-    return { exprToIx := map, e := Term.ofNat v }
+    return { bvToIxMap := map, e := Term.ofNat v }
   -- TODO: bitvector contants.
   match_expr e with
   | BitVec.ofInt _wExpr iExpr =>
@@ -143,34 +168,34 @@ partial def reflectTermUnchecked (map : ReflectMap) (w : Expr) (e : Expr) : Meta
     match i with
     | _ =>
       let (e, map) := map.findOrInsertExpr e
-      return { exprToIx := map, e := Term.var e }
+      return { bvToIxMap := map, e := e }
   | BitVec.ofNat _wExpr nExpr =>
     let n ← getNatValue? nExpr
     match n with
     | .some 0 =>
-      return {exprToIx := map, e := Term.zero }
+      return {bvToIxMap := map, e := Term.zero }
     | .some 1 =>
       let _ := (mkConst ``Term.one)
-      return {exprToIx := map, e := Term.one }
+      return {bvToIxMap := map, e := Term.one }
     | .some n =>
-      return { exprToIx := map, e := Term.ofNat n }
+      return { bvToIxMap := map, e := Term.ofNat n }
     | none =>
       logWarning "expected concrete BitVec.ofNat, found symbol '{n}', creating free variable"
       reflectAtomUnchecked map w e
 
   | HAnd.hAnd _bv _bv _bv _inst a b =>
       let a ← reflectTermUnchecked map w a
-      let b ← reflectTermUnchecked a.exprToIx w b
+      let b ← reflectTermUnchecked a.bvToIxMap w b
       let out := Term.and a.e b.e
       return { b with e := out }
   | HOr.hOr _bv _bv _bv _inst a b =>
       let a ← reflectTermUnchecked map w a
-      let b ← reflectTermUnchecked a.exprToIx w b
+      let b ← reflectTermUnchecked a.bvToIxMap w b
       let out := Term.or a.e b.e
       return { b with e := out }
   | HXor.hXor _bv _bv _bv _inst a b =>
       let a ← reflectTermUnchecked map w a
-      let b ← reflectTermUnchecked a.exprToIx w b
+      let b ← reflectTermUnchecked a.bvToIxMap w b
       let out := Term.xor a.e b.e
       return { b with e := out }
   | Complement.complement _bv _inst a =>
@@ -179,7 +204,7 @@ partial def reflectTermUnchecked (map : ReflectMap) (w : Expr) (e : Expr) : Meta
       return { a with e := out }
   | HAdd.hAdd _bv _bv _bv _inst a b =>
       let a ← reflectTermUnchecked map w a
-      let b ← reflectTermUnchecked a.exprToIx w b
+      let b ← reflectTermUnchecked a.bvToIxMap w b
       let out := Term.add a.e b.e
       return { b with e := out }
   | HShiftLeft.hShiftLeft _bv _nat _bv _inst a n =>
@@ -190,7 +215,7 @@ partial def reflectTermUnchecked (map : ReflectMap) (w : Expr) (e : Expr) : Meta
 
   | HSub.hSub _bv _bv _bv _inst a b =>
       let a ← reflectTermUnchecked map w a
-      let b ← reflectTermUnchecked a.exprToIx w b
+      let b ← reflectTermUnchecked a.bvToIxMap w b
       let out := Term.sub a.e b.e
       return { b with e := out }
   | Neg.neg _bv _inst a =>
@@ -201,7 +226,7 @@ partial def reflectTermUnchecked (map : ReflectMap) (w : Expr) (e : Expr) : Meta
   -- decr
   | _ =>
     let (e, map) := map.findOrInsertExpr e
-    return { exprToIx := map, e := Term.var e }
+    return { bvToIxMap := map, e := e }
 
 set_option pp.explicit true in
 /--
@@ -211,7 +236,7 @@ info: ∀ {w : Nat} (a b : BitVec w), Or (@Eq (BitVec w) a b) (And (@Ne (BitVec 
 #check ∀ {w : Nat} (a b : BitVec w), a = b ∨ (a ≠ b) ∧ a = b
 
 /-- Return a new expression that this is defeq to, along with the expression of the environment that this needs, under which it will be defeq. -/
-partial def reflectPredicateAux (exprToIx : ReflectMap) (e : Expr) (wExpected : Expr) : MetaM (ReflectResult Predicate) := do
+partial def reflectPredicateAux (bvToIxMap : ReflectMap) (e : Expr) (wExpected : Expr) : MetaM (ReflectResult Predicate) := do
   match_expr e with
   | Eq α a b =>
     match_expr α with
@@ -223,12 +248,12 @@ partial def reflectPredicateAux (exprToIx : ReflectMap) (e : Expr) (wExpected : 
       let some natVal ← Lean.Meta.getNatValue? b
         | throwError m!"Expected '{wExpected} ≠ <concrete width>', found symbolic width {indentD b}."
       let out := Predicate.width .eq natVal
-      return { exprToIx := exprToIx, e := out }
+      return { bvToIxMap := bvToIxMap, e := out }
 
     | BitVec w =>
-      let a ←  reflectTermUnchecked exprToIx w a
-      let b ← reflectTermUnchecked a.exprToIx w b
-      return { exprToIx := b.exprToIx, e := Predicate.binary .eq a.e b.e }
+      let a ←  reflectTermUnchecked bvToIxMap w a
+      let b ← reflectTermUnchecked a.bvToIxMap w b
+      return { bvToIxMap := b.bvToIxMap, e := Predicate.binary .eq a.e b.e }
     | Bool =>
       -- Sadly, recall that slt, sle are of type 'BitVec w → BitVec w → Bool',
       -- so we get goal states of them form 'a <ₛb = true'.
@@ -238,21 +263,21 @@ partial def reflectPredicateAux (exprToIx : ReflectMap) (e : Expr) (wExpected : 
         | throwError m!"only boolean conditionals allowed are 'bv.\{u,s}l\{t,e} bv = true'. Found {indentD e}."
       match_expr a with
       | BitVec.slt w a b =>
-        let a ← reflectTermUnchecked exprToIx w a
-        let b ← reflectTermUnchecked a.exprToIx w b
-        return { exprToIx := b.exprToIx, e := Predicate.binary .slt a.e b.e }
+        let a ← reflectTermUnchecked bvToIxMap w a
+        let b ← reflectTermUnchecked a.bvToIxMap w b
+        return { bvToIxMap := b.bvToIxMap, e := Predicate.binary .slt a.e b.e }
       | BitVec.sle w a b =>
-        let a ← reflectTermUnchecked exprToIx w a
-        let b ← reflectTermUnchecked a.exprToIx w b
-        return { exprToIx := b.exprToIx, e := Predicate.binary .sle a.e b.e }
+        let a ← reflectTermUnchecked bvToIxMap w a
+        let b ← reflectTermUnchecked a.bvToIxMap w b
+        return { bvToIxMap := b.bvToIxMap, e := Predicate.binary .sle a.e b.e }
       | BitVec.ult w a b =>
-        let a ← reflectTermUnchecked exprToIx w a
-        let b ← reflectTermUnchecked a.exprToIx w b
-        return { exprToIx := b.exprToIx, e := Predicate.binary .ult a.e b.e }
+        let a ← reflectTermUnchecked bvToIxMap w a
+        let b ← reflectTermUnchecked a.bvToIxMap w b
+        return { bvToIxMap := b.bvToIxMap, e := Predicate.binary .ult a.e b.e }
       | BitVec.ule w a b =>
-        let a ← reflectTermUnchecked exprToIx w a
-        let b ← reflectTermUnchecked a.exprToIx w b
-        return { exprToIx := b.exprToIx, e := Predicate.binary .ule a.e b.e }
+        let a ← reflectTermUnchecked bvToIxMap w a
+        let b ← reflectTermUnchecked a.bvToIxMap w b
+        return { bvToIxMap := b.bvToIxMap, e := Predicate.binary .ule a.e b.e }
       | _ =>
         throwError m!"unknown boolean conditional, expected 'bv.slt bv = true' or 'bv.sle bv = true'. Found {indentD e}"
     | _ =>
@@ -267,31 +292,31 @@ partial def reflectPredicateAux (exprToIx : ReflectMap) (e : Expr) (wExpected : 
       let some natVal ← Lean.Meta.getNatValue? b
         | throwError m!"Expected '{wExpected} ≠ <concrete width>', found symbolic width {indentD b}."
       let out := Predicate.width .neq natVal
-      return { exprToIx := exprToIx, e := out }
+      return { bvToIxMap := bvToIxMap, e := out }
     | BitVec w =>
-      let a ← reflectTermUnchecked exprToIx w a
-      let b ← reflectTermUnchecked a.exprToIx w b
-      return { exprToIx := b.exprToIx, e := Predicate.binary .neq a.e b.e }
+      let a ← reflectTermUnchecked bvToIxMap w a
+      let b ← reflectTermUnchecked a.bvToIxMap w b
+      return { bvToIxMap := b.bvToIxMap, e := Predicate.binary .neq a.e b.e }
     | _ =>
       throwError m!"Expected typeclass to be 'BitVec w' / 'Nat', found '{indentD α}' in {e} when matching against 'Ne'"
   | LT.lt α _inst a b =>
     let_expr BitVec w := α | throwError m!"Expected typeclass to be BitVec w, found '{indentD α}' in {indentD e} when matching against 'LT.lt'"
-    let a ← reflectTermUnchecked exprToIx w a
-    let b ← reflectTermUnchecked a.exprToIx w b
-    return { exprToIx := b.exprToIx, e := Predicate.binary .ult a.e b.e }
+    let a ← reflectTermUnchecked bvToIxMap w a
+    let b ← reflectTermUnchecked a.bvToIxMap w b
+    return { bvToIxMap := b.bvToIxMap, e := Predicate.binary .ult a.e b.e }
   | LE.le α _inst a b =>
     let_expr BitVec w := α | throwError m!"Expected typeclass to be BitVec w, found '{indentD α}' in {indentD e} when matching against 'LE.le'"
-    let a ← reflectTermUnchecked exprToIx w a
-    let b ← reflectTermUnchecked a.exprToIx w b
-    return { exprToIx := b.exprToIx, e := Predicate.binary .ule a.e b.e }
+    let a ← reflectTermUnchecked bvToIxMap w a
+    let b ← reflectTermUnchecked a.bvToIxMap w b
+    return { bvToIxMap := b.bvToIxMap, e := Predicate.binary .ule a.e b.e }
   | Or p q =>
-    let p ← reflectPredicateAux exprToIx p wExpected
-    let q ← reflectPredicateAux p.exprToIx q wExpected
+    let p ← reflectPredicateAux bvToIxMap p wExpected
+    let q ← reflectPredicateAux p.bvToIxMap q wExpected
     let out := Predicate.lor p.e q.e
     return { q with e := out }
   | And p q =>
-    let p ← reflectPredicateAux exprToIx p wExpected
-    let q ← reflectPredicateAux p.exprToIx q wExpected
+    let p ← reflectPredicateAux bvToIxMap p wExpected
+    let q ← reflectPredicateAux p.bvToIxMap q wExpected
     let out := Predicate.land p.e q.e
     return { q with e := out }
   | _ =>
@@ -517,11 +542,11 @@ def reflectUniversalWidthBVs (g : MVarId) (cfg : Config) : TermElabM (List MVarI
 
     -- finally, we perform reflection.
     let predicate ← reflectPredicateAux ∅ (← g.getType) w
-    predicate.exprToIx.throwWarningIfUninterpretedExprs
+    predicate.bvToIxMap.throwWarningIfUninterpretedExprs
 
     trace[Bits.Frontend] m!"predicate (repr): {indentD (repr predicate.e)}"
 
-    let bvToIxMapVal ← predicate.exprToIx.toExpr w
+    let bvToIxMapVal ← predicate.bvToIxMap.toExpr w
 
     let target := (mkAppN (mkConst ``Predicate.denote) #[predicate.e.quote, w, bvToIxMapVal])
     let g ← g.replaceTargetDefEq target
@@ -733,7 +758,7 @@ def evalBvAutomataFragmentNoUninterpreted : Tactic := fun
       -- finally, we perform reflection.
       let result ← reflectPredicateAux ∅ (← g.getType) w
       -- Order the expressions so we get stable error messages.
-      let exprs := result.exprToIx.exprs.toArray.qsort (fun ei ej => ei.1.lt ej.1)
+      let exprs := result.bvToIxMap.exprs.toArray.qsort (fun ei ej => ei.1.lt ej.1)
       let mut out? : Option MessageData := .none
       let header := m!"Tactic has not understood the following expressions, and will treat them as symbolic:"
       for (e, _) in exprs do
@@ -782,7 +807,7 @@ def evalBvAutomataFragmentCheckReflected : Tactic := fun
       trace[Bits.Frontend] m!"goal after preprocessing: {indentD g}"
       -- finally, we perform reflection.
       let result ← reflectPredicateAux ∅ (← g.getType) w
-      let bvToIxMapVal ← result.exprToIx.toExpr w
+      let bvToIxMapVal ← result.bvToIxMap.toExpr w
 
       let target := (mkAppN (mkConst ``Predicate.denote) #[result.e.quote, w, bvToIxMapVal])
       let g ← g.replaceTargetDefEq target

--- a/SSA/Experimental/Bits/MultiWidth/Tactic.lean
+++ b/SSA/Experimental/Bits/MultiWidth/Tactic.lean
@@ -419,7 +419,7 @@ declare_config_elab elabBvMultiWidthConfig Config
 
 syntax (name := bvMultiWidth) "bv_multi_width" (Lean.Parser.Tactic.config)? : tactic
 @[tactic bvMultiWidth]
-def evalBvAutomataCircuit : Tactic := fun
+def evalBvMultiWidth : Tactic := fun
 | `(tactic| bv_multi_width $[$cfg]?) => do
   let cfg ← elabBvMultiWidthConfig (mkOptionalNode cfg)
   let g ← getMainGoal

--- a/SSA/Experimental/Bits/MultiWidth/Tactic.lean
+++ b/SSA/Experimental/Bits/MultiWidth/Tactic.lean
@@ -1,9 +1,9 @@
 import Mathlib.Data.Fintype.Defs
 import SSA.Experimental.Bits.MultiWidth.Defs
-import SSA.Experimental.Bits.MultiWidth.OfExpr
 
 import SSA.Experimental.Bits.KInduction.KInduction
 import SSA.Experimental.Bits.AutoStructs.FormulaToAuto
+import SSA.Experimental.Bits.ReflectMap
 
 initialize Lean.registerTraceClass `Bits.MultiWidth
 
@@ -17,85 +17,11 @@ structure Config where
 /-- Default user configuration -/
 def Config.default : Config := {}
 
-/-- The free variables in the term that is reflected. -/
-structure ReflectMap where
-  /-- Map expressions to their index in the eventual `Reflect.Map`. -/
-  exprs : Std.HashMap Expr Nat
-
-
-instance : EmptyCollection ReflectMap where
-  emptyCollection := { exprs := ∅ }
-
-abbrev ReflectedExpr := Expr
-
-/--
-Insert expression 'e' into the reflection map. This returns the map,
-as well as the denoted term.
--/
-def ReflectMap.findOrInsertExpr (m : ReflectMap) (e : Expr) : _root_.Term × ReflectMap :=
-  let (ix, m) := match m.exprs.get? e with
-    | some ix =>  (ix, m)
-    | none =>
-      let ix := m.exprs.size
-      (ix, { m with exprs := m.exprs.insert e ix })
-  -- let e :=  mkApp (mkConst ``Term.var) (mkNatLit ix)
-  (Term.var ix, m)
-
-
 /--
 Convert the meta-level `ReflectMap` into an object level `Reflect.Map` by
 repeatedly calling `Reflect.Map.empty` and `Reflect.Map.set`.
 -/
-def ReflectMap.toExpr (xs : ReflectMap) (w : Expr) : MetaM ReflectedExpr := do
-  let mut out := mkApp (mkConst ``Reflect.Map.empty) w
-  let exprs := xs.exprs.toArray.qsort (fun ei ej => ei.2 < ej.2)
-  for (e, _) in exprs do
-    -- The 'exprs' will be in order, with 0..n
-    /- Append the expressions into the array -/
-    out := mkAppN (mkConst ``Reflect.Map.append) #[w, e, out]
-  return out
-
-instance : ToMessageData ReflectMap where
-  toMessageData exprs := Id.run do
-    -- sort in order of index.
-    let es := exprs.exprs.toArray.qsort (fun a b => a.2 < b.2)
-    let mut lines := es.map (fun (e, i) => m!"{i}→{e}")
-    return m!"[" ++ m!" ".joinSep lines.toList ++ m!"]"
-
-/--
-If we have variables in the `ReflectMap` that are not FVars,
-then we will throw a warning informing the user that this will be treated as a symbolic variable.
--/
-def ReflectMap.throwWarningIfUninterpretedExprs (xs : ReflectMap) : MetaM Unit := do
-  let mut out? : Option MessageData := none
-  let header := m!"Tactic has not understood the following expressions, and will treat them as symbolic:"
-  -- Order the expressions so we get stable error messages.
-  let exprs := xs.exprs.toArray.qsort (fun ei ej => ei.1.lt ej.1)
-
-  for (e, _) in exprs do
-    if e.isFVar then continue
-    let eshow := indentD m!"- '{e}'"
-    out? := match out? with
-      | .none => header ++ Format.line ++ eshow
-      | .some out => .some (out ++ eshow)
-  let .some out := out? | return ()
-  logWarning out
-
-/--
-Result of reflection, where we have a collection of bitvector variables,
-along with the bitwidth and the final term.
--/
-structure ReflectResult (α : Type) where
-  /-- Map of 'free variables' in the bitvector expression,
-  which are indexed as Term.var. This array is used to build the environment for decide.
-  -/
-  bvToIxMap : ReflectMap
-  e : α
-
-instance [ToMessageData α] : ToMessageData (ReflectResult α) where
-  toMessageData result := m!"{result.e} {result.bvToIxMap}"
-
-
+def ReflectMap.toExpr (xs : ReflectMap) : MetaM ReflectedExpr := sorry
 
 /--
 info: ∀ {w : Nat} (a b : BitVec w),
@@ -145,11 +71,30 @@ info: ∀ {w : Nat} (a : BitVec w),
 #guard_msgs in set_option pp.explicit true in
 #check ∀ {w : Nat} (a : BitVec w),  a.slt 0#w
 
+section MkReflectMapWidth
 
-def reflectAtomUnchecked (map : ReflectMap) (_w : Expr) (e : Expr) : MetaM (ReflectResult _root_.Term) := do
-  let (e, map) := map.findOrInsertExpr e
-  return { bvToIxMap := map, e := e }
+/-#
+This is the first phase of the reflection process,
+which visits subterms and builds a `ReflectMap` of all expressions that are widths (i.e. `Nat` sort).
 
+In the next phase, we will use this `ReflectMap` of widths to reflect terms and predicates.
+-/
+
+
+end MkReflectMapWidth
+
+structure ReflectedWidth (nw : Nat) where
+  wMap : ReflectMap
+  w : MultiWidth.WidthExpr nw
+
+structure ReflectedTerm extends ReflectionCtx where
+  ctx : MultiWidth.Term.Ctx wcard tcard
+  w : MultiWidth.WidthExpr wcard
+  term : MultiWidth.Term ctx w
+
+def reflectBVAtom (wMap : ReflectMap) (bvMap : ReflectMap) (e : Expr) : MetaM (ReflectedTerm) := do
+  if let some (v, _bvTy) ← getOfNatValue? e ``BitVec then
+    return { exprToIx := map, e := Term.ofNat v }
 
 /--
 Return a new expression that this is **defeq** to, along with the expression of the environment that this needs.
@@ -158,9 +103,9 @@ and furthermore, it will reflect all terms as variables.
 
 Precondition: we assume that this is called on bitvectors.
 -/
-partial def reflectTermUnchecked (map : ReflectMap) (w : Expr) (e : Expr) : MetaM (ReflectResult _root_.Term) := do
+partial def reflectTermUnchecked (map : ReflectMap) (w : Expr) (e : Expr) : MetaM (ReflectResult MultiWidth.Term) := do
   if let some (v, _bvTy) ← getOfNatValue? e ``BitVec then
-    return { bvToIxMap := map, e := Term.ofNat v }
+    return { exprToIx := map, e := Term.ofNat v }
   -- TODO: bitvector contants.
   match_expr e with
   | BitVec.ofInt _wExpr iExpr =>
@@ -168,34 +113,34 @@ partial def reflectTermUnchecked (map : ReflectMap) (w : Expr) (e : Expr) : Meta
     match i with
     | _ =>
       let (e, map) := map.findOrInsertExpr e
-      return { bvToIxMap := map, e := e }
+      return { exprToIx := map, e := Term.var e }
   | BitVec.ofNat _wExpr nExpr =>
     let n ← getNatValue? nExpr
     match n with
     | .some 0 =>
-      return {bvToIxMap := map, e := Term.zero }
+      return {exprToIx := map, e := Term.zero }
     | .some 1 =>
       let _ := (mkConst ``Term.one)
-      return {bvToIxMap := map, e := Term.one }
+      return {exprToIx := map, e := Term.one }
     | .some n =>
-      return { bvToIxMap := map, e := Term.ofNat n }
+      return { exprToIx := map, e := Term.ofNat n }
     | none =>
       logWarning "expected concrete BitVec.ofNat, found symbol '{n}', creating free variable"
       reflectAtomUnchecked map w e
 
   | HAnd.hAnd _bv _bv _bv _inst a b =>
       let a ← reflectTermUnchecked map w a
-      let b ← reflectTermUnchecked a.bvToIxMap w b
+      let b ← reflectTermUnchecked a.exprToIx w b
       let out := Term.and a.e b.e
       return { b with e := out }
   | HOr.hOr _bv _bv _bv _inst a b =>
       let a ← reflectTermUnchecked map w a
-      let b ← reflectTermUnchecked a.bvToIxMap w b
+      let b ← reflectTermUnchecked a.exprToIx w b
       let out := Term.or a.e b.e
       return { b with e := out }
   | HXor.hXor _bv _bv _bv _inst a b =>
       let a ← reflectTermUnchecked map w a
-      let b ← reflectTermUnchecked a.bvToIxMap w b
+      let b ← reflectTermUnchecked a.exprToIx w b
       let out := Term.xor a.e b.e
       return { b with e := out }
   | Complement.complement _bv _inst a =>
@@ -204,7 +149,7 @@ partial def reflectTermUnchecked (map : ReflectMap) (w : Expr) (e : Expr) : Meta
       return { a with e := out }
   | HAdd.hAdd _bv _bv _bv _inst a b =>
       let a ← reflectTermUnchecked map w a
-      let b ← reflectTermUnchecked a.bvToIxMap w b
+      let b ← reflectTermUnchecked a.exprToIx w b
       let out := Term.add a.e b.e
       return { b with e := out }
   | HShiftLeft.hShiftLeft _bv _nat _bv _inst a n =>
@@ -215,7 +160,7 @@ partial def reflectTermUnchecked (map : ReflectMap) (w : Expr) (e : Expr) : Meta
 
   | HSub.hSub _bv _bv _bv _inst a b =>
       let a ← reflectTermUnchecked map w a
-      let b ← reflectTermUnchecked a.bvToIxMap w b
+      let b ← reflectTermUnchecked a.exprToIx w b
       let out := Term.sub a.e b.e
       return { b with e := out }
   | Neg.neg _bv _inst a =>
@@ -226,7 +171,7 @@ partial def reflectTermUnchecked (map : ReflectMap) (w : Expr) (e : Expr) : Meta
   -- decr
   | _ =>
     let (e, map) := map.findOrInsertExpr e
-    return { bvToIxMap := map, e := e }
+    return { exprToIx := map, e := Term.var e }
 
 set_option pp.explicit true in
 /--
@@ -236,87 +181,23 @@ info: ∀ {w : Nat} (a b : BitVec w), Or (@Eq (BitVec w) a b) (And (@Ne (BitVec 
 #check ∀ {w : Nat} (a b : BitVec w), a = b ∨ (a ≠ b) ∧ a = b
 
 /-- Return a new expression that this is defeq to, along with the expression of the environment that this needs, under which it will be defeq. -/
-partial def reflectPredicateAux (bvToIxMap : ReflectMap) (e : Expr) (wExpected : Expr) : MetaM (ReflectResult Predicate) := do
+partial def reflectPredicateAux (exprToIx : ReflectMap) (e : Expr)  : MetaM (ReflectResult Predicate) := do
   match_expr e with
   | Eq α a b =>
     match_expr α with
-    | Nat =>
-       -- support width equality constraints
-      -- TODO: canonicalize 'a = w' into 'w = a'.
-      if wExpected != a then
-        throwError m!"Only Nat expressions allowed are '{wExpected} ≠ <concrete value>'. Found {indentD e}."
-      let some natVal ← Lean.Meta.getNatValue? b
-        | throwError m!"Expected '{wExpected} ≠ <concrete width>', found symbolic width {indentD b}."
-      let out := Predicate.width .eq natVal
-      return { bvToIxMap := bvToIxMap, e := out }
-
     | BitVec w =>
-      let a ←  reflectTermUnchecked bvToIxMap w a
-      let b ← reflectTermUnchecked a.bvToIxMap w b
-      return { bvToIxMap := b.bvToIxMap, e := Predicate.binary .eq a.e b.e }
-    | Bool =>
-      -- Sadly, recall that slt, sle are of type 'BitVec w → BitVec w → Bool',
-      -- so we get goal states of them form 'a <ₛb = true'.
-      -- So we need to match on 'Eq _ true' where '_' is 'slt'.
-      -- This makes me unhappy too, but c'est la vie.
-      let_expr true := b
-        | throwError m!"only boolean conditionals allowed are 'bv.\{u,s}l\{t,e} bv = true'. Found {indentD e}."
-      match_expr a with
-      | BitVec.slt w a b =>
-        let a ← reflectTermUnchecked bvToIxMap w a
-        let b ← reflectTermUnchecked a.bvToIxMap w b
-        return { bvToIxMap := b.bvToIxMap, e := Predicate.binary .slt a.e b.e }
-      | BitVec.sle w a b =>
-        let a ← reflectTermUnchecked bvToIxMap w a
-        let b ← reflectTermUnchecked a.bvToIxMap w b
-        return { bvToIxMap := b.bvToIxMap, e := Predicate.binary .sle a.e b.e }
-      | BitVec.ult w a b =>
-        let a ← reflectTermUnchecked bvToIxMap w a
-        let b ← reflectTermUnchecked a.bvToIxMap w b
-        return { bvToIxMap := b.bvToIxMap, e := Predicate.binary .ult a.e b.e }
-      | BitVec.ule w a b =>
-        let a ← reflectTermUnchecked bvToIxMap w a
-        let b ← reflectTermUnchecked a.bvToIxMap w b
-        return { bvToIxMap := b.bvToIxMap, e := Predicate.binary .ule a.e b.e }
-      | _ =>
-        throwError m!"unknown boolean conditional, expected 'bv.slt bv = true' or 'bv.sle bv = true'. Found {indentD e}"
-    | _ =>
-      throwError m!"unknown equality kind, expected 'bv = bv' or 'bv.slt bv = true' or 'bv.sle bv = true'. Found {indentD e}"
-  | Ne α a b =>
-    /- Support width constraints with α = Nat -/
-    match_expr α with
-    | Nat => do
-      -- TODO: canonicalize 'a ≠ w' into 'w ≠ a'.
-      if wExpected != a then
-        throwError m!"Only Nat expressions allowed are '{wExpected} ≠ <concrete value>'. Found {indentD e}."
-      let some natVal ← Lean.Meta.getNatValue? b
-        | throwError m!"Expected '{wExpected} ≠ <concrete width>', found symbolic width {indentD b}."
-      let out := Predicate.width .neq natVal
-      return { bvToIxMap := bvToIxMap, e := out }
-    | BitVec w =>
-      let a ← reflectTermUnchecked bvToIxMap w a
-      let b ← reflectTermUnchecked a.bvToIxMap w b
-      return { bvToIxMap := b.bvToIxMap, e := Predicate.binary .neq a.e b.e }
-    | _ =>
-      throwError m!"Expected typeclass to be 'BitVec w' / 'Nat', found '{indentD α}' in {e} when matching against 'Ne'"
-  | LT.lt α _inst a b =>
-    let_expr BitVec w := α | throwError m!"Expected typeclass to be BitVec w, found '{indentD α}' in {indentD e} when matching against 'LT.lt'"
-    let a ← reflectTermUnchecked bvToIxMap w a
-    let b ← reflectTermUnchecked a.bvToIxMap w b
-    return { bvToIxMap := b.bvToIxMap, e := Predicate.binary .ult a.e b.e }
-  | LE.le α _inst a b =>
-    let_expr BitVec w := α | throwError m!"Expected typeclass to be BitVec w, found '{indentD α}' in {indentD e} when matching against 'LE.le'"
-    let a ← reflectTermUnchecked bvToIxMap w a
-    let b ← reflectTermUnchecked a.bvToIxMap w b
-    return { bvToIxMap := b.bvToIxMap, e := Predicate.binary .ule a.e b.e }
+      let a ←  reflectTermUnchecked exprToIx w a
+      let b ← reflectTermUnchecked a.exprToIx w b
+      return { exprToIx := b.exprToIx, e := Predicate.binary .eq a.e b.e }
+    | _ => throwError m!"expected bitvector equality, found: {indentD e}"
   | Or p q =>
-    let p ← reflectPredicateAux bvToIxMap p wExpected
-    let q ← reflectPredicateAux p.bvToIxMap q wExpected
+    let p ← reflectPredicateAux exprToIx p
+    let q ← reflectPredicateAux p.exprToIx q
     let out := Predicate.lor p.e q.e
     return { q with e := out }
   | And p q =>
-    let p ← reflectPredicateAux bvToIxMap p wExpected
-    let q ← reflectPredicateAux p.bvToIxMap q wExpected
+    let p ← reflectPredicateAux exprToIx p
+    let q ← reflectPredicateAux p.exprToIx q
     let out := Predicate.land p.e q.e
     return { q with e := out }
   | _ =>
@@ -542,11 +423,11 @@ def reflectUniversalWidthBVs (g : MVarId) (cfg : Config) : TermElabM (List MVarI
 
     -- finally, we perform reflection.
     let predicate ← reflectPredicateAux ∅ (← g.getType) w
-    predicate.bvToIxMap.throwWarningIfUninterpretedExprs
+    predicate.exprToIx.throwWarningIfUninterpretedExprs
 
     trace[Bits.Frontend] m!"predicate (repr): {indentD (repr predicate.e)}"
 
-    let bvToIxMapVal ← predicate.bvToIxMap.toExpr w
+    let bvToIxMapVal ← predicate.exprToIx.toExpr w
 
     let target := (mkAppN (mkConst ``Predicate.denote) #[predicate.e.quote, w, bvToIxMapVal])
     let g ← g.replaceTargetDefEq target
@@ -758,7 +639,7 @@ def evalBvAutomataFragmentNoUninterpreted : Tactic := fun
       -- finally, we perform reflection.
       let result ← reflectPredicateAux ∅ (← g.getType) w
       -- Order the expressions so we get stable error messages.
-      let exprs := result.bvToIxMap.exprs.toArray.qsort (fun ei ej => ei.1.lt ej.1)
+      let exprs := result.exprToIx.exprs.toArray.qsort (fun ei ej => ei.1.lt ej.1)
       let mut out? : Option MessageData := .none
       let header := m!"Tactic has not understood the following expressions, and will treat them as symbolic:"
       for (e, _) in exprs do
@@ -807,7 +688,7 @@ def evalBvAutomataFragmentCheckReflected : Tactic := fun
       trace[Bits.Frontend] m!"goal after preprocessing: {indentD g}"
       -- finally, we perform reflection.
       let result ← reflectPredicateAux ∅ (← g.getType) w
-      let bvToIxMapVal ← result.bvToIxMap.toExpr w
+      let bvToIxMapVal ← result.exprToIx.toExpr w
 
       let target := (mkAppN (mkConst ``Predicate.denote) #[result.e.quote, w, bvToIxMapVal])
       let g ← g.replaceTargetDefEq target

--- a/SSA/Experimental/Bits/MultiWidth/Tactic.lean
+++ b/SSA/Experimental/Bits/MultiWidth/Tactic.lean
@@ -213,12 +213,14 @@ info: MultiWidth.Term.Ctx.Env.cons {tcard wcard : ℕ} {wenv : Fin wcard → ℕ
 
 def mkTermEnvCons (reader : CollectState) (wenv : Expr) (tenv : Expr) (w : MultiWidth.Nondep.WidthExpr) (bv : Expr) : MetaM Expr := do
   let wexpr ← mkWidthExpr reader.wcard w
-  mkAppM (``MultiWidth.Term.Ctx.Env.cons)
+  let out ← mkAppM (``MultiWidth.Term.Ctx.Env.cons)
     #[ tenv,
       wexpr,
       bv,
       ← mkEqRefl (← mkAppM ``MultiWidth.WidthExpr.toNat #[wexpr, wenv])
       ]
+  check out
+  return out
 
 /-- Build an expression `tenv` for the `Term.Ctx.Env`. -/
 def CollectState.mkTenvExpr (reader : CollectState) (wenv : Expr) (tctx : Expr) : MetaM Expr := do
@@ -231,6 +233,7 @@ def CollectState.mkTenvExpr (reader : CollectState) (wenv : Expr) (tctx : Expr) 
     out ← mkTermEnvCons (reader := reader) (wenv := wenv) (tenv := out) (w := wexpr) (bv := bv)
     logInfo m!"after out: {out}"
     check out
+    logInfo m!"checked out!"
   return out
 
 /-- info: MultiWidth.WidthExpr.Env.empty : MultiWidth.WidthExpr.Env 0 -/

--- a/SSA/Experimental/Bits/MultiWidth/Tactic.lean
+++ b/SSA/Experimental/Bits/MultiWidth/Tactic.lean
@@ -429,18 +429,7 @@ info: MultiWidth.Decide.Predicate.toProp_of_decide {wcard tcard : ℕ} {tctx : T
 -/
 #guard_msgs in #check MultiWidth.Decide.Predicate.toProp_of_decide
 
-def XXX : True := by simp
-
-
-open private withAppBuilderTrace from Lean.Meta.AppBuilder
-open private mkFun from Lean.Meta.AppBuilder
-open private mkAppMArgs from Lean.Meta.AppBuilder
-def mkAppMUnif (constName : Name) (xs : Array Expr) : MetaM Expr := do
-  withAppBuilderTrace constName xs do -- withNewMCtxDepth (allowLevelAssignments := true) do
-    let (f, fType) ← mkFun constName
-    mkAppMArgs f fType xs
-
-open Lean Meta Elab Term Tactic in
+open Lean Meta Elab Tactic in
 def solve (g : MVarId) : SolverM (List MVarId) := do
   g.withContext do
     let collect : CollectState := {}
@@ -454,46 +443,19 @@ def solve (g : MVarId) : SolverM (List MVarId) := do
       (tctx := tctx)
       (wenv := wenv)
       (tenv := tenv)
-    let gDecideTy ← mkFreshExprMVar (mkSort 0) .natural `MultiWidth.Predicate.decideTy
-    let gDecideExpr ← mkFreshExprMVar gDecideTy .natural `MultiWidth.Predicate.decideExpr
-    -- let eq? ← isDefEq gDecideExpr (mkConst ``MultiWidth.Tactic.XXX)
-    -- let gDecideTy ← instantiateMVars gDecideTy
-    -- let gDecideExpr ← instantiateMVars gDecideExpr
-    -- throwError m!"ty : {indentD gDecideTy} \nexpr : {indentD gDecideExpr} \neq? : {eq?}"
-
-
-    -- let exactPrf ← mkAppMUnif (``MultiWidth.Decide.Predicate.toProp_of_decide)
-    --   #[← mkPredicateExpr collect.wcard collect.tcard tctx p, gDecideExpr, tenv]
-    let exactPrf ← mkAppM (``MultiWidth.Decide.Predicate.toProp_of_decide)
+    let g ← g.replaceTargetDefEq pToProp
+    let exactPrf ← g.withContext <|
+      mkAppM (``MultiWidth.Decide.Predicate.toProp_of_decide)
       #[← mkPredicateExpr collect.wcard collect.tcard tctx p]
-    let exactPrf := mkApp exactPrf gDecideExpr
-    let exactPrf ← mkAppM' exactPrf #[tenv]
-    if ← g.isAssigned then throwError m!"expected goal to be unassigned, but it is already assigned: {indentD g}"
-
-    if ! (← isDefEq (Expr.mvar g) exactPrf) then
-      throwError m!"expected goal to be defeq to the proof, but it is not: {indentD g} != {indentD exactPrf}"
-    synthesizeSyntheticMVarsNoPostponing
-
-    if ! (← gDecideTy.mvarId!.isAssigned) then
-      throwError m!"expected goal type to be assigned, but it is not: {indentD gDecideTy}"
-    let exactPrf ← instantiateMVars exactPrf
-    throwError "exactPrf: {indentD exactPrf}"
-    return [gDecideExpr.mvarId!]
-
-    -- let gDecideTy ← instantiateMVars gDecideTy
-    -- let gDecideExpr ← instantiateMVars gDecideExpr
-    -- throwError m!"ty : {indentD gDecideTy} \nexpr : {indentD gDecideExpr} \n"
-    -- let g ← g.replaceTargetDefEq pToProp
-    -- g.assign exactPrf
-    -- let some (gDecideTy, _) := Expr.arrow? (← inferType exactPrf)
-    --   | throwError "unable to find 'decidable' type in the type {← inferType exactPrf}"
-    -- -- gDecideTy will be of the form `decide ... = true`. We want the '...' part.
-    -- let some (_, gDecideTyLhs, _) := Expr.eq? gDecideTy
-    --   | throwError "expected goal type to be of the form 'decide <...> = true', found: {indentD gDecideTy}"
-    -- let gDecidePrf ← g.withContext <| mkEqRflNativeDecideProof (lhsExpr := gDecideTyLhs) (rhs := true)
-    -- let exactPrf ← g.withContext <| mkAppM' exactPrf #[gDecidePrf, tenv]
-    -- g.assign exactPrf
-    -- return [gDecideExpr.mvarId!]
+    let some (gDecideTy, _) := Expr.arrow? (← inferType exactPrf)
+      | throwError "unable to find 'decidable' type in the type {← inferType exactPrf}"
+    -- gDecideTy will be of the form `decide ... = true`. We want the '...' part.
+    let some (_, gDecideTyLhs, _) := Expr.eq? gDecideTy
+      | throwError "expected goal type to be of the form 'decide <...> = true', found: {indentD gDecideTy}"
+    let gDecidePrf ← g.withContext <| mkEqRflNativeDecideProof (lhsExpr := gDecideTyLhs) (rhs := true)
+    let exactPrf ← g.withContext <| mkAppM' exactPrf #[gDecidePrf, tenv]
+    g.assign exactPrf
+    return []
 
 def solveEntrypoint (g : MVarId) (cfg : Config) : TermElabM (List MVarId) := do
   (solve g).run { toConfig := cfg }

--- a/SSA/Experimental/Bits/MultiWidth/Tests.lean
+++ b/SSA/Experimental/Bits/MultiWidth/Tests.lean
@@ -1,0 +1,7 @@
+import SSA.Experimental.Bits.MultiWidth.Tactic
+
+
+theorem eg1 (w : Nat) (x : BitVec w) : x = x := by
+  bv_multi_width
+  sorry
+

--- a/SSA/Experimental/Bits/MultiWidth/Tests.lean
+++ b/SSA/Experimental/Bits/MultiWidth/Tests.lean
@@ -17,23 +17,5 @@ set_option trace.Meta.check true
 theorem foo (w : Nat) :
   w = WidthExpr.toNat (WidthExpr.var (Fin.mk 0 (by simp))) (WidthExpr.Env.empty.cons w) := rfl
 
-/--
-info: before out: Term.Ctx.Env.empty (WidthExpr.Env.empty.cons w) (Term.Ctx.empty _)
----
-info: after out: Term.Ctx.Env.cons (Term.Ctx.Env.empty (WidthExpr.Env.empty.cons w) (Term.Ctx.empty _)) _ x ⋯
----
-info: produced out: fun wenv tenv =>
-  Predicate.toProp (wcard := 1) (wenv := wenv) (tctx := (Term.Ctx.empty _).cons (WidthExpr.var ⟨_, ⋯⟩)) tenv
-    (Predicate.binRel (wcard := 1) (ctx := (Term.Ctx.empty _).cons (WidthExpr.var ⟨_, ⋯⟩)) (w := WidthExpr.var ⟨_, ⋯⟩)
-        BinaryRelationKind.eq
-        (MultiWidth.Term.var (wcard := 1) (tctx := (Term.Ctx.empty _).cons (WidthExpr.var ⟨_, ⋯⟩)) (⟨0, ⋯⟩ : Fin 1))
-        (MultiWidth.Term.var (wcard := 1) (tctx := (Term.Ctx.empty _).cons (WidthExpr.var ⟨_, ⋯⟩)) (⟨0, ⋯⟩ : Fin 1)) :
-      MultiWidth.Predicate ((Term.Ctx.empty 1).cons (WidthExpr.var (⟨0, ⋯⟩ : Fin 1))))
----
-error: type expected
-  WidthExpr.Env.empty.cons w
--/
 theorem eg1 (w : Nat) (x : BitVec w) : x = x := by
   bv_multi_width
-
-

--- a/SSA/Experimental/Bits/MultiWidth/Tests.lean
+++ b/SSA/Experimental/Bits/MultiWidth/Tests.lean
@@ -11,11 +11,25 @@ theorem hty : ty = BitVec 10 := by
 
 set_option pp.analyze true
 set_option pp.analyze.explicitHoles true
+set_option pp.analyze.checkInstances true
 
 theorem foo (w : Nat) :
   w = WidthExpr.toNat (WidthExpr.var (Fin.mk 0 (by simp))) (WidthExpr.Env.empty.cons w) := rfl
 
-theorem eg1 (w : Nat) (x : BitVec w) : x = x := by
+/--
+info: before out: Term.Ctx.Env.empty (WidthExpr.Env.empty.cons w) (Term.Ctx.empty _)
+---
+error: Application type mismatch: In the application
+  Term.Ctx.Env.cons (Term.Ctx.Env.empty (WidthExpr.Env.empty.cons w) (Term.Ctx.empty _)) _ x ⋯
+the argument
+  Eq.refl _
+has type
+  WidthExpr.toNat (WidthExpr.var (Fin.mk 0)) (WidthExpr.Env.empty.cons w) =
+    WidthExpr.toNat (WidthExpr.var (Fin.mk _)) (WidthExpr.Env.empty.cons w) : Prop
+but is expected to have type
+  w = WidthExpr.toNat (WidthExpr.var (Fin.mk _)) (WidthExpr.Env.empty.cons w) : Prop
+-/
+#guard_msgs in theorem eg1 (w : Nat) (x : BitVec w) : x = x := by
   bv_multi_width
   sorry
 

--- a/SSA/Experimental/Bits/MultiWidth/Tests.lean
+++ b/SSA/Experimental/Bits/MultiWidth/Tests.lean
@@ -12,6 +12,7 @@ theorem hty : ty = BitVec 10 := by
 set_option pp.analyze true
 set_option pp.analyze.explicitHoles true
 set_option pp.analyze.checkInstances true
+set_option trace.Meta.check true
 
 theorem foo (w : Nat) :
   w = WidthExpr.toNat (WidthExpr.var (Fin.mk 0 (by simp))) (WidthExpr.Env.empty.cons w) := rfl
@@ -19,18 +20,20 @@ theorem foo (w : Nat) :
 /--
 info: before out: Term.Ctx.Env.empty (WidthExpr.Env.empty.cons w) (Term.Ctx.empty _)
 ---
-error: Application type mismatch: In the application
-  Term.Ctx.Env.cons (Term.Ctx.Env.empty (WidthExpr.Env.empty.cons w) (Term.Ctx.empty _)) _ x ⋯
-the argument
-  Eq.refl _
-has type
-  WidthExpr.toNat (WidthExpr.var (Fin.mk 0)) (WidthExpr.Env.empty.cons w) =
-    WidthExpr.toNat (WidthExpr.var (Fin.mk _)) (WidthExpr.Env.empty.cons w) : Prop
-but is expected to have type
-  w = WidthExpr.toNat (WidthExpr.var (Fin.mk _)) (WidthExpr.Env.empty.cons w) : Prop
+info: after out: Term.Ctx.Env.cons (Term.Ctx.Env.empty (WidthExpr.Env.empty.cons w) (Term.Ctx.empty _)) _ x ⋯
+---
+info: produced out: fun wenv tenv =>
+  Predicate.toProp (wcard := 1) (wenv := wenv) (tctx := (Term.Ctx.empty _).cons (WidthExpr.var ⟨_, ⋯⟩)) tenv
+    (Predicate.binRel (wcard := 1) (ctx := (Term.Ctx.empty _).cons (WidthExpr.var ⟨_, ⋯⟩)) (w := WidthExpr.var ⟨_, ⋯⟩)
+        BinaryRelationKind.eq
+        (MultiWidth.Term.var (wcard := 1) (tctx := (Term.Ctx.empty _).cons (WidthExpr.var ⟨_, ⋯⟩)) (⟨0, ⋯⟩ : Fin 1))
+        (MultiWidth.Term.var (wcard := 1) (tctx := (Term.Ctx.empty _).cons (WidthExpr.var ⟨_, ⋯⟩)) (⟨0, ⋯⟩ : Fin 1)) :
+      MultiWidth.Predicate ((Term.Ctx.empty 1).cons (WidthExpr.var (⟨0, ⋯⟩ : Fin 1))))
+---
+error: type expected
+  WidthExpr.Env.empty.cons w
 -/
-#guard_msgs in theorem eg1 (w : Nat) (x : BitVec w) : x = x := by
+theorem eg1 (w : Nat) (x : BitVec w) : x = x := by
   bv_multi_width
-  sorry
 
 

--- a/SSA/Experimental/Bits/MultiWidth/Tests.lean
+++ b/SSA/Experimental/Bits/MultiWidth/Tests.lean
@@ -1,7 +1,22 @@
 import SSA.Experimental.Bits.MultiWidth.Tactic
 
+open MultiWidth
+
+
+abbrev ty := BitVec (WidthExpr.toNat (WidthExpr.var (Fin.mk 0 (by simp))) (WidthExpr.Env.empty.cons 10))
+
+theorem hty : ty = BitVec 10 := by
+  unfold ty
+  rfl
+
+set_option pp.analyze true
+set_option pp.analyze.explicitHoles true
+
+theorem foo (w : Nat) :
+  w = WidthExpr.toNat (WidthExpr.var (Fin.mk 0 (by simp))) (WidthExpr.Env.empty.cons w) := rfl
 
 theorem eg1 (w : Nat) (x : BitVec w) : x = x := by
   bv_multi_width
   sorry
+
 

--- a/SSA/Experimental/Bits/ReflectMap.lean
+++ b/SSA/Experimental/Bits/ReflectMap.lean
@@ -11,6 +11,14 @@ structure ReflectMap where
 def ReflectMap.size (m : ReflectMap) : Nat :=
     m.exprs.size
 
+
+/-- Convert the 'ReflectMap' into an array of expressions, sorted by their index. -/
+def ReflectMap.toArray (m : ReflectMap) : Array Expr := Id.run do
+  let vals := m.exprs.toArray
+  let vals := vals.qsort (fun a b => a.2 < b.2)
+  return vals.map Prod.fst
+
+
 instance : EmptyCollection ReflectMap where
   emptyCollection := { exprs := ∅ }
 /--

--- a/SSA/Experimental/Bits/ReflectMap.lean
+++ b/SSA/Experimental/Bits/ReflectMap.lean
@@ -1,0 +1,62 @@
+import Lean
+open Lean Meta Elab
+
+
+/-- The free variables in the term that is reflected. -/
+structure ReflectMap where
+  /-- Map expressions to their index in the eventual `Reflect.Map`. -/
+  exprs : Std.HashMap Expr Nat
+
+
+instance : EmptyCollection ReflectMap where
+  emptyCollection := { exprs := ∅ }
+/--
+Insert expression 'e' into the reflection map. This returns the map,
+as well as the denoted term.
+-/
+def ReflectMap.findOrInsertExpr (m : ReflectMap) (e : Expr) : Nat × ReflectMap :=
+  let (ix, m) := match m.exprs.get? e with
+    | some ix =>  (ix, m)
+    | none =>
+      let ix := m.exprs.size
+      (ix, { m with exprs := m.exprs.insert e ix })
+  (ix, m)
+
+
+instance : ToMessageData ReflectMap where
+  toMessageData exprs := Id.run do
+    -- sort in order of index.
+    let es := exprs.exprs.toArray.qsort (fun a b => a.2 < b.2)
+    let mut lines := es.map (fun (e, i) => m!"{i}→{e}")
+    return m!"[" ++ m!" ".joinSep lines.toList ++ m!"]"
+
+/--
+If we have variables in the `ReflectMap` that are not FVars,
+then we will throw a warning informing the user that this will be treated as a symbolic variable.
+-/
+def ReflectMap.throwWarningIfUninterpretedExprs (xs : ReflectMap) : MetaM Unit := do
+  let mut out? : Option MessageData := none
+  let header := m!"Tactic has not understood the following expressions, and will treat them as symbolic:"
+  -- Order the expressions so we get stable error messages.
+  let exprs := xs.exprs.toArray.qsort (fun ei ej => ei.1.lt ej.1)
+
+  for (e, _) in exprs do
+    if e.isFVar then continue
+    let eshow := indentD m!"- '{e}'"
+    out? := match out? with
+      | .none => header ++ Format.line ++ eshow
+      | .some out => .some (out ++ eshow)
+  let .some out := out? | return ()
+  logWarning out
+
+/--
+Result of reflection, where we have a collection of bitvector variables,
+along with the bitwidth and the final term.
+-/
+structure ReflectResult (α : Type) where
+  /-- Map of 'free variables' in the bitvector expression,
+  which are indexed as Term.var. This array is used to build the environment for decide.
+  -/
+  exprToIx : ReflectMap
+  e : α
+

--- a/SSA/Experimental/Bits/ReflectMap.lean
+++ b/SSA/Experimental/Bits/ReflectMap.lean
@@ -7,6 +7,9 @@ structure ReflectMap where
   /-- Map expressions to their index in the eventual `Reflect.Map`. -/
   exprs : Std.HashMap Expr Nat
 
+/-- The size of the reflect map map. -/
+def ReflectMap.size (m : ReflectMap) : Nat :=
+    m.exprs.size
 
 instance : EmptyCollection ReflectMap where
   emptyCollection := { exprs := ∅ }
@@ -60,3 +63,5 @@ structure ReflectResult (α : Type) where
   exprToIx : ReflectMap
   e : α
 
+instance [ToMessageData α] : ToMessageData (ReflectResult α) where
+  toMessageData result := m!"{result.e} {result.exprToIx}"


### PR DESCRIPTION
The definitions are much more dependently typed, since during reflection, we must correctly reflect the bitwidths, which are themselves variables. 