### PR TITLE
feat: duplicate evaluation CI to run in docker as well

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,12 @@ Dockerfile
 *.pdf
 .venv/
 .lake/
+
+.devcontainer
+.dockerignore
+.envrc
+.git
+.gitattributes
+.github
+.gitignore
+.gitmodules

--- a/.dockerignore
+++ b/.dockerignore
@@ -6,7 +6,6 @@ Dockerfile
 .devcontainer
 .dockerignore
 .envrc
-.git
 .gitattributes
 .github
 .gitignore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,66 +11,6 @@ permissions:
   packages: write
 
 jobs:
-  docker:
-    name: Build Docker image for core library
-    runs-on: namespace-profile-leanmlir-docker-cached 
-    steps:
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Checkout 🛎️
-        uses: actions/checkout@v3
-
-      - name: Setup Docker metadata
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ghcr.io/opencompl/lean-mlir
-          tags: |
-            type=ref,event=branch
-            type=ref,event=pr
-            type=sha
-            type=raw,value=latest,enable={{is_default_branch}}
-
-      - name: Build and push
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-
-  docker-bitwuzla:
-    name: Build Docker image for Bitwuzla
-    runs-on: ubuntu-latest
-    steps:
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Checkout 🛎️
-        uses: actions/checkout@v3
-
-      - name: Build and push Docker image
-        uses: docker/build-push-action@v6
-        with:
-          context: "./bv-evaluation"
-          push: true
-          tags: ghcr.io/opencompl/bitwuzla:latest
-          outputs: type=docker,dest=${{ runner.temp }}/bitwuzla.tar
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-
   build:
     name: core library
     permissions:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -76,6 +76,9 @@ jobs:
     runs-on: ubuntu-latest # Run on GH-provided runner
     needs: core-docker-img
     container: "ghcr.io/opencompl/lean-mlir:${{ github.sha }}"
+    defaults:
+      run:
+        working-directory: /code/lean-mlir
     steps:
       - name: Compile `mlirnatural` Executable 🧐
         run: |

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -136,7 +136,7 @@ jobs:
           (cd SSA/Projects/InstCombine/; uv run ./update_alive_statements.py)
           # /--------------------------- ^^^^^^
           # | TODO: this could be removed if we add a uv shebang to the python file
-          bash -c '! git diff | grep .'  # iff git diff is empty, 'grep .' fails, '!' inverts the failure, and in the forced bash
+          bash -c '! git diff -- SSA/Projects/InstCombine | grep .'  # iff git diff is empty, 'grep .' fails, '!' inverts the failure, and in the forced bash
 
   evaluation-LLVM:
     name: Evaluate LLVM

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -133,7 +133,7 @@ jobs:
       run:
         working-directory: /code/lean-mlir
     env:
-      HOME: /home/user
+      HOME: /root
     steps:
       - name: Checkout git history
         # This is needed because we do `git diff` below
@@ -199,7 +199,7 @@ jobs:
       run:
         working-directory: /code/lean-mlir/bv-evaluation
     env:
-      HOME: /home/user
+      HOME: /root
     strategy:
       matrix:
         extract_offset: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -102,6 +102,9 @@ jobs:
     steps:
       - name: Compile `mlirnatural` Executable 🧐
         run: |
+          echo "PATH=$PATH"
+          echo "PWD=$PWD"
+          echo "USER=$USER"
           lake -R build mlirnatural
 
       - name: Compile `opt` Executable 🧐

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,72 @@
+name: Build & Evaluate (in Docker)
+on:
+  push:
+    branches:
+      - "main"
+  pull_request:
+  merge_group:
+
+permissions:
+  contents: write
+  packages: write
+
+jobs:
+  docker:
+    name: Build Docker image for core library
+    runs-on: namespace-profile-leanmlir-docker-cached 
+    steps:
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Checkout 🛎️
+        uses: actions/checkout@v3
+
+      - name: Setup Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/opencompl/lean-mlir
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=sha
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+  docker-bitwuzla:
+    name: Build Docker image for Bitwuzla
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Checkout 🛎️
+        uses: actions/checkout@v3
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: "./bv-evaluation"
+          push: true
+          tags: ghcr.io/opencompl/bitwuzla:latest
+          outputs: type=docker,dest=${{ runner.temp }}/bitwuzla.tar
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -80,6 +80,8 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: "./bv-evaluation"
+          build-args: |
+            LEANMLIR_TAG=${{ github.sha }}
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
@@ -137,3 +139,45 @@ jobs:
           # /--------------------------- ^^^^^^
           # | TODO: this could be removed if we add a uv shebang to the python file
           bash -c '! git diff | grep .'  # iff git diff is empty, 'grep .' fails, '!' inverts the failure, and in the forced bash
