### PR TITLE
chore: rename 'lemma' to 'theorem' in SSA/Core

### DIFF
--- a/SSA/Core/EffectKind.lean
+++ b/SSA/Core/EffectKind.lean
@@ -65,7 +65,7 @@ end Instances
 section Lemmas
 variable [Monad m]
 
-@[simp] lemma pure_pure (eff : EffectKind) (x : α) :
+@[simp] theorem pure_pure (eff : EffectKind) (x : α) :
     (Pure.pure (Pure.pure x : pure.toMonad m (no_index α)) : eff.toMonad m α) = Pure.pure x :=
   rfl
 

--- a/SSA/Core/ErasedContext.lean
+++ b/SSA/Core/ErasedContext.lean
@@ -46,7 +46,7 @@ def empty : Ctxt Ty := .ofList []
 instance : EmptyCollection (Ctxt Ty) := ⟨Ctxt.empty⟩
 instance : Inhabited (Ctxt Ty) := ⟨Ctxt.empty⟩
 
-lemma empty_eq : (∅ : Ctxt Ty) = .empty := rfl
+theorem empty_eq : (∅ : Ctxt Ty) = .empty := rfl
 
 @[match_pattern]
 def snoc : Ctxt Ty → Ty → Ctxt Ty
@@ -62,9 +62,9 @@ instance : GetElem? (Ctxt Ty) Nat Ty (fun Γ i => i < Γ.length) where
 
 section GetElemLemmas
 
-lemma getElem?_eq_toList_getElem? {i : Nat} : Γ[i]? = Γ.toList[i]? := rfl
-@[simp, grind=] lemma getElem?_ofList (i : Nat) : (ofList ts)[i]? = ts[i]? := rfl
-@[simp, grind=] lemma getElem_ofList (i : Nat) (h : _) : (ofList ts)[i]'h = ts[i]'h := rfl
+theorem getElem?_eq_toList_getElem? {i : Nat} : Γ[i]? = Γ.toList[i]? := rfl
+@[simp, grind=] theorem getElem?_ofList (i : Nat) : (ofList ts)[i]? = ts[i]? := rfl
+@[simp, grind=] theorem getElem_ofList (i : Nat) (h : _) : (ofList ts)[i]'h = ts[i]'h := rfl
 
 instance : LawfulGetElem (Ctxt Ty) Nat Ty (fun as i => i < as.length) where
   getElem?_def Γ i _ := by rcases Γ; grind
@@ -90,38 +90,38 @@ def map (f : Ty₁ → Ty₂) : Ctxt Ty₁ → Ctxt Ty₂ :=
 section Lemmas
 variable (Γ : Ctxt Ty) (ts us : List Ty)
 
-@[simp] lemma snoc_inj : Γ.snoc t = Γ.snoc u ↔ t = u := by
+@[simp] theorem snoc_inj : Γ.snoc t = Γ.snoc u ↔ t = u := by
   constructor <;> (rintro ⟨⟩; rfl)
 
 variable {m} [Monad m] [LawfulMonad m] (t u : m _) in
-@[simp] lemma snoc_map_inj : Γ.snoc <$> t = Γ.snoc <$> u ↔ t = u :=
+@[simp] theorem snoc_map_inj : Γ.snoc <$> t = Γ.snoc <$> u ↔ t = u :=
   (map_inj_right (snoc_inj _).mp)
 
-@[simp] lemma ofList_append : (⟨ts⟩ : Ctxt _) ++ us = us ++ ts := rfl
-@[simp] lemma toList_append : (Γ ++ ts).toList = ts ++ Γ.toList := rfl
+@[simp] theorem ofList_append : (⟨ts⟩ : Ctxt _) ++ us = us ++ ts := rfl
+@[simp] theorem toList_append : (Γ ++ ts).toList = ts ++ Γ.toList := rfl
 
-@[simp] lemma getElem?_snoc_zero (t : Ty)           : (Γ.snoc t)[0]? = some t := rfl
-@[simp] lemma getElem?_snoc_succ (t : Ty) (i : Nat) : (Γ.snoc t)[i+1]? = Γ[i]? := rfl
+@[simp] theorem getElem?_snoc_zero (t : Ty)           : (Γ.snoc t)[0]? = some t := rfl
+@[simp] theorem getElem?_snoc_succ (t : Ty) (i : Nat) : (Γ.snoc t)[i+1]? = Γ[i]? := rfl
 
