### PR TITLE
feat: add RISCV-64 ZBB operations and their semantics

### DIFF
--- a/SSA/Projects/RISCV64/Base.lean
+++ b/SSA/Projects/RISCV64/Base.lean
@@ -249,6 +249,8 @@ def Op.sig : Op → List Ty
   | rori (_shamt : BitVec 5) =>[Ty.bv]
   | roriw (_shamt : BitVec 5) =>[Ty.bv]
   | .rorw => [Ty.bv, Ty.bv]
+  -- orc.b
+  -- rev8
 
 /--
 Specifing the `outTy` of each `RISCV64` operation.
@@ -341,6 +343,8 @@ def Op.outTy : Op  → Ty
   | .rori (_shamt : BitVec 5) => Ty.bv
   | .roriw (_shamt : BitVec 5) => Ty.bv
   | .rorw => Ty.bv
+  -- orc.b
+  -- rev8
 
 /-- Combine `outTy` and `sig` together into a `Signature`. -/
 @[simp, reducible]
@@ -444,7 +448,8 @@ def opToString (op : RISCV64.Op) : String :=
   | .rori (_shamt : BitVec 5) => "rori"
   | .roriw (_shamt : BitVec 5) => "roriw"
   | .rorw => "rorw"
-
+  -- orc.b
+  -- rev8
 
   s!"\"riscv.{op}\""
 
@@ -582,6 +587,7 @@ instance : DialectDenote (RV64) where
   | .rori shamt, regs, _ => ZBB_pure64_RISCV_RORI shamt (regs.getN 0 (by simp [DialectSignature.sig, signature]))
   | .roriw shamt, regs, _ => ZBB_pure64_RISCV_RORIW shamt (regs.getN 0 (by simp [DialectSignature.sig, signature]))
   | .rorw, regs, _ => ZBB_RTYPEW_pure64_RISCV_RORW (regs.getN 1 (by simp [DialectSignature.sig, signature]))  (regs.getN 0 (by simp [DialectSignature.sig, signature]))
-
+  -- orc.b
+  -- rev8
 
 end RISCV64

--- a/SSA/Projects/RISCV64/Base.lean
+++ b/SSA/Projects/RISCV64/Base.lean
@@ -83,13 +83,30 @@ inductive Op
   | sh3add
   | slli.uw (shamt : BitVec 6)
   -- part of the RISC-V `Zbb` & `Zbkb` extension
-  | rol
-  | ror
-  | rolw
-  | rorw
+  | andn
+  | orn
+  | xnor
+  -- | clz
+  -- | clzw
+  -- | ctz
+  -- | ctzw
+  -- | cpop
+  -- | cpopw
+  | max
+  | maxu
+  | min
+  | minu
   | sext.b
   | sext.h
   | zext.h
+  | rol
+  | rolw
+  | ror
+  | rori (_shamt : BitVec 5)
+  | roriw (_shamt : BitVec 5)
+  | rorw
+  -- | orc.b
+  -- | rev8
   /-
   in the future:
   |pack
@@ -153,8 +170,6 @@ def Op.sig : Op → List Ty
   | .mulhu  => [Ty.bv, Ty.bv]
   | .mulhsu  => [Ty.bv, Ty.bv]
   | .divu =>  [Ty.bv, Ty.bv]
-  | .rol => [Ty.bv, Ty.bv]
-  | .ror => [Ty.bv, Ty.bv]
   | .remuw  => [Ty.bv, Ty.bv]
   | .remu  =>  [Ty.bv, Ty.bv]
   | .addiw (_imm : BitVec 12) => [Ty.bv]
@@ -196,9 +211,6 @@ def Op.sig : Op → List Ty
   | .xori (_imm : BitVec 12) => [Ty.bv]
   | RISCV64.Op.czero.eqz =>  [Ty.bv, Ty.bv]
   | RISCV64.Op.czero.nez =>  [Ty.bv, Ty.bv]
-  | RISCV64.Op.sext.b => [Ty.bv]
-  | RISCV64.Op.sext.h => [Ty.bv]
-  | RISCV64.Op.zext.h => [Ty.bv]
   | .bclr => [Ty.bv, Ty.bv]
   | .bext => [Ty.bv, Ty.bv]
   | .binv => [Ty.bv, Ty.bv]