+
+   evaluation-LLVM:
+    name: Evaluate LLVM
+    runs-on: ubuntu-latest # Run on GH-provided runner
+    needs: instcombine-docker-img
+    container: "ghcr.io/opencompl/lean-mlir-instcombine:${{ github.sha }}"
+    defaults:
+      run:
+        working-directory: /code/lean-mlir/bv-evaluation
+    permissions:
+      pull-requests: write
+    steps:     
+      - name: Run LLVM
+        continue-on-error: true
+        run: |
+          uv run ./compare.py instcombine -j48 \
+            || echo "LEANMLIR_STATUS=fail" >> $GITHUB_ENV
+
+      - name: Collect data LLVM
+        continue-on-error: true
+        run: |
+          (uv run ./collect.py instcombine | tee llvm-stats) \
+            || echo "LEANMLIR_STATUS=fail" >> $GITHUB_ENV
+
+      - uses: actions/github-script@v6
+        working-directory: /code/lean-mlir/bv-evaluation
+        if: env.LEANMLIR_STATUS != 'fail' && github.event_name == 'pull_request'
+        with:
+          script: |
+            const fs = require('fs')
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: fs.readFileSync('llvm-stats', 'utf8')
+            })
+
+      - name: Upload LLVM artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: LLVM evaluation
+          path: results

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -140,7 +140,7 @@ jobs:
           # | TODO: this could be removed if we add a uv shebang to the python file
           bash -c '! git diff | grep .'  # iff git diff is empty, 'grep .' fails, '!' inverts the failure, and in the forced bash
 
-   evaluation-LLVM:
+  evaluation-LLVM:
     name: Evaluate LLVM
     runs-on: ubuntu-latest # Run on GH-provided runner
     needs: instcombine-docker-img

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -180,3 +180,26 @@ jobs:
         with:
           name: LLVM evaluation
           path: results
+
+  extract-goals:
+    name: Extract goals
+    runs-on: ubuntu-latest # Run on GH-provided runner
+    needs: instcombine-docker-img
+    container: "ghcr.io/opencompl/lean-mlir-instcombine:${{ github.sha }}"
+    defaults:
+      run:
+        working-directory: /code/lean-mlir/bv-evaluation
+    strategy:
+      matrix:
+        extract_offset: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+        extract_stride: [10]
+    steps:
+      - name: Checkout git history
+        uses: actions/checkout@v3
+        with:
+          sparse-checkout: .git
+      - name: Ensure InstCombine goals are up-to-date
+        env: 
+          GIT_DIR: ${{ github.workspace }}/.git
+        run: |
+          bash SSA/Projects/InstCombine/scripts/test-extract-goals.sh --nfiles 9000 -j7  --stride ${{matrix.extract_stride}} --offset ${{matrix.extract_offset}}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -130,14 +130,15 @@ jobs:
     steps:
       - name: Symlink .elan (to correct for GHA changing $HOME)
         run: '[ -e ~/.elan ] || ln -s /root/.elan ~/.elan'
-      - name: Checkout git history
-        # This is needed because we do `git diff` below
+      
+      - name: Checkout git history 📚
         uses: actions/checkout@v3
         with:
           sparse-checkout: .git
-      - env: 
-          GIT_DIR: ${{ github.workspace }}/.git
-        run: |
+      - name: Symlink git history 📚
+        run: 'ln -s "${{ github.workspace }}/.git" /code/lean-mlir/'
+
+      - run: |
           lake build AliveExamples
           (cd SSA/Projects/InstCombine/; uv run ./update_alive_statements.py)
           # /--------------------------- ^^^^^^
@@ -157,6 +158,14 @@ jobs:
     steps:     
       - name: Symlink .elan (to correct for GHA changing $HOME)
         run: '[ -e ~/.elan ] || ln -s /root/.elan ~/.elan'
+      
+      - name: Checkout git history 📚
+        uses: actions/checkout@v3
+        with:
+          sparse-checkout: .git
+      - name: Symlink git history 📚
+        run: 'ln -s "${{ github.workspace }}/.git" /code/lean-mlir/'
+
       - name: Run LLVM
         continue-on-error: true
         run: |
@@ -194,7 +203,7 @@ jobs:
     container: "ghcr.io/opencompl/lean-mlir-instcombine:${{ github.sha }}"
     defaults:
       run:
-        working-directory: /code/lean-mlir/bv-evaluation
+        working-directory: /code/lean-mlir
     strategy:
       matrix:
         extract_offset: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
@@ -202,10 +211,14 @@ jobs:
     steps:
       - name: Symlink .elan (to correct for GHA changing $HOME)
         run: '[ -e ~/.elan ] || ln -s /root/.elan ~/.elan'
-      - name: Checkout git history
+
+      - name: Checkout git history 📚
         uses: actions/checkout@v3
         with:
           sparse-checkout: .git
+      - name: Symlink git history 📚
+        run: 'ln -s "${{ github.workspace }}/.git" /code/lean-mlir/'
+
       - name: Ensure InstCombine goals are up-to-date
         env: 
           GIT_DIR: ${{ github.workspace }}/.git

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -33,7 +33,7 @@ jobs:
           tags: |
             type=ref,event=branch
             type=ref,event=pr
-            type=sha
+            type=raw,value=${{ github.sha }}
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and push

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -62,12 +62,24 @@ jobs:
       - name: Checkout 🛎️
         uses: actions/checkout@v3
 
+      - name: Setup Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/opencompl/lean-mlir-instcombine
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=raw,value=${{ github.sha }}
+            type=raw,value=latest,enable={{is_default_branch}}
+
       - name: Build and push Docker image
         uses: docker/build-push-action@v6
         with:
           context: "./bv-evaluation"
           push: true
