### PR TITLE
chore: drop custom bitvector notation

### DIFF
--- a/SSA/Projects/InstCombine/ForLean.lean
+++ b/SSA/Projects/InstCombine/ForLean.lean
@@ -296,67 +296,8 @@ theorem intMin_slt_zero (h : 0 < w) :
   norm_cast
   simp [h]
 
-theorem neg_sgt_eq_slt_neg {A B : BitVec w} (h : A ≠ intMin w) (h2 : B ≠ intMin w) :
-    (-A >ₛ B) = (A <ₛ -B) := by
-  unfold BitVec.slt
-  simp only [decide_eq_decide, toInt_neg_of_ne_intMin h, toInt_neg_of_ne_intMin h2]
-  omega
-
-theorem sgt_zero_eq_not_neg_sgt_zero (A : BitVec w) (h_ne_intMin : A ≠ intMin w)
-    (h_ne_zero : A ≠ 0) : (A >ₛ 0#w) ↔ ¬ ((-A) >ₛ 0#w) := by
-  by_cases w0 : w = 0
-  · subst w0
-    simp [BitVec.eq_nil A] at h_ne_zero
-  simp only [Bool.not_eq_true, Bool.coe_true_iff_false]
-  rw [neg_sgt_eq_slt_neg h_ne_intMin _]
-  unfold BitVec.slt
-  by_cases h : A.toInt < 0
-  · simp [h]
-    omega
-  · simp only [toInt_zero, neg_zero, h, decide_false, Bool.not_false, decide_eq_true_eq]
-    simp only [ofNat_eq_ofNat, ne_eq, ← toInt_ne, toInt_zero] at h_ne_zero
-    omega
-  simp only [ne_eq]
-  have h : 0 < w := by omega
-  simp only [ne_eq]
-  have two_pow_pos := Nat.two_pow_pos (w-1)
-  simp only [intMin, toNat_eq, toNat_ofNat, Nat.zero_mod, toNat_twoPow, ne_eq]
-  let w' := w - 1
-  have hw₀: w - 1 = w' := by omega
-  have hw₁: w = w' + 1 := by omega
-  rw [hw₀, hw₁]
-  rw [Nat.mod_eq_of_lt (by simp [Nat.pow_lt_pow_succ])]
-  have := Nat.two_pow_pos (w := w')
-  omega
-
-theorem sgt_same (A : BitVec w) : ¬ (A >ₛ A) := by
+theorem sgt_same (A : BitVec w) : ¬ (A.slt A) := by
   simp [BitVec.slt]
-
-private theorem intMin_lt_zero (h : 0 < w): intMin w <ₛ 0 := by
-  unfold BitVec.slt
-  simp only [toInt_intMin, ofNat_eq_ofNat, toInt_zero, Left.neg_neg_iff, decide_eq_true_eq]
-  norm_cast
-  rw [Nat.two_pow_pred_mod_two_pow (by omega)]
-  exact Nat.two_pow_pos (w-1)
-
-private theorem not_gt_eq_le (A B : BitVec w) : (¬ (A >ₛ B)) = (A ≤ₛ B) := by
-  simp [BitVec.slt, BitVec.sle]
-
-private theorem sge_eq_sle (A B : BitVec w) : (A ≥ₛ B) = (B ≤ₛ A) := by
-  simp [BitVec.sle]
-
-private theorem sge_of_sgt (A B : BitVec w) : (A >ₛ B) → (A ≥ₛ B) := by
-  simp only [BitVec.slt, decide_eq_true_eq, BitVec.sle]
-  omega
-
-theorem intMin_not_gt_zero : ¬ (intMin w >ₛ (0#w)):= by
-  by_cases h : w = 0
-  · subst h
-    simp [of_length_zero]
-  · simp only [not_gt_eq_le]
-    rw [sge_of_sgt]
-    apply intMin_lt_zero
-    omega
 
 @[simp]
 lemma carry_and_xor_false : carry i (a &&& b) (a ^^^ b) false = false := by

--- a/SSA/Projects/InstCombine/ForStd.lean
+++ b/SSA/Projects/InstCombine/ForStd.lean
@@ -21,69 +21,12 @@ instance {n} : ShiftRight (BitVec n) := ⟨fun x y => x >>> y.toNat⟩
 
 infixl:75 ">>>ₛ" => fun x y => BitVec.sshiftRight x (BitVec.toNat y)
 
--- A lot of this should probably go to a differet file here and not Mathlib
-inductive Refinement {α : Type u} : Option α → Option α → Prop
-  | bothSome {x y : α } : x = y → Refinement (some x) (some y)
-  | noneAny {x? : Option α} : Refinement none x?
-
-namespace Refinement
-
-infix:50 (priority:=low) " ⊑ " => Refinement
-
-@[simp]
-theorem some_some {α : Type u} {x y : α} :
-  (some x) ⊑ (some y) ↔ x = y :=
-  ⟨by intro h; cases h; assumption, Refinement.bothSome⟩
-
-@[simp]
-theorem none_left :
-  Refinement none x? := .noneAny
-
-theorem none_right {x? : Option α} :
-    x? ⊑ none ↔ x? = none := by
-  cases x?
-  · simp only [none_left]
-  · simp only [reduceCtorEq, iff_false]
-    rintro ⟨⟩
-
-theorem some_left {x : α} {y? : Option α} :
-    some x ⊑ y? ↔ y? = some x := by
-  cases y? <;> simp [eq_comm, none_right]
-
-@[simp]
-theorem refl {α: Type u} : ∀ x : Option α, Refinement x x := by
-  intro x ; cases x
-  apply Refinement.noneAny
-  apply Refinement.bothSome; rfl
-
-theorem trans {α : Type u} : ∀ x y z : Option α, Refinement x y → Refinement y z → Refinement x z := by
-  intro x y z h₁ h₂
-  cases h₁ <;> cases h₂ <;> try { apply Refinement.noneAny } ; try {apply Refinement.bothSome; assumption}
-  rename_i x y hxy y h
-  rw [hxy, h]; apply refl
-
-instance {α : Type u} [DEQ : DecidableEq α] : DecidableRel (@Refinement α) := by
-  intro x y
-  cases x <;> cases y
-  { apply isTrue; exact Refinement.noneAny}
-  { apply isTrue; exact Refinement.noneAny }
-  { apply isFalse; intro h; cases h }
-  { rename_i val val'
-    cases (DEQ val val')
-    { apply isFalse; intro h; cases h; contradiction }
-    { apply isTrue; apply Refinement.bothSome; assumption }
-  }
-
-end Refinement
 
 instance : Coe Bool (BitVec 1) := ⟨BitVec.ofBool⟩
 
 def coeWidth {m n : Nat} : BitVec m → BitVec n
   | x => BitVec.ofNat n x.toNat
 
--- not sure what the right `Coe`is for this case
--- See: https://leanprover-community.github.io/mathlib4_docs/Init/Coe.html#Important-typeclasses
---instance {m n: Nat} : CoeTail (BitVec m) (BitVec n) := ⟨BitVec.coeWidth⟩
 
 instance decPropToBitvec1 (p : Prop) [Decidable p] : CoeDep Prop p (BitVec 1) where
   coe := BitVec.ofBool $ decide p

--- a/SSA/Projects/InstCombine/ForStd.lean
+++ b/SSA/Projects/InstCombine/ForStd.lean
@@ -5,15 +5,15 @@ Released under Apache 2.0 license as described in the file LICENSE.
 namespace BitVec
 
 
-notation:50 x " ≥ᵤ " y => BitVec.ule y x
-notation:50 x " >ᵤ " y => BitVec.ult y x
-notation:50 x " ≤ᵤ " y => BitVec.ule x y
-notation:50 x " <ᵤ " y => BitVec.ult x y
+-- notation:50 x " ≥ᵤ " y => BitVec.ule y x
+-- notation:50 x " >ᵤ " y => BitVec.ult y x
+-- notation:50 x " ≤ᵤ " y => BitVec.ule x y
+-- notation:50 x " <ᵤ " y => BitVec.ult x y
 
-notation:50 x " ≥ₛ " y => BitVec.sle y x
-notation:50 x " >ₛ " y => BitVec.slt y x
-notation:50 x " ≤ₛ " y => BitVec.sle x y
-notation:50 x " <ₛ " y => BitVec.slt x y
+-- notation:50 x " ≥ₛ " y => BitVec.sle y x
+-- notation:50 x " >ₛ " y => BitVec.slt y x
+-- notation:50 x " ≤ₛ " y => BitVec.sle x y
+-- notation:50 x " <ₛ " y => BitVec.slt x y
 
 instance {n} : ShiftLeft (BitVec n) := ⟨fun x y => x <<< y.toNat⟩
 

--- a/SSA/Projects/InstCombine/LLVM/Semantics.lean
+++ b/SSA/Projects/InstCombine/LLVM/Semantics.lean
@@ -492,14 +492,14 @@ def icmp' {w : Nat} (c : IntPred) (x y : BitVec w) : Bool :=
   match c with
     | .eq => (x == y)
     | .ne => (x != y)
-    | .sgt => (x >ₛ y)
-    | .sge => (x ≥ₛ y)
-    | .slt => (x <ₛ y)
-    | .sle => (x ≤ₛ y)
-    | .ugt => (x >ᵤ y)
-    | .uge => (x ≥ᵤ y)
-    | .ult => (x <ᵤ y)
-    | .ule => (x ≤ᵤ y)
+    | .sgt => (y.slt x)
+    | .sge => (y.sle x)
+    | .slt => (x.slt y)
+    | .sle => (x.slt y)
+    | .ugt => (y.ult x)
+    | .uge => (y.ule x)
+    | .ult => (x.ult y)
+    | .ule => (x.ult y)
 
 
 /--
@@ -528,15 +528,15 @@ def icmp? {w : Nat} (c : IntPred) (x y : BitVec w) : IntW 1 :=
 
 @[simp]
 theorem icmp?_ult_eq {w : Nat} {a b : BitVec w} :
-  icmp? .ult a b = .value (BitVec.ofBool (a <ᵤ b)) := rfl
+  icmp? .ult a b = .value (BitVec.ofBool (a.ult b)) := rfl
 
 @[simp]
 theorem icmp?_slt_eq {w : Nat} {a b : BitVec w} :
-  icmp? .slt a b = .value (BitVec.ofBool (a <ₛ b)) := rfl
+  icmp? .slt a b = .value (BitVec.ofBool (a.slt b)) := rfl
 
 @[simp]
 theorem icmp?_sgt_eq {w : Nat} {a b : BitVec w} :
-  icmp? .sgt a b = .value (BitVec.ofBool (a >ₛ b)) := rfl
+  icmp? .sgt a b = .value (BitVec.ofBool (b.slt a)) := rfl
 
 @[simp_llvm_option]
 def icmp {w : Nat} (c : IntPred) (x y : IntW w) : IntW 1 := do

--- a/SSA/Projects/InstCombine/LLVM/Semantics.lean
+++ b/SSA/Projects/InstCombine/LLVM/Semantics.lean
@@ -495,11 +495,11 @@ def icmp' {w : Nat} (c : IntPred) (x y : BitVec w) : Bool :=
     | .sgt => (y.slt x)
     | .sge => (y.sle x)
     | .slt => (x.slt y)
-    | .sle => (x.slt y)
+    | .sle => (x.sle y)
     | .ugt => (y.ult x)
     | .uge => (y.ule x)
     | .ult => (x.ult y)
-    | .ule => (x.ult y)
+    | .ule => (x.ule y)
 
 
 /--


### PR DESCRIPTION
This PR removes the custom notation we had for signed & unsigned comparisons of bitvectors.

We still need to regenerate the extracted goals