### PR TITLE
feat: Blase/ult: This adds ULT support for the multi-width decision procedure

### DIFF
--- a/Blase/Blase/Fast/BitStream.lean
+++ b/Blase/Blase/Fast/BitStream.lean
@@ -706,6 +706,25 @@ def addAux (x y : BitStream) (i : Nat) :  Bool × Bool :=
     | i + 1 => (addAux x y i).2
   Prod.swap (BitVec.adcb (x i) (y i) carryIn)
 
+def addAux' (carryIn : Bool) (x y : BitStream) (i : Nat) :  Bool × Bool :=
+  let carryIn : Bool := match i with
+    | 0 => carryIn
+    | i + 1 => (addAux' carryIn x y i).2
+  Prod.swap (BitVec.adcb (x i) (y i) carryIn)
+
+@[simp] theorem addAux'_zero (carryIn : Bool)
+  (x y : BitStream) : (addAux' carryIn x y 0) =
+  ((x 0) ^^ (y 0) ^^ carryIn, Bool.atLeastTwo (x 0)  (y 0) carryIn) := by
+  simp [addAux', BitVec.adcb, Prod.swap]
+
+@[simp] theorem addAux'_succ (x y : BitStream) : (addAux' carryIn x y (i+1)) =
+    let out := (addAux' carryIn x y i)
+    let a := x (i + 1)
+    let b := y (i + 1)
+    let carryOut := out.2
+    (a ^^ b ^^ carryOut, Bool.atLeastTwo a  b carryOut) := by
+  simp [addAux', BitVec.adcb, Prod.swap]
+
 @[simp] theorem addAux_zero (x y : BitStream) : (x.addAux y 0) =
   ((x 0) ^^ (y 0), (x 0) && (y 0)) := by
   simp [addAux, addAux,BitVec.adcb]
@@ -720,6 +739,10 @@ def addAux (x y : BitStream) (i : Nat) :  Bool × Bool :=
 
 def add (x y : BitStream) : BitStream :=
   fun n => (addAux x y n).1
+
+/-- The stream of carry bits from the addition -/
+def carry (initCarry : Bool) (x y : BitStream) : BitStream :=
+  fun n => (addAux' initCarry x y n).2
 
 def subAux (x y : BitStream) : Nat → Bool × Bool
   | 0 => (xor (x 0) (y 0), !(x 0) && y 0)

--- a/Blase/Blase/Fast/BitStream.lean
+++ b/Blase/Blase/Fast/BitStream.lean
@@ -756,20 +756,24 @@ def carry (initCarry : Bool) (x y : BitStream) : BitStream :=
   Bool.atLeastTwo a b out := rfl
 
 /-- Shows how to write a `BitStream.carry` as a `BitVec.carry`  -/
-private theorem carry_eq_carry (x y : BitStream) (c : Bool) (hw : n < w):
-    carry c x y n = (BitVec.carry (n + 1) (x.toBitVec w) (y.toBitVec w) c)  := by
+protected theorem carry_eq_carry (x y : BitStream) (c : Bool)
+    (x' y' : BitVec w)
+    (hx : ∀ i, (hi : i < w) → x'[i] = x i)
+    (hy : ∀ i, (hi : i < w) → y'[i] = y i)
+    (hw : n < w):
+    carry c x y n = (BitVec.carry (n + 1) x' y' c) := by
   induction n
   case zero =>
     rw [carry]
     rw [BitVec.carry_succ]
     simp [show 0 < w by omega]
+    simp [hx, hy]
   case succ n ihn =>
     rw [carry_succ]
     rw [BitVec.carry_succ]
-    simp only [show n + 1 < w by omega, BitVec.getLsbD_eq_getElem, getElem_toBitVec, decide_true,
-      Bool.true_and]
-    rw [ihn]
-    · omega
+    simp only [show n + 1 < w by omega, BitVec.getLsbD_eq_getElem]
+    simp [hx, hy]
+    rw [ihn (by omega)]
 
 def subAux (x y : BitStream) : Nat → Bool × Bool
   | 0 => (xor (x 0) (y 0), !(x 0) && y 0)

--- a/Blase/Blase/Fast/BitStream.lean
+++ b/Blase/Blase/Fast/BitStream.lean
@@ -755,6 +755,21 @@ def carry (initCarry : Bool) (x y : BitStream) : BitStream :=
   let b := y (i + 1)
   Bool.atLeastTwo a b out := rfl
 
+/-- Shows how to write a `BitStream.carry` as a `BitVec.carry`  -/
+private theorem carry_eq_carry (x y : BitStream) (c : Bool) (hw : n < w):
+    carry c x y n = (BitVec.carry (n + 1) (x.toBitVec w) (y.toBitVec w) c)  := by
+  induction n
+  case zero =>
+    rw [carry]
+    rw [BitVec.carry_succ]
+    simp [show 0 < w by omega]
+  case succ n ihn =>
+    rw [carry_succ]
+    rw [BitVec.carry_succ]
+    simp only [show n + 1 < w by omega, BitVec.getLsbD_eq_getElem, getElem_toBitVec, decide_true,
+      Bool.true_and]
+    rw [ihn]
+    · omega
 
 def subAux (x y : BitStream) : Nat → Bool × Bool
   | 0 => (xor (x 0) (y 0), !(x 0) && y 0)

--- a/Blase/Blase/Fast/BitStream.lean
+++ b/Blase/Blase/Fast/BitStream.lean
@@ -67,12 +67,16 @@ section Basic
 def head (x : BitStream) : Bool      := x 0
 def tail (x : BitStream) : BitStream := (x <| · + 1)
 
+@[simp]
+theorem tail_eq (x : BitStream) (i : Nat) : x.tail i = x (i + 1) := rfl
+
 /-- Append a single bit to the least significant end of a bitvector.
 That is, the new bit is the least significant bit.
 -/
 def concat (b : Bool) (x : BitStream) : BitStream
   | 0   => b
   | i+1 => x i
+
 
 @[simp]
 theorem concat_zero (b : Bool) (x : BitStream) : concat b x 0 = b := rfl

--- a/Blase/Blase/Fast/BitStream.lean
+++ b/Blase/Blase/Fast/BitStream.lean
@@ -253,11 +253,11 @@ theorem ofBitVecZextMsb_eq_ofBitVecZext_mul_two_zeroExtend (x : BitVec w)
 
 /-- Make a bitstream of a unary natural number. -/
 abbrev ofNatUnary (n : Nat) : BitStream :=
-  fun i => decide (i ≤ n)
+  fun i => decide (i < n)
 
 @[simp]
 theorem eval_ofNatUnary (n : Nat) (i : Nat) :
-    ofNatUnary n i = decide (i ≤ n) := rfl
+    ofNatUnary n i = decide (i < n) := rfl
 
 /-- `x.toBitVec w` returns the first `w` bits of bitstream `x` -/
 def toBitVec (w : Nat) (x : BitStream) : BitVec w :=
@@ -802,8 +802,8 @@ def carry' (initCarry : Bool) (x y : BitStream) : BitStream :=
 /-- Shows how to write a `BitStream.carry` as a `BitVec.carry`  -/
 protected theorem carry'_eq_carry (x y : BitStream) (c : Bool)
     (x' y' : BitVec w)
-    (hx : ∀ i, x'.getLsbD i = x i)
-    (hy : ∀ i,  y'.getLsbD i = y i) :
+    (hx : ∀ i, i < n → x'.getLsbD i = x i)
+    (hy : ∀ i,  i < n → y'.getLsbD i = y i) :
     carry' c x y n = (BitVec.carry n x' y' c) := by
   induction n
   case zero =>
@@ -812,8 +812,36 @@ protected theorem carry'_eq_carry (x y : BitStream) (c : Bool)
   case succ n ihn =>
     rw [carry'_succ]
     rw [BitVec.carry_succ]
-    rw [hx, hy]
+    simp only
     rw [ihn]
+    · rw [hx]
+      · rw [hy]
+        · omega
+      · omega
+    · intros i hi
+      apply hx
+      omega
+    · intros i hi
+      apply hy
+      omega
+
+-- /-- Shows how to write a `BitStream.carry` as a `BitVec.carry`  -/
+-- protected theorem carry'_eq_carry (x y : BitStream) (c : Bool)
+--     (x' y' : BitVec w)
+--     (hx : ∀ i, x'.getLsbD i = x (i + 1))
+--     (hy : ∀ i,  y'.getLsbD i = y (i + 1)) :
+--     carry' c x y n = (BitVec.carry n  x' y' c) := by
+--   induction n
+--   case zero =>
+--     rw [carry]
+--     simp
+--     rw [BitVec.carry_succ]
+--     simp [hx, hy]
+--   case succ n ihn =>
+--     rw [carry_succ]
+--     rw [BitVec.carry_succ]
+--     rw [hx, hy]
+--     rw [ihn]
 
 
 def subAux (x y : BitStream) : Nat → Bool × Bool

--- a/Blase/Blase/Fast/BitStream.lean
+++ b/Blase/Blase/Fast/BitStream.lean
@@ -744,6 +744,18 @@ def add (x y : BitStream) : BitStream :=
 def carry (initCarry : Bool) (x y : BitStream) : BitStream :=
   fun n => (addAux' initCarry x y n).2
 
+@[simp] theorem carry_zero
+    (initCarry : Bool) (x y : BitStream) :
+  (carry initCarry x y 0) = (Bool.atLeastTwo (x 0) (y 0) initCarry) := rfl
+
+@[simp] theorem carry_succ (initCarry : Bool) (x y : BitStream) :
+    (carry initCarry x y (i + 1)) =
+  let out := carry initCarry x y i
+  let a := x (i + 1)
+  let b := y (i + 1)
+  Bool.atLeastTwo a b out := rfl
+
+
 def subAux (x y : BitStream) : Nat → Bool × Bool
   | 0 => (xor (x 0) (y 0), !(x 0) && y 0)
   | n+1 =>

--- a/Blase/Blase/Fast/FiniteStateMachine.lean
+++ b/Blase/Blase/Fast/FiniteStateMachine.lean
@@ -1184,7 +1184,7 @@ def latchImmediate (initVal : Bool) : FSM Bool where
     let state := Circuit.var true (inl ())
     Circuit.ite control xval state
 
-@[simp]
+@[simp low]
 theorem eval_latchImmediate_zero_eq (initVal : Bool)
     (x : Bool → BitStream) :
     (latchImmediate initVal).eval x 0 = if (x true 0) then (x false 0) else initVal := by

--- a/Blase/Blase/Fast/FiniteStateMachine.lean
+++ b/Blase/Blase/Fast/FiniteStateMachine.lean
@@ -1168,7 +1168,9 @@ def repeatBit : FSM Unit where
   nextStateCirc := fun () => (.var true <| .inl ()) ||| (.var true <| .inr ())
 
 /--
-(xval:false, control:true) produce the latch value immediately when 'control = true'.
+(xval:false, control:true)
+update the latch value when 'control = true'.
+output happens *after* update
 -/
 def latchImmediate (initVal : Bool) : FSM Bool where
   α := Unit
@@ -1187,7 +1189,8 @@ def latchImmediate (initVal : Bool) : FSM Bool where
 @[simp low]
 theorem eval_latchImmediate_zero_eq (initVal : Bool)
     (x : Bool → BitStream) :
-    (latchImmediate initVal).eval x 0 = if (x true 0) then (x false 0) else initVal := by
+    (latchImmediate initVal).eval x 0 =
+      if (x true 0) then (x false 0) else initVal := by
   simp [latchImmediate, eval, nextBit]
 
 @[simp]
@@ -1201,7 +1204,8 @@ theorem eval_latchImmediate_succ_eq (initVal : Bool) (i : Nat)
 /--
 (false | true)
 (xval  |  control)
-produce the latch value from the previous iteration when 'control = true'.
+update the latch value  when 'control = true'.
+output happens *before* update.
 -/
 def latchDelayed (initVal : Bool) : FSM Bool where
   α := Unit

--- a/Blase/Blase/Fast/FiniteStateMachine.lean
+++ b/Blase/Blase/Fast/FiniteStateMachine.lean
@@ -158,6 +158,8 @@ def eval' (x : arity → BitStream) : BitStream :=
     ((x_tail, next.fst), next.snd)
   ) (x, p.initCarry)
 
+
+
 /-- `p.changeInitCarry c` yields an FSM with `c` as the initial state -/
 def changeInitCarry (p : FSM arity) (c : p.α → Bool) : FSM arity :=
   { p with initCarry := c }

--- a/Blase/Blase/MultiWidth/Defs.lean
+++ b/Blase/Blase/MultiWidth/Defs.lean
@@ -209,6 +209,7 @@ inductive Predicate
     (a : Term ctx w) (b : Term ctx w) : Predicate ctx
 | and (p1 p2 : Predicate ctx) : Predicate ctx
 | or (p1 p2 : Predicate ctx) : Predicate ctx
+| not (p : Predicate ctx) : Predicate ctx
 -- add predicate NOT, <= for bitvectors, < for bitvectors, <=
 -- for widths, =, not equals for widths.
 
@@ -227,6 +228,7 @@ def Predicate.toProp {wcard tcard : Nat} {wenv : WidthExpr.Env wcard}
   | .binRel .ult _w a b => (a.toBV tenv) < (b.toBV) tenv
   | .and p1 p2 => p1.toProp tenv ∧ p2.toProp tenv
   | .or p1 p2 => p1.toProp tenv ∨ p2.toProp tenv
+  | .not p => ¬ (p.toProp tenv)
 
 -- TODO: is this even needed?
 -- Can't I directly show that the FSM corresponds to the BV?
@@ -373,6 +375,7 @@ inductive Predicate
     (a : Term) (b : Term) : Predicate
 | or (p1 p2 : Predicate) : Predicate
 | and (p1 p2 : Predicate) : Predicate
+| not (p : Predicate) : Predicate
 deriving DecidableEq, Inhabited, Repr, Lean.ToExpr
 
 def Predicate.wcard (p : Predicate) : Nat :=
@@ -381,6 +384,7 @@ def Predicate.wcard (p : Predicate) : Nat :=
   | .binRel .ult _w a _b => a.wcard
   | .or p1 p2 => max (Predicate.wcard p1) (Predicate.wcard p2)
   | .and p1 p2 => max (Predicate.wcard p1) (Predicate.wcard p2)
+  | .not p => Predicate.wcard p
 
 def Predicate.tcard (p : Predicate) : Nat :=
   match p with
@@ -388,6 +392,7 @@ def Predicate.tcard (p : Predicate) : Nat :=
   | .binRel .ult _w a b => max a.tcard b.tcard
   | .or p1 p2 => max (Predicate.tcard p1) (Predicate.tcard p2)
   | .and p1 p2 => max (Predicate.tcard p1) (Predicate.tcard p2)
+  | .not p => Predicate.tcard p
 
 def Predicate.ofDep {wcard tcard : Nat}
     {tctx : Term.Ctx wcard tcard} (p : MultiWidth.Predicate tctx) : Predicate :=
@@ -396,6 +401,7 @@ def Predicate.ofDep {wcard tcard : Nat}
   | .binRel .ult w a b => .binRel .ult (.ofDep w) (.ofDep a) (.ofDep b)
   | .or p1 p2 => .or (.ofDep p1) (.ofDep p2)
   | .and p1 p2 => .and (.ofDep p1) (.ofDep p2)
+  | .not p => .not (.ofDep p)
 
 end Nondep
 
@@ -480,10 +486,12 @@ structure HPredFSMToBitStream
   {tctx : Term.Ctx wcard tcard}
   {p : Predicate tctx} (fsm : PredicateFSM wcard tcard (.ofDep p)) : Prop where
   heq :
-    ∀ {wenv : WidthExpr.Env wcard} (tenv : tctx.Env wenv)
-      (fsmEnv : StateSpace wcard tcard → BitStream),
-      (henv : HTermEnv fsmEnv tenv) →
-        p.toProp tenv ↔ (fsm.toFsm.eval fsmEnv = .negOne)
+    (∀ {wenv : WidthExpr.Env wcard} (tenv : tctx.Env wenv), p.toProp tenv) ↔
+    (∀  {wenv : WidthExpr.Env wcard}
+        (tenv : tctx.Env wenv)
+        (fsmEnv : StateSpace wcard tcard → BitStream),
+          (henv : HTermEnv fsmEnv tenv) →
+          fsm.toFsm.eval fsmEnv = .negOne)
 
 end ToFSM
 end MultiWidth

--- a/Blase/Blase/MultiWidth/Defs.lean
+++ b/Blase/Blase/MultiWidth/Defs.lean
@@ -429,7 +429,7 @@ structure HTermEnv {wcard tcard : Nat}
   (fsmEnv : StateSpace wcard tcard → BitStream) (tenv : tctx.Env wenv) : Prop
   extends HWidthEnv fsmEnv wenv where
     heq_term : ∀ (v : Fin tcard),
-      fsmEnv (StateSpace.termVar v) = BitStream.ofBitVecZextMsb (tenv v)
+      fsmEnv (StateSpace.termVar v) = BitStream.ofBitVecZext (tenv v)
 
 /-- make a 'HTermEnv' of 'ofTenv'. -/
 def HTermEnv.mkFsmEnvOfTenv {wcard tcard : Nat}
@@ -439,7 +439,7 @@ def HTermEnv.mkFsmEnvOfTenv {wcard tcard : Nat}
     | .widthVar v =>
         BitStream.ofNatUnary (wenv v)
     | .termVar v =>
-      BitStream.ofBitVecZextMsb (tenv v)
+      BitStream.ofBitVecZext (tenv v)
 
 @[simp]
 theorem HTermEnv.of_mkFsmEnvOfTenv {wcard tcard : Nat}
@@ -474,7 +474,7 @@ structure HTermFSMToBitStream {w : WidthExpr wcard}
       (fsmEnv : StateSpace wcard tcard → BitStream),
       (henv : HTermEnv fsmEnv tenv) →
         fsm.toFsm.eval fsmEnv =
-        BitStream.ofBitVecZextMsb (t.toBV tenv)
+        BitStream.ofBitVecZext (t.toBV tenv)
 
 structure HPredFSMToBitStream
   {tctx : Term.Ctx wcard tcard}

--- a/Blase/Blase/MultiWidth/Defs.lean
+++ b/Blase/Blase/MultiWidth/Defs.lean
@@ -369,7 +369,7 @@ def Term.tcard (t : Term) : Nat :=
   | .bnot _w a => (Term.tcard a)
 
 inductive Predicate
-| binRel (k : BinaryRelationKind)
+| binRel (k : BinaryRelationKind) (w : WidthExpr)
     (a : Term) (b : Term) : Predicate
 | or (p1 p2 : Predicate) : Predicate
 | and (p1 p2 : Predicate) : Predicate
@@ -377,23 +377,23 @@ deriving DecidableEq, Inhabited, Repr, Lean.ToExpr
 
 def Predicate.wcard (p : Predicate) : Nat :=
   match p with
-  | .binRel .eq a _b => a.wcard
-  | .binRel .ult a _b => a.wcard
+  | .binRel .eq w _a _b => w.wcard
+  | .binRel .ult _w a _b => a.wcard
   | .or p1 p2 => max (Predicate.wcard p1) (Predicate.wcard p2)
   | .and p1 p2 => max (Predicate.wcard p1) (Predicate.wcard p2)
 
 def Predicate.tcard (p : Predicate) : Nat :=
   match p with
-  | .binRel .eq a b => max a.tcard b.tcard
-  | .binRel .ult a b => max a.tcard b.tcard
+  | .binRel .eq _w a b => max a.tcard b.tcard
+  | .binRel .ult _w a b => max a.tcard b.tcard
   | .or p1 p2 => max (Predicate.tcard p1) (Predicate.tcard p2)
   | .and p1 p2 => max (Predicate.tcard p1) (Predicate.tcard p2)
 
 def Predicate.ofDep {wcard tcard : Nat}
     {tctx : Term.Ctx wcard tcard} (p : MultiWidth.Predicate tctx) : Predicate :=
   match p with
-  | .binRel .eq _w a b => .binRel .eq (.ofDep a) (.ofDep b)
-  | .binRel .ult _w a b => .binRel .ult (.ofDep a) (.ofDep b)
+  | .binRel .eq w a b => .binRel .eq (.ofDep w) (.ofDep a) (.ofDep b)
+  | .binRel .ult w a b => .binRel .ult (.ofDep w) (.ofDep a) (.ofDep b)
   | .or p1 p2 => .or (.ofDep p1) (.ofDep p2)
   | .and p1 p2 => .and (.ofDep p1) (.ofDep p2)
 

--- a/Blase/Blase/MultiWidth/GoodFSM.lean
+++ b/Blase/Blase/MultiWidth/GoodFSM.lean
@@ -918,11 +918,6 @@ TODO: rewrite with 'induction' to be a clean proof script.
     simp only [carry_fsmCarry]
     simp
 
-/-- Shows how to write 'BitVec.carry' as an add carry circuit. -/
-private theorem carry_eq_adc (x y : BitVec w) (c : Bool) :
-    BitVec.carry w x y c = (BitVec.adc x y c).1 := by
-  rw [BitVec.adc_spec]
-
 
 /--
 The 'carry' FSM evaluates to the value of the carry bit.
@@ -947,10 +942,13 @@ theorem eval_fsmCary_eq {wcard tcard : Nat}
     (composeBinaryAux' (fsmCarry initCarryVal)
       afsm.toFsm
       bfsm.toFsm).eval fsmEnv i =
-    BitVec.carry i (a.toBV tenv) (b.toBV tenv) initCarryVal := by
-  sorry
-
-
+    BitVec.carry (i + 1) (a.toBV tenv) (b.toBV tenv) initCarryVal := by
+  simp
+  rw [BitStream.carry_eq_carry (x' := Term.toBV tenv a) (y' := Term.toBV tenv b)]
+  · simp [hafsm.heq (henv := henv)]
+    sorry
+  · simp [hbfsm.heq (henv := henv)]
+    sorry
 
 #check BitVec.ult_eq_not_carry
 #check BitVec.carry

--- a/Blase/Blase/MultiWidth/GoodFSM.lean
+++ b/Blase/Blase/MultiWidth/GoodFSM.lean
@@ -232,7 +232,7 @@ theorem eval_fsmUnaryMin_eq_decide
   ((fsmUnaryMin a.toFsm b.toFsm).eval fsmEnv) i =
     (i < (min (v.toNat wenv) (w.toNat wenv))) := by
   simp only [fsmUnaryMin, composeBinaryAux'_eval, _root_.FSM.eval_and, cond_true, cond_false,
-    BitStream.and_eq, Bool.and_eq_true, le_inf_iff, eq_iff_iff]
+    BitStream.and_eq, Bool.and_eq_true, eq_iff_iff]
   rw [ha.heq (henv := henv)]
   rw [hb.heq (henv := henv)]
   simp

--- a/Blase/Blase/MultiWidth/GoodFSM.lean
+++ b/Blase/Blase/MultiWidth/GoodFSM.lean
@@ -950,7 +950,6 @@ theorem eval_fsmCary_eq {wcard tcard : Nat}
     BitVec.carry i (a.toBV tenv) (b.toBV tenv) initCarryVal := by
   sorry
 
-    sorry
 
 
 #check BitVec.ult_eq_not_carry

--- a/Blase/Blase/MultiWidth/GoodFSM.lean
+++ b/Blase/Blase/MultiWidth/GoodFSM.lean
@@ -1203,10 +1203,8 @@ def fsmTermUlt {wcard tcard : Nat}
   (afsm : TermFSM wcard tcard a)
   (bfsm : TermFSM wcard tcard b)
   : FSM (StateSpace wcard tcard) :=
-    let streamFsm :=
-      composeUnaryAux (FSM.ls true) (fsmCarry' true)
+    let streamFsm := composeUnaryAux (FSM.ls true) (fsmCarry'' true)
     (~~~ (composeBinaryAux' streamFsm  afsm.toFsm (~~~ bfsm.toFsm)))
-
 
 /--
 info: BitVec.ult_eq_not_carry {w : ℕ} (x y : BitVec w) :
@@ -1241,13 +1239,23 @@ theorem eval_fsmTermUlt_eq_carry {wcard tcard : Nat}
     rcases i with rfl | i
     · simp
     · simp
-      rw [BitStream.carry_eq_carry]
-      · have := hafsm.heq (henv := henv)
-        rw [this]
+      rw [BitStream.carry'_eq_carry
+        (x' := BitVec.shiftLeftZeroExtend (Term.toBV tenv a) 1)
+        (y' := ~~~ (BitVec.shiftLeftZeroExtend ((Term.toBV tenv b)) 1))]
+      sorry
+      · intros i
+        rw [hafsm.heq (henv := henv)]
         simp
-        sorry
-      · sorry
-
+        rcases i with rfl | i
+        · simp
+        · simp
+      · intros i
+        rw [hbfsm.heq (henv := henv)]
+        simp
+        rcases i with rfl | i
+        · simp
+        · simp
+          sorry
 
 -- fSM that returns 1 ifthe predicate is true, and 0 otherwise -/
 def mkPredicateFSMAux (wcard tcard : Nat) (p : Nondep.Predicate) :

--- a/Blase/Blase/MultiWidth/GoodFSM.lean
+++ b/Blase/Blase/MultiWidth/GoodFSM.lean
@@ -1358,6 +1358,15 @@ def isGoodPredicateFSM_mkPredicateFSMAux {wcard tcard : Nat}
       -- rw [hb.heq (henv := henv)]
       simp [Predicate.toProp]
       constructor
+      -- I understand the problem:
+      -- I need to build an automata that checks that you are ult
+      -- at *that particular width*.
+      -- so the way to do this is to create a latch,
+      -- that allows the 'ult' circuit to propagate until
+      -- we hit that index, and from that index onwards,
+      -- we 'hold' our value.
+      -- This way, if 'a < b', then we print 111...(until w)<isLt><isLt><isLt>...
+      -- jesus this stuff is crazy crazy annoying.
       · intros h
         simp at h
         ext N

--- a/Blase/Blase/MultiWidth/GoodFSM.lean
+++ b/Blase/Blase/MultiWidth/GoodFSM.lean
@@ -877,11 +877,7 @@ theorem initCarry_fsmCarry : (fsmCarry initCarry).initCarry = fun _ => initCarry
 @[simp]
 theorem snd_nextBit_fsmCarry {state : Unit → Bool} {env : Bool → Bool} :
     ((fsmCarry initCarry).nextBit state env).2 =
-    (env true && env false ||
-      env true && state () ||
-      env false && state ())
-    := by
-  simp [fsmCarry, FSM.nextBit]
+      Bool.atLeastTwo (env true) (env false) (state ()) := rfl
 
 @[simp]
 theorem fst_nextBit_fsmCarry_eq_atLeastTwo {state : Unit → Bool} {env : Bool → Bool} :
@@ -906,9 +902,8 @@ TODO: rewrite with 'induction' to be a clean proof script.
     simp [fsmCarry, FSM.carry, FSM.nextBit, BitStream.carry, BitStream.addAux'
       , BitVec.adcb]
   case succ n ih =>
-    rw [carry, ih]
-    simp [nextBit, borrow]
-
+    rw [FSM.carry, ih]
+    simp [FSM.nextBit, fsmCarry]
 
 @[simp] lemma eval_fsmCarry (x : Bool → BitStream) :
     (fsmCarry initCarry).eval x =
@@ -919,11 +914,9 @@ TODO: rewrite with 'induction' to be a clean proof script.
     simp [fsmCarry, BitStream.carry,
       BitStream.addAux', FSM.eval, FSM.nextBit, BitVec.adcb]
   case succ i ih =>
-    rw [eval]
-    simp only [carry_borrow, BitStream.borrow_succ]
-    rw [← ih]
-    simp [nextBit, eval, borrow]
-
+    rw [FSM.eval]
+    simp only [carry_fsmCarry]
+    simp
 
 /-- Shows how to write 'BitVec.carry' as an add carry circuit. -/
 private theorem carry_eq_adc (x y : BitVec w) (c : Bool) :

--- a/Blase/Blase/MultiWidth/GoodFSM.lean
+++ b/Blase/Blase/MultiWidth/GoodFSM.lean
@@ -924,10 +924,6 @@ theorem fst_nextBit_fsmCarry_eq_atLeastTwo {state : Bool → Bool} {env : Bool �
   rcases bit with rfl | rfl
   · simp
   · simp
-    -- by_cases hs : state false
-    -- · simp [hs]
-    --   by_cases hw : width0Val <;> simp [hw]
-    -- · simp [hs]
 
 /--
 The carry state of the borrow bit.
@@ -984,9 +980,15 @@ TODO: rewrite with 'induction' to be a clean proof script.
       simp only [carry_fsmCarry]
       simp
 
--- /-- an FSM for carry, that takes in the init carry after one step. -/
--- def fsmCarryDelayed (initialCarryVal : Bool) : FSM Bool :=
---   composeUnaryAux (FSM.ls false) (fsmCarry initialCarryVal)
+/-- build an FSM that is the 'unconcatenation' of the FSM, which we
+get by evaluating the initial state. -/
+def unConcat (f : FSM arity) : FSM arity where
+  α := f.α
+  initCarry := fun s =>
+    (f.nextStateCirc s).eval
+     (Sum.elim (fun t => (f.initCarry t)) (fun _ => false))
+  nextStateCirc := f.nextStateCirc
+  outputCirc := f.outputCirc
 
 /--
 The 'carry' FSM evaluates to the value of the carry bit.
@@ -1034,12 +1036,82 @@ theorem eval_fsmCarry_eq {wcard tcard : Nat}
       rw [hbfsm.heq (henv := henv)]
       simp
 
+
+def fsmCarry' (initialCarryVal : Bool): FSM Bool :=
+  let outputCirc :=
+    let carry := Circuit.var true (Sum.inl ())
+    let a := Circuit.var true (Sum.inr true)
+    let b := Circuit.var true (Sum.inr false)
+    -- if we are zero, then the output is 'false'.
+    ((a &&& b) ||| (a &&& carry) ||| (b &&& carry))
+  { α := Unit,
+    -- bit at 'false' tells us if we are at the zero state.
+    -- bit at 'true' tells us the carry value.
+    initCarry := fun () => initialCarryVal, -- our carry is the init carry.
+    outputCirc := outputCirc,
+    nextStateCirc := fun () => outputCirc
+  }
+
+
+@[simp]
+theorem initCarry_fsmCarry' : (fsmCarry' initCarry).initCarry =
+    fun _ => initCarry := by
+  simp [fsmCarry']
+
+@[simp]
+theorem snd_nextBit_fsmCarry' {state : Unit → Bool} {env : Bool → Bool} :
+    ((fsmCarry' initCarry).nextBit state env).2 =
+      Bool.atLeastTwo (env true) (env false) (state ()) := by
+  simp [fsmCarry', FSM.nextBit, Lean.Elab.WF.paramLet, FSM.nextBit]
+
+@[simp]
+theorem fst_nextBit_fsmCarry'_eq_atLeastTwo {state : Unit → Bool} {env : Bool → Bool} :
+    ((fsmCarry' initCarry).nextBit state env).1 =
+      fun () => Bool.atLeastTwo (env true) (env false) (state ()) := by
+  simp [fsmCarry', Lean.Elab.WF.paramLet, FSM.nextBit]
+/--
+The carry state of the borrow bit.
+TODO: rewrite with 'induction' to be a clean proof script.
+-/
+@[simp] theorem carry_fsmCarry' (initCarry : Bool)
+    (x : Bool → BitStream) : ∀ (n : ℕ),
+    FSM.carry (fsmCarry' initCarry) x (n + 1) =
+      fun () =>
+        BitStream.carry initCarry ((x true)) ((x false)) n := by
+  intros n
+  induction n
+  case zero =>
+    ext stateIx
+    simp [fsmCarry', FSM.carry, FSM.nextBit]
+      -- by_cases hw : width0Val <;> simp [hw]
+  case succ n ih =>
+    ext stateIx
+    rw [FSM.carry]
+    simp only [ih]
+    clear ih
+    simp [FSM.nextBit, fsmCarry']
+
+@[simp] lemma eval_fsmCarry' (x : Bool → BitStream) :
+    (fsmCarry' initCarry).eval x =
+      (BitStream.carry initCarry (x true) (x false)) := by
+  ext i
+  rcases i with rfl | i
+  · simp [fsmCarry', FSM.eval, FSM.nextBit]
+  · induction i
+    case zero =>
+      simp [FSM.eval]
+    case succ i ih =>
+      rw [FSM.eval]
+      simp only [carry_fsmCarry']
+      simp
+
 def fsmTermUlt {wcard tcard : Nat}
   {a b : Nondep.Term}
   (afsm : TermFSM wcard tcard a)
   (bfsm : TermFSM wcard tcard b)
   : FSM (StateSpace wcard tcard) :=
-    ~~~ (composeBinaryAux' (fsmCarry false true)  afsm.toFsm bfsm.toFsm)
+    ~~~ (composeBinaryAux' (fsmCarry' true) afsm.toFsm bfsm.toFsm)
+
 
 -- fSM that returns 1 ifthe predicate is true, and 0 otherwise -/
 def mkPredicateFSMAux (wcard tcard : Nat) (p : Nondep.Predicate) :
@@ -1053,23 +1125,29 @@ def mkPredicateFSMAux (wcard tcard : Nat) (p : Nondep.Predicate) :
     let fsmA := mkTermFSM wcard tcard a
     let fsmB := mkTermFSM wcard tcard b
     let fsmW := mkWidthFSM wcard tcard w
-    { toFsm := ~~~ fsmW.toFsm ||| fsmTermUlt fsmA fsmB }
+    { toFsm :=
+      composeUnaryAux FSM.scanAnd
+        ((~~~ fsmW.toFsm) ||| fsmTermUlt fsmA fsmB) }
   | .or p q  =>
     let fsmP :=  mkPredicateFSMAux wcard tcard p
     let fsmQ :=  mkPredicateFSMAux wcard tcard q
-    let fsmP := composeUnaryAux FSM.scanAnd fsmP.toFsm
-    let fsmQ := composeUnaryAux FSM.scanAnd fsmQ.toFsm
-    { toFsm := (fsmP ||| fsmQ) }
+    -- let fsmP := composeUnaryAux FSM.scanAnd fsmP.toFsm
+    -- let fsmQ := composeUnaryAux FSM.scanAnd fsmQ.toFsm
+    { toFsm := ~~~ composeUnaryAux FSM.scanAnd (~~~ fsmP.toFsm ||| ~~~ fsmQ.toFsm) }
   | .and p q =>
     let fsmP := mkPredicateFSMAux wcard tcard p
     let fsmQ := mkPredicateFSMAux wcard tcard q
     { toFsm := (fsmP.toFsm &&& fsmQ.toFsm) }
-
+  | .not p =>
+    let fsmP := mkPredicateFSMAux wcard tcard p
+    -- !p is true => p is false.
+    -- !p is true => FSM of p is not always allOnes.
+    -- !p is true => FSM of p is at some point '0'.
+    -- we need to convert this into 'FSM of !p is at some point '1''.
+    { toFsm := ~~~ fsmP.toFsm }
 
 theorem foo (f g : α → β) (h : f ≠ g) : ∃ x, f x ≠ g x := by
   exact Function.ne_iff.mp h
-
-
 
 def isGoodPredicateFSM_mkPredicateFSMAux {wcard tcard : Nat}
     {tctx : Term.Ctx wcard tcard}
@@ -1081,29 +1159,39 @@ def isGoodPredicateFSM_mkPredicateFSMAux {wcard tcard : Nat}
     case eq =>
       -- | TODO: extract proof.
       constructor
-      intros wenv tenv fsmEnv henv
+      -- intros tctx wenv tenv
+      -- intros wenv tenv fsmEnv henv
       simp [mkPredicateFSMAux, Nondep.Predicate.ofDep]
       -- fsmTermEqProof starts here.
       simp [fsmTermEq]
       have ha := IsGoodTermFSM_mkTermFSM wcard tcard a
       have hb := IsGoodTermFSM_mkTermFSM wcard tcard b
-      rw [ha.heq (henv := henv)]
-      rw [hb.heq (henv := henv)]
       simp [Predicate.toProp]
       constructor
       · intros h
         simp at h
+        intros wenv tenv fsmEnv henv
+        rw [ha.heq (henv := henv)]
+        rw [hb.heq (henv := henv)]
         ext N
         simp
         rw [h]
         rw [BitStream.scanAnd_eq_decide]
         simp
       · intros h
+        intros wenv tenv
+        have henv := HTermEnv.of_mkFsmEnvOfTenv tenv
+        specialize h tenv _ henv
         apply BitVec.eq_of_getLsbD_eq
         intros i hi
-        have := congrFun h (i + 1)
-        simp at this
-        simp [this]
+        obtain h := congrFun h (i + 1)
+        rw [BitStream.scanAnd_eq_decide] at h
+        simp at h
+        specialize h (i + 1) (by omega)
+        rw [ha.heq (henv := henv)] at h
+        rw [hb.heq (henv := henv)] at h
+        simp at h
+        exact h
     case ult =>
       constructor
       intros wenv tenv fsmEnv henv
@@ -1113,23 +1201,25 @@ def isGoodPredicateFSM_mkPredicateFSMAux {wcard tcard : Nat}
       have hb := IsGoodTermFSM_mkTermFSM wcard tcard b
       simp [fsmTermUlt]
       rw [hw.heq (henv := henv.toHWidthEnv)]
-      -- rw [ha.heq (henv := henv)]
-      -- rw [hb.heq (henv := henv)]
+      rw [ha.heq (henv := henv)]
+      rw [hb.heq (henv := henv)]
       simp [Predicate.toProp]
       constructor
       · intros h
         simp at h
         ext N
-        simp only [BitStream.or_eq, BitStream.not_eq, BitStream.eval_ofNatUnary,
-          BitStream.negOne_eq, Bool.or_eq_true, Bool.not_eq_eq_eq_not, Bool.not_true,
-          decide_eq_false_iff_not, not_le]
-        by_cases hw : w.toNat wenv < N
+        simp
+        rw [BitStream.scanAnd_true_iff]
+        simp
+        intros i hi
+        by_cases hw : w.toNat wenv < i
         · simp [hw]
         · simp [hw]
-          rcases N with rfl | N
-          · simp
-          · simp
-            sorry
+          simp at hw
+          rw [← BitVec.ult_iff_lt] at h
+          rw [BitVec.ult_eq_not_carry] at h
+          simp at h
+          rw [← h]
       · intros h
         simp at h
         rw [← BitVec.ult_iff_lt]
@@ -1147,18 +1237,43 @@ def isGoodPredicateFSM_mkPredicateFSMAux {wcard tcard : Nat}
         simp at this
         -- rw [BitStream.carry_eq_carry]
         sorry
-  case or p q hp hq =>
+  case not p hp =>
     constructor
-    intros wenv tenv fsmEnv henv
     simp [mkPredicateFSMAux, Nondep.Predicate.ofDep]
     simp [Predicate.toProp]
-    rw [hp.heq (henv := henv)]
-    rw [hq.heq (henv := henv)]
     constructor
     · intros h
+      intros wenv tenv fsmEnv htenv
       ext i
-      simp only [BitStream.or_eq, BitStream.negOne_eq, Bool.or_eq_true]
-      rcases h with h | h
+      have henv := HTermEnv.of_mkFsmEnvOfTenv tenv
+      obtain hp := hp.heq
+      obtain hp := Iff.not hp
+      simp at hp
+      simp [hp]
+    · sorry
+  case or p q hp hq =>
+    constructor
+    -- intros wenv tenv fsmEnv henv
+    simp [mkPredicateFSMAux, Nondep.Predicate.ofDep]
+    simp [Predicate.toProp]
+    -- rw [hp.heq (henv := henv)]
+    -- rw [hq.heq (henv := henv)]
+    constructor
+    · intros h
+      intros wenv tenv fsmEnv henv
+      ext i
+      -- simp only [BitStream.or_eq, BitStream.negOne_eq, Bool.or_eq_true]
+      -- specialize h tenv
+      have henv := HTermEnv.of_mkFsmEnvOfTenv tenv
+      simp [BitStream.scanAnd_eq_decide]
+      -- intros j hj
+      have henv := HTermEnv.of_mkFsmEnvOfTenv tenv
+      obtain hp := hp.heq
+      obtain hq := hq.heq
+      -- simp [hp.heq]
+      -- rw [hp.heq (henv := henv)]
+      -- rw [hq.heq (henv := henv)]
+      -- rcases h with h | h
       · left
         rw [BitStream.scanAnd_eq_decide]
         simp
@@ -1197,25 +1312,47 @@ def isGoodPredicateFSM_mkPredicateFSMAux {wcard tcard : Nat}
   case and p q hp hq =>
     constructor
     simp [mkPredicateFSMAux, Nondep.Predicate.ofDep]
-    intros wenv tenv fsmEnv htenv
     simp [Predicate.toProp]
-    rw [hp.heq (henv := htenv)]
-    rw [hq.heq (henv := htenv)]
     constructor
     · intros h
-      obtain ⟨hpfsm, hqfsm⟩ := h
-      simp [hpfsm, hqfsm]
-      ext i; simp
+      intros wenv tenv fsmEnv htenv
+      -- obtain ⟨hpfsm, hqfsm⟩ := h
+      rw [hp.heq.mp (henv := htenv)]
+      · rw [hq.heq.mp (henv := htenv)]
+        ext i; simp
+        · intros wenv tenv
+          specialize @h wenv tenv
+          simp [h]
+      · intros wenv tenv
+        specialize @h wenv tenv
+        simp [h]
     · intros h
+      intros wenv tenv
+      have htenv := HTermEnv.of_mkFsmEnvOfTenv tenv
+      obtain hp := hp.heq.mpr
+      obtain hp := hp (by
+        intros wenv' tenv' fsmEnv htenv'
+        specialize @h wenv' tenv' fsmEnv htenv'
+        ext i
+        simp
+        obtain h := congrFun h i
+        simp at h
+        simp [h]
+      )
+
+      obtain hq := hq.heq.mpr (tenv := tenv)
+      obtain hq := hq (by
+        intros wenv' tenv' fsmEnv htenv'
+        specialize @h wenv' tenv' fsmEnv htenv'
+        ext i
+        simp
+        obtain h := congrFun h i
+        simp at h
+        simp [h]
+      )
       constructor
-      · ext i
-        have := congrFun h i
-        simp at this
-        simp [this]
-      · ext i
-        have := congrFun h i
-        simp at this
-        simp [this]
+      · apply hp
+      · apply hq
 
 /-- Negate the FSM so we can decide if zeroes. -/
 def mkPredicateFSMNondep (wcard tcard : Nat) (p : Nondep.Predicate) :

--- a/Blase/Blase/MultiWidth/GoodFSM.lean
+++ b/Blase/Blase/MultiWidth/GoodFSM.lean
@@ -1117,9 +1117,11 @@ def isGoodPredicateFSM_mkPredicateFSMAux {wcard tcard : Nat}
       · intros h
         apply BitVec.eq_of_getLsbD_eq
         intros i hi
-        have := congrFun h (i + 1)
+        have := congrFun h i
+        rw [BitStream.scanAnd_eq_decide] at this
         simp at this
-        simp [this]
+        rw [this]
+        omega
     case ult =>
       constructor
       intros wenv tenv fsmEnv henv
@@ -1151,7 +1153,12 @@ def isGoodPredicateFSM_mkPredicateFSMAux {wcard tcard : Nat}
           (a := a)
           (b := b)
           (tenv := tenv)
+          (henv := henv)
         ]
+        by_cases hw : w.toNat wenv ≤ N
+        · simp [hw]
+        · simp [hw]
+      · sorry
   case or p q hp hq =>
     constructor
     intros wenv tenv fsmEnv henv

--- a/Blase/Blase/MultiWidth/Tactic.lean
+++ b/Blase/Blase/MultiWidth/Tactic.lean
@@ -428,15 +428,19 @@ partial def collectBVPredicateAux (state : CollectState) (e : Expr) :
   | Eq α a b =>
     match_expr α with
     | BitVec w =>
-      let (_w, state) ← collectWidthAtom state w
+      let (w, state) ← collectWidthAtom state w
       let (ta, state) ← collectTerm state a
       let (tb, state) ← collectTerm state b
-      return (.binRel .eq ta tb, state)
+      return (.binRel .eq w ta tb, state)
     | _ => throwError m!"expected bitvector equality, found: {indentD e}"
   | Or p q =>
     let (ta, state) ← collectBVPredicateAux state p
     let (tb, state) ← collectBVPredicateAux state q
     return (.or ta tb, state)
+  | And p q =>
+    let (ta, state) ← collectBVPredicateAux state p
+    let (tb, state) ← collectBVPredicateAux state q
+    return (.and ta tb, state)
   | _ =>
      throwError m!"expected predicate over bitvectors (no quantification), found:  {indentD e}"
 
@@ -454,8 +458,7 @@ info: MultiWidth.Predicate.or {wcard tcard : ℕ} {ctx : Term.Ctx wcard tcard} (
 def Expr.mkPredicateExpr (wcard tcard : Nat) (tctx : Expr)
     (p : MultiWidth.Nondep.Predicate) : SolverM Expr := do
   match p with
-  | .binRel .eq a b =>
-    let w := a.width
+  | .binRel .eq w a b =>
     let wExpr ← mkWidthExpr wcard w
     let aExpr ← mkTermExpr wcard tcard tctx a
     let bExpr ← mkTermExpr wcard tcard tctx b


### PR DESCRIPTION
We will then need `slt` and `neq`, at which point we have support for all binary ops (others can be reduced to this core set).