### PR TITLE
chore: remove SSA.Projects.InstCombine dependencies in SSA.Experimental.Bits.Fast

### DIFF
--- a/SSA/Experimental/Bits/AutoStructs/Defs.lean
+++ b/SSA/Experimental/Bits/AutoStructs/Defs.lean
@@ -2,9 +2,8 @@
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
 
-import SSA.Experimental.Bits.AutoStructs.ForMathlib
-import SSA.Experimental.Bits.SingleWidth.Defs
-import SSA.Projects.InstCombine.ForStd
+import BvDecideParametric.AutoStructs.ForMathlib
+import BvDecideParametric.SingleWidth.Defs
 
 open Fin.NatCast
 
@@ -137,14 +136,14 @@ deriving Repr
 def evalRelation (rel : Relation) {w} (bv1 bv2 : BitVec w) : Prop :=
   match rel with
   | .eq => bv1 = bv2
-  | .signed .lt => bv1 <ₛ bv2
-  | .signed .le => bv1 ≤ₛ bv2
-  | .signed .gt => bv1 >ₛ bv2
-  | .signed .ge => bv1 ≥ₛ bv2
-  | .unsigned .lt => bv1 <ᵤ bv2
-  | .unsigned .le => bv1 ≤ᵤ bv2
-  | .unsigned .gt => bv1 >ᵤ bv2
-  | .unsigned .ge => bv1 ≥ᵤ bv2
+  | .signed .lt => bv1.slt bv2
+  | .signed .le => bv1.sle  bv2
+  | .signed .gt => bv2.slt bv1
+  | .signed .ge => bv2.sle bv1
+  | .unsigned .lt => bv1.ult bv2
+  | .unsigned .le => bv1.ule bv2
+  | .unsigned .gt => bv2.ult bv1
+  | .unsigned .ge => bv2.ule bv1
 
 @[simp]
 lemma evalRelation_coe (rel : Relation) (bv1 bv2 : BitVec w1) (heq : w1 = w2) :
@@ -465,3 +464,4 @@ abbrev envOfArray {w} (a : Array (BitVec w)) : Nat → BitVec w := fun n => a.ge
 
 @[simp]
 abbrev envOfList {w} (a : List (BitVec w)) : Nat → BitVec w := fun n => a.getD n 0
+

--- a/SSA/Experimental/Bits/AutoStructs/Defs.lean
+++ b/SSA/Experimental/Bits/AutoStructs/Defs.lean
@@ -2,8 +2,8 @@
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
 
-import BvDecideParametric.AutoStructs.ForMathlib
-import BvDecideParametric.SingleWidth.Defs
+import SSA.Experimental.Bits.AutoStructs.ForMathlib
+import SSA.Experimental.Bits.SingleWidth.Defs
 
 open Fin.NatCast
 

--- a/SSA/Experimental/Bits/AutoStructs/FormulaToAuto.lean
+++ b/SSA/Experimental/Bits/AutoStructs/FormulaToAuto.lean
@@ -8,6 +8,9 @@ import SSA.Experimental.Bits.SingleWidth.Defs
 import SSA.Experimental.Bits.AutoStructs.Constructions
 import SSA.Experimental.Bits.AutoStructs.Defs
 import SSA.Experimental.Bits.AutoStructs.FiniteStateMachine
+import Mathlib.Tactic.Ring
+import Mathlib.Data.Nat.Size -- TODO: remove and get rid of shiftLeft_eq_mul_pow use
+import Mathlib.Data.BitVec
 
 import Mathlib.Tactic.FinCases
 