-@[simp] lemma map_nil (f : Ty → Ty') : map f ∅ = ∅ := rfl
-@[simp] lemma map_snoc : (Γ.snoc a).map f = (Γ.map f).snoc (f a) := rfl
+@[simp] theorem map_nil (f : Ty → Ty') : map f ∅ = ∅ := rfl
+@[simp] theorem map_snoc : (Γ.snoc a).map f = (Γ.map f).snoc (f a) := rfl
 
-@[simp] lemma getElem?_map (Γ : Ctxt Ty) (f : Ty → Ty') (i : Nat) :
+@[simp] theorem getElem?_map (Γ : Ctxt Ty) (f : Ty → Ty') (i : Nat) :
     (Γ.map f)[i]? = Γ[i]?.map f := by
   simp [map]; rfl
 
-@[simp, grind=] lemma length_ofList : (ofList ts).length = ts.length := rfl
-@[simp, grind=] lemma length_snoc (Γ : Ctxt α) (x : α) : (Γ.snoc x).length = Γ.length + 1 := rfl
-@[simp, grind=] lemma length_map : (Γ.map f).length = Γ.length := by simp [map, length]
-@[simp, grind=] lemma length_append : (Γ ++ ts).length = Γ.length + ts.length := by
+@[simp, grind=] theorem length_ofList : (ofList ts).length = ts.length := rfl
+@[simp, grind=] theorem length_snoc (Γ : Ctxt α) (x : α) : (Γ.snoc x).length = Γ.length + 1 := rfl
+@[simp, grind=] theorem length_map : (Γ.map f).length = Γ.length := by simp [map, length]
+@[simp, grind=] theorem length_append : (Γ ++ ts).length = Γ.length + ts.length := by
   simp [length, Nat.add_comm]
 
 instance : Functor Ctxt where
   map := map
 
-@[simp] lemma map_eq_map : f <$> Γ = map f Γ := rfl
+@[simp] theorem map_eq_map : f <$> Γ = map f Γ := rfl
 
-@[simp] lemma map_append (f : Ty₁ → Ty₂) (Γ : Ctxt Ty₁) (ts : List Ty₁) :
+@[simp] theorem map_append (f : Ty₁ → Ty₂) (Γ : Ctxt Ty₁) (ts : List Ty₁) :
     (Γ ++ ts).map f = Γ.map f ++ (ts.map f) := by
   simp [map]
 
@@ -177,15 +177,15 @@ def toSnoc {Γ : Ctxt Ty} {t t' : Ty} (var : Var Γ t) : Var (snoc Γ t') t  :=
 section Lemmas
 variable {Γ : Ctxt Ty} {t : Ty}
 
-lemma val_lt (v : Γ.Var t) : v.val < Γ.length := by
+theorem val_lt (v : Γ.Var t) : v.val < Γ.length := by
   rcases v with ⟨idx, h⟩
   suffices ¬(Γ.length ≤ idx) by grind
   rcases Γ
   simp only [length_ofList, ← List.getElem?_eq_none_iff]
   simp_all
 
-@[simp] lemma zero_eq_last (h) : ⟨0, h⟩ = last Γ t := rfl
-@[simp] lemma succ_eq_toSnoc {w} (h : (Γ.snoc t)[w+1]? = some t') :
+@[simp] theorem zero_eq_last (h) : ⟨0, h⟩ = last Γ t := rfl
+@[simp] theorem succ_eq_toSnoc {w} (h : (Γ.snoc t)[w+1]? = some t') :
     ⟨w+1, h⟩ = toSnoc ⟨w, h⟩ := rfl
 
 end Lemmas
@@ -268,17 +268,17 @@ def castCtxt {Γ : Ctxt Op} (h_eq : Γ = Δ) : Γ.Var ty → Δ.Var ty
 section Lemmas
 variable {t} (v : Var Γ t)
 
-@[simp, grind=] lemma cast_rfl (h : t = t) : v.cast h = v := rfl
+@[simp, grind=] theorem cast_rfl (h : t = t) : v.cast h = v := rfl
 
-@[simp, grind=] lemma castCtxt_rfl (h : Γ = Γ) : v.castCtxt h = v := rfl
-@[simp, grind=] lemma castCtxt_castCtxt (h₁ : Γ = Δ) (h₂ : Δ = Ξ) :
+@[simp, grind=] theorem castCtxt_rfl (h : Γ = Γ) : v.castCtxt h = v := rfl
+@[simp, grind=] theorem castCtxt_castCtxt (h₁ : Γ = Δ) (h₂ : Δ = Ξ) :
     (v.castCtxt h₁).castCtxt h₂ = v.castCtxt (by simp [*]) := by subst h₁ h₂; simp
 
-@[simp, grind=] lemma cast_mk : cast h ⟨vi, hv⟩ = ⟨vi, h ▸ hv⟩ := rfl
-@[simp, grind=] lemma castCtxt_mk : castCtxt h ⟨vi, hv⟩ = ⟨vi, h ▸ hv⟩ := rfl
+@[simp, grind=] theorem cast_mk : cast h ⟨vi, hv⟩ = ⟨vi, h ▸ hv⟩ := rfl
+@[simp, grind=] theorem castCtxt_mk : castCtxt h ⟨vi, hv⟩ = ⟨vi, h ▸ hv⟩ := rfl
 
-@[simp, grind=] lemma val_cast : (cast h v).val = v.val := rfl
-@[simp, grind=] lemma val_castCtxt : (castCtxt h v).val = v.val := rfl
+@[simp, grind=] theorem val_cast : (cast h v).val = v.val := rfl
+@[simp, grind=] theorem val_castCtxt : (castCtxt h v).val = v.val := rfl
 
 end Lemmas
 
@@ -327,10 +327,10 @@ def appendCases
 section Lemmas
 variable {t : Ty} {v : Γ.Var t}
 
-@[simp] lemma val_appendInl {v : Γ.Var t} : (v.appendInl (ts := ts)).val = v.val + ts.length := rfl
-@[simp] lemma val_appendInr {v : Var ts t}  : (v.appendInr (Γ := Γ)).val = v.val := rfl
+@[simp] theorem val_appendInl {v : Γ.Var t} : (v.appendInl (ts := ts)).val = v.val + ts.length := rfl
+@[simp] theorem val_appendInr {v : Var ts t}  : (v.appendInr (Γ := Γ)).val = v.val := rfl
 
-lemma toSnoc_appendInr {v : Var ⟨ts⟩ t} :
+theorem toSnoc_appendInr {v : Var ⟨ts⟩ t} :
     v.toSnoc (t':=t').appendInr (Γ := Γ) = v.appendInr.toSnoc :=
   rfl
 
@@ -374,13 +374,13 @@ instance [DecidableEq Ty] {v : Γ.Var t} {w : Γ.Var u} : Decidable (v.eq w) := 
 
 /-- Given variables `v, w : Γ.Var t` with the same type index `t`, `v.eq w`
 coincides exactly with `v = w`. -/
-@[simp] lemma eq_iff {v w : Γ.Var t} : v.eq w ↔ v = w := by
+@[simp] theorem eq_iff {v w : Γ.Var t} : v.eq w ↔ v = w := by
   simp [Var.eq]
 
-@[inherit_doc eq_iff] lemma eq.to_eq {v w : Γ.Var t} : v.eq w → v = w := eq_iff.mp
+@[inherit_doc eq_iff] theorem eq.to_eq {v w : Γ.Var t} : v.eq w → v = w := eq_iff.mp
 
 /-- From `v.eq w` it follows that the types of `v` and `w` are the same. -/
-lemma eq.ty_eq {v : Γ.Var t} {w : Γ.Var u} (h : v.eq w) : t = u := h.1
+theorem eq.ty_eq {v : Γ.Var t} {w : Γ.Var u} (h : v.eq w) : t = u := h.1
 
 /-! ### Fintype instance -/
 
@@ -413,7 +413,7 @@ def ofFin (i : Fin Γ.length) : Γ.Var (Γ[i]) :=
 
 section Lemmas
 
-@[simp, grind=] lemma ofFin_toFin (v : Γ.Var t) :
+@[simp, grind=] theorem ofFin_toFin (v : Γ.Var t) :
     ofFin v.toFin = v.cast (by have := v.prop; grind [toFin]) := rfl
 
 def ofFinCases
@@ -424,7 +424,7 @@ def ofFinCases
   refine _root_.cast ?h <| ofFin v.toFin
   grind
 
-@[simp] lemma toFin_toSnoc (v : Γ.Var t) : (v.toSnoc (t':=t')).toFin = v.toFin.succ := rfl
+@[simp] theorem toFin_toSnoc (v : Γ.Var t) : (v.toSnoc (t':=t')).toFin = v.toFin.succ := rfl
 
 end Lemmas
 
@@ -454,16 +454,16 @@ instance {Γ} : GetElem (HVector A as) (Var Γ a) (A a) (fun _ _ => as = Γ.toLi
 namespace HVector
 variable {A : α → _} {as : List α} (xs : HVector A as) {Γ : Ctxt α}
 
-@[simp] lemma getElem_ofFin_eq_get (i : Fin as.length) :
+@[simp] theorem getElem_ofFin_eq_get (i : Fin as.length) :
     xs[Ctxt.Var.ofFin i] = xs.get i := rfl
-@[simp] lemma getElem_map (xs : HVector A as) (v : Var ⟨as⟩ a) :
+@[simp] theorem getElem_map (xs : HVector A as) (v : Var ⟨as⟩ a) :
     (xs.map f)[v] = f _ xs[v] := by
   cases v using Var.ofFinCases
   rw [getElem_ofFin_eq_get, getElem_ofFin_eq_get]
   simp only [length_ofList, get_map, List.get_eq_getElem]
   rfl
 
-@[simp] lemma cons_getElem_toSnoc (x : A a) (v : Var Γ u)
+@[simp] theorem cons_getElem_toSnoc (x : A a) (v : Var Γ u)
     (h : as = Γ.toList := by rfl) (h' : a :: as = (Γ.snoc a).toList := by rfl) :
     (HVector.cons x xs)[v.toSnoc (t' := a)]'h' = xs[v]'h := by
   simp only [GetElem.getElem]
@@ -488,7 +488,7 @@ variable {Γ Δ Ξ : Ctxt Ty} (f : Hom Γ Δ) (g : Hom Δ Ξ)
 def Hom.comp : Hom Γ Ξ :=
   fun _t v => g (f v)
 
-@[simp, grind=] lemma Hom.comp_apply : f.comp g v = g (f v) := rfl
+@[simp, grind=] theorem Hom.comp_apply : f.comp g v = g (f v) := rfl
 
 end Comp
 
@@ -512,9 +512,9 @@ def Hom.snocMap {Γ Γ' : Ctxt Ty} (f : Hom Γ Γ') {t : Ty} :
   | toSnoc v => exact Ctxt.Var.toSnoc (f v)
   | last => exact Ctxt.Var.last _ _
 
-@[simp] lemma Hom.snocMap_last {Γ Γ' : Ctxt Ty} (f : Hom Γ Γ') {t : Ty} :
+@[simp] theorem Hom.snocMap_last {Γ Γ' : Ctxt Ty} (f : Hom Γ Γ') {t : Ty} :
     (f.snocMap (Ctxt.Var.last Γ t)) = Ctxt.Var.last Γ' t := rfl
-@[simp] lemma Hom.snocMap_toSnoc {Γ Γ' : Ctxt Ty} (f : Hom Γ Γ') {t t' : Ty} (v : Γ.Var t') :
+@[simp] theorem Hom.snocMap_toSnoc {Γ Γ' : Ctxt Ty} (f : Hom Γ Γ') {t t' : Ty} (v : Γ.Var t') :
     (f.snocMap v.toSnoc (t := t)) = (f v).toSnoc := rfl
 
 @[simp]
@@ -525,7 +525,7 @@ abbrev Hom.snocRight {Γ Γ' : Ctxt Ty} (f : Hom Γ Γ') {t : Ty} : Γ.Hom (Γ'.
 def Hom.unSnoc (f : Hom (Γ.snoc t) Δ) : Hom Γ Δ :=
   fun _ v => f v.toSnoc
 
-@[simp] lemma Hom.unSnoc_apply {Γ : Ctxt Ty} (f : Hom (Γ.snoc t) Δ) (v : Var Γ u) :
+@[simp] theorem Hom.unSnoc_apply {Γ : Ctxt Ty} (f : Hom (Γ.snoc t) Δ) (v : Var Γ u) :
     f.unSnoc v = f v.toSnoc := rfl
 
 instance : Coe (Γ.Var t) ((Γ.snoc t').Var t) := ⟨Ctxt.Var.toSnoc⟩
@@ -565,7 +565,7 @@ section Lemmas
     (f.appendCodomain (ts := ts)) v = (f v).appendInl :=
   rfl
 
-@[simp] lemma Hom.id_append : (Hom.id (Γ:=Γ)).append (ts := ts) = .id := by
+@[simp] theorem Hom.id_append : (Hom.id (Γ:=Γ)).append (ts := ts) = .id := by
   funext t v; cases v using Var.appendCases <;> simp [id, append]
 
 end Lemmas
@@ -576,14 +576,14 @@ variable {Γ Δ Δ' : Ctxt Ty} in
 def Hom.castCodomain (h : Δ = Δ') (f : Γ.Hom Δ) : Γ.Hom Δ' :=
   fun _t v => (f v).castCtxt h
 
-@[simp] lemma Hom.castDomain_apply {h : Δ = Δ'} {f : Γ.Hom Δ} {v : Γ.Var t} :
+@[simp] theorem Hom.castDomain_apply {h : Δ = Δ'} {f : Γ.Hom Δ} {v : Γ.Var t} :
     f.castCodomain h v = (f v).castCtxt h := rfl
 
-@[simp] lemma Hom.castDomain_castCodomain {h₁ : Δ₁ = Δ₂} {h₂ : Δ₂ = Δ₃}
+@[simp] theorem Hom.castDomain_castCodomain {h₁ : Δ₁ = Δ₂} {h₂ : Δ₂ = Δ₃}
     {f : Γ.Hom Δ₁} :
     (f.castCodomain h₁).castCodomain h₂ = f.castCodomain (h₁ ▸ h₂) := rfl
 
-@[simp] lemma Hom.castDomain_rfl {h : Δ = Δ} {f : Γ.Hom Δ} :
+@[simp] theorem Hom.castDomain_rfl {h : Δ = Δ} {f : Γ.Hom Δ} :
     (f.castCodomain h) = f := rfl
 
 /-!
@@ -642,12 +642,12 @@ theorem Valuation.snoc_zero {ty : Ty} (s : Γ.Valuation) (x : toType ty)
     (s.snoc x) ⟨0, h⟩ = x :=
   rfl
 
-@[simp] lemma Valuation.snoc_toSnoc {t t' : Ty} (s : Γ.Valuation)
+@[simp] theorem Valuation.snoc_toSnoc {t t' : Ty} (s : Γ.Valuation)
     (x : toType t) (v : Γ.Var t') :
     (s.snoc x) v.toSnoc = s v :=
   rfl
 
-@[simp] lemma Valuation.snoc_inj {t : Ty} {x y : ⟦t⟧} :
+@[simp] theorem Valuation.snoc_inj {t : Ty} {x y : ⟦t⟧} :
     (V ::ᵥ x) = (V ::ᵥ y) ↔ x = y where
   mpr := by rintro rfl; rfl
   mp := by
@@ -655,7 +655,7 @@ theorem Valuation.snoc_zero {ty : Ty} (s : Γ.Valuation) (x : toType ty)
     rw [← snoc_last V x, ← snoc_last V y, h]
 
 variable {m} [Monad m] [LawfulMonad m] in
-@[simp] lemma Valuation.snoc_map_inj {V : Γ.Valuation} {x y : m ⟦t⟧} :
+@[simp] theorem Valuation.snoc_map_inj {V : Γ.Valuation} {x y : m ⟦t⟧} :
     (V.snoc <$> x) = (V.snoc <$> y) ↔ x = y :=
   map_inj_right <| Valuation.snoc_inj.mp
 
@@ -695,7 +695,7 @@ variable {V : Γ.Valuation} {xs : HVector toType ts}
     (V ++ xs) v.appendInr = xs[v] := by
   simp [(· ++ ·)]
 
-@[simp] lemma Valuation.append_inj {V : Γ.Valuation}
+@[simp] theorem Valuation.append_inj {V : Γ.Valuation}
     {ts : List Ty} {xs ys : HVector toType ts} :
     (V ++ xs) = (V ++ ys) ↔ xs = ys where
   mpr := by rintro rfl; rfl
@@ -707,10 +707,10 @@ variable {V : Γ.Valuation} {xs : HVector toType ts}
     ext i
     exact h (Var.ofFin i)
 
-@[simp] lemma Valuation.append_nil {V : Γ.Valuation} :
+@[simp] theorem Valuation.append_nil {V : Γ.Valuation} :
     V ++ (HVector.nil (α := Ty) (f := toType)) = V := rfl
 
-@[simp] lemma Valuation.append_cons {t : Ty} {V : Γ.Valuation} {x : ⟦t⟧}  {xs : HVector toType ts} :
+@[simp] theorem Valuation.append_cons {t : Ty} {V : Γ.Valuation} {x : ⟦t⟧}  {xs : HVector toType ts} :
     V ++ (HVector.cons x xs) = (V ++ xs).snoc x := by
   funext _t v
   cases v using Var.appendCases with
@@ -770,19 +770,19 @@ def Valuation.comap {Γi Γo : Ctxt Ty} (Γiv: Γi.Valuation) (hom : Ctxt.Hom Γ
   funext t' v
   cases v using Var.casesOn <;> rfl
 
-@[simp] lemma Valuation.comap_id {Γ : Ctxt Ty} (V : Valuation Γ) : comap V Hom.id = V := rfl
+@[simp] theorem Valuation.comap_id {Γ : Ctxt Ty} (V : Valuation Γ) : comap V Hom.id = V := rfl
 
-@[simp] lemma Valuation.comap_snoc_snocRight {Γ Δ : Ctxt Ty} (Γv : Valuation Γ) (f : Hom Δ Γ) :
+@[simp] theorem Valuation.comap_snoc_snocRight {Γ Δ : Ctxt Ty} (Γv : Valuation Γ) (f : Hom Δ Γ) :
     comap (Γv.snoc x) (f.snocRight) = comap Γv f :=
   rfl
 
-@[simp] lemma Valuation.comap_append_append {Γ Δ : Ctxt Ty} {ts : List Ty}
+@[simp] theorem Valuation.comap_append_append {Γ Δ : Ctxt Ty} {ts : List Ty}
     (V : Γ.Valuation) (xs : HVector toType ts)
     (f : Δ.Hom Γ) :
     (V ++ xs).comap (f.append) = (V.comap f) ++ xs := by
   funext t v; cases v using Var.appendCases <;> simp
 
-@[simp] lemma Valuation.comap_appendCodomain {Γ Δ : Ctxt Ty} {ts : List Ty}
+@[simp] theorem Valuation.comap_appendCodomain {Γ Δ : Ctxt Ty} {ts : List Ty}
     (V : Γ.Valuation) (xs : HVector toType ts) (f : Δ.Hom Γ) :
     (V ++ xs).comap f.appendCodomain = V.comap f := by
   funext t v; simp
@@ -797,7 +797,7 @@ def Valuation.reassignVars [DecidableEq Ty] {ts : List Ty} {Γ : Ctxt Ty}
     | none => V vneedle
     | some ⟨i, h⟩ => h ▸ val.get i
 
-@[simp] lemma Valuation.reassignVars_eq [DecidableEq Ty] (V : Γ.Valuation) :
+@[simp] theorem Valuation.reassignVars_eq [DecidableEq Ty] (V : Γ.Valuation) :
     V.reassignVars vs (vs.map V) = V := by
   funext t w
   unfold reassignVars
@@ -815,7 +815,7 @@ def Valuation.reassignVars [DecidableEq Ty] {ts : List Ty} {Γ : Ctxt Ty}
         HVector.map_cons]
       split at ih <;> simp_all
 
-@[simp] lemma Valuation.comap_with [DecidableEq Ty] {Γ Δ : Ctxt Ty}
+@[simp] theorem Valuation.comap_with [DecidableEq Ty] {Γ Δ : Ctxt Ty}
     {V : Valuation Γ} {map : Δ.Hom Γ} {vs : HVector Δ.Var ty} {ws : HVector Γ.Var ty} :
     V.comap (map.with vs ws) = (V.comap map).reassignVars vs (ws.map V) := by
   funext t' v'
@@ -840,9 +840,9 @@ def Valuation.recOn {motive : ∀ {Γ : Ctxt Ty}, Γ.Valuation → Sort*}
 def Valuation.cast {Γ Δ : Ctxt Ty} (h : Γ = Δ) (V : Valuation Γ) : Valuation Δ :=
   fun _ v => V <| v.castCtxt h.symm
 
-@[simp] lemma Valuation.cast_rfl {Γ : Ctxt Ty} (h : Γ = Γ) (V : Valuation Γ) : V.cast h = V := rfl
+@[simp] theorem Valuation.cast_rfl {Γ : Ctxt Ty} (h : Γ = Γ) (V : Valuation Γ) : V.cast h = V := rfl
 
-@[simp] lemma Valuation.cast_apply {Γ : Ctxt Ty} (h : Γ = Δ) (V : Γ.Valuation) (v : Δ.Var t) :
+@[simp] theorem Valuation.cast_apply {Γ : Ctxt Ty} (h : Γ = Δ) (V : Γ.Valuation) (v : Δ.Var t) :
     V.cast h v = V (v.castCtxt h.symm) := rfl
 
 /-- Show that a valuation is equivalent to a `HVector` -/
@@ -982,7 +982,7 @@ def add : Diff Γ₁ Γ₂ → Diff Γ₂ Γ₃ → Diff Γ₁ Γ₃
 
 instance : HAdd (Diff Γ₁ Γ₂) (Diff Γ₂ Γ₃) (Diff Γ₁ Γ₃) := ⟨add⟩
 
-@[simp, grind] lemma val_add (f : Γ.Diff Δ) (g : Δ.Diff Ξ) : (f + g).val = f.val + g.val := rfl
+@[simp, grind] theorem val_add (f : Γ.Diff Δ) (g : Δ.Diff Ξ) : (f + g).val = f.val + g.val := rfl
 
 /-!
 ### `toHom`
@@ -994,7 +994,7 @@ def toHom (d : Diff Γ₁ Γ₂) : Hom Γ₁ Γ₂ :=
 
 section Lemmas
 
-@[simp, grind] lemma val_toHom_apply (d : Diff Γ Δ) (v : Γ.Var t) :
+@[simp, grind] theorem val_toHom_apply (d : Diff Γ Δ) (v : Γ.Var t) :
     (d.toHom v).val = v.val + d.val := rfl
 
 theorem Valid.of_succ {Γ₁ Γ₂ : Ctxt Ty} {d : Nat} (h_valid : Valid Γ₁ (Γ₂.snoc t) (d+1)) :
@@ -1003,15 +1003,15 @@ theorem Valid.of_succ {Γ₁ Γ₂ : Ctxt Ty} {d : Nat} (h_valid : Valid Γ₁ (
   simp [←h_valid h_get, snoc, List.getElem?_cons]
   rfl
 
-lemma toHom_succ {Γ₁ Γ₂ : Ctxt Ty} {d : Nat} (h : Valid Γ₁ (Γ₂.snoc t) (d+1)) :
+theorem toHom_succ {Γ₁ Γ₂ : Ctxt Ty} {d : Nat} (h : Valid Γ₁ (Γ₂.snoc t) (d+1)) :
     toHom ⟨d+1, h⟩ = (toHom ⟨d, Valid.of_succ h⟩).snocRight := by
   rfl
 
-@[simp] lemma toHom_zero {Γ : Ctxt Ty} {h : Valid Γ Γ 0} :
+@[simp] theorem toHom_zero {Γ : Ctxt Ty} {h : Valid Γ Γ 0} :
     toHom ⟨0, h⟩ = Hom.id := by
   rfl
 
-@[simp] lemma toHom_unSnoc {Γ₁ Γ₂ : Ctxt Ty} (d : Diff (Γ₁.snoc t) Γ₂) :
+@[simp] theorem toHom_unSnoc {Γ₁ Γ₂ : Ctxt Ty} (d : Diff (Γ₁.snoc t) Γ₂) :
     toHom (unSnoc d) = fun _ v => (toHom d) v.toSnoc := by
   unfold unSnoc Var.toSnoc toHom
   simp only [Valid]
@@ -1019,7 +1019,7 @@ lemma toHom_succ {Γ₁ Γ₂ : Ctxt Ty} {d : Nat} (h : Valid Γ₁ (Γ₂.snoc 
   congr 1
   rw [Nat.add_assoc, Nat.add_comm 1]
 
-@[simp] lemma toHom_comp_toHom (f : Γ.Diff Δ) (g : Δ.Diff Ξ) :
+@[simp] theorem toHom_comp_toHom (f : Γ.Diff Δ) (g : Δ.Diff Ξ) :
     f.toHom.comp g.toHom = (f + g).toHom := by
   funext t v
   apply Subtype.eq
@@ -1087,23 +1087,23 @@ def dropUntil : Ctxt Ty :=
 
 variable {Γ} {v}
 
-@[simp] lemma dropUntil_last   : dropUntil (snoc Γ ty) (Var.last Γ ty) = Γ := rfl
-@[simp] lemma dropUntil_toSnoc : dropUntil (snoc Γ ty) (Var.toSnoc v) = dropUntil Γ v := rfl
+@[simp] theorem dropUntil_last   : dropUntil (snoc Γ ty) (Var.last Γ ty) = Γ := rfl
+@[simp] theorem dropUntil_toSnoc : dropUntil (snoc Γ ty) (Var.toSnoc v) = dropUntil Γ v := rfl
 
-@[simp] lemma dropUntil_castCtxt {h : Γ = Γ'} :
+@[simp] theorem dropUntil_castCtxt {h : Γ = Γ'} :
     Γ'.dropUntil (v.castCtxt h) = Γ.dropUntil v := by
   subst h; rfl
 
-@[simp] lemma dropUntil_appendInl :
+@[simp] theorem dropUntil_appendInl :
     (Γ ++ ts).dropUntil v.appendInl = Γ.dropUntil v := by
   simp only [dropUntil, Var.val_appendInl]
   rw [Nat.add_right_comm, Nat.add_comm]
   simp
 
-@[simp] lemma dropUntil_appendInr {v : Var ⟨ts⟩ t} :
+@[simp] theorem dropUntil_appendInr {v : Var ⟨ts⟩ t} :
     (Γ ++ ts).dropUntil v.appendInr = Γ ++ (ts.drop <| v.1 + 1) := by
   rcases Γ
-  -- TODO: upstream the following as a `List` lemma
+  -- TODO: upstream the following as a `List` theorem
   suffices ∀ {xs} (i : Nat) (hi : i ≤ xs.length) (ys : List Ty),
     List.drop i (xs ++ ys) = List.drop i xs ++ ys
   by
@@ -1134,10 +1134,10 @@ def dropUntilDiff : Diff (Γ.dropUntil v) Γ :=
 /-- Context homomorphism from `(Γ.dropUntil v)` to `Γ`, see also `dropUntilDiff` -/
 abbrev dropUntilHom : Hom (Γ.dropUntil v) Γ := dropUntilDiff.toHom
 
-@[simp, grind=] lemma val_dropUntilDiff : (@dropUntilDiff _ Γ _ v).val = v.val+1 := rfl
+@[simp, grind=] theorem val_dropUntilDiff : (@dropUntilDiff _ Γ _ v).val = v.val+1 := rfl
 
-@[simp] lemma dropUntilHom_last : dropUntilHom (v := Var.last Γ ty) = Hom.id.snocRight := rfl
-@[simp] lemma dropUntilHom_toSnoc {v : Var Γ t} :
+@[simp] theorem dropUntilHom_last : dropUntilHom (v := Var.last Γ ty) = Hom.id.snocRight := rfl
+@[simp] theorem dropUntilHom_toSnoc {v : Var Γ t} :
   dropUntilHom (v := v.toSnoc (t' := t')) = (dropUntilHom (v:=v)).snocRight := rfl
 
 instance : CoeOut (Var (Γ.dropUntil v) ty) (Var Γ ty) where

--- a/SSA/Core/ErasedContext.lean
+++ b/SSA/Core/ErasedContext.lean
@@ -1103,7 +1103,7 @@ variable {Γ} {v}
 @[simp] theorem dropUntil_appendInr {v : Var ⟨ts⟩ t} :
     (Γ ++ ts).dropUntil v.appendInr = Γ ++ (ts.drop <| v.1 + 1) := by
   rcases Γ
-  -- TODO: upstream the following as a `List` theorem
+  -- TODO: upstream the following as a `List` lemma
   suffices ∀ {xs} (i : Nat) (hi : i ≤ xs.length) (ys : List Ty),
     List.drop i (xs ++ ys) = List.drop i xs ++ ys
   by

--- a/SSA/Core/Framework.lean
+++ b/SSA/Core/Framework.lean
@@ -300,11 +300,11 @@ def Com.rec' {Γ} (com : Com d Γ eff t) : motive com :=
 
 variable {rets} {var} {Γ : Ctxt _}
 
-@[simp] lemma Com.rec'_rets (v : HVector Γ.Var t) :
+@[simp] theorem Com.rec'_rets (v : HVector Γ.Var t) :
     (Com.rets (d:=d) (eff := eff) v).rec' (motive:=motive) rets var = rets v :=
   rfl
 
-@[simp] lemma Com.rec'_var (e : Expr d Γ eff u) (body : Com d _ _ t) :
+@[simp] theorem Com.rec'_var (e : Expr d Γ eff u) (body : Com d _ _ t) :
     (Com.var e body).rec' (motive:=motive) rets var
     = var e body (body.rec' (motive:=motive) rets var) :=
   rfl
@@ -388,16 +388,16 @@ def Com.bvars : Com d Γ eff t → Nat :=
 section Lemmas
 namespace Com
 
-@[simp] lemma size_rets  : (rets v : Com d Γ eff t).size = 0 := rfl
-@[simp] lemma size_var : (var e body : Com d Γ eff t).size = body.size + 1 := rfl
+@[simp] theorem size_rets  : (rets v : Com d Γ eff t).size = 0 := rfl
+@[simp] theorem size_var : (var e body : Com d Γ eff t).size = body.size + 1 := rfl
 
-@[simp] lemma bvars_rets  : (rets v : Com d Γ eff t).bvars = 0 := rfl
-@[simp] lemma bvars_var  :
+@[simp] theorem bvars_rets  : (rets v : Com d Γ eff t).bvars = 0 := rfl
+@[simp] theorem bvars_var  :
   (var e body : Com d Γ eff t).bvars = e.bvars + body.bvars := rfl
 
 end Com
 
-@[simp] lemma Ctxt.get_add_bvars (e : Expr d Γ eff ts) (i : Nat) :
+@[simp] theorem Ctxt.get_add_bvars (e : Expr d Γ eff ts) (i : Nat) :
     e.outContext[i + e.bvars]? = Γ[i]? := by
   rcases e with ⟨op, rfl, _, _⟩
   rcases Γ
@@ -447,13 +447,13 @@ abbrev Expr.contextHom (e : Expr d Γ eff ts) : Γ.Hom e.outContext :=
 
 section Lemmas
 
-@[simp] lemma Com.outContext_rets (vs : HVector Γ.Var t) : (rets vs : Com d Γ eff t).outContext = Γ := rfl
-@[simp] lemma Com.outContext_var {eff} (e : Expr d Γ eff t) (body : Com d e.outContext eff u) :
+@[simp] theorem Com.outContext_rets (vs : HVector Γ.Var t) : (rets vs : Com d Γ eff t).outContext = Γ := rfl
+@[simp] theorem Com.outContext_var {eff} (e : Expr d Γ eff t) (body : Com d e.outContext eff u) :
     (Com.var e body).outContext = body.outContext := rfl
 
-@[simp] lemma Com.outContextHom_rets (v : HVector Γ.Var t) :
+@[simp] theorem Com.outContextHom_rets (v : HVector Γ.Var t) :
     (rets v : Com d Γ eff t).outContextHom = Ctxt.Hom.id := rfl
-@[simp] lemma Com.outContextHom_var :
+@[simp] theorem Com.outContextHom_var :
     (var e body : Com d Γ eff t).outContextHom
     = e.contextHom.comp body.outContextHom := by
   funext t v
@@ -462,8 +462,8 @@ section Lemmas
     e.ty_eq]
   omega
 
-@[simp] lemma Com.returnVars_rets : returnVars (rets vs : Com d Γ eff t) = vs := rfl
-@[simp] lemma Com.returnVars_var :
+@[simp] theorem Com.returnVars_rets : returnVars (rets vs : Com d Γ eff t) = vs := rfl
+@[simp] theorem Com.returnVars_var :
     returnVars (var (d:=d) (eff:=eff) e body) = body.returnVars := rfl
 
 end Lemmas
@@ -527,7 +527,7 @@ omit [LawfulMonad d.m] in
 Unfold `Expr.denote` in terms of the field projections and `Expr.denoteOp`.
 
 NOTE: this allows the unfolding of `Expr.denote` applied to arbitrary expressions,
-whereas the built-in unfold lemma only applies when the argument is an application of
+whereas the built-in unfold theorem only applies when the argument is an application of
 `Expr.mk`.
 
 Unfortunately, if we define `Expr.denote` in terms of the projections directly,
@@ -538,7 +538,7 @@ theorem Expr.denote_unfold (e : Expr d Γ eff ty) :
   rcases e with ⟨op, rfl, _⟩
   simp [denote, denoteOp]
 
-@[simp] lemma Expr.denoteOp_eq_denoteOp_of {e₁ : Expr d Γ eff ty} {e₂ : Expr d Δ eff ty}
+@[simp] theorem Expr.denoteOp_eq_denoteOp_of {e₁ : Expr d Γ eff ty} {e₂ : Expr d Δ eff ty}
     {Γv : Valuation Γ} {Δv : Valuation Δ}
     (op_eq : e₁.op = e₂.op)
     (h_args : HVector.map Γv (op_eq ▸ e₁.args)
@@ -552,15 +552,15 @@ theorem Expr.denote_unfold (e : Expr d Γ eff ty) :
 
 /-
 https://leanprover.zulipchat.com/#narrow/stream/270676-lean4/topic/Equational.20Lemmas
-Recall that `simp` lazily generates equation lemmas.
-Moreover, recall that `simp only` **does not** generate equation lemmas.
-*but* if equation lemmas are present, then `simp only` *uses* the equation lemmas.
+Recall that `simp` lazily generates equation theorems.
+Moreover, recall that `simp only` **does not** generate equation theorems.
+*but* if equation theorems are present, then `simp only` *uses* the equation theorems.
 
-Hence, we build the equation lemmas by invoking the correct Lean meta magic,
+Hence, we build the equation theorems by invoking the correct Lean meta magic,
 so that `simp only` (which we use in `simp_peephole`) can find them!
 
 This allows `simp only [HVector.denote]` to correctly simplify `HVector.denote`
-args, since there now are equation lemmas for it.
+args, since there now are equation theorems for it.
 -/
 /--
 info: some #[`HVector.denote.eq_1, `HVector.denote.eq_2]
@@ -600,45 +600,45 @@ the congruence, you can do: `rw [← Lets.denotePure]; congr`
     Com d Γ .pure ty → Γ.Valuation → (HVector toType ty) :=
   Com.denote
 
-/-! ### simp-lemmas about `denote` functions -/
+/-! ### simp-theorems about `denote` functions -/
 section Lemmas
 
-@[simp] lemma Expr.comap_denote_snocRight (e : Expr d Γ .pure ty) (V : Γ.Valuation) :
+@[simp] theorem Expr.comap_denote_snocRight (e : Expr d Γ .pure ty) (V : Γ.Valuation) :
     (Valuation.comap (e.denote V) e.contextHom) = V := by
   funext t v; simp [Expr.denote_unfold, Id.map_eq']
 
-@[simp] lemma HVector.denote_nil
+@[simp] theorem HVector.denote_nil
     (T : HVector (fun (t : Ctxt d.Ty × List d.Ty) => Com d t.1 .impure t.2) []) :
     HVector.denote T = HVector.nil := by
   cases T; rfl
 
-@[simp] lemma HVector.denote_cons
+@[simp] theorem HVector.denote_cons
     {t : _ × _} {ts : RegionSignature _}
     (a : Com d t.1 .impure t.2) (as : Regions _ ts) :
     HVector.denote (.cons a as) = .cons (a.denote) (as.denote) :=
   rfl
 
-@[simp] lemma Com.denote_rets {eff : EffectKind} (Γ : Ctxt d.Ty) (vs : HVector Γ.Var ts) :
+@[simp] theorem Com.denote_rets {eff : EffectKind} (Γ : Ctxt d.Ty) (vs : HVector Γ.Var ts) :
     (Com.rets (eff := eff) vs).denote = fun V => pure (vs.map V) :=
   rfl
 
-@[simp] lemma Com.denote_var [LawfulMonad d.m] {e : Expr d Γ eff α} :
+@[simp] theorem Com.denote_var [LawfulMonad d.m] {e : Expr d Γ eff α} :
     (Com.var e body).denote =
     fun Γv => (e.denote Γv) >>= body.denote := by
   cases eff <;> rfl
 
-@[simp] lemma Com.denoteLets_var (e : Expr d Γ eff t) (body : Com d _ eff u) [LawfulMonad d.m] :
+@[simp] theorem Com.denoteLets_var (e : Expr d Γ eff t) (body : Com d _ eff u) [LawfulMonad d.m] :
     (Com.var e body).denoteLets =
         fun V => e.denote V >>= body.denoteLets := by
   cases eff
   · rfl
   · simp [denoteLets, bind_pure]
 
-@[simp] lemma Lets.denote_nil {Γ : Ctxt d.Ty} :
+@[simp] theorem Lets.denote_nil {Γ : Ctxt d.Ty} :
     (Lets.nil : Lets d Γ eff Γ).denote = (return ·) := by
   funext; simp [denote]
 
-@[simp] lemma Lets.denote_var {lets : Lets d Γ_in eff Γ_out} {e : Expr d Γ_out eff t} :
+@[simp] theorem Lets.denote_var {lets : Lets d Γ_in eff Γ_out} {e : Expr d Γ_out eff t} :
     (lets.var e).denote = fun V_in => lets.denote V_in >>= e.denote :=
   rfl
 
@@ -661,19 +661,19 @@ def Com.changeVars : Com d Γ eff ty →
   |  .var e body => fun varsMap => .var (e.changeVars varsMap)
       (body.changeVars (fun _ v => varsMap.append v))
 
-/-! simp-lemmas about `changeVars`-/
+/-! simp-theorems about `changeVars`-/
 section Lemmas
 variable {Γ Γ' : Ctxt d.Ty} {t} (f : Γ.Hom Γ') (e : Expr d Γ eff t) (V : Γ'.Valuation)
 
-@[simp] lemma op_changeVars : (e.changeVars f).op = e.op := rfl
-@[simp] lemma regArgs_changeVars : (e.changeVars f).regArgs = e.regArgs := rfl
-@[simp] lemma args_changeVars : (e.changeVars f).args = e.args.map f := rfl
+@[simp] theorem op_changeVars : (e.changeVars f).op = e.op := rfl
+@[simp] theorem regArgs_changeVars : (e.changeVars f).regArgs = e.regArgs := rfl
+@[simp] theorem args_changeVars : (e.changeVars f).args = e.args.map f := rfl
 
-@[simp] lemma Expr.denoteOp_changeVars  :
+@[simp] theorem Expr.denoteOp_changeVars  :
     (e.changeVars f).denoteOp V = e.denoteOp (V.comap f) := by
   simp [denoteOp, HVector.map_map]; rfl
 
-@[simp] lemma Expr.denote_changeVars {Γ Γ' : Ctxt d.Ty}
+@[simp] theorem Expr.denote_changeVars {Γ Γ' : Ctxt d.Ty}
     (varsMap : Γ.Hom Γ')
     (e : Expr d Γ eff Δ)
     (V : Γ'.Valuation)
@@ -685,22 +685,22 @@ variable {Γ Γ' : Ctxt d.Ty} {t} (f : Γ.Hom Γ') (e : Expr d Γ eff t) (V : Γ
 
 end Lemmas
 
-@[simp] lemma Com.changeVars_rets :
+@[simp] theorem Com.changeVars_rets :
     (Com.rets (d:=d) (Γ:=Γ) (eff := eff) vs).changeVars
     = fun (map : Γ.Hom Δ) => Com.rets (vs.map map) := by
   funext map
   simp [changeVars]
 
-@[simp] lemma Com.changeVars_var (e : Expr d Γ eff t) (body : Com d _ eff u) :
+@[simp] theorem Com.changeVars_var (e : Expr d Γ eff t) (body : Com d _ eff u) :
     (Com.var e body).changeVars
     = fun (map : Γ.Hom Δ) => Com.var (e.changeVars map) (body.changeVars map.append) := by
   simp [changeVars]
 
--- TODO: this is implied by simpler simp-lemmas, do we need it?
-@[simp] lemma Com.outContext_changeVars_rets (varsMap : Γ.Hom Γ') (_ : Com d Γ eff ty) :
+-- TODO: this is implied by simpler simp-theorems, do we need it?
+@[simp] theorem Com.outContext_changeVars_rets (varsMap : Γ.Hom Γ') (_ : Com d Γ eff ty) :
   ((Com.rets (d:=d) (eff := eff) v).changeVars varsMap).outContext = Γ' := by simp
 
-@[simp] lemma Com.denote_changeVars
+@[simp] theorem Com.denote_changeVars
     (varsMap : Γ.Hom Γ') (c : Com d Γ eff ty) :
     (c.changeVars varsMap).denote =
     fun V => c.denote (V.comap varsMap) := by
@@ -708,7 +708,7 @@ end Lemmas
   | rets x      => simp [HVector.map_map]; rfl
   | var _ _ ih => simp [denote, ih]
 
-@[simp] lemma Com.denote_changeVars' (varsMap : Γ.Hom Γ') (c : Com d Γ eff ty) :
+@[simp] theorem Com.denote_changeVars' (varsMap : Γ.Hom Γ') (c : Com d Γ eff ty) :
     (c.changeVars varsMap).denote = fun V => c.denote (V.comap varsMap) := by
   simp
 
@@ -718,32 +718,32 @@ end Lemmas
   | .var _ body  => cast (by simp) <|
       Com.outContext_changeVars_hom (map := map.append) map_inv.append (c := body)
 
-@[simp] lemma Com.denoteLets_returnVars (c : Com d Γ .pure tys) (V : Valuation Γ) :
+@[simp] theorem Com.denoteLets_returnVars (c : Com d Γ .pure tys) (V : Valuation Γ) :
     c.returnVars.map (c.denoteLets V) = c.denote V := by
   induction c using Com.rec'
   case rets v  => rfl
   case var ih => simp [denoteLets, Id.pure_eq', Id.bind_eq', ih, denote]
 
-@[simp] lemma Expr.changeVars_changeVars (e : Expr d Γ eff ty) (f : Γ.Hom Δ) (g : Δ.Hom Ξ) :
+@[simp] theorem Expr.changeVars_changeVars (e : Expr d Γ eff ty) (f : Γ.Hom Δ) (g : Δ.Hom Ξ) :
     (e.changeVars f).changeVars g = e.changeVars (f.comp g) := by
   simp [changeVars, HVector.map_map]; rfl
 
 /-! ### ChangeVars & Specific Morphisms -/
 
-lemma Expr.changeVars_castCodomain (e : Expr d Γ eff t)
+theorem Expr.changeVars_castCodomain (e : Expr d Γ eff t)
     (f : Hom Γ Δ) (h : Δ = Δ') :
     e.changeVars (f.castCodomain h) = cast (by simp [h]) (e.changeVars f) := by
   subst h; rfl
 
-@[simp] lemma HVector.changeVars_id {Γ : Ctxt d.Ty} (vs : HVector Γ.Var ts) :
+@[simp] theorem HVector.changeVars_id {Γ : Ctxt d.Ty} (vs : HVector Γ.Var ts) :
     vs.map Hom.id = vs := by
   induction vs <;> simp [map, *]
 
-@[simp] lemma Expr.changeVars_id (e : Expr d Γ eff t) :
+@[simp] theorem Expr.changeVars_id (e : Expr d Γ eff t) :
     e.changeVars .id = e := by
   cases e; simp [changeVars]
 
-@[simp] lemma Com.changeVars_id (c : Com d Γ eff t) :
+@[simp] theorem Com.changeVars_id (c : Com d Γ eff t) :
     c.changeVars .id = c := by
   induction c
   · simp
@@ -841,43 +841,43 @@ def Com.letSup (e : Expr d Γ eff₁ t) (body : Com d (e.outContext) eff₂ u) :
 
 section Lemmas
 
-@[simp] lemma Expr.op_castPureToEff (e : Expr d Γ .pure t) : (e.castPureToEff eff).op = e.op := by
+@[simp] theorem Expr.op_castPureToEff (e : Expr d Γ .pure t) : (e.castPureToEff eff).op = e.op := by
   cases e; cases eff <;> rfl
-@[simp] lemma Expr.args_castPureToEff (e : Expr d Γ .pure t) :
+@[simp] theorem Expr.args_castPureToEff (e : Expr d Γ .pure t) :
     (e.castPureToEff eff).args = cast (by simp) e.args := by
   cases e; cases eff <;> rfl
 
-@[simp] lemma Com.castPureToEff_rets : (rets v : Com d Γ .pure ty).castPureToEff eff = rets v := rfl
-@[simp] lemma Com.castPureToEff_var {com : Com d _ .pure ty} {e : Expr d Γ _ eTy} :
+@[simp] theorem Com.castPureToEff_rets : (rets v : Com d Γ .pure ty).castPureToEff eff = rets v := rfl
+@[simp] theorem Com.castPureToEff_var {com : Com d _ .pure ty} {e : Expr d Γ _ eTy} :
     (var e com).castPureToEff eff = var (e.castPureToEff eff) (com.castPureToEff eff) := rfl
 
-@[simp] lemma Lets.castPureToEff_nil : (nil : Lets d Γ_in _ _).castPureToEff eff = nil := rfl
-@[simp] lemma Lets.castPureToEff_var {lets : Lets d Γ_in .pure Γ_out}
+@[simp] theorem Lets.castPureToEff_nil : (nil : Lets d Γ_in _ _).castPureToEff eff = nil := rfl
+@[simp] theorem Lets.castPureToEff_var {lets : Lets d Γ_in .pure Γ_out}
     {e : Expr d Γ_out .pure eTy} :
     (var lets e).castPureToEff eff = var (lets.castPureToEff eff) (e.castPureToEff eff) :=
   rfl
 
-@[simp] lemma Com.outContext_castPureToEff {com : Com d Γ .pure ty} :
+@[simp] theorem Com.outContext_castPureToEff {com : Com d Γ .pure ty} :
     (com.castPureToEff eff).outContext = com.outContext := by
   induction com <;> simp [*]
 
 /-- `castPureToEff` does not change the size of a `Com` -/
-@[simp] lemma Com.size_castPureToEff {com : Com d Γ .pure ty} :
+@[simp] theorem Com.size_castPureToEff {com : Com d Γ .pure ty} :
     (com.castPureToEff eff).size = com.size := by
   induction com <;> simp [*]
 
 /-- `castPureToEff` does not change the number of bvars of a `Com` -/
-@[simp] lemma Com.bvars_castPureToEff {com : Com d Γ .pure ty} :
+@[simp] theorem Com.bvars_castPureToEff {com : Com d Γ .pure ty} :
     (com.castPureToEff eff).bvars = com.bvars := by
   induction com <;> simp [*]
 
-@[simp] lemma Com.returnVars_castPureToEff (eff : _) (com : Com d Γ .pure tys) :
+@[simp] theorem Com.returnVars_castPureToEff (eff : _) (com : Com d Γ .pure tys) :
     (com.castPureToEff eff).returnVars = com.returnVars.map (fun _ v => v.castCtxt (by simp)) := by
   induction com <;> simp_all
 
 /-! denotations of `castPureToEff` -/
 
-@[simp] lemma Expr.denote_castPureToEff {e : Expr d Γ .pure t} :
+@[simp] theorem Expr.denote_castPureToEff {e : Expr d Γ .pure t} :
     denote (e.castPureToEff eff) = fun V => pure (e.denote V) := by
   rcases e with ⟨op, rfl, eff_le, _, _⟩
   cases eff
@@ -887,7 +887,7 @@ section Lemmas
     simp only [castPureToEff, changeEffect, denote_unfold, denoteOp, op_mk, args_mk, regArgs_mk,
       EffectKind.pure_map, EffectKind.pure_liftEffect]
 
-@[simp] lemma Com.denote_castPureToEff {com : Com d Γ .pure ty} :
+@[simp] theorem Com.denote_castPureToEff {com : Com d Γ .pure ty} :
     denote (com.castPureToEff eff) = fun V => pure (com.denote V) := by
   funext V
   induction com using Com.rec'
@@ -904,7 +904,7 @@ def Expr.HasPureOp (e : Expr d Γ eff ty) : Prop :=
 /-- `e.HasPureOp` is decidable -/
 instance (e : Expr d Γ eff t) : Decidable (e.HasPureOp) := inferInstanceAs (Decidable <| _ = _)
 
-@[simp] lemma Expr.castPureToEff_pure_eq (e : Expr d Γ .pure t) : e.castPureToEff .pure = e := by
+@[simp] theorem Expr.castPureToEff_pure_eq (e : Expr d Γ .pure t) : e.castPureToEff .pure = e := by
   cases e; simp [castPureToEff, changeEffect]
 
 /-- Convert an arbitrary expression into a statically known
@@ -927,9 +927,9 @@ theorem Expr.HasPureOp_of_pure : (e : Expr d Γ .pure t) → e.HasPureOp
 section toPureLemmas
 variable {Γ eff ty} {e : Expr d Γ eff ty} (h : e.HasPureOp)
 
-@[simp] lemma Expr.op_toPure       : (e.toPure h).op = e.op := rfl
-@[simp] lemma Expr.args_toPure     : (e.toPure h).args = e.args := rfl
-@[simp] lemma Expr.regArgs_toPure  : (e.toPure h).regArgs = e.regArgs := rfl
+@[simp] theorem Expr.op_toPure       : (e.toPure h).op = e.op := rfl
+@[simp] theorem Expr.args_toPure     : (e.toPure h).args = e.args := rfl
+@[simp] theorem Expr.regArgs_toPure  : (e.toPure h).regArgs = e.regArgs := rfl
 
 end toPureLemmas
 
@@ -961,13 +961,13 @@ equivalent to the return value of the inserted program `newCom`, then the denota
 after insertion agrees with the original zipper. -/
 section DenoteInsert
 
-@[simp] lemma Expr.denote_appendInl (e : Expr d Γ .pure t) (V : Γ.Valuation) (v : Γ.Var u) :
+@[simp] theorem Expr.denote_appendInl (e : Expr d Γ .pure t) (V : Γ.Valuation) (v : Γ.Var u) :
     e.denote V v.appendInl = V v := by
   simp [denote_unfold, Id.map_eq']
 
 /-- Denoting any of the free variables of a program through `Com.denoteLets` just returns the
 assignment of that variable in the input valuation -/
-@[simp] lemma Com.denoteLets_outContextHom (com : Com d Γ .pure ty) (V : Valuation Γ)
+@[simp] theorem Com.denoteLets_outContextHom (com : Com d Γ .pure ty) (V : Valuation Γ)
     {vTy} (v : Var Γ vTy) :
     com.denoteLets V (com.outContextHom v) = V v := by
   induction com using Com.rec'
@@ -976,7 +976,7 @@ assignment of that variable in the input valuation -/
     rw [outContextHom_var]
     simp [Id.bind_eq', Hom.comp, ih]
 
-@[simp] lemma Ctxt.Valuation.comap_outContextHom_denoteLets {com : Com d Γ .pure ty} {V} :
+@[simp] theorem Ctxt.Valuation.comap_outContextHom_denoteLets {com : Com d Γ .pure ty} {V} :
     Valuation.comap (com.denoteLets V) com.outContextHom = V := by
   unfold comap; simp
 
@@ -1017,9 +1017,9 @@ def Lets.getPureExpr {Γ₁ Γ₂ : Ctxt d.Ty} (lets : Lets d Γ₁ eff Γ₂) {
   (getPureExprAux lets v).map fun ⟨_, v, e⟩ =>
     ⟨_, v, e.changeVars Ctxt.dropUntilHom⟩
 
-@[simp] lemma Lets.getPureExpr_nil : getPureExpr (.nil : Lets d Γ eff Γ) v = none := rfl
+@[simp] theorem Lets.getPureExpr_nil : getPureExpr (.nil : Lets d Γ eff Γ) v = none := rfl
 
-@[simp] lemma Lets.getPureExpr_var_appendInr (lets : Lets d Γ_in eff Γ_out)
+@[simp] theorem Lets.getPureExpr_var_appendInr (lets : Lets d Γ_in eff Γ_out)
     (e : Expr d Γ_out eff ty) (v : Var ⟨ty⟩ u) :
     getPureExpr (lets.var e) v.appendInr
     = e.toPure?.map (fun e => ⟨_, v, e.changeVars <| e.contextHom⟩) := by
@@ -1035,7 +1035,7 @@ def Lets.getPureExpr {Γ₁ Γ₂ : Ctxt d.Ty} (lets : Lets d Γ₁ eff Γ₂) {
   simp; grind
 
 
-@[simp] lemma Lets.getPureExprAux_var_appendInl (lets : Lets d Γ_in eff Γ_out)
+@[simp] theorem Lets.getPureExprAux_var_appendInl (lets : Lets d Γ_in eff Γ_out)
     (e : Expr d Γ_out eff ty₁) (v : Var Γ_out ty₂) :
     getPureExprAux (lets.var e) v.appendInl
     = (getPureExprAux lets v).map fun ⟨_, w, e⟩ =>
@@ -1050,7 +1050,7 @@ def Lets.getPureExpr {Γ₁ Γ₂ : Ctxt d.Ty} (lets : Lets d Γ₁ eff Γ₂) {
     simp only [Option.map_some, cast_eq_iff_heq]
     congr 3 <;> simp [Expr.changeVars_castCodomain]
 
-@[simp] lemma Lets.getPureExpr_var_appendInl (lets : Lets d Γ_in eff Γ_out) (e : Expr d Γ_out _ ty₁)
+@[simp] theorem Lets.getPureExpr_var_appendInl (lets : Lets d Γ_in eff Γ_out) (e : Expr d Γ_out _ ty₁)
     (v : Var Γ_out ty₂):
     getPureExpr (lets.var e) (v.appendInl)
     = (fun ⟨_, w, e'⟩ => ⟨_, w,  e'.changeVars <| e.contextHom⟩) <$> (getPureExpr lets v) := by
@@ -1152,12 +1152,12 @@ def Lets.changeDialect : Lets d Γ_in eff Γ_out → Lets d' (f.mapTy <$> Γ_in)
 
 section Lemmas
 
-@[simp] lemma Com.changeDialect_rets (f : DialectMorphism d d') (vs) :
+@[simp] theorem Com.changeDialect_rets (f : DialectMorphism d d') (vs) :
     Com.changeDialect f (Com.rets vs : Com d Γ eff t)
     = Com.rets (vs.map' f.mapTy (fun _ v => v.toMap)) := by
   cases eff <;> simp [changeDialect]
 
-@[simp] lemma Com.changeDialect_var (f : DialectMorphism d d')
+@[simp] theorem Com.changeDialect_var (f : DialectMorphism d d')
     (e : Expr d Γ eff t) (body : Com d _ eff u) :
     (Com.var e body).changeDialect f
     = have h := by simp
@@ -1165,7 +1165,7 @@ section Lemmas
       <| (body.changeDialect f).changeVars (Hom.id.castCodomain h) := by
   simp only [changeDialect]
 
-@[simp] lemma HVector.changeDialect_nil {eff : EffectKind} (f : DialectMorphism d d') :
+@[simp] theorem HVector.changeDialect_nil {eff : EffectKind} (f : DialectMorphism d d') :
     HVector.changeDialect (eff := eff) f nil = nil := by simp [HVector.changeDialect]
 
 end Lemmas
@@ -1194,16 +1194,16 @@ section Lemmas
 
 /-! #### Basic Lemmas -/
 
-@[simp] lemma Lets.addComToEnd_rets {lets : Lets d Γ_in eff Γ_out} :
+@[simp] theorem Lets.addComToEnd_rets {lets : Lets d Γ_in eff Γ_out} :
     addComToEnd lets (.rets v : Com d Γ_out eff t) = lets             := by simp [addComToEnd]
-@[simp] lemma Lets.addComToEnd_var {lets : Lets d Γ_in eff Γ_out} {com : Com d _ eff t} :
+@[simp] theorem Lets.addComToEnd_var {lets : Lets d Γ_in eff Γ_out} {com : Com d _ eff t} :
     addComToEnd lets (Com.var e com) = addComToEnd (lets.var e) com := by simp [addComToEnd]
 
-@[simp] lemma Com.toLets_rets : toLets (rets v : Com d Γ eff t) = .nil := by simp [toLets]
+@[simp] theorem Com.toLets_rets : toLets (rets v : Com d Γ eff t) = .nil := by simp [toLets]
 
 /-! ### castPureToEff -/
 
-@[simp] lemma Lets.addComToEnd_castPureToEff {lets : Lets d Γ_in .pure Γ_out}
+@[simp] theorem Lets.addComToEnd_castPureToEff {lets : Lets d Γ_in .pure Γ_out}
     {com : Com d Γ_out .pure ty} :
     (lets.castPureToEff eff).addComToEnd (com.castPureToEff eff)
     = cast (by simp) ((lets.addComToEnd com).castPureToEff eff) := by
@@ -1213,7 +1213,7 @@ section Lemmas
     simp only [Com.castPureToEff_var, Com.outContext_var, addComToEnd_var,
       ← Lets.castPureToEff_var, ih]
 
-@[simp] lemma Com.toLets_castPureToEff {com : Com d Γ .pure ty} :
+@[simp] theorem Com.toLets_castPureToEff {com : Com d Γ .pure ty} :
     (com.castPureToEff eff).toLets = cast (by simp) (com.toLets.castPureToEff eff) := by
   unfold toLets
   rw [show (Lets.nil : Lets d Γ eff Γ) = (Lets.nil.castPureToEff eff) from rfl,
@@ -1221,7 +1221,7 @@ section Lemmas
 
 /-! ### Denotation Lemmas-/
 
-@[simp] lemma Lets.denote_addComToEnd
+@[simp] theorem Lets.denote_addComToEnd
     {lets : Lets d Γ_in eff Γ_out} {com : Com d Γ_out eff t} :
     Lets.denote (lets.addComToEnd com) = fun V => (do
         let Vlets ← lets.denote V
@@ -1232,13 +1232,13 @@ section Lemmas
   case rets => simp [Com.denoteLets]
   case var ih => simp [addComToEnd, ih, denote_var]
 
-@[simp] lemma Com.denoteLets_rets : (.rets v : Com d Γ eff t).denoteLets = fun V => pure V := by
+@[simp] theorem Com.denoteLets_rets : (.rets v : Com d Γ eff t).denoteLets = fun V => pure V := by
   funext V; simp [denoteLets]
 
 theorem Com.denoteLets_eq {com : Com d Γ eff t} : com.denoteLets = com.toLets.denote := by
   simp only [toLets]; induction com using Com.rec' <;> simp [Lets.denote_var]
 
-@[simp] lemma Com.denoteLets_castPureToEff {com : Com d Γ .pure ty} :
+@[simp] theorem Com.denoteLets_castPureToEff {com : Com d Γ .pure ty} :
     denoteLets (com.castPureToEff eff)
     = fun V => pure (com.denoteLets V |>.comap fun _ v => v.castCtxt (by simp)) := by
   funext V
@@ -1286,20 +1286,20 @@ def Com.vars (com : Com d Γ eff ts) : VarSet Γ :=
 
 section Lemmas
 
-@[simp] lemma Com.vars_toLets (com : Com d Γ eff t) :
+@[simp] theorem Com.vars_toLets (com : Com d Γ eff t) :
     com.toLets.varsOfVec com.returnVars = com.vars := rfl
 
-@[simp] lemma Lets.vars_var {lets : Lets d Γ_in eff Γ_out}
+@[simp] theorem Lets.vars_var {lets : Lets d Γ_in eff Γ_out}
     {t} {e : Expr d Γ_out eff t} {w : Γ_out.Var u} :
     Lets.vars (Lets.var lets e) w.appendInl
     = Lets.vars lets w := by
   simp [Lets.vars]
 
-@[simp] lemma HVector.vars_nil :
+@[simp] theorem HVector.vars_nil :
     (HVector.nil : HVector (Var Γ) ([] : List d.Ty)).vars = ∅ := by
   simp [HVector.vars, HVector.foldl]
 
-@[simp] lemma HVector.vars_cons {t  : d.Ty} {l : List d.Ty}
+@[simp] theorem HVector.vars_cons {t  : d.Ty} {l : List d.Ty}
     (v : Var Γ t) (T : HVector (Var Γ) l) :
     (HVector.cons v T).vars = insert ⟨_, v⟩ T.vars := by
   rw [HVector.vars, HVector.vars]

--- a/SSA/Core/Framework.lean
+++ b/SSA/Core/Framework.lean
@@ -527,7 +527,7 @@ omit [LawfulMonad d.m] in
 Unfold `Expr.denote` in terms of the field projections and `Expr.denoteOp`.
 
 NOTE: this allows the unfolding of `Expr.denote` applied to arbitrary expressions,
-whereas the built-in unfold theorem only applies when the argument is an application of
+whereas the built-in unfold lemma only applies when the argument is an application of
 `Expr.mk`.
 
 Unfortunately, if we define `Expr.denote` in terms of the projections directly,
@@ -552,15 +552,15 @@ theorem Expr.denote_unfold (e : Expr d Γ eff ty) :
 
 /-
 https://leanprover.zulipchat.com/#narrow/stream/270676-lean4/topic/Equational.20Lemmas
-Recall that `simp` lazily generates equation theorems.
-Moreover, recall that `simp only` **does not** generate equation theorems.
-*but* if equation theorems are present, then `simp only` *uses* the equation theorems.
+Recall that `simp` lazily generates equation lemmas.
+Moreover, recall that `simp only` **does not** generate equation lemmas.
+*but* if equation lemmas are present, then `simp only` *uses* the equation lemmas.
 
-Hence, we build the equation theorems by invoking the correct Lean meta magic,
+Hence, we build the equation lemmas by invoking the correct Lean meta magic,
 so that `simp only` (which we use in `simp_peephole`) can find them!
 
 This allows `simp only [HVector.denote]` to correctly simplify `HVector.denote`
-args, since there now are equation theorems for it.
+args, since there now are equation lemmas for it.
 -/
 /--
 info: some #[`HVector.denote.eq_1, `HVector.denote.eq_2]
@@ -600,7 +600,7 @@ the congruence, you can do: `rw [← Lets.denotePure]; congr`
     Com d Γ .pure ty → Γ.Valuation → (HVector toType ty) :=
   Com.denote
 
-/-! ### simp-theorems about `denote` functions -/
+/-! ### simp-lemmas about `denote` functions -/
 section Lemmas
 
 @[simp] theorem Expr.comap_denote_snocRight (e : Expr d Γ .pure ty) (V : Γ.Valuation) :
@@ -661,7 +661,7 @@ def Com.changeVars : Com d Γ eff ty →
   |  .var e body => fun varsMap => .var (e.changeVars varsMap)
       (body.changeVars (fun _ v => varsMap.append v))
 
-/-! simp-theorems about `changeVars`-/
+/-! simp-lemmas about `changeVars`-/
 section Lemmas
 variable {Γ Γ' : Ctxt d.Ty} {t} (f : Γ.Hom Γ') (e : Expr d Γ eff t) (V : Γ'.Valuation)
 
@@ -696,7 +696,7 @@ end Lemmas
     = fun (map : Γ.Hom Δ) => Com.var (e.changeVars map) (body.changeVars map.append) := by
   simp [changeVars]
 
--- TODO: this is implied by simpler simp-theorems, do we need it?
+-- TODO: this is implied by simpler simp-lemmas, do we need it?
 @[simp] theorem Com.outContext_changeVars_rets (varsMap : Γ.Hom Γ') (_ : Com d Γ eff ty) :
   ((Com.rets (d:=d) (eff := eff) v).changeVars varsMap).outContext = Γ' := by simp
 

--- a/SSA/Core/Framework/Refinement.lean
+++ b/SSA/Core/Framework/Refinement.lean
@@ -206,7 +206,7 @@ open Lean Meta in
 `reduceIsRefinedBy` simplifies certain `HRefinement` instances.
 
 We tend to have a lot of types which are def-eq, but not *reducibly* def-eq,
-to others. Yet, we often want to write simp-theorems just about the underlying
+to others. Yet, we often want to write simp-lemmas just about the underlying
 types and not have to duplicate those.
 
 In particular, this holds for the denotation of dialect types (i.e., `⟦t⟧` for
@@ -217,7 +217,7 @@ terms of `inferInstance(As)` and mark the instance as `@[simp_denote]`.
 Note that the instances are not problematic, per se, as instances are *not* part
 of the discrtree matching that `simp` uses [1], however, the *types* that are
 passed to `HRefinement.IsRefinedBy` *are* part of the discrtree (unless
-explictly marked `no_index` by a particular simp-theorem). While unfolding the
+explictly marked `no_index` by a particular simp-lemma). While unfolding the
 instances, `reduceIsRefinedBy` will also unfold the *types* into the canonical
 spelling for the unfolded type.
 

--- a/SSA/Core/Framework/Refinement.lean
+++ b/SSA/Core/Framework/Refinement.lean
@@ -77,7 +77,7 @@ variable {α β} [inst : HRefinement α β]
 instance instRefinement : HRefinement (Id α) (Id β) := inst
 
 @[simp_denote (high)] -- high priority so that this is tried before the `reduceIsRefinedBy` simproc
-lemma pure_isRefinedBy_pure (x : α) (y : β) :
+theorem pure_isRefinedBy_pure (x : α) (y : β) :
   (pure x : Id _) ⊑ (pure y : Id _) ↔ x ⊑ y := by rfl
 
 end Id
@@ -121,12 +121,12 @@ instance instEffToMonadRefinement :
   IsRefinedBy x y := coe_toMonad x ⊑ coe_toMonad y
 
 open EffectKind (pure) in
-@[simp, simp_denote] lemma effToMonadRefinement_pure (x : pure.toMonad m α) (y : pure.toMonad n β) :
+@[simp, simp_denote] theorem effToMonadRefinement_pure (x : pure.toMonad m α) (y : pure.toMonad n β) :
     x ⊑ y ↔ pure (f := m) (@id α x) ⊑ pure (f := n) (@id β y) := by
   rfl
 
 open EffectKind (impure) in
-@[simp, simp_denote] lemma effToMonadRefinement_impure (x : impure.toMonad m α) (y : impure.toMonad n β) :
+@[simp, simp_denote] theorem effToMonadRefinement_impure (x : impure.toMonad m α) (y : impure.toMonad n β) :
     x ⊑ y ↔ (@id (m α) x) ⊑ (@id (n β) y) := by
   rfl
 
@@ -206,7 +206,7 @@ open Lean Meta in
 `reduceIsRefinedBy` simplifies certain `HRefinement` instances.
 
 We tend to have a lot of types which are def-eq, but not *reducibly* def-eq,
-to others. Yet, we often want to write simp-lemmas just about the underlying
+to others. Yet, we often want to write simp-theorems just about the underlying
 types and not have to duplicate those.
 
 In particular, this holds for the denotation of dialect types (i.e., `⟦t⟧` for
@@ -217,7 +217,7 @@ terms of `inferInstance(As)` and mark the instance as `@[simp_denote]`.
 Note that the instances are not problematic, per se, as instances are *not* part
 of the discrtree matching that `simp` uses [1], however, the *types* that are
 passed to `HRefinement.IsRefinedBy` *are* part of the discrtree (unless
-explictly marked `no_index` by a particular simp-lemma). While unfolding the
+explictly marked `no_index` by a particular simp-theorem). While unfolding the
 instances, `reduceIsRefinedBy` will also unfold the *types* into the canonical
 spelling for the unfolded type.
 
@@ -322,11 +322,11 @@ instance  : HRefinement (HVector A as) (HVector B bs) where
 
 variable {x : A a} {xs : HVector A as} {y : B b} {ys : HVector B bs}
 
-@[simp, simp_denote] lemma cons_isRefinedBy_cons  : ((x ::ₕ xs) ⊑ (y ::ₕ ys)) ↔ (x ⊑ y ∧ xs ⊑ ys) := by rfl
-@[simp, simp_denote] lemma nil_isRefinedBy_nil    : (nil : HVector A _) ⊑ (nil : HVector B _)     := True.intro
+@[simp, simp_denote] theorem cons_isRefinedBy_cons  : ((x ::ₕ xs) ⊑ (y ::ₕ ys)) ↔ (x ⊑ y ∧ xs ⊑ ys) := by rfl
+@[simp, simp_denote] theorem nil_isRefinedBy_nil    : (nil : HVector A _) ⊑ (nil : HVector B _)     := True.intro
 
-@[simp, simp_denote] lemma not_nil_isRefinedBy_cons : ¬((nil : HVector A _) ⊑ (y ::ₕ ys)) := by rintro ⟨⟩
-@[simp, simp_denote] lemma not_cons_isRefinedBy_nil : ¬((x ::ₕ xs) ⊑ (nil : HVector B _)) := by rintro ⟨⟩
+@[simp, simp_denote] theorem not_nil_isRefinedBy_cons : ¬((nil : HVector A _) ⊑ (y ::ₕ ys)) := by rintro ⟨⟩
+@[simp, simp_denote] theorem not_cons_isRefinedBy_nil : ¬((x ::ₕ xs) ⊑ (nil : HVector B _)) := by rintro ⟨⟩
 
 end HVector
 

--- a/SSA/Core/Framework/Zipper.lean
+++ b/SSA/Core/Framework/Zipper.lean
@@ -102,7 +102,7 @@ def insertPureCom (zip : Zipper d Γ_in eff ty)
     (newCom : Com d zip.Γ_mid .pure newTy) : Zipper d Γ_in eff ty :=
   zip.insertCom vs (newCom.castPureToEff eff)
 
-/-! simp-theorems -/
+/-! simp-lemmas -/
 section Lemmas
 variable [TyDenote d.Ty] [DialectDenote d] [Monad d.m]
 

--- a/SSA/Core/Framework/Zipper.lean
+++ b/SSA/Core/Framework/Zipper.lean
@@ -42,7 +42,7 @@ def denote (zip : Zipper d Γ_in eff tys) (V_in : Valuation Γ_in) :
     eff.toMonad d.m (HVector toType tys) :=
   (zip.top.denote V_in) >>= zip.bot.denote
 
-@[simp] lemma denote_mk {lets : Lets d Γ_in eff Γ_out} {com : Com d Γ_out eff ty} :
+@[simp] theorem denote_mk {lets : Lets d Γ_in eff Γ_out} {com : Com d Γ_out eff ty} :
     denote ⟨lets, com⟩ = fun V => (lets.denote V) >>= com.denote := rfl
 
 end Denote
@@ -63,8 +63,8 @@ def toCom (zip : Zipper d Γ_in eff ty) : Com d Γ_in eff ty :=
       | _, .nil, com          => com
       | _, .var body e, com  => go body (.var e com)
 
-@[simp] lemma toCom_nil {com : Com d Γ eff ty} : toCom ⟨.nil, com⟩ = com := rfl
-@[simp] lemma toCom_var {lets : Lets d Γ_in eff Γ_mid} :
+@[simp] theorem toCom_nil {com : Com d Γ eff ty} : toCom ⟨.nil, com⟩ = com := rfl
+@[simp] theorem toCom_var {lets : Lets d Γ_in eff Γ_mid} :
     toCom ⟨Lets.var lets e, com⟩ = toCom ⟨lets, Com.var e com⟩ := rfl
 
 variable [TyDenote d.Ty] [DialectDenote d] [Monad d.m]
@@ -102,7 +102,7 @@ def insertPureCom (zip : Zipper d Γ_in eff ty)
     (newCom : Com d zip.Γ_mid .pure newTy) : Zipper d Γ_in eff ty :=
   zip.insertCom vs (newCom.castPureToEff eff)
 
-/-! simp-lemmas -/
+/-! simp-theorems -/
 section Lemmas
 variable [TyDenote d.Ty] [DialectDenote d] [Monad d.m]
 

--- a/SSA/Core/Tactic.lean
+++ b/SSA/Core/Tactic.lean
@@ -13,7 +13,7 @@ import Lean.Meta.KAbstract
 import Lean.Elab.Tactic.ElabTerm
 
 variable [DialectSignature d] [TyDenote d.Ty] [DialectDenote d] [Monad d.m] [LawfulMonad d.m] in
-@[simp_denote] lemma Expr.denote_unfold' {ty} (e : Expr d Γ eff ty) :
+@[simp_denote] theorem Expr.denote_unfold' {ty} (e : Expr d Γ eff ty) :
     e.denote V = do
       let x ← e.denoteOp V
       return V ++ x := by
@@ -70,15 +70,15 @@ We've observed `simp [HVector.denote]` not working in such situations.
 According to Zulip (https://leanprover.zulipchat.com/#narrow/stream/270676-lean4/topic/simp.20.5BX.5D.20fails.2C.20rw.20.5BX.5D.20works/near/358861409):
 > simp [(X)] is a standard trick to fix simp [X] not working
 
-By default, it seems that `simp` will synthesize typeclass arguments of a lemma, and then
-use the *default* instance to determine whether a simp-lemma applies to the current goal.
+By default, it seems that `simp` will synthesize typeclass arguments of a theorem, and then
+use the *default* instance to determine whether a simp-theorem applies to the current goal.
 Writing `simp [(X)]`, on the other hand, is equivalent to writing `simp [@X _ _ _]`
   (for as many underscores as `X` takes arguments, implicit or explicit).
 The parentheses seems to enable `simp` to unify typeclass arguments as well, and thus the
-  simp-lemma applies even for non-standard instances.
+  simp-theorem applies even for non-standard instances.
 
 We've replicated this effect by defining `HVector.denote_{nil,cons}'`, as analogues
-to their non-primed lemmas, which instead take all instances as regular implicit
+to their non-primed theorems, which instead take all instances as regular implicit
 arguments, thus guiding `simp` to unify against non-standard instances.
 -/
 section
@@ -86,12 +86,12 @@ variable {d : Dialect} {instSig : DialectSignature d}
   {instTyDenote : TyDenote d.Ty} {instDenote : DialectDenote d}
   {instMonad : Monad d.m}
 
-@[simp_denote] lemma HVector.denote_nil'
+@[simp_denote] theorem HVector.denote_nil'
     (T : HVector (fun (t : Ctxt d.Ty × List d.Ty) => Com d t.1 .impure t.2) []) :
     HVector.denote T = HVector.nil := by
   cases T; simp [HVector.denote]
 
-@[simp_denote] lemma HVector.denote_cons'
+@[simp_denote] theorem HVector.denote_cons'
     (t : Ctxt d.Ty × List d.Ty) (ts : List (Ctxt d.Ty × List d.Ty))
     (a : Com d t.1 .impure t.2) (as : HVector (fun t => Com d t.1 .impure t.2) ts) :
     HVector.denote (.cons a as) = .cons (a.denote) (as.denote) := by
@@ -187,12 +187,12 @@ end SimpValuationApply
 
 WORKAROUND: Simplifying the semantics can yield equalities of the form:
   `@Eq (Id <| HVector _ _) (x ::ₕ xs) (y ::ₕ ys)`
-The `Id _` in the type of the equality somehow blocks the injectivity lemma
+The `Id _` in the type of the equality somehow blocks the injectivity theorem
 for `HVector.cons` from applying, so we first have to clean up the equality.
 -/
-@[simp_denote] lemma eq_id_iff (x y : α) : @Eq (Id α) x y ↔ x = y := by rfl
+@[simp_denote] theorem eq_id_iff (x y : α) : @Eq (Id α) x y ↔ x = y := by rfl
 
-@[simp_denote] lemma HVector.cons_inj {α : Type u_1} {f : α → Type u_2}
+@[simp_denote] theorem HVector.cons_inj {α : Type u_1} {f : α → Type u_2}
     {as : List α} {a : α}  (x y : f a) (xs ys : HVector f as) :
     @Eq (no_index _) (x ::ₕ xs) (y ::ₕ ys) ↔ (x = y ∧ xs = ys) := by
   rw [HVector.cons.injEq]

--- a/SSA/Core/Tactic.lean
+++ b/SSA/Core/Tactic.lean
@@ -70,15 +70,15 @@ We've observed `simp [HVector.denote]` not working in such situations.
 According to Zulip (https://leanprover.zulipchat.com/#narrow/stream/270676-lean4/topic/simp.20.5BX.5D.20fails.2C.20rw.20.5BX.5D.20works/near/358861409):
 > simp [(X)] is a standard trick to fix simp [X] not working
 
-By default, it seems that `simp` will synthesize typeclass arguments of a theorem, and then
-use the *default* instance to determine whether a simp-theorem applies to the current goal.
+By default, it seems that `simp` will synthesize typeclass arguments of a lemma, and then
+use the *default* instance to determine whether a simp-lemma applies to the current goal.
 Writing `simp [(X)]`, on the other hand, is equivalent to writing `simp [@X _ _ _]`
   (for as many underscores as `X` takes arguments, implicit or explicit).
 The parentheses seems to enable `simp` to unify typeclass arguments as well, and thus the
-  simp-theorem applies even for non-standard instances.
+  simp-lemma applies even for non-standard instances.
 
 We've replicated this effect by defining `HVector.denote_{nil,cons}'`, as analogues
-to their non-primed theorems, which instead take all instances as regular implicit
+to their non-primed lemmas, which instead take all instances as regular implicit
 arguments, thus guiding `simp` to unify against non-standard instances.
 -/
 section

--- a/SSA/Core/Transforms/Rewrite/Mapping.lean
+++ b/SSA/Core/Transforms/Rewrite/Mapping.lean
@@ -94,7 +94,7 @@ def mapValuation (m : Mapping Γ Δ) (V : Δ.Valuation) : Γ.Valuation :=
 section Lemmas
 variable {m : Mapping Γ Δ} {V : Δ.Valuation}
 
-lemma toHom_eq_mapValuation (h : m.IsTotal) :
+theorem toHom_eq_mapValuation (h : m.IsTotal) :
     V.comap (m.toHom h) = m.mapValuation V := by
   funext t v
   obtain ⟨_, h_lookup⟩ := Option.isSome_iff_exists.mp <| AList.lookup_isSome.2 (h v)

--- a/SSA/Core/Transforms/Rewrite/Match.lean
+++ b/SSA/Core/Transforms/Rewrite/Match.lean
@@ -226,7 +226,7 @@ def MatchArgResult.mk {mapOut : Mapping _ _}
   ⟨mapOut, mapIn, mapOut, ⟨by rfl, by rfl, h⟩⟩
 
 /-!
-### Subtype-based theorems
+### Subtype-based lemmas
 -/
 
 @[simp] theorem lookup_matchVar_nil (m : MatchVarResult lets v .nil w ma) :
@@ -245,14 +245,14 @@ theorem ofSubsetEntries {varMap₁ : MatchVarResult lets v matchLets w ma} {varM
   refine ⟨⟨varMap₂, mapIn', map', h₁, ?_, h₃⟩, rfl⟩
   trans; exact h₂; exact h_sub
 
-/-! ### nil theorems -/
+/-! ### nil lemmas -/
 
 variable [TyDenote d.Ty] [∀ (t : d.Ty), Inhabited ⟦t⟧] in
 @[simp] theorem mapValuation_nil (mapOut : MatchVarResult lets v .nil w mapIn) (V) :
     mapOut.val.mapValuation V w = V v := by
   simp [Mapping.mapValuation]
 
-/-! ### var_appendInl theorems -/
+/-! ### var_appendInl lemmas -/
 section Left
 variable {w : Δ_out.Var t}
 
@@ -271,7 +271,7 @@ variable {mapIn} (mapOut : MatchVarResult lets v (.var matchLets matchExpr) w.ap
 @[simp, defeq] theorem entries_eqvVar : (eqvVarLeft mapOut).val.entries = mapOut.val.entries := rfl
 
 end Left
-/-! ### var_appendInr theorems -/
+/-! ### var_appendInr lemmas -/
 variable {w : Var ⟨te⟩ _} {mapIn}
 
 theorem getPureExpr_eq_some

--- a/SSA/Core/Transforms/Rewrite/Match.lean
+++ b/SSA/Core/Transforms/Rewrite/Match.lean
@@ -130,7 +130,7 @@ variable [DecidableEq d.Op] {Γ_in Γ_out Δ_in Δ_out t te}
           {matchLets : Lets d Δ_in .pure Δ_out}
           {matchExpr : Expr d Δ_out .pure te}
 
-@[simp] lemma matchVar_appendInl (w : Δ_out.Var t) :
+@[simp] theorem matchVar_appendInl (w : Δ_out.Var t) :
     matchVar lets v (.var matchLets matchExpr) w.appendInl
     = matchVar lets v matchLets w := by
   simp [matchVar]
@@ -144,7 +144,7 @@ theorem unifyVars_eq_some_iff :
   simp only [unifyVars]
   split <;> simp_all
 
-@[simp] lemma matchVar_nil_eq {lets : Lets d Γ_in eff Γ_out} :
+@[simp] theorem matchVar_nil_eq {lets : Lets d Γ_in eff Γ_out} :
     matchVar lets v (.nil : Lets d Δ .pure Δ) w = unifyVars w v := by
   simp only [matchVar]
 
@@ -226,10 +226,10 @@ def MatchArgResult.mk {mapOut : Mapping _ _}
   ⟨mapOut, mapIn, mapOut, ⟨by rfl, by rfl, h⟩⟩
 
 /-!
-### Subtype-based lemmas
+### Subtype-based theorems
 -/
 
-@[simp] lemma lookup_matchVar_nil (m : MatchVarResult lets v .nil w ma) :
+@[simp] theorem lookup_matchVar_nil (m : MatchVarResult lets v .nil w ma) :
     m.val.lookup ⟨_, w⟩ = some v := by
   rcases m with ⟨m, -, m', -, h_entries_out, hm'⟩
   rw [← Option.mem_def, AList.mem_lookup_iff]
@@ -245,14 +245,14 @@ theorem ofSubsetEntries {varMap₁ : MatchVarResult lets v matchLets w ma} {varM
   refine ⟨⟨varMap₂, mapIn', map', h₁, ?_, h₃⟩, rfl⟩
   trans; exact h₂; exact h_sub
 
-/-! ### nil lemmas -/
+/-! ### nil theorems -/
 
 variable [TyDenote d.Ty] [∀ (t : d.Ty), Inhabited ⟦t⟧] in
-@[simp] lemma mapValuation_nil (mapOut : MatchVarResult lets v .nil w mapIn) (V) :
+@[simp] theorem mapValuation_nil (mapOut : MatchVarResult lets v .nil w mapIn) (V) :
     mapOut.val.mapValuation V w = V v := by
   simp [Mapping.mapValuation]
 
-/-! ### var_appendInl lemmas -/
+/-! ### var_appendInl theorems -/
 section Left
 variable {w : Δ_out.Var t}
 
@@ -263,15 +263,15 @@ def eqvVarLeft  :
   invFun := fun ⟨x, h⟩ => ⟨x, by simp_all⟩
 
 @[simp, defeq]
-lemma entries_symm_eqvVar (varMap : MatchVarResult lets v matchLets w ma) :
+theorem entries_symm_eqvVar (varMap : MatchVarResult lets v matchLets w ma) :
   (eqvVarLeft (matchExpr:=matchExpr) |>.symm  varMap).val.entries = varMap.val.entries := rfl
 
 variable {mapIn} (mapOut : MatchVarResult lets v (.var matchLets matchExpr) w.appendInl mapIn)
 
-@[simp, defeq] lemma entries_eqvVar : (eqvVarLeft mapOut).val.entries = mapOut.val.entries := rfl
+@[simp, defeq] theorem entries_eqvVar : (eqvVarLeft mapOut).val.entries = mapOut.val.entries := rfl
 
 end Left
-/-! ### var_appendInr lemmas -/
+/-! ### var_appendInr theorems -/
 variable {w : Var ⟨te⟩ _} {mapIn}
 
 theorem getPureExpr_eq_some
@@ -307,7 +307,7 @@ noncomputable instance :
          MatchArgResult lets matchLets args matchExpr.args mapIn) where
   coe := mapOut.toArgResult
 
-@[simp] lemma val_toArgResult (mapOut : MatchVarResult lets v (.var matchLets matchExpr) w.appendInr mapIn) :
+@[simp] theorem val_toArgResult (mapOut : MatchVarResult lets v (.var matchLets matchExpr) w.appendInr mapIn) :
     mapOut.toArgResult.val = mapOut.val := rfl
 
 end MatchVarResult
@@ -486,8 +486,8 @@ def consRight : MatchArgResult lets matchLets vs ws mapIn :=
     · exact isMonotone_matchVar _ _ h₁
   ⟩
 
-@[simp, grind=] lemma val_consLeft : mapOut.consLeft.val = mapOut.val := rfl
-@[simp, grind=] lemma val_consRight : mapOut.consRight.val = mapOut.val := rfl
+@[simp, grind=] theorem val_consLeft : mapOut.consLeft.val = mapOut.val := rfl
+@[simp, grind=] theorem val_consRight : mapOut.consRight.val = mapOut.val := rfl
 
 end MatchArgResult
 
@@ -597,7 +597,7 @@ theorem Lets.denote_eq_denoteIntoSubtype (lets : Lets d Γ_in eff Γ_out) (Γv :
 
 end DenoteIntoSubtype
 
-@[simp] lemma Lets.denote_var_appendInr_pure (lets : Lets d Γ_in .pure Γ_out)
+@[simp] theorem Lets.denote_var_appendInr_pure (lets : Lets d Γ_in .pure Γ_out)
     (e : Expr d Γ_out .pure tys) (V_in : Valuation Γ_in) (v : Var _ u) :
     Lets.denote (var lets e) V_in (v.appendInr)
     = let xs : HVector .. := e.denoteOp (lets.denote V_in)

--- a/SSA/Core/Transforms/Rewrite/Rewrite.lean
+++ b/SSA/Core/Transforms/Rewrite/Rewrite.lean
@@ -98,11 +98,11 @@ def rewriteAt
     return zip.toCom
   else none
 
-@[simp] lemma Com.denote_toFlatCom_lets [LawfulMonad d.m] (com : Com d Γ .pure t) :
+@[simp] theorem Com.denote_toFlatCom_lets [LawfulMonad d.m] (com : Com d Γ .pure t) :
     com.toFlatCom.lets.denote = com.denoteLets := by
   funext Γv; simp [toFlatCom, Com.denoteLets_eq]
 
-@[simp] lemma Com.toFlatCom_ret [LawfulMonad d.m] (com : Com d Γ .pure t) :
+@[simp] theorem Com.toFlatCom_ret [LawfulMonad d.m] (com : Com d Γ .pure t) :
     com.toFlatCom.rets = com.returnVars := by
   simp [toFlatCom]
 
@@ -237,10 +237,10 @@ def multiRewritePeephole (fuel : ℕ)
     (prs : List (Σ Γ, Σ ty, PeepholeRewrite d Γ ty)) (target : Com d Γ₂ eff t₂) : (Com d Γ₂ eff t₂) :=
   multiRewritePeepholeAt fuel prs 0 target
 
-/-- helper lemma for the proof of `denote_rewritePeephole_go_multi`. It proofs that folding
+/-- helper theorem for the proof of `denote_rewritePeephole_go_multi`. It proofs that folding
 a list of semantics preserving peephole rewrites over the target program does preserve the semantics
 of the target program. -/
-lemma denote_foldl_rewritePeepholeAt
+theorem denote_foldl_rewritePeepholeAt
   (prs : List (Σ Γ, Σ ty, PeepholeRewrite d Γ ty)) (ix : ℕ) (target : Com d Γ₂ eff t₂) :
     (prs.foldl (fun acc ⟨_Γ, _ty, pr⟩=> rewritePeepholeAt pr ix acc) target).denote = target.denote := by
   induction prs generalizing target

--- a/SSA/Core/Transforms/Rewrite/Rewrite.lean
+++ b/SSA/Core/Transforms/Rewrite/Rewrite.lean
@@ -237,7 +237,7 @@ def multiRewritePeephole (fuel : ℕ)
     (prs : List (Σ Γ, Σ ty, PeepholeRewrite d Γ ty)) (target : Com d Γ₂ eff t₂) : (Com d Γ₂ eff t₂) :=
   multiRewritePeepholeAt fuel prs 0 target
 
-/-- helper theorem for the proof of `denote_rewritePeephole_go_multi`. It proves that folding
+/-- helper lemma for the proof of `denote_rewritePeephole_go_multi`. It proves that folding
 a list of semantics preserving peephole rewrites over the target program does preserve the semantics
 of the target program. -/
 theorem denote_foldl_rewritePeepholeAt

--- a/SSA/Core/Transforms/Rewrite/Rewrite.lean
+++ b/SSA/Core/Transforms/Rewrite/Rewrite.lean
@@ -237,7 +237,7 @@ def multiRewritePeephole (fuel : ℕ)
     (prs : List (Σ Γ, Σ ty, PeepholeRewrite d Γ ty)) (target : Com d Γ₂ eff t₂) : (Com d Γ₂ eff t₂) :=
   multiRewritePeepholeAt fuel prs 0 target
 
-/-- helper theorem for the proof of `denote_rewritePeephole_go_multi`. It proofs that folding
+/-- helper theorem for the proof of `denote_rewritePeephole_go_multi`. It proves that folding
 a list of semantics preserving peephole rewrites over the target program does preserve the semantics
 of the target program. -/
 theorem denote_foldl_rewritePeepholeAt

--- a/SSA/Core/Util/ConcreteOrMVar.lean
+++ b/SSA/Core/Util/ConcreteOrMVar.lean
@@ -68,17 +68,17 @@ def instantiate_ofNat_eq (as : List.Vector Nat φ) (x : Nat) :
    ConcreteOrMVar.instantiate as (OfNat.ofNat x) = x := rfl
 
 @[simp]
-lemma instantiate_mvar_zero {hφ : List.length (w :: ws) = φ} {h0 : 0 < φ} :
+theorem instantiate_mvar_zero {hφ : List.length (w :: ws) = φ} {h0 : 0 < φ} :
     ConcreteOrMVar.instantiate (Subtype.mk (w :: ws) hφ)  (ConcreteOrMVar.mvar ⟨0, h0⟩) = w := by
   simp [instantiate]
   simp [List.Vector.get]
 
 @[simp]
-lemma instantiate_mvar_zero' :
+theorem instantiate_mvar_zero' :
     (mvar (φ := 1) ⟨0, by simp⟩).instantiate (Subtype.mk [w] (by simp)) = w := rfl
 
 @[simp]
-lemma instantiate_mvar_zero'' :
+theorem instantiate_mvar_zero'' :
     (mvar (φ := 1) 0).instantiate (Subtype.mk [w] h1) = w := rfl
 
 end ConcreteOrMVar

--- a/SSA/Core/Util/Poison.lean
+++ b/SSA/Core/Util/Poison.lean
@@ -66,7 +66,7 @@ instance [ToString α] : ToString (PoisonOr α) where
   | .poison  => "poison"
   | .value a => "(value " ++ addParenHeuristic (toString a) ++ ")"
 
-/-! ### Monad instance and lemmas -/
+/-! ### Monad instance and theorems -/
 instance : Monad PoisonOr where
   pure := value
   bind := fun a f => match a with

--- a/SSA/Core/Util/Poison.lean
+++ b/SSA/Core/Util/Poison.lean
@@ -66,7 +66,7 @@ instance [ToString α] : ToString (PoisonOr α) where
   | .poison  => "poison"
   | .value a => "(value " ++ addParenHeuristic (toString a) ++ ")"
 
-/-! ### Monad instance and theorems -/
+/-! ### Monad instance and lemmas -/
 instance : Monad PoisonOr where
   pure := value
   bind := fun a f => match a with


### PR DESCRIPTION
This frees SSA/Core from another dependency on mathlib. In this particular case, this is purely cosmetic.

Reducing our dependency on mathlib has a chance to speedup CI, as less of mathlib needs to be build and cached.

This is nudging us towards minimizing the dependencies on mathlib. 