### PR TITLE
chore: organize HVector refinement instance

### DIFF
--- a/SSA/Core/Framework/Refinement.lean
+++ b/SSA/Core/Framework/Refinement.lean
@@ -132,33 +132,6 @@ open EffectKind (impure) in
 
 end EffectKind
 
-/-! ### HVector Refinement -/
-namespace HVector
-variable {A : α → Type} {B : β → Type} [∀ a b, HRefinement (A a) (B b)]
-
-/--
-We say that a vector of values `xs` is refined by another vector `ys` (written
-`xs ⊑ ys`) when `xs` and `ys` have the same number of elements, and each element
-of `xs` is refined by the corresponding element of `ys` at the same index.
--/
-def IsRefinedBy {as} {bs} : HVector A as → HVector B bs → Prop
-  | .nil, .nil => True
-  | .cons x xs, .cons y ys => x ⊑ y ∧ xs.IsRefinedBy ys
-  | _, _ => False
-
-instance  : HRefinement (HVector A as) (HVector B bs) where
-  IsRefinedBy := HVector.IsRefinedBy
-
-variable {x : A a} {xs : HVector A as} {y : B b} {ys : HVector B bs}
-
-@[simp, simp_denote] lemma cons_isRefinedBy_cons  : ((x ::ₕ xs) ⊑ (y ::ₕ ys)) ↔ (x ⊑ y ∧ xs ⊑ ys) := by rfl
-@[simp, simp_denote] lemma nil_isRefinedBy_nil    : (nil : HVector A _) ⊑ (nil : HVector B _)     := True.intro
-
-@[simp, simp_denote] lemma not_nil_isRefinedBy_cons : ¬((nil : HVector A _) ⊑ (y ::ₕ ys)) := by rintro ⟨⟩
-@[simp, simp_denote] lemma not_cons_isRefinedBy_nil : ¬((x ::ₕ xs) ⊑ (nil : HVector B _)) := by rintro ⟨⟩
-
-end HVector
-
 /-! ## Canonicalization -/
 section SimpDenote
 open Lean Meta
@@ -323,6 +296,34 @@ We provide some generic refinement instances
 -/
 section Instances
 
+/-! ### HVector Refinement -/
+namespace HVector
+variable {A : α → Type} {B : β → Type} [∀ a b, HRefinement (A a) (B b)]
+
+/--
+We say that a vector of values `xs` is refined by another vector `ys` (written
+`xs ⊑ ys`) when `xs` and `ys` have the same number of elements, and each element
+of `xs` is refined by the corresponding element of `ys` at the same index.
+-/
+def IsRefinedBy {as} {bs} : HVector A as → HVector B bs → Prop
+  | .nil, .nil => True
+  | .cons x xs, .cons y ys => x ⊑ y ∧ xs.IsRefinedBy ys
+  | _, _ => False
+
+instance  : HRefinement (HVector A as) (HVector B bs) where
+  IsRefinedBy := HVector.IsRefinedBy
+
+variable {x : A a} {xs : HVector A as} {y : B b} {ys : HVector B bs}
+
+@[simp, simp_denote] lemma cons_isRefinedBy_cons  : ((x ::ₕ xs) ⊑ (y ::ₕ ys)) ↔ (x ⊑ y ∧ xs ⊑ ys) := by rfl
+@[simp, simp_denote] lemma nil_isRefinedBy_nil    : (nil : HVector A _) ⊑ (nil : HVector B _)     := True.intro
+
+@[simp, simp_denote] lemma not_nil_isRefinedBy_cons : ¬((nil : HVector A _) ⊑ (y ::ₕ ys)) := by rintro ⟨⟩
+@[simp, simp_denote] lemma not_cons_isRefinedBy_nil : ¬((x ::ₕ xs) ⊑ (nil : HVector B _)) := by rintro ⟨⟩
+
+end HVector
+
+/-! ### Prod -/
 namespace Prod
 
 instance [HRefinement α γ] [HRefinement β δ] : HRefinement (α × β) (γ × δ) where
@@ -335,6 +336,7 @@ theorem isRefinedBy_iff [HRefinement α γ] [HRefinement β δ]
   rfl
 end Prod
 
+/-! ### StateT -/
 namespace StateT
 variable {m n : Type → Type} [HRefinement (m (α × σ)) (n (β × σ))]
 


### PR DESCRIPTION
In particular, move the instance lower down the file with the other instances, since it isn't needed before.

Peeled off from #1511 