@@ -207,8 +219,6 @@ def Op.sig : Op → List Ty
   | .bexti (_shamt : BitVec 6) => [Ty.bv]
   | .binvi (_shamt : BitVec 6) => [Ty.bv]
   | .bseti (_shamt : BitVec 6) => [Ty.bv]
-  | .rolw => [Ty.bv, Ty.bv]
-  | .rorw => [Ty.bv, Ty.bv]
   | RISCV64.Op.add.uw => [Ty.bv, Ty.bv]
   | RISCV64.Op.sh1add.uw => [Ty.bv, Ty.bv]
   | RISCV64.Op.sh2add.uw => [Ty.bv, Ty.bv]
@@ -217,6 +227,28 @@ def Op.sig : Op → List Ty
   | .sh2add => [Ty.bv, Ty.bv]
   | .sh3add => [Ty.bv, Ty.bv]
   | RISCV64.Op.slli.uw (_shamt : BitVec 6) => [Ty.bv]
+  | andn => [Ty.bv, Ty.bv]
+  | orn => [Ty.bv, Ty.bv]
+  | xnor => [Ty.bv, Ty.bv]
+  -- | clz
+  -- | clzw
+  -- | ctz
+  -- | ctzw
+  -- | cpop
+  -- | cpopw
+  | max => [Ty.bv, Ty.bv]
+  | maxu => [Ty.bv, Ty.bv]
+  | min  => [Ty.bv, Ty.bv]
+  | minu  => [Ty.bv, Ty.bv]
+  | RISCV64.Op.sext.b => [Ty.bv]
+  | RISCV64.Op.sext.h => [Ty.bv]
+  | RISCV64.Op.zext.h => [Ty.bv]
+  | .rol => [Ty.bv, Ty.bv]
+  | .rolw => [Ty.bv, Ty.bv]
+  | .ror => [Ty.bv, Ty.bv]
+  | rori (_shamt : BitVec 5) =>[Ty.bv]
+  | roriw (_shamt : BitVec 5) =>[Ty.bv]
+  | .rorw => [Ty.bv, Ty.bv]
 
 /--
 Specifing the `outTy` of each `RISCV64` operation.
@@ -229,8 +261,7 @@ def Op.outTy : Op  → Ty
   | .mulhu => Ty.bv
   | .mulhsu => Ty.bv
   | .divu => Ty.bv
-  | .rol => Ty.bv
-  | .ror => Ty.bv
+
   | .remuw => Ty.bv
   | .remu =>  Ty.bv
   | .addiw (_imm : BitVec 12) => Ty.bv
@@ -272,9 +303,6 @@ def Op.outTy : Op  → Ty
   | .xori (_imm : BitVec 12) => Ty.bv
   | RISCV64.Op.czero.eqz => Ty.bv
   | RISCV64.Op.czero.nez => Ty.bv
-  | RISCV64.Op.sext.b => Ty.bv
-  | RISCV64.Op.sext.h => Ty.bv
-  | RISCV64.Op.zext.h => Ty.bv
   | .bclr => Ty.bv
   | .bext => Ty.bv
   | .binv => Ty.bv
@@ -283,8 +311,6 @@ def Op.outTy : Op  → Ty
   | .bexti (_shamt : BitVec 6) => Ty.bv
   | .binvi (_shamt : BitVec 6) => Ty.bv
   | .bseti (_shamt : BitVec 6) => Ty.bv
-  | .rolw => Ty.bv
-  | .rorw => Ty.bv
   | RISCV64.Op.add.uw => Ty.bv
   | RISCV64.Op.sh1add.uw => Ty.bv
   | RISCV64.Op.sh2add.uw => Ty.bv
@@ -293,6 +319,28 @@ def Op.outTy : Op  → Ty
   | .sh2add => Ty.bv
   | .sh3add => Ty.bv
   | RISCV64.Op.slli.uw (_shamt : BitVec 6) => Ty.bv