-          tags: ghcr.io/opencompl/lean-mlir-instcombine:latest
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -99,6 +99,8 @@ jobs:
     defaults:
       run:
         working-directory: /code/lean-mlir
+    env:
+      HOME: /home/user
     steps:
       - name: Compile `mlirnatural` Executable 🧐
         run: |
@@ -130,6 +132,8 @@ jobs:
     defaults:
       run:
         working-directory: /code/lean-mlir
+    env:
+      HOME: /home/user
     steps:
       - name: Checkout git history
         # This is needed because we do `git diff` below
@@ -194,6 +198,8 @@ jobs:
     defaults:
       run:
         working-directory: /code/lean-mlir/bv-evaluation
+    env:
+      HOME: /home/user
     strategy:
       matrix:
         extract_offset: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -11,6 +11,9 @@ permissions:
   packages: write
 
 jobs:
+  #
+  # Docker image builders
+  #
   core-docker-img:
     name: Build Docker image for core library
     runs-on: namespace-profile-leanmlir-docker-cached 
@@ -83,6 +86,9 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+  #
+  # Evaluation & test jobs
+  # 
   build-tools:
     name: tools, scaling, and auto-generated stmts
     runs-on: ubuntu-latest # Run on GH-provided runner

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -130,13 +130,6 @@ jobs:
     steps:
       - name: Symlink .elan (to correct for GHA changing $HOME)
         run: '[ -e ~/.elan ] || ln -s /root/.elan ~/.elan'
-      
-      - name: Checkout git history 📚
-        uses: actions/checkout@v3
-        with:
-          sparse-checkout: .git
-      - name: Symlink git history 📚
-        run: 'ln -s "${{ github.workspace }}/.git" /code/lean-mlir/'
 
       - run: |
           lake build AliveExamples
@@ -158,13 +151,6 @@ jobs:
     steps:     
       - name: Symlink .elan (to correct for GHA changing $HOME)
         run: '[ -e ~/.elan ] || ln -s /root/.elan ~/.elan'
-      
-      - name: Checkout git history 📚
-        uses: actions/checkout@v3
-        with:
-          sparse-checkout: .git
-      - name: Symlink git history 📚
-        run: 'ln -s "${{ github.workspace }}/.git" /code/lean-mlir/'
 
       - name: Run LLVM
         continue-on-error: true
@@ -211,13 +197,6 @@ jobs:
     steps:
       - name: Symlink .elan (to correct for GHA changing $HOME)
         run: '[ -e ~/.elan ] || ln -s /root/.elan ~/.elan'
-
-      - name: Checkout git history 📚
-        uses: actions/checkout@v3
-        with:
-          sparse-checkout: .git
-      - name: Symlink git history 📚
-        run: 'ln -s "${{ github.workspace }}/.git" /code/lean-mlir/'
 
       - name: Ensure InstCombine goals are up-to-date
         env: 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -99,16 +99,10 @@ jobs:
     defaults:
       run:
         working-directory: /code/lean-mlir
-    env:
-      HOME: /home/user
     steps:
+      - run: '[ -e ~/.elan ] || ln -s /root/.elan ~/.elan'
       - name: Compile `mlirnatural` Executable 🧐
         run: |
-          echo "PATH=$PATH"
-          echo "working-dir="
-          pwd
-          echo "USER="
-          whoami
           lake -R build mlirnatural
 
       - name: Compile `opt` Executable 🧐
@@ -132,9 +126,8 @@ jobs:
     defaults:
       run:
         working-directory: /code/lean-mlir
-    env:
-      HOME: /root
     steps:
+      - run: '[ -e ~/.elan ] || ln -s /root/.elan ~/.elan'
       - name: Checkout git history
         # This is needed because we do `git diff` below
         uses: actions/checkout@v3
@@ -160,6 +153,7 @@ jobs:
     permissions:
       pull-requests: write
     steps:     
+      - run: '[ -e ~/.elan ] || ln -s /root/.elan ~/.elan'
       - name: Run LLVM
         continue-on-error: true
         run: |
@@ -198,13 +192,12 @@ jobs:
     defaults:
       run:
         working-directory: /code/lean-mlir/bv-evaluation
-    env:
-      HOME: /root
     strategy:
       matrix:
         extract_offset: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
         extract_stride: [10]
     steps:
+      - run: '[ -e ~/.elan ] || ln -s /root/.elan ~/.elan'
       - name: Checkout git history
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -103,8 +103,10 @@ jobs:
       - name: Compile `mlirnatural` Executable 🧐
         run: |
           echo "PATH=$PATH"
-          echo "PWD=$PWD"
-          echo "USER=$USER"
+          echo "working-dir="
+          pwd
+          echo "USER="
+          whoami
           lake -R build mlirnatural
 
       - name: Compile `opt` Executable 🧐

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -100,7 +100,8 @@ jobs:
       run:
         working-directory: /code/lean-mlir
     steps:
