### PR TITLE
refactor: get llvm-mca from PATH

### DIFF
--- a/SSA/Projects/LLVMRiscV/Evaluation/mca-analysis/README.md
+++ b/SSA/Projects/LLVMRiscV/Evaluation/mca-analysis/README.md
@@ -1,11 +1,27 @@
+
+# MCA Analysis
+
+## Dependencies
+
+This evaluation requires `llvm-mca`, either install it through your favourite
+package manager, or, if you've built LLVM from source, add the `bin` directory
+to your path.
+
+For example, if you've built LLVM at `~/llvm-project/build`, and you run bash as
+your shell, you should run the following before you run the script:
+
+```bash
+export PATH=$PATH:~/llvm-project/build/bin/
+```
+
 ## How to run
 
-To repreoduce the mca analysis results, run: 
+To repreoduce the mca analysis results, run:
 ```
 python3 run_mca.py 
 ```
 
-This file will run LLVM's `llvm-mca` tool on the RISCV assembly files produced by both LLVM and Lean-MLIR + XDSL, using the following command: 
+This file will run LLVM's `llvm-mca` tool on the RISCV assembly files produced by both LLVM and Lean-MLIR + XDSL, using the following command:
 ```
 llvm-mca -mtriple=riscv64 -mcpu=sifive-u74 -mattr=+m,+zba,+zbb,+zbs $input_file
 ```

--- a/SSA/Projects/LLVMRiscV/Evaluation/mca-analysis/README.md
+++ b/SSA/Projects/LLVMRiscV/Evaluation/mca-analysis/README.md
@@ -16,7 +16,7 @@ export PATH=$PATH:~/llvm-project/build/bin/
 
 ## How to run
 
-To repreoduce the mca analysis results, run:
+To reproduce the mca analysis results, run:
 ```
 python3 run_mca.py 
 ```

--- a/SSA/Projects/LLVMRiscV/Evaluation/mca-analysis/run_mca.py
+++ b/SSA/Projects/LLVMRiscV/Evaluation/mca-analysis/run_mca.py
@@ -15,8 +15,6 @@ ROOT_DIR = (
 )
 TIMEOUT = 1800  # seconds
 
-LLVM_BUILD_DIR = "~/llvm-project/build/bin/"
-
 LLC_ASM_DIR = (
     f"{ROOT_DIR}/SSA/Projects/LLVMRiscV/Evaluation/benchmarks/LLC_ASM/"
 )
@@ -74,7 +72,7 @@ def mca_analysis(input_file, output_file, log_file):
     cmd_base = (
         "llvm-mca -mtriple=riscv64 -mcpu=sifive-u74 -mattr=+m,+zba,+zbb,+zbs "
     )
-    cmd = LLVM_BUILD_DIR + cmd_base + input_file + " > " + output_file
+    cmd = cmd_base + input_file + " > " + output_file
     print(cmd)
     run_command(cmd, log_file)
     


### PR DESCRIPTION
This PR drops the hard-coded `LLVM_BUILD_DIR` path from the `run_mca.py` script, so that the llvm-mca binary is found in the PATH instead. I've also added instructions to the README on how to add a locally-built LLVM to the path (let me know if the instructions are unclear!).

By getting the binary from the path, we can also use package-manager provided `llvm-mca`, instead of forcing everybody to locally build LLVM at some specific path.