### PR TITLE
fix: make ::ₕ notation right-associative

### DIFF
--- a/SSA/Core/HVector.lean
+++ b/SSA/Core/HVector.lean
@@ -183,7 +183,7 @@ macro_rules
     else
       `(%[ $elems,* | List.nil ])
 
-infixl:50 "::ₕ" => HVector.cons
+infixr:50 "::ₕ" => HVector.cons
 
 
 /-!


### PR DESCRIPTION
This PR fixes the ::ₕ notation to be right-associative, so that `x ::ₕ y ::ₕ _` parses as you'd expect.