-      - run: '[ -e ~/.elan ] || ln -s /root/.elan ~/.elan'
+      - name: Symlink .elan (to correct for GHA changing $HOME)
+        run: '[ -e ~/.elan ] || ln -s /root/.elan ~/.elan'
       - name: Compile `mlirnatural` Executable 🧐
         run: |
           lake -R build mlirnatural
@@ -127,7 +128,8 @@ jobs:
       run:
         working-directory: /code/lean-mlir
     steps:
-      - run: '[ -e ~/.elan ] || ln -s /root/.elan ~/.elan'
+      - name: Symlink .elan (to correct for GHA changing $HOME)
+        run: '[ -e ~/.elan ] || ln -s /root/.elan ~/.elan'
       - name: Checkout git history
         # This is needed because we do `git diff` below
         uses: actions/checkout@v3
@@ -153,7 +155,8 @@ jobs:
     permissions:
       pull-requests: write
     steps:     
-      - run: '[ -e ~/.elan ] || ln -s /root/.elan ~/.elan'
+      - name: Symlink .elan (to correct for GHA changing $HOME)
+        run: '[ -e ~/.elan ] || ln -s /root/.elan ~/.elan'
       - name: Run LLVM
         continue-on-error: true
         run: |
@@ -197,7 +200,8 @@ jobs:
         extract_offset: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
         extract_stride: [10]
     steps:
-      - run: '[ -e ~/.elan ] || ln -s /root/.elan ~/.elan'
+      - name: Symlink .elan (to correct for GHA changing $HOME)
+        run: '[ -e ~/.elan ] || ln -s /root/.elan ~/.elan'
       - name: Checkout git history
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -164,16 +164,15 @@ jobs:
             || echo "LEANMLIR_STATUS=fail" >> $GITHUB_ENV
 
       - uses: actions/github-script@v6
-        working-directory: /code/lean-mlir/bv-evaluation
         if: env.LEANMLIR_STATUS != 'fail' && github.event_name == 'pull_request'
-        with:
+        with: 
           script: |
             const fs = require('fs')
             github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: fs.readFileSync('llvm-stats', 'utf8')
+              body: fs.readFileSync('/code/lean-mlir/bv-evaluation/llvm-stats', 'utf8')
             })
 
       - name: Upload LLVM artifact

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -11,7 +11,7 @@ permissions:
   packages: write
 
 jobs:
-  docker:
+  core-docker-img:
     name: Build Docker image for core library
     runs-on: namespace-profile-leanmlir-docker-cached 
     steps:
@@ -44,7 +44,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
-  docker-bitwuzla:
+  bitwuzla-docker-img:
     name: Build Docker image for Bitwuzla
     runs-on: ubuntu-latest
     steps:
@@ -70,3 +70,32 @@ jobs:
           outputs: type=docker,dest=${{ runner.temp }}/bitwuzla.tar
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+  build-tools:
+    name: tools, scaling, and auto-generated stmts
+    runs-on: ubuntu-latest # Run on GH-provided runner
+    needs: core-docker-img
+    container: "ghcr.io/opencompl/lean-mlir:${{ github.sha }}"
+    steps:
+      - name: Compile `mlirnatural` Executable 🧐
+        run: |
+          lake -R build mlirnatural
+
+      - name: Compile `opt` Executable 🧐
+        run: |
+          lake -R build opt
+
+#      This broke the build during a recent update
+#      - name: LLVM opt round trip test
+#        run: |
+#          lake exec opt test/LLVMDialect/InstCombine/bb0.mlir
+
+      - name: Compile Alive Scaling
+        run: |
+          lake -R build SSA.Projects.InstCombine.ScalingTest
+
+      - name: Check for changes in AliveStatements
+        run: |
+          lake build AliveExamples
+          (cd SSA/Projects/InstCombine/; ./update_alive_statements.py)
+          bash -c '! git diff | grep .'  # iff git diff is empty, 'grep .' fails, '!' inverts the failure, and in the forced bash

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -44,9 +44,10 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
-  bitwuzla-docker-img:
-    name: Build Docker image for Bitwuzla
-    runs-on: ubuntu-latest
+  instcombine-docker-img:
+    name: Build Docker image for InstCombine Evaluation
+    runs-on: ubuntu-latest # Run on GH-provided runner
+    needs: core-docker-img
     steps:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -66,8 +67,7 @@ jobs:
         with:
           context: "./bv-evaluation"
           push: true
-          tags: ghcr.io/opencompl/bitwuzla:latest
-          outputs: type=docker,dest=${{ runner.temp }}/bitwuzla.tar
+          tags: ghcr.io/opencompl/lean-mlir-instcombine:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -97,8 +97,25 @@ jobs:
         run: |
           lake -R build SSA.Projects.InstCombine.ScalingTest
 
-      - name: Check for changes in AliveStatements
+  alive-check-changes:
+    name: Check for changes in AliveStatements
+    runs-on: ubuntu-latest # Run on GH-provided runner
+    needs: instcombine-docker-img
+    container: "ghcr.io/opencompl/lean-mlir-instcombine:${{ github.sha }}"
+    defaults:
+      run:
+        working-directory: /code/lean-mlir
+    steps:
+      - name: Checkout git history
+        # This is needed because we do `git diff` below
+        uses: actions/checkout@v3
+        with:
+          sparse-checkout: .git
+      - env: 
+          GIT_DIR: ${{ github.workspace }}/.git
         run: |
           lake build AliveExamples
