### PR TITLE
chore: remove unnecessary maxHeartBeats from RV64 semantics

### DIFF
--- a/SSA/Projects/RISCV64/Semantics.lean
+++ b/SSA/Projects/RISCV64/Semantics.lean
@@ -1,7 +1,6 @@
 import SSA.Core.MLIRSyntax.EDSL
 import SSA.Projects.InstCombine.ForLean
 import SSA.Projects.RISCV64.Tactic.SimpRiscVAttr
-set_option maxHeartbeats 1000000000000000000
 
 open BitVec
 /-!


### PR DESCRIPTION
This maxHeartBeats setting was unneccessary and should consequently be removed.