### PR TITLE
chore: add attributes for RISCV slli.uw

### DIFF
--- a/SSA/Projects/RISCV64/Base.lean
+++ b/SSA/Projects/RISCV64/Base.lean
@@ -404,6 +404,7 @@ def attributesToPrint: RISCV64.Op → String
   | .bexti (_shamt : BitVec 6) =>s!"\{immediate = { _shamt.toInt} : i6 }"
   | .binvi (_shamt : BitVec 6) => s!"\{immediate = { _shamt.toInt} : i6 }"
   | .bseti (_shamt : BitVec 6) => s!"\{immediate = { _shamt.toInt} : i6 }"
+  | RISCV64.Op.slli.uw (_shamt : BitVec 6) => s!"\{immediate = { _shamt.toInt} : i6 }"
   | _ => ""
 
 instance : ToString (Op) where


### PR DESCRIPTION
This was forgotten in ba2bd1f544abdbebacfa10f62c9b3c39da7e61b6.