-          (cd SSA/Projects/InstCombine/; ./update_alive_statements.py)
+          (cd SSA/Projects/InstCombine/; uv run ./update_alive_statements.py)
+          # /--------------------------- ^^^^^^
+          # | TODO: this could be removed if we add a uv shebang to the python file
           bash -c '! git diff | grep .'  # iff git diff is empty, 'grep .' fails, '!' inverts the failure, and in the forced bash

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,15 +14,14 @@ ENV UID=9000
 ENV HOME=/home/user
 RUN \
   useradd user --create-home --uid $UID --home-dir="$HOME" && \
-  mkdir -p /code/lean-mlir && \
-  mkdir -p /github/home && \
-  chown -R user /code /github/home && \
-  ln -s $HOME/.elan /github/home/.elan
+  mkdir -p /code/lean-mlir /github/home && \
+  chown -R user /code /github/home
+USER user
+WORKDIR $HOME
+RUN ln -s $HOME/.elan /github/home/.elan
   # ^^ Github Actions overrides the home directory [1]. Rather than fight it we
   #    choose to symlink our stuff in the directory it expects.
   #    [1] https://github.com/actions/runner/issues/863
-USER user
-WORKDIR $HOME
 
 # Install elan and update environment
 RUN curl https://elan.lean-lang.org/elan-init.sh -sSf | sh -s -- -y --default-toolchain none

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,14 +11,15 @@ RUN update-ca-certificates -f
 
 # Drop privilege to non-root user
 ENV UID=9000
-ENV HOME=/github/home
-# ^^ Github Actions overrides the home directory [1]. Rather than fight it we
-#    choose to directly install our stuff in the directory it expects.
-#    [1] https://github.com/actions/runner/issues/863
+ENV HOME=/home/user
 RUN \
   useradd user --create-home --uid $UID --home-dir="$HOME" && \
   mkdir -p /code/lean-mlir && \
-  chown -R user /code 
+  chown -R user /code && \
+  ln -s /github/home/.elan $HOME/.elan
+  # ^^ Github Actions overrides the home directory [1]. Rather than fight it we
+  #    choose to symlink our stuff in the directory it expects.
+  #    [1] https://github.com/actions/runner/issues/863
 USER user
 WORKDIR $HOME
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN \
   chown -R user /code /github/home
 USER user
 WORKDIR $HOME
-RUN ln -s $HOME/.elan /github/home/.elan
+# RUN ln -s $HOME/.elan /github/home/.elan
   # ^^ Github Actions overrides the home directory [1]. Rather than fight it we
   #    choose to symlink our stuff in the directory it expects.
   #    [1] https://github.com/actions/runner/issues/863

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,9 @@ ENV HOME=/home/user
 RUN \
   useradd user --create-home --uid $UID --home-dir="$HOME" && \
   mkdir -p /code/lean-mlir && \
-  chown -R user /code && \
-  ln -s /github/home/.elan $HOME/.elan
+  mkdir -p /github/home && \
+  chown -R user /code /github/home && \
+  ln -s $HOME/.elan /github/home/.elan
   # ^^ Github Actions overrides the home directory [1]. Rather than fight it we
   #    choose to symlink our stuff in the directory it expects.
   #    [1] https://github.com/actions/runner/issues/863

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,12 +11,15 @@ RUN update-ca-certificates -f
 
 # Drop privilege to non-root user
 ENV UID=9000
+ENV HOME=/github/home
+# ^^ Github Actions overrides the home directory [1]. Rather than fight it we
+#    choose to directly install our stuff in the directory it expects.
+#    [1] https://github.com/actions/runner/issues/863
 RUN \
-  useradd user --create-home --uid $UID && \
+  useradd user --create-home --uid $UID --home-dir="$HOME" && \
   mkdir -p /code/lean-mlir && \
   chown -R user /code 
 USER user
-ENV HOME=/home/user
 WORKDIR $HOME
 
 # Install elan and update environment

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ ENV HOME=/home/user
 RUN \
   useradd user --create-home --uid $UID --home-dir="$HOME" && \
   mkdir -p /code/lean-mlir /github/home && \
-  chown -R user /code /github/home
+  chown -R user /code /github
 USER user
 WORKDIR $HOME
 # RUN ln -s $HOME/.elan /github/home/.elan

--- a/bv-evaluation/Dockerfile
+++ b/bv-evaluation/Dockerfile
@@ -8,6 +8,8 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 	apt-get install -yqq --no-install-recommends \
         python3 \
         curl wget unzip ca-certificates \
+        # evaluation tools
+        ripgrep \
         # bitwuzla dependencies
         git ninja-build build-essential \
         meson libgmp-dev libcadical-dev libsymfpu-dev pkg-config
@@ -39,7 +41,7 @@ USER user
 WORKDIR $HOME
 
 # Install uv