@@ -102,7 +105,7 @@ theorem BitVec.append_inj {x1 x2 : BitVec w} {y1 y2 : BitVec w'} :
 
 @[simp]
 lemma BitVec.cons_inj : cons b1 bv1 = cons b2 bv2 ↔ (b1 = b2) ∧ bv1 = bv2 := by
-  simp [cons]
+  simp only [cons, cast_inj, append_inj, ofBool_eq_iff_eq]
 
 @[simp] lemma BitVec.lk30 : (3#2 : BitVec 2)[0] = true := by rfl
 @[simp] lemma BitVec.lk31 : (3#2 : BitVec 2)[1] = true := by rfl
@@ -1139,7 +1142,8 @@ def NFA.autWidth_correct : (autWidth wp n).correct (autWidthSA n) (autWidthLang 
             rw [Fin.val_add_one_of_lt hlt]
           · use ⟨q, hq⟩; simp_all
             omega
-        · simp at h
+        · simp only [Language.mem_setOf_eq, List.length_append, List.length_cons, List.length_nil,
+          zero_add] at h
           use q - 1
           have hneq : (q : Fin (n+2)) - 1 ≠ Fin.last (n + 1) := by
             rintro habs
@@ -1154,9 +1158,10 @@ def NFA.autWidth_correct : (autWidth wp n).correct (autWidthSA n) (autWidthLang 
               simp_all only
               have : q ≥ 1 := by omega
               simpa [Fin.le_def, Nat.mod_eq_of_lt hq]
-          simp [hneq]
+          simp only [hneq, ↓reduceIte, Language.mem_setOf_eq, sub_add_cancel,
+            Set.setOf_eq_eq_singleton, Set.mem_singleton_iff]
           nth_rw 1 [←h]
-          simp
+          simp only [Nat.cast_add, Nat.cast_one, add_sub_cancel_right, Fin.val_natCast]
           constructor
           · exact (Nat.mod_eq_of_lt (by omega)).symm
           · ext; simp; exact (Nat.mod_eq_of_lt (by omega)).symm

--- a/SSA/Experimental/Bits/AutoStructs/FormulaToAuto.lean
+++ b/SSA/Experimental/Bits/AutoStructs/FormulaToAuto.lean
@@ -586,24 +586,24 @@ instance {cmp} : DecidableNFA' (NFA'.autUnsignedCmp cmp) where
 
 def RelationOrdering.urel (cmp : RelationOrdering) : BVRel :=
   match cmp with
-  | .lt => fun _ bv1 bv2 => bv1 <ᵤ bv2
-  | .le => fun _ bv1 bv2 => bv1 ≤ᵤ bv2
-  | .gt => fun _ bv1 bv2 => bv1 >ᵤ bv2
-  | .ge => fun _ bv1 bv2 => bv1 ≥ᵤ bv2
+  | .lt => fun _ bv1 bv2 => bv1.ult bv2
+  | .le => fun _ bv1 bv2 => bv1.ule bv2
+  | .gt => fun _ bv1 bv2 => bv2.ult bv1
+  | .ge => fun _ bv1 bv2 => bv2.ule bv1
 
 def NFA'.autUnsignedCmpSA (q : NFA.unsignedCmpState) : BVRel :=
   match q with
   | .eq => fun _ bv1 bv2 => bv1 = bv2
-  | .lt => fun _ bv1 bv2 => bv1 <ᵤ bv2
-  | .gt => fun _ bv1 bv2 => bv1 >ᵤ bv2
+  | .lt => fun _ bv1 bv2 => bv1.ult bv2
+  | .gt => fun _ bv1 bv2 => bv2.ult bv1
 
 lemma BitVec.ule_iff_ult_or_eq {w : ℕ} (bv1 bv2 : BitVec w):
-    (bv2 ≥ᵤ bv1) = true ↔ (bv2 >ᵤ bv1) = true ∨ bv1 = bv2 := by
+    (bv1.ule bv2) = true ↔ (bv1.ult bv2) = true ∨ bv1 = bv2 := by
   simp [BitVec.ule, BitVec.ult, le_iff_lt_or_eq, BitVec.toNat_eq]
 
 @[simp]
 lemma BitVec.cons_ugt_iff {w} {bv1 bv2 : BitVec w} :
-    (BitVec.cons b1 bv1 >ᵤ BitVec.cons b2 bv2) ↔ (if b1 = b2 then bv1 >ᵤ bv2 else b1) := by
+    ((BitVec.cons b2 bv2).ult (BitVec.cons b1 bv1)) ↔ (if b1 = b2 then bv2.ult bv1 else b1) := by
   simp [BitVec.ult, Nat.shiftLeft_eq]
   rw [Nat.mul_comm]
   nth_rw 2 [Nat.mul_comm]
@@ -613,30 +613,30 @@ lemma BitVec.cons_ugt_iff {w} {bv1 bv2 : BitVec w} :
   cases b1 <;> cases b2 <;> simp <;> omega
 
 @[simp]
-lemma ucmp_tricho : (bv1 >ᵤ bv2) = false → (bv2 >ᵤ bv1) = false → bv1 = bv2 := by
+lemma ucmp_tricho {bv1 bv2 : BitVec w} : (bv2.ult bv1) = false → (bv1.ult bv2) = false → bv1 = bv2 := by
   simp [BitVec.ult, BitVec.toNat_eq]
   apply Nat.le_antisymm
 
 set_option maxHeartbeats 1000000 in
 lemma NFA'.autUnsignedCmp_correct cmp : autUnsignedCmp cmp |>.correct2 autUnsignedCmpSA cmp.urel := by
   let getState {w} (bv1 bv2 : BitVec w) : NFA.unsignedCmpState :=
-    if bv1 >ᵤ bv2 then .gt else if bv2 >ᵤ bv1 then .lt else .eq
+    if bv2.ult bv1 then .gt else if bv1.ult bv2 then .lt else .eq
   constructor <;> simp [NFA.autUnsignedCmp, autUnsignedCmp, autUnsignedCmpSA, RelationOrdering.urel]
   · rintro _ _ _; cases cmp <;> simp [BitVec.ule_iff_ult_or_eq]; tauto
   · rintro (_ | _ | _) <;> simp
   · rintro (_ | _ | _) a w bv1 bv2 <;> simp [NFA.stepSet, NFA.unsignedCmpStep]
     · constructor
-      · rintro ⟨i, hi⟩; cases i <;> fin_cases a <;> simp_all [instFinEnumBitVec_sSA]
-      · rintro ⟨_, _⟩; use .eq; simp; fin_cases a <;> simp [instFinEnumBitVec_sSA] at * <;> tauto
+      · rintro ⟨i, hi⟩; cases i <;> fin_cases a <;> simp_all [instFinEnumBV]
+      · rintro ⟨_, _⟩; use .eq; simp; fin_cases a <;> simp [instFinEnumBV] at * <;> tauto
     · constructor
-      · rintro ⟨i, hi⟩; cases i <;> fin_cases a <;> simp_all [instFinEnumBitVec_sSA]
-      · rintro _; fin_cases a <;> simp [instFinEnumBitVec_sSA] at *
+      · rintro ⟨i, hi⟩; cases i <;> fin_cases a <;> simp_all [instFinEnumBV]
+      · rintro _; fin_cases a <;> simp [instFinEnumBV] at *
         · use .gt; simp_all
         · use (getState bv1 bv2); simp [getState]; split_ifs <;> simp_all; apply ucmp_tricho <;> assumption
         · use .gt; simp_all
     · constructor
-      · rintro ⟨i, hi⟩; cases i <;> fin_cases a <;> simp_all [instFinEnumBitVec_sSA]
-      · rintro _; fin_cases a <;> simp [instFinEnumBitVec_sSA] at *
+      · rintro ⟨i, hi⟩; cases i <;> fin_cases a <;> simp_all [instFinEnumBV]
+      · rintro _; fin_cases a <;> simp [instFinEnumBV] at *
         · use .lt; simp_all
         · use (getState bv1 bv2); simp [getState]; split_ifs <;> simp_all; apply ucmp_tricho <;> assumption
         · use .lt; simp_all
@@ -730,23 +730,23 @@ instance {cmp} : DecidableNFA' (NFA'.autSignedCmp cmp) where
 
 def RelationOrdering.srel (cmp : RelationOrdering) : BVRel :=
   match cmp with
-  | .lt => fun _ bv1 bv2 => bv1 <ₛ bv2
-  | .le => fun _ bv1 bv2 => bv1 ≤ₛ bv2
-  | .gt => fun _ bv1 bv2 => bv1 >ₛ bv2
-  | .ge => fun _ bv1 bv2 => bv1 ≥ₛ bv2
+  | .lt => fun _ bv1 bv2 => bv1.slt bv2
+  | .le => fun _ bv1 bv2 => bv1.sle bv2
+  | .gt => fun _ bv1 bv2 => bv2.slt bv1
+  | .ge => fun _ bv1 bv2 => bv2.sle bv1
 
 def NFA'.autSignedCmpSA (q : NFA.signedCmpState) : BVRel :=
   match q with
   | .eq => fun _ bv1 bv2 => bv1 = bv2
-  | .lt => fun _ bv1 bv2 => bv1 <ᵤ bv2
-  | .gt => fun _ bv1 bv2 => bv1 >ᵤ bv2
-  | .ltfin => fun _ bv1 bv2 => bv1 <ₛ bv2
-  | .gtfin => fun _ bv1 bv2 => bv1 >ₛ bv2
+  | .lt => fun _ bv1 bv2 => bv1.ult bv2
+  | .gt => fun _ bv1 bv2 => bv2.ult bv1
+  | .ltfin => fun _ bv1 bv2 => bv1.slt bv2
+  | .gtfin => fun _ bv1 bv2 => bv2.slt bv1
 
 -- TODO: why is it BitVec.toInt_inj but its BitVec.toNat_eq?
 
 private lemma BitVec.sle_iff_slt_or_eq {w : ℕ} (bv1 bv2 : BitVec w):
-    (bv2 ≥ₛ bv1) = true ↔ (bv2 >ₛ bv1) = true ∨ bv1 = bv2 := by
+    (bv1.sle bv2) = true ↔ (bv1.slt bv2) = true ∨ bv1 = bv2 := by
   simp [BitVec.sle, BitVec.slt, le_iff_lt_or_eq, BitVec.toInt_inj]
 
 theorem Nat.add_lt_is_or {a} (a_lt : a < 2^i) :
@@ -756,8 +756,8 @@ theorem Nat.add_lt_is_or {a} (a_lt : a < 2^i) :
 
 @[simp]
 lemma BitVec.cons_sgt_iff {w} {bv1 bv2 : BitVec w} :
-    (BitVec.cons b1 bv1 >ₛ BitVec.cons b2 bv2) ↔
-      (if b1 = b2 then bv1 >ᵤ bv2 else b2) := by
+    ((BitVec.cons b2 bv2).slt (BitVec.cons b1 bv1)) ↔
+      (if b1 = b2 then bv2.ult bv1 else b2) := by
   simp [BitVec.slt, BitVec.toInt_eq_msb_cond]
   have hbv1 := bv1.isLt
   have hbv2 := bv2.isLt
@@ -776,35 +776,35 @@ lemma BitVec.cons_sgt_iff {w} {bv1 bv2 : BitVec w} :
 set_option maxHeartbeats 1000000 in
 lemma NFA'.autSignedCmp_correct cmp : autSignedCmp cmp |>.correct2 autSignedCmpSA cmp.srel := by
   let getState {w} (bv1 bv2 : BitVec w) : NFA.signedCmpState :=
-    if bv1 >ᵤ bv2 then .gt else if bv2 >ᵤ bv1 then .lt else .eq
+    if bv2.ult bv1 then .gt else if bv1.ult bv2 then .lt else .eq
   constructor <;> simp [NFA.autSignedCmp, autSignedCmp, autSignedCmpSA, RelationOrdering.srel]
   · cases cmp <;> simp [BitVec.sle_iff_slt_or_eq]; tauto
   · rintro (_ | _ | _) <;> simp
   · rintro (_ | _ | _) a w bv1 bv2 <;> simp [NFA.stepSet]
     · constructor
-      · rintro ⟨i, hi⟩; cases i <;> fin_cases a <;> simp_all [NFA.signedCmpStep, instFinEnumBitVec_sSA]
-      · rintro ⟨_, _⟩; use .eq; simp; fin_cases a <;> simp [instFinEnumBitVec_sSA] at * <;> tauto
+      · rintro ⟨i, hi⟩; cases i <;> fin_cases a <;> simp_all [NFA.signedCmpStep, instFinEnumBV]
+      · rintro ⟨_, _⟩; use .eq; simp; fin_cases a <;> simp [instFinEnumBV] at * <;> tauto
     · constructor
-      · rintro ⟨i, hi⟩; cases i <;> fin_cases a <;> simp_all [NFA.signedCmpStep, instFinEnumBitVec_sSA]
-      · rintro _; fin_cases a <;> simp [NFA.signedCmpStep, instFinEnumBitVec_sSA] at *
+      · rintro ⟨i, hi⟩; cases i <;> fin_cases a <;> simp_all [NFA.signedCmpStep, instFinEnumBV]
+      · rintro _; fin_cases a <;> simp [NFA.signedCmpStep, instFinEnumBV] at *
         · use .gt; simp_all
         · use (getState bv1 bv2); simp [getState]; split_ifs <;> simp_all; apply ucmp_tricho <;> assumption
         · use .gt; simp_all
     · constructor
-      · rintro ⟨i, hi⟩; cases i <;> fin_cases a <;> simp_all [NFA.signedCmpStep, instFinEnumBitVec_sSA]
-      · rintro _; fin_cases a <;> simp [NFA.signedCmpStep, instFinEnumBitVec_sSA] at *
+      · rintro ⟨i, hi⟩; cases i <;> fin_cases a <;> simp_all [NFA.signedCmpStep, instFinEnumBV]
+      · rintro _; fin_cases a <;> simp [NFA.signedCmpStep, instFinEnumBV] at *
         · use .lt; simp_all
         · use (getState bv1 bv2); simp [getState]; split_ifs <;> simp_all; apply ucmp_tricho <;> assumption
         · use .lt; simp_all
     · constructor
-      · rintro ⟨i, hi⟩; cases i <;> fin_cases a <;> simp_all [NFA.signedCmpStep, instFinEnumBitVec_sSA]
-      · rintro _; fin_cases a <;> simp [NFA.signedCmpStep, instFinEnumBitVec_sSA] at *
+      · rintro ⟨i, hi⟩; cases i <;> fin_cases a <;> simp_all [NFA.signedCmpStep, instFinEnumBV]
+      · rintro _; fin_cases a <;> simp [NFA.signedCmpStep, instFinEnumBV] at *
         · use .lt; simp_all
         · use (getState bv1 bv2); simp [getState]; split_ifs <;> simp_all; apply ucmp_tricho <;> assumption
         · use .lt; simp_all
     · constructor
-      · rintro ⟨i, hi⟩; cases i <;> fin_cases a <;> simp_all [NFA.signedCmpStep, instFinEnumBitVec_sSA]
-      · rintro _; fin_cases a <;> simp [NFA.signedCmpStep, instFinEnumBitVec_sSA] at *
+      · rintro ⟨i, hi⟩; cases i <;> fin_cases a <;> simp_all [NFA.signedCmpStep, instFinEnumBV]
+      · rintro _; fin_cases a <;> simp [NFA.signedCmpStep, instFinEnumBV] at *
         · use .gt; simp_all
         · use (getState bv1 bv2); simp [getState]; split_ifs <;> simp_all; apply ucmp_tricho <;> assumption
         · use .gt; simp_all
@@ -920,9 +920,9 @@ def NFA.msbCorrect : NFA.autMsbSet.correct msbSA msbLang := by
       have h : NFA.autMsbSet.eval w = { q | w ∈ msbSA q } := by ext; simp [ih]
       simp [h]; rintro (_ | _)
       · simp [NFA.autMsbSet, msbSA, msbLang, stepSet, msbStep]
-        use .i; simp; fin_cases a <;> simp [instFinEnumBitVec_sSA]
+        use .i; simp; fin_cases a <;> simp [instFinEnumBV]
       · simp [NFA.autMsbSet, msbSA, msbLang, stepSet, msbStep]; constructor
-        · intro ⟨q, hq⟩; fin_cases a <;> simp [instFinEnumBitVec_sSA] at *
+        · intro ⟨q, hq⟩; fin_cases a <;> simp [instFinEnumBV] at *
           cases q <;> simp_all
         · rintro rfl; use .i; simp
 
@@ -1208,7 +1208,7 @@ lemma CNFA.autWidth_spec : autWidth wp n |>.Sim (NFA'.autWidth wp n) := by
   · rintro q; simp_all [NFA'.autWidth, NFA.autWidth]; apply autWidth_finals (q.isLt)
   · rintro q; simp_all [NFA'.autWidth, NFA.autWidth]; rw [autWidth_initials]; exact
     eq_iff_eq_of_cmp_eq_cmp rfl
-  · rintro a q q'; fin_cases a; simp_all [NFA'.autWidth, NFA.autWidth, instFinEnumBitVec_sSA];
+  · rintro a q q'; fin_cases a; simp_all [NFA'.autWidth, NFA.autWidth, instFinEnumBV];
     have h := @autWidth_tr q.val n q'.val wp q.isLt q'.isLt
     unfold State at *
     simp_all

--- a/SSA/Experimental/Bits/Fast/Defs.lean
+++ b/SSA/Experimental/Bits/Fast/Defs.lean
@@ -372,10 +372,10 @@ theorem Predicate.evalEq_denote_true_iff {w : Nat} (a b : Term) (vars : List (Bi
 
 
 private theorem BitVec.lt_eq_decide_ult {x y : BitVec w} : (x < y) = decide (x.ult y) := by
-  simp [BitVec.lt_def, BitVec.ult_toNat]
+  simp [BitVec.lt_def, BitVec.ult]
 
 private theorem BitVec.lt_iff_ult {x y : BitVec w} : (x < y) ↔ (x.ult y) := by
-  simp [BitVec.lt_def, BitVec.ult_toNat]
+  simp [BitVec.lt_def, BitVec.ult]
 
 theorem Predicate.evalUlt_denote_false_iff {w : Nat} (a b : Term) (vars : List (BitVec w)) :
     evalUlt (a.eval (List.map .ofBitVecSext vars)) (b.eval (List.map .ofBitVecSext vars)) w = false ↔
@@ -433,7 +433,7 @@ constructor
 /-- TODO: Minimize this proof by a metric fuckton. -/
 private theorem Predicate.evalSlt_denote_false_iff {w : Nat} (a b : Term) (vars : List (BitVec w)) :
     evalSlt (a.eval (List.map .ofBitVecSext vars)) (b.eval (List.map .ofBitVecSext vars)) w = false ↔
-    (Term.denote w a vars <ₛ Term.denote w b vars) := by
+    (Term.denote w a vars).slt (Term.denote w b vars) := by
   simp [evalSlt, BitStream.xor_eq]
   have hult_iff := Predicate.evalUlt_denote_false_iff a b vars
   by_cases hUlt : evalUlt (a.eval (List.map .ofBitVecSext vars)) (b.eval (List.map .ofBitVecSext vars)) w
@@ -481,7 +481,7 @@ private theorem Predicate.evalSlt_denote_false_iff {w : Nat} (a b : Term) (vars 
 
 private theorem Predicate.evalSlt_denote_true_iff {w : Nat} (a b : Term) (vars : List (BitVec w)) :
     evalSlt (a.eval (List.map .ofBitVecSext vars)) (b.eval (List.map .ofBitVecSext vars)) w = true ↔
-    ¬ (Term.denote w a vars <ₛ Term.denote w b vars) := by
+    ¬ (Term.denote w a vars).slt (Term.denote w b vars) := by
   rw [eq_true_iff_of_eq_false_iff]
   simp [Predicate.evalSlt_denote_false_iff]
 
@@ -489,8 +489,8 @@ private theorem Predicate.evalSlt_denote_true_iff {w : Nat} (a b : Term) (vars :
 private theorem BitVec.ForLean.ule_iff_ult_or_eq (x y : BitVec w) : x ≤ y ↔ (x = y ∨ x < y) := by
   constructor <;> bv_omega
 
-private theorem BitVec.ForLean.ule_iff_ult_or_eq' (x y : BitVec w) : (x ≤ᵤ y) = (decide (x = y ∨ x < y)) := by
-  simp only [· ≤ᵤ ·]
+private theorem BitVec.ForLean.ule_iff_ult_or_eq' (x y : BitVec w) : (x.ule y) = (decide (x = y ∨ x < y)) := by
+  simp only [BitVec.ule]
   by_cases hx : x = y ∨ x < y
   case pos => simp [hx]; bv_omega
   case neg => simp [hx]; bv_omega
@@ -509,8 +509,8 @@ private theorem BitVec.sle_iff_slt_or_eq (x y : BitVec w) : x.sle y ↔ (decide 
   · intros h
     rcases h with rfl | h  <;> omega
 
-theorem BitVec.ult_notation_eq_decide_ult (x y : BitVec w) : (x <ᵤ y) = decide (x < y) := by
-  simp [BitVec.lt_def, BitVec.ult_toNat]
+theorem BitVec.ult_notation_eq_decide_ult (x y : BitVec w) : (x.ult y) = decide (x < y) := by
+  simp [BitVec.lt_def, BitVec.ult]
 /--
 The semantics of a predicate:
 The predicate, when evaluated, at index `i` is false iff the denotation is true.
@@ -531,7 +531,7 @@ theorem Predicate.eval_eq_denote (w : Nat) (p : Predicate) (vars : List (BitVec 
       case neg => simp only [h, decide_false, Bool.not_false]; rw [evalUlt_denote_true_iff]; simpa using h
     | slt =>
       simp [eval, denote];
-      by_cases h : Term.denote w a vars <ₛ Term.denote w b vars
+      by_cases h : (Term.denote w a vars).slt (Term.denote w b vars)
       · rw [h]
         simp [Predicate.evalSlt_denote_false_iff, h]
       · simp at h
@@ -561,7 +561,7 @@ theorem Predicate.eval_eq_denote (w : Nat) (p : Predicate) (vars : List (BitVec 
       simp [eval, denote]
       simp only [evalLor, BitStream.and_eq]
       have h := BitVec.sle_iff_slt_or_eq (Term.denote w a vars) (Term.denote w b vars) |>.eq
-      rcases hSle : Term.denote w a vars ≤ₛ Term.denote w b vars
+      rcases hSle : (Term.denote w a vars).sle (Term.denote w b vars)
       · simp [hSle] at h ⊢
         obtain ⟨h₁, h₂⟩ := h
         simp [evalEq_denote_true_iff .. |>.mpr h₁]

--- a/SSA/Experimental/Bits/Fast/FiniteStateMachine.lean
+++ b/SSA/Experimental/Bits/Fast/FiniteStateMachine.lean
@@ -712,8 +712,8 @@ lemma eval_scanAnd_eq_decide (x : Unit → BitStream) (n : Nat) : scanAnd.eval x
 
 @[simp] lemma eval_nxor (x : Bool → BitStream) : nxor.eval x = ((x true).nxor (x false)) := by
   ext n; cases n
-  · simp [nxor, eval, nextBit]
-  · simp [nxor, eval, nextBit]
+  · simp [nxor, eval, nextBit]; bv_decide
+  · simp [nxor, eval, nextBit]; bv_decide
 
 def scanOr  : FSM Unit :=
   {
@@ -938,7 +938,7 @@ TODO: rewrite with 'induction' to be a clean proof script.
     simp [borrow, BitStream.borrow, BitStream.subAux, eval, nextBit]
   case succ i ih =>
     rw [eval]
-    simp only [carry_borrow, BitStream.borrow_succ, Bool.not_bne']
+    simp only [carry_borrow, BitStream.borrow_succ]
     rw [← ih]
     simp [nextBit, eval, borrow]
 

--- a/SSA/Experimental/Bits/FinEnum.lean
+++ b/SSA/Experimental/Bits/FinEnum.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 import Mathlib.Data.FinEnum
 import Mathlib.Tactic.FinCases
 
-instance: FinEnum (BitVec w) where
+instance instFinEnumBV : FinEnum (BitVec w) where
   card := 2^w
   equiv := {
     toFun := fun x => x.toFin

--- a/SSA/Experimental/Bits/KInduction/KInduction.lean
+++ b/SSA/Experimental/Bits/KInduction/KInduction.lean
@@ -1832,6 +1832,8 @@ theorem Predicate.denote_of_verifyCircuit_mkSafetyCircuit_of_verifyCircuit_mkInd
 /--
 info: 'ReflectVerif.BvDecide.KInductionCircuits.Predicate.denote_of_verifyCircuit_mkSafetyCircuit_of_verifyCircuit_mkIndHypCycleBreaking' depends on axioms: [propext,
  Classical.choice,
+ Lean.ofReduceBool,
+ Lean.trustCompiler,
  Quot.sound]
 -/
 #guard_msgs in #print axioms Predicate.denote_of_verifyCircuit_mkSafetyCircuit_of_verifyCircuit_mkIndHypCycleBreaking

--- a/SSA/Experimental/Bits/KInduction/Tests.lean
+++ b/SSA/Experimental/Bits/KInduction/Tests.lean
@@ -9,7 +9,6 @@ Authors: Siddharth Bhat
 -/
 import SSA.Experimental.Bits.SingleWidth.Tactic
 import SSA.Experimental.Bits.Fast.MBA
-import SSA.Projects.InstCombine.TacticAuto
 
 open Lean Meta Elab Tactic in
 #eval show TermElabM Unit from do


### PR DESCRIPTION
This is a *intra*-project, safe change that removes a dependency from `Experimental/` to `Projects/` via our automata theory development. 