### PR TITLE
refactor: move `simp_alive_split` to SimpLLVM file

### DIFF
--- a/SSA/Projects/InstCombine/Tactic/SimpLLVM.lean
+++ b/SSA/Projects/InstCombine/Tactic/SimpLLVM.lean
@@ -105,6 +105,26 @@ macro_rules
     )
   )
 
+/-! ### simp_alive_split -/
+macro "simp_alive_split": tactic =>
+  `(tactic|
+      (
+        all_goals try intros
+        repeat(
+          all_goals try simp -implicitDefEqProofs only [simp_llvm_split]
+          all_goals try simp -implicitDefEqProofs only [simp_llvm_split] at *
+          any_goals split_ifs
+        )
+        repeat(
+          all_goals try simp -implicitDefEqProofs only [simp_llvm_split]
+          all_goals try simp -implicitDefEqProofs only [simp_llvm_split] at *
+          any_goals split
+        )
+        all_goals try simp -implicitDefEqProofs only [simp_llvm_split]
+        all_goals try simp -implicitDefEqProofs only [simp_llvm_split] at *
+      )
+   )
+
 /-! ### Constant Hiding Workaround
 The following section defines two tactics, `hide_constants` and `unhide_constants`.
 * `hide_constants` will rewrite occurences of `LLVM.const?` or `BitVec.ofInt`

--- a/SSA/Projects/InstCombine/TacticAuto.lean
+++ b/SSA/Projects/InstCombine/TacticAuto.lean
@@ -151,25 +151,6 @@ macro "bv_compare'": tactic =>
       )
    )
 
-macro "simp_alive_split": tactic =>
-  `(tactic|
-      (
-        all_goals try intros
-        repeat(
-          all_goals try simp -implicitDefEqProofs only [simp_llvm_split]
-          all_goals try simp -implicitDefEqProofs only [simp_llvm_split] at *
-          any_goals split_ifs
-        )
-        repeat(
-          all_goals try simp -implicitDefEqProofs only [simp_llvm_split]
-          all_goals try simp -implicitDefEqProofs only [simp_llvm_split] at *
-          any_goals split
-        )
-        all_goals try simp -implicitDefEqProofs only [simp_llvm_split]
-        all_goals try simp -implicitDefEqProofs only [simp_llvm_split] at *
-      )
-   )
-
 macro "simp_alive_benchmark": tactic =>
   `(tactic|
       (


### PR DESCRIPTION
This puts the entire LLVM -> BitVec simplification pipeline in SimpLLVM, which is important because TacticAuto also contains a bunch of solvers (and thus depends on AutoStructs and similar slow files