### PR TITLE
chore: rename blase CI build step to "blase"

### DIFF
--- a/.github/workflows/blase.yml
+++ b/.github/workflows/blase.yml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   build:
-    name: core library
+    name: blase
     permissions:
       pull-requests: write
     # Exclude expensive self-hosted runner. Reserved for performance benchmarking.


### PR DESCRIPTION
Was called "core library" which makes it confusing.