### PR TITLE
feat: refactor FSM [1/?]

### DIFF
--- a/SSA/Experimental/Bits/AutoStructs/FormulaToAuto.lean
+++ b/SSA/Experimental/Bits/AutoStructs/FormulaToAuto.lean
@@ -392,7 +392,11 @@ def CNFA.ofFSM (p : FSM arity) : CNFA (FinEnum.card arity + 1) :=
         process carry ts a
     @[inline]
     process carry ts a :=
-        let eval x := (p.nextBitCirc x).eval (Sum.elim (bitVecToFinFun carry) (bitVecToFinFun a))
+        let eval x :=
+          let env := (Sum.elim (bitVecToFinFun carry) (bitVecToFinFun a))
+          match x with
+          | none => p.outputCirc.eval env
+          | some x => (p.nextStateCirc x).eval env
         let res : Bool := eval none
         let carry' : BitVec (FinEnum.card p.α) := finFunToBitVec (fun c => eval (some c))
         ts.push (a.cons res, carry')

--- a/SSA/Experimental/Bits/Fast/Circuit.lean
+++ b/SSA/Experimental/Bits/Fast/Circuit.lean
@@ -348,6 +348,27 @@ def simplify : ∀ (_c : Circuit α), Circuit α
   | or c₁ c₂ => (simplify c₁) ||| (simplify c₂)
   | xor c₁ c₂ => (simplify c₁) ^^^ (simplify c₂)
 
+
+def ite (cond t f : Circuit α) : Circuit α :=
+  (cond &&& t) ||| (~~~ cond &&& f)
+
+lemma ite_def (cond t f : Circuit α) :
+  Circuit.ite cond t f = (cond &&& t) ||| (~~~ cond &&& f) := rfl
+
+@[simp] lemma eval_ite {cond t f : Circuit α} :
+    (ite cond t f).eval g =
+    if cond.eval g then t.eval g else f.eval g := by
+  simp only [ite_def, eval_or, eval_and, eval_complement]
+  rcases heval : cond.eval g <;> simp
+
+theorem ite_eq_of_eq_true {cond t f : Circuit α} (h : cond.eval g = true) :
+    (ite cond t f).eval g = t.eval g := by
+  simp [ite_def, eval_ite, h]
+
+theorem ite_eq_of_eq_false {cond t f : Circuit α} (h : cond.eval g = false) :
+    (ite cond t f).eval g = f.eval g := by
+  simp [ite_def, eval_ite, h]
+
 @[simp] lemma eval_simplify : ∀ (c : Circuit α) (f : α → Bool),
     eval (simplify c) f = eval c f
   | tru, _ => rfl

--- a/SSA/Experimental/Bits/Fast/FiniteStateMachine.lean
+++ b/SSA/Experimental/Bits/Fast/FiniteStateMachine.lean
@@ -9,6 +9,7 @@ import Mathlib.Tactic.Ring
 import SSA.Experimental.Bits.FinEnum
 import SSA.Experimental.Bits.Fast.Defs
 import SSA.Experimental.Bits.Fast.Circuit
+import SSA.Experimental.Bits.Vars
 
 open Sum
 
@@ -39,7 +40,8 @@ structure FSM (arity : Type) : Type 1 where
 
   `nextBitCirc none` computes the current output bit as a function of the state and inputs.
   `nextBitCirc (some a)`, computes the *one* bit of the new state that corresponds to `a : α`. -/
-  ( nextBitCirc : Option α → Circuit (α ⊕ arity) )
+  outputCirc : Circuit (α ⊕ arity)
+  nextStateCirc : α → Circuit (α ⊕ arity)
 
 attribute [instance] FSM.i FSM.dec_eq FSM.h
 
@@ -86,10 +88,10 @@ Note that this implicitly counts the size of the state space of the FSM,
 and consequently, is the natural notion of complexity of the FSM.
 -/
 def circuitSize : Nat := Id.run do
-  let outCircSize := p.nextBitCirc none |>.size
+  let outCircSize := p.outputCirc |>.size
   let mut stateCircSize := 0
   for hi : i in List.range (FinEnum.card p.α) do
-    let a := p.nextBitCirc (.some ((FinEnum.equiv (α := p.α)).symm.toFun ⟨i, by simpa using hi⟩))
+    let a := p.nextStateCirc (((FinEnum.equiv (α := p.α)).symm.toFun ⟨i, by simpa using hi⟩))
     stateCircSize := stateCircSize + a.size
   return outCircSize + stateCircSize
 
@@ -133,8 +135,8 @@ where `state` are the *current* state bits, and `in` are the current input bits.
 def nextBit : p.State → (arity → Bool) → p.State × Bool :=
   fun carry inputBits =>
     let input := Sum.elim carry inputBits
-    let newState : p.State  := fun (a : p.α) => (p.nextBitCirc (some a)).eval input
-    let outBit : Bool       := (p.nextBitCirc none).eval input
+    let newState : p.State  := fun (a : p.α) => (p.nextStateCirc a).eval input
+    let outBit : Bool       := (p.outputCirc).eval input
     (newState, outBit)
 
 /-- `p.carry in i` computes the internal carry state at step `i`, given input *streams* `in` -/
@@ -164,8 +166,12 @@ theorem initCarry_changeInitCarry_eq (p : FSM arity) (c : p.α → Bool) :
     (p.changeInitCarry c).initCarry = c := rfl
 
 @[simp]
-theorem nextBitCirc_changeInitCarry_eq (p : FSM arity) (c : p.α → Bool) :
-    (p.changeInitCarry c).nextBitCirc = p.nextBitCirc := rfl
+theorem outputCirc_changeInitCarry_eq (p : FSM arity) (c : p.α → Bool) :
+    (p.changeInitCarry c).outputCirc = p.outputCirc := rfl
+
+@[simp]
+theorem nextStateCirc_changeInitCarry_eq (p : FSM arity) (c : p.α → Bool) :
+    (p.changeInitCarry c).nextStateCirc = p.nextStateCirc := rfl
 
 theorem carry_changeInitCarry_succ
     (p : FSM arity) (c : p.α → Bool) (x : arity → BitStream) : ∀ n,
@@ -329,7 +335,7 @@ theorem evalWith_congrEnv {p : FSM arity}
 
 /-- One step transition of the FSM.-/
 def delta' (p : FSM arity) (carryState : p.α → Bool) (x : arity → Bool) : p.α → Bool :=
-  fun s => (p.nextBitCirc (some s)).eval fun v =>
+  fun s => (p.nextStateCirc s).eval fun v =>
     Sum.elim carryState (fun a => x a) v
 
 
@@ -357,7 +363,7 @@ theorem evalWith_succ_eq (p : FSM arity) (carryState : p.α → Bool)
 
 /-- compute the output of the FSM, given the carry state and the environment of the immediate next bits. -/
 def outputWith (p : FSM arity) (carryState : p.α → Bool) (env : arity → Bool) : Bool :=
-  (p.nextBitCirc none).eval (Sum.elim carryState env)
+  (p.outputCirc).eval (Sum.elim carryState env)
 
 /-- evalWith agrees with eval when we set the carry to the init carry. -/
 theorem evalWith_eq_eval_of_eq_init (p : FSM arity) (carryState : p.α → Bool) (x : arity → BitStream)
@@ -477,7 +483,10 @@ theorem evalWith_add_eq_evalWith_carryWith
 /-- `p.changeVars f` changes the arity of an `FSM`.
 The function `f` determines how the new input bits map to the input expected by `p` -/
 def changeVars {arity2 : Type} (changeVars : arity → arity2) : FSM arity2 :=
-  { p with nextBitCirc := fun a => (p.nextBitCirc a).map (Sum.map id changeVars) }
+  { p with
+     outputCirc := p.outputCirc.map (Sum.map id changeVars),
+     nextStateCirc := fun a => (p.nextStateCirc a).map (Sum.map id changeVars)
+  }
 
 instance {α : Type _} [Hashable α] {f : α → Type _} [∀ (a : α), Hashable (f a)] : Hashable (Sigma f) where
   hash v := hash (v.fst, v.snd)
@@ -508,21 +517,22 @@ def compose [FinEnum arity] [DecidableEq arity] [Hashable arity]
       letI := fun a => (q a).dec_eq
       infer_instance,
     initCarry := Sum.elim p.initCarry (λ x => (q x.1).initCarry x.2),
-    nextBitCirc := λ a =>
-      match a with
-      | none => (p.nextBitCirc none).bind
+    outputCirc :=
+      (p.outputCirc).bind
         (Sum.elim
           (fun a => Circuit.var true (inl (inl a)))
-          (fun a => ((q a).nextBitCirc none).map
+          (fun a => ((q a).outputCirc).map
             (Sum.elim (fun d => (inl (inr ⟨a, d⟩))) (fun q => inr (vars a q)))))
-      | some (inl a) =>
-        (p.nextBitCirc (some a)).bind
+    nextStateCirc := fun x =>
+      match x with
+      | (inl a) =>
+        (p.nextStateCirc (a)).bind
           (Sum.elim
             (fun a => Circuit.var true (inl (inl a)))
-            (fun a => ((q a).nextBitCirc none).map
+            (fun a => ((q a).outputCirc).map
             (Sum.elim (fun d => (inl (inr ⟨a, d⟩))) (fun q => inr (vars a q)))))
-      | some (inr ⟨x, y⟩) =>
-          ((q x).nextBitCirc (some y)).map
+      | inr ⟨x, y⟩ =>
+          ((q x).nextStateCirc (y)).map
             (Sum.elim
               (fun a => inl (inr ⟨_, a⟩))
               (fun a => inr (vars x a))) }
@@ -588,9 +598,9 @@ instance : Hashable Empty where
 def and : FSM Bool :=
   { α := Empty,
     initCarry := Empty.elim,
-    nextBitCirc := fun a => a.elim
-      ((Circuit.var true (inr true)) &&&
-        (Circuit.var true (inr false))) Empty.elim }
+    nextStateCirc := fun a => a.elim,
+    outputCirc := Circuit.var true (inr true) &&& Circuit.var true (inr false),
+  }
 
 @[simp] lemma eval_and (x : Bool → BitStream) : and.eval x = (x true) &&& (x false) := by
   ext n; cases n <;> simp [and, eval, nextBit]
@@ -598,9 +608,9 @@ def and : FSM Bool :=
 def or : FSM Bool :=
   { α := Empty,
     initCarry := Empty.elim,
-    nextBitCirc := fun a => a.elim
-      ((Circuit.var true (inr true)) |||
-        (Circuit.var true (inr false))) Empty.elim }
+    outputCirc := Circuit.var true (inr true) ||| Circuit.var true (inr false),
+    nextStateCirc := fun a => a.elim
+  }
 
 @[simp] lemma eval_or (x : Bool → BitStream) : or.eval x = (x true) ||| (x false) := by
   ext n; cases n <;> simp [or, eval, nextBit]
