### PR TITLE
chore: disable namespace-run docker-based ci

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,10 +1,14 @@
 name: Build & Evaluate (in Docker)
-on:
-  push:
-    branches:
-      - "main"
-  pull_request:
-  merge_group:
+on: 
+  workflow_dispatch
+  # push:
+  #   branches:
+  #     - "main"
+  # pull_request:
+  # merge_group:
+
+# ^^ This workflow does not run automatically, to make sure we don't burn through too many
+# namespace.so credits. For now, it is only triggered manually if desired.
 
 permissions:
   contents: write


### PR DESCRIPTION
This PR disables the docker-based CI I've been experimenting with using namespace.so runners.

The immediate reason to disable them is because these particular CI jobs have been failing with [no space left on device](https://github.com/opencompl/lean-mlir/actions/runs/17768338663/job/50497421554#step:6:527) errors which I don't wish to debug right now.

The result of this experiment is roughly as follows:
- Namespace.so has proper caching for Docker cache-mounts, which make our builds much faster
- Unfortunately, running a Github Action in a container (using GH-provided runners) incurs a minute to minute-and-a-half "container initialization" cost, meaning it tends to be *slower* than the old non-dockerized CI jobs
    - This is not exactly a fair comparison, the non-dockerized CI job deliberately does *not* use the lake cache, but builds Mathlib from scratch instead, whereas the dockerized CI job just uses the lake cache
    - This is relevant, because the former will only build those files which are actually used in the project, whereas the rather just downloads all of mathlib. This means the non-dockerized cache is much smaller (since we don't actually use that much of Mathlib), whereas the Docker image is quite big (couple of GBs); a big chunk of that initialization time is presumably downloading the image.
    - This could be sped up by adopting a similar strategy in the Docker build, by building Mathlib from scratch there, too. I was a bit hesitant to implement this, as I wasn't sure how long that'd take (and thus how costly it would be in terms of namespace credits)
    - Alternatively, (and/or additionally) we could move all runners to namespace and use namespace-provided image caches to speed up this initialization -- but this is likely to be much more expensive still