### PR TITLE
chore: add `core` build target to lakefile.toml

### DIFF
--- a/lakefile.toml
+++ b/lakefile.toml
@@ -57,3 +57,7 @@ root = "SSA.Projects.InstCombine.LLVM.Enumerator"
 [[lean_lib]]
 name = "Tests"
 root = "SSA.Tests.Tests"
+
+[[lean_lib]]
+name = "core"
+roots = ["SSA.Core"]


### PR DESCRIPTION
This makes it easier to build just the core framework (by running `lake build core`)