### PR TITLE
chore:Multi-width Arithmetic Relations (slt, ult, sle, ule, neq)

### DIFF
--- a/SSA/Experimental/Bits/MultiWidth/GoodFSM.lean
+++ b/SSA/Experimental/Bits/MultiWidth/GoodFSM.lean
@@ -842,7 +842,7 @@ def fsmTermEq {wcard tcard : Nat}
 def mkPredicateFSMAux (wcard tcard : Nat) (p : Nondep.Predicate) :
   (PredicateFSM wcard tcard p) :=
   match p with
-  | .binRel .eq a b =>
+  | .tbinRel .eq a b =>
     let fsmA := mkTermFSM wcard tcard a
     let fsmB := mkTermFSM wcard tcard b
     { toFsm := fsmTermEq fsmA fsmB }
@@ -961,6 +961,28 @@ def isGoodPredicateFSM_mkPredicateFSMAux {wcard tcard : Nat}
         have := congrFun h i
         simp at this
         simp [this]
+  case not p hp =>
+    constructor
+    simp [mkPredicateFSMAux, Nondep.Predicate.ofDep]
+    intros wenv tenv fsmEnv htenv
+    simp [Predicate.toProp]
+    rw [hp.heq (henv := htenv)]
+    constructor
+    · intros h
+      ext i
+      rw [BitStream.scanOr_eq_decide]
+      rw [← ne_eq, Function.ne_iff] at h
+      simp
+      sorry
+    · intros h
+      simp at h ⊢
+      apply Function.ne_iff .. |>.mpr
+      have := fun ix => congrFun h ix
+      simp [BitStream.scanOr_eq_decide] at this
+      specialize this 0
+      obtain ⟨i, hi⟩ := this
+      exists i
+      simp [hi]
 
 /-- Negate the FSM so we can decide if zeroes. -/
 def mkPredicateFSMNondep (wcard tcard : Nat) (p : Nondep.Predicate) :

--- a/SSA/Experimental/Bits/MultiWidth/Tactic.lean
+++ b/SSA/Experimental/Bits/MultiWidth/Tactic.lean
@@ -431,7 +431,7 @@ partial def collectBVPredicateAux (state : CollectState) (e : Expr) :
       let (_w, state) ← collectWidthAtom state w
       let (ta, state) ← collectTerm state a
       let (tb, state) ← collectTerm state b
-      return (.binRel .eq ta tb, state)
+      return (tbinRel .eq ta tb, state)
     | _ => throwError m!"expected bitvector equality, found: {indentD e}"
   | Or p q =>
     let (ta, state) ← collectBVPredicateAux state p
@@ -444,7 +444,7 @@ partial def collectBVPredicateAux (state : CollectState) (e : Expr) :
 info: MultiWidth.Predicate.binRel {wcard tcard : ℕ} {ctx : Term.Ctx wcard tcard} (k : BinaryRelationKind)
   (w : WidthExpr wcard) (a b : Term ctx w) : Predicate ctx
 -/
-#guard_msgs in #check MultiWidth.Predicate.binRel
+#guard_msgs in #check tbinRel
 
 /--
 info: MultiWidth.Predicate.or {wcard tcard : ℕ} {ctx : Term.Ctx wcard tcard} (p1 p2 : Predicate ctx) : Predicate ctx
@@ -454,7 +454,7 @@ info: MultiWidth.Predicate.or {wcard tcard : ℕ} {ctx : Term.Ctx wcard tcard} (
 def Expr.mkPredicateExpr (wcard tcard : Nat) (tctx : Expr)
     (p : MultiWidth.Nondep.Predicate) : SolverM Expr := do
   match p with
-  | .binRel .eq a b =>
+  | tbinRel .eq a b =>
     let w := a.width
     let wExpr ← mkWidthExpr wcard w
     let aExpr ← mkTermExpr wcard tcard tctx a


### PR DESCRIPTION
This completes our support for the arithmetic fragment. I realized that `neq` is more nontrivial than I originally thought due to a change in encoding. 