### PR TITLE
refactor: stop uploading Docker image as artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,13 +43,6 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          outputs: type=docker,dest=${{ runner.temp }}/lean-mlir.tar
-
-      - name: Upload Docker image as artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: lean-mlir-docker
-          path: ${{ runner.temp }}/lean-mlir.tar
 
   docker-bitwuzla:
     name: Build Docker image for Bitwuzla


### PR DESCRIPTION
Since we already upload the image to ghcr.io, tagged with the exact commit sha, there is no need to also upload it as an artifact. This upload currently takes roughly a minute of the namespace.so runner time, so the benefit of having the artifact is not worth the associated cost