### PR TITLE
chore: ignore '.ruff_cache' throughout the repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@ test-semantics/*.llvm
 lakefile.olean
 .lake/
 SSA/Projects/InstCombine/tests/logs/generalizer
+
+**/.ruff_cache


### PR DESCRIPTION
This idea comes from Sarah's branch.