### PR TITLE
feat: Context & HVector API

### DIFF
--- a/SSA/Core/ErasedContext.lean
+++ b/SSA/Core/ErasedContext.lean
@@ -3,6 +3,9 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import Mathlib.Data.Finset.Basic
 import Mathlib.Data.Finset.Union
+import Mathlib.Data.Fintype.Basic
+import Mathlib.Tactic.DepRewrite
+
 import SSA.Core.HVector
 
 /--
@@ -52,9 +55,30 @@ lemma empty_eq : (∅ : Ctxt Ty) = .empty := rfl
 def snoc : Ctxt Ty → Ty → Ctxt Ty
   | ⟨tl⟩, hd => ⟨hd :: tl⟩
 
-instance : GetElem? (Ctxt Ty) Nat Ty (fun as i => i < as.toList.length) where
-  getElem xs i h := xs.toList[i]
-  getElem? xs i  := xs.toList[i]?
+
+@[grind=]
+def length (Γ : Ctxt Ty) : Nat := Γ.toList.length
+
+instance : GetElem? (Ctxt Ty) Nat Ty (fun Γ i => i < Γ.length) where
+  getElem Γ i h := Γ.toList[i]
+  getElem? Γ i  := Γ.toList[i]?
+
+section GetElemLemmas
+
+lemma getElem?_eq_toList_getElem? {i : Nat} : Γ[i]? = Γ.toList[i]? := rfl
+@[simp, grind=] lemma getElem?_ofList (i : Nat) : (ofList ts)[i]? = ts[i]? := rfl
+@[simp, grind=] lemma getElem_ofList (i : Nat) (h : _) : (ofList ts)[i]'h = ts[i]'h := rfl
+
+instance : LawfulGetElem (Ctxt Ty) Nat Ty (fun as i => i < as.length) where
+  getElem?_def Γ i _ := by rcases Γ; grind
+
+@[ext]
+theorem ext_getElem? {Γ Δ : Ctxt Ty} (h : ∀ (i : Nat), Γ[i]? = Δ[i]?) : Γ = Δ := by
+  rcases Γ; rcases Δ;
+  rw [ofList.injEq]
+  exact List.ext_getElem?_iff.mpr h
+
+end GetElemLemmas
 
 instance instAppend : HAppend (Ctxt Ty) (List Ty) (Ctxt Ty) where
   hAppend Γ tys := ⟨tys ++ Γ.toList⟩
@@ -65,8 +89,6 @@ def get? : Ctxt Ty → Nat → Option Ty := (·[·]?)
 /-- Map a function from one type universe to another over a context -/
 def map (f : Ty₁ → Ty₂) : Ctxt Ty₁ → Ctxt Ty₂ :=
   ofList ∘ (List.map f) ∘ toList
-
-def length (Γ : Ctxt Ty) : Nat := Γ.toList.length
 
 section Lemmas
 variable (Γ : Ctxt Ty) (ts us : List Ty)
@@ -81,9 +103,6 @@ variable {m} [Monad m] [LawfulMonad m] (t u : m _) in
 @[simp] lemma ofList_append : (⟨ts⟩ : Ctxt _) ++ us = us ++ ts := rfl
 @[simp] lemma toList_append : (Γ ++ ts).toList = ts ++ Γ.toList := rfl
 
-lemma getElem?_eq_toList_getElem? {i : Nat} : Γ[i]? = Γ.toList[i]? := rfl
-@[simp] lemma getElem?_ofList (i : Nat) : (ofList ts)[i]? = ts[i]? := rfl
-
 @[simp] lemma getElem?_snoc_zero (t : Ty)           : (Γ.snoc t)[0]? = some t := rfl
 @[simp] lemma getElem?_snoc_succ (t : Ty) (i : Nat) : (Γ.snoc t)[i+1]? = Γ[i]? := rfl
 
@@ -94,9 +113,11 @@ lemma getElem?_eq_toList_getElem? {i : Nat} : Γ[i]? = Γ.toList[i]? := rfl
     (Γ.map f)[i]? = Γ[i]?.map f := by
   simp [map]; rfl
 
-@[simp] lemma length_ofList : (ofList ts).length = ts.length := rfl
-@[simp] lemma length_snoc (Γ : Ctxt α) (x : α) : (Γ.snoc x).length = Γ.length + 1 := rfl
-@[simp] lemma length_map : (Γ.map f).length = Γ.length := by simp [map, length]
+@[simp, grind=] lemma length_ofList : (ofList ts).length = ts.length := rfl
+@[simp, grind=] lemma length_snoc (Γ : Ctxt α) (x : α) : (Γ.snoc x).length = Γ.length + 1 := rfl
+@[simp, grind=] lemma length_map : (Γ.map f).length = Γ.length := by simp [map, length]
+@[simp, grind=] lemma length_append : (Γ ++ ts).length = Γ.length + ts.length := by
+  simp [length, Nat.add_comm]
 
 instance : Functor Ctxt where
   map := map