-ADD https://astral.sh/uv/0.8.13/install.sh ./uv-installer.sh
+ADD --chown=user https://astral.sh/uv/0.8.13/install.sh ./uv-installer.sh
 RUN sh ./uv-installer.sh && rm ./uv-installer.sh
 ENV PATH="$HOME/.local/bin/:$PATH"
 

--- a/bv-evaluation/Dockerfile
+++ b/bv-evaluation/Dockerfile
@@ -25,10 +25,23 @@ RUN \
     ./configure.py && \
     cd build && ninja && ninja install
 
+# Drop privilege to non-root user
+ENV UID=9000
+ENV HOME=/github/home
+# ^^ Github Actions overrides the home directory [1]. Rather than fight it we
+#    choose to directly install our stuff in the directory it expects.
+#    [1] https://github.com/actions/runner/issues/863
+RUN \
+  useradd user --create-home --uid $UID --home-dir="$HOME" && \
+  mkdir -p /code/lean-mlir && \
+  chown -R user /code 
+USER user
+WORKDIR $HOME
+
 # Install uv
 ADD https://astral.sh/uv/0.8.13/install.sh ./uv-installer.sh
 RUN sh ./uv-installer.sh && rm ./uv-installer.sh
-ENV PATH="/root/.local/bin/:$PATH"
+ENV PATH="$HOME/.local/bin/:$PATH"
 
 # Switch to Lean MLIR workdir
 WORKDIR /code/lean-mlir/
@@ -38,6 +51,6 @@ COPY --from=lean-mlir /code/lean-mlir/requirements.txt ./
 RUN uv venv && uv pip install -r requirements.txt
 
 # Copy LeanMLIR toolchain & build artifacts from image
-COPY --from=lean-mlir /root/.elan/ /root/.elan/
+COPY --from=lean-mlir $HOME/.elan/ $HOME/.elan/
 COPY --from=lean-mlir /code/lean-mlir/ /code/lean-mlir/
-ENV PATH="/root/.elan/bin/:$PATH"
+ENV PATH="$HOME/.elan/bin/:$PATH"

--- a/bv-evaluation/Dockerfile
+++ b/bv-evaluation/Dockerfile
@@ -34,13 +34,13 @@ RUN \
   useradd user --create-home --uid $UID --home-dir="$HOME" && \
   mkdir -p /code/lean-mlir && \
   mkdir -p /github/home && \
-  chown -R user /code /github/home && \
-  ln -s $HOME/.elan /github/home/.elan
+  chown -R user /code /github/home
+USER user
+WORKDIR $HOME
+RUN ln -s $HOME/.elan /github/home/.elan
   # ^^ Github Actions overrides the home directory [1]. Rather than fight it we
   #    choose to symlink our stuff in the directory it expects.
   #    [1] https://github.com/actions/runner/issues/863
-USER user
-WORKDIR $HOME
 
 # Install uv
 ADD --link --chown=$UID https://astral.sh/uv/0.8.13/install.sh ./uv-installer.sh

--- a/bv-evaluation/Dockerfile
+++ b/bv-evaluation/Dockerfile
@@ -47,10 +47,10 @@ ENV PATH="$HOME/.local/bin/:$PATH"
 WORKDIR /code/lean-mlir/
 
 # Install LeanMLIR Python dependencies (via uv)
-COPY --from=lean-mlir /code/lean-mlir/requirements.txt ./
+COPY --from=lean-mlir --chown=user /code/lean-mlir/requirements.txt ./
 RUN uv venv && uv pip install -r requirements.txt
 
 # Copy LeanMLIR toolchain & build artifacts from image
-COPY --from=lean-mlir $HOME/.elan/ $HOME/.elan/
-COPY --from=lean-mlir /code/lean-mlir/ /code/lean-mlir/
+COPY --from=lean-mlir --chown=user $HOME/.elan/ $HOME/.elan/
+COPY --from=lean-mlir --chown=user /code/lean-mlir/ /code/lean-mlir/
 ENV PATH="$HOME/.elan/bin/:$PATH"

--- a/bv-evaluation/Dockerfile
+++ b/bv-evaluation/Dockerfile
@@ -33,8 +33,9 @@ ENV HOME=/home/user
 RUN \
   useradd user --create-home --uid $UID --home-dir="$HOME" && \
   mkdir -p /code/lean-mlir && \
-  chown -R user /code && \
-  ln -s /github/home/.elan $HOME/.elan
+  mkdir -p /github/home && \
+  chown -R user /code /github/home && \
+  ln -s $HOME/.elan /github/home/.elan
   # ^^ Github Actions overrides the home directory [1]. Rather than fight it we
   #    choose to symlink our stuff in the directory it expects.
   #    [1] https://github.com/actions/runner/issues/863

--- a/bv-evaluation/Dockerfile
+++ b/bv-evaluation/Dockerfile
@@ -37,7 +37,7 @@ RUN \
   chown -R user /code /github/home
 USER user
 WORKDIR $HOME
-RUN ln -s $HOME/.elan /github/home/.elan
+# RUN ln -s $HOME/.elan /github/home/.elan
   # ^^ Github Actions overrides the home directory [1]. Rather than fight it we
   #    choose to symlink our stuff in the directory it expects.
   #    [1] https://github.com/actions/runner/issues/863