@@ -608,17 +618,17 @@ def or : FSM Bool :=
 def xor : FSM Bool :=
   { α := Empty,
     initCarry := Empty.elim,
-    nextBitCirc := fun a => a.elim
-      ( (Circuit.var true (inr true)) ^^^
-        (Circuit.var true (inr false))) Empty.elim }
+    outputCirc := Circuit.var true (inr true) ^^^ Circuit.var true (inr false),
+    nextStateCirc := Empty.elim
+  }
+
 
 /-- Equality, or alternatively, negation of the xor -/
 def nxor : FSM Bool :=
   { α := Empty,
     initCarry := Empty.elim,
-    nextBitCirc := fun a =>
-     match a with
-     | none =>
+    nextStateCirc := Empty.elim,
+    outputCirc :=
       -- x ⊕ y ⊕ T
       -- 0 ⊕ 0 ⊕ 1 = 1
       -- 0 ⊕ 1 ⊕ 1 = 0 -- value is 0 iff they differ
@@ -627,15 +637,9 @@ def nxor : FSM Bool :=
       (Circuit.tru ^^^
         ( (Circuit.var true (inr true)) ^^^
         (Circuit.var true (inr false))))
-     | some empty => empty.elim
   }
 
-def simplify (p : FSM arity) : FSM arity := {
-  α := p.α
-  initCarry := p.initCarry
-  -- nextBitCirc := Circuit.simplify ∘ p.nextBitCirc
-  nextBitCirc := p.nextBitCirc
-}
+def simplify (p : FSM arity) : FSM arity := p
 
 /-- Evaluating the value after `simplify` is the same as the original value. -/
 @[simp] lemma eval_simplify :
