### PR TITLE
chore: use `docker/metadata-action` for more fine-grained Docker image tagging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,12 +28,24 @@ jobs:
       - name: Checkout 🛎️
         uses: actions/checkout@v3
 
+      - name: Setup Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/opencompl/lean-mlir
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=sha
+            type=raw,value=latest,enable={{is_default_branch}}
+
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
           context: .
           push: true
-          tags: ghcr.io/opencompl/lean-mlir:latest,ghcr.io/opencompl/lean-mlir:${{ github.sha }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
           outputs: type=docker,dest=${{ runner.temp }}/lean-mlir.tar
           cache-from: type=gha
           cache-to: type=gha,mode=max


### PR DESCRIPTION
In particular, we only want to tag an image `latest` when building commits on the main branch!