+  | .andn =>  Ty.bv
+  | .orn =>  Ty.bv
+  | .xnor =>  Ty.bv
+  -- | clz
+  -- | clzw
+  -- | ctz
+  -- | ctzw
+  -- | cpop
+  -- | cpopw
+  | .max =>  Ty.bv
+  | .maxu =>  Ty.bv
+  | .min  =>  Ty.bv
+  | .minu  =>  Ty.bv
+  | RISCV64.Op.sext.b => Ty.bv
+  | RISCV64.Op.sext.h => Ty.bv
+  | RISCV64.Op.zext.h => Ty.bv
+  | .rol => Ty.bv
+  | .rolw => Ty.bv
+  | .ror => Ty.bv
+  | .rori (_shamt : BitVec 5) => Ty.bv
+  | .roriw (_shamt : BitVec 5) => Ty.bv
+  | .rorw => Ty.bv
 
 /-- Combine `outTy` and `sig` together into a `Signature`. -/
 @[simp, reducible]
@@ -317,8 +365,6 @@ def opToString (op : RISCV64.Op) : String :=
   | .mulhu => "mulhu"
   | .mulhsu => "mulhsu"
   | .divu => "divu"
-  | .rol => "rol"
-  | .ror => "ror"
   | .remuw => "remuw"
   | .remu => "remu"
   | .addiw (_imm : BitVec 12) => "addiw"
@@ -360,9 +406,6 @@ def opToString (op : RISCV64.Op) : String :=
   | .xori (_imm : BitVec 12) => "xori"
   | RISCV64.Op.czero.eqz => "czero.eqz"
   | RISCV64.Op.czero.nez => "czero.nez"
-  | RISCV64.Op.sext.b => "sext.b"
-  | RISCV64.Op.sext.h => "sext.h"
-  | RISCV64.Op.zext.h => "zext.h"
   | .bclr => "bclr"
   | .bext => "bext"
   | .binv => "binv"
@@ -371,8 +414,6 @@ def opToString (op : RISCV64.Op) : String :=
   | .bexti (_shamt : BitVec 6) => "bexti"
   | .binvi (_shamt : BitVec 6) => "binvi"
   | .bseti (_shamt : BitVec 6) => "bseti"
-  | .rolw => "rolw"
-  | .rorw => "rorw"
   | RISCV64.Op.add.uw => "add.uw"
   | RISCV64.Op.sh1add.uw => "sh1add.uw"
   | RISCV64.Op.sh2add.uw => "sh2add.uw"
@@ -381,6 +422,30 @@ def opToString (op : RISCV64.Op) : String :=
   | .sh2add => "sh2add"
   | .sh3add => "sh3add"
   | RISCV64.Op.slli.uw (_shamt : BitVec 6) => "slli.uw"
+  | .andn => "andn"
+  | .orn => "orn"
+  | .xnor => "xnor"
+  -- | clz
+  -- | clzw
+  -- | ctz
+  -- | ctzw
+  -- | cpop
+  -- | cpopw
+  | .max => "max"
+  | .maxu => "maxu"
+  | .min  => "min"
+  | .minu  => "minu"
+  | RISCV64.Op.sext.b => "sext.b"
+  | RISCV64.Op.sext.h => "sext.h"
+  | RISCV64.Op.zext.h => "zext.h"
+  | .rol => "rol"
+  | .rolw => "rolw"
+  | .ror => "ror"
+  | .rori (_shamt : BitVec 5) => "rori"
+  | .roriw (_shamt : BitVec 5) => "roriw"
+  | .rorw => "rorw"
+
+
   s!"\"riscv.{op}\""
 
 def attributesToPrint: RISCV64.Op → String
@@ -404,6 +469,8 @@ def attributesToPrint: RISCV64.Op → String
   | .bexti (_shamt : BitVec 6) =>s!"\{immediate = { _shamt.toInt} : i6 }"
   | .binvi (_shamt : BitVec 6) => s!"\{immediate = { _shamt.toInt} : i6 }"
   | .bseti (_shamt : BitVec 6) => s!"\{immediate = { _shamt.toInt} : i6 }"
+  | .rori (_shamt : BitVec 5) => s!"\{immediate = { _shamt.toInt} : i5 }"
+  | .roriw (_shamt : BitVec 5) => s!"\{immediate = { _shamt.toInt} : i5 }"
   | _ => ""
 
 instance : ToString (Op) where