@@ -659,7 +663,8 @@ def scanAnd  : FSM Unit :=
   {
    α := Unit,
    initCarry := fun () => true,
-   nextBitCirc := fun _a => (Circuit.var true (inl ())) &&& (Circuit.var true (inr ()))
+   outputCirc := Circuit.var true (inl ()) &&& Circuit.var true (inr ()),
+   nextStateCirc := fun () => (Circuit.var true (inl ())) &&& (Circuit.var true (inr ()))
   }
 
 @[simp]
@@ -707,7 +712,8 @@ def scanOr  : FSM Unit :=
   {
    α := Unit,
    initCarry := fun () => false,
-   nextBitCirc := fun _α => (Circuit.var true (inl ())) ||| (Circuit.var true (inr ()))
+   outputCirc := Circuit.var true (inl ()) ||| Circuit.var true (inr ()),
+   nextStateCirc := fun () => Circuit.var true (inl ()) ||| Circuit.var true (inr ())
   }
 
 @[simp]
@@ -759,18 +765,18 @@ lemma eval_scanOr_succ (x : Unit → BitStream) (n : Nat) :
 def add : FSM Bool :=
   { α := Unit,
     initCarry := λ _ => false,
-    nextBitCirc := fun a =>
-      match a with
-      | some () =>
-             (Circuit.var true (inr true)  &&& Circuit.var true (inr false))
-             ||| (Circuit.var true (inr true)  &&& Circuit.var true (inl ()))
-             ||| (Circuit.var true (inr false) &&& Circuit.var true (inl ()))
-      | none => Circuit.var true (inr true) ^^^
-                Circuit.var true (inr false) ^^^
-                Circuit.var true (inl ()) }
+    nextStateCirc := fun () =>
+      Circuit.var true (inr true) &&& Circuit.var true (inr false) |||
+      Circuit.var true (inr true) &&& Circuit.var true (inl ()) |||
+      Circuit.var true (inr false) &&& Circuit.var true (inl ()),
+    outputCirc := Circuit.var true (inr true) ^^^
+                  Circuit.var true (inr false) ^^^
+                  Circuit.var true (inl ()),
+  }
 
-theorem add_nextBitCirc_some_eval :
-    (add.nextBitCirc (some ())).eval =
+
+theorem add_nextStateCirc_eval :
+    (add.nextStateCirc ()).eval =
       fun x => x (inr true) && x (inr false) || x (inr true)
         && x (inl ()) || x (inr false) && x (inl ()) := by
   ext x
@@ -787,7 +793,7 @@ theorem carry_add_succ (x : Bool → BitStream) (n : ℕ) :
     simp [carry, BitStream.addAux, nextBit, add, BitVec.adcb]
   | succ n ih =>
     unfold carry
-    simp [add_nextBitCirc_some_eval, nextBit, ih, BitStream.addAux, BitVec.adcb]
+    simp [add_nextStateCirc_eval, nextBit, ih, BitStream.addAux, BitVec.adcb]
 
 @[simp] theorem carry_zero (x : arity → BitStream) : carry p x 0 = p.initCarry := rfl
 @[simp] theorem initCarry_add : add.initCarry = (fun _ => false) := rfl
@@ -807,15 +813,14 @@ given that we can reduce both those operations to just addition and bitwise comp
 def sub : FSM Bool :=
   { α := Unit,
     initCarry := fun _ => false,
-    nextBitCirc := fun a =>
-      match a with
-      | some () =>
-             (Circuit.var false (inr true) &&& Circuit.var true (inr false)) |||
-             ((Circuit.var false (inr true) ^^^ Circuit.var true (inr false)) &&&
-              (Circuit.var true (inl ())))
-      | none => Circuit.var true (inr true) ^^^
-                Circuit.var true (inr false) ^^^
-                Circuit.var true (inl ()) }
+    outputCirc := Circuit.var true (inr true) ^^^
+                  Circuit.var true (inr false) ^^^
+                  Circuit.var true (inl ()),
+    nextStateCirc := fun _ =>
+      (Circuit.var false (inr true) &&& Circuit.var true (inr false)) |||
+      (Circuit.var false (inr true) ^^^ Circuit.var true (inr false)) &&&
+      (Circuit.var true (inl ()))
+  }
 
 theorem carry_sub (x : Bool → BitStream) : ∀ (n : ℕ), sub.carry x (n+1) =
     fun _ => (BitStream.subAux (x true) (x false) n).2
@@ -845,9 +850,14 @@ def borrow : FSM Bool :=
   { α := Unit,
     -- Internal state is the current borrow.
     initCarry := fun _ => false,
-    -- | TODO: check that this is in fact the borrow bit of the subtraction automata.
-    -- Check that we do correctly compute the borrow bit here.
-    nextBitCirc := fun _i =>
+    outputCirc :=
+      let borrow := Circuit.var true (inl ())
+      let a := Circuit.var true (inr true)
+      let nota := Circuit.var false (inr true)
+      let b := Circuit.var true (inr false)
+      (nota &&& b/- !a && b-/) |||
+      ((~~~ (a ^^^ b) /- !(xor a b) -/) &&& borrow)
+    nextStateCirc := fun () =>
       let borrow := Circuit.var true (inl ())
       let a := Circuit.var true (inr true)
       let nota := Circuit.var false (inr true)
@@ -866,7 +876,6 @@ def borrow : FSM Bool :=
       -- (!a && b || ((!(xor a b)) && borrow))
       (nota &&& b/- !a && b-/) |||
       ((~~~ (a ^^^ b) /- !(xor a b) -/) &&& borrow)
-
   }
 
 /--
