### PR TITLE
chore: drop concurrency limit from eval CI

### DIFF
--- a/.github/workflows/evaluation.yml
+++ b/.github/workflows/evaluation.yml
@@ -4,9 +4,6 @@ on:
     branches:
       - "main"
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-
 permissions:
   contents: write
 


### PR DESCRIPTION
After we moved back to running our eval on GitHub there is no need for a concurrency limit as GitHub supplies multiple runners.