@@ -477,9 +544,6 @@ instance : DialectDenote (RV64) where
   | .xori imm, reg, _ => ITYPE_pure64_RISCV_XORI  imm (reg.getN 0 (by simp [DialectSignature.sig, signature]))
   | RISCV64.Op.czero.eqz, regs, _ => ZICOND_RTYPE_pure64_RISCV_CZERO_EQZ (regs.getN 1 (by simp [DialectSignature.sig, signature]))  (regs.getN 0 (by simp [DialectSignature.sig, signature]))
   | RISCV64.Op.czero.nez, regs, _ => ZICOND_RTYPE_pure64_RISCV_CZERO_NEZ (regs.getN 1 (by simp [DialectSignature.sig, signature]))  (regs.getN 0 (by simp [DialectSignature.sig, signature]))
-  | RISCV64.Op.sext.b, reg, _ => ZBB_EXTOP_pure64_RISCV_SEXTB (reg.getN 0 (by simp [DialectSignature.sig, signature]))
-  | RISCV64.Op.sext.h, reg, _ => ZBB_EXTOP_pure64_RISCV_SEXTH (reg.getN 0 (by simp [DialectSignature.sig, signature]))
-  | RISCV64.Op.zext.h, reg, _ => ZBB_EXTOP_pure64_RISCV_ZEXTH (reg.getN 0 (by simp [DialectSignature.sig, signature]))
   | .bclr, regs, _ => ZBS_RTYPE_pure64_RISCV_BCLR_bv (regs.getN 1 (by simp [DialectSignature.sig, signature]))  (regs.getN 0 (by simp [DialectSignature.sig, signature]))
   | .bext, regs, _ => ZBS_RTYPE_pure64_RISCV_BEXT_bv (regs.getN 1 (by simp [DialectSignature.sig, signature]))  (regs.getN 0 (by simp [DialectSignature.sig, signature]))
   | .binv, regs, _ => ZBS_RTYPE_pure64_BINV_bv (regs.getN 1 (by simp [DialectSignature.sig, signature]))  (regs.getN 0 (by simp [DialectSignature.sig, signature]))
@@ -488,10 +552,6 @@ instance : DialectDenote (RV64) where
   | .bexti shamt, reg, _ => ZBS_IOP_pure64_RISCV_BEXTI_bv shamt (reg.getN 0 (by simp [DialectSignature.sig, signature]))
   | .binvi shamt, reg, _ => ZBS_IOP_pure64_RISCV_BINVI_bv shamt (reg.getN 0 (by simp [DialectSignature.sig, signature]))
   | .bseti shamt, reg, _ => ZBS_IOP_pure64_RISCV_BSETI_bv shamt (reg.getN 0 (by simp [DialectSignature.sig, signature]))
-  | .rolw, regs, _ => ZBB_RTYPEW_pure64_RISCV_ROLW (regs.getN 1 (by simp [DialectSignature.sig, signature]))  (regs.getN 0 (by simp [DialectSignature.sig, signature]))
-  | .rorw, regs, _ => ZBB_RTYPEW_pure64_RISCV_RORW (regs.getN 1 (by simp [DialectSignature.sig, signature]))  (regs.getN 0 (by simp [DialectSignature.sig, signature]))
-  | .rol, regs, _ => ZBB_RTYPE_pure64_RISCV_ROL_bv (regs.getN 1 (by simp [DialectSignature.sig, signature]))  (regs.getN 0 (by simp [DialectSignature.sig, signature]))
-  | .ror, regs, _ => ZBB_RTYPE_pure64_RISCV_ROR_bv (regs.getN 1 (by simp [DialectSignature.sig, signature]))  (regs.getN 0 (by simp [DialectSignature.sig, signature]))
   | RISCV64.Op.add.uw, regs, _ => ZBA_RTYPEUW_pure64_RISCV_ADDUW (regs.getN 1 (by simp [DialectSignature.sig, signature]))  (regs.getN 0 (by simp [DialectSignature.sig, signature]))
   | RISCV64.Op.sh1add.uw , regs, _ => ZBA_RTYPEUW_pure64_RISCV_SH1ADDUW (regs.getN 1 (by simp [DialectSignature.sig, signature]))  (regs.getN 0 (by simp [DialectSignature.sig, signature]))
   | RISCV64.Op.sh2add.uw, regs, _ => ZBA_RTYPEUW_pure64_RISCV_SH2ADDUW (regs.getN 1 (by simp [DialectSignature.sig, signature]))  (regs.getN 0 (by simp [DialectSignature.sig, signature]))
