### PR TITLE
refactor: denote Expr into a Valuation map

### DIFF
--- a/SSA/Core/EffectKind.lean
+++ b/SSA/Core/EffectKind.lean
@@ -225,6 +225,10 @@ theorem liftEffect_eq_pure_cast {m : Type → Type} [Pure m]
       Pure.pure (cast (by rw [eff_eq]; rfl) x) := by
   subst eff_eq; rfl
 
+@[deprecated "liftEffect_eq_pure_cast_of" (since := "")]
+theorem liftEffect_pure [Pure m] {e} (hle : e ≤ pure) :
+    liftEffect hle (α := α) (m := m) = cast (by rw [eq_of_le_pure hle]) := by
+  cases hle; rfl
 
 @[simp] theorem liftEffect_impure [Pure m] {e} (hle : e ≤ impure) :
     liftEffect hle (α := α) (m := m) = match e with

--- a/SSA/Core/EffectKind.lean
+++ b/SSA/Core/EffectKind.lean
@@ -62,6 +62,20 @@ instance [Monad m] [LawfulMonad m] : LawfulMonad (e.toMonad m) := by
 
 end Instances
 
+section Lemmas
+variable [Monad m]
+
+@[simp] lemma pure_pure (eff : EffectKind) (x : α) :
+    (Pure.pure (Pure.pure x : pure.toMonad m (no_index α)) : eff.toMonad m α) = Pure.pure x :=
+  rfl
+
+variable [LawfulMonad m] in
+theorem pure_map (f : α → β) (x : pure.toMonad m α) (eff : EffectKind) :
+    (Pure.pure (f <$> x : pure.toMonad m _) : eff.toMonad m _) = f <$> (Pure.pure x) := by
+  simp; rfl
+
+end Lemmas
+
 /-!
 ## `PartialOrder`
 Establish a partial order on `EffectKind`
@@ -211,15 +225,16 @@ theorem liftEffect_eq_pure_cast {m : Type → Type} [Pure m]
       Pure.pure (cast (by rw [eff_eq]; rfl) x) := by
   subst eff_eq; rfl
 
-@[simp] theorem liftEffect_pure [Pure m] {e} (hle : e ≤ pure) :
-    liftEffect hle (α := α) (m := m) = cast (by rw [eq_of_le_pure hle]) := by
-  cases hle; rfl
 
 @[simp] theorem liftEffect_impure [Pure m] {e} (hle : e ≤ impure) :
     liftEffect hle (α := α) (m := m) = match e with
       | .pure => fun v => Pure.pure v
       | .impure => id := by
   cases e <;> rfl
+
+theorem liftEffect_eq_pure_cast_of [Pure m] {e₁ e₂} (heq : e₁ = .pure) (hle : e₁ ≤ e₂) :
+    liftEffect hle (α := α) (m := m) = fun x => Pure.pure (cast (by subst heq; rfl) x) := by
+  subst heq; cases e₂ <;> rfl
 
 /-- toMonad is functorial: it preserves identity. -/
 @[simp]
@@ -234,6 +249,14 @@ def liftEffect_compose {e1 e2 e3 : EffectKind} {α : Type} [Pure m]
     (h13 : e1 ≤ e3 := le_trans h12 h23) :
     ((liftEffect (α := α) h23) ∘ (liftEffect h12)) = liftEffect (m := m) h13 := by
   cases e1 <;> cases e2 <;> cases e3 <;> (solve | rfl | contradiction)
+
+@[simp]
+theorem pure_liftEffect {eff₁ eff₂ : EffectKind}
+    (hle : eff₁ ≤ .pure) [Monad m] (x : eff₁.toMonad m α) :
+    (Pure.pure (liftEffect hle x) : eff₂.toMonad m α)
+    = liftEffect (by cases hle; constructor) x := by
+  obtain rfl : eff₁ = .pure := eq_of_le_pure hle
+  cases eff₂ <;> rfl
 
 /-!
 ## `toMonad` coercion

--- a/SSA/Core/ErasedContext.lean
+++ b/SSA/Core/ErasedContext.lean
@@ -71,6 +71,13 @@ def length (Γ : Ctxt Ty) : Nat := Γ.toList.length
 section Lemmas
 variable (Γ : Ctxt Ty) (ts us : List Ty)
 
+@[simp] lemma snoc_inj : Γ.snoc t = Γ.snoc u ↔ t = u := by
+  constructor <;> (rintro ⟨⟩; rfl)
+
+variable {m} [Monad m] [LawfulMonad m] (t u : m _) in
+@[simp] lemma snoc_map_inj : Γ.snoc <$> t = Γ.snoc <$> u ↔ t = u :=
+  (map_inj_right (snoc_inj _).mp)
+
 @[simp] lemma ofList_append : (⟨ts⟩ : Ctxt _) ++ us = us ++ ts := rfl
 @[simp] lemma toList_append : (Γ ++ ts).toList = ts ++ Γ.toList := rfl
 
