### PR TITLE
chore: use git-hash as part of the cache key for eval

### DIFF
--- a/.github/workflows/evaluation.yml
+++ b/.github/workflows/evaluation.yml
@@ -25,7 +25,7 @@ jobs:
             .lake/packages
             .lake/build
             TacBench/.lake
-          key: ${{ runner.os }}-lake-packages-${{ hashFiles('lake-manifest.json') }}
+          key: ${{ runner.os }}-lake-packages-${{ hashFiles('lake-manifest.json') }}-${{ github.sha }}
 
       - name: Install Elan & Lean
         if: steps.cache-lake.outputs.cache-hit != 'true'

--- a/.github/workflows/evaluation.yml
+++ b/.github/workflows/evaluation.yml
@@ -26,6 +26,9 @@ jobs:
             .lake/build
             TacBench/.lake
           key: ${{ runner.os }}-lake-packages-${{ hashFiles('lake-manifest.json') }}-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-lake-packages-${{ hashFiles('lake-manifest.json') }}-${{ github.sha }}
+            ${{ runner.os }}-lake-packages-${{ hashFiles('lake-manifest.json') }}
 
       - name: Install Elan & Lean
         if: steps.cache-lake.outputs.cache-hit != 'true'
@@ -67,7 +70,7 @@ jobs:
             .lake/packages
             .lake/build
             TacBench/.lake
-          key: ${{ runner.os }}-lake-packages-${{ hashFiles('lake-manifest.json') }}
+          key: ${{ runner.os }}-lake-packages-${{ hashFiles('lake-manifest.json') }}-${{ github.sha }}
 
       - name: Add Lean to PATH
         run: |
@@ -100,7 +103,7 @@ jobs:
             .lake/packages
             .lake/build
             TacBench/.lake
-          key: ${{ runner.os }}-lake-packages-${{ hashFiles('lake-manifest.json') }}
+          key: ${{ runner.os }}-lake-packages-${{ hashFiles('lake-manifest.json') }}-${{ github.sha }}
 
       - name: Add Lean to PATH
         run: |


### PR DESCRIPTION
This ensures that the latest build is always uploaded to the repo, such that it can be reused across the action.