@@ -900,10 +909,11 @@ def neg : FSM Unit :=
   { α := Unit,
     i := by infer_instance,
     initCarry := λ _ => true,
-    nextBitCirc := fun a =>
-      match a with
-      | some () => Circuit.var false (inr ()) &&& Circuit.var true (inl ())
-      | none => Circuit.var false (inr ()) ^^^ Circuit.var true (inl ())  }
+    outputCirc :=
+      Circuit.var false (inr ()) ^^^ Circuit.var true (inl ())
+    nextStateCirc := fun () =>
+      Circuit.var false (inr ()) &&& Circuit.var true (inl ())
+  }
 
 theorem carry_neg (x : Unit → BitStream) : ∀ (n : ℕ), neg.carry x (n+1) =
     fun _ => (BitStream.negAux (x ()) n).2
@@ -924,7 +934,9 @@ theorem carry_neg (x : Unit → BitStream) : ∀ (n : ℕ), neg.carry x (n+1) =
 def not : FSM Unit :=
   { α := Empty,
     initCarry := Empty.elim,
-    nextBitCirc := fun _ => Circuit.var false (inr ()) }
+    nextStateCirc := Empty.elim,
+    outputCirc := Circuit.var false (inr ())
+  }
 
 @[simp] lemma eval_not (x : Unit → BitStream) : not.eval x = ~~~(x ()) := by
   ext; simp [eval, not, nextBit]
@@ -932,7 +944,9 @@ def not : FSM Unit :=
 def zero : FSM (Fin 0) :=
   { α := Empty,
     initCarry := Empty.elim,
-    nextBitCirc := fun _ => Circuit.fals }
+    nextStateCirc := Empty.elim,
+    outputCirc := Circuit.fals
+  }
 
 @[simp] lemma eval_zero (x : Fin 0 → BitStream) : zero.eval x = BitStream.zero := by
   ext; simp [zero, eval, nextBit]
@@ -941,10 +955,9 @@ def one : FSM (Fin 0) :=
   { α := Unit,
     i := by infer_instance,
     initCarry := λ _ => true,
-    nextBitCirc := fun a =>
-      match a with
-      | some () => Circuit.fals
-      | none => Circuit.var true (inl ()) }
+    outputCirc := Circuit.var true (inl ()),
+    nextStateCirc := fun () => Circuit.fals
+  }
 
 @[simp] theorem carry_one (x : Fin 0 → BitStream) (n : ℕ) :
     one.carry x (n+1) = fun _ => false := by
@@ -960,7 +973,9 @@ def negOne : FSM (Fin 0) :=
   { α := Empty,
     i := by infer_instance,
     initCarry := Empty.elim,
-    nextBitCirc := fun _ => Circuit.tru }
+    nextStateCirc := Empty.elim,
+    outputCirc := Circuit.tru
+  }
 
 @[simp] lemma eval_negOne (x : Fin 0 → BitStream) : negOne.eval x = BitStream.negOne := by
   ext; simp [negOne, eval, nextBit]
@@ -971,10 +986,9 @@ An FSM whose first output is `b`, and later outputs are whatever the input is.
 def ls (b : Bool) : FSM Unit :=
   { α := Unit,
     initCarry := fun _ => b,
-    nextBitCirc := fun x =>
-      match x with
-      | none => Circuit.var true (inl ()) -- next state bit = state bit
-      | some () => Circuit.var true (inr ()) } --
+    nextStateCirc := fun () => Circuit.var true (inr ()),
+    outputCirc := Circuit.var true (inl ())
+  }
 
 theorem carry_ls (b : Bool) (x : Unit → BitStream) : ∀ (n : ℕ),
     (ls b).carry x (n+1) = fun _ => x () n
@@ -995,7 +1009,9 @@ def var (n : ℕ) : FSM (Fin (n+1)) :=
   { α := Empty,
     i := by infer_instance,
     initCarry := Empty.elim,
-    nextBitCirc := λ _ => Circuit.var true (inr (Fin.last _)) }
+    nextStateCirc := Empty.elim
+    outputCirc := Circuit.var true (inr (Fin.last _))
+  }
 
 @[simp] lemma eval_var (n : ℕ) (x : Fin (n+1) → BitStream) : (var n).eval x = x (Fin.last n) := by
   ext m; cases m <;> simp [var, eval, carry, nextBit]
@@ -1003,10 +1019,11 @@ def var (n : ℕ) : FSM (Fin (n+1)) :=
 def incr : FSM Unit :=
   { α := Unit,
     initCarry := fun _ => true,
-    nextBitCirc := fun x =>
-      match x with
-      | none => (Circuit.var true (inr ())) ^^^ (Circuit.var true (inl ()))
-      | some _ => (Circuit.var true (inr ())) &&& (Circuit.var true (inl ())) }
+    outputCirc :=
+      (Circuit.var true (inr ())) ^^^ (Circuit.var true (inl ()))
+    nextStateCirc := fun () =>
+      (Circuit.var true (inr ())) &&& (Circuit.var true (inl ()))
+  }
 
 theorem carry_incr (x : Unit → BitStream) : ∀ (n : ℕ),
     incr.carry x (n+1) = fun _ => (BitStream.incrAux (x ()) n).2
@@ -1026,10 +1043,10 @@ def decr : FSM Unit :=
   { α := Unit,
     i := by infer_instance,
     initCarry := λ _ => true,
-    nextBitCirc := fun x =>
-      match x with
-      | none => (Circuit.var true (inr ())) ^^^ (Circuit.var true (inl ()))
-      | some _ => (Circuit.var false (inr ())) &&& (Circuit.var true (inl ())) }
+    outputCirc :=
+      (Circuit.var true (inr ())) ^^^ (Circuit.var true (inl ()))
+    nextStateCirc := fun () => (Circuit.var false (inr ())) &&& (Circuit.var true (inl ()))
+  }
 
 theorem carry_decr (x : Unit → BitStream) : ∀ (n : ℕ), decr.carry x (n+1) =
     fun _ => (BitStream.decrAux (x ()) n).2
@@ -1070,9 +1087,8 @@ theorem eval_eq_zero_of_set {arity : Type _} (p : FSM arity)
 def repeatBit : FSM Unit where
   α := Unit
   initCarry := fun () => false
