### PR TITLE
chore: remove riscv.mulu

### DIFF
--- a/SSA/Projects/RISCV64/Base.lean
+++ b/SSA/Projects/RISCV64/Base.lean
@@ -61,7 +61,6 @@ inductive Op
   | sltu
   -- RISC-V `M` extension instructions (multiply & divide)
   | mul    -- performs signed multiplication on 64 x 64 bits and returns the lower 64 bits of the result .
-  | mulu   -- performs unsigned multiplication on 64 x 64 bits and returns the lower 64 bits of the result .
   | mulw
   | mulh   -- performs signed multiplication on 64 x 64 bits and returns the upper 64 bits of the result.
   | mulhu  -- performs unsigned multiplication on 64 x 64 bits and returns the upper 64 bits of the result.
@@ -150,7 +149,6 @@ encounters a `sig` it can replace it by its definition.
 @[simp, reducible]
 def Op.sig : Op → List Ty
   | .li _ => []
-  | .mulu  => [Ty.bv, Ty.bv]
   | .mulh  => [Ty.bv, Ty.bv]
   | .mulhu  => [Ty.bv, Ty.bv]
   | .mulhsu  => [Ty.bv, Ty.bv]
@@ -226,7 +224,6 @@ Again, we mark  it as `simp` and `reducible`.
 @[simp, reducible]
 def Op.outTy : Op  → Ty
   | .li _ => Ty.bv
-  | .mulu => Ty.bv
   | .mulh => Ty.bv
   | .mulhu => Ty.bv
   | .mulhsu => Ty.bv
@@ -314,7 +311,6 @@ instance : DialectSignature RV64 := ⟨Op.signature⟩
 def opToString (op : RISCV64.Op) : String :=
   let op  : String := match op with
   | .li imm => s! "li \{immediate = { imm.toInt } : i20 }"
-  | .mulu => "mulu"
   | .mulh => "mulh"
   | .mulhu => "mulhu"
   | .mulhsu => "mulhsu"
@@ -429,7 +425,6 @@ instance : DialectDenote (RV64) where
   | .remuw, regs, _ => UNSIGNED_pure64_REMW_bv (regs.getN 1 (by simp [DialectSignature.sig, signature]))  (regs.getN 0 (by simp [DialectSignature.sig, signature]))
   | .rem, regs, _ => SIGNED_pure64_REM_bv (regs.getN 1 (by simp [DialectSignature.sig, signature]))  (regs.getN 0 (by simp [DialectSignature.sig, signature]))
   | .remu, regs, _ => UNSIGNED_pure64_REM_bv (regs.getN 1 (by simp [DialectSignature.sig, signature]))  (regs.getN 0 (by simp [DialectSignature.sig, signature]))
-  | .mulu, regs, _ => pure64_MUL_bv_fff (regs.getN 1 (by simp [DialectSignature.sig, signature]))  (regs.getN 0 (by simp [DialectSignature.sig, signature]))
   | .mulhu,regs, _ => pure64_MUL_bv_tff (regs.getN 1 (by simp [DialectSignature.sig, signature]))  (regs.getN 0 (by simp [DialectSignature.sig, signature]))
   | .mul ,regs, _ => pure64_MUL_ftt (regs.getN 1 (by simp [DialectSignature.sig, signature]))  (regs.getN 0 (by simp [DialectSignature.sig, signature]))
   | .mulhsu ,regs, _ => pure64_MUL_bv_ttf (regs.getN 1 (by simp [DialectSignature.sig, signature]))  (regs.getN 0 (by simp [DialectSignature.sig, signature]))

--- a/SSA/Projects/RISCV64/Syntax.lean
+++ b/SSA/Projects/RISCV64/Syntax.lean
@@ -454,10 +454,6 @@ def mkExpr (Γ : Ctxt _) (opStx : MLIR.AST.Op 0) :
             return ⟨ .pure, .bv ,⟨ .mul, by rfl, by constructor,
                .cons v₁ <| .cons v₂ <| .nil,
                 .nil⟩⟩
-      | .bv , .bv , "mulu" =>
-            return ⟨ .pure, .bv ,⟨ .mulu, by rfl, by constructor,
-               .cons v₁ <| .cons v₂ <| .nil,
-                .nil⟩⟩
       | .bv , .bv , "mulh" =>
             return ⟨ .pure, .bv ,⟨ .mulh, by rfl, by constructor,
                .cons v₁ <| .cons v₂ <| .nil,


### PR DESCRIPTION
The RISCV isa does not have a `mulu` instruction. Hence, having this instruction in our definitions was an oversight. To align our dialect with RISCV we remove this instruction.