### PR TITLE
chore: refine options for large Op inductive in RISCV64

### DIFF
--- a/SSA/Projects/RISCV64/Base.lean
+++ b/SSA/Projects/RISCV64/Base.lean
@@ -1,11 +1,5 @@
 import SSA.Projects.RISCV64.Semantics
 import SSA.Core.Framework
-/- This file has a number of very large inductive types, which seem to cause Lean to run out of heartbeats.
-We avoid the issue by increasing the heartbeats. Since this applies to most inductives in this file, we do so globally.
-Additionally, this file contains definitions that match on these large inductive types. These also causes Lean to require
-more heartbeats.  -/
-set_option maxHeartbeats 1000000000000000000
-set_option maxRecDepth 10000000000000
 
 open RV64Semantics
 
@@ -13,6 +7,10 @@ namespace RISCV64
 /-! ## The `RISCV64` dialect -/
 
 /-! ## Dialect operation definitions -/
+
+-- Options needed for `Deriving DecidableEQ` on large inductives:
+set_option maxHeartbeats 1000000000000000000 in
+set_option maxRecDepth 10000000000000 in
 /--
 `Op` models the RV64I base instruction set [1] plus selected RISC-V ISA extensions:
 `M` for standard integer division and multiplication [2],

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -2,6 +2,7 @@ name = "SSA"
 # precompileModules = true # Ensure that reflective code that uses native_decide runs compiled code, not in the ir_interpreter.
 defaultTargets = ["SSA"]
 moreLeanArgs = ["--tstack=400000"]
+moreServerArgs = ["--tstack=400000"]
 
 [[require]]
 name = "mathlib"


### PR DESCRIPTION
Given that there is only one inductive that needs more heartbeats and recursion depth, this change moves to a local `set_option ... in`.

In preparation of upcoming changes, we also increase the stack-space usage of the lean server to avoid crashes of VScode as we will add more constructors to the inductive.