--- a/bv-evaluation/Dockerfile
+++ b/bv-evaluation/Dockerfile
@@ -27,23 +27,11 @@ RUN \
     ./configure.py && \
     cd build && ninja && ninja install
 
-# Drop privilege to non-root user
-ENV UID=9000
-ENV HOME=/home/user
-RUN \
-  useradd user --create-home --uid $UID --home-dir="$HOME" && \
-  mkdir -p /code/lean-mlir && \
-  mkdir -p /github/home && \
-  chown -R user /code /github
-USER user
-WORKDIR $HOME
-# RUN ln -s $HOME/.elan /github/home/.elan
-  # ^^ Github Actions overrides the home directory [1]. Rather than fight it we
-  #    choose to symlink our stuff in the directory it expects.
-  #    [1] https://github.com/actions/runner/issues/863
+# Set user env vars
+ENV HOME=/root
 
 # Install uv
-ADD --link --chown=$UID https://astral.sh/uv/0.8.13/install.sh ./uv-installer.sh
+ADD --link https://astral.sh/uv/0.8.13/install.sh ./uv-installer.sh
 RUN sh ./uv-installer.sh && rm ./uv-installer.sh
 ENV PATH="$HOME/.local/bin/:$PATH"
 
@@ -51,10 +39,10 @@ ENV PATH="$HOME/.local/bin/:$PATH"
 WORKDIR /code/lean-mlir/
 
 # Install LeanMLIR Python dependencies (via uv)
-COPY --link --from=lean-mlir --chown=$UID /code/lean-mlir/requirements.txt ./
+COPY --link --from=lean-mlir /code/lean-mlir/requirements.txt ./
 RUN uv venv && uv pip install -r requirements.txt
 
 # Copy LeanMLIR toolchain & build artifacts from image
-COPY --link --from=lean-mlir --chown=$UID $HOME/.elan/ $HOME/.elan/
-COPY --link --from=lean-mlir --chown=$UID /code/lean-mlir/ /code/lean-mlir/
+COPY --link --from=lean-mlir $HOME/.elan/ $HOME/.elan/
+COPY --link --from=lean-mlir /code/lean-mlir/ /code/lean-mlir/
 ENV PATH="$HOME/.elan/bin/:$PATH"

--- a/bv-evaluation/Dockerfile
+++ b/bv-evaluation/Dockerfile
@@ -1,10 +1,13 @@
+ARG LEANMLIR_TAG="latest"
+FROM ghcr.io/opencompl/lean-mlir:${LEANMLIR_TAG} AS lean-mlir
+
 FROM ubuntu:25.04
 
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 	apt-get update && \
 	apt-get install -yqq --no-install-recommends \
-        elan \
-        wget unzip python3 ca-certificates \
+        python3 \
+        curl wget unzip ca-certificates \
         # bitwuzla dependencies
         git ninja-build build-essential \
         meson libgmp-dev libcadical-dev libsymfpu-dev pkg-config
@@ -21,3 +24,20 @@ RUN \
     cd bitwuzla && \
     ./configure.py && \
     cd build && ninja && ninja install
+
+# Install uv
+ADD https://astral.sh/uv/0.8.13/install.sh ./uv-installer.sh
+RUN sh ./uv-installer.sh && rm ./uv-installer.sh
+ENV PATH="/root/.local/bin/:$PATH"
+
+# Switch to Lean MLIR workdir
+WORKDIR /code/lean-mlir/
+
+# Install LeanMLIR Python dependencies (via uv)
+COPY --from=lean-mlir /code/lean-mlir/requirements.txt ./
+RUN uv venv && uv pip install -r requirements.txt
+
+# Copy LeanMLIR toolchain & build artifacts from image
+COPY --from=lean-mlir /root/.elan/ /root/.elan/
+COPY --from=lean-mlir /code/lean-mlir/ /code/lean-mlir/
+ENV PATH="/root/.elan/bin/:$PATH"

--- a/bv-evaluation/Dockerfile
+++ b/bv-evaluation/Dockerfile
@@ -41,7 +41,7 @@ USER user
 WORKDIR $HOME
 
 # Install uv
-ADD --chown=user https://astral.sh/uv/0.8.13/install.sh ./uv-installer.sh
+ADD --link --chown=user https://astral.sh/uv/0.8.13/install.sh ./uv-installer.sh
 RUN sh ./uv-installer.sh && rm ./uv-installer.sh
 ENV PATH="$HOME/.local/bin/:$PATH"
 
@@ -49,10 +49,10 @@ ENV PATH="$HOME/.local/bin/:$PATH"
 WORKDIR /code/lean-mlir/
 
 # Install LeanMLIR Python dependencies (via uv)
-COPY --from=lean-mlir --chown=user /code/lean-mlir/requirements.txt ./
+COPY --link --from=lean-mlir --chown=user /code/lean-mlir/requirements.txt ./
 RUN uv venv && uv pip install -r requirements.txt
 
 # Copy LeanMLIR toolchain & build artifacts from image
