### PR TITLE
refactor: structure `splitProgramAt` return type

### DIFF
--- a/SSA/Core/Framework.lean
+++ b/SSA/Core/Framework.lean
@@ -440,6 +440,10 @@ def Expr.regArgs {Γ : Ctxt d.Ty} {ty : d.Ty} (e : Expr d Γ eff ty) :
     HVector (fun t : Ctxt d.Ty × d.Ty => Com d t.1 .impure t.2) (DialectSignature.regSig e.op) :=
   Expr.casesOn e (fun _ _ _ _ regArgs => regArgs)
 
+/-- `e.returnVar` is the variable in `e.outContext` which is bound by `e`. -/
+def Expr.returnVar (e : Expr d Γ eff ty) : e.outContext.Var ty :=
+  Var.last _ _
+
 /-! Projection equations for `Expr` -/
 @[simp]
 theorem Expr.op_mk {Γ : Ctxt d.Ty} {ty : d.Ty} {eff : EffectKind} (op : d.Op)
@@ -511,6 +515,9 @@ def Com.outContextHom (com : Com d Γ eff t) : Γ.Hom com.outContext :=
 def Com.returnVar : (com : Com d Γ eff t) → Var com.outContext t
   | .ret v => v
   | .var _ body => body.returnVar
+
+@[simp] def Expr.contextHom (e : Expr d Γ eff ts) : Γ.Hom e.outContext :=
+  @fun _ => Var.toSnoc
 
 section Lemmas
 

--- a/SSA/Core/Framework.lean
+++ b/SSA/Core/Framework.lean
@@ -178,21 +178,6 @@ inductive Lets (Γ_in : Ctxt d.Ty) (eff : EffectKind) :
   | nil : Lets Γ_in eff Γ_in
   | var (body : Lets Γ_in eff Γ_out) (e : Expr d Γ_out eff t) : Lets Γ_in eff (Γ_out.snoc t)
 
-/-- `Zipper d Γ_in eff Γ_mid ty` represents a particular position in a program, by storing the
-`Lets` that come before this position separately from the `Com` that represents the rest.
-Thus, `Γ_in` is the context of the program as a whole, while `Γ_mid` is the context at the
-current position.
-
-While technically the position is in between two let-bindings, by convention we say that the first
-binding of `top : Lets ..` is the current binding of a particular zipper. -/
-structure Zipper (Γ_in : Ctxt d.Ty) (eff : EffectKind) (Γ_mid : Ctxt d.Ty) (ty : d.Ty) where
-  /-- The let-bindings at the top of the zipper -/
-  top : Lets d Γ_in eff Γ_mid
-  /-- The program at the bottom of the zipper -/
-  bot : Com d Γ_mid eff ty
-
-
-
 /-! ### Repr instance -/
 section Repr
 open Std (Format)
@@ -626,12 +611,6 @@ the congruence, you can do: `rw [← Lets.denotePure]; congr`
 -/
 @[simp] abbrev Lets.denotePure [DialectSignature d] [DialectDenote d] :
     Lets d Γ₁ .pure Γ₂ → Valuation Γ₁ → Valuation Γ₂ := Lets.denote
-
-/-- The denotation of a zipper is a composition of the denotations of the constituent
-`Lets` and `Com` -/
-def Zipper.denote (zip : Zipper d Γ_in eff Γ_out ty) (V_in : Valuation Γ_in) :
-    eff.toMonad d.m ⟦ty⟧ :=
-  (zip.top.denote V_in) >>= zip.bot.denote
 
 section Unfoldings
 
@@ -1113,85 +1092,6 @@ Various machinery to combine `Lets` and `Com`s in various ways.
 def Com.toFlatCom {t : d.Ty} (com : Com d Γ .pure t) : FlatCom d Γ .pure com.outContext t :=
   ⟨com.toLets, com.returnVar⟩
 