@@ -500,5 +560,28 @@ instance : DialectDenote (RV64) where
   | .sh2add, regs, _ => ZBA_RTYPE_pure64_RISCV_SH2ADD (regs.getN 1 (by simp [DialectSignature.sig, signature]))  (regs.getN 0 (by simp [DialectSignature.sig, signature]))
   | .sh3add, regs, _ => ZBA_RTYPE_pure64_RISCV_SH3ADD (regs.getN 1 (by simp [DialectSignature.sig, signature]))  (regs.getN 0 (by simp [DialectSignature.sig, signature]))
   | RISCV64.Op.slli.uw shamt, regs, _ => ZBA_pure64_RISCV_SLLIUW shamt (regs.getN 0 (by simp [DialectSignature.sig, signature]))
+  | .andn, regs, _ => ZBB_RTYPE_pure_RISCV_ANDN (regs.getN 1 (by simp [DialectSignature.sig, signature])) (regs.getN 0 (by simp [DialectSignature.sig, signature]))
+  | .orn, regs, _ => ZBB_RTYPE_pure_RISCV_ORN (regs.getN 1 (by simp [DialectSignature.sig, signature])) (regs.getN 0 (by simp [DialectSignature.sig, signature]))
+  | .xnor, regs, _ => ZBB_RTYPE_pure_RISCV_XNOR (regs.getN 1 (by simp [DialectSignature.sig, signature])) (regs.getN 0 (by simp [DialectSignature.sig, signature]))
+  -- | clz
+  -- | clzw
+  -- | ctz
+  -- | ctzw
+  -- | cpop
+  -- | cpopw
+  | .max, regs, _ => ZBB_RTYPE_pure_RISCV_MAX (regs.getN 1 (by simp [DialectSignature.sig, signature])) (regs.getN 0 (by simp [DialectSignature.sig, signature]))
+  | .maxu, regs, _ => ZBB_RTYPE_pure_RISCV_MAXU (regs.getN 1 (by simp [DialectSignature.sig, signature])) (regs.getN 0 (by simp [DialectSignature.sig, signature]))
+  | .min, regs, _ => ZBB_RTYPE_pure_RISCV_MIN (regs.getN 1 (by simp [DialectSignature.sig, signature])) (regs.getN 0 (by simp [DialectSignature.sig, signature]))
+  | .minu, regs, _ => ZBB_RTYPE_pure_RISCV_MINU (regs.getN 1 (by simp [DialectSignature.sig, signature])) (regs.getN 0 (by simp [DialectSignature.sig, signature]))
+  | RISCV64.Op.sext.b, reg, _ => ZBB_EXTOP_pure64_RISCV_SEXTB (reg.getN 0 (by simp [DialectSignature.sig, signature]))
+  | RISCV64.Op.sext.h, reg, _ => ZBB_EXTOP_pure64_RISCV_SEXTH (reg.getN 0 (by simp [DialectSignature.sig, signature]))
+  | RISCV64.Op.zext.h, reg, _ => ZBB_EXTOP_pure64_RISCV_ZEXTH (reg.getN 0 (by simp [DialectSignature.sig, signature]))
+  | .rol, regs, _ => ZBB_RTYPE_pure64_RISCV_ROL_bv (regs.getN 1 (by simp [DialectSignature.sig, signature]))  (regs.getN 0 (by simp [DialectSignature.sig, signature]))
+  | .rolw, regs, _ => ZBB_RTYPEW_pure64_RISCV_ROLW (regs.getN 1 (by simp [DialectSignature.sig, signature]))  (regs.getN 0 (by simp [DialectSignature.sig, signature]))
+  | .ror, regs, _ => ZBB_RTYPE_pure64_RISCV_ROR_bv (regs.getN 1 (by simp [DialectSignature.sig, signature]))  (regs.getN 0 (by simp [DialectSignature.sig, signature]))
+  | .rori shamt, regs, _ => ZBB_pure64_RISCV_RORI shamt (regs.getN 0 (by simp [DialectSignature.sig, signature]))
+  | .roriw shamt, regs, _ => ZBB_pure64_RISCV_RORIW shamt (regs.getN 0 (by simp [DialectSignature.sig, signature]))
+  | .rorw, regs, _ => ZBB_RTYPEW_pure64_RISCV_RORW (regs.getN 1 (by simp [DialectSignature.sig, signature]))  (regs.getN 0 (by simp [DialectSignature.sig, signature]))
+
 
 end RISCV64

