### PR TITLE
chore: reduce loglevel for extract-goal CI

### DIFF
--- a/SSA/Projects/InstCombine/scripts/extract-goals.py
+++ b/SSA/Projects/InstCombine/scripts/extract-goals.py
@@ -206,7 +206,7 @@ if __name__ == "__main__":
   parser.add_argument('--timeout', type=int, default=600, help="timeout in seconds for each file processing")
   parser.add_argument('--stride', type=int, default=1, help="Files that are processed have index 'ix = ∃ k, stride * k + offset'")
   parser.add_argument('--offset', type=int, default=0, help="Files that are processed have index 'ix = ∃ k, stride * k + offset'")
-  parser.add_argument('--loglevel', type=str, default="DEBUG", help="Log level",
+  parser.add_argument('--loglevel', type=str, default="INFO", help="Log level",
     choices=["DEBUG", "INFO", "WARNING", "ERROR"])
   args = parser.parse_args()
   setup_logging(args.db, args.loglevel)


### PR DESCRIPTION
The current log-level was very verbose (linear in # of test cases). Thanks to Sid's 6d0b3d168, the verbosity can now easily be reduced.