### PR TITLE
refactor: introduce Mapping.mapValuation

### DIFF
--- a/SSA/Core/Transforms/Rewrite/Mapping.lean
+++ b/SSA/Core/Transforms/Rewrite/Mapping.lean
@@ -76,3 +76,29 @@ def toHom (m : Mapping Γ Δ) (h : m.IsTotal) : Γ.Hom Δ :=
   fun t v =>
     m.lookup ⟨t, v⟩ |>.get <| by
       simpa [AList.lookup_isSome] using h _
+
+section MapValuation
+variable [TyDenote Ty] [∀ t' : Ty, Inhabited ⟦t'⟧]
+
+/--
+Map a valuation of context `Δ` along a partial map `m : Mapping Γ Δ` into
+a valuation of context `Γ`. This returns the default value of `⟦t'⟧` for
+any variable `Γ.Var t'` which is not mapped in `m`.
+-/
+def mapValuation (m : Mapping Γ Δ) (V : Δ.Valuation) : Γ.Valuation :=
+  fun t' v' =>
+    match m.lookup ⟨t', v'⟩ with
+    | some mappedVar => V mappedVar
+    | none => default
+
+section Lemmas
+variable {m : Mapping Γ Δ} {V : Δ.Valuation}
+
+lemma toHom_eq_mapValuation (h : m.IsTotal) :
+    V.comap (m.toHom h) = m.mapValuation V := by
+  funext t v
+  obtain ⟨_, h_lookup⟩ := Option.isSome_iff_exists.mp <| AList.lookup_isSome.2 (h v)
+  simp [mapValuation, toHom, h_lookup]
+
+end Lemmas
+end MapValuation

--- a/SSA/Core/Transforms/Rewrite/Match.lean
+++ b/SSA/Core/Transforms/Rewrite/Match.lean
@@ -451,16 +451,10 @@ theorem denote_matchVar
     {v w : Var _ t}
     (h_matchVar : ((), varMap₁) ∈ matchVar lets v matchLets w ma)
     (V : lets.ValidDenotation) :
-    (matchLets.denote (fun t' v' =>
-        match varMap₁.lookup ⟨t', v'⟩ with
-        | .some mappedVar => by exact (V.val mappedVar)
-        | .none => default) w)
+    (matchLets.denote (varMap₁.mapValuation V.val) w)
     = V.val v := by
   suffices ∀ {varMap₂ : Mapping _ _}, varMap₁.entries ⊆ varMap₂.entries →
-    (matchLets.denote (fun t' v' =>
-        match varMap₂.lookup ⟨t', v'⟩ with
-        | .some mappedVar => by exact (V.val mappedVar)
-        | .none => default) w)
+    (matchLets.denote (varMap₂.mapValuation V.val) w)
     = V.val v
   by
     apply this (List.Subset.refl _)
@@ -469,7 +463,7 @@ theorem denote_matchVar
   induction matchLets generalizing v ma varMap₁ varMap₂ t
   case nil =>
     simp only [Lets.denote, Id.pure_eq']
-    rw [AList.mem_lookup_iff.mpr ?_]
+    rw [Mapping.mapValuation, AList.mem_lookup_iff.mpr ?_]
     apply h_sub <| AList.mem_lookup_iff.mp <| matchVar_nil h_matchVar
   case var t' matchLets matchExpr ih =>
     match w with
@@ -630,15 +624,8 @@ theorem denote_matchLets_of_matchVarMap
   split at hmap
   next => contradiction
   next m hm =>
-    obtain rfl : m.toHom _ = map := by
+    obtain rfl : m.toHom ?isTotal = map := by
       simpa using hmap
-
-    rw [← denote_matchVar hm]
-    apply congrFun; apply congrFun; apply congrArg
-
-    funext t' v'
-    have := AList.lookup_isSome.2 (mem_matchVar hm (hvars _ v'))
-    split <;> simp_all [Mapping.toHom]
-
+    rw [m.toHom_eq_mapValuation ?isTotal, denote_matchVar hm]
 
 end DenoteLemmas


### PR DESCRIPTION
This PR simplifies some proofs by introduce a new `Mapping.mapValuation` definition