-  nextBitCirc := fun _ =>
-    .or (.var true <| .inl ()) (.var true <| .inr ())
-
+  outputCirc :=  (.var true <| .inl ()) ||| (.var true <| .inr ())
+  nextStateCirc := fun () => (.var true <| .inl ()) ||| (.var true <| .inr ())
 -- @[simp] theorem eval_repeatBit :
 --     repeatBit.eval x = BitStream.repeatBit (x ()) := by
 --   unfold BitStream.repeatBit
@@ -1300,10 +1316,8 @@ theorem eval_ofInt (x : Int) (i : Nat) {env : Fin 0 → BitStream} :
 def id : FSM Unit := {
  α := Empty,
  initCarry := Empty.elim,
- nextBitCirc := fun a =>
-   match a with
-   | none => (Circuit.var true (inr ()))
-   | some f => f.elim
+ outputCirc := Circuit.var true (inr ()),
+ nextStateCirc := Empty.elim
 }
 
 @[simp]
@@ -1518,19 +1532,17 @@ If not, we produce an infinite sequence of `1`.
 -/
 def and : FSM Bool :=
   { α := Unit,
-    initCarry := fun _ => false,
-    nextBitCirc := fun a =>
-      match a with
-      | some () =>
-             -- Only if both are `0` we produce a `0`.
-             (Circuit.var true (inr false)  |||
-             ((Circuit.var false (inr true) |||
-              -- But if we have failed and have value `1`, then we produce a `1` from our state.
-              (Circuit.var true (inl ())))))
-      | none => -- must succeed in both arguments, so we are `0` if both are `0`.
-                Circuit.var true (inr true) |||
-                Circuit.var true (inr false)
-                }
+    initCarry := fun () => false,
+    nextStateCirc := fun () =>
+      -- Only if both are `0` we produce a `0`.
+      (Circuit.var true (inr false)  |||
+      ((Circuit.var false (inr true) |||
+      -- But if we have failed and have value `1`, then we produce a `1` from our state.
+      (Circuit.var true (inl ())))))
+    outputCirc := -- must succeed in both arguments, so we are `0` if both are `0`.
+      Circuit.var true (inr true) |||
+      Circuit.var true (inr false)
+  }
 
 /-!
 FSM that implement bitwise-or. Since we use `0` as the good state,
