### PR TITLE
fix: stop swallowing LLVM status code on evaluation CI failure

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -156,13 +156,13 @@ jobs:
         continue-on-error: true
         run: |
           uv run ./compare.py instcombine -j48 \
-            || echo "LEANMLIR_STATUS=fail" >> $GITHUB_ENV
+            || (echo "LEANMLIR_STATUS=fail" >> $GITHUB_ENV; exit 1)
 
       - name: Collect data LLVM
         continue-on-error: true
         run: |
           (uv run ./collect.py instcombine | tee llvm-stats) \
-            || echo "LEANMLIR_STATUS=fail" >> $GITHUB_ENV
+            || (echo "LEANMLIR_STATUS=fail" >> $GITHUB_ENV; exit 1)
 
       - uses: actions/github-script@v6
         if: env.LEANMLIR_STATUS != 'fail' && github.event_name == 'pull_request'

--- a/.github/workflows/evaluation.yml
+++ b/.github/workflows/evaluation.yml
@@ -123,14 +123,14 @@ jobs:
         run: |
           cd bv-evaluation
           python3 ./compare.py instcombine -j48 \
-            || echo "LEANMLIR_STATUS=fail" >> $GITHUB_ENV
+            || (echo "LEANMLIR_STATUS=fail" >> $GITHUB_ENV; exit 1)
 
       - name: Collect data LLVM
         continue-on-error: true
         run: |
           cd bv-evaluation
           (python3 ./collect.py instcombine | tee llvm-stats) \
-            || echo "LEANMLIR_STATUS=fail" >> $GITHUB_ENV
+            || (echo "LEANMLIR_STATUS=fail" >> $GITHUB_ENV; exit 1)
 
       - uses: actions/github-script@v6
         if: env.LEANMLIR_STATUS != 'fail' && github.event_name == 'pull_request'


### PR DESCRIPTION
Previously the CI would be green even if the script raised an error, because our script would swallow the non-zero status code in the code that persisted the error to the environment, so we ensure that the second branch also exits with a non-zero code.