### PR TITLE
chore: write a simproc to simplify `HVector.getN` applied to a fully concrete HVector

### DIFF
--- a/SSA/Projects/CIRCT/Handshake/HandshakeExample.lean
+++ b/SSA/Projects/CIRCT/Handshake/HandshakeExample.lean
@@ -1,11 +1,7 @@
 import SSA.Projects.CIRCT.Handshake.Handshake
 import SSA.Projects.CIRCT.Stream.Stream
 import SSA.Projects.CIRCT.Stream.WeakBisim
-import SSA.Core.Tactic
-import SSA.Core.ErasedContext
-import SSA.Core.HVector
-import SSA.Core.EffectKind
-import SSA.Core.Util
+import SSA.Core
 
 namespace CIRCTStream
 

--- a/SSA/Projects/RISCV64/Base.lean
+++ b/SSA/Projects/RISCV64/Base.lean
@@ -654,6 +654,7 @@ abbrev Op.denote : (o : RV64.Op) → HVector toType o.sig → ⟦o.outTy⟧
   | .sltz, regs => SLTZ_pure64_pseudo (regs.getN 0)
   | .sgtz, regs => SGZT_pure64_pseudo (regs.getN 0)
 
+@[simp, reducible]
 instance : DialectDenote RV64 where
   denote o args _ := o.denote args
 

--- a/SSA/Projects/RISCV64/Tactic/SimpRiscV.lean
+++ b/SSA/Projects/RISCV64/Tactic/SimpRiscV.lean
@@ -9,6 +9,8 @@ import Lean.LabelAttribute
 open Lean
 open Lean.Elab.Tactic
 
+attribute [simp_riscv] HVector.reduceGetN
+
 /-!
 This file defines the `simp_riscv` tactic, which unfolds and simplifies the RISC-V semantic definitions.
 It also defines the `simp_riscv` attribute, used to tag semantic definition functions so that
@@ -16,7 +18,6 @@ they are automatically simplified when `simp_riscv` is invoked.
 
 The purpose of this tactic is to reduce proof size when reasoning about instruction lowerings.
 -/
-syntax "simp_riscv" : tactic
 macro "simp_riscv" : tactic =>
   `(tactic|(
       simp (config := {failIfUnchanged := false}) only [


### PR DESCRIPTION
This ought to fix the recent opt breakage