### PR TITLE
feat: call 'scanAnd' on unary width encoded bitvectors

### DIFF
--- a/Blase/Blase/Fast/FiniteStateMachine.lean
+++ b/Blase/Blase/Fast/FiniteStateMachine.lean
@@ -1170,7 +1170,7 @@ def repeatBit : FSM Unit where
 /--
 (xval:false, control:true)
 update the latch value when 'control = true'.
-output happens *after* update
+output happens *
 -/
 def latchImmediate (initVal : Bool) : FSM Bool where
   α := Unit
@@ -1607,8 +1607,9 @@ and 'false' after.
 -/
 def trueUptoExcluding (n : Nat) : FSM (Fin 0) :=
   ofNat (BitVec.allOnes n).toNat
-@[simp] theorem eval_trueUptoExcluding (n : Nat) (i : Nat) {env : Fin 0 → BitStream} :
-    (trueUptoExcluding n).eval env i = decide (i < n) := by simp [trueUptoExcluding]
+
+@[simp] theorem eval_trueUptoExcluding (n : Nat) {env : Fin 0 → BitStream} :
+    (trueUptoExcluding n).eval env = fun i => decide (i < n) := by ext i; simp [trueUptoExcluding]
 
 def falseAfterIncluding (n : Nat) : FSM (Fin 0) := trueUptoExcluding n
 private theorem falseAfterIncluding_false_iff (n i : Nat) {env : Fin 0 → BitStream} :