-/-- Recombine a zipper into a single program by adding the `lets` to the beginning of the `com` -/
-def Zipper.toCom (zip : Zipper d Γ_in eff Γ_mid ty) : Com d Γ_in eff ty :=
-  go zip.top zip.bot
-  where
-    go : {Γ_mid : _} → Lets d Γ_in eff Γ_mid → Com d Γ_mid eff ty → Com d Γ_in eff ty
-      | _, .nil, com          => com
-      | _, .var body e, com  => go body (.var e com)
-
-/-- Add a `Com` directly before the current position of a zipper, while reassigning every
-occurence of a given free variable (`v`) of `zip.com` to the output of the new `Com`  -/
-def Zipper.insertCom (zip : Zipper d Γ_in eff Γ_mid ty) (v : Var Γ_mid newTy)
-    (newCom : Com d Γ_mid eff newTy) : Zipper d Γ_in eff newCom.outContext ty :=
-  let newTop := zip.top.addComToEnd newCom
-  --  ^^^^^^ The combination of the previous `top` with the `newCom` inserted
-  let newBot := zip.bot.changeVars <| newCom.outContextHom.with v newCom.returnVar
-  --  ^^^^^^ Adjust variables in `bot` to the intermediate context of the new zipper --- which is
-  --         `newCom.outContext` --- while also reassigning `v`
-  ⟨newTop, newBot⟩
-
-/-- Add a pure `Com` directly before the current position of a possibly impure
-zipper, while r eassigning every occurence of a given free variable (`v`) of
-`zip.com` to the output of the new `Com`
-
-This is a wrapper around `insertCom` (which expects `newCom` to have the same effect as `zip`)
-and `castPureToEff` -/
-def Zipper.insertPureCom (zip : Zipper d Γ_in eff Γ_mid ty) (v : Var Γ_mid newTy)
-    (newCom : Com d Γ_mid .pure newTy) : Zipper d Γ_in eff newCom.outContext ty :=
-  (by simp : (newCom.castPureToEff eff).outContext = newCom.outContext)
-    ▸ zip.insertCom v (newCom.castPureToEff eff)
-
-/-! simp-lemmas -/
-section Lemmas
-
-@[simp] lemma Zipper.toCom_nil {com : Com d Γ eff ty} : Zipper.toCom ⟨.nil, com⟩ = com := rfl
-@[simp] lemma Zipper.toCom_var {lets : Lets d Γ_in eff Γ_mid} :
-    Zipper.toCom ⟨Lets.var lets e, com⟩ = Zipper.toCom ⟨lets, Com.var e com⟩ := rfl
-
-@[simp] theorem Zipper.denote_toCom [LawfulMonad d.m] (zip : Zipper d Γ_in eff Γ_mid ty) :
-    zip.toCom.denote = zip.denote := by
-  rcases zip with ⟨lets, com⟩
-  funext Γv; induction lets <;> simp [Lets.denote, Zipper.denote, *]
-
-@[simp] lemma Zipper.denote_mk {lets : Lets d Γ_in eff Γ_out} {com : Com d Γ_out eff ty} :
-    denote ⟨lets, com⟩ = fun V => (lets.denote V) >>= com.denote := rfl
-
-theorem Zipper.denote_insertCom {zip : Zipper d Γ_in eff Γ_mid ty₁}
-    {newCom : Com d _ eff newTy} [LawfulMonad d.m] :
-    (zip.insertCom v newCom).denote = (fun (V_in : Valuation Γ_in) => do
-      let V_mid ← zip.top.denote V_in
-      let V_newMid ← newCom.denoteLets V_mid
-      zip.bot.denote
-        (V_newMid.comap <| newCom.outContextHom.with v newCom.returnVar)
-      ) := by
-  funext V
-  simp [insertCom, Com.denoteLets_eq]
-
-/-- Casting the intermediate context is not relevant for the denotation -/
-@[simp] lemma Zipper.denoteLets_eqRec_Γ_mid {zip : Zipper d Γ_in eff Γ_mid ty}
-    (h : Γ_mid = Γ_mid') :
-    denote (h ▸ zip) = zip.denote := by
-  subst h; rfl
-
-theorem Zipper.denote_insertPureCom {zip : Zipper d Γ_in eff Γ_mid ty₁}
-    {newCom : Com d _ .pure newTy} [LawfulMonad d.m] :
-    (zip.insertPureCom v newCom).denote = (fun (V_in : Valuation Γ_in) => do
-      let V_mid ← zip.top.denote V_in
-      zip.bot.denote
-        ((Com.denoteLets newCom V_mid).comap <| newCom.outContextHom.with v newCom.returnVar)
-      ) := by
-  have (V_mid) (h : Com.outContext (Com.castPureToEff eff newCom) = Com.outContext newCom) :
-      ((Com.denoteLets newCom V_mid).comap fun x v => v.castCtxt h).comap
-        (newCom.castPureToEff eff).outContextHom
-      = (Com.denoteLets newCom V_mid).comap newCom.outContextHom := by
-    funext t' ⟨v', hv'⟩
-    simp only [Com.outContextHom, Com.outContextDiff, Com.size_castPureToEff]
-    rfl
-  funext V; simp [insertPureCom, denote_insertCom, Valuation.comap, this]
-
-end Lemmas
 
 /-!
 ### Semantic preservation of `Zipper.insertPureCom`

--- a/SSA/Core/Framework/Zipper.lean
+++ b/SSA/Core/Framework/Zipper.lean
@@ -1,0 +1,135 @@
+import SSA.Core.Framework
+
+open Ctxt (Valuation Var)
+
+/-!
+# Zipper
+-/
+
+variable (d : Dialect) [DialectSignature d]
+
+/-- `Zipper d Γ_in eff Γ_mid ty` represents a particular position in a program, by storing the
+`Lets` that come before this position separately from the `Com` that represents the rest.
+Thus, `Γ_in` is the context of the program as a whole, while `Γ_mid` is the context at the
+current position.
+
+While technically the position is in between two let-bindings, by convention we say that the first
+binding of `top : Lets ..` is the current binding of a particular zipper. -/
+structure Zipper (Γ_in : Ctxt d.Ty) (eff : EffectKind) (Γ_mid : Ctxt d.Ty) (ty : d.Ty) where
+  /-- The let-bindings at the top of the zipper -/
+  top : Lets d Γ_in eff Γ_mid
+  /-- The program at the bottom of the zipper -/
+  bot : Com d Γ_mid eff ty
+
+
+-- namespace Zipper
+variable {d}
+
+/-!
+## Denotation
+-/
+section Denote
+variable [TyDenote d.Ty] [DialectDenote d] [Monad d.m]
+
+/-- The denotation of a zipper is a composition of the denotations of the constituent
+`Lets` and `Com` -/
+def Zipper.denote (zip : Zipper d Γ_in eff Γ_out ty) (V_in : Valuation Γ_in) :
+    eff.toMonad d.m ⟦ty⟧ :=
+  (zip.top.denote V_in) >>= zip.bot.denote
+
+@[simp] lemma Zipper.denote_mk {lets : Lets d Γ_in eff Γ_out} {com : Com d Γ_out eff ty} :
+    denote ⟨lets, com⟩ = fun V => (lets.denote V) >>= com.denote := rfl
+
+/-- Casting the intermediate context is not relevant for the denotation -/
+@[simp] lemma Zipper.denoteLets_eqRec_Γ_mid {zip : Zipper d Γ_in eff Γ_mid ty}
+    (h : Γ_mid = Γ_mid') :
+    denote (h ▸ zip) = zip.denote := by
+  subst h; rfl
+
+end Denote
+
+/-!
+## Structural Manipulations
+-/
+
+/-! ### Com Reconstruction -/
+section ToCom
+
+/-- Recombine a zipper into a single program by adding the `lets` to the beginning of the `com` -/
+def Zipper.toCom (zip : Zipper d Γ_in eff Γ_mid ty) : Com d Γ_in eff ty :=
+  go zip.top zip.bot
+  where
+    go : {Γ_mid : _} → Lets d Γ_in eff Γ_mid → Com d Γ_mid eff ty → Com d Γ_in eff ty
+      | _, .nil, com          => com
+      | _, .var body e, com  => go body (.var e com)
+
+@[simp] lemma Zipper.toCom_nil {com : Com d Γ eff ty} : Zipper.toCom ⟨.nil, com⟩ = com := rfl
+@[simp] lemma Zipper.toCom_var {lets : Lets d Γ_in eff Γ_mid} :
+    Zipper.toCom ⟨Lets.var lets e, com⟩ = Zipper.toCom ⟨lets, Com.var e com⟩ := rfl
+
+variable [TyDenote d.Ty] [DialectDenote d] [Monad d.m]
+@[simp] theorem Zipper.denote_toCom [LawfulMonad d.m] (zip : Zipper d Γ_in eff Γ_mid ty) :
+    zip.toCom.denote = zip.denote := by
+  rcases zip with ⟨lets, com⟩
+  funext Γv; induction lets <;> simp [Lets.denote, Zipper.denote, *]
+
+end ToCom
+
+/-! ### Insertion -/
+section InsertCom
+variable [DecidableEq d.Ty]
+
+/-- Add a `Com` directly before the current position of a zipper, while reassigning every
+occurence of a given free variable (`v`) of `zip.com` to the output of the new `Com`  -/
+def Zipper.insertCom (zip : Zipper d Γ_in eff Γ_mid ty) (v : Var Γ_mid newTy)
+    (newCom : Com d Γ_mid eff newTy) : Zipper d Γ_in eff newCom.outContext ty :=
+  let newTop := zip.top.addComToEnd newCom
+  --  ^^^^^^ The combination of the previous `top` with the `newCom` inserted
+  let newBot := zip.bot.changeVars <| newCom.outContextHom.with v newCom.returnVar
+  --  ^^^^^^ Adjust variables in `bot` to the intermediate context of the new zipper --- which is
+  --         `newCom.outContext` --- while also reassigning `v`
+  ⟨newTop, newBot⟩
+
+/-- Add a pure `Com` directly before the current position of a possibly impure
+zipper, while r eassigning every occurence of a given free variable (`v`) of
+`zip.com` to the output of the new `Com`
+
+This is a wrapper around `insertCom` (which expects `newCom` to have the same effect as `zip`)
+and `castPureToEff` -/
+def Zipper.insertPureCom (zip : Zipper d Γ_in eff Γ_mid ty) (v : Var Γ_mid newTy)
+    (newCom : Com d Γ_mid .pure newTy) : Zipper d Γ_in eff newCom.outContext ty :=
+  (by simp : (newCom.castPureToEff eff).outContext = newCom.outContext)
+    ▸ zip.insertCom v (newCom.castPureToEff eff)
+
+/-! simp-lemmas -/
+section Lemmas
+variable [TyDenote d.Ty] [DialectDenote d] [Monad d.m]
+
+theorem Zipper.denote_insertCom {zip : Zipper d Γ_in eff Γ_mid ty₁}
+    {newCom : Com d _ eff newTy} [LawfulMonad d.m] :
+    (zip.insertCom v newCom).denote = (fun (V_in : Valuation Γ_in) => do
+      let V_mid ← zip.top.denote V_in
+      let V_newMid ← newCom.denoteLets V_mid
+      zip.bot.denote
+        (V_newMid.comap <| newCom.outContextHom.with v newCom.returnVar)
+      ) := by
+  funext V
+  simp [insertCom, Com.denoteLets_eq]
+
+theorem Zipper.denote_insertPureCom {zip : Zipper d Γ_in eff Γ_mid ty₁}
+    {newCom : Com d _ .pure newTy} [LawfulMonad d.m] :
+    (zip.insertPureCom v newCom).denote = (fun (V_in : Valuation Γ_in) => do
+      let V_mid ← zip.top.denote V_in
+      zip.bot.denote
+        ((Com.denoteLets newCom V_mid).comap <| newCom.outContextHom.with v newCom.returnVar)
+      ) := by
+  have (V_mid) (h : Com.outContext (Com.castPureToEff eff newCom) = Com.outContext newCom) :
+      ((Com.denoteLets newCom V_mid).comap fun x v => v.castCtxt h).comap
+        (newCom.castPureToEff eff).outContextHom
+      = (Com.denoteLets newCom V_mid).comap newCom.outContextHom := by
+    funext t' ⟨v', hv'⟩
+    simp only [Com.outContextHom, Com.outContextDiff, Com.size_castPureToEff]
+    rfl
+  funext V; simp [insertPureCom, denote_insertCom, Valuation.comap, this]
+
+end Lemmas

--- a/SSA/Core/Framework/Zipper.lean
+++ b/SSA/Core/Framework/Zipper.lean
@@ -8,14 +8,16 @@ open Ctxt (Valuation Var)
 
 variable (d : Dialect) [DialectSignature d]
 
-/-- `Zipper d Γ_in eff Γ_mid ty` represents a particular position in a program, by storing the
+/-- `Zipper d Γ_in eff t` represents a particular position in a program, by storing the
 `Lets` that come before this position separately from the `Com` that represents the rest.
 Thus, `Γ_in` is the context of the program as a whole, while `Γ_mid` is the context at the
 current position.
 
 While technically the position is in between two let-bindings, by convention we say that the first
 binding of `top : Lets ..` is the current binding of a particular zipper. -/
-structure Zipper (Γ_in : Ctxt d.Ty) (eff : EffectKind) (Γ_mid : Ctxt d.Ty) (ty : d.Ty) where
+structure Zipper (Γ_in : Ctxt d.Ty) (eff : EffectKind) (ty : d.Ty) where
+  /-- The context directly after `top` -/
+  {Γ_mid : Ctxt d.Ty}
   /-- The let-bindings at the top of the zipper -/
   top : Lets d Γ_in eff Γ_mid
   /-- The program at the bottom of the zipper -/
@@ -33,18 +35,12 @@ variable [TyDenote d.Ty] [DialectDenote d] [Monad d.m]
 
 /-- The denotation of a zipper is a composition of the denotations of the constituent
 `Lets` and `Com` -/
-def denote (zip : Zipper d Γ_in eff Γ_out ty) (V_in : Valuation Γ_in) :
+def denote (zip : Zipper d Γ_in eff ty) (V_in : Valuation Γ_in) :
     eff.toMonad d.m ⟦ty⟧ :=
   (zip.top.denote V_in) >>= zip.bot.denote
 
 @[simp] lemma denote_mk {lets : Lets d Γ_in eff Γ_out} {com : Com d Γ_out eff ty} :
     denote ⟨lets, com⟩ = fun V => (lets.denote V) >>= com.denote := rfl
-
-/-- Casting the intermediate context is not relevant for the denotation -/
-@[simp] lemma denoteLets_eqRec_Γ_mid {zip : Zipper d Γ_in eff Γ_mid ty}
-    (h : Γ_mid = Γ_mid') :
-    denote (h ▸ zip) = zip.denote := by
-  subst h; rfl
 
 end Denote
 
@@ -54,9 +50,10 @@ end Denote
 
 /-! ### Com Reconstruction -/
 section ToCom
+variable {Γ_mid}
 
 /-- Recombine a zipper into a single program by adding the `lets` to the beginning of the `com` -/
-def toCom (zip : Zipper d Γ_in eff Γ_mid ty) : Com d Γ_in eff ty :=
+def toCom (zip : Zipper d Γ_in eff ty) : Com d Γ_in eff ty :=
   go zip.top zip.bot
   where
     go : {Γ_mid : _} → Lets d Γ_in eff Γ_mid → Com d Γ_mid eff ty → Com d Γ_in eff ty
@@ -68,7 +65,7 @@ def toCom (zip : Zipper d Γ_in eff Γ_mid ty) : Com d Γ_in eff ty :=
     toCom ⟨Lets.var lets e, com⟩ = toCom ⟨lets, Com.var e com⟩ := rfl
 
 variable [TyDenote d.Ty] [DialectDenote d] [Monad d.m]
-@[simp] theorem denote_toCom [LawfulMonad d.m] (zip : Zipper d Γ_in eff Γ_mid ty) :
+@[simp] theorem denote_toCom [LawfulMonad d.m] (zip : Zipper d Γ_in eff ty) :
     zip.toCom.denote = zip.denote := by
   rcases zip with ⟨lets, com⟩
   funext Γv; induction lets <;> simp [Lets.denote, denote, *]
@@ -81,8 +78,8 @@ variable [DecidableEq d.Ty]
 
 /-- Add a `Com` directly before the current position of a zipper, while reassigning every
 occurence of a given free variable (`v`) of `zip.com` to the output of the new `Com`  -/
-def insertCom (zip : Zipper d Γ_in eff Γ_mid ty) (v : Var Γ_mid newTy)
-    (newCom : Com d Γ_mid eff newTy) : Zipper d Γ_in eff newCom.outContext ty :=
+def insertCom (zip : Zipper d Γ_in eff ty) (v : Var zip.Γ_mid newTy)
+    (newCom : Com d zip.Γ_mid eff newTy) : Zipper d Γ_in eff ty :=
   let newTop := zip.top.addComToEnd newCom
   --  ^^^^^^ The combination of the previous `top` with the `newCom` inserted
   let newBot := zip.bot.changeVars <| newCom.outContextHom.with v newCom.returnVar
@@ -96,17 +93,16 @@ zipper, while r eassigning every occurence of a given free variable (`v`) of
 
 This is a wrapper around `insertCom` (which expects `newCom` to have the same effect as `zip`)
 and `castPureToEff` -/
-def insertPureCom (zip : Zipper d Γ_in eff Γ_mid ty) (v : Var Γ_mid newTy)
-    (newCom : Com d Γ_mid .pure newTy) : Zipper d Γ_in eff newCom.outContext ty :=
-  (by simp : (newCom.castPureToEff eff).outContext = newCom.outContext)
-    ▸ zip.insertCom v (newCom.castPureToEff eff)
+def insertPureCom (zip : Zipper d Γ_in eff ty) (v : Var zip.Γ_mid newTy)
+    (newCom : Com d zip.Γ_mid .pure newTy) : Zipper d Γ_in eff ty :=
+  zip.insertCom v (newCom.castPureToEff eff)
 
 /-! simp-lemmas -/
 section Lemmas
 variable [TyDenote d.Ty] [DialectDenote d] [Monad d.m]
 
-theorem denote_insertCom {zip : Zipper d Γ_in eff Γ_mid ty₁}
-    {newCom : Com d _ eff newTy} [LawfulMonad d.m] :
+theorem denote_insertCom {zip : Zipper d Γ_in eff t₁} [LawfulMonad d.m]
+    {newCom : Com d zip.Γ_mid eff newTy} {v : Var zip.Γ_mid _} :
     (zip.insertCom v newCom).denote = (fun (V_in : Valuation Γ_in) => do
       let V_mid ← zip.top.denote V_in
       let V_newMid ← newCom.denoteLets V_mid
@@ -116,8 +112,8 @@ theorem denote_insertCom {zip : Zipper d Γ_in eff Γ_mid ty₁}
   funext V
   simp [insertCom, Com.denoteLets_eq]
 
-theorem denote_insertPureCom {zip : Zipper d Γ_in eff Γ_mid ty₁}
-    {newCom : Com d _ .pure newTy} [LawfulMonad d.m] :
+theorem denote_insertPureCom {zip : Zipper d Γ_in eff t₁} [LawfulMonad d.m]
+    {newCom : Com d zip.Γ_mid .pure newTy} {v : Var zip.Γ_mid _} :
     (zip.insertPureCom v newCom).denote = (fun (V_in : Valuation Γ_in) => do
       let V_mid ← zip.top.denote V_in
       zip.bot.denote

--- a/SSA/Core/Framework/Zipper.lean
+++ b/SSA/Core/Framework/Zipper.lean
@@ -1,4 +1,5 @@
 import SSA.Core.Framework
+import SSA.Core.Transforms.Rewrite.Match
 
 open Ctxt (Valuation Var Hom)
 
@@ -129,6 +130,21 @@ theorem denote_insertPureCom {zip : Zipper d Γ_in eff t₁} [LawfulMonad d.m]
     simp only [Com.outContextHom, Com.outContextDiff, Com.size_castPureToEff]
     rfl
   funext V; simp [insertPureCom, denote_insertCom, Valuation.comap, this]
+
+theorem denote_insertPureCom_eq_of [LawfulMonad d.m]
+    {zip : Zipper d Γ_in eff ty₁} {v}
+    {newCom : Com d zip.Γ_mid _ newTy} {V_in : Valuation Γ_in}
+    (h : ∀ V : zip.top.ValidDenotation, newCom.denote V.val = V.val v) :
+    (zip.insertPureCom v newCom).denote V_in = zip.denote V_in := by
+  simp only [denote_insertPureCom, Valuation.comap_with,
+  Valuation.comap_outContextHom_denoteLets, Com.denoteLets_returnVar_pure]
+  unfold Valuation.reassignVar Zipper.denote
+  simp only [Lets.denote_eq_denoteIntoSubtype, bind_map_left]
+  congr; funext V_mid; congr
+  funext t' v'
+  simp only [dite_eq_right_iff, forall_exists_index]
+  rintro rfl rfl
+  simpa using h _
 
 end Lemmas
 end InsertCom

--- a/SSA/Core/Framework/Zipper.lean
+++ b/SSA/Core/Framework/Zipper.lean
@@ -22,7 +22,7 @@ structure Zipper (Γ_in : Ctxt d.Ty) (eff : EffectKind) (Γ_mid : Ctxt d.Ty) (ty
   bot : Com d Γ_mid eff ty
 
 
--- namespace Zipper
+namespace Zipper
 variable {d}
 
 /-!
@@ -33,15 +33,15 @@ variable [TyDenote d.Ty] [DialectDenote d] [Monad d.m]
 
 /-- The denotation of a zipper is a composition of the denotations of the constituent
 `Lets` and `Com` -/
-def Zipper.denote (zip : Zipper d Γ_in eff Γ_out ty) (V_in : Valuation Γ_in) :
+def denote (zip : Zipper d Γ_in eff Γ_out ty) (V_in : Valuation Γ_in) :
     eff.toMonad d.m ⟦ty⟧ :=
   (zip.top.denote V_in) >>= zip.bot.denote
 
-@[simp] lemma Zipper.denote_mk {lets : Lets d Γ_in eff Γ_out} {com : Com d Γ_out eff ty} :
+@[simp] lemma denote_mk {lets : Lets d Γ_in eff Γ_out} {com : Com d Γ_out eff ty} :
     denote ⟨lets, com⟩ = fun V => (lets.denote V) >>= com.denote := rfl
 
 /-- Casting the intermediate context is not relevant for the denotation -/
-@[simp] lemma Zipper.denoteLets_eqRec_Γ_mid {zip : Zipper d Γ_in eff Γ_mid ty}
+@[simp] lemma denoteLets_eqRec_Γ_mid {zip : Zipper d Γ_in eff Γ_mid ty}
     (h : Γ_mid = Γ_mid') :
     denote (h ▸ zip) = zip.denote := by
   subst h; rfl
@@ -56,22 +56,22 @@ end Denote
 section ToCom
 
 /-- Recombine a zipper into a single program by adding the `lets` to the beginning of the `com` -/
-def Zipper.toCom (zip : Zipper d Γ_in eff Γ_mid ty) : Com d Γ_in eff ty :=
+def toCom (zip : Zipper d Γ_in eff Γ_mid ty) : Com d Γ_in eff ty :=
   go zip.top zip.bot
   where
     go : {Γ_mid : _} → Lets d Γ_in eff Γ_mid → Com d Γ_mid eff ty → Com d Γ_in eff ty
       | _, .nil, com          => com
       | _, .var body e, com  => go body (.var e com)
 
-@[simp] lemma Zipper.toCom_nil {com : Com d Γ eff ty} : Zipper.toCom ⟨.nil, com⟩ = com := rfl
-@[simp] lemma Zipper.toCom_var {lets : Lets d Γ_in eff Γ_mid} :
-    Zipper.toCom ⟨Lets.var lets e, com⟩ = Zipper.toCom ⟨lets, Com.var e com⟩ := rfl
+@[simp] lemma toCom_nil {com : Com d Γ eff ty} : toCom ⟨.nil, com⟩ = com := rfl
+@[simp] lemma toCom_var {lets : Lets d Γ_in eff Γ_mid} :
+    toCom ⟨Lets.var lets e, com⟩ = toCom ⟨lets, Com.var e com⟩ := rfl
 
 variable [TyDenote d.Ty] [DialectDenote d] [Monad d.m]
-@[simp] theorem Zipper.denote_toCom [LawfulMonad d.m] (zip : Zipper d Γ_in eff Γ_mid ty) :
+@[simp] theorem denote_toCom [LawfulMonad d.m] (zip : Zipper d Γ_in eff Γ_mid ty) :
     zip.toCom.denote = zip.denote := by
   rcases zip with ⟨lets, com⟩
-  funext Γv; induction lets <;> simp [Lets.denote, Zipper.denote, *]
+  funext Γv; induction lets <;> simp [Lets.denote, denote, *]
 
 end ToCom
 
@@ -81,7 +81,7 @@ variable [DecidableEq d.Ty]
 
 /-- Add a `Com` directly before the current position of a zipper, while reassigning every
 occurence of a given free variable (`v`) of `zip.com` to the output of the new `Com`  -/
-def Zipper.insertCom (zip : Zipper d Γ_in eff Γ_mid ty) (v : Var Γ_mid newTy)
+def insertCom (zip : Zipper d Γ_in eff Γ_mid ty) (v : Var Γ_mid newTy)
     (newCom : Com d Γ_mid eff newTy) : Zipper d Γ_in eff newCom.outContext ty :=
   let newTop := zip.top.addComToEnd newCom
   --  ^^^^^^ The combination of the previous `top` with the `newCom` inserted
@@ -96,7 +96,7 @@ zipper, while r eassigning every occurence of a given free variable (`v`) of
 
 This is a wrapper around `insertCom` (which expects `newCom` to have the same effect as `zip`)
 and `castPureToEff` -/
-def Zipper.insertPureCom (zip : Zipper d Γ_in eff Γ_mid ty) (v : Var Γ_mid newTy)
+def insertPureCom (zip : Zipper d Γ_in eff Γ_mid ty) (v : Var Γ_mid newTy)
     (newCom : Com d Γ_mid .pure newTy) : Zipper d Γ_in eff newCom.outContext ty :=
   (by simp : (newCom.castPureToEff eff).outContext = newCom.outContext)
     ▸ zip.insertCom v (newCom.castPureToEff eff)
@@ -105,7 +105,7 @@ def Zipper.insertPureCom (zip : Zipper d Γ_in eff Γ_mid ty) (v : Var Γ_mid ne
 section Lemmas
 variable [TyDenote d.Ty] [DialectDenote d] [Monad d.m]
 
-theorem Zipper.denote_insertCom {zip : Zipper d Γ_in eff Γ_mid ty₁}
+theorem denote_insertCom {zip : Zipper d Γ_in eff Γ_mid ty₁}
     {newCom : Com d _ eff newTy} [LawfulMonad d.m] :
     (zip.insertCom v newCom).denote = (fun (V_in : Valuation Γ_in) => do
       let V_mid ← zip.top.denote V_in
@@ -116,7 +116,7 @@ theorem Zipper.denote_insertCom {zip : Zipper d Γ_in eff Γ_mid ty₁}
   funext V
   simp [insertCom, Com.denoteLets_eq]
 
-theorem Zipper.denote_insertPureCom {zip : Zipper d Γ_in eff Γ_mid ty₁}
+theorem denote_insertPureCom {zip : Zipper d Γ_in eff Γ_mid ty₁}
     {newCom : Com d _ .pure newTy} [LawfulMonad d.m] :
     (zip.insertPureCom v newCom).denote = (fun (V_in : Valuation Γ_in) => do
       let V_mid ← zip.top.denote V_in
@@ -133,3 +133,4 @@ theorem Zipper.denote_insertPureCom {zip : Zipper d Γ_in eff Γ_mid ty₁}
   funext V; simp [insertPureCom, denote_insertCom, Valuation.comap, this]
 
 end Lemmas
+end InsertCom

--- a/SSA/Core/Framework/Zipper.lean
+++ b/SSA/Core/Framework/Zipper.lean
@@ -1,10 +1,12 @@
 import SSA.Core.Framework
 
-open Ctxt (Valuation Var)
+open Ctxt (Valuation Var Hom)
 
 /-!
 # Zipper
 -/
+
+/-! ## Zipper Definition -/
 
 variable (d : Dialect) [DialectSignature d]
 
@@ -23,7 +25,7 @@ structure Zipper (Γ_in : Ctxt d.Ty) (eff : EffectKind) (ty : d.Ty) where
   /-- The program at the bottom of the zipper -/
   bot : Com d Γ_mid eff ty
 
-
+/-! ## Zipper API -/
 namespace Zipper
 variable {d}
 
@@ -80,12 +82,12 @@ variable [DecidableEq d.Ty]
 occurence of a given free variable (`v`) of `zip.com` to the output of the new `Com`  -/
 def insertCom (zip : Zipper d Γ_in eff ty) (v : Var zip.Γ_mid newTy)
     (newCom : Com d zip.Γ_mid eff newTy) : Zipper d Γ_in eff ty :=
-  let newTop := zip.top.addComToEnd newCom
-  --  ^^^^^^ The combination of the previous `top` with the `newCom` inserted
-  let newBot := zip.bot.changeVars <| newCom.outContextHom.with v newCom.returnVar
-  --  ^^^^^^ Adjust variables in `bot` to the intermediate context of the new zipper --- which is
+  let top := zip.top.addComToEnd newCom
+  --  ^^^ The combination of the previous `top` with the `newCom` inserted
+  let bot := zip.bot.changeVars <| newCom.outContextHom.with v newCom.returnVar
+  --  ^^^ Adjust variables in `bot` to the intermediate context of the new zipper --- which is
   --         `newCom.outContext` --- while also reassigning `v`
-  ⟨newTop, newBot⟩
+  { top, bot }
 
 /-- Add a pure `Com` directly before the current position of a possibly impure
 zipper, while r eassigning every occurence of a given free variable (`v`) of

--- a/SSA/Core/Transforms/Rewrite/Rewrite.lean
+++ b/SSA/Core/Transforms/Rewrite/Rewrite.lean
@@ -1,4 +1,5 @@
 import SSA.Core.Framework
+import SSA.Core.Framework.Zipper
 import SSA.Core.Transforms.Rewrite.Match
 
 /-!


### PR DESCRIPTION
This PR moves the `Zipper` file to a separate file, cleans up the API, and then defines a new `SplitProgramResult` type, which extends `Zipper`, to replace the ad-hoc large sigma `splitProgramAt` used to return.