### PR TITLE
WIP: feat: use matrix strategy to distribute LLVM evaluation

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -146,8 +146,10 @@ jobs:
     defaults:
       run:
         working-directory: /code/lean-mlir/bv-evaluation
-    permissions:
-      pull-requests: write
+    strategy:
+      matrix:
+        offset: [0, 1, 2]
+        stride: [3]
     steps:     
       - name: Symlink .elan (to correct for GHA changing $HOME)
         run: '[ -e ~/.elan ] || ln -s /root/.elan ~/.elan'
@@ -155,8 +157,35 @@ jobs:
       - name: Run LLVM
         continue-on-error: true
         run: |
-          uv run ./compare.py instcombine -j48 \
+          uv run ./compare.py instcombine -j48 --stride=${{matrix.stride}} --offset=${{matrix.offset}} \
             || echo "LEANMLIR_STATUS=fail" >> $GITHUB_ENV
+      
+      - name: Upload logs
+        id: upload
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ github.run_id }}-instcombine-logs-${{matrix.offset}}
+          retention-days: 1
+          path: |
+            /code/lean-mlir/bv-evaluation/results/InstCombine/
+
+  report-LLVM:
+    name: Collect & report LLVM evaluation data   
+    runs-on: ubuntu-latest # Run on GH-provided runner
+    needs: evaluation-LLVM
+    container: "ghcr.io/opencompl/lean-mlir-instcombine:${{ github.sha }}"
+    defaults:
+      run:
+        working-directory: /code/lean-mlir/bv-evaluation
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Download data
+        uses: actions/download-artifact@v5
+        with:
+          path: /code/lean-mlir/bv-evaluation/results/InstCombine/
+          pattern: ${{ github.run_id }}-instcombine-logs-*
+          merge-multiple: true
 
       - name: Collect data LLVM
         continue-on-error: true


### PR DESCRIPTION
This PR adds `--stride` and `--offset` parameters to the `compare.py` script (for now only used in the instcombine benchmark), which can be used to control which subset of the input files are to be run. We then use these parameters in a matrix strategy to distribute the LLVM evaluation CI job over 3 runners (but this could be scaled arbitrarily).

Only after implementing this I noticed that the collect.py script seems to be broken, it reports the following error:
```
Traceback (most recent call last):
  File "/home/runner/work/lean-mlir/lean-mlir/bv-evaluation/./collect.py", line 1149, in <module>
    main()
  File "/home/runner/work/lean-mlir/lean-mlir/bv-evaluation/./collect.py", line 1145, in main
    collect(b, reps=reps)
  File "/home/runner/work/lean-mlir/lean-mlir/bv-evaluation/./collect.py", line 941, in collect
    print("max of percentage stddev/av: "+str(np.max(ratios))+ "%")
                                              ^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/numpy/core/fromnumeric.py", line 2810, in max
    return _wrapreduction(a, np.maximum, 'max', axis, None, out,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/numpy/core/fromnumeric.py", line 88, in _wrapreduction
    return ufunc.reduce(obj, axis, dtype, out, **passkwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ValueError: zero-size array to reduction operation maximum which has no identity
```

So I can't really confirm that I didn't broke anything.