### PR TITLE
chore: only post evaluation data on success

### DIFF
--- a/.github/workflows/evaluation.yml
+++ b/.github/workflows/evaluation.yml
@@ -57,15 +57,19 @@ jobs:
       - name: Run LLVM
         continue-on-error: true
         run: |
-          (cd bv-evaluation; python3 ./compare.py instcombine -j48)
+          cd bv-evaluation
+          python3 ./compare.py instcombine -j48 \
+            || echo "LEANMLIR_STATUS=fail" >> $GITHUB_ENV
 
       - name: Collect data LLVM
         continue-on-error: true
         run: |
-          (cd bv-evaluation; python3 ./collect.py instcombine | tee llvm-stats)
+          cd bv-evaluation
+          (python3 ./collect.py instcombine | tee llvm-stats) \
+            || echo "LEANMLIR_STATUS=fail" >> $GITHUB_ENV
 
       - uses: actions/github-script@v6
-        if: github.event_name == 'pull_request'
+        if: env.LEANMLIR_STATUS != 'fail' && github.event_name == 'pull_request'
         with:
           script: |
             const fs = require('fs')


### PR DESCRIPTION
This PR tracks whether an error was raised (i.e., a non-zero status code returned) in the evaluation, and if so, does *not* post the evaluation data to the PR. This reduces noise from a ton of evaluation data that is currently posted to WIP PRs: if the evaluation failed the data is bogus, and the failure is already communicated through the CI status!