### PR TITLE
feat: prove multi-width zext, sext correct

### DIFF
--- a/SSA/Experimental/Bits/AutoStructs/FiniteStateMachine.lean
+++ b/SSA/Experimental/Bits/AutoStructs/FiniteStateMachine.lean
@@ -13,10 +13,10 @@ attribute [instance] FSM.i FSM.dec_eq
 variable {ar : Type} (p : FSM ar)
 
 def carryBV (x : ar → BitVec w) : p.State :=
-  p.carry (fun ar => BitStream.ofBitVec (x ar)) w
+  p.carry (fun ar => .ofBitVecSext (x ar)) w
 
 def evalBV {w} (x : ar → BitVec w) : BitVec w :=
-  BitVec.ofFn fun k => p.eval (fun ar => BitStream.ofBitVec (x ar)) k
+  BitVec.ofFn fun k => p.eval (fun ar => .ofBitVecSext (x ar)) k
 
 instance {α β : Type} [Fintype α] [Fintype β] (b : Bool) :
     Fintype (cond b α β) := by

--- a/SSA/Experimental/Bits/AutoStructs/FormulaToAuto.lean
+++ b/SSA/Experimental/Bits/AutoStructs/FormulaToAuto.lean
@@ -239,7 +239,7 @@ def NFA'.ofFSM_correct (p : FSM arity) :
           congr
           rcases hsa with ⟨-, rfl⟩
           simp [FSM.carryBV]
-          · apply FSM.carry_eq_up_to; rintro ar k hk; simp [BitStream.ofBitVec]
+          · apply FSM.carry_eq_up_to; rintro ar k hk; simp [BitStream.ofBitVecSext]
             rw [ite_cond_eq_true]
             on_goal 2 => simp; omega
             rw [ite_cond_eq_true]
@@ -251,7 +251,7 @@ def NFA'.ofFSM_correct (p : FSM arity) :
           have hlt : i < w := by omega
           rcases hsa with ⟨hsa, -⟩; simp [inFSMRel] at hsa
           simp [hsa, FSM.evalBV]
-          apply FSM.eval_eq_up_to; rintro ar k hk; simp [BitStream.ofBitVec]
+          apply FSM.eval_eq_up_to; rintro ar k hk; simp [BitStream.ofBitVecSext]
           rw [ite_cond_eq_true]
           on_goal 2 => simp; omega
           rw [ite_cond_eq_true]
@@ -261,7 +261,7 @@ def NFA'.ofFSM_correct (p : FSM arity) :
       · rw [hq]
         rcases hsa with ⟨-, rfl⟩
         simp [FSM.carryBV, FSM.carry]; congr 2
-        · apply FSM.carry_eq_up_to; rintro ar k hk; simp [BitStream.ofBitVec]
+        · apply FSM.carry_eq_up_to; rintro ar k hk; simp [BitStream.ofBitVecSext]
           rw [ite_cond_eq_true]
           on_goal 2 => simp; omega
           rw [ite_cond_eq_true]
@@ -283,7 +283,7 @@ def NFA'.ofFSM_correct (p : FSM arity) :
         rw [hrel]
         simp only [FSM.evalBV]
         repeat rw [BitVec.ofFn_getElem _ (by omega)]
-        apply FSM.eval_eq_up_to; rintro ar k hk; simp [BitStream.ofBitVec]
+        apply FSM.eval_eq_up_to; rintro ar k hk; simp [BitStream.ofBitVecSext]
         rw [ite_cond_eq_true]
         on_goal 2 => simp; omega
         rw [ite_cond_eq_true]
@@ -293,7 +293,7 @@ def NFA'.ofFSM_correct (p : FSM arity) :
       · rw [hcar]; simp [NFA.ofFSM]
         constructor
         · simp [FSM.carryBV, FSM.carry]; congr 2
-          · apply FSM.carry_eq_up_to; rintro ar k hk; simp [BitStream.ofBitVec]
+          · apply FSM.carry_eq_up_to; rintro ar k hk; simp [BitStream.ofBitVecSext]
             rw [ite_cond_eq_true]
             on_goal 2 => simp; omega
             rw [ite_cond_eq_true]
@@ -306,7 +306,7 @@ def NFA'.ofFSM_correct (p : FSM arity) :
           specialize hrel (Fin.last w)
           simp [BitVec.getElem_cons, heq] at hrel
           rw [hrel]; simp [FSM.evalBV, FSM.eval, FSM.carryBV]; congr 2
-          · apply FSM.carry_eq_up_to; rintro ar k hk; simp [BitStream.ofBitVec]
+          · apply FSM.carry_eq_up_to; rintro ar k hk; simp [BitStream.ofBitVecSext]
             rw [ite_cond_eq_true]
             on_goal 2 => simp; omega
             rw [ite_cond_eq_true]
@@ -320,18 +320,18 @@ def _root_.NFA'.ofFSM  (p : FSM arity) : NFA' (FinEnum.card arity + 1) :=
 
 open BitStream in
 lemma evalFinStream_evalFin {t : Term} {k : Nat} (hlt : k < w) (vars : Fin t.arity → BitVec w) :
-    EqualUpTo w (t.evalFin (fun ar => BitStream.ofBitVec (vars ar))) (ofBitVec $ t.evalFinBV vars) := by
+    EqualUpTo w (t.evalFin (fun ar => BitStream.ofBitVecSext (vars ar))) (BitStream.ofBitVecSext $ t.evalFinBV vars) := by
   induction t <;> simp
   case var => rfl
-  case zero => unfold BitStream.ofBitVec; rintro _ _; simp
+  case zero => unfold BitStream.ofBitVecSext; rintro _ _; simp
   case negOne =>
-    unfold BitStream.ofBitVec; rintro _ _; simp [BitVec.neg_one_eq_allOnes]; left; assumption
+    unfold BitStream.ofBitVecSext; rintro _ _; simp [BitVec.neg_one_eq_allOnes]; left; assumption
   case one =>
-    unfold BitStream.ofBitVec; rintro k hk; simp
+    unfold BitStream.ofBitVecSext; rintro k hk; simp
     cases k <;> simp_all
   case ofNat =>
     intros i hi
-    simp_all only [ofNat, ofBitVec, BitVec.getLsbD_eq_getElem, ite_true]
+    simp_all only [ofNat, BitStream.ofBitVecSext, BitVec.getLsbD_eq_getElem, ite_true]
     -- TODO: should there be a BitVec.getElem_ofNat ?
     rw [←BitVec.getLsbD_eq_getElem]
     rw [BitVec.getLsbD_ofNat]