@@ -1540,18 +1552,16 @@ If not, we produce a `1`.
 def or : FSM Bool :=
   { α := Unit,
     initCarry := fun _ => false,
-    nextBitCirc := fun a =>
-      match a with
-      | some () =>
-             -- If either succeeds, then the full thing succeeds
-             ((Circuit.var true (inr false)  &&&
-             ((Circuit.var false (inr true)) |||
-             -- On the other hand, if we have failed, then propagate failure.
-              (Circuit.var true (inl ())))))
-      | none => -- can succeed in either argument, so we are `0` if either is `0`.
-                Circuit.var true (inr true) &&&
-                Circuit.var true (inr false)
-                }
+    nextStateCirc := fun () =>
+      -- If either succeeds, then the full thing succeeds
+      ((Circuit.var true (inr false)  &&&
+      ((Circuit.var false (inr true)) |||
+      -- On the other hand, if we have failed, then propagate failure.
+      (Circuit.var true (inl ())))))
+    outputCirc :=-- can succeed in either argument, so we are `0` if either is `0`.
+      Circuit.var true (inr true) &&&
+      Circuit.var true (inr false)
+  }
 
 /-- An `FSMPredicateSolution `t` is an FSM with a witness that the FSM evaluates to the same value as `t` does -/
 structure FSMPredicateSolution (p : Predicate) extends FSM (Fin p.arity) where
@@ -1770,7 +1780,7 @@ def decideIfZerosAux {arity : Type _} [DecidableEq arity]
   else
     -- compute circuit that produces output at the (k+1)th state.
     -- [c' = false] ↔ ∀ i < (n + 1), ∀ env, p.eval env i = 0
-    have c' := (c.bind (p.nextBitCirc ∘ some)).fst
+    have c' := (c.bind (p.nextStateCirc)).fst
     if h : c' ≤ c then true
     else
       have _wf : card_compl (c' ||| c) < card_compl c :=
@@ -1801,7 +1811,7 @@ def decideIfZerosAuxM {arity : Type _} [DecidableEq arity] [Monad m]
   if c.eval p.initCarry
   then return false
   else
-    have c' := (c.bind (p.nextBitCirc ∘ some)).fst
+    have c' := (c.bind (p.nextStateCirc)).fst
     let le ← decLe c' c
     if h : le then return true
     else
@@ -1836,7 +1846,7 @@ theorem decideIfZerosAuxM_Id_eq_decideIfZerosAux {arity : Type _}
   case neg =>
     simp [h]
     clear h
-    by_cases h : (c.bind (p.nextBitCirc ∘ some)).fst ≤ c
+    by_cases h : (c.bind (p.nextStateCirc)).fst ≤ c
     case pos =>
       simp [h]
       rfl
@@ -1869,7 +1879,7 @@ theorem decideIfZerosAux_correct {arity : Type _} [DecidableEq arity]
         apply h'
       · assumption
       · exact hc₂
-    · let c' := (c.bind (p.nextBitCirc ∘ some)).fst
+    · let c' := (c.bind (p.nextStateCirc)).fst
       have _wf : card_compl (c' ||| c) < card_compl c :=
         decideIfZeroAux_wf h'
       apply decideIfZerosAux_correct p (c' ||| c)
@@ -1904,22 +1914,18 @@ def decideIfZerosAuxUnverified {σ ι : Type _}
   termination_by card_compl π
 
 
-def FSM.optimize {arity : Type _} (p : FSM arity) [DecidableEq arity] : FSM arity where
-  α := p.α
-  initCarry := p.initCarry
-  nextBitCirc := fun v => (p.nextBitCirc v).optimize
-
+def FSM.optimize {arity : Type _} (p : FSM arity) [DecidableEq arity] : FSM arity :=
+  p
 
 def decideIfZeros {arity : Type _} [DecidableEq arity]
     (p : FSM arity) : Bool :=
-  -- let p := FSM.optimize p
-  decideIfZerosAux p (p.nextBitCirc none).fst
+  decideIfZerosAux p (p.outputCirc).fst
 
 def decideIfZerosM {arity : Type _} [DecidableEq arity] [Monad m]
     (decLe : {α : Type} → [DecidableEq α] → [Fintype α] → [Hashable α] →
         (c : Circuit α) → (c' : Circuit α) → m { b : Bool // b ↔ c ≤ c' })
     (p : FSM arity) : m Bool :=
-  decideIfZerosAuxM decLe p (p.nextBitCirc none).fst
+  decideIfZerosAuxM decLe p (p.outputCirc).fst
 
 
 theorem decideIfZeros_correct {arity : Type _} [DecidableEq arity]
@@ -1944,11 +1950,11 @@ def FSM.nextBitCircIterate {arity : Type _ } [DecidableEq arity]
   match n with
   | 0 =>
      -- | the .fst performs quantifier elimination, by running over all possible values of inputs.
-    fsm.nextBitCirc none |>.fst
+    fsm.outputCirc |>.fst
   | n' + 1 =>
      let c := fsm.nextBitCircIterate n'
      -- | for each input, compute the next bit circuit, quantifier eliminate it for all inputs, and then compose.
-     let c' := (c.bind (fsm.nextBitCirc ∘ some)).fst
+     let c' := (c.bind (fsm.nextStateCirc)).fst
      c'
 
 /-- Decide if the FSM produces zeroes for all inputs at a given index of the bitstream -/
@@ -1968,14 +1974,14 @@ def decideIfZerosAtIxAux {arity : Type _} [DecidableEq arity]
       | 0 => true -- c has accumulated the effects so far.
       | nItersLeft' + 1 =>
         -- accumulate one iteration
-        have c' := (c.bind (fsm.nextBitCirc ∘ some)).fst
+        have c' := (c.bind (fsm.nextStateCirc)).fst
         if _ : c' ≤ c
         then true
         else decideIfZerosAtIxAux fsm (c' ||| c) nItersLeft'
 
 def decideIfZerosAtIx {arity : Type _} [DecidableEq arity]
       (fsm : FSM arity) (w : Nat) : Bool :=
-    decideIfZerosAtIxAux fsm (fsm.nextBitCirc none).fst w
+    decideIfZerosAtIxAux fsm (fsm.outputCirc).fst w
 /--
 The correctness statement of decideIfZeroesAtIx.
 This tells us that decideIfZeroesAtIx is correct iff the FSM 'p' when evaluated returns false

--- a/SSA/Experimental/Bits/KInduction/KInduction.lean
+++ b/SSA/Experimental/Bits/KInduction/KInduction.lean
@@ -108,7 +108,7 @@ def mkCarryAssignCircuitNAux {arity : Type _}
   [Fintype arity]
   [Hashable arity]
   (p : FSM arity) (s : p.α) (n : Nat) : Circuit (Vars p.α arity (n + 1)) :=
-    (p.nextBitCirc (some s)).map fun v =>
+    (p.nextStateCirc s).map fun v =>
       match v with
         | .inl t => Vars.stateN t n
         | .inr i => Vars.inputN i n
@@ -126,7 +126,7 @@ theorem mkCarryAssignCircuitNAux_eval_eq_ {arity : Type _}
     {env' : p.α ⊕ arity → Bool}
     (hEnvState : ∀ (s : p.α), env (Vars.stateN s n) = env' (Sum.inl s))
     (hEnvInput : ∀ (i : arity), env (Vars.inputN i n) = env' (Sum.inr i)) :
-    ((mkCarryAssignCircuitNAux p s n).eval env) = ((p.nextBitCirc (some s)).eval env') := by
+    ((mkCarryAssignCircuitNAux p s n).eval env) = ((p.nextStateCirc s).eval env') := by
   rw [mkCarryAssignCircuitNAux]
   rw [Circuit.eval_map]
   congr
@@ -145,7 +145,7 @@ theorem mkCarryAssignCircuitNAux_eval_eq {arity : Type _}
     [Hashable arity]
     (p : FSM arity) (s : p.α) (n : Nat)
     {env : Vars p.α arity (n + 1) → Bool} :
-    ((mkCarryAssignCircuitNAux p s n).eval env) = ((p.nextBitCirc (some s)).eval
+    ((mkCarryAssignCircuitNAux p s n).eval env) = ((p.nextStateCirc s).eval
       (fun x => match x with | .inl x => env (Vars.stateN x n) | .inr x => env (Vars.inputN x n))) := by
   rw [mkCarryAssignCircuitNAux]
   rw [Circuit.eval_map]
@@ -289,7 +289,7 @@ def mkOutputAssignCircuitNAux {arity : Type _}
   [Fintype arity]
   [Hashable arity]
   (p : FSM arity) (n : Nat) : Circuit (Vars p.α arity (n + 1)) :=
-    (p.nextBitCirc none).map fun v =>
+    (p.outputCirc).map fun v =>
       match v with
         | .inl s' => Vars.stateN s' n
         | .inr i => Vars.inputN i n
@@ -301,7 +301,7 @@ theorem eval_mkOutputAssignCircuitNAux_eq {arity : Type _}
   [Hashable arity]
   (p : FSM arity) (n : Nat) (env : Vars p.α arity (n + 1) → Bool) :
   (mkOutputAssignCircuitNAux p n).eval env =
-    (p.nextBitCirc none).eval
+    (p.outputCirc).eval
       (fun x => match x with
         | .inl s => env (Vars.stateN s n)
         | .inr i => env (Vars.inputN i n)) := by
@@ -333,7 +333,7 @@ theorem eval_mkOutputAssignCircuitN_eq_false_iff {arity : Type _}
   {env : Vars p.α arity (n + 1) → Bool}
   :
   ((mkOutputAssignCircuitN p n).eval env = false) ↔
-    (p.nextBitCirc none).eval
+    (p.outputCirc).eval
       (fun x => match x with
         | .inl s => env (Vars.stateN s n)
         | .inr i => env (Vars.inputN i n)) =
@@ -359,7 +359,7 @@ theorem mkOutputAssignCircuitLeN_eq_false_iff {arity : Type _}
   (env : Vars p.α arity (n + 1) → Bool) :
   ((mkOutputAssignCircuitLeN p n).eval env = false) ↔
   (∀ (i : Nat) (hi : i < n + 1),
-    (p.nextBitCirc none).eval
+    (p.outputCirc).eval
       (fun x => match x with
         | .inl s => env (Vars.stateN s i)
         | .inr j => env (Vars.inputN j i)) =
@@ -615,7 +615,7 @@ structure KInductionCircuits.IsLawful {arity : Type _}
     ∀ {env : Vars fsm.α arity (n + 2) → Bool},
       (circs.cOutAssignCirc.eval env = false)
       ↔ (∀ (i : Nat) (hi : i < n + 2),
-        (fsm.nextBitCirc none).eval
+        (fsm.outputCirc).eval
           (fun x => match x with
             | .inl s => env (Vars.stateN s i)
             | .inr j => env (Vars.inputN j i)) =
@@ -835,7 +835,7 @@ theorem eval_mkSuccCarryAndOutAssignPrecond_eq_false_iff₁
       ((mkCarryAssignCircuitNAux fsm s i).map
         (fun v => v.castLe (by omega))).eval env) ∧
   (∀ (i : Nat) (hi : i < n + 2),
-    (fsm.nextBitCirc none).eval
+    (fsm.outputCirc).eval
       (fun x => match x with
         | .inl s => env (Vars.stateN s i)
         | .inr j => env (Vars.inputN j i)) =
@@ -1464,7 +1464,7 @@ noncomputable def mkSimplePathOfPath (fsm : FSM arity)
         · generalize fsm.carryWith s0 path'.simplePath path'.k = s0'
           -- | TODO: find lemmas.
           ext a
-          simp [FSM.carryWith, FSM.carry, FSM.nextBit, FSM.nextBitCirc_changeInitCarry_eq,
+          simp [FSM.carryWith, FSM.carry, FSM.nextBit,
             FSM.initCarry_changeInitCarry_eq, add_zero]
         · omega
       hStatesUniqueLe := by
@@ -1487,7 +1487,7 @@ noncomputable def mkSimplePathOfPath (fsm : FSM arity)
               · rw [path'.hCarryWith]
                 generalize fsm.carryWith s0 path'.simplePath path'.k = s0'
                 ext a
-                simp [FSM.carryWith, FSM.carry, FSM.nextBit, FSM.nextBitCirc_changeInitCarry_eq,
+                simp [FSM.carryWith, FSM.carry, FSM.nextBit,
                   FSM.initCarry_changeInitCarry_eq, add_zero]
               · omega
             rw [← hsn]

--- a/SSA/Experimental/Bits/KInduction/Tests.lean
+++ b/SSA/Experimental/Bits/KInduction/Tests.lean
@@ -17,11 +17,8 @@ open Lean Meta Elab Tactic in
     (initCarry :=
       fun
       | _ => false)
-    (nextBitCirc :=
-      fun
-      | .some () => .var true (.inr 0) -- stores input in state variables.
-      | .none => .var true (.inl ()) -- spits out the output.
-    )
+    (outputCirc := .var true (.inl ()))
+    (nextStateCirc := fun () => .var true (.inr 0))
   let _ ← fsm.decideIfZerosVerified 0
   logInfo "done test."
   return ()

--- a/SSA/Experimental/Bits/MultiWidth/Defs.lean
+++ b/SSA/Experimental/Bits/MultiWidth/Defs.lean
@@ -168,11 +168,11 @@ structure Term.Ctx.GoodBitstreamEnv {wcard tcard : Nat}
     BitStream.ofBitVec (tenv v) = bs (StateSpace.termVar v)
 
 /-- the FSM that corresponds to a given nat-predicate. -/
-structure NatFSM (wcard : Nat) (v : WidthExpr wcard) where
-  fsm : FSM (StateSpace wcard 0)
+structure NatFSM {wcard : Nat} (v : WidthExpr wcard) where
+  fsm : FSM (StateSpace wcard tcard)
 
-structure TermFSM {w : WidthExpr wcard}
-  (ctx : Term.Ctx wcard tcard)
+structure TermFSM {wcard tcard : Nat} {w : WidthExpr wcard}
+  {tctx : Term.Ctx wcard tcard}
   (t : Term tctx w) where
   fsm : FSM (StateSpace wcard tcard)
 
@@ -181,20 +181,22 @@ structure PredicateFSM
   (p : Predicate tctx) where
   fsm : FSM (StateSpace wcard tcard)
 
-structure GoodNatFSM (wcard : Nat) (v : WidthExpr wcard)
-  extends NatFSM wcard v where
+structure GoodNatFSM {wcard : Nat} (v : WidthExpr wcard)
+  extends NatFSM v where
   heval_eq :
     ∀ (env : Fin wcard → Nat)
     (fsmEnv : StateSpace wcard 0 → BitStream),
       fsm.eval fsmEnv = v.toBitstream env
 
+/-
 structure GoodTermFSM {w : WidthExpr wcard}
-  (ctx : Term.Ctx wcard tcard)
-  (t : Term tctx w) extends TermFSM ctx t where
+  (tctx : Term.Ctx wcard tcard)
+  (t : Term tctx w) extends TermFSM t where
   heval_eq :
     ∀ {wenv : WidthExpr.Env wcard} (tenv : tctx.Env wenv)
       (fsmEnv : StateSpace wcard tcard → BitStream),
       fsm.eval fsmEnv = t.toBitstream tenv
+-/
 
 structure GoodPredicateFSM
   {tctx : Term.Ctx wcard tcard}

--- a/SSA/Experimental/Bits/MultiWidth/GoodFSM.lean
+++ b/SSA/Experimental/Bits/MultiWidth/GoodFSM.lean
@@ -6,3 +6,139 @@ multi-width bitstream semantics.
 import SSA.Experimental.Bits.Fast.FiniteStateMachine
 import SSA.Experimental.Bits.Vars
 import SSA.Experimental.Bits.MultiWidth.Defs
+
+namespace MultiWidth
+
+
+instance : HAnd (FSM α) (FSM α) (FSM α) where
+  hAnd := composeBinaryAux' FSM.and
+
+instance : HOr (FSM α) (FSM α) (FSM α) where
+  hOr := composeBinaryAux' FSM.or
+
+instance : HXor (FSM α) (FSM α) (FSM α) where
+  hXor := composeBinaryAux' FSM.xor
+
+instance : Complement (FSM α) where
+  complement := composeUnaryAux FSM.not
+
+
+-- build an FSM whose output is unary, and is 1 in the beginning, and becomes 0
+-- forever after.
+-- TODO: I am pretty sure we can just do this with binary encodings as well?
+def mkWidthFSM (w : WidthExpr wcard) : NatFSM w :=
+   match w with
+   | .var v => { fsm :=
+      composeUnaryAux FSM.scanAnd (FSM.var' (StateSpace.widthVar v))
+    }
+
+
+-- when we compute 'a - b', if the borrow bit is zero,
+-- then we know that 'a' is greater than or equal to 'b'.
+-- if the borrow bit is one, then we know that 'a' is less than 'b'.
+-- a: 0 <= b: 0 = 1
+-- a: 0 <= b: 1 = 1
+-- a: 1 <= b: 0 = 0
+-- a: 1 <= b: 1 = 1
+def fsmUltUnary (a : FSM α) (b : FSM α) : FSM α :=
+  a ||| ~~~ b
+
+-- returns 1 if a is equal to b.
+def fsmEqBitwise (a : FSM α) (b : FSM α) : FSM α :=
+  composeUnaryAux FSM.scanAnd <|  composeBinaryAux' FSM.nxor a  b
+
+-- returns 1 if a is less than or equal to b.
+def fsmUleUnary (a : FSM α) (b : FSM α) : FSM α :=
+  (fsmUltUnary a b) &&& (fsmEqBitwise a b)
+
+-- | if 'cond' is true, then return 't', otherwise return 'e'.
+def ite (cond : FSM α) (t : FSM α) (e : FSM α) : FSM α :=
+  (cond &&& t) ||| (~~~ cond &&& e)
+
+def fsmZext (a wold wnew : FSM (StateSpace wcard tcard))
+    : FSM (StateSpace wcard tcard) :=
+  ite (fsmUleUnary wold wnew) a (FSM.zero.map Fin.elim0)
+
+/-- The inputs given to the sext fsm. -/
+inductive fsmSext.inputs
+| a
+| a0
+| wold
+| wnew
+
+def fsmSext.inputs.toFin : fsmSext.inputs → Fin 4
+| .a => 0
+| .a0 => 1
+| .wold => 2
+| .wnew => 3
+
+
+def fsmSext (a wold wnew : FSM (StateSpace wcard tcard))
+    : FSM (StateSpace wcard tcard) :=
+    ite (fsmUleUnary wnew wold)
+      /- wnew ≤ wold, so it's the same as zext. -/
+      (fsmZext a wold wnew)
+      /- wnew > wold. -/
+    (composeQuaternaryAux'
+      (composer.map fsmSext.inputs.toFin)
+      a
+      (composeUnaryAux (FSM.ls false) a)
+      wold
+      wnew)
+  where
+    -- precondition: wnew > wold.
+    composer : FSM fsmSext.inputs := {
+      α := Unit,
+      initCarry := fun () => false,
+      outputCirc :=
+        .ite (.var true (.inr fsmSext.inputs.wold)) -- i ≤ wold < wnew
+          (.var true (.inr fsmSext.inputs.a)) -- return the bit of a.
+          -- else: wold < i ≤ wnew
+          (.ite (.var true (.inr fsmSext.inputs.wnew))
+            (.var true (.inl ())) -- return our state bit.
+            -- else: wnew < i.
+            .fals
+          )
+      nextStateCirc :=
+        /- while we are i ≤ wold, store the bit from a. -/
+        /- otherwise, save the old bit. -/
+        fun () =>
+          .ite (.var true (.inr fsmSext.inputs.wold))
+            (.var true (.inr fsmSext.inputs.a)) -- i ≤ wold
+            (.var true (.inl ())) -- i > wold
+    }
+
+
+def mkTermFSM {wcard tcard : Nat} {tctx : Term.Ctx wcard tcard} {w : WidthExpr wcard}
+  (t : Term tctx w) : TermFSM t :=
+  match t with
+  | .var v => { fsm := composeUnaryAux FSM.scanAnd (FSM.var' (StateSpace.termVar v)) }
+  | .add a b =>
+    let fsmA := mkTermFSM a
+    let fsmB := mkTermFSM b
+    { fsm := (composeBinaryAux' FSM.add fsmA.fsm fsmB.fsm) }
+  | .zext (w := wold) a wnew =>
+    { fsm := fsmZext (mkTermFSM a).fsm (mkWidthFSM wold).fsm (mkWidthFSM wnew).fsm }
+  | .sext (w := wa) a v =>
+    { fsm := fsmSext (mkTermFSM a).fsm (mkWidthFSM wa).fsm (mkWidthFSM v).fsm }
+
+def mkPredicateFSM {tctx : Term.Ctx wcard tcard} (p : Predicate tctx) :
+  PredicateFSM p :=
+  match p with
+  | .binRel .eq a b =>
+    let fsmA := mkTermFSM a
+    let fsmB := mkTermFSM b
+    { fsm := fsmEqBitwise fsmA.fsm fsmB.fsm }
+  | .or p q  =>
+    let fsmP := mkPredicateFSM p
+    let fsmQ := mkPredicateFSM q
+    { fsm := composeUnaryAux FSM.scanAnd (fsmP.fsm ||| fsmQ.fsm) }
+  | .and p q =>
+    let fsmP := mkPredicateFSM p
+    let fsmQ := mkPredicateFSM q
+    { fsm := composeUnaryAux FSM.scanAnd (fsmP.fsm &&& fsmQ.fsm) }
+  | .not p =>
+    let fsmP := mkPredicateFSM p
+    { fsm := composeUnaryAux FSM.scanAnd (~~~ fsmP.fsm) }
+
+end MultiWidth


### PR DESCRIPTION
This refactoring splits the 'outputcirc' field into two fields: one that computes the output bit, and one that computes the next state bit. As a future PR, we will replace the state space with 'Vars α 1'.