### PR TITLE
refactor: Base lean-mlir Docker image on ubuntu

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,25 +1,21 @@
-ARG NIXOS_VERSION="25.05"
-ARG SYSTEM="x86_64-linux"
-FROM nixpkgs/nix:nixos-$NIXOS_VERSION-$SYSTEM
+FROM ubuntu:25.04
 
-# Enable flakes and set up nix configuration
-RUN mkdir -p /etc/nix && \
-    echo "experimental-features = nix-command flakes" >> /etc/nix/nix.conf
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+  apt-get update && \
+  apt-get install -yqq --no-install-recommends \
+    ca-certificates curl \
+    git
 
-# Add the nix profile to path
-ENV PATH="${PATH}:/root/.nix-profile/bin"
+# Ensure CA certificates are up-to-date
+RUN update-ca-certificates -f
 
-# Install busybox, for `adduser`
-RUN nix profile install "nixpkgs#busybox"
+# Install elan and update environment
+WORKDIR /code
 
-# Install the development environment package
-# To add another package to be installed in the Dockerfile,
-# please modify the `flake.nix` file.
-RUN mkdir -p /code/lean-mlir
+RUN curl https://elan.lean-lang.org/elan-init.sh -sSf | sh -s -- -y --default-toolchain none
+ENV PATH=/root/.elan/bin:$PATH
+
 WORKDIR /code/lean-mlir
-
-COPY flake.nix flake.lock ./
-RUN nix profile install ".#"
 
 # Install Lean & checkout dependencies.
 # I agree this looks funky.
@@ -28,7 +24,7 @@ RUN nix profile install ".#"
 # This then lets us copy the framework *after* a build.
 # This way, Docker does not have to re-download the dependencies every time the code changes
 COPY lean-toolchain lakefile.* lake-manifest.json TacBench/lean-toolchain TacBench/lakefile.* TacBench/lake-manifest.json ./
-RUN lean-mlir-init-env
+RUN lake env echo
 
 # Build the framework
 COPY . ./


### PR DESCRIPTION
This PR changes the "minimal" lean-mlir Dockerfile to use Ubuntu as its base image, rather than nixpkgs. Re-using the flake.nix dependencies was a cute idea, but unless we fully commit to actually building the Docker image using nix, the interim solution of using `nix profile install` just wasn't really playing nicely with Dockers cache, and furthermore, we occasionally would get failed buils because of rate limits.

Finally, the flake.nix dev environment just isn't very minimal...