@@ -499,6 +506,18 @@ theorem Valuation.snoc_zero {ty : Ty} (s : Γ.Valuation) (x : toType ty)
     (x : toType t) (v : Γ.Var t') :
     (s.snoc x) v.toSnoc = s v :=
   rfl
+
+@[simp] lemma Valuation.snoc_inj {t : Ty} {x y : ⟦t⟧} :
+    (V ::ᵥ x) = (V ::ᵥ y) ↔ x = y where
+  mpr := by rintro rfl; rfl
+  mp := by
+    intro h
+    rw [← snoc_last V x, ← snoc_last V y, h]
+
+variable {m} [Monad m] [LawfulMonad m] in
+@[simp] lemma Valuation.snoc_map_inj {V : Γ.Valuation} {x y : m ⟦t⟧} :
+    (V.snoc <$> x) = (V.snoc <$> y) ↔ x = y :=
+  map_inj_right <| Valuation.snoc_inj.mp
 
 /-!
 # Helper to simplify context manipulation with toSnoc and variable access.

--- a/SSA/Core/ErasedContext.lean
+++ b/SSA/Core/ErasedContext.lean
@@ -485,19 +485,19 @@ theorem Valuation.snoc_eq {Γ : Ctxt Ty} {t : Ty} (s : Γ.Valuation) (x : toType
   · rfl
 
 @[simp]
-theorem Valuation.snoc_last {Γ : Ctxt Ty} {t : Ty} (s : Γ.Valuation) (x : toType t) :
-    (s.snoc x) (Ctxt.Var.last _ _) = x := by
+theorem Valuation.snoc_last {t : Ty} (s : Γ.Valuation) (x : toType t) :
+    (s.snoc x) (Ctxt.Var.last _ _) = x :=
   rfl
 
 @[simp]
-theorem Valuation.snoc_zero {Γ : Ctxt Ty} {ty : Ty} (s : Γ.Valuation) (x : toType ty)
+theorem Valuation.snoc_zero {ty : Ty} (s : Γ.Valuation) (x : toType ty)
     (h : (Ctxt.snoc Γ ty)[0]? = some ty) :
-    (s.snoc x) ⟨0, h⟩ = x := by
+    (s.snoc x) ⟨0, h⟩ = x :=
   rfl
 
-@[simp]
-theorem Valuation.snoc_toSnoc {Γ : Ctxt Ty} {t t' : Ty} (s : Γ.Valuation) (x : toType t)
-    (v : Γ.Var t') : (s.snoc x) v.toSnoc = s v := by
+@[simp] lemma Valuation.snoc_toSnoc {t t' : Ty} (s : Γ.Valuation)
+    (x : toType t) (v : Γ.Var t') :
+    (s.snoc x) v.toSnoc = s v :=
   rfl
 
 /-!
@@ -627,6 +627,9 @@ def Valuation.cast {Γ Δ : Ctxt Ty} (h : Γ = Δ) (V : Valuation Γ) : Valuatio
   fun _ v => V <| v.castCtxt h.symm
 
 @[simp] lemma Valuation.cast_rfl {Γ : Ctxt Ty} (h : Γ = Γ) (V : Valuation Γ) : V.cast h = V := rfl
+
+@[simp] lemma Valuation.cast_apply {Γ : Ctxt Ty} (h : Γ = Δ) (V : Γ.Valuation) (v : Δ.Var t) :
+    V.cast h v = V (v.castCtxt h.symm) := rfl
 
 /-- reassigning a variable to the same value that has been looked up is identity. -/
 theorem Valuation.reassignVar_eq_of_lookup [DecidableEq Ty]

--- a/SSA/Core/Framework.lean
+++ b/SSA/Core/Framework.lean
@@ -1005,16 +1005,6 @@ section Lemmas
 
 /-! denotations of `castPureToEff` -/
 
--- @[simp] lemma Expr.denote_changeEffect {e : Expr d Γ eff t}
---     (eff_le' : eff ≤ eff'):
---     denote (e.changeEffect eff_le') = (EffectKind.liftEffect eff_le' <| e.denote ·) := by
---   rcases e with ⟨op, _, eff_le, _, _⟩
---   funext V
---   -- simp [denote]
---   cases eff_le'
---   · simp
---   · rfl
-
 @[simp] lemma Expr.denote_castPureToEff {e : Expr d Γ .pure t} :
     denote (e.castPureToEff eff) = fun V => pure (e.denote V) := by
   rcases e with ⟨op, rfl, eff_le, _, _⟩
@@ -1345,7 +1335,6 @@ theorem DialectMorphism.preserves_effectKind (op : d.Op) :
 
 mutual
 
--- TODO: `map` is ambiguous, rename it to `changeDialect` (to mirror `changeVars`)
 def Com.changeDialect : Com d Γ eff ty → Com d' (f.mapTy <$> Γ) eff (f.mapTy ty)
   | .ret v          => .ret v.toMap
   | .var body rest => .var body.changeDialect rest.changeDialect

--- a/SSA/Core/Framework.lean
+++ b/SSA/Core/Framework.lean
@@ -970,6 +970,12 @@ def Com.letSup (e : Expr d Γ eff₁ t) (body : Com d (Γ.snoc t) eff₂ u) :
 
 section Lemmas
 
+@[simp] lemma Expr.op_castPureToEff (e : Expr d Γ .pure t) : (e.castPureToEff eff).op = e.op := by
+  cases e; cases eff <;> rfl
+@[simp] lemma Expr.args_castPureToEff (e : Expr d Γ .pure t) :
+    (e.castPureToEff eff).args = cast (by simp) e.args := by
+  cases e; cases eff <;> rfl
+
 @[simp] lemma Com.castPureToEff_ret : (ret v : Com d Γ .pure ty).castPureToEff eff = ret v := rfl
 @[simp] lemma Com.castPureToEff_var {com : Com d _ .pure ty} {e : Expr d Γ _ eTy} :
     (var e com).castPureToEff eff = var (e.castPureToEff eff) (com.castPureToEff eff) := rfl

--- a/SSA/Core/Framework.lean
+++ b/SSA/Core/Framework.lean
@@ -670,6 +670,18 @@ theorem Expr.denote_unfold (e : Expr d Γ eff ty) :
   rcases e with ⟨op, rfl, _⟩
   simp [denote, denoteOp]
 
+@[simp] lemma Expr.denoteOp_eq_denoteOp_of {e₁ : Expr d Γ eff ty} {e₂ : Expr d Δ eff ty}
+    {Γv : Valuation Γ} {Δv : Valuation Δ}
+    (op_eq : e₁.op = e₂.op)
+    (h_args : HVector.map Γv (op_eq ▸ e₁.args)
+              = HVector.map Δv e₂.args)
+    (h_regArgs : HEq e₁.regArgs.denote e₂.regArgs.denote) :
+    e₁.denoteOp Γv = e₂.denoteOp Δv := by
+  rcases e₁ with ⟨op₁, rfl, _, args₁, regArgs₁⟩
+  rcases e₂ with ⟨op₂, _, _, args₂, _⟩
+  obtain rfl : op₁ = op₂ := op_eq
+  simp_all [op_mk, regArgs_mk, heq_eq_eq, args_mk, denoteOp]
+
 /-
 https://leanprover.zulipchat.com/#narrow/stream/270676-lean4/topic/Equational.20Lemmas
 Recall that `simp` lazily generates equation lemmas.

--- a/SSA/Core/Framework.lean
+++ b/SSA/Core/Framework.lean
@@ -17,7 +17,7 @@ set_option deprecated.oldSectionVars true
 theorem Id.pure_eq' (a : α) : (pure a : Id α) = a := rfl
 theorem Id.bind_eq' (x : Id α) (f : α → id β) : x >>= f = f x := rfl
 
-open Ctxt (Var VarSet Valuation)
+open Ctxt (Var VarSet Valuation Hom)
 open TyDenote (toType)
 
 /-!
@@ -648,11 +648,13 @@ section Unfoldings
 
 open EffectKind (liftEffect)
 
+omit [LawfulMonad d.m] in
 /-- Returns only the result of the current expression. -/
 def Expr.denoteOp (e : Expr d Γ eff ty) (V : Γ.Valuation) : eff.toMonad d.m ⟦ty⟧ :=
   EffectKind.liftEffect e.eff_le <| cast (by rw [← e.ty_eq]) <|
     DialectDenote.denote e.op (e.args.map V) e.regArgs.denote
 
+omit [LawfulMonad d.m] in
 /--
 Unfold `Expr.denote` in terms of the field projections and `Expr.denoteOp`.
 
@@ -697,6 +699,10 @@ end Unfoldings
 
 /-! simp-lemmas about `denote` functions -/
 section Lemmas
+
+@[simp] lemma Expr.comap_denote_snocRight (e : Expr d Γ .pure ty) (V : Γ.Valuation) :
+    (Valuation.comap (e.denote V) Hom.id.snocRight) = V := by
+  funext t v; simp [Expr.denote_unfold]; rfl
 
 @[simp] lemma HVector.denote_nil
     (T : HVector (fun (t : Ctxt d.Ty × d.Ty) => Com d t.1 .impure t.2) []) :

--- a/SSA/Core/Tactic.lean
+++ b/SSA/Core/Tactic.lean
@@ -47,6 +47,7 @@ attribute [simp_denote]
   EffectKind.toMonad_pure EffectKind.toMonad_impure
   EffectKind.liftEffect_rfl
   Id.pure_eq Id.bind_eq id_eq
+  pure_bind
   cast_eq
 
 /-!

--- a/SSA/Core/Tactic.lean
+++ b/SSA/Core/Tactic.lean
@@ -10,6 +10,13 @@ import Qq
 import Lean.Meta.KAbstract
 import Lean.Elab.Tactic.ElabTerm
 
+variable [DialectSignature d] [TyDenote d.Ty] [DialectDenote d] [Monad d.m] [LawfulMonad d.m] in
+@[simp_denote] lemma Expr.denote_unfold' {ty} (e : Expr d Γ eff ty) :
+    e.denote V = do
+      let x ← e.denoteOp V
+      return V ::ᵥ x := by
+  rw [Expr.denote_unfold, ← map_eq_pure_bind]
+
 namespace SSA
 
 open Ctxt (Var Valuation DerivedCtxt)
@@ -31,12 +38,16 @@ attribute [simp_denote]
   bind_assoc pairBind
   /- `castPureToEff` -/
   Com.letPure Expr.denote_castPureToEff
+  Expr.denote_castPureToEff
   /- Unfold denotation -/
-  Com.denote_var Com.denote_ret Expr.denote_unfold HVector.denote
+  Com.denote_var Com.denote_ret Expr.denoteOp HVector.denote
+  Expr.op_mk Expr.args_mk Expr.regArgs_mk
+  Expr.op_castPureToEff Expr.args_castPureToEff
   /- Effect massaging -/
   EffectKind.toMonad_pure EffectKind.toMonad_impure
   EffectKind.liftEffect_rfl
   Id.pure_eq Id.bind_eq id_eq
+  cast_eq
 
 /-!
 NOTE (Here Be Dragons 🐉):
@@ -138,7 +149,11 @@ macro "simp_peephole" loc:(location)? : tactic =>
       | skip
 
       -- Then, we simplify with the `simp_denote` simpset
-      simp (config := {failIfUnchanged := false}) only [simp_denote] $[$loc]?
+      simp (config := {failIfUnchanged := false}) only
+        [Expr.denote_castPureToEff, simp_denote] $[$loc]?
+      -- ^^^^^^^^^^^^^^^^^^^^^^^^^
+      -- `denote_castPureToEff` is already part of the simp_denote simpset
+      -- Still, omitting it here somehow causes motive-related errors.
   ))
 
 /-

--- a/SSA/Core/Transforms/Rewrite/Match.lean
+++ b/SSA/Core/Transforms/Rewrite/Match.lean
@@ -380,10 +380,6 @@ theorem Lets.denote_eq_denoteIntoSubtype (lets : Lets d Γ_in eff Γ_out) (Γv :
     simp [ValidDenotation, denote, denoteIntoSubtype, ih,
       Expr.denote_unfold, Expr.denoteOp_eq_denoteOpIntoSubtype]
 
-#print axioms Expr.pure_denoteOp_toPure
-#print axioms Expr.denoteOp_eq_denoteOpIntoSubtype
-#print axioms Lets.denote_eq_denoteIntoSubtype
-
 end DenoteIntoSubtype
 
 theorem matchVar_nil {lets : Lets d Γ_in eff Γ_out} :
@@ -439,20 +435,6 @@ theorem matchVar_var_last {lets : Lets d Γ_in eff Γ_out} {matchLets : Lets d �
   simp only [Expr.denote_unfold]
   show (lets.denote V_in |>.snoc _) _ = _
   simp
-
-@[simp] lemma Expr.denoteOp_eq_denoteOp_of {e₁ : Expr d Γ eff ty} {e₂ : Expr d Δ eff ty}
-    {Γv : Valuation Γ} {Δv : Valuation Δ}
-    (op_eq : e₁.op = e₂.op)
-    (h_regArgs : HEq e₁.regArgs e₂.regArgs)
-    (h_args : HVector.map Γv (op_eq ▸ e₁.args)
-              = HVector.map Δv e₂.args) :
-    e₁.denoteOp Γv = e₂.denoteOp Δv := by
-  rcases e₁ with ⟨op₁, rfl, _, args₁, regArgs₁⟩
-  rcases e₂ with ⟨op₂, _, _, args₂, _⟩
-  obtain rfl : op₁ = op₂ := op_eq
-  simp_all only [op_mk, regArgs_mk, heq_eq_eq, args_mk]
-  subst h_regArgs
-  simp [denoteOp, h_args]
 
 variable {Γ_in Γ_out Δ_in Δ_out : Ctxt d.Ty}
     {lets : Lets d Γ_in eff Γ_out}

--- a/SSA/Core/Transforms/Rewrite/Match.lean
+++ b/SSA/Core/Transforms/Rewrite/Match.lean
@@ -333,16 +333,16 @@ implies `lets.getPureExpr v = some e → e.denote V = V v` -/
 `Γv`, assuming that `e` has a pure operation.
 If `e` has an impure operation, the property holds vacuously. -/
 abbrev Expr.IsDenotationForPureE (e : Expr d Γ eff ty) (Γv : Valuation Γ) (x : ⟦ty⟧) : Prop :=
-  ∀ (ePure : Expr d Γ .pure ty), e.toPure? = some ePure → ePure.denote Γv = x
+  ∀ (ePure : Expr d Γ .pure ty), e.toPure? = some ePure → ePure.denoteOp Γv = x
 
-def Expr.denoteIntoSubtype (e : Expr d Γ_in eff ty) (Γv : Valuation Γ_in) :
+def Expr.denoteOpIntoSubtype (e : Expr d Γ_in eff ty) (Γv : Valuation Γ_in) :
     eff.toMonad d.m {x : ⟦ty⟧ // e.IsDenotationForPureE Γv x} :=
   match h_pure : e.toPure? with
-    | some ePure => pure ⟨ePure.denote Γv, by simp [IsDenotationForPureE, h_pure]⟩
-    | none => (Subtype.mk · (by simp [IsDenotationForPureE, h_pure])) <$> (e.denote Γv)
+    | some ePure => pure ⟨ePure.denoteOp Γv, by simp [IsDenotationForPureE, h_pure]⟩
+    | none => (Subtype.mk · (by simp [IsDenotationForPureE, h_pure])) <$> (e.denoteOp Γv)
 
 def Lets.ValidDenotation (lets : Lets d Γ_in eff Γ_out) :=
-  { V // ∀ {t} (v : Var _ t) e, lets.getPureExpr v = some e → e.denote V = V v }
+  { V // ∀ {t} (v : Var _ t) e, lets.getPureExpr v = some e → e.denoteOp V = V v }
 
 /-- An alternative version of `Lets.denote`, whose returned type carries a proof that the valuation
 agrees with the denotation of every pure expression in `lets`.
@@ -355,20 +355,21 @@ def Lets.denoteIntoSubtype (lets : Lets d Γ_in eff Γ_out) (Γv : Valuation Γ_
     | .nil => return ⟨Γv, by simp⟩
     | @Lets.var _ _ _ _ Γ_out eTy body e => do
         let ⟨Vout, h⟩ ← body.denoteIntoSubtype Γv
-        let v ← e.denoteIntoSubtype Vout
+        let v ← e.denoteOpIntoSubtype Vout
         return ⟨Vout.snoc v.val, by
           intro t' v'; cases v' using Var.casesOn
           · simpa using h _
           · simpa using v.prop
           ⟩
 
-theorem Expr.denote_eq_denoteIntoSubtype (e : Expr d Γ eff ty) (Γv : Valuation Γ) :
-    e.denote Γv = Subtype.val <$> e.denoteIntoSubtype Γv := by
-  simp only [denoteIntoSubtype]
+theorem Expr.denoteOp_eq_denoteOpIntoSubtype (e : Expr d Γ eff ty) (V : Valuation Γ) :
+    e.denoteOp V = Subtype.val <$> e.denoteOpIntoSubtype V := by
+  simp only [denoteOpIntoSubtype]
   split
   next h_pure =>
-    simp only [denote_toPure? h_pure, map_pure]
-    split <;> rfl
+    simp only [toPure?, Option.dite_none_right_eq_some, Option.some.injEq] at h_pure
+    rcases h_pure with ⟨_, rfl⟩
+    simpa using (pure_denoteOp_toPure ..).symm
   next => simp
 
 theorem Lets.denote_eq_denoteIntoSubtype (lets : Lets d Γ_in eff Γ_out) (Γv : Valuation Γ_in) :
@@ -376,8 +377,12 @@ theorem Lets.denote_eq_denoteIntoSubtype (lets : Lets d Γ_in eff Γ_out) (Γv :
   induction lets
   case nil => simp [denoteIntoSubtype]
   case var body e ih =>
-    simp [ValidDenotation, denote, denoteIntoSubtype, ih, Expr.denote_eq_denoteIntoSubtype]
+    simp [ValidDenotation, denote, denoteIntoSubtype, ih,
+      Expr.denote_unfold, Expr.denoteOp_eq_denoteOpIntoSubtype]
 
+#print axioms Expr.pure_denoteOp_toPure
+#print axioms Expr.denoteOp_eq_denoteOpIntoSubtype
+#print axioms Lets.denote_eq_denoteIntoSubtype
 
 end DenoteIntoSubtype
 
@@ -429,24 +434,25 @@ theorem matchVar_var_last {lets : Lets d Γ_in eff Γ_out} {matchLets : Lets d �
 
 @[simp] lemma Lets.denote_var_last_pure (lets : Lets d Γ_in .pure Γ_out)
     (e : Expr d Γ_out .pure ty) (V_in : Valuation Γ_in) :
-    Lets.denote (var lets e) V_in (Var.last ..) = e.denote (lets.denote V_in) := by
-  apply Id.ext
-  simp [Lets.denote]
-  congr
+    Lets.denote (var lets e) V_in (Var.last ..) = e.denoteOp (lets.denote V_in) := by
+  show e.denote (lets.denote _) _ = _
+  simp only [Expr.denote_unfold]
+  show (lets.denote V_in |>.snoc _) _ = _
+  simp
 
-@[simp] lemma Expr.denote_eq_denote_of {e₁ : Expr d Γ eff ty} {e₂ : Expr d Δ eff ty}
+@[simp] lemma Expr.denoteOp_eq_denoteOp_of {e₁ : Expr d Γ eff ty} {e₂ : Expr d Δ eff ty}
     {Γv : Valuation Γ} {Δv : Valuation Δ}
     (op_eq : e₁.op = e₂.op)
     (h_regArgs : HEq e₁.regArgs e₂.regArgs)
-    (h_args : HVector.map (fun _ v => Γv v) (op_eq ▸ e₁.args)
-              = HVector.map (fun _ v => Δv v) e₂.args) :
-    e₁.denote Γv = e₂.denote Δv := by
-  rcases e₁ with ⟨op₁, ty_eq, _, args₁, regArgs₁⟩
-  rcases e₂ with ⟨_, _, _, args₂, _⟩
-  cases op_eq
+    (h_args : HVector.map Γv (op_eq ▸ e₁.args)
+              = HVector.map Δv e₂.args) :
+    e₁.denoteOp Γv = e₂.denoteOp Δv := by
+  rcases e₁ with ⟨op₁, rfl, _, args₁, regArgs₁⟩
+  rcases e₂ with ⟨op₂, _, _, args₂, _⟩
+  obtain rfl : op₁ = op₂ := op_eq
   simp_all only [op_mk, regArgs_mk, heq_eq_eq, args_mk]
-  subst ty_eq h_regArgs
-  rw [denote, denote, h_args]
+  subst h_regArgs
+  simp [denoteOp, h_args]
 
 variable {Γ_in Γ_out Δ_in Δ_out : Ctxt d.Ty}
     {lets : Lets d Γ_in eff Γ_out}
@@ -487,7 +493,7 @@ theorem denote_matchVar
     match w with
     | ⟨w+1, h⟩ =>
       simp only [Option.mem_def, Var.succ_eq_toSnoc, Lets.denote,
-        EffectKind.toMonad_pure, Id.pure_eq', Id.bind_eq', Valuation.snoc_toSnoc] at *
+        EffectKind.toMonad_pure, Id.bind_eq', Expr.denote_snoc] at *
       rw [Var.toSnoc, matchVar_var_succ_eq] at h_matchVar
       apply ih h_matchVar h_sub
 
@@ -497,7 +503,7 @@ theorem denote_matchVar
       have ⟨args, h_pure, h_matchArgs⟩ := matchVar_var_last h_matchVar
       rw [← V.property v _ h_pure]
       simp only [Var.zero_eq_last, Lets.denote_var_last_pure]
-      apply Expr.denote_eq_denote_of <;> (try rfl)
+      apply Expr.denoteOp_eq_denoteOp_of <;> (try rfl)
       simp only [Expr.op_mk, Expr.args_mk]
 
       apply denote_matchVar_matchArg (hvarMap := h_matchArgs) h_sub

--- a/SSA/Core/Transforms/Rewrite/Rewrite.lean
+++ b/SSA/Core/Transforms/Rewrite/Rewrite.lean
@@ -41,7 +41,7 @@ theorem denote_splitProgramAtAux [LawfulMonad d.m] : {pos : ℕ} → {lets : Let
   | 0, lets, .var e body, res, hres, s => by
     obtain rfl := by
       simpa only [splitProgramAtAux, Option.mem_def, Option.some.injEq] using hres
-    simp only [Lets.denote, bind_assoc, pure_bind, Com.denote_var]
+    simp only [Lets.denote, bind_assoc, Com.denote_var]
   | _+1, _, .ret _, res, hres, s => by
     simp [splitProgramAtAux, Option.mem_def] at hres
   | n+1, lets, .var e body, res, hres, s => by
@@ -196,13 +196,13 @@ theorem denote_rewritePeephole_go (pr : PeepholeRewrite d Γ t)
   case zero =>
     simp [rewritePeephole_go]
   case succ fuel' hfuel =>
-    simp[rewritePeephole_go, denote_rewritePeepholeAt, hfuel]
+    simpa [rewritePeephole_go, hfuel] using denote_rewritePeepholeAt ..
 
 /-- `rewritePeephole` preserves semantics. -/
 theorem denote_rewritePeephole (fuel : ℕ)
     (pr : PeepholeRewrite d Γ t) (target : Com d Γ₂ eff t₂) :
     (rewritePeephole fuel pr target).denote = target.denote := by
-  simp[rewritePeephole, denote_rewritePeephole_go]
+  exact denote_rewritePeephole_go ..
 
 /-- info: 'denote_rewritePeephole' depends on axioms: [propext, Classical.choice, Quot.sound] -/
 #guard_msgs in #print axioms denote_rewritePeephole
@@ -255,13 +255,13 @@ theorem denote_multiRewritePeepholeAt (fuel : ℕ)
   case zero =>
     simp [multiRewritePeepholeAt]
   case succ hp =>
-    simp [multiRewritePeepholeAt, hp, denote_foldl_rewritePeepholeAt]
+    simpa [multiRewritePeepholeAt, hp] using denote_foldl_rewritePeepholeAt ..
 
 /- The proof that `rewritePeephole_multi` is semantics preserving  -/
 theorem denote_multiRewritePeephole (fuel : ℕ)
   (prs : List (Σ Γ, Σ ty, PeepholeRewrite d Γ ty)) (target : Com d Γ₂ eff t₂) :
     (multiRewritePeephole fuel prs target).denote = target.denote := by
-  simp [multiRewritePeephole, denote_multiRewritePeepholeAt]
+  exact denote_multiRewritePeepholeAt ..
 
 theorem Expr.denote_eq_of_region_denote_eq {ty} (op : d.Op)
     (ty_eq : ty = DialectSignature.outTy op)

--- a/SSA/Projects/CSE/CSE.lean
+++ b/SSA/Projects/CSE/CSE.lean
@@ -7,6 +7,24 @@ This file implements common subexpression elimination for our SSA based IR.
 import SSA.Core
 import SSA.Projects.DCE.DCE
 
+/-! ## Prelims  -/
+
+namespace Ctxt
+variable {Ty} [TyDenote Ty]
+
+/-- Remap the last variable in a context, to get a new context without the last variable -/
+def Hom.remapLast {α : Ty} (Γ : Ctxt Ty) (var : Γ.Var α) :
+  Ctxt.Hom (Γ.snoc α) Γ := fun ty' var' => by
+    cases var' using Ctxt.Var.casesOn
+    case toSnoc var' => exact var'
+    case last => exact var
+
+@[simp] lemma Valuation.comap_remapList {Γ : Ctxt Ty} (V : Valuation Γ) (v : Γ.Var t) :
+    V.comap (.remapLast _ v) = V.snoc (V v) := by
+  funext t v; cases v <;> simp [Hom.remapLast]
+
+end Ctxt
+
 /- Decidable Equality for Coms. -/
 section DecEqCom
 variable {d : Dialect}
@@ -16,6 +34,20 @@ variable [DialectSignature d]
 def argVector.decEq : DecidableEq (HVector (Ctxt.Var Γ) ts) := inferInstance
 
 
+/-- denoting a `var` is the same as `snoc`ing the denotation of `e` onto the old valuation `V`. -/
+@[simp]
+theorem Lets.denote_var_pure [TyDenote d.Ty] [DialectDenote d] [Monad d.m] [LawfulMonad d.m]
+  {Γstart Γ : Ctxt d.Ty}
+  {lets : Lets d Γstart .pure Γ}
+  (e : Expr d Γ .pure α)
+  (V : Ctxt.Valuation Γstart) :
+  Lets.denote (Lets.var lets e) V =
+    (Ctxt.Valuation.snoc (Lets.denote lets V) (Expr.denoteOp e (Lets.denote lets V))) := by
+  simp [Expr.denote_unfold]; rfl
+
+/-! # CSE  -/
+
+variable [TyDenote d.Ty] [DialectDenote d] [Monad d.m]
 namespace CSE
 
 /-- State stored by CSE pass. -/
@@ -28,74 +60,41 @@ structure State (d : Dialect) [TyDenote d.Ty] [DialectSignature d] [DialectDenot
   /-- map an Expr to its canonical variable -/
   expr2cache : (α : d.Ty) → (e : Expr d Γ .pure α) →
     Option ({ v : Γ.Var α // ∀ (V : Γstart.Valuation), (lets.denote V) v =
-    e.denote (lets.denote V) })
-
-variable [TyDenote d.Ty] [DialectDenote d] [Monad d.m]
+    e.denoteOp (lets.denote V) })
 
 /-- The empty CSEing state. -/
 def State.empty (lets : Lets d Γstart .pure Γ) : State d lets where
   var2var := fun v => ⟨v, by intros V; rfl⟩
   expr2cache := fun α e => .none
 
+variable [LawfulMonad d.m]
+
 def State.snocNewExpr2Cache [DecidableEq d.Ty] [DecidableEq d.Op]
- {Γ : Ctxt d.Ty} {α : d.Ty}
- {lets : Lets d Γstart .pure Γ}
- (s : State d lets) (e : Expr d Γ .pure α) : State d (Lets.var lets e) :=
- {
-  var2var := fun v => by
+    {Γ : Ctxt d.Ty} {α : d.Ty}
+    {lets : Lets d Γstart .pure Γ}
+    (s : State d lets) (e : Expr d Γ .pure α) : State d (Lets.var lets e) where
+  var2var v := by
     apply Subtype.mk
     intros V
     rfl
-  expr2cache := fun β eneedle =>
-    let eneedleΓ? := DCE.Expr.deleteVar? (DEL := Deleted.deleteSnoc Γ α) (eneedle)
-    match eneedleΓ? with
-    | .none => .none -- this expression actually uses β in some nontrivial way, we're fucked,
-    | .some ⟨eneedleΓ, heneedleΓ⟩ =>
-        match s.expr2cache _ eneedleΓ with /- find in cache -/
-        | .some ⟨v', hv'⟩ =>
-          .some ⟨v', by {
-            intros V
-            rw [heneedleΓ]
-            simp only [Lets.denote, EffectKind.toMonad_pure, Id.pure_eq', Id.bind_eq',
-              Ctxt.Valuation.snoc_toSnoc]
-            rw [hv' V]
-            congr
-          }⟩
-        | .none => /- not in cache, check if new expr. -/
-          match decEq α β with
-          | .isFalse _neq => .none
-          | .isTrue hβ =>
-            match (inferInstance : Decidable ((hβ ▸ eneedleΓ) = e)) with
-            | .isTrue exprEq => /- same expression, return the variable. -/
-                .some ⟨hβ ▸ Ctxt.Var.last Γ α, by {
-                  intros V
-                  subst hβ
-                  subst exprEq
-                  simp only [heneedleΓ]
-                  rfl
-                }⟩
-            | .isFalse _neq => .none
-            -- s.expr2cache β eneedleΓ /- different expression, query cache. -/
- }
-
-/-- denoting a `var` is the same as `snoc`ing the denotation of `e` onto the old valuation `V`. -/
-@[simp]
-theorem Lets.denote_var
-  {Γstart Γ : Ctxt d.Ty}
-  {lets : Lets d Γstart .pure Γ}
-  (e : Expr d Γ .pure α)
-  (V : Ctxt.Valuation Γstart) :
-  Lets.denote (Lets.var lets e) V =
-    (Ctxt.Valuation.snoc (Lets.denote lets V) (Expr.denote e (Lets.denote lets V))) := by
-  simp [Lets.denote]
-  rfl
-
-/-- Remap the last variable in a context, to get a new context without the last variable -/
-def _root_.Ctxt.Hom.remapLast [TyDenote d.Ty]  {α : d.Ty} (Γ : Ctxt d.Ty) (var : Γ.Var α) :
-  Ctxt.Hom (Γ.snoc α) Γ := fun ty' var' => by
-    cases var' using Ctxt.Var.casesOn
-    case toSnoc var' => exact var'
-    case last => exact var
+  expr2cache β eneedle := do
+    let ⟨eneedleΓ, heneedleΓ⟩ ← DCE.Expr.deleteVar? (DEL := Deleted.deleteSnoc Γ α) (eneedle)
+    -- If `eneedleΓ` is none, this expression actually uses β in some nontrivial way,
+    -- and there's nothing we can really do
+    match s.expr2cache _ eneedleΓ with /- find in cache -/
+    | .some ⟨v', hv'⟩ => .some ⟨v', by
+        simp [heneedleΓ, hv']
+      ⟩
+    | .none => /- not in cache, check if new expr. -/
+      if hβ : α = β then
+        if exprEq : (hβ ▸ eneedleΓ) = e then
+          some ⟨hβ ▸ Ctxt.Var.last Γ α, by
+            subst hβ; simp [heneedleΓ, exprEq]
+          ⟩
+        else
+          none
+      else
+        none
 
 section RemapVar
 def VarRemapVar [DecidableEq d.Ty] [DecidableEq d.Op]
@@ -155,15 +154,15 @@ def ExprRemapVar [DecidableEq d.Ty] [DecidableEq d.Op]
     ((lets.denote Vstart).comap hom) vnew)
   (e' : Expr d Γ' .pure β) :
   { e : Expr d Γ .pure β  // ∀ (Vstart : Ctxt.Valuation Γstart),
-    e.denote (lets.denote Vstart) = e'.denote ((lets.denote Vstart).comap hom) } :=
+    e.denoteOp (lets.denote Vstart) = e'.denoteOp ((lets.denote Vstart).comap hom) } :=
     match e' with
     | ⟨op, ty_eq, eff_le, args, regArgs⟩ =>
       let ⟨args', hargs'⟩ := arglistRemapVar lets hom vold vnew VNEW args
       ⟨.mk op ty_eq eff_le args' regArgs, by
         intros Vstart
         subst ty_eq
-        simp only [EffectKind.toMonad_pure, Expr.denote, EffectKind.liftEffect_pure, cast_inj]
-        rw [hargs']
+        simp [Expr.denoteOp, hargs']
+        rfl
       ⟩
     -- TODO: extend to Com.
 end RemapVar
@@ -184,7 +183,7 @@ def State.snocOldExpr2Cache [DecidableEq d.Ty] [DecidableEq d.Op]
  {lets : Lets d Γstart .pure Γ}
  (s : State d lets) (enew : Expr d Γ .pure α) (eold : Expr d Γ .pure α) (henew :
     ∀ (V : Γstart.Valuation), enew.denote (lets.denote V) = eold.denote (lets.denote V))
-  (vold : Γ.Var α) (hv : ∀ (V : Γstart.Valuation), eold.denote (lets.denote V) =
+  (vold : Γ.Var α) (hv : ∀ (V : Γstart.Valuation), eold.denoteOp (lets.denote V) =
     lets.denote V vold) :
   State d (Lets.var lets enew) := {
     var2var := fun v => by
@@ -193,16 +192,12 @@ def State.snocOldExpr2Cache [DecidableEq d.Ty] [DecidableEq d.Op]
         let ⟨v', hv'⟩ := s.var2var v
         apply (Subtype.mk v'.toSnoc)
         intros V
-        simp only [Lets.denote_var, Ctxt.Valuation.snoc_toSnoc]
+        simp only [Lets.denote_var_pure, Ctxt.Valuation.snoc_toSnoc]
         rw [hv']
 
       case last => -- new variable, return the CSE'd variable.
-        apply (Subtype.mk vold.toSnoc)
-        intros V
-        simp only [Lets.denote_var, Ctxt.Valuation.snoc_toSnoc]
-        rw [← hv]
-        rw [henew]
-        rfl
+        apply Subtype.mk vold.toSnoc
+        simp_all [Expr.denote_unfold]
     expr2cache := fun β eneedle =>
       let homRemap := Ctxt.Hom.remapLast Γ vold
       let lastVar := (Ctxt.Var.last Γ α)
@@ -213,23 +208,9 @@ def State.snocOldExpr2Cache [DecidableEq d.Ty] [DecidableEq d.Op]
       })  eneedle
       match s.expr2cache β eneedle' with
       | .none => .none
-      | .some ⟨e', he'⟩ =>
-        .some ⟨e', by {
-          intros V
-          simp only [Lets.denote_var, Ctxt.Valuation.snoc_toSnoc]
-          rw [he']
-          rw [heneedle']
-          congr
-          funext ty var
-          cases var using Ctxt.Var.casesOn
-          case e_Γv.h.h.toSnoc v =>
-            simp (config := {zetaDelta := true}) [Ctxt.Valuation.comap, Ctxt.Hom.remapLast]
-          case e_Γv.h.h.last =>
-            simp (config := { zetaDelta := true }) only [Ctxt.Valuation.comap, Ctxt.Hom.remapLast,
-              Ctxt.Var.casesOn_last, Ctxt.Valuation.snoc_last]
-            rw [henew]
-            rw [hv]
-        }⟩
+      | .some ⟨e', he'⟩ => .some ⟨e', by
+          simp_all [Expr.denote_unfold, homRemap]
+        ⟩
 }
 
 /-- Replace the variables in `as` with new variables that have the same valuation -/
@@ -320,7 +301,7 @@ def State.cseExpr
  {e' : Expr d Γ .pure α //
   ∀ (V : Γstart.Valuation), e'.denote (lets.denote V) =
     e.denote (lets.denote V) } × Option ({ v' : Γ.Var α // ∀ (V : Γstart.Valuation),
-      (lets.denote V) v' = e.denote (lets.denote V) }) :=
+      (lets.denote V) v' = e.denoteOp (lets.denote V) }) :=
   match E : e with
   | .mk op ty_eq eff_le args regArgs =>
       let ⟨args', hargs'⟩ := s.cseArgList args
@@ -329,12 +310,11 @@ def State.cseExpr
       let e' : Expr d Γ .pure α  := .mk op ty_eq eff_le args' regArgs'
       ⟨⟨e', by {
         intros V
-        simp (config := { zetaDelta := true }) only [EffectKind.toMonad_pure, Expr.denote_unfold,
-          EffectKind.liftEffect_pure, eq_rec_inj, cast_inj]
-        congr 1
-        · unfold Ctxt.Valuation.eval at hargs'
-          rw [hargs']
-        · rw [hregArgs']
+        simp +zetaDelta only [Expr.denote_unfold, Ctxt.Valuation.snoc_map_inj]
+        apply Expr.denoteOp_eq_denoteOp_of
+        · simpa [Ctxt.Valuation.eval] using (hargs' _).symm
+        · simpa using hregArgs'.symm
+        · rfl
       }⟩,
         match s.expr2cache _ e with
         | .some ⟨v', hv'⟩ =>
@@ -366,7 +346,7 @@ def State.cseCom {α : d.Ty}
         ⟨.var e' body',  by
             intros VΓ
             simp only [EffectKind.toMonad_pure, Com.denote]
-            simp only [EffectKind.toMonad_pure, Lets.denote_var] at hbody' ⊢
+            simp only [EffectKind.toMonad_pure, Lets.denote_var, Id.bind_eq'] at hbody' ⊢
             rw [← hbody']
             rw [he']⟩
       | .some ⟨v', hv'⟩ =>
@@ -379,7 +359,7 @@ def State.cseCom {α : d.Ty}
         , by
             intros V
             simp only [EffectKind.toMonad_pure, Com.denote]
-            simp only [EffectKind.toMonad_pure, Lets.denote_var] at hbody' ⊢
+            simp only [EffectKind.toMonad_pure, Lets.denote_var, Id.bind_eq'] at hbody' ⊢
             specialize (hbody' V)
             specialize (he' V)
             rw [he'] at hbody'

--- a/SSA/Projects/DCE/DCE.lean
+++ b/SSA/Projects/DCE/DCE.lean
@@ -73,6 +73,11 @@ def Deleted.toHom (h : Deleted Γ v Γ') : Γ'.Hom Γ :=
   · simp
   · simp [Hom.delete]
 
+@[simp] lemma Deleted.toHom_last (DEL : Deleted (Γ.snoc u) (Var.last _ _) Γ) :
+    DEL.toHom = Hom.id.snocRight := rfl
+
+/-! ## tryDelete? -/
+
 /-- Given  `Γ' := Γ/delv`, transport a variable from `Γ` to `Γ', if `v ≠ delv`. -/
 def Var.tryDelete? [TyDenote Ty] {Γ Γ' : Ctxt Ty} {delv : Γ.Var α}
   (DEL : Deleted Γ delv Γ') (v : Γ.Var β) :
@@ -121,50 +126,40 @@ def arglistDeleteVar? {Γ: Ctxt d.Ty} {delv : Γ.Var α} {Γ' : Ctxt d.Ty} {ts :
       | .none => .none
       | .some ⟨as', has'⟩ => .some ⟨.cons a' as', by simp [HVector.map_cons, *]⟩
 
-variable [DialectSignature d] [DialectDenote d] [Monad d.m]
+variable [DialectSignature d] [DialectDenote d] [Monad d.m] [LawfulMonad d.m]
 
 /- Try to delete a variable from an Expr -/
 def Expr.deleteVar? (DEL : Deleted Γ delv Γ') (e: Expr d Γ .pure t) :
   Option { e' : Expr d Γ' .pure t // ∀ (V : Γ.Valuation),
-    e.denote V = e'.denote (V.comap DEL.toHom) } :=
+    e.denoteOp V = e'.denoteOp (V.comap DEL.toHom) } :=
   match e with
-  | .mk op ty_eq eff_le args regArgs =>
-    match arglistDeleteVar? DEL args with
-    | .none => .none
-    | .some args' =>
-      .some ⟨.mk op ty_eq eff_le args' regArgs, by
-        obtain ⟨ args', rfl ⟩ := args'
-        intros V
-        simp only [EffectKind.toMonad_pure, Expr.denote_unfold, EffectKind.liftEffect_pure,
-          Valuation.comap_apply, eq_rec_inj, cast_inj]
-        congr 1
-        simp [HVector.map_map]
-      ⟩
+  | .mk op ty_eq eff_le args regArgs => do
+    let args' ← arglistDeleteVar? DEL args
+    some ⟨.mk op ty_eq eff_le args' regArgs, by
+      obtain ⟨ args', rfl ⟩ := args'
+      intros V
+      simp [Expr.denoteOp, HVector.map_map]
+      rfl
+    ⟩
 
 /-- Delete a variable from an Com. -/
 def Com.deleteVar? (DEL : Deleted Γ delv Γ') (com : Com d Γ .pure t) :
   Option { com' : Com d Γ' .pure t // ∀ (V : Γ.Valuation),
     com.denote V = com'.denote (V.comap DEL.toHom) } :=
   match com with
-  | .ret v =>
-    match Var.tryDelete? DEL v with
-    | .none => .none
-    | .some ⟨v, hv⟩ =>
-      .some ⟨.ret v, by simp [hv]⟩
-  | .var (α := ω) e body =>
-    match Com.deleteVar? (DEL.snoc _) body with
-    | .none => .none
-    | .some ⟨body', hbody'⟩ =>
-      match Expr.deleteVar? DEL e with
-        | .none => .none
-        | .some ⟨e', he'⟩ =>
-          .some ⟨.var e' body', by
-            intros V
-            simp only [EffectKind.toMonad_pure, Com.denote]
-            rw [←he', hbody']
-            congr
-            simp
-            ⟩
+  | .ret v => do
+    let ⟨v, hv⟩ ← Var.tryDelete? DEL v
+    return ⟨.ret v, by simp [hv]⟩
+  | .var (α := ω) e body => do
+    let ⟨body', hbody'⟩ ← Com.deleteVar? (DEL.snoc _) body
+    let ⟨e', he'⟩ ← Expr.deleteVar? DEL e
+    .some ⟨.var e' body', by
+      intros V
+      apply Id.ext
+      simp [Com.denote, Expr.denote_unfold, ←he', hbody']
+    ⟩
+
+-- theorem
 
 /-- Declare the type of DCE up-front, so we can declare an `Inhabited` instance.
 This is necessary so that we can mark the DCE implementation as a `partial def`
@@ -210,8 +205,8 @@ partial def dce_ {Γ : Ctxt d.Ty} {t : d.Ty}
       let com' := Com.var (α := α) e (body'.changeVars hom')
       ⟨Γ, Hom.id, com', by
         intros V
-        simp (config := {zetaDelta := true}) [Com.denote]
-        rw [hbody']
+        apply Id.ext
+        simp (config := {zetaDelta := true}) [Com.denote, hbody']
       ⟩
     | .some ⟨body', hbody⟩ =>
       let ⟨Γ', hom', ⟨com', hcom'⟩⟩
@@ -219,10 +214,9 @@ partial def dce_ {Γ : Ctxt d.Ty} {t : d.Ty}
         { com' : Com d Γ' .pure t //  ∀ (V : Γ.Valuation),
           com.denote V = com'.denote (V.comap hom)} :=
         ⟨Γ, Hom.id, ⟨body', by -- NOTE: we deleted the `let` binding.
-          simp only [EffectKind.toMonad_pure, HCOM, Com.denote_var, Id.bind_eq',
-            Ctxt.Valuation.comap_id]
           intros V
-          apply hbody
+          simp [EffectKind.toMonad_pure, HCOM, Com.denote_var,
+            Ctxt.Valuation.comap_id, hbody, Id.bind_eq']
         ⟩⟩
       let ⟨Γ'', hom'', ⟨com'', hcom''⟩⟩
         :   Σ (Γ'' : Ctxt d.Ty) (hom : Hom Γ'' Γ'),
@@ -237,12 +231,6 @@ partial def dce_ {Γ : Ctxt d.Ty} {t : d.Ty}
         rw [hcom']
         rw [hcom'']
         rfl⟩
-/-
-decreasing_by {
-  simp[invImage, InvImage, WellFoundedRelation.rel, Nat.lt_wfRel]
-  sorry -- Lean bug: *no goals to be solved*?!
-}
--/
 
 /-- This is the real entrypoint to `dce` which unfolds the type of `dce_`, where
 we play the `DCEType` trick to convince Lean that the output type is in fact

--- a/SSA/Projects/DCE/DCE.lean
+++ b/SSA/Projects/DCE/DCE.lean
@@ -159,8 +159,6 @@ def Com.deleteVar? (DEL : Deleted Γ delv Γ') (com : Com d Γ .pure t) :
       simp [Com.denote, Expr.denote_unfold, ←he', hbody']
     ⟩
 
--- theorem
-
 /-- Declare the type of DCE up-front, so we can declare an `Inhabited` instance.
 This is necessary so that we can mark the DCE implementation as a `partial def`
 and ensure that Lean does not freak out on us, since it's indeed unclear to Lean

--- a/SSA/Projects/LLVMRiscV/simpproc.lean
+++ b/SSA/Projects/LLVMRiscV/simpproc.lean
@@ -38,10 +38,15 @@ private theorem valuation_var_last_eq.lemma {Ty : Type} [TyDenote Ty] {Γ : Ctxt
 open Lean Meta Elab in
 simproc [simp_denote] valuation_var_last_eq ((Ctxt.Valuation.snoc _ _) (Ctxt.Var.last _ _)) := fun e => do
   let (_f, xs) := e.getAppFnArgs
-  let ty := xs[0]!
+  let Ty := xs[0]!
+  let instTyDenote := xs[1]!
+  let Γ := xs[2]!
+  let t := xs[3]!
   let s := xs[4]!
   let x := xs[xs.size - 1 - 2]!
-  let proof ← mkAppOptM ``valuation_var_last_eq.lemma #[.some ty, .none, .none, .none, .some s, .some x]
+  let proof := mkAppN (mkConst ``valuation_var_last_eq.lemma) #[
+      Ty, instTyDenote, Γ, t, s, x
+    ]
   return .visit {
     expr := x,
     proof? := proof

--- a/SSA/Projects/SLLVM/Evaluation/AliveAutoGeneratedCopy.lean
+++ b/SSA/Projects/SLLVM/Evaluation/AliveAutoGeneratedCopy.lean
@@ -3060,6 +3060,9 @@ def alive_275_tgt  :=
   %v3 = llvm.sub %X, %v1 : i5
   llvm.return %v3 : i5
 }]
+
+-- attribute [simp_denote] bind_pure bind_pure_comp map_pure pure_bind
+
 theorem alive_275   : alive_275_src ⊑ alive_275_tgt := by
   unfold alive_275_src alive_275_tgt
   simp_peephole

--- a/SSA/Projects/Scf/ScfFunctor.lean
+++ b/SSA/Projects/Scf/ScfFunctor.lean
@@ -433,7 +433,7 @@ theorem if_false' {t : Arith.Ty} (cond : Var Γ Arith.Ty.bool) (hcond : Γv cond
   just fetching the loop variable. -/
 theorem for_return {t : Arith.Ty} (istart istep: Var Γ Arith.Ty.int)
     (niters : Var Γ .nat) (v : Var Γ t) :
-    Expr.denote (for_ (t := t) istart istep niters v (RegionRet t ⟨1, by simp⟩)) Γv = Γv v := by
+    Expr.denoteOp (for_ (t := t) istart istep niters v (RegionRet t ⟨1, by simp⟩)) Γv = Γv v := by
   simp_peephole
   simp [Scf.LoopBody.counterDecorator.constant_iterate]
 


### PR DESCRIPTION
This PR changes `Expr.denote` to return the new Valuation (which is the input valuation with the result of the current expression added to the end). The result of *only* the current expression is now called `Expr.denoteOp`.

This serves to deduplicate the effect that an Expr has on Valuations, which previously was expressed both in Com and in Lets.

This PR prepares for multiple return values.