### PR TITLE
chore: run evaluation on pull requests

### DIFF
--- a/.github/workflows/evaluation.yml
+++ b/.github/workflows/evaluation.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - "main"
+  pull_request:
 
 permissions:
   contents: write


### PR DESCRIPTION
As we moved back to GitHub we have enough resources to run our evaluation on each PR, which is helpful as it will indicate changes to our evaluation before merge.