### PR TITLE
chore: replace uses of `Ctxt.get?` with `getElem?`

### DIFF
--- a/SSA/Core/ErasedContext.lean
+++ b/SSA/Core/ErasedContext.lean
@@ -113,10 +113,10 @@ end Rec
 /-! ## Variables -/
 
 def Var (Γ : Ctxt Ty) (t : Ty) : Type :=
-  { i : Nat // Γ.get? i = some t }
+  { i : Nat // Γ[i]? = some t }
 
 /-- constructor for Var. -/
-def Var.mk {Γ : Ctxt Ty} {t : Ty} (i : Nat) (hi : Γ.get? i = some t) : Γ.Var t :=
+def Var.mk {Γ : Ctxt Ty} {t : Ty} (i : Nat) (hi : Γ[i]? = some t) : Γ.Var t :=
   ⟨i, hi⟩
 
 namespace Var
@@ -145,7 +145,7 @@ theorem zero_eq_last {Γ : Ctxt Ty} {t : Ty} (h) :
   rfl
 
 @[simp]
-theorem succ_eq_toSnoc {Γ : Ctxt Ty} {t : Ty} {w} (h : (Γ.snoc t).get? (w+1) = some t') :
+theorem succ_eq_toSnoc {Γ : Ctxt Ty} {t : Ty} {w} (h : (Γ.snoc t)[w+1]? = some t') :
     ⟨w+1, h⟩ = toSnoc ⟨w, h⟩ :=
   rfl
 
@@ -179,7 +179,7 @@ def casesOn
     | ⟨0, h⟩ =>
         _root_.cast (by
           obtain rfl : t' = t := by simpa [snoc] using h
-          simp_all only [get?, zero_eq_last]
+          simp_all only [zero_eq_last]
           ) <| @last Γ t
     | ⟨i+1, h⟩ =>
         toSnoc ⟨i, by simpa [snoc] using h⟩
@@ -360,7 +360,7 @@ theorem Valuation.snoc_last {Γ : Ctxt Ty} {t : Ty} (s : Γ.Valuation) (x : toTy
 
 @[simp]
 theorem Valuation.snoc_zero {Γ : Ctxt Ty} {ty : Ty} (s : Γ.Valuation) (x : toType ty)
-    (h : get? (Ctxt.snoc Γ ty) 0 = some ty) :
+    (h : (Ctxt.snoc Γ ty)[0]? = some ty) :
     (s.snoc x) ⟨0, h⟩ = x := by
   rfl
 
@@ -375,7 +375,7 @@ theorem Valuation.snoc_toSnoc {Γ : Ctxt Ty} {t t' : Ty} (s : Γ.Valuation) (x :
 /--  (ctx.snoc v₁) ⟨n+1, _⟩ = ctx ⟨n, _⟩ -/
 @[simp]
 theorem Valuation.snoc_eval {ty : Ty} (Γ : Ctxt Ty) (V : Γ.Valuation) (v : ⟦ty⟧)
-    (hvar : Ctxt.get? (Ctxt.snoc Γ ty) (n+1) = some var_val) :
+    (hvar : (Ctxt.snoc Γ ty)[n+1]? = some var_val) :
     (V.snoc v) ⟨n+1, hvar⟩ = V ⟨n, by simpa using hvar⟩ :=
   rfl
 
@@ -485,7 +485,7 @@ def Valuation.equivHVector {Γ : List Ty} : Valuation ⟨Γ⟩ ≃ HVector toTyp
   invFun    := Valuation.ofHVector
   left_inv V := by
     funext t v
-    simp only [Fin.getElem_fin, get?]
+    simp only [Fin.getElem_fin]
     induction Γ
     case nil =>
       rcases v with ⟨_, _⟩
@@ -495,7 +495,7 @@ def Valuation.equivHVector {Γ : List Ty} : Valuation ⟨Γ⟩ ≃ HVector toTyp
       case last   => rfl
       case toSnoc => apply ih (fun t v => V v.toSnoc)
   right_inv vs := by
-    simp only [Fin.getElem_fin, get?]
+    simp only [Fin.getElem_fin]
     induction vs
     case nil => rfl
     case cons Γ t v vs ih => simp [HVector.ofFn, ofHVector, ih]
@@ -540,7 +540,7 @@ end Var
 
 @[simp]
 abbrev Diff.Valid (Γ₁ Γ₂ : Ctxt Ty) (d : Nat) : Prop :=
-  ∀ {i t}, Γ₁.get? i = some t → Γ₂.get? (i+d) = some t
+  ∀ {i t}, Γ₁[i]? = some t → Γ₂[i+d]? = some t
 
 /--
   If `Γ₁` is a prefix of `Γ₂`,
@@ -560,7 +560,7 @@ def toSnoc (d : Diff Γ₁ Γ₂) : Diff Γ₁ (Γ₂.snoc t) :=
   ⟨d.val + 1, by
     intro i _ h_get_snoc
     rcases d with ⟨d, h_get_d⟩
-    simp only [get?, ← h_get_d h_get_snoc]
+    simp only [← h_get_d h_get_snoc]
     rfl
   ⟩
 
@@ -570,7 +570,7 @@ def unSnoc (d : Diff (Γ₁.snoc t) Γ₂) : Diff Γ₁ Γ₂ :=
     intro i t h_get
     rcases d with ⟨d, h_get_d⟩
     specialize @h_get_d (i+1) t
-    rw [←h_get_d h_get, Nat.add_assoc, Nat.add_comm 1, get?]
+    rw [←h_get_d h_get, Nat.add_assoc, Nat.add_comm 1]
   ⟩
 
 /-!
@@ -582,7 +582,7 @@ def unSnoc (d : Diff (Γ₁.snoc t) Γ₂) : Diff Γ₁ Γ₂ :=
 def toMap (d : Diff Γ₁ Γ₂) : Diff (Γ₁.map f) (Γ₂.map f) :=
   ⟨d.val, by
     rcases d with ⟨d, h_get_d⟩
-    simp only [Valid, get?, getElem?_map, Option.map_eq_some_iff, forall_exists_index, and_imp,
+    simp only [Valid, getElem?_map, Option.map_eq_some_iff, forall_exists_index, and_imp,
       forall_apply_eq_imp_iff₂] at h_get_d ⊢
     intros a b c
     simp [h_get_d c]
@@ -648,7 +648,7 @@ lemma toHom_succ {Γ₁ Γ₂ : Ctxt Ty} {d : Nat} (h : Valid Γ₁ (Γ₂.snoc 
 @[simp] lemma toHom_unSnoc {Γ₁ Γ₂ : Ctxt Ty} (d : Diff (Γ₁.snoc t) Γ₂) :
     toHom (unSnoc d) = fun _ v => (toHom d) v.toSnoc := by
   unfold unSnoc Var.toSnoc toHom
-  simp only [get?, Valid]
+  simp only [Valid]
   funext x v
   congr 1
   rw [Nat.add_assoc, Nat.add_comm 1]
@@ -658,7 +658,7 @@ lemma toHom_succ {Γ₁ Γ₂ : Ctxt Ty} {d : Nat} (h : Valid Γ₁ (Γ₂.snoc 
   funext t v
   apply Subtype.eq
   simp
-  simp only [Hom.comp, toHom, get?, Valid]
+  simp only [Hom.comp, toHom, Valid]
   grind
 
 end Lemmas
@@ -730,7 +730,7 @@ def dropUntilDiff {Γ : Ctxt Ty} {v : Var Γ ty} : Diff (Γ.dropUntil v) Γ :=
     case nil => exact v.emptyElim
     case snoc Γ _ ih =>
       cases v using Var.casesOn
-      · simp only [get?, dropUntil_toSnoc, Var.val_toSnoc] at h ⊢
+      · simp only [dropUntil_toSnoc, Var.val_toSnoc] at h ⊢
         apply ih h
       · simpa! using h
   ⟩
@@ -755,18 +755,19 @@ variable [ToExpr Ty] {Γ : Ctxt Ty} {ty : Ty}
 
 /-- Construct an expression of type `Var Γ ty`.
 
-If no proof `hi : Γ.get? i = some ty` is provided,
+If no proof `hi : Γ[i]? = some ty` is provided,
 it's assumed to be true by rfl. -/
 def mkVar (Ty : Q(Type)) (Γ : Q(Ctxt $Ty)) (ty : Q($Ty)) (i : Q(Nat))
-    (hi? : Option Q(($Γ).get? $i = some $ty) := none) :
+    (hi? : Option Q(($Γ)[$i]? = some $ty) := none) :
     Q(($Γ).Var $ty) :=
   let optTy := mkApp (.const ``Option [0]) Ty
   let someTy := mkApp2 (.const ``Option.some [0]) Ty ty
   let P :=
-    let getE := mkApp3 (mkConst ``Ctxt.get?) Ty Γ (.bvar 0)
+    let i : Q(Nat) := Expr.bvar 0
+    let getE := q($Γ[$i]?)
     let eq := mkApp3 (.const ``Eq [1]) optTy getE someTy
     Expr.lam `i (mkConst ``Nat) eq .default
-  let hi := hi?.getD <| /- : Γ.get? i = some ty := rfl -/
+  let hi := hi?.getD <| /- : Γ[i]? = some ty := rfl -/
     mkApp2 (.const ``rfl [1]) optTy someTy
   mkApp4 (.const ``Subtype.mk [1]) (mkConst ``Nat) P i hi
 

--- a/SSA/Core/Framework.lean
+++ b/SSA/Core/Framework.lean
@@ -1583,7 +1583,7 @@ def Com.vars : Com d Γ .pure t → VarSet Γ :=
 
 theorem Lets.vars_var_eq {lets : Lets d Γ_in eff Γ_out}
   {t: d.Ty} {e : Expr d Γ_out eff t}
-  {w : ℕ} {tw : d.Ty} {wh : Ctxt.get? Γ_out w = some tw} :
+  {w : ℕ} {tw : d.Ty} {wh : Γ_out[w]? = some tw} :
   Lets.vars (Lets.var lets e) ⟨w + 1, by simpa [Ctxt.snoc] using wh⟩ =
   Lets.vars lets ⟨w, wh⟩ := by simp [Lets.vars]
 

--- a/SSA/Core/Transforms/Rewrite/Match.lean
+++ b/SSA/Core/Transforms/Rewrite/Match.lean
@@ -126,7 +126,7 @@ theorem matchVar_var_succ_eq {Γ_in Γ_out Δ_in Δ_out : Ctxt d.Ty} {t te : d.T
     (matchLets : Lets d Δ_in .pure Δ_out)
     (matchE : Expr d Δ_out .pure te)
     (w : ℕ)
-    (hw : Ctxt.get? Δ_out w = .some t)
+    (hw : Δ_out[w]? = .some t)
     (ma : Mapping Δ_in Γ_out) :
   matchVar lets v (matchLets := .var matchLets matchE)
     ⟨w + 1, by simpa using hw⟩ ma =
@@ -245,7 +245,7 @@ theorem isMonotone_matchVarArg_aux (lets : Lets d Γ_in eff Γ_out) :
 
   · intro Δ_out t_1 matchLets
     intro matchExpr property? ih_matchArg
-    simp only [Ctxt.get?, matchVar, isMonotone_bind_liftM, Option.mem_def]
+    simp only [matchVar, isMonotone_bind_liftM, Option.mem_def]
     intro e he
     split
     next h =>
@@ -473,7 +473,7 @@ theorem denote_matchVar2_of_subset
   case var t' matchLets matchExpr ih =>
     match w with
     | ⟨w+1, h⟩ =>
-      simp only [Option.mem_def, Ctxt.get?, Var.succ_eq_toSnoc, Lets.denote,
+      simp only [Option.mem_def, Var.succ_eq_toSnoc, Lets.denote,
         EffectKind.toMonad_pure, Id.pure_eq', Id.bind_eq', Valuation.snoc_toSnoc] at *
       rw [Var.toSnoc, matchVar_var_succ_eq] at h_matchVar
       apply ih h_sub h_matchVar
@@ -483,7 +483,7 @@ theorem denote_matchVar2_of_subset
         symm; simpa using h_w
       have ⟨args, h_pure, h_matchArgs⟩ := matchVar_var_last h_matchVar
       rw [← Vout.property v _ h_pure]
-      simp only [Ctxt.get?, Var.zero_eq_last, Lets.denote_var_last_pure]
+      simp only [Var.zero_eq_last, Lets.denote_var_last_pure]
       apply Expr.denote_eq_denote_of <;> (try rfl)
       simp only [Expr.op_mk, Expr.args_mk]
 
@@ -595,7 +595,7 @@ theorem mem_matchVar
     revert hMatchLets
     obtain rfl : t = t' := by
       symm; simpa using hw
-    simp only [Lets.vars, Ctxt.get?, Var.zero_eq_last, Var.casesOn_last, Finset.mem_biUnion,
+    simp only [Lets.vars, Var.zero_eq_last, Var.casesOn_last, Finset.mem_biUnion,
       Sigma.exists, forall_exists_index, and_imp]
     intro _ _ hl h_v'
     obtain ⟨

--- a/SSA/Projects/DCE/DCE.lean
+++ b/SSA/Projects/DCE/DCE.lean
@@ -45,7 +45,7 @@ def Deleted.deleteSnoc (Γ : Ctxt Ty) (α : Ty) : Deleted (Γ.snoc α) (Ctxt.Var
 def Deleted.snoc {α : Ty} {Γ : Ctxt Ty} {v : Γ.Var α}
     (DEL : Deleted Γ v Γ') (ω : Ty) :
     Deleted (Γ.snoc ω) v.toSnoc (Γ'.snoc ω) := by
-  simp only [Deleted, Ctxt.delete, Ctxt.get?, Ctxt.Var.val_toSnoc] at DEL ⊢
+  simp only [Deleted, Ctxt.delete, Ctxt.Var.val_toSnoc] at DEL ⊢
   subst DEL
   rfl
 
@@ -83,7 +83,7 @@ def Var.tryDelete? [TyDenote Ty] {Γ Γ' : Ctxt Ty} {delv : Γ.Var α}
     let idx := if v.val < delv.val then v.val else v.val - 1
     let v' := ⟨idx, by
       subst DEL
-      simp only [Ctxt.get?, Ctxt.delete, Ctxt.getElem?_ofList, List.getElem?_eraseIdx, idx]
+      simp only [Ctxt.delete, Ctxt.getElem?_ofList, List.getElem?_eraseIdx, idx]
       split_ifs with h_val_lt h_val_sub_lt
       · exact v.prop
       · omega

--- a/SSA/Projects/InstCombine/ComWrappers.lean
+++ b/SSA/Projects/InstCombine/ComWrappers.lean
@@ -22,7 +22,7 @@ def const {Γ : Ctxt _} (w : ℕ) (n : ℤ) : Expr InstCombine.LLVM Γ .pure (LL
 
 @[simp_denote]
 def not {Γ : Ctxt _} (w : ℕ) (l : Nat)
-    (lp : (Ctxt.get? Γ l = some (InstCombine.MTy.bitvec (ConcreteOrMVar.concrete w)))
+    (lp : (Γ[l]? = some (InstCombine.MTy.bitvec (ConcreteOrMVar.concrete w)))
       := by get_elem_tactic):
     Expr InstCombine.LLVM Γ .pure (LLVM.Ty.bitvec w) :=
   Expr.mk
@@ -34,7 +34,7 @@ def not {Γ : Ctxt _} (w : ℕ) (l : Nat)
 
 @[simp_denote]
 def neg {Γ : Ctxt _} (w : ℕ) (l : Nat)
-    (lp : (Ctxt.get? Γ l = some (InstCombine.MTy.bitvec (ConcreteOrMVar.concrete w)))
+    (lp : (Γ[l]? = some (InstCombine.MTy.bitvec (ConcreteOrMVar.concrete w)))
       := by get_elem_tactic):
     Expr InstCombine.LLVM Γ .pure (LLVM.Ty.bitvec w) :=
   Expr.mk
@@ -46,9 +46,9 @@ def neg {Γ : Ctxt _} (w : ℕ) (l : Nat)
 
 @[simp_denote]
 def and {Γ : Ctxt _} (w : ℕ) (l r : Nat)
-    (lp : (Ctxt.get? Γ l = some (InstCombine.MTy.bitvec (ConcreteOrMVar.concrete w)))
+    (lp : (Γ[l]? = some (InstCombine.MTy.bitvec (ConcreteOrMVar.concrete w)))
       := by get_elem_tactic)
-    (rp : (Ctxt.get? Γ r = some (InstCombine.MTy.bitvec (ConcreteOrMVar.concrete w)))
+    (rp : (Γ[r]? = some (InstCombine.MTy.bitvec (ConcreteOrMVar.concrete w)))
       := by get_elem_tactic) :
     Expr InstCombine.LLVM Γ .pure (LLVM.Ty.bitvec w) :=
   Expr.mk
@@ -60,9 +60,9 @@ def and {Γ : Ctxt _} (w : ℕ) (l r : Nat)
 
 @[simp_denote]
 def or {Γ : Ctxt _} (w : ℕ) (l r : Nat)
-    (lp : (Ctxt.get? Γ l = some (InstCombine.MTy.bitvec (ConcreteOrMVar.concrete w)))
+    (lp : (Γ[l]? = some (InstCombine.MTy.bitvec (ConcreteOrMVar.concrete w)))
       := by get_elem_tactic)
-    (rp : (Ctxt.get? Γ r = some (InstCombine.MTy.bitvec (ConcreteOrMVar.concrete w)))
+    (rp : (Γ[r]? = some (InstCombine.MTy.bitvec (ConcreteOrMVar.concrete w)))
       := by get_elem_tactic) :
     Expr InstCombine.LLVM Γ .pure (LLVM.Ty.bitvec w) :=
   Expr.mk
@@ -74,9 +74,9 @@ def or {Γ : Ctxt _} (w : ℕ) (l r : Nat)
 
 @[simp_denote]
 def xor {Γ : Ctxt _} (w : ℕ) (l r : Nat)
-    (lp : (Ctxt.get? Γ l = some (InstCombine.MTy.bitvec (ConcreteOrMVar.concrete w)))
+    (lp : (Γ[l]? = some (InstCombine.MTy.bitvec (ConcreteOrMVar.concrete w)))
       := by get_elem_tactic)
-    (rp : (Ctxt.get? Γ r = some (InstCombine.MTy.bitvec (ConcreteOrMVar.concrete w)))
+    (rp : (Γ[r]? = some (InstCombine.MTy.bitvec (ConcreteOrMVar.concrete w)))
       := by get_elem_tactic) :
     Expr InstCombine.LLVM Γ .pure (LLVM.Ty.bitvec w) :=
   Expr.mk
@@ -88,9 +88,9 @@ def xor {Γ : Ctxt _} (w : ℕ) (l r : Nat)
 
 @[simp_denote]
 def shl {Γ : Ctxt _} (w : ℕ) (l r : Nat)
-    (lp : (Ctxt.get? Γ l = some (InstCombine.MTy.bitvec (ConcreteOrMVar.concrete w)))
+    (lp : (Γ[l]? = some (InstCombine.MTy.bitvec (ConcreteOrMVar.concrete w)))
       := by get_elem_tactic)
-    (rp : (Ctxt.get? Γ r = some (InstCombine.MTy.bitvec (ConcreteOrMVar.concrete w)))
+    (rp : (Γ[r]? = some (InstCombine.MTy.bitvec (ConcreteOrMVar.concrete w)))
       := by get_elem_tactic) :
     Expr InstCombine.LLVM Γ .pure (LLVM.Ty.bitvec w) :=
   Expr.mk
@@ -102,9 +102,9 @@ def shl {Γ : Ctxt _} (w : ℕ) (l r : Nat)
 
 @[simp_denote]
 def lshr {Γ : Ctxt _} (w : ℕ) (l r : Nat)
-    (lp : (Ctxt.get? Γ l = some (InstCombine.MTy.bitvec (ConcreteOrMVar.concrete w)))
+    (lp : (Γ[l]? = some (InstCombine.MTy.bitvec (ConcreteOrMVar.concrete w)))
       := by get_elem_tactic)
-    (rp : (Ctxt.get? Γ r = some (InstCombine.MTy.bitvec (ConcreteOrMVar.concrete w)))
+    (rp : (Γ[r]? = some (InstCombine.MTy.bitvec (ConcreteOrMVar.concrete w)))
       := by get_elem_tactic) :
     Expr InstCombine.LLVM Γ .pure (LLVM.Ty.bitvec w) :=
   Expr.mk
@@ -116,9 +116,9 @@ def lshr {Γ : Ctxt _} (w : ℕ) (l r : Nat)
 
 @[simp_denote]
 def ashr {Γ : Ctxt _} (w : ℕ) (l r : Nat)
-    (lp : (Ctxt.get? Γ l = some (InstCombine.MTy.bitvec (ConcreteOrMVar.concrete w)))
+    (lp : (Γ[l]? = some (InstCombine.MTy.bitvec (ConcreteOrMVar.concrete w)))
       := by get_elem_tactic)
-    (rp : (Ctxt.get? Γ r = some (InstCombine.MTy.bitvec (ConcreteOrMVar.concrete w)))
+    (rp : (Γ[r]? = some (InstCombine.MTy.bitvec (ConcreteOrMVar.concrete w)))
       := by get_elem_tactic) :
     Expr InstCombine.LLVM Γ .pure (LLVM.Ty.bitvec w) :=
   Expr.mk
@@ -130,9 +130,9 @@ def ashr {Γ : Ctxt _} (w : ℕ) (l r : Nat)
 
 @[simp_denote]
 def sub {Γ : Ctxt _} (w : ℕ) (l r : Nat)
-    (lp : (Ctxt.get? Γ l = some (InstCombine.MTy.bitvec (ConcreteOrMVar.concrete w)))
+    (lp : (Γ[l]? = some (InstCombine.MTy.bitvec (ConcreteOrMVar.concrete w)))
       := by get_elem_tactic)
-    (rp : (Ctxt.get? Γ r = some (InstCombine.MTy.bitvec (ConcreteOrMVar.concrete w)))
+    (rp : (Γ[r]? = some (InstCombine.MTy.bitvec (ConcreteOrMVar.concrete w)))
       := by get_elem_tactic) :
     Expr InstCombine.LLVM Γ .pure (LLVM.Ty.bitvec w) :=
   Expr.mk
@@ -144,9 +144,9 @@ def sub {Γ : Ctxt _} (w : ℕ) (l r : Nat)
 
 @[simp_denote]
 def add {Γ : Ctxt _} (w : ℕ) (l r : Nat)
-    (lp : (Ctxt.get? Γ l = some (InstCombine.MTy.bitvec (ConcreteOrMVar.concrete w)))
+    (lp : (Γ[l]? = some (InstCombine.MTy.bitvec (ConcreteOrMVar.concrete w)))
       := by get_elem_tactic)
-    (rp : (Ctxt.get? Γ r = some (InstCombine.MTy.bitvec (ConcreteOrMVar.concrete w)))
+    (rp : (Γ[r]? = some (InstCombine.MTy.bitvec (ConcreteOrMVar.concrete w)))
       := by get_elem_tactic) :
     Expr InstCombine.LLVM Γ .pure (LLVM.Ty.bitvec w) :=
   Expr.mk
@@ -158,9 +158,9 @@ def add {Γ : Ctxt _} (w : ℕ) (l r : Nat)
 
 @[simp_denote]
 def mul {Γ : Ctxt _} (w : ℕ) (l r : Nat)
-    (lp : (Ctxt.get? Γ l = some (InstCombine.MTy.bitvec (ConcreteOrMVar.concrete w)))
+    (lp : (Γ[l]? = some (InstCombine.MTy.bitvec (ConcreteOrMVar.concrete w)))
       := by get_elem_tactic)
-    (rp : (Ctxt.get? Γ r = some (InstCombine.MTy.bitvec (ConcreteOrMVar.concrete w)))
+    (rp : (Γ[r]? = some (InstCombine.MTy.bitvec (ConcreteOrMVar.concrete w)))
       := by get_elem_tactic) :
     Expr InstCombine.LLVM Γ .pure (LLVM.Ty.bitvec w) :=
   Expr.mk
@@ -172,9 +172,9 @@ def mul {Γ : Ctxt _} (w : ℕ) (l r : Nat)
 
 @[simp_denote]
 def sdiv {Γ : Ctxt _} (w : ℕ) (l r : Nat)
-    (lp : (Ctxt.get? Γ l = some (InstCombine.MTy.bitvec (ConcreteOrMVar.concrete w)))
+    (lp : (Γ[l]? = some (InstCombine.MTy.bitvec (ConcreteOrMVar.concrete w)))
       := by get_elem_tactic)
-    (rp : (Ctxt.get? Γ r = some (InstCombine.MTy.bitvec (ConcreteOrMVar.concrete w)))
+    (rp : (Γ[r]? = some (InstCombine.MTy.bitvec (ConcreteOrMVar.concrete w)))
       := by get_elem_tactic) :
     Expr InstCombine.LLVM Γ .pure (LLVM.Ty.bitvec w) :=
   Expr.mk
@@ -186,9 +186,9 @@ def sdiv {Γ : Ctxt _} (w : ℕ) (l r : Nat)
 
 @[simp_denote]
 def udiv {Γ : Ctxt _} (w : ℕ) (l r : Nat)
-    (lp : (Ctxt.get? Γ l = some (InstCombine.MTy.bitvec (ConcreteOrMVar.concrete w)))
+    (lp : (Γ[l]? = some (InstCombine.MTy.bitvec (ConcreteOrMVar.concrete w)))
       := by get_elem_tactic)
-    (rp : (Ctxt.get? Γ r = some (InstCombine.MTy.bitvec (ConcreteOrMVar.concrete w)))
+    (rp : (Γ[r]? = some (InstCombine.MTy.bitvec (ConcreteOrMVar.concrete w)))
       := by get_elem_tactic) :
     Expr InstCombine.LLVM Γ .pure (LLVM.Ty.bitvec w) :=
   Expr.mk
@@ -200,9 +200,9 @@ def udiv {Γ : Ctxt _} (w : ℕ) (l r : Nat)
 
 @[simp_denote]
 def srem {Γ : Ctxt _} (w : ℕ) (l r : Nat)
-    (lp : (Ctxt.get? Γ l = some (InstCombine.MTy.bitvec (ConcreteOrMVar.concrete w)))
+    (lp : (Γ[l]? = some (InstCombine.MTy.bitvec (ConcreteOrMVar.concrete w)))
       := by get_elem_tactic)
-    (rp : (Ctxt.get? Γ r = some (InstCombine.MTy.bitvec (ConcreteOrMVar.concrete w)))
+    (rp : (Γ[r]? = some (InstCombine.MTy.bitvec (ConcreteOrMVar.concrete w)))
       := by get_elem_tactic) :
     Expr InstCombine.LLVM Γ .pure (LLVM.Ty.bitvec w) :=
   Expr.mk
@@ -214,9 +214,9 @@ def srem {Γ : Ctxt _} (w : ℕ) (l r : Nat)
 
 @[simp_denote]
 def urem {Γ : Ctxt _} (w : ℕ) (l r : Nat)
-    (lp : (Ctxt.get? Γ l = some (InstCombine.MTy.bitvec (ConcreteOrMVar.concrete w)))
+    (lp : (Γ[l]? = some (InstCombine.MTy.bitvec (ConcreteOrMVar.concrete w)))
       := by get_elem_tactic)
-    (rp : (Ctxt.get? Γ r = some (InstCombine.MTy.bitvec (ConcreteOrMVar.concrete w)))
+    (rp : (Γ[r]? = some (InstCombine.MTy.bitvec (ConcreteOrMVar.concrete w)))
       := by get_elem_tactic) :
     Expr InstCombine.LLVM Γ .pure (LLVM.Ty.bitvec w) :=
   Expr.mk
@@ -228,9 +228,9 @@ def urem {Γ : Ctxt _} (w : ℕ) (l r : Nat)
 
 @[simp_denote]
 def icmp {Γ : Ctxt _} (w : ℕ) (pred : LLVM.IntPred) (l r : Nat)
-    (lp : (Ctxt.get? Γ l = some (InstCombine.MTy.bitvec (ConcreteOrMVar.concrete w)))
+    (lp : (Γ[l]? = some (InstCombine.MTy.bitvec (ConcreteOrMVar.concrete w)))
       := by get_elem_tactic)
-    (rp : (Ctxt.get? Γ r = some (InstCombine.MTy.bitvec (ConcreteOrMVar.concrete w)))
+    (rp : (Γ[r]? = some (InstCombine.MTy.bitvec (ConcreteOrMVar.concrete w)))
       := by get_elem_tactic) :
     Expr InstCombine.LLVM Γ .pure (LLVM.Ty.bitvec 1) :=
   Expr.mk
@@ -242,11 +242,11 @@ def icmp {Γ : Ctxt _} (w : ℕ) (pred : LLVM.IntPred) (l r : Nat)
 
 @[simp_denote]
 def select {Γ : Ctxt _} (w : ℕ) (l m r : Nat)
-    (lp : (Ctxt.get? Γ l = some (InstCombine.MTy.bitvec (ConcreteOrMVar.concrete 1)))
+    (lp : (Γ[l]? = some (InstCombine.MTy.bitvec (ConcreteOrMVar.concrete 1)))
       := by get_elem_tactic)
-    (mp : (Ctxt.get? Γ m = some (InstCombine.MTy.bitvec (ConcreteOrMVar.concrete w)))
+    (mp : (Γ[m]? = some (InstCombine.MTy.bitvec (ConcreteOrMVar.concrete w)))
       := by get_elem_tactic)
-    (rp : (Ctxt.get? Γ r = some (InstCombine.MTy.bitvec (ConcreteOrMVar.concrete w)))
+    (rp : (Γ[r]? = some (InstCombine.MTy.bitvec (ConcreteOrMVar.concrete w)))
       := by get_elem_tactic) :
     Expr InstCombine.LLVM Γ .pure (LLVM.Ty.bitvec w)  :=
   Expr.mk

--- a/SSA/Projects/LLVMRiscV/LLVMAndRiscv.lean
+++ b/SSA/Projects/LLVMRiscV/LLVMAndRiscv.lean
@@ -153,7 +153,7 @@ def transformExprLLVM (e : Expr (InstCombine.MetaLLVM 0) (ctxtTransformToLLVM Γ
     | Expr.mk op1 ty_eq1 eff_le1 args1 regArgs1 => do
         let args' : HVector (Ctxt.Var Γ) (.llvm <$> DialectSignature.sig op1) ←
           args1.mapM' fun t v => do
-            match h : Γ.get? v.val with
+            match h : Γ[v.val]? with
             | some ty' => do
               match hty : ty' with
               | .riscv _ => /- This is impossible, because mixing LLVM and RiscV variables would've already
@@ -256,7 +256,7 @@ instance : MLIR.AST.TransformExpr (LLVMPlusRiscV) 0   where
 @[simp_denote]
 def transformVarLLVM (v : Ctxt.Var (ctxtTransformToLLVM Γ) ty) :
      MLIR.AST.ReaderM LLVMPlusRiscV (Ctxt.Var Γ (LLVMRiscV.Ty.llvm ty)) :=
-  if h : Γ.get? v.1 = some (LLVMRiscV.Ty.llvm ty) then
+  if h : Γ[v.1]? = some (LLVMRiscV.Ty.llvm ty) then
    return ⟨_ , h⟩
   else
     throw <| .generic s!"TransformVarLLVM FAILED: Tried to convert a variable of wrong type."
@@ -264,7 +264,7 @@ def transformVarLLVM (v : Ctxt.Var (ctxtTransformToLLVM Γ) ty) :
 @[simp_denote]
 def transformVarRISCV (v : Ctxt.Var (ctxtTransformToRiscV Γ) ty) :
     MLIR.AST.ReaderM LLVMPlusRiscV (Ctxt.Var Γ (LLVMRiscV.Ty.riscv ty)) :=
-  if h : Γ.get? v.1 = some (LLVMRiscV.Ty.riscv ty) then
+  if h : Γ[v.1]? = some (LLVMRiscV.Ty.riscv ty) then
    return ⟨_ , h⟩
   else
      throw <| .generic s!"TransformVarRISCV FAILED: Tried to convert a variable of wrong type."

--- a/SSA/Projects/Scf/ScfFunctor.lean
+++ b/SSA/Projects/Scf/ScfFunctor.lean
@@ -538,11 +538,10 @@ def rhs : Com ScfArith ⟨[/- start-/ .int, /- delta -/.int, /- steps -/ .nat, /
 theorem Ctxt.Var.toSnoc (ty snocty : Arith.Ty) (Γ : Ctxt Arith.Ty)  (V : Ctxt.Valuation Γ)
     {snocval : ⟦snocty⟧}
     {v: ℕ}
-    {hvproof : Ctxt.get? Γ v = some ty}
+    {hvproof : Γ[v]? = some ty}
     {var : Γ.Var ty}
     (hvar : var = ⟨v, hvproof⟩) :
-    V var = (Ctxt.Valuation.snoc V snocval) ⟨v+1, by
-      simp at hvproof; simp [hvproof]⟩ := by
+    V var = (V ::ᵥ snocval) ⟨v+1, by simp [hvproof]⟩ := by
   simp [Ctxt.Valuation.snoc, hvar]
 
 theorem correct : Com.denote (lhs rgn) Γv = Com.denote (rhs rgn) Γv := by


### PR DESCRIPTION
This PR replaces all uses of `Ctxt.get?` with `getElem?` (i.e., the `-[-]?` notation), following the deprecation of the former.