--- a/Blase/Blase/MultiWidth/GoodFSM.lean
+++ b/Blase/Blase/MultiWidth/GoodFSM.lean
@@ -42,8 +42,8 @@ def mkWidthFSM (wcard : Nat) (tcard : Nat) (w : Nondep.WidthExpr) :
   | .var wnat =>
     if h : wnat < wcard then
       { toFsm :=
-        -- composeUnaryAux FSM.scanAnd (FSM.var' (StateSpace.widthVar ⟨w.toNat, h⟩))
-        (FSM.var' (StateSpace.widthVar ⟨wnat, h⟩))
+        composeUnaryAux FSM.scanAnd (FSM.var' (StateSpace.widthVar ⟨wnat, h⟩))
+        -- (FSM.var' (StateSpace.widthVar ⟨wnat, h⟩))
       }
     else
       { toFsm := FSM.zero' } -- default, should not be used.
@@ -69,6 +69,16 @@ def IsGoodNatFSM_mkWidthFSM {wcard : Nat} (tcard : Nat) (w : WidthExpr wcard) :
       simp [mkWidthFSM]
       have ⟨henv⟩ := henv
       rw [henv]
+      ext i
+      rw [BitStream.scanAnd_eq_decide]
+      simp
+      constructor
+      · intros hi
+        apply hi
+        omega
+      · intros hi
+        intros j hj
+        omega
     case min v w hv hw =>
       simp [mkWidthFSM]
       rw [hv, hw]

--- a/Blase/Blase/MultiWidth/GoodFSM.lean
+++ b/Blase/Blase/MultiWidth/GoodFSM.lean
@@ -39,6 +39,9 @@ private theorem decide_or_decide_eq_decide {P Q : Prop}
 def mkWidthFSM (wcard : Nat) (tcard : Nat) (w : Nondep.WidthExpr) :
     (NatFSM wcard tcard w) :=
   match w with
+  | .const nat => {
+      toFsm := (FSM.trueUptoExcluding nat).map Fin.elim0
+    }
   | .var wnat =>
     if h : wnat < wcard then
       { toFsm :=
@@ -65,6 +68,8 @@ def IsGoodNatFSM_mkWidthFSM {wcard : Nat} (tcard : Nat) (w : WidthExpr wcard) :
   heq := by
     intros wenv fsmEnv henv
     induction w
+    case const n =>
+      simp [mkWidthFSM, FSM.eval_trueUptoExcluding]
     case var v =>
       simp [mkWidthFSM]
       have ⟨henv⟩ := henv
@@ -660,6 +665,10 @@ theorem eval_mkMaskZeroFsm_eq_decide (env : α → BitStream):
 def mkTermFSM (wcard tcard : Nat) (t : Nondep.Term) :
     (TermFSM wcard tcard t) :=
   match t with
+  | .ofNat w n =>
+    let fsmW : FSM (StateSpace wcard tcard) := (mkWidthFSM wcard tcard w).toFsm
+    let fsmN : FSM (StateSpace wcard tcard) := (FSM.ofNat n).map Fin.elim0
+    { toFsmZext := fsmW &&& fsmN }
   | .var v _w =>
     if h : v < tcard then
       {
@@ -760,6 +769,24 @@ def IsGoodTermFSM_mkTermFSM (wcard tcard : Nat) {tctx : Term.Ctx wcard tcard}
     (t : Term tctx wold) :
     (HTermFSMToBitStream (mkTermFSM wcard tcard (.ofDep t))) := by
   induction t
+  case ofNat w n =>
+    constructor
+    intros wenv tenv fsmEnv htenv
+    obtain htenv_term := htenv.heq_term
+    obtain htenv_width := htenv.heq_width
+    have hwgood := IsGoodNatFSM_mkWidthFSM (wcard := wcard) (tcard := tcard) w
+    simp [mkTermFSM, Nondep.Term.ofDep]
+    rw [hwgood.heq (henv := htenv.toHWidthEnv)]
+    ext i
+    simp
+    by_cases hi : i < w.toNat wenv
+    · simp [hi]
+      rw [BitVec.getElem_eq_testBit_toNat]
+      simp
+      omega
+    · simp [hi]
+      apply BitVec.getLsbD_of_ge
+      omega
   case var v =>
     constructor
     intros wenv tenv fsmEnv htenv

--- a/Blase/Blase/MultiWidth/Preprocessing.lean
+++ b/Blase/Blase/MultiWidth/Preprocessing.lean
@@ -96,7 +96,10 @@ theorem BitVec.odd_mul_eq_shiftLeft_mul_of_eq_mul_two_add_one (w : Nat) (x : Bit
 
 -- @[bv_multi_width_normalize] theorem BitVec.neg_one_mul (x : BitVec w) : -1#w * x = -x := by simp
 
-@[bv_multi_width_normalize] theorem BitVec.neg_mul (x y : BitVec w) : (- x) * y = -(x * y) := by simp
+
+/-# Rewrite subtraction to addition with bitvec not. -/
+attribute [bv_multi_width_normalize] BitVec.sub_eq_add_neg
+attribute [bv_multi_width_normalize] BitVec.neg_eq_not_add
 
 
 open Lean Meta Elab in

--- a/Blase/Blase/MultiWidth/Preprocessing.lean
+++ b/Blase/Blase/MultiWidth/Preprocessing.lean
@@ -30,21 +30,30 @@ with BitVec.ofNat -/
 
 /-! Normal form for shifts
 
-See that `x <<< (n : Nat)` is strictly more expression than `x <<< BitVec.ofNat w n`,
-because in the former case, we can shift by arbitrary amounts, while in the latter case,
-we can only shift by numbers upto `2^w`. Therefore, we choose `x <<< (n : Nat)` as our simp
-and preprocessing normal form for the tactic.
+We normalize all shifts into multiplication by constant bitvector on the left.
 -/
 
-@[simp] theorem BitVec.shiftLeft_ofNat_eq (x : BitVec w) (n : Nat) :
-  x <<< BitVec.ofNat w n = x <<< (n % 2^w) := by simp
+@[bv_multi_width_normalize] theorem BitVec.shiftLeft_ofNat_eq (x : BitVec w) (n : Nat) :
+  x <<< BitVec.ofNat w n = (BitVec.ofNat w (2 ^ (n % 2^w))) * x := by
+  apply BitVec.eq_of_toNat_eq
+  simp
+  rw [Nat.shiftLeft_eq]
+  rw [Nat.mul_comm]
+
+@[bv_multi_width_normalize] theorem BitVec.shiftLeft_nat_eq (x : BitVec w) (n : Nat) :
+  x <<< n = (BitVec.ofNat w (2 ^ n)) * x := by
+  apply BitVec.eq_of_toNat_eq
+  simp
+  rw [Nat.shiftLeft_eq]
+  rw [Nat.mul_comm]
 
 /--
 Multiplying by an even number `e` is the same as shifting by `1`,
 followed by multiplying by half of `e` (the number `n`).
 This is used to simplify multiplications into shifts.
 -/
-theorem BitVec.even_mul_eq_shiftLeft_mul_of_eq_mul_two (w : Nat) (x : BitVec w) (n e : Nat) (he : e = n * 2) :
+theorem BitVec.even_mul_eq_shiftLeft_mul_of_eq_mul_two
+    (w : Nat) (x : BitVec w) (n e : Nat) (he : e = n * 2) :
     (BitVec.ofNat w e) * x = (BitVec.ofNat w n) * (x <<< (1 : Nat)) := by
   apply BitVec.eq_of_toNat_eq
   simp [Nat.shiftLeft_eq, he]
@@ -130,38 +139,6 @@ simproc↓ [bv_multi_width_normalize] shiftLeft_break_down ((BitVec.ofNat _ _) *
     return .visit { proof? := eqProof, expr := ← getEqRhs eqProof }
   | _ => return .continue
 
-open Lean Elab Meta
-def runPreprocessing (g : MVarId) : MetaM (Option MVarId) := do
-  let some ext ← (getSimpExtension? `bv_multi_width_normalize)
-    | throwError m!"'bv_multi_width_preprocess' simp attribute not found!"
-  let theorems ← ext.getTheorems
-  let some ext ← (Simp.getSimprocExtension? `bv_multi_width_normalize)
-    | throwError m!" 'bv_multi_width_preprocess' simp attribute not found!"
-  let simprocs ← ext.getSimprocs
-  let config : Simp.Config := { }
-  let config := { config with failIfUnchanged := false }
-  let ctx ← Simp.mkContext (config := config)
-    (simpTheorems := #[theorems])
-    (congrTheorems := ← Meta.getSimpCongrTheorems)
-  match ← simpGoal g ctx (simprocs := #[simprocs]) with
-  | (none, _) => return none
-  | (some (_newHyps, g'), _) => pure g'
-
-
-open Lean Elab Meta
-open Lean Elab Meta Tactic in
-/-- Convert the goal into negation normal form. -/
-elab "bv_multi_width_normalize" : tactic => do
-  liftMetaTactic fun g => do
-    match ← runPreprocessing g with
-    | none => return []
-    | some g => do
-      -- revert after running the simp-set, so that we don't transform
-      -- with `forall_and : (∀ x, p x ∧ q x) ↔ (∀ x, p x) ∧ (∀ x, q x)`.
-      -- TODO(@bollu): This opens up an interesting possibility, where we can handle smaller problems
-      -- by just working on disjunctions.
-      -- let g ← g.revertAll
-      return [g]
 
 attribute [bv_multi_width_normalize] BitVec.not_lt
 attribute [bv_multi_width_normalize] BitVec.not_le
@@ -359,6 +336,50 @@ simproc [bv_multi_width_normalize] boolEqIff (@Eq Bool _ _) := fun e => do
         let pf := mkApp2 (.const ``bool_eq_iff []) e₁ e₂
         pure $ .done { expr := e', proof? := some pf }
   | _ => pure .continue
+
+open Lean Elab Meta
+def getSimpData (simpsetName : Name) : MetaM (SimpTheorems × Simprocs) := do
+  let some ext ← (getSimpExtension? simpsetName)
+    | throwError m!"'{simpsetName}' simp attribute not found!"
+  let theorems ← ext.getTheorems
+  let some ext ← (Simp.getSimprocExtension? simpsetName)
+    | throwError m!"'{simpsetName}' simp attribute not found!"
+  let simprocs ← ext.getSimprocs
+  return (theorems, simprocs)
+
+open Lean Elab Meta
+def runPreprocessing (g : MVarId) : MetaM (Option MVarId) := do
+  let mut theorems : Array SimpTheorems := #[]
+  let mut simprocs : Array Simprocs := #[]
+
+  for name in [`seval, `bv_multi_width_normalize] do
+    let res ← getSimpData name
+    theorems := theorems.push res.1
+    simprocs := simprocs.push res.2
+
+  let config : Simp.Config := { }
+  let config := { config with failIfUnchanged := false }
+  let ctx ← Simp.mkContext (config := config)
+    (simpTheorems := theorems)
+    (congrTheorems := ← Meta.getSimpCongrTheorems)
+  match ← simpGoal g ctx (simprocs := simprocs) with
+  | (none, _) => return none
+  | (some (_newHyps, g'), _) => pure g'
+
+open Lean Elab Meta
+open Lean Elab Meta Tactic in
+/-- Convert the goal into negation normal form. -/
+elab "bv_multi_width_normalize" : tactic => do
+  liftMetaTactic fun g => do
+    match ← runPreprocessing g with
+    | none => return []
+    | some g => do
+      -- revert after running the simp-set, so that we don't transform
+      -- with `forall_and : (∀ x, p x ∧ q x) ↔ (∀ x, p x) ∧ (∀ x, q x)`.
+      -- TODO(@bollu): This opens up an interesting possibility, where we can handle smaller problems
+      -- by just working on disjunctions.
+      -- let g ← g.revertAll
+      return [g]
 
 
 /--

--- a/Blase/Blase/MultiWidth/Tactic.lean
+++ b/Blase/Blase/MultiWidth/Tactic.lean
@@ -188,9 +188,15 @@ private def mkFinLit (n : Nat) (i : Nat) : SolverM Expr := do
 /-- info: MultiWidth.WidthExpr.addK {wcard : ℕ} (v : WidthExpr wcard) (k : ℕ) : WidthExpr wcard -/
 #guard_msgs in #check MultiWidth.WidthExpr.addK
 
+/- This needs to be checked carefully for equivalence. -/
 def mkWidthExpr (wcard : Nat) (ve : MultiWidth.Nondep.WidthExpr) :
     SolverM Expr := do
   match ve with
+  | .const w =>
+    let out := mkAppN (mkConst ``MultiWidth.WidthExpr.const)
+      #[mkNatLit wcard, mkNatLit w]
+    debugCheck out
+    return out
   | .var v =>
     let out := mkAppN (mkConst ``MultiWidth.WidthExpr.var)
       #[mkNatLit wcard, ← mkFinLit wcard v]
@@ -388,10 +394,17 @@ info: MultiWidth.Term.var {wcard tcard : ℕ} {tctx : Term.Ctx wcard tcard} (v :
 -/
 #guard_msgs in #check MultiWidth.Term.var
 
-/-- Convert a raw expression into a `Term`. -/
+/-- Convert a raw expression into a `Term`.
+This needs to be checked carefully for equivalence. -/
 def mkTermExpr (wcard tcard : Nat) (tctx : Expr)
     (t : MultiWidth.Nondep.Term) : SolverM Expr := do
   match t with
+  | .ofNat w n =>
+    let wExpr ← mkWidthExpr wcard w
+    let out := mkAppN (mkConst ``MultiWidth.Term.ofNat [])
+      #[mkNatLit wcard, mkNatLit tcard, tctx, wExpr, mkNatLit n]
+    debugCheck out
+    return out
   | .var v _wexpr =>
     let out := mkAppN (mkConst ``MultiWidth.Term.var [])
       #[mkNatLit wcard, mkNatLit tcard, tctx, ← mkFinLit tcard v]

--- a/Blase/Blase/MultiWidth/Tactic.lean
+++ b/Blase/Blase/MultiWidth/Tactic.lean
@@ -736,6 +736,7 @@ def solve (g : MVarId) : SolverM (List MVarId) := do
       collect.logSuspiciousFvars
       throwError m!"exhausted iterations for predicate {repr p}"
     | .provenByKIndCycleBreaking niters safetyCert indCert =>
+      collect.logSuspiciousFvars
       debugLog m!"proven by KInduction with {niters} iterations"
       let prf ← g.withContext <| do
         -- let predFsmExpr ← Expr.mkPredicateFSMDep collect.wcard collect.tcard tctx pExpr

--- a/Blase/Blase/MultiWidth/Tactic.lean
+++ b/Blase/Blase/MultiWidth/Tactic.lean
@@ -681,7 +681,7 @@ def Expr.mkPredicateFSMtoFSM (p : Expr) : SolverM Expr := do
 
 open Lean Meta Elab Tactic in
 def solve (g : MVarId) : SolverM (List MVarId) := do
-  let .some g ← g.withContext (Simplifications.runPreprocessing g)
+  let .some g ← g.withContext (Normalize.runPreprocessing g)
     | do
         debugLog m!"Preprocessing automatically closed goal."
         return []

--- a/Blase/Blase/MultiWidth/Tests.lean
+++ b/Blase/Blase/MultiWidth/Tests.lean
@@ -33,27 +33,26 @@ set_option pp.analyze true in
 def test5 (x y z : BitVec w) : (x + y) = (y + x) := by
   bv_multi_width +verbose? +debugFillFinalReflectionProofWithSorry
 
-#eval test5.safetyCert.lhs_1
-#eval test5.indCert.lhs_3
-
 def test6 (x y z : BitVec w) : (x + (y + z)) = ((x + y) + z) := by
-  bv_multi_width (config := { niter := 10 })
+  bv_multi_width +verbose? +debugFillFinalReflectionProofWithSorry
 
 theorem add_eq_or_add_and (x y : BitVec w) :
     x + y = (x ||| y) + (x &&& y) := by
-  bv_multi_width (config := { niter := 10, verbose? := True })
+  bv_multi_width +verbose? +debugFillFinalReflectionProofWithSorry
 
 theorem add_eq_xor_add_mul_and_1 (x y : BitVec w) :
     x + y = (x ^^^ y) + 2 * (x &&& y) := by
-  bv_multi_width (config := { niter := 10, verbose? := True })
+  bv_multi_width +verbose? +debugFillFinalReflectionProofWithSorry
 
 theorem add_eq_xor_add_mul_and_2 (x y : BitVec w) :
     x + y = (x ^^^ y) + (x &&& y) <<< 1 := by
-  bv_multi_width (config := { niter := 2, verbose? := True })
+  -- bv_multi_width_normalize
+  -- simp only [seval, bv_multi_width_normalize]
+  bv_multi_width +verbose? +debugFillFinalReflectionProofWithSorry
 
 theorem add_eq_xor_add_mul_and_3 (x y : BitVec w) :
     x + y = (x ^^^ y) + (x &&& y) * 2#w := by
-  bv_multi_width (config := { niter := 2, verbose? := True })
+  bv_multi_width +verbose? +debugFillFinalReflectionProofWithSorry
 
 
 theorem add_eq_xor_add_mul_and_nt_zext (x y : BitVec w) :

--- a/Blase/Blase/MultiWidth/Tests.lean
+++ b/Blase/Blase/MultiWidth/Tests.lean
@@ -61,7 +61,17 @@ theorem add_eq_xor_add_mul_and_nt_zext (x y : BitVec w) :
   bv_multi_width +verbose? +debugFillFinalReflectionProofWithSorry
   -- bv_multi_width (config := { niter := 10, verbose? := True })
 
- theorem eg2 (w : Nat) (x : BitVec w) : x + 2 = x + 1 + 1 := by
+/-- For fixed-width problems, we encode constraints correctly, and understand
+e.g. characteristic. -/
+theorem egFixedWidthTwo (x : BitVec 2) : x + x + x + x = 0 := by
+  bv_multi_width
+
+/-- We understand constant numerals. -/
+theorem egConstNumeral (w : Nat) (x : BitVec w) : x + 2 = x + 1 + 1 := by
+  bv_multi_width
+
+/-- We understand constant BVs. -/
+theorem egConstBV (w : Nat) (x : BitVec w) : x + (2#w) = x + (1#w) + (1#w) := by
   bv_multi_width
 
 /-

--- a/Blase/Blase/MultiWidth/Tests.lean
+++ b/Blase/Blase/MultiWidth/Tests.lean
@@ -31,7 +31,7 @@ theorem hty : ty = BitVec 10 := by
 
 set_option pp.analyze true in
 def test5 (x y z : BitVec w) : (x + y) = (y + x) := by
-  bv_multi_width (config := { niter := 10, verbose? := True, check? := True })
+  bv_multi_width +verbose? +debugFillFinalReflectionProofWithSorry
 
 #eval test5.safetyCert.lhs_1
 #eval test5.indCert.lhs_3

--- a/Blase/Blase/MultiWidth/Tests.lean
+++ b/Blase/Blase/MultiWidth/Tests.lean
@@ -58,7 +58,8 @@ theorem add_eq_xor_add_mul_and_3 (x y : BitVec w) :
 theorem add_eq_xor_add_mul_and_nt_zext (x y : BitVec w) :
     x.zeroExtend (w + 1) + y.zeroExtend (w + 1) =
       (x ^^^ y).zeroExtend (w + 1) + 2 * (x &&& y).zeroExtend (w + 1) := by
-  bv_multi_width (config := { niter := 10, verbose? := True })
+  bv_multi_width +verbose? +debugFillFinalReflectionProofWithSorry
+  -- bv_multi_width (config := { niter := 10, verbose? := True })
 
 /-
 

--- a/Blase/Blase/MultiWidth/Tests.lean
+++ b/Blase/Blase/MultiWidth/Tests.lean
@@ -75,6 +75,12 @@ theorem egConstBV (w : Nat) (x : BitVec w) : x + (2#w) = x + (1#w) + (1#w) := by
   bv_multi_width
 
 /-
+theorem egZextMin (u v : Nat) (x : BitVec w) :
+    u ≤ v → (x.zeroExtend u).zeroExtend v = x.zeroExtend v := by
+  bv_multi_width (config := { niter := 2 })
+-/
+
+/-
 theorem eg3 (u w : Nat) (x : BitVec w) :
     (x.zeroExtend u).zeroExtend u = x.zeroExtend u := by
   bv_multi_width (config := { niter := 2 })

--- a/Blase/Blase/MultiWidth/Tests.lean
+++ b/Blase/Blase/MultiWidth/Tests.lean
@@ -61,11 +61,10 @@ theorem add_eq_xor_add_mul_and_nt_zext (x y : BitVec w) :
   bv_multi_width +verbose? +debugFillFinalReflectionProofWithSorry
   -- bv_multi_width (config := { niter := 10, verbose? := True })
 
-/-
-
  theorem eg2 (w : Nat) (x : BitVec w) : x + 2 = x + 1 + 1 := by
   bv_multi_width
 
+/-
 theorem eg3 (u w : Nat) (x : BitVec w) :
     (x.zeroExtend u).zeroExtend u = x.zeroExtend u := by
   bv_multi_width (config := { niter := 2 })

--- a/Blase/README.md
+++ b/Blase/README.md
@@ -1,1 +1,9 @@
-# Blase - Blaster for StrEams
+# Blase - **Bla**ter for **S**tr**E**ams
+
+A decision procedure that is sound and complete for parametric bitvector expressions
+with linear arithmetic, bitwise operationrs, zeroExtend, signExtend, and bitwidth constraints.
+
+#### Algorithms Improvements TODO
+
+- Check if a variable is used both as a width variable and a nat variable,
+  and then complain about it.


### PR DESCRIPTION
This allows us to prove the right things. However, there is still the weird wrinkle that the kernel does not believe our proof. So we currently prove with:

```lean
theorem add_eq_xor_add_mul_and_nt_zext (x y : BitVec w) :
    x.zeroExtend (w + 1) + y.zeroExtend (w + 1) =
      (x ^^^ y).zeroExtend (w + 1) + 2 * (x &&& y).zeroExtend (w + 1) := by
  bv_multi_width +verbose? +debugFillFinalReflectionProofWithSorry
```

where we:

- run the decision procedure at meta-time
- produce the proof certificates
- but do not build the final proof, since this leads to a kernel type checking error, which is quite mysterious, since we in fact `check` at every step, so everything should be well-formed.

CC @ineol , I could use your help debugging this!