@@ -356,7 +356,7 @@ lemma evalFinStream_evalFin {t : Term} {k : Nat} (hlt : k < w) (vars : Fin t.ari
     intros i hi
     have hik : i - k < w := by omega
     specialize ih vars (i-k) hik
-    simp_all [ofBitVec]
+    simp_all [BitStream.ofBitVecSext]
 
 @[simp]
 lemma FSM.eval_bv (bvn : List.Vector (BitVec w) (t.arity + 1)) :

--- a/SSA/Experimental/Bits/Fast/BitStream.lean
+++ b/SSA/Experimental/Bits/Fast/BitStream.lean
@@ -452,6 +452,7 @@ theorem scanAnd_true_iff (s : BitStream) (n : Nat) :
         exact h _ (by omega)
       · apply h _ (by omega)
 
+
 /-- The result of `scanAnd` is true at index `i` if the bitstream has been true upto (and including) time `n`. -/
 theorem scanAnd_false_iff (s : BitStream) (n : Nat)
     : s.scanAnd n = false ↔ ∃ (i : Nat), (i ≤ n) ∧ s i = false := by
@@ -464,6 +465,12 @@ theorem scanAnd_false_iff (s : BitStream) (n : Nat)
     contrapose h
     simp_all
     apply (scanAnd_true_iff _ _).mp (by assumption)
+
+theorem scanAnd_eq_decide (s : BitStream) (n : Nat) :
+    s.scanAnd n = decide (∀ (i : Nat), i ≤ n → s i = true) := by
+  have := scanAnd_true_iff s n
+  by_cases hs : s.scanAnd n <;> simp [hs] at ⊢ this <;> apply this
+
 
 end Scan
 

--- a/SSA/Experimental/Bits/Fast/BitStream.lean
+++ b/SSA/Experimental/Bits/Fast/BitStream.lean
@@ -545,7 +545,7 @@ section FindIndex
 
 /-- Starting from index 'ix', walking backward, find the largest index
 where the bitstream has value 'v'. -/
-def findLargestIxOf (x : BitStream) (ix : Nat) (value : Bool): Option Nat :=
+def findLargestIxOf (x : BitStream) (ix : Nat) (value : Bool) : Option Nat :=
   if x ix = value then some ix
   else
     match ix with
@@ -553,115 +553,89 @@ def findLargestIxOf (x : BitStream) (ix : Nat) (value : Bool): Option Nat :=
     | ix' + 1 => findLargestIxOf x ix' value
 
 /--
-if `findLargestIxOf` returns a `some ix`,
-then `x ix = value`.
+Characgterize the results of 'findLargestIxOf'.
 -/
-theorem findLargestIxOf.eq_of_eq_some (x : BitStream) (n ix : Nat) (value : Bool) :
-    findLargestIxOf x n value = some ix →
-    x ix = value := by
-  induction n generalizing ix
+theorem findLargestIxOf.eq_iff (x : BitStream) (n : Nat) (value : Bool) :
+    (findLargestIxOf x n value = some ix ↔
+    (ix ≤ n ∧ x ix = value ∧
+      -- it's the larget 'ix < j ≤ n' with value 'value'.
+      (∀ (j : Nat), ix < j → j ≤ n → x j ≠ value))) ∧
+    (findLargestIxOf x n value = none ↔
+      ∀ (j : Nat), j ≤ n → x j ≠ value) := by
+  induction n
   case zero =>
     simp [findLargestIxOf]
-    intros hx hi
-    subst hi
-    simp [hx]
-  case succ j hind =>
-    simp [findLargestIxOf]
-    intros hj
-    by_cases hx : x (j + 1) = value
-    · simp [hx] at hj ⊢
-      subst hj
+    constructor
+    · intros h
+      obtain ⟨hx, hix⟩ := h
+      subst hix
       simp [hx]
-    · simp [hx] at hj
-      apply hind
-      exact hj
-
-/--
-if `findLargestIxOf` returns a `some ix`,
-then `x ix = value`.
--/
-theorem findLargestIxOf.neq_value_of_eq_some (x : BitStream) (n ix : Nat) (value : Bool) :
-    findLargestIxOf x n value = some ix →
-    ∀ j, ix < j → j ≤ n → x j ≠ value := by
-  induction n
-  case zero =>
-    simp [findLargestIxOf]
-    intros hx0 hix ix' hix'Lt hix'Eq
-    subst hix
-    omega
-  case succ n hn =>
-    simp [findLargestIxOf]
-    intros h
-    intros j hjLt hjLe
-    split at h
-    case isTrue hsplit =>
-      simp at h
+      intros ixl hIxlLt hIxlEq
+      subst hIxlEq
       omega
-    case isFalse hsplit =>
-      by_cases hjn : j = n + 1
-      · simp [hjn]
-        exact hsplit
-      · apply hn
-        · exact h
-        · omega
-        · omega
-/--
-if `findLargestIxOf` returns a `none`,
-then `x ix ≠ value` for all `ix ≤ n`.
--/
-theorem findLargestIxOf.eq_of_eq_none (x : BitStream) (n : Nat) (value : Bool) :
-  findLargestIxOf x n value = none →
-  ∀ (j : Nat), j ≤ n → x j ≠ value := by
-  intros hnone
-  induction n
-  case zero =>
-    simp [findLargestIxOf] at hnone
-    intros j hj
-    have : j = 0 := by omega
-    subst this
-    simp [hnone]
-  case succ n hind =>
-    intros k hk
-    simp [findLargestIxOf] at hnone
-    split at hnone
-    case isTrue hcontra =>
-      simp at hnone
-    case isFalse hrec =>
-      simp [hnone] at hind
-      by_cases hk : k = n + 1
-      · simp [hk, hrec]
-      · apply hind
-        omega
-
-theorem findLargestIxOf.eq_some_of
-    (ix : ℕ)
-    (x : BitStream)
-    (n : ℕ)
-    (value : Bool)
-    (hEqValue : x ix = value)
-    (hNeqValue: ∀ (ix' : ℕ), ix < ix' → ix' ≤ n → x ix' ≠ value) :
-    x.findLargestIxOf n value = some ix := by
-  induction n generalizing ix
-  case zero =>
+    · intros h
+      obtain ⟨hixEq, hXIxEq, hixLt⟩ := h
+      subst hixEq
+      simp [hXIxEq]
+  case succ n ihn =>
+    obtain ⟨ihnSome, ihnNone⟩ := ihn
     simp [findLargestIxOf]
-    sorry
-  case succ n' hn =>
-    sorry
-
-theorem findLargestIxOf.eq_some_iff (x : BitStream) (n : Nat) (value : Bool) :
-    findLargestIxOf x n value = some ix ↔
-    (x ix = value ∧ (∀ (ix' : Nat), ix < ix' → ix' ≤ n → x ix' ≠ value)) := by
-  constructor
-  · intros heq
-    simp [findLargestIxOf.eq_of_eq_some _ _ _ _ heq]
-    intros j hjLt hjLe
-    apply findLargestIxOf.neq_value_of_eq_some x n ix value heq <;> omega
-  · intros heq
-    obtain ⟨h1, h2⟩ := heq
-    apply findLargestIxOf.eq_some_of
-    · apply h1
-    · apply h2
-
+    by_cases hxEq : x (n + 1) = value
+    · simp [hxEq]
+      constructor
+      · constructor
+        · intros hIxEq
+          subst hIxEq
+          simp [hxEq]
+          intros ixl hixl1 hixl2
+          omega
+        · intros hIx
+          have ⟨hIx1, hIx2, hIx3⟩ := hIx
+          by_cases hIx : ix = n + 1
+          · subst hIx
+            omega
+          · specialize hIx3 (n + 1) (by omega) (by omega)
+            simp [hxEq] at hIx3
+      · exists n + 1
+    · simp [hxEq]
+      constructor
+      · constructor
+        · intros hSome
+          obtain ⟨hSome1, hSome2, hSome3⟩ := ihnSome.mp hSome
+          simp [show ix ≤ n + 1 by omega, hSome2]
+          intros k hkLt hkLe
+          by_cases hk : k = n + 1
+          · subst hk
+            omega
+          · apply hSome3
+            · omega
+            · omega
+        · intros hSome
+          have ⟨hSome1, hSome2, hSome3⟩ := hSome
+          have hIxNe : ix ≠ n + 1 := by
+            intros hIxEq
+            subst hIxEq
+            simp [hSome2] at hxEq
+          apply ihnSome.mpr
+          simp [show ix ≤ n by omega, hSome2]
+          intros k hkLt hkLe
+          apply hSome3
+          · omega
+          · omega
+      · constructor
+        · intros hNone
+          have := ihnNone.mp hNone
+          intros k hk
+          by_cases hkEq : k = n + 1
+          · subst hkEq
+            simp [hxEq]
+          · apply this
+            omega
+        · intros hNone
+          apply ihnNone.mpr
+          intros h Hj
+          apply hNone
+          omega
 
 /-! # Addition, Subtraction, Negation -/
 section Arith

--- a/SSA/Experimental/Bits/Fast/BitStream.lean
+++ b/SSA/Experimental/Bits/Fast/BitStream.lean
@@ -185,6 +185,10 @@ section ToBitVec
 abbrev ofBitVec {w} (x : BitVec w) : BitStream :=
   fun i => if i < w then x.getLsbD i else x.msb
 
+/-- Make a bitstream of a unary natural number. -/
+abbrev ofNatUnary (n : Nat) : BitStream :=
+  fun i => decide (i ≤ n)
+
 /-- `x.toBitVec w` returns the first `w` bits of bitstream `x` -/
 def toBitVec (w : Nat) (x : BitStream) : BitVec w :=
   match w with

--- a/SSA/Experimental/Bits/Fast/BitStream.lean
+++ b/SSA/Experimental/Bits/Fast/BitStream.lean
@@ -189,15 +189,29 @@ abbrev ofBitVecSext {w} (x : BitVec w) : BitStream :=
 abbrev ofBitVecZext {w} (x : BitVec w) : BitStream :=
   fun i => x.getLsbD i
 
-/-- Zero extend a finite bitvector 'x' to the infinite stream of 'x.msb' -/
-def ofBitvecSextMsb {w} (x : BitVec w) : BitStream :=
+/-- Sign extend a finite bitvector 'x' to the infinite stream of 'x.msb' -/
+def ofBitVecSextMsb {w} (x : BitVec w) : BitStream :=
   fun i => (x.signExtend i).msb
 
+/-- Zero extend a finite bitvector 'x' to the infinite stream of 'x.msb' -/
+def ofBitVecZextMsb {w} (x : BitVec w) : BitStream :=
+  fun i => (x.zeroExtend i).msb
+
 @[simp]
-theorem ofBitvecSextMsb_eq_concat_ofBitVec (x : BitVec w) :
-    ofBitvecSextMsb x = (ofBitVecSext x).concat false := by
+theorem ofBitVecZextMsb_eq_concat_ofBitVecZext (x : BitVec w) :
+    ofBitVecZextMsb x = (ofBitVecZext x).concat false := by
   ext i
-  simp [ofBitvecSextMsb, BitVec.msb_eq_getLsbD_last]
+  simp [ofBitVecZextMsb, BitVec.msb_eq_getLsbD_last]
+  rcases i with rfl | i
+  · simp
+  · simp only [add_tsub_cancel_right, concat_succ, ofBitVecZext]
+    by_cases hi : i < w <;> simp [hi]
+
+@[simp]
+theorem ofBitVecSextMsb_eq_concat_ofBitVec (x : BitVec w) :
+    ofBitVecSextMsb x = (ofBitVecSext x).concat false := by
+  ext i
+  simp [ofBitVecSextMsb, BitVec.msb_eq_getLsbD_last]
   rcases i with rfl | i
   · simp
   · simp only [add_tsub_cancel_right, lt_add_iff_pos_right, zero_lt_one, BitVec.getLsbD_eq_getElem,

--- a/SSA/Experimental/Bits/Fast/BitStream.lean
+++ b/SSA/Experimental/Bits/Fast/BitStream.lean
@@ -227,6 +227,14 @@ def toBitVec (w : Nat) (x : BitStream) : BitVec w :=
     (x.toBitVec w)[i] = ((decide (i < w)) && x i) := by
   simp [← BitVec.getLsbD_eq_getElem]
 
+
+def zeroExtend (b : BitStream) (n : Nat) : BitStream := fun i =>
+  (b i) && decide (i ≤ n)
+
+@[simp]
+theorem zeroExtend_eval_eq (b : BitStream) (n : Nat) (i : Nat) :
+  b.zeroExtend n i = ((b i) && decide (i ≤ n)) := rfl
+
 /-- `EqualUpTo w x y` holds iff `x` and `y` are equal in the first `w` bits -/
 def EqualUpTo (w : Nat) (x y : BitStream) : Prop :=
   ∀ i < w, x i = y i

--- a/SSA/Experimental/Bits/Fast/BitStream.lean
+++ b/SSA/Experimental/Bits/Fast/BitStream.lean
@@ -185,6 +185,9 @@ section ToBitVec
 abbrev ofBitVec {w} (x : BitVec w) : BitStream :=
   fun i => if i < w then x.getLsbD i else x.msb
 
+def ofBitVecZextMsb {w} (x : BitVec w) : BitStream :=
+  fun i => (x.zeroExtend i).msb
+
 /-- Make a bitstream of a unary natural number. -/
 abbrev ofNatUnary (n : Nat) : BitStream :=
   fun i => decide (i ≤ n)

--- a/SSA/Experimental/Bits/Fast/BitStream.lean
+++ b/SSA/Experimental/Bits/Fast/BitStream.lean
@@ -410,6 +410,12 @@ theorem scanOr_true_iff (s : BitStream) (n : Nat)
     simp_all
     apply (scanOr_false_iff _ _).mp (by assumption)
 
+theorem scanOr_eq_decide (s : BitStream) (n : Nat) :
+    s.scanOr n = decide (∃ (i : Nat), i ≤ n ∧ s i = true) := by
+  have := scanOr_true_iff s n
+  by_cases hs : s.scanOr n <;> simp [hs] at ⊢ this <;> apply this
+
+
 /--
 (scan s)[0] = s[0]
 (scan s)[i+1] = (scan s)[i] && s[i+1]

--- a/SSA/Experimental/Bits/Fast/BitStream.lean
+++ b/SSA/Experimental/Bits/Fast/BitStream.lean
@@ -81,6 +81,15 @@ theorem concat_zero (b : Bool) (x : BitStream) : concat b x 0 = b := rfl
 @[simp]
 theorem concat_succ (b : Bool) (x : BitStream) : concat b x (n+1) = x n := rfl
 
+@[simp]
+theorem concat_eq_sub_of_lt
+    {b : Bool} {x : BitStream} {i : Nat} (hi : 0 < i) :
+    concat b x i = x (i - 1) := by
+  simp [concat]
+  rcases i with rfl | i
+  · omega
+  · simp
+
 /-- `map f` maps a (unary) function over a bitstreams -/
 abbrev map (f : Bool → Bool) : BitStream → BitStream :=
   fun x i => f (x i)
@@ -198,6 +207,7 @@ def ofBitVecSextMsb {w} (x : BitVec w) : BitStream :=
 def ofBitVecZextMsb {w} (x : BitVec w) : BitStream :=
   fun i => (x.zeroExtend i).msb
 
+
 @[simp]
 theorem ofBitVecZextMsb_eq_concat_ofBitVecZext (x : BitVec w) :
     ofBitVecZextMsb x = (ofBitVecZext x).concat false := by
@@ -218,6 +228,10 @@ theorem ofBitVecSextMsb_eq_concat_ofBitVec (x : BitVec w) :
   · simp only [add_tsub_cancel_right, lt_add_iff_pos_right, zero_lt_one, BitVec.getLsbD_eq_getElem,
     BitVec.getElem_signExtend, concat_succ, ofBitVecSext]
     by_cases hi : i < w <;> simp [hi]
+
+@[simp]
+theorem ofBitVecZext_eq_getLsbD (x : BitVec w) (i : Nat) :
+  ofBitVecZext x i = x.getLsbD i := rfl
 
 /-- Make a bitstream of a unary natural number. -/
 abbrev ofNatUnary (n : Nat) : BitStream :=
@@ -264,10 +278,6 @@ theorem ofBitVecZext_inj (x y : BitVec w) :
   · intros h
     subst h
     rfl
-
-@[simp]
-theorem ofBitVecZext_eq_getLsbD (x : BitVec w) :
-  ofBitVecZext x i = x.getLsbD i := rfl
 
 
 @[simp] theorem getElem_toBitVec (w : Nat) (x : BitStream) (i : Nat) (hi : i < w) :

--- a/SSA/Experimental/Bits/Fast/BitStream.lean
+++ b/SSA/Experimental/Bits/Fast/BitStream.lean
@@ -189,6 +189,10 @@ abbrev ofBitVec {w} (x : BitVec w) : BitStream :=
 abbrev ofNatUnary (n : Nat) : BitStream :=
   fun i => decide (i ≤ n)
 
+@[simp]
+theorem eval_ofNatUnary (n : Nat) (i : Nat) :
+    ofNatUnary n i = decide (i ≤ n) := rfl
+
 /-- `x.toBitVec w` returns the first `w` bits of bitstream `x` -/
 def toBitVec (w : Nat) (x : BitStream) : BitVec w :=
   match w with

--- a/SSA/Experimental/Bits/Fast/BitStream.lean
+++ b/SSA/Experimental/Bits/Fast/BitStream.lean
@@ -251,6 +251,24 @@ def toBitVec (w : Nat) (x : BitStream) : BitVec w :=
         omega
 
 
+@[simp]
+theorem ofBitVecZext_inj (x y : BitVec w) :
+  (ofBitVecZext x = ofBitVecZext y) ↔ (x = y) := by
+  constructor
+  · intro h
+    apply BitVec.eq_of_getLsbD_eq
+    intros i hi
+    have := congrFun h i
+    simp [this]
+  · intros h
+    subst h
+    rfl
+
+@[simp]
+theorem ofBitVecZext_eq_getLsbD (x : BitVec w) :
+  ofBitVecZext x i = x.getLsbD i := rfl
+
+
 @[simp] theorem getElem_toBitVec (w : Nat) (x : BitStream) (i : Nat) (hi : i < w) :
     (x.toBitVec w)[i] = ((decide (i < w)) && x i) := by
   rw [← BitVec.getLsbD_eq_getElem]

--- a/SSA/Experimental/Bits/Fast/Circuit.lean
+++ b/SSA/Experimental/Bits/Fast/Circuit.lean
@@ -22,7 +22,7 @@ inductive Circuit (α : Type u) : Type u
   | tru : Circuit α
   | fals : Circuit α
   /-- `var b x` represents literal `x` if `b = true` or the negated literat `¬x` if `b = false` -/
-  | var : Bool → α → Circuit α
+  | var : (positive: Bool) → α → Circuit α
   | and : Circuit α → Circuit α → Circuit α
   | or : Circuit α → Circuit α → Circuit α
   | xor : Circuit α → Circuit α → Circuit α

--- a/SSA/Experimental/Bits/Fast/Defs.lean
+++ b/SSA/Experimental/Bits/Fast/Defs.lean
@@ -233,7 +233,7 @@ match p with
 Evaluating the term and then coercing the term to a bitvector is equal to denoting the term directly.
 -/
 @[simp] theorem Term.eval_eq_denote (t : Term) (w : Nat) (vars : List (BitVec w)) :
-    (t.eval (vars.map BitStream.ofBitVec)).toBitVec w = t.denote w vars := by
+    (t.eval (vars.map BitStream.ofBitVecSext)).toBitVec w = t.denote w vars := by
   induction t generalizing w vars
   case var x =>
     simp [eval, denote]
@@ -259,10 +259,10 @@ This says that calling 'eval' at an index equals calling 'denote' and grabbing t
  -/
 theorem Term.eval_eq_denote_apply (t : Term) {w : Nat} {vars : List (BitVec w)}
     {i : Nat} (hi : i < w) :
-    (t.eval (vars.map BitStream.ofBitVec)) i = (t.denote w vars).getLsbD i := by
+    (t.eval (vars.map BitStream.ofBitVecSext)) i = (t.denote w vars).getLsbD i := by
   have := t.eval_eq_denote w vars
   have :
-    (BitStream.toBitVec w (t.eval (List.map BitStream.ofBitVec vars))).getLsbD i =
+    (BitStream.toBitVec w (t.eval (List.map .ofBitVecSext vars))).getLsbD i =
     (denote w t vars).getLsbD i := by simp [this]
   rw [BitStream.getLsbD_toBitVec] at this
   simp only [show i < w by omega, decide_true, Bool.true_and] at this
@@ -274,10 +274,10 @@ This says that calling 'eval' at an index equals calling 'denote' and grabbing t
  -/
 theorem Term.denote_eq_eval_land_lt (t : Term) {w : Nat} {vars : List (BitVec w)}
     {i : Nat} :
-    (t.denote w vars).getLsbD i = ((t.eval (vars.map BitStream.ofBitVec)) i && (decide (i < w))) := by
+    (t.denote w vars).getLsbD i = ((t.eval (vars.map .ofBitVecSext)) i && (decide (i < w))) := by
   have := t.eval_eq_denote w vars
   have :
-    (BitStream.toBitVec w (t.eval (List.map BitStream.ofBitVec vars))).getLsbD i =
+    (BitStream.toBitVec w (t.eval (List.map .ofBitVecSext vars))).getLsbD i =
     (denote w t vars).getLsbD i := by simp [this]
   rw [BitStream.getLsbD_toBitVec] at this
   by_cases hi : i < w
@@ -289,7 +289,7 @@ theorem Term.denote_eq_eval_land_lt (t : Term) {w : Nat} {vars : List (BitVec w)
 if 'evalEq' evaluates to 'false', then indeed the denotations of the terms are equal.
 -/
 theorem Predicate.evalEq_denote_false_iff {w : Nat} (a b : Term) (vars : List (BitVec w)) :
-    evalEq (a.eval (List.map BitStream.ofBitVec vars)) (b.eval (List.map BitStream.ofBitVec vars)) w = false ↔
+    evalEq (a.eval (List.map .ofBitVecSext vars)) (b.eval (List.map .ofBitVecSext vars)) w = false ↔
     Term.denote w a vars = Term.denote w b vars := by
   simp [evalEq]
   constructor
@@ -345,27 +345,27 @@ theorem Predicate.evalEq_iff_not_evalNeq (a b : BitStream) :
 
 /-- 'evalNeq' correctly witnesses when terms are disequal -/
 theorem Predicate.evalNeq_denote {w : Nat} (a b : Term) (vars : List (BitVec w)) :
-    evalNeq (a.eval (List.map BitStream.ofBitVec vars)) (b.eval (List.map BitStream.ofBitVec vars)) w = false ↔
+    evalNeq (a.eval (List.map .ofBitVecSext vars)) (b.eval (List.map .ofBitVecSext vars)) w = false ↔
     Term.denote w a vars ≠ Term.denote w b vars := by
   constructor
   · intros h
     apply Predicate.evalEq_denote_false_iff .. |>.not.mp
     simp only [Bool.not_eq_false]
     have := Predicate.evalEq_iff_not_evalNeq
-      (a.eval (List.map BitStream.ofBitVec vars))
-      (b.eval (List.map BitStream.ofBitVec vars))
+      (a.eval (List.map .ofBitVecSext vars))
+      (b.eval (List.map .ofBitVecSext vars))
     apply this .. |>.mpr
     simp [h]
   · intros h
     have this' := Predicate.evalEq_denote_false_iff .. |>.not.mpr h
     simp at this'
     have := Predicate.evalEq_iff_not_evalNeq
-      (a.eval (List.map BitStream.ofBitVec vars))
-      (b.eval (List.map BitStream.ofBitVec vars)) w |>.mp this'
+      (a.eval (List.map .ofBitVecSext vars))
+      (b.eval (List.map .ofBitVecSext vars)) w |>.mp this'
     simpa using this
 
 theorem Predicate.evalEq_denote_true_iff {w : Nat} (a b : Term) (vars : List (BitVec w)) :
-    evalEq (a.eval (List.map BitStream.ofBitVec vars)) (b.eval (List.map BitStream.ofBitVec vars)) w = true ↔
+    evalEq (a.eval (List.map .ofBitVecSext vars)) (b.eval (List.map .ofBitVecSext vars)) w = true ↔
     Term.denote w a vars ≠ Term.denote w b vars := by
   rw [Predicate.evalEq_iff_not_evalNeq]
   simp [evalNeq_denote]
@@ -378,7 +378,7 @@ private theorem BitVec.lt_iff_ult {x y : BitVec w} : (x < y) ↔ (x.ult y) := by
   simp [BitVec.lt_def, BitVec.ult_toNat]
 
 theorem Predicate.evalUlt_denote_false_iff {w : Nat} (a b : Term) (vars : List (BitVec w)) :
-    evalUlt (a.eval (List.map BitStream.ofBitVec vars)) (b.eval (List.map BitStream.ofBitVec vars)) w = false ↔
+    evalUlt (a.eval (List.map .ofBitVecSext vars)) (b.eval (List.map .ofBitVecSext vars)) w = false ↔
     (Term.denote w a vars < Term.denote w b vars) := by
   simp [evalUlt, BitVec.lt_eq_decide_ult, BitVec.ult_eq_not_carry]
   rcases w with rfl | w
@@ -387,7 +387,7 @@ theorem Predicate.evalUlt_denote_false_iff {w : Nat} (a b : Term) (vars : List (
     simp [BitStream.borrow, BitStream.subAux_eq_BitVec_carry (w := w + 1)]
 
 theorem Predicate.evalUlt_denote_true_iff {w : Nat} (a b : Term) (vars : List (BitVec w)) :
-    evalUlt (a.eval (List.map BitStream.ofBitVec vars)) (b.eval (List.map BitStream.ofBitVec vars)) w = true ↔
+    evalUlt (a.eval (List.map .ofBitVecSext vars)) (b.eval (List.map .ofBitVecSext vars)) w = true ↔
       (Term.denote w b vars) ≤ (Term.denote w a vars) := by
   obtain ⟨h₁, h₂⟩ := evalUlt_denote_false_iff a b vars
   constructor
@@ -403,7 +403,7 @@ theorem Predicate.evalUlt_denote_true_iff {w : Nat} (a b : Term) (vars : List (B
     bv_omega
 
 private theorem evalMsbEq_denote_false_iff {w : Nat} (a b : Term) (vars : List (BitVec w)) :
-    Predicate.evalMsbEq (a.eval (List.map BitStream.ofBitVec vars)) (b.eval (List.map BitStream.ofBitVec vars)) w = false ↔
+    Predicate.evalMsbEq (a.eval (List.map .ofBitVecSext vars)) (b.eval (List.map .ofBitVecSext vars)) w = false ↔
    ((Term.denote w a vars).msb = (Term.denote w b vars).msb) := by
   simp [Predicate.evalMsbEq]
   rcases w with rfl | w
@@ -411,7 +411,7 @@ private theorem evalMsbEq_denote_false_iff {w : Nat} (a b : Term) (vars : List (
   · simp [BitVec.msb_eq_getLsbD_last, Term.eval_eq_denote_apply]
 
 private theorem evalMsbEq_denote_true_iff {w : Nat} (a b : Term) (vars : List (BitVec w)) :
-    Predicate.evalMsbEq (a.eval (List.map BitStream.ofBitVec vars)) (b.eval (List.map BitStream.ofBitVec vars)) w = true ↔
+    Predicate.evalMsbEq (a.eval (List.map .ofBitVecSext vars)) (b.eval (List.map .ofBitVecSext vars)) w = true ↔
    ((Term.denote w a vars).msb ≠ (Term.denote w b vars).msb) := by
   simp [Predicate.evalMsbEq]
   rcases w with rfl | w
@@ -432,15 +432,15 @@ constructor
 
 /-- TODO: Minimize this proof by a metric fuckton. -/
 private theorem Predicate.evalSlt_denote_false_iff {w : Nat} (a b : Term) (vars : List (BitVec w)) :
-    evalSlt (a.eval (List.map BitStream.ofBitVec vars)) (b.eval (List.map BitStream.ofBitVec vars)) w = false ↔
+    evalSlt (a.eval (List.map .ofBitVecSext vars)) (b.eval (List.map .ofBitVecSext vars)) w = false ↔
     (Term.denote w a vars <ₛ Term.denote w b vars) := by
   simp [evalSlt, BitStream.xor_eq]
   have hult_iff := Predicate.evalUlt_denote_false_iff a b vars
-  by_cases hUlt : evalUlt (a.eval (List.map BitStream.ofBitVec vars)) (b.eval (List.map BitStream.ofBitVec vars)) w
+  by_cases hUlt : evalUlt (a.eval (List.map .ofBitVecSext vars)) (b.eval (List.map .ofBitVecSext vars)) w
   · rw [hUlt]
     have hUlt' := evalUlt_denote_true_iff .. |>.mp hUlt
     simp
-    by_cases hMsbEq : evalMsbEq (a.eval (List.map BitStream.ofBitVec vars)) (b.eval (List.map BitStream.ofBitVec vars)) w
+    by_cases hMsbEq : evalMsbEq (a.eval (List.map .ofBitVecSext vars)) (b.eval (List.map .ofBitVecSext vars)) w
     · rw [hMsbEq]
       have hMsbEq' := evalMsbEq_denote_true_iff .. |>.mp hMsbEq
       simp
@@ -464,7 +464,7 @@ private theorem Predicate.evalSlt_denote_false_iff {w : Nat} (a b : Term) (vars 
     rw [hUlt]
     have hUlt' := evalUlt_denote_false_iff .. |>.mp hUlt
     simp
-    by_cases h' : evalMsbEq (a.eval (List.map BitStream.ofBitVec vars)) (b.eval (List.map BitStream.ofBitVec vars)) w
+    by_cases h' : evalMsbEq (a.eval (List.map .ofBitVecSext vars)) (b.eval (List.map .ofBitVecSext vars)) w
     · simp [h']
       rw [BitVec.slt_eq_ult]
       rw [BitVec.ult]
@@ -480,7 +480,7 @@ private theorem Predicate.evalSlt_denote_false_iff {w : Nat} (a b : Term) (vars 
       simp [evalMsbEq_denote_false_iff .. |>.mp h']
 
 private theorem Predicate.evalSlt_denote_true_iff {w : Nat} (a b : Term) (vars : List (BitVec w)) :
-    evalSlt (a.eval (List.map BitStream.ofBitVec vars)) (b.eval (List.map BitStream.ofBitVec vars)) w = true ↔
+    evalSlt (a.eval (List.map .ofBitVecSext vars)) (b.eval (List.map .ofBitVecSext vars)) w = true ↔
     ¬ (Term.denote w a vars <ₛ Term.denote w b vars) := by
   rw [eq_true_iff_of_eq_false_iff]
   simp [Predicate.evalSlt_denote_false_iff]
@@ -516,7 +516,7 @@ The semantics of a predicate:
 The predicate, when evaluated, at index `i` is false iff the denotation is true.
 -/
 theorem Predicate.eval_eq_denote (w : Nat) (p : Predicate) (vars : List (BitVec w)) :
-    (p.eval (vars.map BitStream.ofBitVec) w = false) ↔ p.denote w vars := by
+    (p.eval (vars.map .ofBitVecSext) w = false) ↔ p.denote w vars := by
   induction p generalizing vars w
   case width wp n => cases wp <;> simp [eval, denote]
   case binary p a b =>
@@ -593,7 +593,7 @@ theorem Predicate.eval_eq_denote (w : Nat) (p : Predicate) (vars : List (BitVec 
         simp [this]
 
 theorem Predicate.denote_of_eval {w : Nat} {p : Predicate} {vars : List (BitVec w)}
-    (heval : (p.eval (vars.map BitStream.ofBitVec) w = false)) : p.denote w vars := by
+    (heval : (p.eval (vars.map .ofBitVecSext) w = false)) : p.denote w vars := by
   apply Predicate.eval_eq_denote w p vars |>.mp heval
 
 
@@ -616,7 +616,7 @@ theorem Predicate.denote_of_eval_eq {p : Predicate}
     (heval : ∀ (w : Nat) (vars : List BitStream), p.eval vars w = false) :
     ∀ (w : Nat) (vars : List (BitVec w)), p.denote w vars := by
   intros w vars
-  apply p.eval_eq_denote w vars |>.mp (heval w <| vars.map BitStream.ofBitVec)
+  apply p.eval_eq_denote w vars |>.mp (heval w <| vars.map .ofBitVecSext)
 
 
 /-- To prove that `p` holds, it suffices to show that `p.eval ... = false`. -/
@@ -624,4 +624,4 @@ theorem Predicate.denote_of_eval_eq_fixedWidth {p : Predicate} (w : Nat)
     (heval : ∀ (vars : List BitStream), p.eval vars w = false) :
     ∀ (vars : List (BitVec w)), p.denote w vars := by
   intros vars
-  apply p.eval_eq_denote w vars |>.mp (heval <| vars.map BitStream.ofBitVec)
+  apply p.eval_eq_denote w vars |>.mp (heval <| vars.map .ofBitVecSext)

--- a/SSA/Experimental/Bits/Fast/FiniteStateMachine.lean
+++ b/SSA/Experimental/Bits/Fast/FiniteStateMachine.lean
@@ -1257,6 +1257,18 @@ instance {α β : Type} [Fintype α] [Fintype β] (b : Bool) :
     Fintype (cond b α β) := by
   cases b <;> simp <;> infer_instance
 
+@[simp] lemma composeBinaryAux'_eval
+    (p : FSM Bool)
+    (q₁ : FSM s)
+    (q₂ : FSM s)
+    (x : s → BitStream) :
+    (composeBinaryAux' p q₁ q₂).eval x = p.eval
+      (λ b => cond b (q₁.eval (fun i => x i))
+                  (q₂.eval (fun i => x i))) := by
+  rw [composeBinaryAux', FSM.eval_compose]
+  ext b
+  cases b <;> dsimp <;> congr <;> funext b <;> cases b <;> simp
+
 
 namespace FSM
 

--- a/SSA/Experimental/Bits/Fast/FiniteStateMachine.lean
+++ b/SSA/Experimental/Bits/Fast/FiniteStateMachine.lean
@@ -1548,6 +1548,15 @@ if and only if 'falseUptoExcluding' evaluates to 'false
 private theorem falseUptoIncluding_eq_false_iff (n : Nat) (i : Nat) {env : Fin 0 → BitStream} :
     ((falseUptoIncluding n).eval env i = false) ↔ i ≤ n := by simp
 
+
+/-- Produce the FSM after consuming the input stream for one clock cycle 'arity2b'. -/
+def nextFSM (fsm : FSM arity) (arity2b : arity → Bool) : FSM arity where
+  α := fsm.α
+  initCarry := fun abit =>
+    (fsm.nextStateCirc abit).eval (Sum.elim fsm.initCarry arity2b)
+  nextStateCirc := fsm.nextStateCirc
+  outputCirc := fsm.outputCirc
+
 end FSM
 
 open Term

--- a/SSA/Experimental/Bits/Fast/FiniteStateMachine.lean
+++ b/SSA/Experimental/Bits/Fast/FiniteStateMachine.lean
@@ -2018,6 +2018,8 @@ def decideIfZerosAuxUnverified {σ ι : Type _}
 def FSM.optimize {arity : Type _} (p : FSM arity) [DecidableEq arity] : FSM arity :=
   p
 
+
+
 def decideIfZeros {arity : Type _} [DecidableEq arity]
     (p : FSM arity) : Bool :=
   decideIfZerosAux p (p.outputCirc).fst
@@ -2094,3 +2096,43 @@ axiom decideIfZeroesAtIx_correct {arity : Type _} [DecidableEq arity]
     (p : FSM arity) (w : Nat) : decideIfZerosAtIx p w = true ↔ ∀ (x : arity → BitStream), p.eval x w = false
 
 end FSM
+
+instance : HAnd (FSM arity) (FSM arity) (FSM arity) where
+  hAnd := composeBinaryAux' FSM.and
+
+theorem FSM.and_eq (a b : FSM arity) : (a &&& b) = composeBinaryAux' FSM.and a b := rfl
+
+@[simp]
+theorem FSM.eval_and' (a b : FSM arity) : (a &&& b).eval env = a.eval env &&& b.eval env := by
+  rw [FSM.and_eq]
+  simp
+
+instance : HOr (FSM arity) (FSM arity) (FSM arity) where
+  hOr := composeBinaryAux' FSM.or
+
+theorem FSM.or_eq (a b : FSM arity) : (a ||| b) = composeBinaryAux' FSM.or a b := rfl
+
+@[simp]
+theorem FSM.eval_or' (a b : FSM arity) : (a ||| b).eval env = a.eval env ||| b.eval env := by
+  rw [FSM.or_eq]
+  simp
+
+instance : HXor (FSM arity) (FSM arity) (FSM arity) where
+  hXor := composeBinaryAux' FSM.xor
+
+theorem FSM.xor_eq (a b : FSM arity) : (a ^^^ b) = composeBinaryAux' FSM.xor a b := rfl
+
+@[simp]
+theorem FSM.eval_xor' (a b : FSM arity) : (a ^^^ b).eval env = a.eval env ^^^ b.eval env := by
+  rw [FSM.xor_eq]
+  simp
+
+instance : Complement (FSM arity) where
+  complement := composeUnaryAux FSM.not
+
+theorem FSM.not_eq (a : FSM arity) : (~~~ a) = composeUnaryAux FSM.not a := rfl
+
+@[simp]
+theorem FSM.eval_not' (a : FSM arity) : (~~~ a).eval env = ~~~ (a.eval env) := by
+  rw [FSM.not_eq]
+  simp

--- a/SSA/Experimental/Bits/Fast/FiniteStateMachine.lean
+++ b/SSA/Experimental/Bits/Fast/FiniteStateMachine.lean
@@ -1139,8 +1139,7 @@ def repeatBit : FSM Unit where
   nextStateCirc := fun () => (.var true <| .inl ()) ||| (.var true <| .inr ())
 
 /--
-(xval, control)
-produce the latch value immediately when 'control = true'.
+(xval:false, control:true) produce the latch value immediately when 'control = true'.
 -/
 def latchImmediate (initVal : Bool) : FSM Bool where
   α := Unit
@@ -1241,15 +1240,15 @@ def composeBinaryAux
 -- TODO: replace 'composeBinaryAux' with 'composeBinaryAux'.
 def composeBinaryAux'
     (p : FSM Bool)
-    (q₁ : FSM α)
-    (q₂ : FSM α) :
+    (qtrue : FSM α)
+    (qfalse : FSM α) :
     FSM α :=
   p.compose (α)
     (λ _ => α)
     (λ _ i => i)
     (λ b => match b with
-      | true => q₁
-      | false => q₂)
+      | true => qtrue
+      | false => qfalse)
 
 def composeTernaryAux' (p : FSM (Fin 3)) (q₀ q₁ q₂ : FSM α) : FSM α :=
   p.compose (α)

--- a/SSA/Experimental/Bits/Fast/FiniteStateMachine.lean
+++ b/SSA/Experimental/Bits/Fast/FiniteStateMachine.lean
@@ -1626,6 +1626,7 @@ def termEvalEqFSM : ∀ (t : Term), FSMTermSolution t
          · simp [hi]; omega
      }
 
+
 /-!
 FSM that implement bitwise-and. Since we use `0` as the good state,
 we keep the invariant that if both inputs are good and our state is `0`, then we produce a `0`.
@@ -2136,3 +2137,15 @@ theorem FSM.not_eq (a : FSM arity) : (~~~ a) = composeUnaryAux FSM.not a := rfl
 theorem FSM.eval_not' (a : FSM arity) : (~~~ a).eval env = ~~~ (a.eval env) := by
   rw [FSM.not_eq]
   simp
+
+def FSM.ite {α : Type _} (cond : FSM α) (t : FSM α) (e : FSM α) : FSM α :=
+  (cond &&& t) ||| (~~~ cond &&& e)
+
+@[simp]
+theorem FSM.eval_ite_eq_decide {α : Type}
+    (cond t e : FSM α)
+    (env : α → BitStream) (i : Nat) :
+    (FSM.ite cond t e).eval env i =
+    if (cond.eval env i) then t.eval env i else e.eval env i := by
+  simp [FSM.ite]
+  by_cases hcond : cond.eval env i <;> simp [hcond]

--- a/SSA/Experimental/Bits/Fast/FiniteStateMachine.lean
+++ b/SSA/Experimental/Bits/Fast/FiniteStateMachine.lean
@@ -1037,6 +1037,7 @@ def var (n : ℕ) : FSM (Fin (n+1)) :=
     outputCirc := Circuit.var true (inr (Fin.last _))
   }
 
+
 @[simp] lemma eval_var (n : ℕ) (x : Fin (n+1) → BitStream) : (var n).eval x = x (Fin.last n) := by
   ext m; cases m <;> simp [var, eval, carry, nextBit]
 

--- a/SSA/Experimental/Bits/Fast/FiniteStateMachine.lean
+++ b/SSA/Experimental/Bits/Fast/FiniteStateMachine.lean
@@ -1172,6 +1172,7 @@ def composeBinaryAux
       | true => q₁
       | false => q₂)
 
+-- TODO: replace 'composeBinaryAux' with 'composeBinaryAux'.
 def composeBinaryAux'
     (p : FSM Bool)
     (q₁ : FSM α)

--- a/SSA/Experimental/Bits/Fast/FiniteStateMachine.lean
+++ b/SSA/Experimental/Bits/Fast/FiniteStateMachine.lean
@@ -1171,8 +1171,9 @@ theorem eval_latchImmediate_succ_eq (initVal : Bool) (i : Nat)
   simp [latchImmediate, eval, nextBit, carry]
 
 /--
-(xval, control)
-produce the latch value immediately when 'control = true'.
+(false | true)
+(xval  |  control)
+produce the latch value from the previous iteration when 'control = true'.
 -/
 def latchDelayed (initVal : Bool) : FSM Bool where
   α := Unit

--- a/SSA/Experimental/Bits/Fast/FiniteStateMachine.lean
+++ b/SSA/Experimental/Bits/Fast/FiniteStateMachine.lean
@@ -704,6 +704,17 @@ lemma eval_scanAnd_succ (x : Unit → BitStream) (n : Nat) :
       intros j hj
       exact h j (by omega)
 
+/-- The result of `scanAnd` is true at `n` iff the bitvector has been true upto (and including) `n`. -/
+lemma eval_scanAnd_eq_decide (x : Unit → BitStream) (n : Nat) : scanAnd.eval x n =
+  decide (∀ (i : Nat), (hi : i ≤ n) → x () i = true) := by
+  have := eval_scanAnd_true_iff x n
+  by_cases hscan : scanAnd.eval x n
+  · simp only [hscan, true_iff, true_eq_decide_iff] at this ⊢;
+    apply this
+  · simp only [hscan, Bool.false_eq_true, false_iff, not_forall,
+    Bool.not_eq_true, false_eq_decide_iff] at this ⊢
+    apply this
+
 @[simp] lemma eval_xor (x : Bool → BitStream) : xor.eval x = (x true) ^^^ (x false) := by
   ext n; cases n <;> simp [xor, eval, nextBit]
 

--- a/SSA/Experimental/Bits/KInduction/KInduction.lean
+++ b/SSA/Experimental/Bits/KInduction/KInduction.lean
@@ -1742,6 +1742,64 @@ theorem eval_eq_false_of_mkIndHypCycleBreaking_eval_eq_false_of_mkSafetyCircuit_
       omega
 
 /--
+Safety on all paths, given that our evaluation of
+`mkSafetyCircuit` is false, and `mkIndHypCycleBreaking` is false.
+This is the theorem that is hooked to the external world.
+-/
+theorem eval_eq_zero_of_mkIndHypCycleBreaking_eval_eq_false_of_mkSafetyCircuit_eval_eq_false
+    (circs : KInductionCircuits fsm K)
+    (hCircs : circs.IsLawful)
+    (hSafety : ∀ (env : _), (mkSafetyCircuit circs).eval env = false)
+    (hIndHyp : ∀ (env : _), (mkIndHypCycleBreaking circs).eval env = false) :
+    (∀ (envBitstream : _), fsm.eval envBitstream = BitStream.zero) := by
+  intros envBitstream
+  ext i
+  apply eval_eq_false_of_mkIndHypCycleBreaking_eval_eq_false_of_mkSafetyCircuit_eval_eq_false
+    (hSafety := hSafety)
+    (hIndHyp := hIndHyp)
+    (hCircs := hCircs)
+
+/--
+If the FSM produces zeros, then the negation of the FSM always produces 1s.
+-/
+theorem eval_eq_negOne_of_mkIndHypCycleBreaking_eval_eq_false_of_mkSafetyCircuit_eval_eq_false
+    (circs : KInductionCircuits fsm K)
+    (hCircs : circs.IsLawful)
+    (hSafety : ∀ (env : _), (mkSafetyCircuit circs).eval env = false)
+    (hIndHyp : ∀ (env : _), (mkIndHypCycleBreaking circs).eval env = false) :
+    (∀ (envBitstream : _), (~~~ fsm).eval envBitstream = BitStream.negOne) := by
+  intros envBitstream
+  ext i
+  simp
+  apply eval_eq_false_of_mkIndHypCycleBreaking_eval_eq_false_of_mkSafetyCircuit_eval_eq_false
+    (hSafety := hSafety)
+    (hIndHyp := hIndHyp)
+    (hCircs := hCircs)
+
+/--
+It suffices to show that the negation of the fsm produces all zeroes,
+to show that the FSM always produces a '1'.
+-/
+theorem eval_eq_negOne_of_mkIndHypCycleBreaking_eval_eq_false_of_mkSafetyCircuit_eval_eq_false'
+    (circs : KInductionCircuits (~~~ fsm) K)
+    (hCircs : circs.IsLawful)
+    (hSafety : ∀ (env : _), (mkSafetyCircuit circs).eval env = false)
+    (hIndHyp : ∀ (env : _), (mkIndHypCycleBreaking circs).eval env = false) :
+    (∀ (envBitstream : _), (fsm).eval envBitstream = BitStream.negOne) := by
+  intros envBitstream
+  ext i
+  simp
+  have := eval_eq_negOne_of_mkIndHypCycleBreaking_eval_eq_false_of_mkSafetyCircuit_eval_eq_false
+    (hSafety := hSafety)
+    (hIndHyp := hIndHyp)
+    (hCircs := hCircs)
+  specialize this envBitstream
+  simp at this
+  have : (~~~ ~~~ (fsm.eval envBitstream)) i = BitStream.negOne i := by
+    rw [this]
+  simpa using this
+
+/--
 The predicate `p` holds for all variables `vars`
 if we can verify the safety circuit and the inductive hypothesis cycle breaking circuit.
 -/

--- a/SSA/Experimental/Bits/KInduction/KInduction.lean
+++ b/SSA/Experimental/Bits/KInduction/KInduction.lean
@@ -1759,8 +1759,8 @@ theorem Predicate.denote_of_verifyCircuit_mkSafetyCircuit_of_verifyCircuit_mkInd
     p.denote w vars := by
   apply Predicate.denote_of_eval
   rw [← Predicate.evalFin_eq_eval p
-    (varsList := (List.map BitStream.ofBitVec vars))
-    (varsFin := fun i => (List.map BitStream.ofBitVec vars).getD i default)]
+    (varsList := (List.map .ofBitVecSext vars))
+    (varsFin := fun i => (List.map .ofBitVecSext vars).getD i default)]
   · rw [(predicateEvalEqFSM p).good]
     apply eval_eq_false_of_mkIndHypCycleBreaking_eval_eq_false_of_mkSafetyCircuit_eval_eq_false
       (circs := circs) (hCircs := hCircs)

--- a/SSA/Experimental/Bits/MultiWidth/Defs.lean
+++ b/SSA/Experimental/Bits/MultiWidth/Defs.lean
@@ -331,19 +331,19 @@ structure HTermEnv {wcard tcard : Nat}
     heq_term : ∀ (v : Fin tcard),
       fsmEnv (StateSpace.termVar v) = BitStream.ofBitVec (tenv v)
 
-structure GoodNatFSM {wcard : Nat} (v : WidthExpr wcard) (tcard : Nat)
-  extends NatFSM wcard tcard (.ofDep v) where
+structure IsGoodNatFSM {wcard : Nat} (v : WidthExpr wcard) (tcard : Nat)
+   (fsm : NatFSM wcard tcard (.ofDep v)) : Prop where
   heq :
     ∀ (wenv : Fin wcard → Nat) (fsmEnv : StateSpace wcard tcard → BitStream),
-    (henv : HWidthEnv fsmEnv wenv) → toFsm.eval fsmEnv = v.toBitstream wenv
+    (henv : HWidthEnv fsmEnv wenv) → fsm.toFsm.eval fsmEnv = v.toBitstream wenv
 
-structure GoodTermFSM {w : WidthExpr wcard}
+structure IsGoodTermFSM {w : WidthExpr wcard}
   {tctx : Term.Ctx wcard tcard}
-  (t : Term tctx w) extends TermFSM wcard tcard (.ofDep t) where
+  {t : Term tctx w} (fsm : TermFSM wcard tcard (.ofDep t)) : Prop where
   heq :
     ∀ {wenv : WidthExpr.Env wcard} (tenv : tctx.Env wenv)
       (fsmEnv : StateSpace wcard tcard → BitStream),
-      (henv : HTermEnv fsmEnv tenv) → toFsm.eval fsmEnv = t.toBitstream tenv
+      (henv : HTermEnv fsmEnv tenv) → fsm.toFsm.eval fsmEnv = t.toBitstream tenv
 
 structure GoodPredicateFSM
   {tctx : Term.Ctx wcard tcard}

--- a/SSA/Experimental/Bits/MultiWidth/Defs.lean
+++ b/SSA/Experimental/Bits/MultiWidth/Defs.lean
@@ -171,12 +171,13 @@ theorem Term.toBitstream_zext {wcard tcard : Nat}
     {wenv : WidthExpr.Env wcard}
     (tenv : tctx.Env wenv) (t : Term tctx w) (wnew : WidthExpr wcard) :
   (Term.toBitstream (.zext t wnew) tenv) = BitStream.zeroExtend (Term.toBitstream t tenv) (wnew.toNat wenv) := by
-  simp [Term.toBitstream, BitStream.zeroExtend]
+  simp only [toBitstream]
   ext i
   simp
-  simp [BitStream.ofBitVecZextMsb]
-  simp [BitVec.msb_eq_getLsbD_last]
-  simp [Term.toBV]
+  simp only [BitStream.ofBitVecZextMsb, BitVec.truncate_eq_setWidth]
+  simp only [BitVec.msb_eq_getLsbD_last, BitVec.getLsbD_setWidth, tsub_lt_self_iff, zero_lt_one,
+    and_true]
+  simp only [toBV, BitVec.truncate_eq_setWidth, BitVec.getLsbD_setWidth]
   generalize (toBV tenv t) = tbv
   generalize (wnew.toNat wenv) = wnat
   by_cases hi0 : 0 < i

--- a/SSA/Experimental/Bits/MultiWidth/Defs.lean
+++ b/SSA/Experimental/Bits/MultiWidth/Defs.lean
@@ -154,20 +154,8 @@ theorem Term.toBV_zext {wenv : WidthExpr.Env wcard}
 theorem Term.toBV_sext {wenv : WidthExpr.Env wcard}
     {tctx : Term.Ctx wcard tcard}
     (tenv : tctx.Env wenv) (a : Term tctx w) (v : WidthExpr wcard) :
-  Term.toBV tenv (.sext a v) = (a.toBV tenv).signExtend (v.toNat wenv) := rfl
-
--- def Term.toBitstream {wcard tcard : Nat}
---     {tctx :Term.Ctx wcard tcard}
---     {w : WidthExpr wcard}
---     (t : Term tctx w)
---     (bsEnv : StateSpace wcard tcard → BitStream) :
---     BitStream := match t with
---   | .var v => bsEnv (StateSpace.termVar v)
---   | .add a b => a.toBitstream bsEnv + b.toBitstream bsEnv
---   | .zext a v => (a.toBitstream bsEnv) &&& (v.toBitStream bsEnv)
---   | .sext a v =>
---     -- TODO: need to implement this.
---     (a.toBitstream bsEnv) &&& (v.toBitStream bsEnv)
+  Term.toBV tenv (.sext a v) =
+    (a.toBV tenv).signExtend (v.toNat wenv) := rfl
 
 inductive BinaryRelationKind
 | eq

--- a/SSA/Experimental/Bits/MultiWidth/Defs.lean
+++ b/SSA/Experimental/Bits/MultiWidth/Defs.lean
@@ -125,7 +125,7 @@ def Term.toBitstream {wcard tcard : Nat}
     {wenv : WidthExpr.Env wcard}
     (tenv : tctx.Env wenv) :
     BitStream :=
-  BitStream.ofBitvecSextMsb (t.toBV tenv)
+  BitStream.ofBitVecZextMsb (t.toBV tenv)
 
 inductive BinaryRelationKind
 | eq

--- a/SSA/Experimental/Bits/MultiWidth/Defs.lean
+++ b/SSA/Experimental/Bits/MultiWidth/Defs.lean
@@ -253,6 +253,23 @@ def Term.width (t : Term) : WidthExpr :=
   | .zext _a wnew => wnew
   | .sext _a wnew => wnew
 
+/-- The width of the non-dependently typed 't' equals the width 'w',
+converting into the non-dependent version. -/
+@[simp]
+theorem Term.width_ofDep_eq_ofDep {wcard tcard : Nat}
+    {w : MultiWidth.WidthExpr wcard}
+    {tctx : Term.Ctx wcard tcard}
+    (t : MultiWidth.Term tctx w)
+    : (Term.ofDep t).width = (.ofDep w) := by
+  induction t
+  case var v => simp [Term.width]
+  case add v a b ha hb =>
+    simp [Term.ofDep, Term.width, ha]
+  case zext a wnew =>
+    simp [Term.ofDep, Term.width]
+  case sext a wnew =>
+    simp [Term.ofDep, Term.width]
+
 def Term.wcard (t : Term) : Nat := t.width.wcard
 
 def Term.tcard (t : Term) : Nat :=

--- a/SSA/Experimental/Bits/MultiWidth/Defs.lean
+++ b/SSA/Experimental/Bits/MultiWidth/Defs.lean
@@ -150,6 +150,12 @@ theorem Term.toBV_zext {wenv : WidthExpr.Env wcard}
     (tenv : tctx.Env wenv) (a : Term tctx w) (v : WidthExpr wcard) :
   Term.toBV tenv (.zext a v) = (a.toBV tenv).zeroExtend (v.toNat wenv) := rfl
 
+@[simp]
+theorem Term.toBV_sext {wenv : WidthExpr.Env wcard}
+    {tctx : Term.Ctx wcard tcard}
+    (tenv : tctx.Env wenv) (a : Term tctx w) (v : WidthExpr wcard) :
+  Term.toBV tenv (.sext a v) = (a.toBV tenv).signExtend (v.toNat wenv) := rfl
+
 -- def Term.toBitstream {wcard tcard : Nat}
 --     {tctx :Term.Ctx wcard tcard}
 --     {w : WidthExpr wcard}

--- a/SSA/Experimental/Bits/MultiWidth/Defs.lean
+++ b/SSA/Experimental/Bits/MultiWidth/Defs.lean
@@ -333,13 +333,19 @@ structure IsGoodNatFSM {wcard : Nat} {v : WidthExpr wcard} {tcard : Nat}
     (henv : HWidthEnv fsmEnv wenv) → fsm.toFsm.eval fsmEnv =
       BitStream.ofNatUnary (v.toNat wenv)
 
+/--
+Our term FSMs start unconditionally with a '0',
+and then proceed to produce outputs.
+This ensures that the width-0 value is assumed to be '0',
+followed by the output at a width 'i'.
+-/
 structure IsGoodTermFSM {w : WidthExpr wcard}
   {tctx : Term.Ctx wcard tcard}
   {t : Term tctx w} (fsm : TermFSM wcard tcard (.ofDep t)) : Prop where
   heq :
     ∀ {wenv : WidthExpr.Env wcard} (tenv : tctx.Env wenv)
       (fsmEnv : StateSpace wcard tcard → BitStream),
-      (henv : HTermEnv fsmEnv tenv) → fsm.toFsm.eval fsmEnv = t.toBitstream tenv
+      (henv : HTermEnv fsmEnv tenv) → fsm.toFsm.eval fsmEnv = (t.toBitstream tenv).concat false
 
 structure GoodPredicateFSM
   {tctx : Term.Ctx wcard tcard}

--- a/SSA/Experimental/Bits/MultiWidth/Defs.lean
+++ b/SSA/Experimental/Bits/MultiWidth/Defs.lean
@@ -173,7 +173,6 @@ inductive Predicate
     (a : Term ctx w) (b : Term ctx w) : Predicate ctx
 | and (p1 p2 : Predicate ctx) : Predicate ctx
 | or (p1 p2 : Predicate ctx) : Predicate ctx
-| not (p : Predicate ctx) : Predicate ctx
 
 structure PackedPredicate where
   wcard : Nat
@@ -191,7 +190,6 @@ def Predicate.toProp {wcard tcard : Nat} {wenv : WidthExpr.Env wcard}
     | .eq => a.toBV tenv = b.toBV tenv
   | .and p1 p2 => p1.toProp tenv ∧ p2.toProp tenv
   | .or p1 p2 => p1.toProp tenv ∨ p2.toProp tenv
-  | .not p => ¬ p.toProp tenv
 
 -- TODO: is this even needed?
 -- Can't I directly show that the FSM corresponds to the BV?
@@ -275,7 +273,6 @@ inductive Predicate
     (a : Term) (b : Term) : Predicate
 | or (p1 p2 : Predicate) : Predicate
 | and (p1 p2 : Predicate) : Predicate
-| not (p : Predicate) : Predicate
 deriving DecidableEq, Inhabited, Repr, Lean.ToExpr
 
 def Predicate.wcard (p : Predicate) : Nat :=
@@ -283,14 +280,12 @@ def Predicate.wcard (p : Predicate) : Nat :=
   | .binRel .eq a _b => a.wcard
   | .or p1 p2 => max (Predicate.wcard p1) (Predicate.wcard p2)
   | .and p1 p2 => max (Predicate.wcard p1) (Predicate.wcard p2)
-  | .not p => Predicate.wcard p
 
 def Predicate.tcard (p : Predicate) : Nat :=
   match p with
   | .binRel .eq a b => max a.tcard b.tcard
   | .or p1 p2 => max (Predicate.tcard p1) (Predicate.tcard p2)
   | .and p1 p2 => max (Predicate.tcard p1) (Predicate.tcard p2)
-  | .not p => Predicate.tcard p
 
 def Predicate.ofDep {wcard tcard : Nat}
     {tctx : Term.Ctx wcard tcard} (p : MultiWidth.Predicate tctx) : Predicate :=
@@ -300,7 +295,6 @@ def Predicate.ofDep {wcard tcard : Nat}
     | .eq  => .binRel .eq (.ofDep a) (.ofDep b)
   | .or p1 p2 => .or (.ofDep p1) (.ofDep p2)
   | .and p1 p2 => .and (.ofDep p1) (.ofDep p2)
-  | .not p => .not (.ofDep p)
 
 end Nondep
 

--- a/SSA/Experimental/Bits/MultiWidth/Defs.lean
+++ b/SSA/Experimental/Bits/MultiWidth/Defs.lean
@@ -145,7 +145,9 @@ def Predicate.toProp {wcard tcard : Nat} {wenv : WidthExpr.Env wcard}
 
 section ToBitstream
 
-
+/-- Our bitstreams start with '0',
+since we want the denotation of the bitstream at 'i' to be equal to
+'Term.zeroExtend i.msb'. -/
 def Term.toBitstream {wcard tcard : Nat}
     {tctx :Term.Ctx wcard tcard}
     {w : WidthExpr wcard}
@@ -153,7 +155,7 @@ def Term.toBitstream {wcard tcard : Nat}
     {wenv : WidthExpr.Env wcard}
     (tenv : tctx.Env wenv) :
     BitStream :=
-  BitStream.ofBitVec (t.toBV tenv)
+  BitStream.ofBitVec (t.toBV tenv) |>.concat false
 
 def Predicate.toBitstream {tctx : Term.Ctx wcard tcard}
     (p : Predicate tctx)
@@ -345,7 +347,8 @@ structure IsGoodTermFSM {w : WidthExpr wcard}
   heq :
     ∀ {wenv : WidthExpr.Env wcard} (tenv : tctx.Env wenv)
       (fsmEnv : StateSpace wcard tcard → BitStream),
-      (henv : HTermEnv fsmEnv tenv) → fsm.toFsm.eval fsmEnv = (t.toBitstream tenv).concat false
+      (henv : HTermEnv fsmEnv tenv) → fsm.toFsm.eval fsmEnv =
+        (t.toBitstream tenv)
 
 structure GoodPredicateFSM
   {tctx : Term.Ctx wcard tcard}

--- a/SSA/Experimental/Bits/MultiWidth/Defs.lean
+++ b/SSA/Experimental/Bits/MultiWidth/Defs.lean
@@ -34,6 +34,10 @@ def WidthExpr.toNat (e : WidthExpr wcard) (env : WidthExpr.Env wcard) : Nat :=
   match e with
   | .var v => env v
 
+@[simp]
+def WidthExpr.toNat_var (v : Fin wcard) (env : WidthExpr.Env wcard) :
+    WidthExpr.toNat (.var v) env = env v := rfl
+
 inductive NatPredicate (wcard : Nat) : Type
 | eq : WidthExpr wcard → WidthExpr wcard → NatPredicate wcard
 
@@ -141,15 +145,6 @@ def Predicate.toProp {wcard tcard : Nat} {wenv : WidthExpr.Env wcard}
 
 section ToBitstream
 
-/--
-A width expression denotes a bitstream, whose
-value is true if for all indeces larger than 'env v'.
--/
-def WidthExpr.toBitstream
-  (e : WidthExpr n)
-  (env : WidthExpr.Env n) : BitStream :=
-  match e with
-  | .var v => BitStream.ofNatUnary (env v)
 
 def Term.toBitstream {wcard tcard : Nat}
     {tctx :Term.Ctx wcard tcard}
@@ -335,7 +330,8 @@ structure IsGoodNatFSM {wcard : Nat} {v : WidthExpr wcard} {tcard : Nat}
    (fsm : NatFSM wcard tcard (.ofDep v)) : Prop where
   heq :
     ∀ (wenv : Fin wcard → Nat) (fsmEnv : StateSpace wcard tcard → BitStream),
-    (henv : HWidthEnv fsmEnv wenv) → fsm.toFsm.eval fsmEnv = v.toBitstream wenv
+    (henv : HWidthEnv fsmEnv wenv) → fsm.toFsm.eval fsmEnv =
+      BitStream.ofNatUnary (v.toNat wenv)
 
 structure IsGoodTermFSM {w : WidthExpr wcard}
   {tctx : Term.Ctx wcard tcard}

--- a/SSA/Experimental/Bits/MultiWidth/Defs.lean
+++ b/SSA/Experimental/Bits/MultiWidth/Defs.lean
@@ -331,7 +331,7 @@ structure HTermEnv {wcard tcard : Nat}
     heq_term : ∀ (v : Fin tcard),
       fsmEnv (StateSpace.termVar v) = BitStream.ofBitVec (tenv v)
 
-structure IsGoodNatFSM {wcard : Nat} (v : WidthExpr wcard) (tcard : Nat)
+structure IsGoodNatFSM {wcard : Nat} {v : WidthExpr wcard} {tcard : Nat}
    (fsm : NatFSM wcard tcard (.ofDep v)) : Prop where
   heq :
     ∀ (wenv : Fin wcard → Nat) (fsmEnv : StateSpace wcard tcard → BitStream),

--- a/SSA/Experimental/Bits/MultiWidth/Defs.lean
+++ b/SSA/Experimental/Bits/MultiWidth/Defs.lean
@@ -39,6 +39,11 @@ def WidthExpr.toNat (e : WidthExpr wcard) (env : WidthExpr.Env wcard) : Nat :=
   match e with
   | .var v => env v
 
+
+def WidthExpr.toBitStream (e : WidthExpr wcard) (wenv : WidthExpr.Env wcard) : BitStream :=
+  match e with
+  | .var v => BitStream.ofNatUnary (wenv v)
+
 @[simp]
 def WidthExpr.toNat_var (v : Fin wcard) (env : WidthExpr.Env wcard) :
     WidthExpr.toNat (.var v) env = env v := rfl
@@ -330,25 +335,23 @@ structure HTermEnv {wcard tcard : Nat}
 def HTermEnv.mkFsmEnvOfTenv {wcard tcard : Nat}
     {wenv : Fin wcard → Nat} {tctx : Term.Ctx wcard tcard}
     (tenv : tctx.Env wenv) :
-    StateSpace wcard tcard → BitStream := sorry
-
-/-- make a 'HTermEnv' of 'ofTenv'. -/
-def HTermEnv.mkTenvOfFsmEnv {wcard tcard : Nat}
-    (wenv : Fin wcard → Nat) (tctx : Term.Ctx wcard tcard)
-    (fsmEnv : StateSpace wcard tcard → BitStream) :
-    tctx.Env wenv := sorry
+    StateSpace wcard tcard → BitStream := fun
+    | .widthVar v =>
+        BitStream.ofNatUnary (wenv v)
+    | .termVar v =>
+      BitStream.ofBitVecSext (tenv v)
 
 @[simp]
 theorem HTermEnv.of_mkFsmEnvOfTenv {wcard tcard : Nat}
     {wenv : Fin wcard → Nat} {tctx : Term.Ctx wcard tcard}
     (tenv : tctx.Env wenv) :
-    HTermEnv (mkFsmEnvOfTenv tenv) tenv := sorry
-
-@[simp]
-theorem HTermEnv.of_mkTenvOfFsmEnv {wcard tcard : Nat}
-    {wenv : Fin wcard → Nat} {tctx : Term.Ctx wcard tcard}
-    (fsmEnv : StateSpace wcard tcard → BitStream) :
-    HTermEnv fsmEnv (mkTenvOfFsmEnv wenv tctx fsmEnv) := sorry
+    HTermEnv (mkFsmEnvOfTenv tenv) tenv := by
+  constructor
+  · constructor
+    · intros v
+      simp [mkFsmEnvOfTenv]
+  · intros v
+    simp [mkFsmEnvOfTenv]
 
 structure IsGoodNatFSM {wcard : Nat} {v : WidthExpr wcard} {tcard : Nat}
    (fsm : NatFSM wcard tcard (.ofDep v)) : Prop where

--- a/SSA/Experimental/Bits/MultiWidth/GoodFSM.lean
+++ b/SSA/Experimental/Bits/MultiWidth/GoodFSM.lean
@@ -88,6 +88,22 @@ theorem getLsbD_signExtend_eq {wold : Nat} (x : BitVec wold) {wnew : Nat} :
       simp [show min i (wold - 1) = wold - 1 by omega]
   · simp [hnew]
 
+-- | Found a cuter expression for 'getLsbD_signExtend'.
+theorem getLsbD_signExtend_eq' {wold : Nat} (x : BitVec wold) {wnew : Nat} :
+  (x.signExtend wnew).getLsbD i =
+    (x.getLsbD (min i (wold - 1)) && decide (i < wnew))
+      := by
+  simp [BitVec.getLsbD_signExtend]
+  rw [BitVec.msb_eq_getLsbD_last]
+  by_cases hnew : i < wnew
+  · simp [hnew]
+    by_cases hi : i < wold
+    · simp [hi]
+      simp [show min i (wold - 1) = i by omega]
+    · simp [hi]
+      simp [show min i (wold - 1) = wold - 1 by omega]
+  · simp [hnew]
+
 theorem eval_fsmMsb_eq_decide
     {wenv : WidthExpr.Env wcard}
     {fsmEnv : StateSpace wcard tcard → BitStream}

--- a/SSA/Experimental/Bits/MultiWidth/GoodFSM.lean
+++ b/SSA/Experimental/Bits/MultiWidth/GoodFSM.lean
@@ -454,7 +454,15 @@ theorem fsmZext_eval_eq
   rw [ht.heq (henv := htenv)]
   rw [hwnew.heq (henv := htenv.toHWidthEnv)]
   simp
-  sorry
+  rcases i with rfl | i
+  · simp
+  · simp
+    by_cases hi : i < wnew.toNat wenv
+    · simp [hi]
+      intros hval
+      omega
+    · simp [hi]
+      omega
 
 /-- The inputs given to the sext fsm. -/
 inductive fsmSext.inputs
@@ -760,7 +768,6 @@ theorem Predicate.toProp_of_KInductionCircuits
 
 /--
 info: 'MultiWidth.Predicate.toProp_of_KInductionCircuits' depends on axioms: [propext,
- sorryAx,
  Classical.choice,
  MultiWidth.AxAdd,
  MultiWidth.AxSext,

--- a/SSA/Experimental/Bits/MultiWidth/GoodFSM.lean
+++ b/SSA/Experimental/Bits/MultiWidth/GoodFSM.lean
@@ -594,9 +594,6 @@ def mkPredicateFSMAux (wcard tcard : Nat) (p : Nondep.Predicate) :
     let fsmP := mkPredicateFSMAux wcard tcard p
     let fsmQ := mkPredicateFSMAux wcard tcard q
     { toFsm := (fsmP.toFsm &&& fsmQ.toFsm) }
-  | .not p =>
-    let fsmP := mkPredicateFSMAux wcard tcard p
-    { toFsm := (~~~ fsmP.toFsm) }
 
 def isGoodPredicateFSM_mkPredicateFSMAux {wcard tcard : Nat}
     {tctx : Term.Ctx wcard tcard}
@@ -617,7 +614,8 @@ def isGoodPredicateFSM_mkPredicateFSMAux {wcard tcard : Nat}
       rw [hb.heq (henv := henv)]
       simp [Predicate.toProp]
       constructor
-      · sorry
+      · intros h
+        sorry
       · sorry
   case or p q hp hq =>
     constructor
@@ -626,7 +624,10 @@ def isGoodPredicateFSM_mkPredicateFSMAux {wcard tcard : Nat}
     simp [Predicate.toProp]
     rw [hp.heq (henv := henv)]
     rw [hq.heq (henv := henv)]
-    sorry
+    constructor
+    · intros h
+      sorry
+    · sorry
   case and p q hp hq =>
     constructor
     simp [mkPredicateFSMAux, Nondep.Predicate.ofDep]
@@ -634,24 +635,21 @@ def isGoodPredicateFSM_mkPredicateFSMAux {wcard tcard : Nat}
     simp [Predicate.toProp]
     rw [hp.heq (henv := htenv)]
     rw [hq.heq (henv := htenv)]
-    sorry
-  case not p hp =>
-    constructor
-    simp [mkPredicateFSMAux, Nondep.Predicate.ofDep]
-    intros wenv tenv fsmEnv htenv
-    simp [Predicate.toProp]
-    rw [hp.heq (henv := htenv)]
     constructor
     · intros h
-      -- obtain hx := congrFun h 1
-      sorry
+      obtain ⟨hpfsm, hqfsm⟩ := h
+      simp [hpfsm, hqfsm]
+      ext i; simp
     · intros h
-      intros h'
-      have h0 := congrFun h 0
-      have h'0 := congrFun h' 0
-      simp at h0
-      simp at h'0
-      simp [h0] at h'0
+      constructor
+      · ext i
+        have := congrFun h i
+        simp at this
+        simp [this]
+      · ext i
+        have := congrFun h i
+        simp at this
+        simp [this]
 
 /-- Negate the FSM so we can decide if zeroes. -/
 def mkPredicateFSMNondep (wcard tcard : Nat) (p : Nondep.Predicate) :

--- a/SSA/Experimental/Bits/MultiWidth/GoodFSM.lean
+++ b/SSA/Experimental/Bits/MultiWidth/GoodFSM.lean
@@ -30,7 +30,7 @@ instance : Complement (FSM α) where
 def mkWidthFSM (wcard : Nat) (tcard : Nat) (w : Nondep.WidthExpr) : (NatFSM wcard tcard w) :=
   if h : w.toNat < wcard then
     { toFsm := composeUnaryAux FSM.scanAnd (FSM.var' (StateSpace.widthVar ⟨w.toNat, h⟩)) }
-  else 
+  else
     { toFsm := FSM.zero.map Fin.elim0 } -- default, should not be used.
 
 
@@ -110,13 +110,14 @@ def fsmSext (a wold wnew : FSM (StateSpace wcard tcard))
     }
 
 
-def mkTermFSM (wcard tcard : Nat) (t : Nondep.Term) : 
+def mkTermFSM (wcard tcard : Nat) (t : Nondep.Term) :
     (TermFSM wcard tcard t) :=
   match t with
   | .var v _w =>
     if h : v < tcard then
       {
-      toFsm := composeUnaryAux FSM.scanAnd (FSM.var' (StateSpace.termVar ⟨v, h⟩))
+      -- toFsm := composeUnaryAux FSM.scanAnd (FSM.var' (StateSpace.termVar ⟨v, h⟩))
+      toFsm := (FSM.var' (StateSpace.termVar ⟨v, h⟩))
       }
     else
       { toFsm := FSM.zero.map Fin.elim0 } -- default, should not be ued.
@@ -136,6 +137,18 @@ def mkTermFSM (wcard tcard : Nat) (t : Nondep.Term) :
     let woldFsm := mkWidthFSM wcard tcard wold
     let vFsm := mkWidthFSM wcard tcard v
     { toFsm := fsmSext afsm.toFsm woldFsm.toFsm vFsm.toFsm }
+
+def mkGoodTermFSM {wcard tcard : Nat} (tctx : Term.Ctx wcard tcard) {w : WidthExpr wcard} (t : Term tctx w)  :
+    (GoodTermFSM t) :=
+  GoodTermFSM.mk (mkTermFSM wcard tcard (.ofDep t)) (by
+    intros wenv tenv fsmEnv
+    induction t generalizing wenv tenv fsmEnv
+    case var v =>
+      simp
+    case add w a b => sorry
+    case zext w' a b => sorry
+    case sext w' a b => sorry
+  )
 
 /-- fSM that returns 1 ifthe predicate is true, and 0 otherwise -/
 def mkPredicateFSMAux (wcard tcard : Nat) (p : Nondep.Predicate) :

--- a/SSA/Experimental/Bits/MultiWidth/GoodFSM.lean
+++ b/SSA/Experimental/Bits/MultiWidth/GoodFSM.lean
@@ -68,7 +68,7 @@ the MSB finite state machine
 returns the 'msb' upto the current width.
 -/
 def fsmMsb (x w : FSM α) : FSM α :=
-  composeBinaryAux' (FSM.latchImmediate false) x w
+  composeBinaryAux' (FSM.latchImmediate false) (qfalse := x) (qtrue := w)
 
 theorem eval_fsmMsb_eq {wenv : WidthExpr.Env wcard}
     {fsmEnv : StateSpace wcard tcard → BitStream}
@@ -80,12 +80,9 @@ theorem eval_fsmMsb_eq {wenv : WidthExpr.Env wcard}
     (hxfsm : HTermFSMToBitStream xfsm)
     (wfsm : NatFSM wcard tcard (.ofDep w))
     (hwfsm : HNatFSMToBitstream wfsm)
-    (htenv : HTermEnv fsmEnv tenv)
-
-    :
-    (fsmMsb xfsm.toFsm wfsm.toFsm).eval fsmEnv =
-      (BitStream.concat false
-        (fun i => ((x.toBV tenv).getLsbD (min i (w.toNat wenv))))) := by
+    (htenv : HTermEnv fsmEnv tenv) :
+    (fsmMsb xfsm.toFsm wfsm.toFsm).eval fsmEnv = (fun i =>
+      BitStream.ofBitVecZextMsb (x.toBV tenv) (min i (w.toNat wenv))) := by
   simp [fsmMsb]
   have wfsmEval := hwfsm.heq (henv := htenv.toHWidthEnv)
   have tfsmEval := hxfsm.heq (henv := htenv)
@@ -93,54 +90,46 @@ theorem eval_fsmMsb_eq {wenv : WidthExpr.Env wcard}
   rcases i with rfl | i
   · simp
     intros hxFsmEq
-    simp [tfsmEval] at hxFsmEq
+    simp [tfsmEval]
   · simp
     rw [tfsmEval, wfsmEval]
     simp
     induction i
     case zero =>
       simp
-      have wfsmEval := hwfsm.heq (henv := htenv.toHWidthEnv)
-      have tfsmEval := hxfsm.heq (henv := htenv)
-      intros hXEq
-      apply Nat.le_iff_lt_add_one .. |>.mpr
-      simp only [lt_add_iff_pos_left]
-      apply BitVec.lt_of_getLsbD hXEq
+      by_cases hw : 1 ≤ w.toNat wenv
+      · simp [hw]
+      · simp at hw
+        simp [hw]
     case succ i hi =>
       simp
       by_cases hxiSucc : (Term.toBV tenv x).getLsbD (i + 1) = true
       · simp [hxiSucc]
-        by_cases hiwLe : i + 2 ≤ w.toNat wenv
+        by_cases hiwLe : i + 1 + 1  ≤ w.toNat wenv
         · simp [hiwLe]
-          simp [show min (i + 1) (w.toNat wenv) = i + 1 by omega]
-          exact hxiSucc
+          simp [hxiSucc]
         · simp [hiwLe]
+          simp at hiwLe
+          have hiwLt := BitVec.lt_of_getLsbD hxiSucc
+          omega
+      · simp at hxiSucc
+        simp [hxiSucc]
+        rw [hi]
+        clear hi
+        generalize hbv : (Term.toBV tenv x) = bv
+        rw [hbv] at hxiSucc
+        by_cases hiSucc : i + 1 ≤ w.toNat wenv
+        · simp [hiSucc]
+          by_cases hiSuccSucc : i + 1 + 1 ≤ w.toNat wenv
+          · simp [hiSuccSucc]
+            rw [hxiSucc]
+          · simp at hiSuccSucc
+            have hwEq : w.toNat wenv = i + 1 := by omega
+            simp [hwEq]
+        · simp at hiSucc
+          simp [show ¬ i + 1 + 1 ≤ w.toNat wenv by omega]
           simp [show min (i + 1) (w.toNat wenv) = w.toNat wenv by omega]
-      · simp [hxiSucc]
-        by_cases hxi : (Term.toBV tenv x).getLsbD i = true
-        · simp [hxi]
-          simp [hxi] at hi
-          by_cases hiwLe : i + 1 ≤ w.toNat wenv
-          · simp [hiwLe]
-            simp [hiwLe] at hi
-            simp [show min i (w.toNat wenv) = i by omega] at hi
-            sorry
-          · simp [hiwLe]
-            sorry
-        · simp [hxi]
-          simp [hxi] at hi
-          rw [hi]
-          by_cases hiwLeSucc : i + 1 ≤ w.toNat wenv
-          · simp [hiwLeSucc]
-            by_cases hiwLe : i ≤ w.toNat wenv
-            · simp [hiwLe]
-              simp at hxi hxiSucc
-              simp [hxi, hxiSucc]
-            · simp [show min i (w.toNat wenv) = w.toNat wenv by omega]
-              apply BitVec.getLsbD_of_ge
-              omega
-          · simp [show min (i + 1) (w.toNat wenv) = w.toNat wenv by omega]
-            simp [show min (i) (w.toNat wenv) = w.toNat wenv by omega]
+          simp [show min (i + 1 + 1) (w.toNat wenv) = w.toNat wenv by omega]
 
 
 -- | Found a cuter expression for 'getLsbD_signExtend'.

--- a/SSA/Experimental/Bits/MultiWidth/GoodFSM.lean
+++ b/SSA/Experimental/Bits/MultiWidth/GoodFSM.lean
@@ -516,8 +516,7 @@ theorem fsmZext_eval_eq
       ((BitStream.ofBitVecZextMsb ((Term.zext t wnew).toBV tenv))) i := by
   ext i
   rw [fsmZext]
-  simp only [FSM.eval_and', BitStream.and_eq, BitStream.ofBitVecZextMsb_eq_concat_ofBitVecZext,
-    BitStream.zeroExtend_eval_eq]
+  simp only [FSM.eval_and', BitStream.and_eq, BitStream.ofBitVecZextMsb_eq_concat_ofBitVecZext]
   rw [ht.heq (henv := htenv)]
   rw [hwnew.heq (henv := htenv.toHWidthEnv)]
   simp
@@ -550,9 +549,7 @@ theorem fsmSext_eval_eq
   ext i
   rw [fsmSext]
   simp only [FSM.eval_and', BitStream.and_eq,
-    BitStream.ofBitVecZextMsb_eq_concat_ofBitVecZext,
-    BitStream.zeroExtend_eval_eq,
-    FSM.eval_ite_eq_decide, composeBinaryAux'_eval]
+    BitStream.ofBitVecZextMsb_eq_concat_ofBitVecZext]
   rw [hwnew.heq (henv := htenv.toHWidthEnv)]
   rw [eval_fsmMsb_eq
         (xfsm := tFsm) (wfsm := woldFsm) (htenv := htenv)
@@ -594,8 +591,7 @@ theorem fsmSext_eval_eq
       · simp
       · simp
         rw [BitVec.getLsbD_signExtend]
-        simp [hwold, hwnew]
-        omega
+        simp; omega
 
 /-- info: 'MultiWidth.fsmSext_eval_eq' depends on axioms: [propext, Classical.choice, Quot.sound] -/
 #guard_msgs in #print axioms fsmSext_eval_eq

--- a/SSA/Experimental/Bits/MultiWidth/GoodFSM.lean
+++ b/SSA/Experimental/Bits/MultiWidth/GoodFSM.lean
@@ -70,12 +70,12 @@ theorem getLsbD_signExtend_eq {wold : Nat} (x : BitVec wold) {wnew : Nat} :
     -- if the new width is smaller than the old width,
     -- then it is the same as zero extension.
     if wnew ≤ wold
-    then x.getLsbD i && decide (i < wnew)
+    then x.getLsbD (min i (wold - 1)) && decide (i < wnew)
     else
       -- if the new width is larger than the old width,
       -- then we return the value of sign extension,
       -- which is the value at index 'wold - 1'.
-      x.getLsbD (min i (wold - 1)) && (i < wnew)
+      x.getLsbD (min i (wold - 1)) && decide (i < wnew)
       := by
   simp [BitVec.getLsbD_signExtend]
   rw [BitVec.msb_eq_getLsbD_last]
@@ -83,12 +83,9 @@ theorem getLsbD_signExtend_eq {wold : Nat} (x : BitVec wold) {wnew : Nat} :
   · simp [hnew]
     by_cases hi : i < wold
     · simp [hi]
-      intros hwold
       simp [show min i (wold - 1) = i by omega]
     · simp [hi]
-      simp [show ¬ wnew ≤ wold by omega]
-      apply congrArg
-      omega
+      simp [show min i (wold - 1) = wold - 1 by omega]
   · simp [hnew]
 
 theorem eval_fsmMsb_eq_decide

--- a/SSA/Experimental/Bits/MultiWidth/GoodFSM.lean
+++ b/SSA/Experimental/Bits/MultiWidth/GoodFSM.lean
@@ -26,8 +26,8 @@ def mkWidthFSM (wcard : Nat) (tcard : Nat) (w : Nondep.WidthExpr) :
     { toFsm := FSM.zero.map Fin.elim0 } -- default, should not be used.
 
 
-def IsGoodNatFSM_mkWidthFSM {wcard : Nat} (tcard : Nat) {w : WidthExpr wcard} :
-    IsGoodNatFSM (mkWidthFSM wcard tcard (.ofDep w)) where
+def IsGoodNatFSM_mkWidthFSM {wcard : Nat} (tcard : Nat) (w : WidthExpr wcard) :
+    HNatFSMToBitstream (mkWidthFSM wcard tcard (.ofDep w)) where
   heq := by
     intros wenv fsmEnv henv
     induction w
@@ -67,7 +67,7 @@ theorem eval_fsmMsb_eq_decide
   (x : Term tctx w)
   (w : WidthExpr wcard)
   (xfsm : TermFSM wcard tcard (.ofDep x))
-  (hxfsm : IsGoodTermFSM xfsm)
+  (hxfsm : HTermFSMToBitStream xfsm)
   (wfsm : NatFSM wcard tcard (.ofDep w)) :
   (fsmMsb xfsm.toFsm wfsm.toFsm).eval env i =
   ((x.toBV tenv).signExtend (w.toNat wenv)).getLsbD i
@@ -84,7 +84,7 @@ theorem eval_fsmUnaryMax_eq_decide
   {wenv : WidthExpr.Env wcard}
   {fsmEnv : StateSpace wcard tcard → BitStream}
   (henv : HWidthEnv fsmEnv wenv)
-  (ha : IsGoodNatFSM a) (hb : IsGoodNatFSM b) :
+  (ha : HNatFSMToBitstream a) (hb : HNatFSMToBitstream b) :
   ((fsmUnaryMax a.toFsm b.toFsm).eval fsmEnv) i =
     (i ≤ (max (v.toNat wenv) (w.toNat wenv))) := by
   simp only [fsmUnaryMax, composeBinaryAux'_eval, eq_iff_iff]
@@ -103,7 +103,7 @@ theorem eval_fsmUnaryMin_eq_decide
   {wenv : WidthExpr.Env wcard}
   {fsmEnv : StateSpace wcard tcard → BitStream}
   (henv : HWidthEnv fsmEnv wenv)
-  (ha : IsGoodNatFSM a) (hb : IsGoodNatFSM b) :
+  (ha : HNatFSMToBitstream a) (hb : HNatFSMToBitstream b) :
   ((fsmUnaryMin a.toFsm b.toFsm).eval fsmEnv) i =
     (i ≤ (min (v.toNat wenv) (w.toNat wenv))) := by
   simp only [fsmUnaryMin, composeBinaryAux'_eval, _root_.FSM.eval_and, cond_true, cond_false,
@@ -123,7 +123,7 @@ theorem eval_fsmUnaryIncrK_eq_decide
   {wenv : WidthExpr.Env wcard}
   {fsmEnv : StateSpace wcard tcard → BitStream}
   (henv : HWidthEnv fsmEnv wenv)
-  (ha : IsGoodNatFSM a) :
+  (ha : HNatFSMToBitstream a) :
   ((fsmUnaryIncrK k a.toFsm).eval fsmEnv) = fun i =>
   decide (i ≤ (v.toNat wenv) + k) := by
   induction k
@@ -157,7 +157,7 @@ theorem eval_fsmUnaryUle_eq_decide
     {wenv : WidthExpr.Env wcard}
     {fsmEnv : StateSpace wcard tcard → BitStream}
     (henv : HWidthEnv fsmEnv wenv)
-    (ha : IsGoodNatFSM a) (hb : IsGoodNatFSM b) :
+    (ha : HNatFSMToBitstream a) (hb : HNatFSMToBitstream b) :
     ((fsmUnaryUle a.toFsm b.toFsm).eval fsmEnv) i =
     decide (min i (v.toNat wenv) ≤ min i (w.toNat wenv)) := by
   simp [fsmUnaryUle]
@@ -209,7 +209,7 @@ theorem eval_fsmUnaryUle_eq_lt_or_decide
     {wenv : WidthExpr.Env wcard}
     {fsmEnv : StateSpace wcard tcard → BitStream}
     (henv : HWidthEnv fsmEnv wenv)
-    (ha : IsGoodNatFSM a) (hb : IsGoodNatFSM b) :
+    (ha : HNatFSMToBitstream a) (hb : HNatFSMToBitstream b) :
     ((fsmUnaryUle a.toFsm b.toFsm).eval fsmEnv) i =
     decide (i ≤ min (v.toNat wenv) (w.toNat wenv) ∨ (v.toNat wenv) ≤ (w.toNat wenv)) := by
   rw [eval_fsmUnaryUle_eq_decide (wenv := wenv) (henv := henv) (ha := ha) (hb := hb)]
@@ -242,7 +242,7 @@ theorem eval_FsmEqUpto_eq_decide
     {wenv : WidthExpr.Env wcard}
     {fsmEnv : StateSpace wcard tcard → BitStream}
     (henv : HWidthEnv fsmEnv wenv)
-    (ha : IsGoodNatFSM a) (hb : IsGoodNatFSM b) :
+    (ha : HNatFSMToBitstream a) (hb : HNatFSMToBitstream b) :
     ((fsmEqUnaryUpto a.toFsm b.toFsm).eval fsmEnv) i =
     decide (min i (v.toNat wenv) = min i (w.toNat wenv)) := by
   simp [fsmEqUnaryUpto]
@@ -280,7 +280,7 @@ theorem eval_FsmEqUpto_eq_decide'
     {wenv : WidthExpr.Env wcard}
     {fsmEnv : StateSpace wcard tcard → BitStream}
     (henv : HWidthEnv fsmEnv wenv)
-    (ha : IsGoodNatFSM a) (hb : IsGoodNatFSM b) :
+    (ha : HNatFSMToBitstream a) (hb : HNatFSMToBitstream b) :
     ((fsmEqUnaryUpto a.toFsm b.toFsm).eval fsmEnv) = fun i =>
     decide (min i (v.toNat wenv) = min i (w.toNat wenv)) := by
   ext i
@@ -328,7 +328,7 @@ theorem eval_fsmUnaryNeqUpto_eq_decide
     {wenv : WidthExpr.Env wcard}
     {fsmEnv : StateSpace wcard tcard → BitStream}
     (henv : HWidthEnv fsmEnv wenv)
-    (ha : IsGoodNatFSM a) (hb : IsGoodNatFSM b) :
+    (ha : HNatFSMToBitstream a) (hb : HNatFSMToBitstream b) :
     ((fsmUnaryNeqUpto a.toFsm b.toFsm).eval fsmEnv) i =
     (decide (min i (v.toNat wenv) ≠ min i (w.toNat wenv))) := by
   simp [fsmUnaryNeqUpto]
@@ -393,7 +393,7 @@ theorem eval_fsmUltUnary_eq_decide
     {wenv : WidthExpr.Env wcard}
     {fsmEnv : StateSpace wcard tcard → BitStream}
     (henv : HWidthEnv fsmEnv wenv)
-    (ha : IsGoodNatFSM a) (hb : IsGoodNatFSM b) :
+    (ha : HNatFSMToBitstream a) (hb : HNatFSMToBitstream b) :
     ((fsmUltUnary a.toFsm b.toFsm).eval fsmEnv) i =
    (decide (min i (v.toNat wenv) < min i (w.toNat wenv))) := by
   simp [fsmUltUnary]
@@ -422,7 +422,7 @@ theorem fsmIndexUle_eval_eq
     {wenv : WidthExpr.Env wcard}
     {fsmEnv : StateSpace wcard tcard → BitStream}
     (henv : HWidthEnv fsmEnv wenv)
-    (ha : IsGoodNatFSM a) :
+    (ha : HNatFSMToBitstream a) :
     (fsmUnaryIndexUle a).eval fsmEnv i =
     decide (i ≤ v.toNat wenv) := by
   rw [fsmUnaryIndexUle]
@@ -438,22 +438,23 @@ theorem fsmZext_eval_eq
     (wnewFsm : NatFSM wcard tcard (.ofDep wnew))
     {wenv : WidthExpr.Env wcard}
     {fsmEnv : StateSpace wcard tcard → BitStream}
-    (hwnew : IsGoodNatFSM wnewFsm)
+    (hwnew : HNatFSMToBitstream wnewFsm)
     {tctx : Term.Ctx wcard tcard}
     (tenv : Term.Ctx.Env tctx wenv)
     (t : Term tctx w)
     (tFsm : TermFSM wcard tcard (.ofDep t))
-    (ht : IsGoodTermFSM tFsm)
+    (ht : HTermFSMToBitStream tFsm)
     (htenv : HTermEnv fsmEnv tenv) :
     (fsmZext tFsm.toFsm wnewFsm.toFsm).eval fsmEnv = fun i =>
-      (BitStream.zeroExtend (t.toBitstream tenv) (wnew.toNat wenv)) i := by
+      ((BitStream.ofBitVecZextMsb ((Term.zext t wnew).toBV tenv))) i := by
   ext i
   rw [fsmZext]
-  simp
+  simp only [FSM.eval_and', BitStream.and_eq, BitStream.ofBitVecZextMsb_eq_concat_ofBitVecZext,
+    BitStream.zeroExtend_eval_eq]
   rw [ht.heq (henv := htenv)]
   rw [hwnew.heq (henv := htenv.toHWidthEnv)]
+  simp
   sorry
-
 
 /-- The inputs given to the sext fsm. -/
 inductive fsmSext.inputs
@@ -536,8 +537,10 @@ def mkTermFSM (wcard tcard : Nat) (t : Nondep.Term) :
 axiom AxSext {P : Prop} : P
 axiom AxAdd {P : Prop} : P
 
-def IsGoodTermFSM_mkTermFSM (wcard tcard : Nat) {tctx : Term.Ctx wcard tcard} {w : WidthExpr wcard} (t : Term tctx w)  :
-    (IsGoodTermFSM (mkTermFSM wcard tcard (.ofDep t))) := by
+def IsGoodTermFSM_mkTermFSM (wcard tcard : Nat) {tctx : Term.Ctx wcard tcard}
+    {w : WidthExpr wcard}
+      (t : Term tctx w)  :
+    (HTermFSMToBitStream (mkTermFSM wcard tcard (.ofDep t))) := by
   induction t
   case var v =>
     constructor
@@ -545,8 +548,8 @@ def IsGoodTermFSM_mkTermFSM (wcard tcard : Nat) {tctx : Term.Ctx wcard tcard} {w
     obtain htenv_term := htenv.heq_term
     obtain htenv_width := htenv.heq_width
     simp only [Nondep.Term.ofDep_var, mkTermFSM,
-      Fin.is_lt, ↓reduceDIte, Fin.eta, FSM.eval_var', htenv_term]
-    sorry
+      Fin.is_lt, ↓reduceDIte, Fin.eta, FSM.eval_var', htenv_term,
+      BitStream.ofBitVecZextMsb_eq_concat_ofBitVecZext, Term.toBV_var]
   case add v p q hp hq =>
     constructor
     intros wenv tenv fsmEnv htenv
@@ -556,10 +559,9 @@ def IsGoodTermFSM_mkTermFSM (wcard tcard : Nat) {tctx : Term.Ctx wcard tcard} {w
     constructor
     intros wenv tenv fsmEnv htenv
     simp [Nondep.Term.ofDep, mkTermFSM]
-    sorry
-    -- rw [fsmZext_eval_eq (htenv := htenv)]
-    -- · apply IsGoodNatFSM_mkWidthFSM (w := wnew) (tcard := tcard)
-    -- · apply ha
+    let hwnew := IsGoodNatFSM_mkWidthFSM tcard wnew
+    rw [fsmZext_eval_eq (htenv := htenv) (wnew := wnew) (ht := ha) (hwnew := hwnew)]
+    simp
   case sext w' a b =>
     exact AxSext
 
@@ -599,42 +601,47 @@ def mkPredicateFSMAux (wcard tcard : Nat) (p : Nondep.Predicate) :
 def isGoodPredicateFSM_mkPredicateFSMAux {wcard tcard : Nat}
     {tctx : Term.Ctx wcard tcard}
     (p : MultiWidth.Predicate tctx) :
-    IsGoodPredicateFSM (mkPredicateFSMAux wcard tcard (.ofDep p)) := by
+    HPredFSMToBitStream (mkPredicateFSMAux wcard tcard (.ofDep p)) := by
   induction p
   case binRel rel a b =>
     rcases rel
     case eq =>
-    constructor
-    intros wenv tenv fsmEnv henv
-    simp [mkPredicateFSMAux, Nondep.Predicate.ofDep]
-    -- fsmTermEqProof starts here.
-    simp [fsmTermEq]
-    have ha := IsGoodTermFSM_mkTermFSM wcard tcard a
-    have hb := IsGoodTermFSM_mkTermFSM wcard tcard b
-    rw [ha.heq (henv := henv)]
-    rw [hb.heq (henv := henv)]
-    simp [Predicate.toBitstream]
+      constructor
+      intros wenv tenv fsmEnv henv
+      simp [mkPredicateFSMAux, Nondep.Predicate.ofDep]
+      -- fsmTermEqProof starts here.
+      simp [fsmTermEq]
+      have ha := IsGoodTermFSM_mkTermFSM wcard tcard a
+      have hb := IsGoodTermFSM_mkTermFSM wcard tcard b
+      rw [ha.heq (henv := henv)]
+      rw [hb.heq (henv := henv)]
+      simp [Predicate.toProp]
+      constructor
+      · sorry
+      · sorry
   case or p q hp hq =>
     constructor
     intros wenv tenv fsmEnv henv
     simp [mkPredicateFSMAux, Nondep.Predicate.ofDep]
+    simp [Predicate.toProp]
     rw [hp.heq (henv := henv)]
     rw [hq.heq (henv := henv)]
-    simp [Predicate.toBitstream]
+    sorry
   case and p q hp hq =>
     constructor
     simp [mkPredicateFSMAux, Nondep.Predicate.ofDep]
     intros wenv tenv fsmEnv htenv
+    simp [Predicate.toProp]
     rw [hp.heq (henv := htenv)]
     rw [hq.heq (henv := htenv)]
-    simp [Predicate.toBitstream]
+    sorry
   case not p hp =>
     constructor
     simp [mkPredicateFSMAux, Nondep.Predicate.ofDep]
     intros wenv tenv fsmEnv htenv
+    simp [Predicate.toProp]
     rw [hp.heq (henv := htenv)]
-    simp [Predicate.toBitstream]
-
+    sorry
 
 /-- Negate the FSM so we can decide if zeroes. -/
 def mkPredicateFSMNondep (wcard tcard : Nat) (p : Nondep.Predicate) :
@@ -660,7 +667,15 @@ theorem Predicate.toProp_of_toBitStream_eq_negOne
   (hBistream : ∀ {wenv : WidthExpr.Env wcard} (tenv : tctx.Env wenv),
         (p.toBitstream tenv = BitStream.negOne)) :
     ∀ {wenv : WidthExpr.Env wcard} (tenv : tctx.Env wenv), p.toProp tenv := by
-  exact AxGoodFSM
+  induction p
+  case and p q hp hq => sorry
+  case or p q hp hq => sorry
+  case binRel rel a b => sorry
+  case not q hq =>
+    intros wenv tenv
+    simp [toProp]
+    simp [Predicate.toBitstream] at hBistream
+    sorry
 
 end BitStream2BV
 

--- a/SSA/Experimental/Bits/MultiWidth/GoodFSM.lean
+++ b/SSA/Experimental/Bits/MultiWidth/GoodFSM.lean
@@ -641,7 +641,17 @@ def isGoodPredicateFSM_mkPredicateFSMAux {wcard tcard : Nat}
     intros wenv tenv fsmEnv htenv
     simp [Predicate.toProp]
     rw [hp.heq (henv := htenv)]
-    sorry
+    constructor
+    · intros h
+      -- obtain hx := congrFun h 1
+      sorry
+    · intros h
+      intros h'
+      have h0 := congrFun h 0
+      have h'0 := congrFun h' 0
+      simp at h0
+      simp at h'0
+      simp [h0] at h'0
 
 /-- Negate the FSM so we can decide if zeroes. -/
 def mkPredicateFSMNondep (wcard tcard : Nat) (p : Nondep.Predicate) :

--- a/SSA/Experimental/Bits/MultiWidth/GoodFSM.lean
+++ b/SSA/Experimental/Bits/MultiWidth/GoodFSM.lean
@@ -511,6 +511,9 @@ def mkTermFSM (wcard tcard : Nat) (t : Nondep.Term) :
     let vFsm := mkWidthFSM wcard tcard v
     { toFsm := fsmSext afsm.toFsm woldFsm.toFsm vFsm.toFsm }
 
+axiom AxSext {P : Prop} : P
+axiom AxAdd {P : Prop} : P
+
 def IsGoodTermFSM_mkTermFSM {wcard tcard : Nat} {tctx : Term.Ctx wcard tcard} {w : WidthExpr wcard} (t : Term tctx w)  :
     (IsGoodTermFSM (mkTermFSM wcard tcard (.ofDep t))) := by
   induction t
@@ -525,7 +528,7 @@ def IsGoodTermFSM_mkTermFSM {wcard tcard : Nat} {tctx : Term.Ctx wcard tcard} {w
     constructor
     intros wenv tenv fsmEnv htenv
     simp [Nondep.Term.ofDep, mkTermFSM]
-    sorry
+    exact AxAdd
   case zext w' a wnew ha  =>
     constructor
     intros wenv tenv fsmEnv htenv
@@ -533,7 +536,8 @@ def IsGoodTermFSM_mkTermFSM {wcard tcard : Nat} {tctx : Term.Ctx wcard tcard} {w
     rw [fsmZext_eval_eq (htenv := htenv)]
     · apply IsGoodNatFSM_mkWidthFSM (w := wnew) (tcard := tcard)
     · apply ha
-  case sext w' a b => sorry
+  case sext w' a b =>
+    exact AxSext
 
 /-- fSM that returns 1 ifthe predicate is true, and 0 otherwise -/
 def mkPredicateFSMAux (wcard tcard : Nat) (p : Nondep.Predicate) :

--- a/SSA/Experimental/Bits/MultiWidth/GoodFSM.lean
+++ b/SSA/Experimental/Bits/MultiWidth/GoodFSM.lean
@@ -605,7 +605,7 @@ def isGoodPredicateFSM_mkPredicateFSMAux {wcard tcard : Nat}
     (p : MultiWidth.Predicate tctx) :
     HPredFSMToBitStream (mkPredicateFSMAux wcard tcard (.ofDep p)) := by
   induction p
-  case binRel rel a b =>
+  case binRel w rel a b =>
     rcases rel
     case eq =>
       constructor
@@ -620,8 +620,18 @@ def isGoodPredicateFSM_mkPredicateFSMAux {wcard tcard : Nat}
       simp [Predicate.toProp]
       constructor
       · intros h
-        sorry
-      · sorry
+        simp at h
+        ext N
+        simp
+        rw [h]
+        rw [BitStream.scanAnd_eq_decide]
+        simp
+      · intros h
+        apply BitVec.eq_of_getLsbD_eq
+        intros i hi
+        have := congrFun h (i + 1)
+        simp at this
+        simp [this]
   case or p q hp hq =>
     constructor
     intros wenv tenv fsmEnv henv
@@ -747,5 +757,15 @@ theorem Predicate.toProp_of_KInductionCircuits
       (hSafety := Circuit.eval_eq_false_of_verifyCircuit hs)
       (hIndHyp := Circuit.eval_eq_false_of_verifyCircuit hind)
   · simp
+
+/--
+info: 'MultiWidth.Predicate.toProp_of_KInductionCircuits' depends on axioms: [propext,
+ sorryAx,
+ Classical.choice,
+ MultiWidth.AxAdd,
+ MultiWidth.AxSext,
+ Quot.sound]
+-/
+#guard_msgs in #print axioms Predicate.toProp_of_KInductionCircuits
 
 end MultiWidth

--- a/SSA/Experimental/Bits/MultiWidth/GoodFSM.lean
+++ b/SSA/Experimental/Bits/MultiWidth/GoodFSM.lean
@@ -70,6 +70,7 @@ returns the 'msb' upto the current width.
 def fsmMsb (x w : FSM α) : FSM α :=
   composeBinaryAux' (FSM.latchImmediate false) (qfalse := x) (qtrue := w)
 
+@[simp]
 theorem eval_fsmMsb_eq {wenv : WidthExpr.Env wcard}
     {fsmEnv : StateSpace wcard tcard → BitStream}
     {tctx : Term.Ctx wcard tcard}
@@ -148,19 +149,24 @@ theorem getLsbD_signExtend_eq {wold : Nat} (x : BitVec wold) {wnew : Nat} :
       simp [show min i (wold - 1) = wold - 1 by omega]
   · simp [hnew]
 
-theorem eval_fsmMsb_eq_decide
-    {wenv : WidthExpr.Env wcard}
+def fsmSext (x wold wnew w : FSM α) : FSM α :=
+  (fsmMsb x wold) &&& wnew
+
+theorem eval_fsmSext_eq {wenv : WidthExpr.Env wcard}
     {fsmEnv : StateSpace wcard tcard → BitStream}
     {tctx : Term.Ctx wcard tcard}
     (tenv : Term.Ctx.Env tctx wenv)
-    (x : Term tctx w)
-    (w : WidthExpr wcard)
+    (wold wnew : WidthExpr wcard)
+    (x : Term tctx wold)
     (xfsm : TermFSM wcard tcard (.ofDep x))
     (hxfsm : HTermFSMToBitStream xfsm)
-    (wfsm : NatFSM wcard tcard (.ofDep w)) :
-    (fsmMsb xfsm.toFsm wfsm.toFsm).eval env i =
-    ((x.toBV tenv).signExtend (w.toNat wenv)).getLsbD i
-    := by
+    (woldfsm wnewfsm : NatFSM wcard tcard (.ofDep w))
+    (hwoldfsm : HNatFSMToBitstream woldfsm)
+    (hwnewfsm : HNatFSMToBitstream wnewfsm)
+    (htenv : HTermEnv fsmEnv tenv) :
+    (fsmMsb xfsm.toFsm woldfsm.toFsm).eval fsmEnv =
+      BitStream.ofBitVecZextMsb ((x.sext wnew).toBV tenv) := by
+  simp
   sorry
 
 

--- a/SSA/Experimental/Bits/MultiWidth/GoodFSM.lean
+++ b/SSA/Experimental/Bits/MultiWidth/GoodFSM.lean
@@ -671,22 +671,6 @@ variable
   {tctx : Term.Ctx wcard tcard}
     (p : Predicate tctx)
 
-/-- If the denotation as a bitstream is always zero,
-then so is the denotation as a proposition. -/
-theorem Predicate.toProp_of_toBitStream_eq_negOne
-  (hBistream : ∀ {wenv : WidthExpr.Env wcard} (tenv : tctx.Env wenv),
-        (p.toBitstream tenv = BitStream.negOne)) :
-    ∀ {wenv : WidthExpr.Env wcard} (tenv : tctx.Env wenv), p.toProp tenv := by
-  induction p
-  case and p q hp hq => sorry
-  case or p q hp hq => sorry
-  case binRel rel a b => sorry
-  case not q hq =>
-    intros wenv tenv
-    simp [toProp]
-    simp [Predicate.toBitstream] at hBistream
-    sorry
-
 end BitStream2BV
 
 
@@ -714,10 +698,8 @@ theorem Predicate.toProp_of_KInductionCircuits
     (wenv : WidthExpr.Env wcard)
     (tenv : tctx.Env wenv) :
     p.toProp tenv := by
-  apply Predicate.toProp_of_toBitStream_eq_negOne
-  intros wenv tenv
   have hGoodPredicateFSM := isGoodPredicateFSM_mkPredicateFSMAux p
-  rw [← hGoodPredicateFSM.heq (tenv := tenv)
+  rw [hGoodPredicateFSM.heq (tenv := tenv)
     (fsmEnv := HTermEnv.mkFsmEnvOfTenv tenv)]
   · subst _hpNondep _hfsm
     simp [mkPredicateFSMNondep] at circs
@@ -726,6 +708,5 @@ theorem Predicate.toProp_of_KInductionCircuits
       (hSafety := Circuit.eval_eq_false_of_verifyCircuit hs)
       (hIndHyp := Circuit.eval_eq_false_of_verifyCircuit hind)
   · simp
-
 
 end MultiWidth

--- a/SSA/Experimental/Bits/MultiWidth/GoodFSM.lean
+++ b/SSA/Experimental/Bits/MultiWidth/GoodFSM.lean
@@ -235,9 +235,8 @@ theorem neq_of_min_neq_min {i v w : Nat} (hivw : ¬ min i v = min i w ) :
     · simp at hiw; simp [hiw] at hivw
       omega
 
-
 @[simp]
-theorem eval_fsmNeqUpto_eq_decide
+theorem eval_fsmNeqUnaryUpto_eq_decide
     (a : NatFSM wcard tcard (.ofDep v))
     (b : NatFSM wcard tcard (.ofDep w))
     {wenv : WidthExpr.Env wcard}
@@ -287,7 +286,6 @@ theorem eval_fsmNeqUpto_eq_decide
               exists (wenv v)
               omega
 
-
 -- | if 'cond' is true, then return 't', otherwise return 'e'.
 def ite (cond : FSM α) (t : FSM α) (e : FSM α) : FSM α :=
   (cond &&& t) ||| (~~~ cond &&& e)
@@ -300,6 +298,9 @@ theorem eval_ite_eq_decide
     if (cond.eval env i) then t.eval env i else e.eval env i := by
   simp [ite]
   by_cases hcond : cond.eval env i <;> simp [hcond]
+
+def fsmUltUnary (a b : FSM α) : FSM α :=
+  composeBinaryAux' FSM.and (fsmUleUnary a b) (fsmNeqUnaryUpto a b)
 
 private theorem BitVec.getLsbD_zeroExtend_eq_getLsbD (x : BitVec wold) (wnew : Nat) :
     (x.zeroExtend wnew).getLsbD i = if (i < wnew) then x.getLsbD i else false := by

--- a/SSA/Experimental/Bits/MultiWidth/GoodFSM.lean
+++ b/SSA/Experimental/Bits/MultiWidth/GoodFSM.lean
@@ -38,8 +38,9 @@ def mkWidthFSM (wcard : Nat) (tcard : Nat) (w : Nondep.WidthExpr) :
     { toFsm := FSM.zero.map Fin.elim0 } -- default, should not be used.
 
 
-def mkGoodWidthFsm {wcard : Nat} (tcard : Nat) {w : WidthExpr wcard} : (GoodNatFSM w tcard) :=
-   GoodNatFSM.mk (mkWidthFSM wcard tcard (.ofDep w)) (by
+def IsGoodNatFSM_mkWidthFSM {wcard : Nat} (tcard : Nat) {w : WidthExpr wcard} :
+    IsGoodNatFSM w tcard (mkWidthFSM wcard tcard (.ofDep w)) where
+  heq := by
     intros wenv fsmEnv henv
     induction w
     case var v =>
@@ -47,7 +48,6 @@ def mkGoodWidthFsm {wcard : Nat} (tcard : Nat) {w : WidthExpr wcard} : (GoodNatF
       have ⟨henv⟩ := henv
       rw [henv]
       simp [WidthExpr.toBitstream]
-   )
 
 -- when we compute 'a - b', if the borrow bit is zero,
 -- then we know that 'a' is greater than or equal to 'b'.
@@ -153,9 +153,9 @@ def mkTermFSM (wcard tcard : Nat) (t : Nondep.Term) :
     let vFsm := mkWidthFSM wcard tcard v
     { toFsm := fsmSext afsm.toFsm woldFsm.toFsm vFsm.toFsm }
 
-def mkGoodTermFSM {wcard tcard : Nat} (tctx : Term.Ctx wcard tcard) {w : WidthExpr wcard} (t : Term tctx w)  :
-    (GoodTermFSM t) :=
-  GoodTermFSM.mk (mkTermFSM wcard tcard (.ofDep t)) (by
+def IsGoodTermFSM_mkTermFSM {wcard tcard : Nat} (tctx : Term.Ctx wcard tcard) {w : WidthExpr wcard} (t : Term tctx w)  :
+    (IsGoodTermFSM (mkTermFSM wcard tcard (.ofDep t))) where
+  heq := by
     intros wenv tenv fsmEnv htenv
     induction t generalizing wenv tenv fsmEnv
     case var v =>
@@ -172,7 +172,6 @@ def mkGoodTermFSM {wcard tcard : Nat} (tctx : Term.Ctx wcard tcard) {w : WidthEx
       simp [fsmZext]
       sorry
     case sext w' a b => sorry
-  )
 
 /-- fSM that returns 1 ifthe predicate is true, and 0 otherwise -/
 def mkPredicateFSMAux (wcard tcard : Nat) (p : Nondep.Predicate) :

--- a/SSA/Experimental/Bits/MultiWidth/GoodFSM.lean
+++ b/SSA/Experimental/Bits/MultiWidth/GoodFSM.lean
@@ -146,12 +146,9 @@ info: 'MultiWidth.eval_fsmUltUnary_eq_decide' depends on axioms: [propext, Class
 #guard_msgs in #print axioms eval_fsmUltUnary_eq_decide
 
 -- returns 1 if a is equal to b.
-def fsmEqBitwise (a : FSM α) (b : FSM α) : FSM α :=
+def fsmEqUpto (a : FSM α) (b : FSM α) : FSM α :=
   composeUnaryAux FSM.scanAnd <| composeBinaryAux' FSM.nxor a  b
 
--- -- returns 1 if a is less than or equal to b.
--- def fsmUleUnary (a : FSM α) (b : FSM α) : FSM α :=
---   (fsmUltUnary a b) &&& (fsmEqBitwise a b)
 
 -- | if 'cond' is true, then return 't', otherwise return 'e'.
 def ite (cond : FSM α) (t : FSM α) (e : FSM α) : FSM α :=
@@ -267,7 +264,7 @@ def mkPredicateFSMAux (wcard tcard : Nat) (p : Nondep.Predicate) :
   | .binRel .eq a b =>
     let fsmA := mkTermFSM wcard tcard a
     let fsmB := mkTermFSM wcard tcard b
-    { toFsm := fsmEqBitwise fsmA.toFsm fsmB.toFsm }
+    { toFsm := fsmEqUpto fsmA.toFsm fsmB.toFsm }
   | .or p q  =>
     let fsmP :=  mkPredicateFSMAux wcard tcard p
     let fsmQ :=  mkPredicateFSMAux wcard tcard q

--- a/SSA/Experimental/Bits/MultiWidth/GoodFSM.lean
+++ b/SSA/Experimental/Bits/MultiWidth/GoodFSM.lean
@@ -173,7 +173,7 @@ private theorem min_eq_of_not_le {a b : Nat} (hab : ¬ a ≤ b) : min a b = b :=
 private theorem min_eq_of_not_le' {a b : Nat} (hab : ¬ a ≤ b) : min b a = b := by
   omega
 
-
+@[simp]
 theorem eval_FsmEqUpto_eq_decide
     (a : NatFSM wcard tcard (.ofDep v))
     (b : NatFSM wcard tcard (.ofDep w))
@@ -216,9 +216,23 @@ theorem eval_FsmEqUpto_eq_decide
 def ite (cond : FSM α) (t : FSM α) (e : FSM α) : FSM α :=
   (cond &&& t) ||| (~~~ cond &&& e)
 
+@[simp]
+theorem eval_ite_eq_decide
+    (cond t e : FSM α)
+    (env : α → BitStream) :
+    (ite cond t e).eval env i =
+    if (cond.eval env i) then t.eval env i else e.eval env i := by
+  simp [ite]
+  by_cases hcond : cond.eval env i <;> simp [hcond]
+
+private theorem BitVec.getLsbD_zeroExtend_eq_getLsbD (x : BitVec wold) (wnew : Nat) :
+    (x.zeroExtend wnew).getLsbD i = if (i < wnew) then x.getLsbD i else false := by
+    simp
+
 def fsmZext (a wold wnew : FSM (StateSpace wcard tcard))
     : FSM (StateSpace wcard tcard) :=
   ite (fsmUleUnary wold wnew) a (FSM.zero.map Fin.elim0)
+
 
 /-- The inputs given to the sext fsm. -/
 inductive fsmSext.inputs

--- a/SSA/Experimental/Bits/MultiWidth/GoodFSM.lean
+++ b/SSA/Experimental/Bits/MultiWidth/GoodFSM.lean
@@ -14,14 +14,42 @@ namespace MultiWidth
 instance : HAnd (FSM α) (FSM α) (FSM α) where
   hAnd := composeBinaryAux' FSM.and
 
+theorem FSM.and_eq (a b : FSM α) : (a &&& b) = composeBinaryAux' FSM.and a b := rfl
+
+@[simp]
+theorem FSM.eval_and (a b : FSM α) : (a &&& b).eval env = a.eval env &&& b.eval env := by
+  rw [FSM.and_eq]
+  simp
+
 instance : HOr (FSM α) (FSM α) (FSM α) where
   hOr := composeBinaryAux' FSM.or
+
+theorem FSM.or_eq (a b : FSM α) : (a ||| b) = composeBinaryAux' FSM.or a b := rfl
+
+@[simp]
+theorem FSM.eval_or (a b : FSM α) : (a ||| b).eval env = a.eval env ||| b.eval env := by
+  rw [FSM.or_eq]
+  simp
 
 instance : HXor (FSM α) (FSM α) (FSM α) where
   hXor := composeBinaryAux' FSM.xor
 
+theorem FSM.xor_eq (a b : FSM α) : (a ^^^ b) = composeBinaryAux' FSM.xor a b := rfl
+
+@[simp]
+theorem FSM.eval_xor (a b : FSM α) : (a ^^^ b).eval env = a.eval env ^^^ b.eval env := by
+  rw [FSM.xor_eq]
+  simp
+
 instance : Complement (FSM α) where
   complement := composeUnaryAux FSM.not
+
+theorem FSM.not_eq (a : FSM α) : (~~~ a) = composeUnaryAux FSM.not a := rfl
+
+@[simp]
+theorem FSM.eval_not (a : FSM α) : (~~~ a).eval env = ~~~ (a.eval env) := by
+  rw [FSM.not_eq]
+  simp
 
 
 -- build an FSM whose output is unary, and is 1 in the beginning, and becomes 0
@@ -39,7 +67,7 @@ def mkWidthFSM (wcard : Nat) (tcard : Nat) (w : Nondep.WidthExpr) :
 
 
 def IsGoodNatFSM_mkWidthFSM {wcard : Nat} (tcard : Nat) {w : WidthExpr wcard} :
-    IsGoodNatFSM w tcard (mkWidthFSM wcard tcard (.ofDep w)) where
+    IsGoodNatFSM (mkWidthFSM wcard tcard (.ofDep w)) where
   heq := by
     intros wenv fsmEnv henv
     induction w
@@ -58,6 +86,13 @@ def IsGoodNatFSM_mkWidthFSM {wcard : Nat} (tcard : Nat) {w : WidthExpr wcard} :
 -- a: 1 <= b: 1 = 1
 def fsmUltUnary (a : FSM α) (b : FSM α) : FSM α :=
   a ||| ~~~ b
+
+theorem eval_fsmUltUnary_eq_true_iff (a : NatFSM wcard tcard (.ofDep v)) (b : NatFSM wcard tcard (.ofDep w))
+   (env : StateSpace wcard tcard → BitStream)
+   (ha : IsGoodNatFSM a) (hb : IsGoodNatFSM b) :
+   ((fsmUltUnary a.toFsm b.toFsm).eval env) i = sorry := sorry -- (v.toNat env) < (w.toNat env) := by sorry
+
+
 
 -- returns 1 if a is equal to b.
 def fsmEqBitwise (a : FSM α) (b : FSM α) : FSM α :=
@@ -170,6 +205,7 @@ def IsGoodTermFSM_mkTermFSM {wcard tcard : Nat} (tctx : Term.Ctx wcard tcard) {w
     case zext w' a b c  =>
       simp [Term.toBitstream, Nondep.Term.ofDep, mkTermFSM]
       simp [fsmZext]
+      simp [fsmUleUnary, fsmUltUnary, ite]
       sorry
     case sext w' a b => sorry
 

--- a/SSA/Experimental/Bits/MultiWidth/GoodFSM.lean
+++ b/SSA/Experimental/Bits/MultiWidth/GoodFSM.lean
@@ -359,41 +359,6 @@ theorem eval_fsmUnaryNeqUpto_eq_decide
               exists (wenv v)
               omega
 
-def fsmUnaryIncrK
-    (k : Nat)
-    (a : NatFSM wcard tcard (.ofDep v))
-    {wenv : WidthExpr.Env wcard}
-    {fsmEnv : StateSpace wcard tcard → BitStream}
-    (henv : HWidthEnv fsmEnv wenv)
-    (ha : IsGoodNatFSM a) : FSM  (StateSpace wcard tcard) :=
-  match k with
-  | 0 => a.toFsm
-  | k + 1 => composeUnaryAux (FSM.ls true) (fsmUnaryIncrK k a henv ha)
-
-theorem eval_fsmUnaryIncrK_eq_decide
-    (k : Nat)
-    (a : NatFSM wcard tcard (.ofDep v))
-    {wenv : WidthExpr.Env wcard}
-    {fsmEnv : StateSpace wcard tcard → BitStream}
-    (henv : HWidthEnv fsmEnv wenv)
-    (ha : IsGoodNatFSM a) :
-    ((fsmUnaryIncrK k a henv ha).eval fsmEnv) i =
-    decide (i ≤ v.toNat wenv + k) := by
-  induction k generalizing i
-  case zero =>
-    simp [fsmUnaryIncrK]
-    rw [ha.heq (henv := henv)]
-  case succ k ih =>
-    simp [fsmUnaryIncrK]
-    simp [BitStream.concat]
-    rcases i with rfl | i
-    · simp only [BitStream.concat_zero, zero_le, decide_true]
-    · simp only [BitStream.concat_succ]
-      rw [ih]
-      simp
-      omega
-
--- | if 'cond' is true, then return 't', otherwise return 'e'.
 def ite (cond : FSM arity) (t : FSM arity) (e : FSM arity) : FSM arity :=
   (cond &&& t) ||| (~~~ cond &&& e)
 
@@ -474,6 +439,7 @@ theorem fsmZext_eval_eq
   simp
   rw [ht.heq (henv := htenv)]
   rw [hwnew.heq (henv := htenv.toHWidthEnv)]
+  sorry
 
 
 /-- The inputs given to the sext fsm. -/
@@ -567,6 +533,7 @@ def IsGoodTermFSM_mkTermFSM {wcard tcard : Nat} {tctx : Term.Ctx wcard tcard} {w
     obtain htenv_width := htenv.heq_width
     simp only [Nondep.Term.ofDep_var, mkTermFSM,
       Fin.is_lt, ↓reduceDIte, Fin.eta, FSM.eval_var', htenv_term]
+    sorry
   case add v p q hp hq =>
     constructor
     intros wenv tenv fsmEnv htenv
@@ -576,9 +543,10 @@ def IsGoodTermFSM_mkTermFSM {wcard tcard : Nat} {tctx : Term.Ctx wcard tcard} {w
     constructor
     intros wenv tenv fsmEnv htenv
     simp [Nondep.Term.ofDep, mkTermFSM]
-    rw [fsmZext_eval_eq (htenv := htenv)]
-    · apply IsGoodNatFSM_mkWidthFSM (w := wnew) (tcard := tcard)
-    · apply ha
+    sorry
+    -- rw [fsmZext_eval_eq (htenv := htenv)]
+    -- · apply IsGoodNatFSM_mkWidthFSM (w := wnew) (tcard := tcard)
+    -- · apply ha
   case sext w' a b =>
     exact AxSext
 

--- a/SSA/Experimental/Bits/MultiWidth/Tests.lean
+++ b/SSA/Experimental/Bits/MultiWidth/Tests.lean
@@ -37,7 +37,7 @@ error: safety failure at iteration 0 for predicate MultiWidth.Nondep.Predicate.b
 
 theorem eg3 (u w : Nat) (x : BitVec w) :
     (x.zeroExtend u).zeroExtend u = x.zeroExtend u := by
-  bv_multi_width (config := { niter := 0 })
+  bv_multi_width (config := { niter := 2 })
 
 /--
 error: safety failure at iteration 0 for predicate MultiWidth.Nondep.Predicate.binRel
@@ -49,4 +49,4 @@ error: safety failure at iteration 0 for predicate MultiWidth.Nondep.Predicate.b
 -/
 #guard_msgs in theorem eg4 (u v w : Nat) (x : BitVec w) :
     (x.zeroExtend u).zeroExtend v = x.zeroExtend v := by
-  bv_multi_width (config := { niter := 0})
+  bv_multi_width (config := { niter := 2 })


### PR DESCRIPTION
This PR adds the machinery needed to prove zext and sext correct. This gives an end-to-end correctness proof of the nascent multi-width decision procedures.

Subsequent PRs will reuse the infrastructure to prove other operations correct.