### PR TITLE
refactor: change `toMonad_pure` to `toMonad_pure_apply`

### DIFF
--- a/SSA/Core/EffectKind.lean
+++ b/SSA/Core/EffectKind.lean
@@ -17,7 +17,8 @@ def toMonad (e : EffectKind) (m : Type → Type) : Type → Type :=
 
 section Lemmas
 
-@[simp_denote] theorem toMonad_pure   : pure.toMonad m = Id := rfl
+@[deprecated] theorem toMonad_pure : pure.toMonad m = Id := rfl
+@[simp_denote] theorem toMonad_pure_apply : pure.toMonad m α = α := rfl
 @[simp_denote] theorem toMonad_impure : impure.toMonad m = m := rfl
 
 end Lemmas

--- a/SSA/Core/EffectKind.lean
+++ b/SSA/Core/EffectKind.lean
@@ -17,7 +17,6 @@ def toMonad (e : EffectKind) (m : Type → Type) : Type → Type :=
 
 section Lemmas
 
-@[deprecated] theorem toMonad_pure : pure.toMonad m = Id := rfl
 @[simp_denote] theorem toMonad_pure_apply : pure.toMonad m α = α := rfl
 @[simp_denote] theorem toMonad_impure : impure.toMonad m = m := rfl
 

--- a/SSA/Core/Framework.lean
+++ b/SSA/Core/Framework.lean
@@ -867,7 +867,7 @@ end Lemmas
   induction c using Com.rec'
   · simp; rfl
   · rename_i a
-    simp only [denoteLets, EffectKind.toMonad_pure, outContext_var, Valuation.cast_rfl, Id.pure_eq',
+    simp only [denoteLets, outContext_var, Valuation.cast_rfl, Id.pure_eq',
       Id.bind_eq', returnVar_var, a, denote]
 
 @[simp] lemma Expr.changeVars_changeVars (e : Expr d Γ eff ty) (f : Γ.Hom Δ) (g : Δ.Hom Ξ) :
@@ -1099,7 +1099,7 @@ assignment of that variable in the input valuation -/
   · simp; rfl
   case var e body ih =>
     rw [outContextHom_var]
-    simp only [Ctxt.Hom.unSnoc_apply, denoteLets_var, EffectKind.toMonad_pure]
+    simp only [Ctxt.Hom.unSnoc_apply, denoteLets_var]
     show body.denoteLets (e.denote V) _ = _
     simp [ih]
 

--- a/SSA/Core/Tactic.lean
+++ b/SSA/Core/Tactic.lean
@@ -44,7 +44,6 @@ attribute [simp_denote]
   Expr.op_mk Expr.args_mk Expr.regArgs_mk
   Expr.op_castPureToEff Expr.args_castPureToEff
   /- Effect massaging -/
-  EffectKind.toMonad_pure EffectKind.toMonad_impure
   EffectKind.liftEffect_rfl
   Id.pure_eq Id.bind_eq id_eq
   pure_bind

--- a/SSA/Core/Transforms/Rewrite/Match.lean
+++ b/SSA/Core/Transforms/Rewrite/Match.lean
@@ -469,7 +469,7 @@ theorem denote_matchVar
     match w with
     | ⟨w+1, h⟩ =>
       simp only [Option.mem_def, Var.succ_eq_toSnoc, Lets.denote,
-        EffectKind.toMonad_pure, Id.bind_eq', Expr.denote_snoc] at *
+        Id.bind_eq', Expr.denote_snoc] at *
       rw [Var.toSnoc, matchVar_var_succ_eq] at h_matchVar
       apply ih h_matchVar h_sub
 

--- a/SSA/Projects/CSE/CSE.lean
+++ b/SSA/Projects/CSE/CSE.lean
@@ -345,8 +345,8 @@ def State.cseCom {α : d.Ty}
         let ⟨body', hbody'⟩ := s'.cseCom body
         ⟨.var e' body',  by
             intros VΓ
-            simp only [EffectKind.toMonad_pure, Com.denote]
-            simp only [EffectKind.toMonad_pure, Lets.denote_var, Id.bind_eq'] at hbody' ⊢
+            simp only [Com.denote]
+            simp only [Lets.denote_var, Id.bind_eq'] at hbody' ⊢
             rw [← hbody']
             rw [he']⟩
       | .some ⟨v', hv'⟩ =>
@@ -358,8 +358,8 @@ def State.cseCom {α : d.Ty}
         ⟨.var e body' -- we still keep the `e` for now. In the next version, we will delete the `e`
         , by
             intros V
-            simp only [EffectKind.toMonad_pure, Com.denote]
-            simp only [EffectKind.toMonad_pure, Lets.denote_var, Id.bind_eq'] at hbody' ⊢
+            simp only [Com.denote]
+            simp only [Lets.denote_var, Id.bind_eq'] at hbody' ⊢
             specialize (hbody' V)
             specialize (he' V)
             rw [he'] at hbody'
@@ -376,7 +376,7 @@ def cse' [DecidableEq d.Ty] [DecidableEq d.Op]
     ⟨com', by {
       intros V
       specialize (hcom' V)
-      simp only [EffectKind.toMonad_pure, Lets.denote] at hcom'
+      simp only [Lets.denote] at hcom'
       assumption
     }⟩
 

--- a/SSA/Projects/DCE/DCE.lean
+++ b/SSA/Projects/DCE/DCE.lean
@@ -213,7 +213,7 @@ partial def dce_ {Γ : Ctxt d.Ty} {t : d.Ty}
           com.denote V = com'.denote (V.comap hom)} :=
         ⟨Γ, Hom.id, ⟨body', by -- NOTE: we deleted the `let` binding.
           intros V
-          simp [EffectKind.toMonad_pure, HCOM, Com.denote_var,
+          simp [HCOM, Com.denote_var,
             Ctxt.Valuation.comap_id, hbody, Id.bind_eq']
         ⟩⟩
       let ⟨Γ'', hom'', ⟨com'', hcom''⟩⟩


### PR DESCRIPTION
This PR changes the unfolding lemma for the monad for a `pure` effectkind to unfold directly to the applied type \alpha, instead of unfolding to `Id`. Having `Id` show up everywhere was causing issues, since it would block simp-lemmas for the actual type.