@@ -132,11 +153,11 @@ end Rec
 def Var (Γ : Ctxt Ty) (t : Ty) : Type :=
   { i : Nat // Γ[i]? = some t }
 
-/-- constructor for Var. -/
-def Var.mk {Γ : Ctxt Ty} {t : Ty} (i : Nat) (hi : Γ[i]? = some t) : Γ.Var t :=
-  ⟨i, hi⟩
-
 namespace Var
+
+/-- constructor for Var. -/
+def mk {Γ : Ctxt Ty} {t : Ty} (i : Nat) (hi : Γ[i]? = some t) : Γ.Var t :=
+  ⟨i, hi⟩
 
 instance : DecidableEq (Var Γ t) := by
   delta Var
@@ -148,7 +169,7 @@ def last (Γ : Ctxt Ty) (t : Ty) : Ctxt.Var (Ctxt.snoc Γ t) t :=
 
 def emptyElim {α : Sort _} {t : Ty} : Ctxt.Var ∅ t → α :=
   fun ⟨_, h⟩ => by
-    simp [getElem?_eq_toList_getElem?, EmptyCollection.emptyCollection, empty] at h
+    simp [EmptyCollection.emptyCollection, empty] at h
 
 /-- Take a variable in a context `Γ` and get the corresponding variable
 in context `Γ.snoc t`. This is marked as a coercion. -/
@@ -156,15 +177,21 @@ in context `Γ.snoc t`. This is marked as a coercion. -/
 def toSnoc {Γ : Ctxt Ty} {t t' : Ty} (var : Var Γ t) : Var (snoc Γ t') t  :=
   ⟨var.1+1, var.2⟩
 
-@[simp]
-theorem zero_eq_last {Γ : Ctxt Ty} {t : Ty} (h) :
-    ⟨0, h⟩ = last Γ t :=
-  rfl
+section Lemmas
+variable {Γ : Ctxt Ty} {t : Ty}
 
-@[simp]
-theorem succ_eq_toSnoc {Γ : Ctxt Ty} {t : Ty} {w} (h : (Γ.snoc t)[w+1]? = some t') :
-    ⟨w+1, h⟩ = toSnoc ⟨w, h⟩ :=
-  rfl
+lemma val_lt (v : Γ.Var t) : v.val < Γ.length := by
+  rcases v with ⟨idx, h⟩
+  suffices ¬(Γ.length ≤ idx) by grind
+  rcases Γ
+  simp only [length_ofList, ← List.getElem?_eq_none_iff]
+  simp_all
+
+@[simp] lemma zero_eq_last (h) : ⟨0, h⟩ = last Γ t := rfl
+@[simp] lemma succ_eq_toSnoc {w} (h : (Γ.snoc t)[w+1]? = some t') :
+    ⟨w+1, h⟩ = toSnoc ⟨w, h⟩ := rfl
+
+end Lemmas
 
 /-! ### toMap-/
 
@@ -244,36 +271,39 @@ def castCtxt {Γ : Ctxt Op} (h_eq : Γ = Δ) : Γ.Var ty → Δ.Var ty
 section Lemmas
 variable {t} (v : Var Γ t)
 
-@[simp] lemma cast_rfl (h : t = t) : v.cast h = v := rfl
+@[simp, grind=] lemma cast_rfl (h : t = t) : v.cast h = v := rfl
 
-@[simp] lemma castCtxt_rfl (h : Γ = Γ) : v.castCtxt h = v := rfl
-@[simp] lemma castCtxt_castCtxt (h₁ : Γ = Δ) (h₂ : Δ = Ξ) :
+@[simp, grind=] lemma castCtxt_rfl (h : Γ = Γ) : v.castCtxt h = v := rfl
+@[simp, grind=] lemma castCtxt_castCtxt (h₁ : Γ = Δ) (h₂ : Δ = Ξ) :
     (v.castCtxt h₁).castCtxt h₂ = v.castCtxt (by simp [*]) := by subst h₁ h₂; simp
 
-@[simp] lemma cast_mk : cast h ⟨vi, hv⟩ = ⟨vi, h ▸ hv⟩ := rfl
-@[simp] lemma castCtxt_mk : castCtxt h ⟨vi, hv⟩ = ⟨vi, h ▸ hv⟩ := rfl
+@[simp, grind=] lemma cast_mk : cast h ⟨vi, hv⟩ = ⟨vi, h ▸ hv⟩ := rfl
+@[simp, grind=] lemma castCtxt_mk : castCtxt h ⟨vi, hv⟩ = ⟨vi, h ▸ hv⟩ := rfl
 
-@[simp] lemma val_cast : (cast h v).val = v.val := rfl
-@[simp] lemma val_castCtxt : (castCtxt h v).val = v.val := rfl
+@[simp, grind=] lemma val_cast : (cast h v).val = v.val := rfl
+@[simp, grind=] lemma val_castCtxt : (castCtxt h v).val = v.val := rfl
 
 end Lemmas
 
 /-! ### Var Append -/
 
-def appendInl : Γ.Var t → (Γ ++ ts).Var t
-  | ⟨v, h⟩ => ⟨v + ts.length, by
-      rcases Γ; simp_all [List.getElem?_append_right]
+def appendInl (v : Γ.Var t) : (Γ ++ ts).Var t :=
+  ⟨v.val + ts.length, by
+      have := v.prop
+      rcases Γ
+      simp_all [List.getElem?_append_right]
     ⟩
 instance : Coe (Γ.Var t) ((Γ ++ ts).Var t) where coe := appendInl
 
-def appendInr : Var ⟨ts⟩ t → (Γ ++ ts).Var t
-  | ⟨v, h⟩ => ⟨v, by
+def appendInr (v : Var ⟨ts⟩ t) : (Γ ++ ts).Var t :=
+  ⟨v.val, by
       rcases Γ
+      rcases v with ⟨v, h⟩
       have : v < ts.length := by
         suffices ¬(ts.length ≤ v) by omega
         rw [← List.getElem?_eq_none_iff]
         simp_all
-      simp_all [List.getElem?_append_left]
+      simpa [List.getElem?_append_left this] using h
     ⟩
 
 @[elab_as_elim]
@@ -294,8 +324,7 @@ def appendCases
       ⟩
       have eq : v'.appendInl = ⟨idx, h⟩ := by
         show Subtype.mk _ _ = _
-        congr 1
-        omega
+        simp [v']; omega
       eq ▸ left v'
 
 section Lemmas
@@ -303,6 +332,10 @@ variable {t : Ty} {v : Γ.Var t}
 
 @[simp] lemma val_appendInl {v : Γ.Var t} : (v.appendInl (ts := ts)).val = v.val + ts.length := rfl
 @[simp] lemma val_appendInr {v : Var ts t}  : (v.appendInr (Γ := Γ)).val = v.val := rfl
+
+lemma toSnoc_appendInr {v : Var ⟨ts⟩ t} :
+    v.toSnoc (t':=t').appendInr (Γ := Γ) = v.appendInr.toSnoc :=
+  rfl
 
 @[simp] theorem appendCases_appendInl (v : Γ.Var t) :
     appendCases (motive := motive) left right v.appendInl = (left v) := by
@@ -329,22 +362,81 @@ variable {t : Ty} {v : Γ.Var t}
 
 end Lemmas
 
+/-! ### Var equality -/
+
+/--
+Given two variables `v, w` in the same context `Γ`, but with potentially
+different types `t` and `u`, `v.eq w` holds if `v = w` (after
+substituing along a proof that `t = u`).
+-/
+def eq (v : Γ.Var t) (w : Γ.Var u) : Prop :=
+  ∃ (h : t = u), v = h ▸ w
+
+instance [DecidableEq Ty] {v : Γ.Var t} {w : Γ.Var u} : Decidable (v.eq w) := by
+  unfold Var.eq; infer_instance
+
+/-- Given variables `v, w : Γ.Var t` with the same type index `t`, `v.eq w`
+coincides exactly with `v = w`. -/
+@[simp] lemma eq_iff {v w : Γ.Var t} : v.eq w ↔ v = w := by
+  simp [Var.eq]
+
+@[inherit_doc eq_iff] lemma eq.to_eq {v w : Γ.Var t} : v.eq w → v = w := eq_iff.mp
+
+/-- From `v.eq w` it follows that the types of `v` and `w` are the same. -/
+lemma eq.ty_eq {v : Γ.Var t} {w : Γ.Var u} (h : v.eq w) : t = u := h.1
+
+/-! ### Fintype instance -/
+
+instance [DecidableEq Ty] {Γ : Ctxt Ty} {t : Ty} : Fintype (Γ.Var t) where
+  elems := {
+      val := .ofList <|
+                List.range Γ.length
+                |>.filterMap fun i =>
+                    if h : Γ[i]? = some t then
+                      some ⟨i, h⟩
+                    else
+                      none
+      nodup := by
+        apply List.Nodup.filterMap ?_ List.nodup_range
+        simp only [Option.mem_def, Option.dite_none_right_eq_some, Option.some.injEq,
+          forall_exists_index, forall_apply_eq_imp_iff]
+        intro i j hi hj h_eq
+        cases h_eq
+        rfl
+    }
+  complete v := by simpa using ⟨v.val, v.val_lt, v.prop, rfl⟩
+
 /-! ### Var Fin Helpers -/
 
-def toFin : Γ.Var t → Fin Γ.length
-  | ⟨idx, h⟩ => ⟨idx, by
-      suffices ¬(Γ.length ≤ idx) by omega
-      rcases Γ
-      simp only [length_ofList, ← List.getElem?_eq_none_iff]
-      simp_all
-    ⟩
+def toFin (v : Γ.Var t) : Fin Γ.length :=
+  ⟨v.val, v.val_lt⟩
 
-def ofFin : (i : Fin Γ.length) → Γ.Var (Γ[i])
-  | ⟨idx, h⟩ => ⟨idx, by simpa using List.getElem?_eq_getElem _⟩
+def ofFin (i : Fin Γ.length) : Γ.Var (Γ[i]) :=
+  ⟨i.val, by simp⟩
+
+section Lemmas
+
+@[simp, grind=] lemma ofFin_toFin (v : Γ.Var t) :
+    ofFin v.toFin = v.cast (by have := v.prop; grind [toFin]) := rfl
+
+def ofFinCases
+    {motive : ∀ {t}, Γ.Var t → Sort u}
+    (ofFin : (i : Fin Γ.length) → motive (ofFin i))
+    (v : Γ.Var t) :
+    motive v := by
+  refine _root_.cast ?h <| ofFin v.toFin
+  grind
+
+@[simp] lemma toFin_toSnoc (v : Γ.Var t) : (v.toSnoc (t':=t')).toFin = v.toFin.succ := rfl
+
+end Lemmas
+
+/-! ### All vars in a context -/
+
+def allVarsIn (ts : List Ty) : HVector (Var ⟨ts⟩) ts :=
+  .ofFn _ ts Var.ofFin
 
 end Var
-
-end Ctxt
 
 /-!
 ### Indexing an HVector by `Var`
@@ -352,12 +444,35 @@ Note that a `Var` is quite similar to a `Fin`, plus a static proof of the item
 at the particular index. This extra knowledge is useful when indexing into an
 HVector as well.
 -/
-instance : GetElem (HVector A as) (Ctxt.Var ⟨as⟩ a) (A a) (fun _ _ => True) where
-  getElem xs i _ := (cast · <| xs.get i.toFin) <| by
+end Ctxt
+open Ctxt
+
+instance {Γ} : GetElem (HVector A as) (Var Γ a) (A a) (fun _ _ => as = Γ.toList) where
+  getElem xs i h := (cast · <| xs.get <| i.toFin.cast <| by rw [h]; rfl) <| by
+    subst h
     congr 1
     rcases i with ⟨i, h⟩
     simpa [Ctxt.Var.toFin, List.getElem_eq_iff] using h
 
+namespace HVector
+variable {A : α → _} {as : List α} (xs : HVector A as) {Γ : Ctxt α}
+
+@[simp] lemma getElem_ofFin_eq_get (i : Fin as.length) :
+    xs[Ctxt.Var.ofFin i] = xs.get i := rfl
+@[simp] lemma getElem_map (xs : HVector A as) (v : Var ⟨as⟩ a) :
+    (xs.map f)[v] = f _ xs[v] := by
+  cases v using Var.ofFinCases
+  rw [getElem_ofFin_eq_get, getElem_ofFin_eq_get]
+  simp only [length_ofList, get_map, List.get_eq_getElem]
+  rfl
+
+@[simp] lemma cons_getElem_toSnoc (x : A a) (v : Var Γ u)
+    (h : as = Γ.toList := by rfl) (h' : a :: as = (Γ.snoc a).toList := by rfl) :
+    (HVector.cons x xs)[v.toSnoc (t' := a)]'h' = xs[v]'h := by
+  simp only [GetElem.getElem]
+  simp
+
+end HVector
 namespace Ctxt
 /-!
 ## Context Homomorphisms
@@ -365,13 +480,20 @@ namespace Ctxt
 
 abbrev Hom (Γ Γ' : Ctxt Ty) := ⦃t : Ty⦄ → Γ.Var t → Γ'.Var t
 
-@[simp]
-abbrev Hom.id {Γ : Ctxt Ty} : Γ.Hom Γ :=
+@[simp] abbrev Hom.id {Γ : Ctxt Ty} : Γ.Hom Γ :=
   fun _ v => v
 
+/-! ### Morphism Composition -/
+section Comp
+variable {Γ Δ Ξ : Ctxt Ty} (f : Hom Γ Δ) (g : Hom Δ Ξ)
+
 /-- `f.comp g := g(f(x))` -/
-def Hom.comp {Γ Δ Ξ : Ctxt Ty} (f : Hom Γ Δ) (g : Hom Δ Ξ) : Hom Γ Ξ :=
+def Hom.comp : Hom Γ Ξ :=
   fun _t v => g (f v)
+
+@[simp, grind=] lemma Hom.comp_apply : f.comp g v = g (f v) := rfl
+
+end Comp
 
 /--
   `map.with v₁ v₂` adjusts a single variable of a Context map, so that in the resulting map
@@ -415,7 +537,7 @@ instance : Coe (Γ.Var t) ((Γ.snoc t').Var t) := ⟨Ctxt.Var.toSnoc⟩
 
 /--
 Lift a context morphism `f` from context `Γ` to context `Δ` into a morphism
-where an arbitrary list of types is append to both the domain and codomain.
+where a list of types `ts` is appended to *both* the domain and codomain.
 That is, on any variables in the original domain `Γ`, `f.append` acts like `f`,
 but on any *new* variables, in the appended list of types `ts`, `f.append`
 maps to the corresponding new variable in the codomain (`Δ ++ ts`).
@@ -424,6 +546,13 @@ def Hom.append {ts : List Ty} (f : Γ.Hom Δ) : Hom (Γ ++ ts) (Δ ++ ts) :=
   fun _ => Var.appendCases
     (fun v => (f v).appendInl)
     (fun v => v.appendInr)
+
+/--
+Lift a context morphism `f` from context `Γ` to context `Δ` into a morphism
+where a list of types is appended to just to codomain `Δ`.
+-/
+def Hom.appendCodomain {ts : List Ty} (f : Γ.Hom Δ) : Hom Γ (Δ ++ ts) :=
+  fun _ v => (f v).appendInl
 
 section Lemmas
 
@@ -435,6 +564,13 @@ section Lemmas
     (f.append (ts := ts)) v.appendInr = v.appendInr := by
   simp [append]
 
+@[simp] theorem Hom.appendCodomain_apply (f : Γ.Hom Δ) (v : Γ.Var t) :
+    (f.appendCodomain (ts := ts)) v = (f v).appendInl :=
+  rfl
+
+@[simp] lemma Hom.id_append : (Hom.id (Γ:=Γ)).append (ts := ts) = .id := by
+  funext t v; cases v using Var.appendCases <;> simp [id, append]
+
 end Lemmas
 
 /-! ### Cast -/
@@ -445,6 +581,13 @@ def Hom.castCodomain (h : Δ = Δ') (f : Γ.Hom Δ) : Γ.Hom Δ' :=
 
 @[simp] lemma Hom.castDomain_apply {h : Δ = Δ'} {f : Γ.Hom Δ} {v : Γ.Var t} :
     f.castCodomain h v = (f v).castCtxt h := rfl
+
+@[simp] lemma Hom.castDomain_castCodomain {h₁ : Δ₁ = Δ₂} {h₂ : Δ₂ = Δ₃}
+    {f : Γ.Hom Δ₁} :
+    (f.castCodomain h₁).castCodomain h₂ = f.castCodomain (h₁ ▸ h₂) := rfl
+
+@[simp] lemma Hom.castDomain_rfl {h : Δ = Δ} {f : Γ.Hom Δ} :
+    (f.castCodomain h) = f := rfl
 
 /-!
 ## Context Valuations
@@ -493,7 +636,7 @@ theorem Valuation.snoc_eq {Γ : Ctxt Ty} {t : Ty} (s : Γ.Valuation) (x : toType
 
 @[simp]
 theorem Valuation.snoc_last {t : Ty} (s : Γ.Valuation) (x : toType t) :
-    (s.snoc x) (Ctxt.Var.last _ _) = x :=
+    (s.snoc x : no_index _) (Ctxt.Var.last _ _) = x :=
   rfl
 
 @[simp]
@@ -555,6 +698,38 @@ variable {V : Γ.Valuation} {xs : HVector toType ts}
     (V ++ xs) v.appendInr = xs[v] := by
   simp [(· ++ ·)]
 
+@[simp] lemma Valuation.append_inj {V : Γ.Valuation}
+    {ts : List Ty} {xs ys : HVector toType ts} :
+    (V ++ xs) = (V ++ ys) ↔ xs = ys where
+  mpr := by rintro rfl; rfl
+  mp := by
+    intro h
+    replace h {t} (v : Var _ t) : (V ++ xs) v.appendInr = (V ++ ys) v.appendInr := by
+      rw [h]
+    simp only [append_appendInr] at h
+    ext i
+    exact h (Var.ofFin i)
+
+@[simp] lemma Valuation.append_nil {V : Γ.Valuation} :
+    V ++ (HVector.nil (α := Ty) (f := toType)) = V := rfl
+
+@[simp] lemma Valuation.append_cons {t : Ty} {V : Γ.Valuation} {x : ⟦t⟧}  {xs : HVector toType ts} :
+    V ++ (HVector.cons x xs) = (V ++ xs).snoc x := by
+  funext _t v
+  cases v using Var.appendCases with
+  | left v =>
+      simp only [append_appendInl]
+      have : v.appendInl (ts := t :: ts) = (v.appendInl (ts:=ts) |>.toSnoc (t':=t)) := by
+        rfl
+      simp [this]
+  | right v =>
+      simp only [append_appendInr]
+      cases v using Var.casesOn with
+      | toSnoc v =>
+          simp only [Var.toSnoc_appendInr, snoc_toSnoc, append_appendInr]
+          apply HVector.cons_getElem_toSnoc
+      | last => rfl
+
 /-! ## Valuation Construction Helpers -/
 
 /-- Make a a valuation for a singleton value -/
@@ -598,7 +773,8 @@ def Valuation.comap {Γi Γo : Ctxt Ty} (Γiv: Γi.Valuation) (hom : Ctxt.Hom Γ
   funext t' v
   cases v using Var.casesOn <;> rfl
 
-@[simp] lemma Valuation.comap_id {Γ : Ctxt Ty} (Γv : Valuation Γ) : comap Γv Hom.id = Γv := rfl
+@[simp] lemma Valuation.comap_id {Γ : Ctxt Ty} (V : Valuation Γ) : comap V Hom.id = V := rfl
+
 @[simp] lemma Valuation.comap_snoc_snocRight {Γ Δ : Ctxt Ty} (Γv : Valuation Γ) (f : Hom Δ Γ) :
     comap (Γv.snoc x) (f.snocRight) = comap Γv f :=
   rfl
@@ -608,6 +784,13 @@ def Valuation.comap {Γi Γo : Ctxt Ty} (Γiv: Γi.Valuation) (hom : Ctxt.Hom Γ
     (f : Δ.Hom Γ) :
     (V ++ xs).comap (f.append) = (V.comap f) ++ xs := by
   funext t v; cases v using Var.appendCases <;> simp
+
+@[simp] lemma Valuation.comap_appendCodomain {Γ Δ : Ctxt Ty} {ts : List Ty}
+    (V : Γ.Valuation) (xs : HVector toType ts) (f : Δ.Hom Γ) :
+    (V ++ xs).comap f.appendCodomain = V.comap f := by
+  funext t v; simp
+
+/-! ### Reassign Variables-/
 
 /-- Reassign the variable var to value val in context ctxt -/
 def Valuation.reassignVar [DecidableEq Ty] {t : Ty} {Γ : Ctxt Ty}
@@ -641,6 +824,8 @@ def Valuation.recOn {motive : ∀ {Γ : Ctxt Ty}, Γ.Valuation → Sort*}
   induction' Γ with Γ t ih
   · exact (eq_nil V).symm ▸ nil
   · exact snoc_toSnoc_last V ▸ (snoc (fun _ v' => V v'.toSnoc) (V <|.last ..) (ih _))
+
+/-! ### Cast -/
 
 def Valuation.cast {Γ Δ : Ctxt Ty} (h : Γ = Δ) (V : Valuation Γ) : Valuation Δ :=
   fun _ v => V <| v.castCtxt h.symm
@@ -839,8 +1024,6 @@ lemma toHom_succ {Γ₁ Γ₂ : Ctxt Ty} {d : Nat} (h : Valid Γ₁ (Γ₂.snoc 
     f.toHom.comp g.toHom = (f + g).toHom := by
   funext t v
   apply Subtype.eq
-  simp
-  simp only [Hom.comp, toHom, Valid]
   grind
 
 end Lemmas
@@ -896,39 +1079,63 @@ instance {Γ' : DerivedCtxt Γ} : Coe (Ctxt.Var Γ t) (Ctxt.Var (Γ' : Ctxt Ty) 
 end DerivedCtxt
 
 /-! ## `dropUntil` -/
+section DropUntil
+variable (Γ : Ctxt Ty) {ty} (v : Var Γ ty)
 
-/-- `Γ.dropUntil v` is the largest prefix of context `Γ` that no longer contains variable `v` -/
-def dropUntil (Γ : Ctxt Ty) (v : Var Γ ty) : Ctxt Ty :=
+/-- `Γ.dropUntil v` is the largest prefix of context `Γ` that no longer contains variable `v`. -/
+def dropUntil : Ctxt Ty :=
   ⟨List.drop (v.val + 1) Γ.toList⟩
+
+variable {Γ} {v}
 
 @[simp] lemma dropUntil_last   : dropUntil (snoc Γ ty) (Var.last Γ ty) = Γ := rfl
 @[simp] lemma dropUntil_toSnoc : dropUntil (snoc Γ ty) (Var.toSnoc v) = dropUntil Γ v := rfl
 
-@[simp] lemma dropUntil_castCtxt {v : Γ'.Var t} {h : Γ' = Γ} :
-    Γ.dropUntil (v.castCtxt h) = Γ'.dropUntil v := by
+@[simp] lemma dropUntil_castCtxt {h : Γ = Γ'} :
+    Γ'.dropUntil (v.castCtxt h) = Γ.dropUntil v := by
   subst h; rfl
 
-@[simp] lemma dropUntil_appendInl {v : Γ.Var t} :
+@[simp] lemma dropUntil_appendInl :
     (Γ ++ ts).dropUntil v.appendInl = Γ.dropUntil v := by
   simp only [dropUntil, Var.val_appendInl]
   rw [Nat.add_right_comm, Nat.add_comm]
   simp
 
+@[simp] lemma dropUntil_appendInr {v : Var ⟨ts⟩ t} :
+    (Γ ++ ts).dropUntil v.appendInr = Γ ++ (ts.drop <| v.1 + 1) := by
+  rcases Γ
+  -- TODO: upstream the following as a `List` lemma
+  suffices ∀ {xs} (i : Nat) (hi : i ≤ xs.length) (ys : List Ty),
+    List.drop i (xs ++ ys) = List.drop i xs ++ ys
+  by
+    have hi : v.val + 1 ≤ ts.length := by
+      simpa using v.val_lt
+    simpa [dropUntil] using this _ hi _
+  intro xs i hi ys
+  induction xs generalizing i
+  case nil => cases i <;> simp_all
+  case cons ih =>
+    rcases i with _|i
+    · rfl
+    · simp [ih i (by simp_all)]
+
 /-- The difference between `Γ.dropUntil v` and `Γ` is exactly `v.val + 1` -/
-def dropUntilDiff {Γ : Ctxt Ty} {v : Var Γ ty} : Diff (Γ.dropUntil v) Γ :=
+def dropUntilDiff : Diff (Γ.dropUntil v) Γ :=
   ⟨v.val+1, by
     intro i _ h
     induction Γ
     case nil => exact v.emptyElim
     case snoc Γ _ ih =>
       cases v using Var.casesOn
-      · simp only [dropUntil_toSnoc, Var.val_toSnoc] at h ⊢
+      · simp only [Var.val_toSnoc] at h ⊢
         apply ih h
       · simpa! using h
   ⟩
 
 /-- Context homomorphism from `(Γ.dropUntil v)` to `Γ`, see also `dropUntilDiff` -/
 abbrev dropUntilHom : Hom (Γ.dropUntil v) Γ := dropUntilDiff.toHom
+
+@[simp, grind=] lemma val_dropUntilDiff : (@dropUntilDiff _ Γ _ v).val = v.val+1 := rfl
 
 @[simp] lemma dropUntilHom_last : dropUntilHom (v := Var.last Γ ty) = Hom.id.snocRight := rfl
 @[simp] lemma dropUntilHom_toSnoc {v : Var Γ t} :
@@ -937,6 +1144,7 @@ abbrev dropUntilHom : Hom (Γ.dropUntil v) Γ := dropUntilDiff.toHom
 instance : CoeOut (Var (Γ.dropUntil v) ty) (Var Γ ty) where
   coe v := dropUntilDiff.toHom v
 
+end DropUntil
 
 /-!
 # ToExpr

--- a/SSA/Core/Framework.lean
+++ b/SSA/Core/Framework.lean
@@ -979,9 +979,9 @@ def Lets.getPureExpr {Γ₁ Γ₂ : Ctxt d.Ty} (lets : Lets d Γ₁ eff Γ₂) {
     (v : Var Γ_out ty₂):
     getPureExpr (lets.var e) (v.toSnoc)
     = (Expr.changeVars <| Ctxt.Hom.id.snocRight) <$> (getPureExpr lets v) := by
-  simp only [getPureExpr, Ctxt.dropUntil_toSnoc, Ctxt.dropUntilHom_toSnoc,
+  simp only [getPureExpr, Ctxt.dropUntilHom_toSnoc,
     getPureExprAux_var_toSnoc, Option.map_eq_map, Option.map_map, Function.comp_def,
-    Expr.changeVars_changeVars];
+    Expr.changeVars_changeVars]
   rfl
 
 /-!

--- a/SSA/Core/HVector.lean
+++ b/SSA/Core/HVector.lean
@@ -117,6 +117,8 @@ abbrev getN (x : HVector A as) (i : Nat) (hi : i < as.length := by hvector_get_e
     A (as.get ⟨i, hi⟩) :=
   x.get ⟨i, hi⟩
 
+/-! ## ToTuple -/
+
 def ToTupleType (A : α → Type*) : List α → Type _
   | [] => PUnit
   | [a] => A a
@@ -134,23 +136,48 @@ abbrev toSingle : HVector A [a₁] → A a₁ := toTuple
 abbrev toPair   : HVector A [a₁, a₂] → A a₁ × A a₂ := toTuple
 abbrev toTriple : HVector A [a₁, a₂, a₃] → A a₁ × A a₂ × A a₃ := toTuple
 
-section Repr
-open Std (Format format)
 
-private def reprInner [∀ a, Repr (f a)] (prec : Nat) : ∀ {as}, HVector f as → List Format
-  | _, .nil => []
-  | _, .cons x xs => (reprPrec x prec) :: (reprInner prec xs)
+/-!
+## Conversion to a List
+-/
+
+/-- Convert an hvector where every element provably has the same type β into
+a `List` of βs-/
+def toListOf {A : α → _} {as} (β : Type _)
+    (hα : ∀ a ∈ as, A a = β := by intros; rfl) :
+    HVector A as → List β
+  | .nil => []
+  | .cons x xs =>
+    let y := cast (hα _ <| by simp) x
+    let ys := xs.toListOf β (fun a h => hα a <| by simpa using .inr h)
+    y :: ys
+
+/-!
+## Repr
+-/
 
 instance [∀ a, Repr (f a)] : Repr (HVector f as) where
-  reprPrec xs prec := f!"[{(xs.reprInner prec).intersperse f!","}]"
-
-end Repr
+  reprPrec xs prec :=
+    let xs := xs.map (fun _ x => s!"{repr x}") |>.toListOf String |> ", ".intercalate
+    f!"[{xs}]"
 
 /-
   # Theorems
 -/
 
-theorem map_cons {A B : α → Type u} {as : List α} {f : (a : α) → A a → B a}
+/-! ## get -/
+
+@[simp] theorem cons_get_zero {A : α → Type*} {a: α} {as : List α} {e : A a} {vec : HVector A as} :
+   (HVector.cons e vec).get (@OfNat.ofNat (Fin (as.length + 1)) 0 Fin.instOfNat) = e :=
+  rfl
+
+@[simp] theorem cons_get_succ {A : α → Type*} {a: α} {as : List α} {e : A a} {vec : HVector A as} {i : Fin as.length} :
+   (HVector.cons e vec).get (i.succ) = vec.get i :=
+  rfl
+
+/-! ## map -/
+
+@[simp] theorem map_cons {A B : α → Type u} {as : List α} {f : (a : α) → A a → B a}
     {x : A a} {xs : HVector A as} :
     map f (cons x xs) = cons (f _ x) (map f xs) := by
   induction xs <;> simp_all [map]
@@ -160,15 +187,43 @@ theorem map_map {A B C : α → Type*} {l : List α} (t : HVector A l)
     (t.map f).map g = t.map (fun a v => g a (f a v)) := by
   induction t <;> simp_all [map]
 
+@[simp] theorem get_map (xs : HVector A as) (f : (a : α) → A a → B a) :
+    (xs.map f).get i = f _ (xs.get i) := by
+  induction xs with
+  | nil     => exact i.elim0
+  | cons x xs ih =>
+    cases i using Fin.succRecOn
+    · rfl
+    · simp_all [map]
+
+/-! ## fold -/
+
+@[simp] theorem foldl_cons :
+    foldl f b (cons x xs) = foldl f (f _ b x) xs :=
+  rfl
+
+@[simp] theorem foldl_map :
+    foldl f b (map g xs) = foldl (fun a x b => f a x (g _ b)) b xs := by
+  induction xs generalizing f b with
+  | nil => rfl
+  | cons _ _ ih => simp [foldl, map, ih]
+
+/-! ## misc -/
+
 theorem eq_of_type_eq_nil {A : α → Type*} {l : List α}
     {t₁ t₂ : HVector A l} (h : l = []) : t₁ = t₂ := by
   cases h; cases t₁; cases t₂; rfl
 syntax "[" withoutPosition(term,*) "]ₕ"  : term
 
-@[simp]
-theorem cons_get_zero {A : α → Type*} {a: α} {as : List α} {e : A a} {vec : HVector A as} :
-   (HVector.cons e vec).get (@OfNat.ofNat (Fin (as.length + 1)) 0 Fin.instOfNat) = e := by
-  rfl
+
+@[ext] theorem ext {xs ys : HVector A as}
+    (h : ∀ i, xs.get i = ys.get i) : xs = ys := by
+  induction xs <;> cases ys
+  case nil => rfl
+  case cons ih _ _ =>
+    specialize ih (fun i => by simpa using h i.succ)
+    specialize h (0 : Fin <| _ + 1)
+    simp_all
 
 -- Copied from core for List
 macro_rules
@@ -189,6 +244,7 @@ infixr:50 "::ₕ" => HVector.cons
 /-!
   ## OfFn
 -/
+section OfFn
 
 def ofFn (A : α → Type _) (as : List α) (f : (i : Fin as.length) → A as[i]) :
     HVector A as :=
@@ -196,7 +252,38 @@ def ofFn (A : α → Type _) (as : List α) (f : (i : Fin as.length) → A as[i]
   | _ :: as => f (0 : Fin (_ + 1)) ::ₕ ofFn A as (fun i => f i.succ)
   | [] => .nil
 
-@[simp] theorem ofFn_nil : ofFn A [] f = .nil := by rfl
+@[simp] theorem ofFn_nil : ofFn A [] f = .nil := rfl
+
+@[simp] theorem get_ofFn : (ofFn A as f).get i = f i := by
+  induction as
+  case nil => exact i.elim0
+  case cons ih =>
+    cases i using Fin.succRec
+    · rfl
+    · simp [ofFn, ih]
+
+end OfFn
+
+/-!
+## Append
+-/
+section Append
+
+def append {as bs} : HVector A as → HVector A bs → HVector A (as ++ bs)
+  | .nil, ys => ys
+  | x ::ₕ xs, ys => x ::ₕ (append xs ys)
+
+instance : HAppend (HVector A as) (HVector A bs) (HVector A (as ++ bs)) where
+  hAppend := append
+
+variable {bs} {xs : HVector A as} {ys : HVector A bs}
+
+@[simp] theorem append_eq : append xs ys = xs ++ ys := rfl
+
+@[simp] theorem nil_append : nil (f:=A) ++ ys = ys := rfl
+@[simp] theorem cons_append : (x ::ₕ xs) ++ ys = (x ::ₕ (xs ++ ys)) := rfl
+
+end Append
 
 /-
   # ToExpr and other Meta helpers
@@ -273,7 +360,33 @@ def cast {A : α → Type u} {B : β → Type u} {as : List α} {bs : List β}
                         (fun i => by simpa using h_elem i.succ)
       (h₀ ▸ x) ::ₕ xs
 
-/-! ## Meta helpers & simprocs -/
+/-!
+## Find
+-/
+
+def idxOf? (x : A a) {as} [DecidableEq α] [∀ a, DecidableEq (A a)] :
+    HVector A as → Option { i : Fin <| as.length // as.get i = a }
+  | .nil => none
+  | .cons (a:=b) y ys =>
+      if h : ∃ h : a = b, x = h ▸ y then
+        some ⟨(0 : Fin <| _ + 1), h.1 ▸ rfl⟩
+      else
+        (ys.idxOf? x).map fun ⟨i, h⟩ =>
+          ⟨i.succ, by simpa⟩
+
+section Lemmas
+variable [DecidableEq α] [∀ a, DecidableEq (A a)]
+variable (xs : HVector A as) {a : α} (x : A a)
+
+@[simp] theorem idxOf?_cons_same :
+    idxOf? x (x ::ₕ xs) = some ⟨(0 : Fin <| _ + 1), rfl⟩ := by
+  simp [idxOf?]
+
+end Lemmas
+
+/-!
+## Meta helpers & simprocs
+-/
 section Meta
 open Lean Meta Qq
 

--- a/SSA/Projects/InstCombine/AliveHandwrittenLargeExamples.lean
+++ b/SSA/Projects/InstCombine/AliveHandwrittenLargeExamples.lean
@@ -47,8 +47,9 @@ theorem alive_DivRemOfSelect (w : Nat) :
   simp_alive_split
   alive_auto
 
-/--info: 'AliveHandwritten.DivRemOfSelect.alive_DivRemOfSelect' depends on
-axioms: [propext, Quot.sound] -/
+/--
+info: 'AliveHandwritten.DivRemOfSelect.alive_DivRemOfSelect' depends on axioms: [propext, Classical.choice, Quot.sound]
+-/
 #guard_msgs in #print axioms alive_DivRemOfSelect
 
 end DivRemOfSelect


### PR DESCRIPTION
This PR extracts the API on `Ctxt` and `HVector` needed for multiple return values from #1511.

In particular, for `Ctxt`:
- We add `grind` tags to existing lemma for better automation
- We prove that the GetElem instance is Lawful (which needed some moving around of lemmas)
- Refactor `appendIn{l,r}` to use projections over pattern-matching, for easier unfolding
- Add `Var.eq` as a convenient way to state equality of variables with different types (but in the same context)
- Prove `ofFinCases`, a cases-principle in terms of `Fin`
- Add assorted missing lemmas

And for HVector:
- Add `toListOf` to convert an HVector into a List (under certain conditions)
- Add a way to append hvectors together
- Add `idxOf?` to find elements in an HVector