### PR TITLE
Only run evaluation on 'main'

### DIFF
--- a/.github/workflows/evaluation.yml
+++ b/.github/workflows/evaluation.yml
@@ -3,11 +3,9 @@ on:
   push:
     branches:
       - "main"
-  pull_request:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
 
 permissions:
   contents: write


### PR DESCRIPTION
Our evaluation is currently to slow to run on all pushes. Let's run it on master only to make sure the red crosses do not add unnecessary noise.