--- a/SSA/Projects/RISCV64/Semantics.lean
+++ b/SSA/Projects/RISCV64/Semantics.lean
@@ -910,6 +910,43 @@ theorem ZBB_RTYPE_pure64_RISCV_ROR_eq_ZBB_RTYPE_pure64_RISCV_ROR_bv (rs2_val : B
   simp
 
 @[simp_riscv]
+def ZBB_pure64_RISCV_RORIW (shamt : (BitVec 5)) (rs1_val : BitVec 64) : BitVec 64 :=
+  BitVec.signExtend 64
+    (BitVec.extractLsb 31 0 rs1_val >>> shamt.toNat ||| BitVec.extractLsb 31 0 rs1_val <<< ((32 - shamt.toNat) % 32))
+
+@[simp_riscv]
+def ZBB_pure64_RISCV_RORI (shamt : (BitVec 5)) (rs1_val : BitVec 64) : BitVec 64 :=
+  rs1_val >>> shamt.toNat ||| rs1_val <<< ((64 - shamt.toNat) % 64)
+
+@[simp_riscv]
+def ZBB_RTYPE_pure_RISCV_XNOR (rs2_val : BitVec 64) (rs1_val : BitVec 64) : BitVec 64 :=
+  ~~~(rs1_val ^^^ rs2_val)
+
+@[simp_riscv]
+def ZBB_RTYPE_pure_RISCV_ORN (rs2_val : BitVec 64) (rs1_val : BitVec 64) : BitVec 64 :=
+  rs1_val ||| ~~~rs2_val
+
+@[simp_riscv]
+def ZBB_RTYPE_pure_RISCV_ANDN (rs2_val : BitVec 64) (rs1_val : BitVec 64) : BitVec 64 :=
+  rs1_val &&& ~~~rs2_val
+
+@[simp_riscv]
+def ZBB_RTYPE_pure_RISCV_MIN (rs2_val : BitVec 64) (rs1_val : BitVec 64) : BitVec 64 :=
+  BitVec.extractLsb' 0 64 (BitVec.ofInt 65 (min rs1_val.toInt rs2_val.toInt))
+
+@[simp_riscv]
+def ZBB_RTYPE_pure_RISCV_MINU (rs2_val : BitVec 64) (rs1_val : BitVec 64) : BitVec 64 :=
+  BitVec.extractLsb' 0 64 (BitVec.ofInt 65 (min ↑rs1_val.toNat ↑rs2_val.toNat))
+
+@[simp_riscv]
+def ZBB_RTYPE_pure_RISCV_MAXU (rs2_val : BitVec 64) (rs1_val : BitVec 64) : BitVec 64 :=
+  BitVec.extractLsb' 0 64 (BitVec.ofInt (65) (max ↑rs1_val.toNat ↑rs2_val.toNat))
+
+@[simp_riscv]
+def ZBB_RTYPE_pure_RISCV_MAX (rs2_val : BitVec 64) (rs1_val : BitVec 64) : BitVec 64 :=
+  BitVec.extractLsb' 0 64 (BitVec.ofInt 65 (max rs1_val.toInt rs2_val.toInt))
+
+@[simp_riscv]
 def ZBA_RTYPEUW_pure64_RISCV_ADDUW (rs2_val : BitVec 64) (rs1_val : BitVec 64) : BitVec 64 :=
   BitVec.zeroExtend 64 (BitVec.extractLsb 31 0 rs1_val) <<< 0#2 + rs2_val
 


### PR DESCRIPTION
This PR also re-orders the ZBB operations to have the same ordering throughout all the file.

Co-authored-by: @salinhkuhn 