-COPY --from=lean-mlir --chown=user $HOME/.elan/ $HOME/.elan/
-COPY --from=lean-mlir --chown=user /code/lean-mlir/ /code/lean-mlir/
+COPY --link --from=lean-mlir --chown=user $HOME/.elan/ $HOME/.elan/
+COPY --link --from=lean-mlir --chown=user /code/lean-mlir/ /code/lean-mlir/
 ENV PATH="$HOME/.elan/bin/:$PATH"

--- a/bv-evaluation/Dockerfile
+++ b/bv-evaluation/Dockerfile
@@ -29,14 +29,15 @@ RUN \
 
 # Drop privilege to non-root user
 ENV UID=9000
-ENV HOME=/github/home
-# ^^ Github Actions overrides the home directory [1]. Rather than fight it we
-#    choose to directly install our stuff in the directory it expects.
-#    [1] https://github.com/actions/runner/issues/863
+ENV HOME=/home/user
 RUN \
   useradd user --create-home --uid $UID --home-dir="$HOME" && \
   mkdir -p /code/lean-mlir && \
-  chown -R user /code 
+  chown -R user /code && \
+  ln -s /github/home/.elan $HOME/.elan
+  # ^^ Github Actions overrides the home directory [1]. Rather than fight it we
+  #    choose to symlink our stuff in the directory it expects.
+  #    [1] https://github.com/actions/runner/issues/863
 USER user
 WORKDIR $HOME
 

--- a/bv-evaluation/Dockerfile
+++ b/bv-evaluation/Dockerfile
@@ -34,7 +34,7 @@ RUN \
   useradd user --create-home --uid $UID --home-dir="$HOME" && \
   mkdir -p /code/lean-mlir && \
   mkdir -p /github/home && \
-  chown -R user /code /github/home
+  chown -R user /code /github
 USER user
 WORKDIR $HOME
 # RUN ln -s $HOME/.elan /github/home/.elan

--- a/bv-evaluation/Dockerfile
+++ b/bv-evaluation/Dockerfile
@@ -41,7 +41,7 @@ USER user
 WORKDIR $HOME
 
 # Install uv
-ADD --link --chown=user https://astral.sh/uv/0.8.13/install.sh ./uv-installer.sh
+ADD --link --chown=$UID https://astral.sh/uv/0.8.13/install.sh ./uv-installer.sh
 RUN sh ./uv-installer.sh && rm ./uv-installer.sh
 ENV PATH="$HOME/.local/bin/:$PATH"
 
@@ -49,10 +49,10 @@ ENV PATH="$HOME/.local/bin/:$PATH"
 WORKDIR /code/lean-mlir/
 
 # Install LeanMLIR Python dependencies (via uv)
-COPY --link --from=lean-mlir --chown=user /code/lean-mlir/requirements.txt ./
+COPY --link --from=lean-mlir --chown=$UID /code/lean-mlir/requirements.txt ./
 RUN uv venv && uv pip install -r requirements.txt
 
 # Copy LeanMLIR toolchain & build artifacts from image
-COPY --link --from=lean-mlir --chown=user $HOME/.elan/ $HOME/.elan/
-COPY --link --from=lean-mlir --chown=user /code/lean-mlir/ /code/lean-mlir/
+COPY --link --from=lean-mlir --chown=$UID $HOME/.elan/ $HOME/.elan/
+COPY --link --from=lean-mlir --chown=$UID /code/lean-mlir/ /code/lean-mlir/
 ENV PATH="$HOME/.elan/bin/:$PATH"


### PR DESCRIPTION
As per #1613, I'm experimenting with an alternative CI setup where we run everything inside a Docker container. Until we commit to this being the workflow we like, I'll duplicate existing CI jobs and have a *seperate* job run the same action inside the container (on a GH-provided runner, but using the image we built on namespace's runner).

This PR does so for the CI job that builds the non-standard build targets and the Instcombine evaluation (but not yet for hackersdelight, for that I'm waiting on #1549).

To make this work, I:
- Add more stuff to the .dockerignore file, so files which are not needed are not copied to the Docker image (and thus won't trigger cache misses).
- Expand the existing bitwuzla image to also install uv, use uv to install the python dependencies specified in requirements.txt, and copy the lean-mlir files from the base-image to get a full-blown instcombine image; the produced image is thus renamed to `lean-mlir-instcombine`. Note that this second image is still build on GH runner infrastructure! This is fine as we don't actually `lake build` anything here, so there is no need for incremental caching (but of course, using namespace.so would still likely be faster).
- I tried dropping permissions in the Dockerfile to use a non-root user
  - Github will change the home-directory to `/github/home`, so I originally thought it was using a github user because of security concerns with using a root user. Thus, I tried to set a `USER` in the dockerfile.
  - However, it just made everything more complicated, and random actions started failing with permission errors.
  - Then I tried setting the home-directory explictly to `/root` using `env.var`, but then actions started complaining about `/root/.docker/config.json` not existing...
  - Just leaving the status quo is non-ideal, as .elan was re-downloading the toolchain (since the Docker image has it at /root/.elan, while in the action it was looking at `/github/home/.elan`
  - Finally, I worked around it by adding a first run step that symlinks the latter to the former to every job that runs in a container. It's not the most elegant, as it adds a boilerplate run step to every job, but it actually works, so :shrug: 