### PR TITLE
refactor: clean-up printing via ToPrint typeclass

### DIFF
--- a/SSA/Core/Framework.lean
+++ b/SSA/Core/Framework.lean
@@ -140,23 +140,6 @@ Another option, which would be more complicated, but correct by construction, is
 impurely.
 -/
 
-/--
-ToPrint includes the functions to print the components of a dialect.
--/
-class ToPrint (d : Dialect) where
-  /-- Prints the operation in the dialect. -/
-  printOpName : d.Op → String
-  /-- Prints the type in the dialect. -/
-  printTy : d.Ty → String
-  /-- Prints the attributes of the operation. -/
-  printAttributes : d.Op → String
-  /-- Prints the name of the dialect. -/
-  printDialect : String
-  /-- Prints the return instruction of the dialect. -/
-  printReturn : List d.Ty → String
-  /-- Prints the function header of the dialect. -/
-  printFunc : List d.Ty → String
-
 /- # Datastructures -/
 section DataStructures
 

--- a/SSA/Core/Framework/Print.lean
+++ b/SSA/Core/Framework/Print.lean
@@ -151,7 +151,27 @@ instance : ToString (Expr d Γ eff t) where toString := Expr.toString
 
 end ToString
 
-/- # ToPrint instances for Com and Expr  -/
+/-!
+## DialectPrint infrastructure
+-/
+
+/--
+ToPrint includes the functions to print the components of a dialect.
+-/
+class ToPrint (d : Dialect) where
+  /-- Prints the operation in the dialect. -/
+  printOpName : d.Op → String
+  /-- Prints the type in the dialect. -/
+  printTy : d.Ty → String
+  /-- Prints the attributes of the operation. -/
+  printAttributes : d.Op → String
+  /-- Prints the name of the dialect. -/
+  printDialect : String
+  /-- Prints the return instruction of the dialect. -/
+  printReturn : List d.Ty → String
+  /-- Prints the function header of the dialect. -/
+  printFunc : List d.Ty → String
+
 section ToPrint
 
 open Std (Format)

--- a/SSA/Core/Framework/Print.lean
+++ b/SSA/Core/Framework/Print.lean
@@ -156,94 +156,155 @@ end ToString
 -/
 
 /--
-ToPrint includes the functions to print the components of a dialect.
+`DialectPrint d` tells us how to print programs in dialect `d`.
+
+An instance of `DialectPrint d` implies instances of `Repr` for the
+core LeanMLIR datastructures (e.g., `Com` and `Expr`)
+instantiated to dialect `d`.
+Additionally, we generate an instance of `ToString d.Ty`
+
+Note: operations have different components which are printed differently (i.e.,
+the operation name and the attributes), which is why `ToString d.Op` is not
+granular enough.
 -/
-class ToPrint (d : Dialect) where
-  /-- Prints the operation in the dialect. -/
+class DialectPrint (d : Dialect) where
+  /--
+  Print the name of an operation.
+
+  NOTE: this should not contain any properties or attributes, those are
+  printed separately.
+  -/
   printOpName : d.Op → String
-  /-- Prints the type in the dialect. -/
-  printTy : d.Ty → String
-  /-- Prints the attributes of the operation. -/
+  /--
+  Print the attributes of an operation.
+  -/
   printAttributes : d.Op → String
-  /-- Prints the name of the dialect. -/
-  printDialect : String
+
+  /--
+  Prints the type in the dialect.
+  -/
+  printTy : d.Ty → String
+
+  /-- The name of the dialect. -/
+  dialectName : String
+  -- ^^ TODO: `dialectName` seems unused
+
   /-- Prints the return instruction of the dialect. -/
   printReturn : List d.Ty → String
   /-- Prints the function header of the dialect. -/
   printFunc : List d.Ty → String
+  -- TODO: ^^ `printFunc` seems to be used to print the name of the entry block,
+  -- e.g., for LLVM, `printFunc` just returns `^bb0`. This doesn't feel like
+  -- something which needs to be dialect-specific, rather, we should just
+  -- hardcode this to be `^entry` or something like that.
 
-section ToPrint
+section DialectPrint
 
 open Std (Format)
-variable {d} [ToPrint d] [DialectSignature d] [Repr d.Op] [Repr d.Ty] [ToString d.Ty] [ToString d.Op]
+open DialectPrint
+variable {d} [DialectPrint d]
 
-/-- Format a list of formal arguments as `(%0 : tₙ , ... %n : t₀)` -/
-partial def formatFormalArgListTuplePrint [ToString d.Ty] (ts : List d.Ty) : String :=
-  let args := (List.range ts.length).zip ts.reverse |>.map
-    (fun (i, t) => s!"%{i} : {ToPrint.printTy t}")
-  "(" ++ String.intercalate ", " args ++ ")"
+namespace DialectPrint
 
--- Format a sequence of types as `(t₁, ..., tₙ)` using toString instances -/
-private def formatTypeTuplePrint [ToString d.Ty] (xs : List d.Ty) : String :=
-  "(" ++ String.intercalate ", " (xs.map ToPrint.printTy) ++ ")"
-
-/-- Parenthesize and separate with 'separator' if the list is nonempty, and return
-the "()" if the list is empty. -/
-private def Format.parenIfNonemptyForPrint (l : String) (r : String) (separator : Format)
-    (xs : List Format) : Format :=
-  match xs with
-  | [] => "() "
-  | _  =>  l ++ (Format.joinSep xs separator) ++ r
-
-/-- Format a tuple of arguments as `a₁, ..., aₙ`. -/
-private def formatArgTupleForPrint [Repr Ty] {Γ : List Ty}
-    (args : HVector (fun t => Var Γ₂ t) Γ) : Format :=
-  Format.parenIfNonemptyForPrint "(" ")" ", " (formatArgTupleAux args)
-where
-  formatArgTupleAux [Repr Ty] {Γ : List Ty} (args : HVector (fun t => Var Γ₂ t) Γ) : List Format :=
-    match Γ with
-    | .nil => []
-    | .cons .. =>
-      match args with
-      | .cons a as => (repr a) :: (formatArgTupleAux as)
+instance instToStringTy : ToString (Dialect.Ty d) where
+  toString := printTy
 
 /--
+Given the context `Γ` of a `Com`, print the arguments and their types of the
+implicit entry block.
+
+Note that argument names are not preserved by the parser, so simply number the
+printed arguments according to their DeBruijn index.
+
+For example, if the contex is `Γ := ⟨[i64, i32]⟩` then the expected output is:
+  `(%0 : i32, %1 : i64)`
+-/
+partial def printBlockArgs (Γ : Ctxt d.Ty) : String :=
+  let ts := Γ.toList
+  let args := (List.range ts.length).zip ts.reverse |>.map
+    (fun (i, t) => s!"%{i} : {printTy t}")
+  "(" ++ String.intercalate ", " args ++ ")"
+
+/--
+Print a variable. Recall that variable names are *not* preserved by the parser.
+Instead, while printing we implicitly number the variables in the order they are
+defined in the program.
+
+The number assigned to a variable is thus in a sense the *inverse* of its
+DeBruijn index. This is by design, so that the variable number is constant
+throughout the program, c.f. the DeBrijn index that refers to a specific
+let-binding, which depends on where the reference occurs.
+-/
+def printVar {Γ : Ctxt d.Ty} (v : Γ.Var t) : Format :=
+  f!"%{Γ.toList.length - v.val - 1}"
+
+end DialectPrint
+
+
+variable [DialectSignature d]
+
+/--
+Print the arguments to an expression as `($x, %y, %z, ...)`.
+
+See `printVar` for details on how variables are printed.
+-/
+def Expr.printArgs (e : Expr d Γ eff t) : Format :=
+  let args := e.args.mapToList printVar
+  let args := Format.joinSep args ", "
+  f!"({args})"
+
+/--
+Print the type of an expression, e.g., `(i64, i64) -> (i64)`.
+-/
+def Expr.printType (e : Expr d Γ eff ts) : Format :=
+  let argTys := e.args.mapToList (@fun t _ => printTy t)
+  let argTys := Format.group <| Format.joinSep argTys ", "
+  let retTys := ts.map printTy
+  let retTys := Format.group <| Format.joinSep retTys ", "
+  f!"({argTys}) -> ({retTys})"
+
+/--
+Print an `Expr` in generic MLIR syntax.
+
+Note: this prints just the operation, it's argument
+
 Converts an expression within a dialect to its MLIR string representation.
 Since MLIR generic syntax uses double quotes (`"..."`) to print operations, this function uses
 the ToPrint typeclass of each dialect to print the various parts of an expressiom such as
 operation and types. Lastly, it arranges the expression printing according to MLIR syntax.
 -/
-partial def Expr.toPrint [ToString d.Op] : Expr d Γ eff t → String
-  | Expr.mk (op : d.Op) _ _ args _regArgs =>
-    let returnTypes := DialectSignature.returnTypes op
-    let returnTypes := ", ".intercalate <| returnTypes.map ToPrint.printTy
-    let argTys := DialectSignature.sig op
-    s!"\"{ToPrint.printOpName op}\"{formatArgTupleForPrint args}{ToPrint.printAttributes op} : {formatTypeTuplePrint argTys} -> ({returnTypes})"
+partial def Expr.print (e : Expr d Γ eff t) : Format :=
+  f!"\"{printOpName e.op}\"{e.printArgs}{printAttributes e.op} : {e.printType}"
 
 /--
-  This function recursively converts the body of a `Com` into its string representation.
-  Each bound variable is printed with its index and corresponding expression.
+Recursively print a `Com` in generic MLIR syntax.
+Each bound variable is printed with its index and corresponding expression.
 -/
-partial def Com.toPrintBody : Com d Γ eff ts → String
+private partial def Com.printAux : Com d Γ eff ts → Format
   | .rets vs =>
       let vs := (vs.map fun _ v => s!"{_root_.repr v}").toListOf String (by intros; rfl)
       let vs := ", ".intercalate vs
-      let ret := ToPrint.printReturn ts
-      let ts := ", ".intercalate <| ts.map ToPrint.printTy
-      s!"  \"{ret}\"({vs}) : ({ts}) -> ()"
+      let ret := printReturn ts
+      let ts := ", ".intercalate <| ts.map printTy
+      Format.align true ++ f!"\"{ret}\"({vs}) : ({ts}) -> ()"
   | .var e body =>
-    s!"  %{_root_.repr <|(Γ.length)} = {Expr.toPrint e }" ++ "\n" ++
-    Com.toPrintBody body
+    Format.align true ++ f!"%{Γ.length} = {e.print}" ++
+    Com.printAux body
 
 /--
-  `Com.toPrint` implements a `ToPrint` instance for the type `Com`.
-  This has a more general behaviour than `toString` and allows customizing the
-  printing of dialect objects.
+Print a `Com` in generic MLIR syntax.
 -/
-partial def Com.toPrint (com : Com d Γ eff ts) : String :=
-   "builtin.module { \n"
-  ++ ToPrint.printFunc ts ++ ((formatFormalArgListTuplePrint Γ.toList)) ++ ":" ++ "\n"
-  ++ (Com.toPrintBody com) ++
-   "\n }"
+partial def Com.print (com : Com d Γ eff ts) : Format :=
+  Format.align true ++ f!"{printFunc ts}{printBlockArgs Γ}:\n"
+  ++ (Format.nest 2 <|
+    com.printAux
+  )
 
-end ToPrint
+/--
+Print a `Com` in generic MLIR syntax, wrapped in an implicit `builtin.module`.
+-/
+partial def Com.printModule (com : Com d Γ eff ts) : Format :=
+  f!"builtin.module \{\n" ++ (Format.nest 2 com.print) ++ f!"\n}"
+
+
+end DialectPrint

--- a/SSA/Core/HVector.lean
+++ b/SSA/Core/HVector.lean
@@ -151,6 +151,12 @@ def toListOf {A : α → _} {as} (β : Type _)
     let ys := xs.toListOf β (fun a h => hα a <| by simpa using .inr h)
     y :: ys
 
+/--
+Map a function with a constant output type over an hvector to produce a list.
+-/
+def mapToList (f : ∀ {a : α}, A a → β) {as : List α} (xs : HVector A as) : List β :=
+  xs.map @f |>.toListOf β
+
 /-!
 ## Repr
 -/

--- a/SSA/Projects/InstCombine/LLVM/CLITests.lean
+++ b/SSA/Projects/InstCombine/LLVM/CLITests.lean
@@ -28,9 +28,6 @@ abbrev Context := Ctxt LLVM.Ty
 abbrev MCom φ := Com (MetaLLVM φ)
 abbrev MExpr φ := Expr (MetaLLVM φ)
 
-instance : ToString Context where
-  toString Γ := toString Γ.toList
-
 structure CliTest where
   name : Name
   mvars : Nat
@@ -211,9 +208,6 @@ def ConcreteCliTest.parseableInputs (test : ConcreteCliTest) :
 def CocreteCliTest.signature (test : ConcreteCliTest) :
     Ctxt (InstCombine.MTy 0) × (InstCombine.MTy 0) :=
   (⟨test.context.toList.reverse⟩, test.ty)
-
-def ConcreteCliTest.printSignature (test : ConcreteCliTest) : String :=
-  s!"{test.context.toList.reverse} → {test.ty}"
 
 open LLVM.Ty in
 instance {test : ConcreteCliTest} : ToString (toType test.ty) where

--- a/SSA/Projects/InstCombine/LLVM/CLITests.lean
+++ b/SSA/Projects/InstCombine/LLVM/CLITests.lean
@@ -209,6 +209,9 @@ def CocreteCliTest.signature (test : ConcreteCliTest) :
     Ctxt (InstCombine.MTy 0) × (InstCombine.MTy 0) :=
   (⟨test.context.toList.reverse⟩, test.ty)
 
+def ConcreteCliTest.printSignature (test : ConcreteCliTest) : String :=
+  s!"{test.context.toList.reverse} → {test.ty}"
+
 open LLVM.Ty in
 instance {test : ConcreteCliTest} : ToString (toType test.ty) where
   toString :=

--- a/SSA/Projects/InstCombine/LLVM/Opt.lean
+++ b/SSA/Projects/InstCombine/LLVM/Opt.lean
@@ -22,7 +22,7 @@ def wellformed (fileName : String ) : IO UInt32 := do
     match icom? with
     | none => return 1
     | some (Sigma.mk _Γ ⟨_eff, ⟨_retTy, c⟩⟩) => do
-      IO.println s!"{Com.toPrint c}"
+      IO.println s!"{Com.printModule c}"
       return 0
 
 def runMainCmd (args : Cli.Parsed) : IO UInt32 := do

--- a/SSA/Projects/InstCombine/Tests/Print.lean
+++ b/SSA/Projects/InstCombine/Tests/Print.lean
@@ -50,7 +50,7 @@ info: {
 
 Note: for each operation we have a test without flags for each of the three
 printing methods. If the operation takes flags, we additionally have flagged
-test-cases *only* for `toPrint`, as it's the only printing method that handles
+test-cases *only* for `Com.print`, as it's the only printing method that handles
 flags well.
 
 The goal for these tests is that the output is parse-able, and the result of parsing

--- a/SSA/Projects/InstCombine/Tests/Print.lean
+++ b/SSA/Projects/InstCombine/Tests/Print.lean
@@ -1,24 +1,24 @@
 import SSA.Projects.InstCombine.LLVM.PrettyEDSL
 
 /-!
-## Print Tests
+# Print Tests
 -/
 namespace Tests
 
 /-!
-### General print tests
+## General print tests
 
 First, we assert that variables in a basic block are printed in the correct
 order.
 -/
 
 /--
-info: builtin.module { ⏎
-^bb0(%0 : i64, %1 : i1):
-  "llvm.return"(%0) : (i64) -> ()
- }
+info: builtin.module {
+  ^bb0(%0 : i64, %1 : i1):
+    "llvm.return"(%0) : (i64) -> ()
+}
 -/
-#guard_msgs in #eval String.toFormat <| Com.toPrint [llvm| {
+#guard_msgs in #eval Com.printModule [llvm| {
   ^bb0(%0: i64, %1: i1):
     "llvm.return"(%0) : (i64) -> ()
 }]
@@ -46,7 +46,7 @@ info: {
 }]
 
 /-!
-### Per-operation tests
+## Per-operation tests
 
 Note: for each operation we have a test without flags for each of the three
 printing methods. If the operation takes flags, we additionally have flagged
@@ -71,13 +71,13 @@ expose the current behaviour for easier diagnosis.
 /-! #### add -/
 
 /--
-info: builtin.module { ⏎
-^bb0(%0 : i64, %1 : i64):
-  %2 = "llvm."llvm.add""(%0, %1)<{overflowFlags = #llvm.overflow<none>}> : (i64, i64) -> (i64)
-  "llvm.return"(%2) : (i64) -> ()
- }
+info: builtin.module {
+  ^bb0(%0 : i64, %1 : i64):
+    %2 = "llvm.add"(%0, %1)<{overflowFlags = #llvm.overflow<none>}> : (i64, i64) -> (i64)
+    "llvm.return"(%2) : (i64) -> ()
+}
 -/
-#guard_msgs in #eval String.toFormat <| Com.toPrint [llvm| {
+#guard_msgs in #eval Com.printModule [llvm| {
   ^bb0(%x: i64, %y: i64):
     %z = "llvm.add"(%x, %y) : (i64, i64) -> (i64)
     "llvm.return"(%z) : (i64) -> ()
@@ -111,49 +111,49 @@ info: {
 
 /-! #### add (flags) -/
 /--
-info: builtin.module { ⏎
-^bb0(%0 : i64, %1 : i64):
-  %2 = "llvm."llvm.add""(%0, %1)<{overflowFlags = #llvm.overflow<none>}> : (i64, i64) -> (i64)
-  "llvm.return"(%2) : (i64) -> ()
- }
+info: builtin.module {
+  ^bb0(%0 : i64, %1 : i64):
+    %2 = "llvm.add"(%0, %1)<{overflowFlags = #llvm.overflow<none>}> : (i64, i64) -> (i64)
+    "llvm.return"(%2) : (i64) -> ()
+}
 -/
-#guard_msgs in #eval String.toFormat <| Com.toPrint [llvm| {
+#guard_msgs in #eval Com.printModule [llvm| {
   ^bb0(%x: i64, %y: i64):
     %z = "llvm.add"(%x, %y) {overflowFlags = #llvm.overflow<none>} : (i64, i64) -> (i64)
     "llvm.return"(%z) : (i64) -> ()
 }]
 /--
-info: builtin.module { ⏎
-^bb0(%0 : i64, %1 : i64):
-  %2 = "llvm."llvm.add true false""(%0, %1)<{overflowFlags = #llvm.overflow<nsw>}> : (i64, i64) -> (i64)
-  "llvm.return"(%2) : (i64) -> ()
- }
+info: builtin.module {
+  ^bb0(%0 : i64, %1 : i64):
+    %2 = "llvm.add"(%0, %1)<{overflowFlags = #llvm.overflow<nsw>}> : (i64, i64) -> (i64)
+    "llvm.return"(%2) : (i64) -> ()
+}
 -/
-#guard_msgs in #eval String.toFormat <| Com.toPrint [llvm| {
+#guard_msgs in #eval Com.printModule [llvm| {
   ^bb0(%x: i64, %y: i64):
     %z = "llvm.add"(%x, %y) {overflowFlags = #llvm.overflow<"nsw">} : (i64, i64) -> (i64)
     "llvm.return"(%z) : (i64) -> ()
 }]
 /--
-info: builtin.module { ⏎
-^bb0(%0 : i64, %1 : i64):
-  %2 = "llvm."llvm.add false true""(%0, %1)<{overflowFlags = #llvm.overflow<nuw>}> : (i64, i64) -> (i64)
-  "llvm.return"(%2) : (i64) -> ()
- }
+info: builtin.module {
+  ^bb0(%0 : i64, %1 : i64):
+    %2 = "llvm.add"(%0, %1)<{overflowFlags = #llvm.overflow<nuw>}> : (i64, i64) -> (i64)
+    "llvm.return"(%2) : (i64) -> ()
+}
 -/
-#guard_msgs in #eval String.toFormat <| Com.toPrint [llvm| {
+#guard_msgs in #eval Com.printModule [llvm| {
   ^bb0(%x: i64, %y: i64):
     %z = "llvm.add"(%x, %y) {overflowFlags = #llvm.overflow<"nuw">} : (i64, i64) -> (i64)
     "llvm.return"(%z) : (i64) -> ()
 }]
 /--
-info: builtin.module { ⏎
-^bb0(%0 : i64, %1 : i64):
-  %2 = "llvm."llvm.add true true""(%0, %1)<{overflowFlags = #llvm.overflow<nsw,nuw>}> : (i64, i64) -> (i64)
-  "llvm.return"(%2) : (i64) -> ()
- }
+info: builtin.module {
+  ^bb0(%0 : i64, %1 : i64):
+    %2 = "llvm.add"(%0, %1)<{overflowFlags = #llvm.overflow<nsw,nuw>}> : (i64, i64) -> (i64)
+    "llvm.return"(%2) : (i64) -> ()
+}
 -/
-#guard_msgs in #eval String.toFormat <| Com.toPrint [llvm| {
+#guard_msgs in #eval Com.printModule [llvm| {
   ^bb0(%x: i64, %y: i64):
     %z = "llvm.add"(%x, %y) {overflowFlags = #llvm.overflow<"nsw","nuw">} : (i64, i64) -> (i64)
     "llvm.return"(%z) : (i64) -> ()
@@ -162,13 +162,13 @@ info: builtin.module { ⏎
 /-! #### sub -/
 
 /--
-info: builtin.module { ⏎
-^bb0(%0 : i64, %1 : i64):
-  %2 = "llvm."llvm.sub""(%0, %1)<{overflowFlags = #llvm.overflow<none>}> : (i64, i64) -> (i64)
-  "llvm.return"(%2) : (i64) -> ()
- }
+info: builtin.module {
+  ^bb0(%0 : i64, %1 : i64):
+    %2 = "llvm.sub"(%0, %1)<{overflowFlags = #llvm.overflow<none>}> : (i64, i64) -> (i64)
+    "llvm.return"(%2) : (i64) -> ()
+}
 -/
-#guard_msgs in #eval String.toFormat <| Com.toPrint [llvm| {
+#guard_msgs in #eval Com.printModule [llvm| {
   ^bb0(%x: i64, %y: i64):
     %z = "llvm.sub"(%x, %y) : (i64, i64) -> (i64)
     "llvm.return"(%z) : (i64) -> ()
@@ -202,50 +202,50 @@ info: {
 
 /-! #### sub (flags) -/
 /--
-info: builtin.module { ⏎
-^bb0(%0 : i64, %1 : i64):
-  %2 = "llvm."llvm.sub""(%0, %1)<{overflowFlags = #llvm.overflow<none>}> : (i64, i64) -> (i64)
-  "llvm.return"(%2) : (i64) -> ()
- }
+info: builtin.module {
+  ^bb0(%0 : i64, %1 : i64):
+    %2 = "llvm.sub"(%0, %1)<{overflowFlags = #llvm.overflow<none>}> : (i64, i64) -> (i64)
+    "llvm.return"(%2) : (i64) -> ()
+}
 -/
-#guard_msgs in #eval String.toFormat <| Com.toPrint [llvm| {
+#guard_msgs in #eval Com.printModule [llvm| {
   ^bb0(%x: i64, %y: i64):
     %z = "llvm.sub"(%x, %y) {overflowFlags = #llvm.overflow<"none">} : (i64, i64) -> (i64)
     "llvm.return"(%z) : (i64) -> ()
 }]
 /-! #### sub (flags) -/
 /--
-info: builtin.module { ⏎
-^bb0(%0 : i64, %1 : i64):
-  %2 = "llvm."llvm.sub true false""(%0, %1)<{overflowFlags = #llvm.overflow<nsw>}> : (i64, i64) -> (i64)
-  "llvm.return"(%2) : (i64) -> ()
- }
+info: builtin.module {
+  ^bb0(%0 : i64, %1 : i64):
+    %2 = "llvm.sub"(%0, %1)<{overflowFlags = #llvm.overflow<nsw>}> : (i64, i64) -> (i64)
+    "llvm.return"(%2) : (i64) -> ()
+}
 -/
-#guard_msgs in #eval String.toFormat <| Com.toPrint [llvm| {
+#guard_msgs in #eval Com.printModule [llvm| {
   ^bb0(%x: i64, %y: i64):
     %z = "llvm.sub"(%x, %y) {overflowFlags = #llvm.overflow<"nsw">} : (i64, i64) -> (i64)
     "llvm.return"(%z) : (i64) -> ()
 }]
 /--
-info: builtin.module { ⏎
-^bb0(%0 : i64, %1 : i64):
-  %2 = "llvm."llvm.sub false true""(%0, %1)<{overflowFlags = #llvm.overflow<nuw>}> : (i64, i64) -> (i64)
-  "llvm.return"(%2) : (i64) -> ()
- }
+info: builtin.module {
+  ^bb0(%0 : i64, %1 : i64):
+    %2 = "llvm.sub"(%0, %1)<{overflowFlags = #llvm.overflow<nuw>}> : (i64, i64) -> (i64)
+    "llvm.return"(%2) : (i64) -> ()
+}
 -/
-#guard_msgs in #eval String.toFormat <| Com.toPrint [llvm| {
+#guard_msgs in #eval Com.printModule [llvm| {
   ^bb0(%x: i64, %y: i64):
     %z = "llvm.sub"(%x, %y) {overflowFlags = #llvm.overflow<"nuw">} : (i64, i64) -> (i64)
     "llvm.return"(%z) : (i64) -> ()
 }]
 /--
-info: builtin.module { ⏎
-^bb0(%0 : i64, %1 : i64):
-  %2 = "llvm."llvm.sub true true""(%0, %1)<{overflowFlags = #llvm.overflow<nsw,nuw>}> : (i64, i64) -> (i64)
-  "llvm.return"(%2) : (i64) -> ()
- }
+info: builtin.module {
+  ^bb0(%0 : i64, %1 : i64):
+    %2 = "llvm.sub"(%0, %1)<{overflowFlags = #llvm.overflow<nsw,nuw>}> : (i64, i64) -> (i64)
+    "llvm.return"(%2) : (i64) -> ()
+}
 -/
-#guard_msgs in #eval String.toFormat <| Com.toPrint [llvm| {
+#guard_msgs in #eval Com.printModule [llvm| {
   ^bb0(%x: i64, %y: i64):
     %z = "llvm.sub"(%x, %y) {overflowFlags = #llvm.overflow<"nsw","nuw">} : (i64, i64) -> (i64)
     "llvm.return"(%z) : (i64) -> ()
@@ -254,13 +254,13 @@ info: builtin.module { ⏎
 /-! #### mul -/
 
 /--
-info: builtin.module { ⏎
-^bb0(%0 : i64, %1 : i64):
-  %2 = "llvm."llvm.mul""(%0, %1)<{overflowFlags = #llvm.overflow<none>}> : (i64, i64) -> (i64)
-  "llvm.return"(%2) : (i64) -> ()
- }
+info: builtin.module {
+  ^bb0(%0 : i64, %1 : i64):
+    %2 = "llvm.mul"(%0, %1)<{overflowFlags = #llvm.overflow<none>}> : (i64, i64) -> (i64)
+    "llvm.return"(%2) : (i64) -> ()
+}
 -/
-#guard_msgs in #eval String.toFormat <| Com.toPrint [llvm| {
+#guard_msgs in #eval Com.printModule [llvm| {
   ^bb0(%x: i64, %y: i64):
     %z = "llvm.mul"(%x, %y) : (i64, i64) -> (i64)
     "llvm.return"(%z) : (i64) -> ()
@@ -294,49 +294,49 @@ info: {
 
 /-! #### mul (flags) -/
 /--
-info: builtin.module { ⏎
-^bb0(%0 : i64, %1 : i64):
-  %2 = "llvm."llvm.mul""(%0, %1)<{overflowFlags = #llvm.overflow<none>}> : (i64, i64) -> (i64)
-  "llvm.return"(%2) : (i64) -> ()
- }
+info: builtin.module {
+  ^bb0(%0 : i64, %1 : i64):
+    %2 = "llvm.mul"(%0, %1)<{overflowFlags = #llvm.overflow<none>}> : (i64, i64) -> (i64)
+    "llvm.return"(%2) : (i64) -> ()
+}
 -/
-#guard_msgs in #eval String.toFormat <| Com.toPrint [llvm| {
+#guard_msgs in #eval Com.printModule [llvm| {
   ^bb0(%x: i64, %y: i64):
     %z = "llvm.mul"(%x, %y) {overflowFlags = #llvm.overflow<"none">} : (i64, i64) -> (i64)
     "llvm.return"(%z) : (i64) -> ()
 }]
 /--
-info: builtin.module { ⏎
-^bb0(%0 : i64, %1 : i64):
-  %2 = "llvm."llvm.mul true false""(%0, %1)<{overflowFlags = #llvm.overflow<nsw>}> : (i64, i64) -> (i64)
-  "llvm.return"(%2) : (i64) -> ()
- }
+info: builtin.module {
+  ^bb0(%0 : i64, %1 : i64):
+    %2 = "llvm.mul"(%0, %1)<{overflowFlags = #llvm.overflow<nsw>}> : (i64, i64) -> (i64)
+    "llvm.return"(%2) : (i64) -> ()
+}
 -/
-#guard_msgs in #eval String.toFormat <| Com.toPrint [llvm| {
+#guard_msgs in #eval Com.printModule [llvm| {
   ^bb0(%x: i64, %y: i64):
     %z = "llvm.mul"(%x, %y) {overflowFlags = #llvm.overflow<"nsw">} : (i64, i64) -> (i64)
     "llvm.return"(%z) : (i64) -> ()
 }]
 /--
-info: builtin.module { ⏎
-^bb0(%0 : i64, %1 : i64):
-  %2 = "llvm."llvm.mul false true""(%0, %1)<{overflowFlags = #llvm.overflow<nuw>}> : (i64, i64) -> (i64)
-  "llvm.return"(%2) : (i64) -> ()
- }
+info: builtin.module {
+  ^bb0(%0 : i64, %1 : i64):
+    %2 = "llvm.mul"(%0, %1)<{overflowFlags = #llvm.overflow<nuw>}> : (i64, i64) -> (i64)
+    "llvm.return"(%2) : (i64) -> ()
+}
 -/
-#guard_msgs in #eval String.toFormat <| Com.toPrint [llvm| {
+#guard_msgs in #eval Com.printModule [llvm| {
   ^bb0(%x: i64, %y: i64):
     %z = "llvm.mul"(%x, %y) {overflowFlags = #llvm.overflow<"nuw">} : (i64, i64) -> (i64)
     "llvm.return"(%z) : (i64) -> ()
 }]
 /--
-info: builtin.module { ⏎
-^bb0(%0 : i64, %1 : i64):
-  %2 = "llvm."llvm.mul true true""(%0, %1)<{overflowFlags = #llvm.overflow<nsw,nuw>}> : (i64, i64) -> (i64)
-  "llvm.return"(%2) : (i64) -> ()
- }
+info: builtin.module {
+  ^bb0(%0 : i64, %1 : i64):
+    %2 = "llvm.mul"(%0, %1)<{overflowFlags = #llvm.overflow<nsw,nuw>}> : (i64, i64) -> (i64)
+    "llvm.return"(%2) : (i64) -> ()
+}
 -/
-#guard_msgs in #eval String.toFormat <| Com.toPrint [llvm| {
+#guard_msgs in #eval Com.printModule [llvm| {
   ^bb0(%x: i64, %y: i64):
     %z = "llvm.mul"(%x, %y) {overflowFlags = #llvm.overflow<"nsw","nuw">} : (i64, i64) -> (i64)
     "llvm.return"(%z) : (i64) -> ()
@@ -345,13 +345,13 @@ info: builtin.module { ⏎
 /-! #### udiv -/
 
 /--
-info: builtin.module { ⏎
-^bb0(%0 : i64, %1 : i64):
-  %2 = "llvm."llvm.udiv""(%0, %1) : (i64, i64) -> (i64)
-  "llvm.return"(%2) : (i64) -> ()
- }
+info: builtin.module {
+  ^bb0(%0 : i64, %1 : i64):
+    %2 = "llvm.udiv"(%0, %1) : (i64, i64) -> (i64)
+    "llvm.return"(%2) : (i64) -> ()
+}
 -/
-#guard_msgs in #eval String.toFormat <| Com.toPrint [llvm| {
+#guard_msgs in #eval Com.printModule [llvm| {
   ^bb0(%x: i64, %y: i64):
     %z = "llvm.udiv"(%x, %y) : (i64, i64) -> (i64)
     "llvm.return"(%z) : (i64) -> ()
@@ -387,13 +387,13 @@ info: {
 
 /-! #### udiv (exact) -/
 /--
-info: builtin.module { ⏎
-^bb0(%0 : i64, %1 : i64):
-  %2 = "llvm."llvm.udiv exact""(%0, %1)<{isExact}>  : (i64, i64) -> (i64)
-  "llvm.return"(%2) : (i64) -> ()
- }
+info: builtin.module {
+  ^bb0(%0 : i64, %1 : i64):
+    %2 = "llvm.udiv"(%0, %1)<{isExact}>  : (i64, i64) -> (i64)
+    "llvm.return"(%2) : (i64) -> ()
+}
 -/
-#guard_msgs in #eval String.toFormat <| Com.toPrint [llvm| {
+#guard_msgs in #eval Com.printModule [llvm| {
   ^bb0(%x: i64, %y: i64):
     %z = "llvm.udiv"(%x, %y) {isExact} : (i64, i64) -> (i64)
     "llvm.return"(%z) : (i64) -> ()
@@ -402,13 +402,13 @@ info: builtin.module { ⏎
 /-! #### sdiv -/
 
 /--
-info: builtin.module { ⏎
-^bb0(%0 : i64, %1 : i64):
-  %2 = "llvm."llvm.sdiv""(%0, %1) : (i64, i64) -> (i64)
-  "llvm.return"(%2) : (i64) -> ()
- }
+info: builtin.module {
+  ^bb0(%0 : i64, %1 : i64):
+    %2 = "llvm.sdiv"(%0, %1) : (i64, i64) -> (i64)
+    "llvm.return"(%2) : (i64) -> ()
+}
 -/
-#guard_msgs in #eval String.toFormat <| Com.toPrint [llvm| {
+#guard_msgs in #eval Com.printModule [llvm| {
   ^bb0(%x: i64, %y: i64):
     %z = "llvm.sdiv"(%x, %y) : (i64, i64) -> (i64)
     "llvm.return"(%z) : (i64) -> ()
@@ -444,13 +444,13 @@ info: {
 
 /-! #### sdiv (exact) -/
 /--
-info: builtin.module { ⏎
-^bb0(%0 : i64, %1 : i64):
-  %2 = "llvm."llvm.sdiv exact""(%0, %1)<{isExact}>  : (i64, i64) -> (i64)
-  "llvm.return"(%2) : (i64) -> ()
- }
+info: builtin.module {
+  ^bb0(%0 : i64, %1 : i64):
+    %2 = "llvm.sdiv"(%0, %1)<{isExact}>  : (i64, i64) -> (i64)
+    "llvm.return"(%2) : (i64) -> ()
+}
 -/
-#guard_msgs in #eval String.toFormat <| Com.toPrint [llvm| {
+#guard_msgs in #eval Com.printModule [llvm| {
   ^bb0(%x: i64, %y: i64):
     %z = "llvm.sdiv"(%x, %y) {isExact} : (i64, i64) -> (i64)
     "llvm.return"(%z) : (i64) -> ()
@@ -459,13 +459,13 @@ info: builtin.module { ⏎
 /-! #### urem -/
 
 /--
-info: builtin.module { ⏎
-^bb0(%0 : i64, %1 : i64):
-  %2 = "llvm."llvm.urem""(%0, %1) : (i64, i64) -> (i64)
-  "llvm.return"(%2) : (i64) -> ()
- }
+info: builtin.module {
+  ^bb0(%0 : i64, %1 : i64):
+    %2 = "llvm.urem"(%0, %1) : (i64, i64) -> (i64)
+    "llvm.return"(%2) : (i64) -> ()
+}
 -/
-#guard_msgs in #eval String.toFormat <| Com.toPrint [llvm| {
+#guard_msgs in #eval Com.printModule [llvm| {
   ^bb0(%x: i64, %y: i64):
     %z = "llvm.urem"(%x, %y) : (i64, i64) -> (i64)
     "llvm.return"(%z) : (i64) -> ()
@@ -502,13 +502,13 @@ info: {
 /-! #### srem -/
 
 /--
-info: builtin.module { ⏎
-^bb0(%0 : i64, %1 : i64):
-  %2 = "llvm."llvm.srem""(%0, %1) : (i64, i64) -> (i64)
-  "llvm.return"(%2) : (i64) -> ()
- }
+info: builtin.module {
+  ^bb0(%0 : i64, %1 : i64):
+    %2 = "llvm.srem"(%0, %1) : (i64, i64) -> (i64)
+    "llvm.return"(%2) : (i64) -> ()
+}
 -/
-#guard_msgs in #eval String.toFormat <| Com.toPrint [llvm| {
+#guard_msgs in #eval Com.printModule [llvm| {
   ^bb0(%x: i64, %y: i64):
     %z = "llvm.srem"(%x, %y) : (i64, i64) -> (i64)
     "llvm.return"(%z) : (i64) -> ()
@@ -544,13 +544,13 @@ info: {
 
 /-! #### and -/
 /--
-info: builtin.module { ⏎
-^bb0(%0 : i64, %1 : i64):
-  %2 = "llvm."llvm.and""(%0, %1) : (i64, i64) -> (i64)
-  "llvm.return"(%2) : (i64) -> ()
- }
+info: builtin.module {
+  ^bb0(%0 : i64, %1 : i64):
+    %2 = "llvm.and"(%0, %1) : (i64, i64) -> (i64)
+    "llvm.return"(%2) : (i64) -> ()
+}
 -/
-#guard_msgs in #eval String.toFormat <| Com.toPrint [llvm| {
+#guard_msgs in #eval Com.printModule [llvm| {
   ^bb0(%x: i64, %y: i64):
     %z = "llvm.and"(%x, %y) : (i64, i64) -> (i64)
     "llvm.return"(%z) : (i64) -> ()
@@ -582,13 +582,13 @@ info: {
 
 /-! #### or -/
 /--
-info: builtin.module { ⏎
-^bb0(%0 : i64, %1 : i64):
-  %2 = "llvm."llvm.or""(%0, %1) : (i64, i64) -> (i64)
-  "llvm.return"(%2) : (i64) -> ()
- }
+info: builtin.module {
+  ^bb0(%0 : i64, %1 : i64):
+    %2 = "llvm.or"(%0, %1) : (i64, i64) -> (i64)
+    "llvm.return"(%2) : (i64) -> ()
+}
 -/
-#guard_msgs in #eval String.toFormat <| Com.toPrint [llvm| {
+#guard_msgs in #eval Com.printModule [llvm| {
   ^bb0(%x: i64, %y: i64):
     %z = "llvm.or"(%x, %y) : (i64, i64) -> (i64)
     "llvm.return"(%z) : (i64) -> ()
@@ -620,13 +620,13 @@ info: {
 
 /-! #### xor -/
 /--
-info: builtin.module { ⏎
-^bb0(%0 : i64, %1 : i64):
-  %2 = "llvm."llvm.xor""(%0, %1) : (i64, i64) -> (i64)
-  "llvm.return"(%2) : (i64) -> ()
- }
+info: builtin.module {
+  ^bb0(%0 : i64, %1 : i64):
+    %2 = "llvm.xor"(%0, %1) : (i64, i64) -> (i64)
+    "llvm.return"(%2) : (i64) -> ()
+}
 -/
-#guard_msgs in #eval String.toFormat <| Com.toPrint [llvm| {
+#guard_msgs in #eval Com.printModule [llvm| {
   ^bb0(%x: i64, %y: i64):
     %z = "llvm.xor"(%x, %y) : (i64, i64) -> (i64)
     "llvm.return"(%z) : (i64) -> ()
@@ -658,13 +658,13 @@ info: {
 
 /-! #### not -/
 /--
-info: builtin.module { ⏎
-^bb0(%0 : i64):
-  %1 = "llvm."InstCombine.MOp.UnaryOp.not""(%0) : (i64) -> (i64)
-  "llvm.return"(%1) : (i64) -> ()
- }
+info: builtin.module {
+  ^bb0(%0 : i64):
+    %1 = "llvm.not"(%0) : (i64) -> (i64)
+    "llvm.return"(%1) : (i64) -> ()
+}
 -/
-#guard_msgs in #eval String.toFormat <| Com.toPrint [llvm| {
+#guard_msgs in #eval Com.printModule [llvm| {
   ^bb0(%x: i64):
     %z = "llvm.not"(%x) : (i64) -> (i64)
     "llvm.return"(%z) : (i64) -> ()
@@ -696,13 +696,13 @@ info: {
 
 /-! #### neg -/
 /--
-info: builtin.module { ⏎
-^bb0(%0 : i64):
-  %1 = "llvm."InstCombine.MOp.UnaryOp.neg""(%0) : (i64) -> (i64)
-  "llvm.return"(%1) : (i64) -> ()
- }
+info: builtin.module {
+  ^bb0(%0 : i64):
+    %1 = "llvm.neg"(%0) : (i64) -> (i64)
+    "llvm.return"(%1) : (i64) -> ()
+}
 -/
-#guard_msgs in #eval String.toFormat <| Com.toPrint [llvm| {
+#guard_msgs in #eval Com.printModule [llvm| {
   ^bb0(%x: i64):
     %z = "llvm.neg"(%x) : (i64) -> (i64)
     "llvm.return"(%z) : (i64) -> ()
@@ -734,13 +734,13 @@ info: {
 
 /-! #### copy -/
 /--
-info: builtin.module { ⏎
-^bb0(%0 : i64):
-  %1 = "llvm."InstCombine.MOp.UnaryOp.copy""(%0) : (i64) -> (i64)
-  "llvm.return"(%1) : (i64) -> ()
- }
+info: builtin.module {
+  ^bb0(%0 : i64):
+    %1 = "llvm.copy"(%0) : (i64) -> (i64)
+    "llvm.return"(%1) : (i64) -> ()
+}
 -/
-#guard_msgs in #eval String.toFormat <| Com.toPrint [llvm| {
+#guard_msgs in #eval Com.printModule [llvm| {
   ^bb0(%x: i64):
     %z = "llvm.copy"(%x) : (i64) -> (i64)
     "llvm.return"(%z) : (i64) -> ()
@@ -772,13 +772,13 @@ info: {
 
 /-! #### shl -/
 /--
-info: builtin.module { ⏎
-^bb0(%0 : i64, %1 : i64):
-  %2 = "llvm."llvm.shl""(%0, %1)<{overflowFlags = #llvm.overflow<none>}> : (i64, i64) -> (i64)
-  "llvm.return"(%2) : (i64) -> ()
- }
+info: builtin.module {
+  ^bb0(%0 : i64, %1 : i64):
+    %2 = "llvm.shl"(%0, %1)<{overflowFlags = #llvm.overflow<none>}> : (i64, i64) -> (i64)
+    "llvm.return"(%2) : (i64) -> ()
+}
 -/
-#guard_msgs in #eval String.toFormat <| Com.toPrint [llvm| {
+#guard_msgs in #eval Com.printModule [llvm| {
   ^bb0(%x: i64, %y: i64):
     %z = "llvm.shl"(%x, %y) : (i64, i64) -> (i64)
     "llvm.return"(%z) : (i64) -> ()
@@ -810,37 +810,37 @@ info: {
 
 /-! #### shl (flags) -/
 /--
-info: builtin.module { ⏎
-^bb0(%0 : i64, %1 : i64):
-  %2 = "llvm."llvm.shl true false""(%0, %1)<{overflowFlags = #llvm.overflow<nsw>}> : (i64, i64) -> (i64)
-  "llvm.return"(%2) : (i64) -> ()
- }
+info: builtin.module {
+  ^bb0(%0 : i64, %1 : i64):
+    %2 = "llvm.shl"(%0, %1)<{overflowFlags = #llvm.overflow<nsw>}> : (i64, i64) -> (i64)
+    "llvm.return"(%2) : (i64) -> ()
+}
 -/
-#guard_msgs in #eval String.toFormat <| Com.toPrint [llvm| {
+#guard_msgs in #eval Com.printModule [llvm| {
   ^bb0(%x: i64, %y: i64):
     %z = "llvm.shl"(%x, %y) {overflowFlags = #llvm.overflow<"nsw">} : (i64, i64) -> (i64)
     "llvm.return"(%z) : (i64) -> ()
 }]
 /--
-info: builtin.module { ⏎
-^bb0(%0 : i64, %1 : i64):
-  %2 = "llvm."llvm.shl false true""(%0, %1)<{overflowFlags = #llvm.overflow<nuw>}> : (i64, i64) -> (i64)
-  "llvm.return"(%2) : (i64) -> ()
- }
+info: builtin.module {
+  ^bb0(%0 : i64, %1 : i64):
+    %2 = "llvm.shl"(%0, %1)<{overflowFlags = #llvm.overflow<nuw>}> : (i64, i64) -> (i64)
+    "llvm.return"(%2) : (i64) -> ()
+}
 -/
-#guard_msgs in #eval String.toFormat <| Com.toPrint [llvm| {
+#guard_msgs in #eval Com.printModule [llvm| {
   ^bb0(%x: i64, %y: i64):
     %z = "llvm.shl"(%x, %y) {overflowFlags = #llvm.overflow<"nuw">} : (i64, i64) -> (i64)
     "llvm.return"(%z) : (i64) -> ()
 }]
 /--
-info: builtin.module { ⏎
-^bb0(%0 : i64, %1 : i64):
-  %2 = "llvm."llvm.shl true true""(%0, %1)<{overflowFlags = #llvm.overflow<nsw,nuw>}> : (i64, i64) -> (i64)
-  "llvm.return"(%2) : (i64) -> ()
- }
+info: builtin.module {
+  ^bb0(%0 : i64, %1 : i64):
+    %2 = "llvm.shl"(%0, %1)<{overflowFlags = #llvm.overflow<nsw,nuw>}> : (i64, i64) -> (i64)
+    "llvm.return"(%2) : (i64) -> ()
+}
 -/
-#guard_msgs in #eval String.toFormat <| Com.toPrint [llvm| {
+#guard_msgs in #eval Com.printModule [llvm| {
   ^bb0(%x: i64, %y: i64):
     %z = "llvm.shl"(%x, %y) {overflowFlags = #llvm.overflow<"nsw","nuw">} : (i64, i64) -> (i64)
     "llvm.return"(%z) : (i64) -> ()
@@ -848,13 +848,13 @@ info: builtin.module { ⏎
 
 /-! #### lshr -/
 /--
-info: builtin.module { ⏎
-^bb0(%0 : i64, %1 : i64):
-  %2 = "llvm."llvm.lshr""(%0, %1) : (i64, i64) -> (i64)
-  "llvm.return"(%2) : (i64) -> ()
- }
+info: builtin.module {
+  ^bb0(%0 : i64, %1 : i64):
+    %2 = "llvm.lshr"(%0, %1) : (i64, i64) -> (i64)
+    "llvm.return"(%2) : (i64) -> ()
+}
 -/
-#guard_msgs in #eval String.toFormat <| Com.toPrint [llvm| {
+#guard_msgs in #eval Com.printModule [llvm| {
   ^bb0(%x: i64, %y: i64):
     %z = "llvm.lshr"(%x, %y) : (i64, i64) -> (i64)
     "llvm.return"(%z) : (i64) -> ()
@@ -888,13 +888,13 @@ info: {
 
 /-! #### ashr -/
 /--
-info: builtin.module { ⏎
-^bb0(%0 : i64, %1 : i64):
-  %2 = "llvm."llvm.ashr""(%0, %1) : (i64, i64) -> (i64)
-  "llvm.return"(%2) : (i64) -> ()
- }
+info: builtin.module {
+  ^bb0(%0 : i64, %1 : i64):
+    %2 = "llvm.ashr"(%0, %1) : (i64, i64) -> (i64)
+    "llvm.return"(%2) : (i64) -> ()
+}
 -/
-#guard_msgs in #eval String.toFormat <| Com.toPrint [llvm| {
+#guard_msgs in #eval Com.printModule [llvm| {
   ^bb0(%x: i64, %y: i64):
     %z = "llvm.ashr"(%x, %y) : (i64, i64) -> (i64)
     "llvm.return"(%z) : (i64) -> ()
@@ -928,13 +928,13 @@ info: {
 
 /-! #### trunc -/
 /--
-info: builtin.module { ⏎
-^bb0(%0 : i64):
-  %1 = "llvm."InstCombine.MOp.UnaryOp.trunc (ConcreteOrMVar.concrete 64) { nsw := false, nuw := false }""(%0) : (i64) -> (i64)
-  "llvm.return"(%1) : (i64) -> ()
- }
+info: builtin.module {
+  ^bb0(%0 : i64):
+    %1 = "llvm.trunc"(%0) : (i64) -> (i64)
+    "llvm.return"(%1) : (i64) -> ()
+}
 -/
-#guard_msgs in #eval String.toFormat <| Com.toPrint [llvm| {
+#guard_msgs in #eval Com.printModule [llvm| {
   ^bb0(%x: i64):
     %z = "llvm.trunc"(%x) : (i64) -> (i64)
     "llvm.return"(%z) : (i64) -> ()
@@ -968,13 +968,13 @@ info: {
 
 /-! #### zext -/
 /--
-info: builtin.module { ⏎
-^bb0(%0 : i64):
-  %1 = "llvm."InstCombine.MOp.UnaryOp.zext (ConcreteOrMVar.concrete 64) { nneg := false }""(%0) : (i64) -> (i64)
-  "llvm.return"(%1) : (i64) -> ()
- }
+info: builtin.module {
+  ^bb0(%0 : i64):
+    %1 = "llvm.zext"(%0) : (i64) -> (i64)
+    "llvm.return"(%1) : (i64) -> ()
+}
 -/
-#guard_msgs in #eval String.toFormat <| Com.toPrint [llvm| {
+#guard_msgs in #eval Com.printModule [llvm| {
   ^bb0(%x: i64):
     %z = "llvm.zext"(%x) : (i64) -> (i64)
     "llvm.return"(%z) : (i64) -> ()
@@ -1008,13 +1008,13 @@ info: {
 
 /-! #### sext -/
 /--
-info: builtin.module { ⏎
-^bb0(%0 : i64):
-  %1 = "llvm."InstCombine.MOp.UnaryOp.sext (ConcreteOrMVar.concrete 64)""(%0) : (i64) -> (i64)
-  "llvm.return"(%1) : (i64) -> ()
- }
+info: builtin.module {
+  ^bb0(%0 : i64):
+    %1 = "llvm.sext"(%0) : (i64) -> (i64)
+    "llvm.return"(%1) : (i64) -> ()
+}
 -/
-#guard_msgs in #eval String.toFormat <| Com.toPrint [llvm| {
+#guard_msgs in #eval Com.printModule [llvm| {
   ^bb0(%x: i64):
     %z = "llvm.sext"(%x) : (i64) -> (i64)
     "llvm.return"(%z) : (i64) -> ()
@@ -1048,13 +1048,13 @@ info: {
 
 /-! #### select -/
 /--
-info: builtin.module { ⏎
-^bb0(%0 : i1, %1 : i64, %2 : i64):
-  %3 = "llvm.select"(%0, %1, %2) : (i1, i64, i64) -> (i64)
-  "llvm.return"(%3) : (i64) -> ()
- }
+info: builtin.module {
+  ^bb0(%0 : i1, %1 : i64, %2 : i64):
+    %3 = "llvm.select"(%0, %1, %2) : (i1, i64, i64) -> (i64)
+    "llvm.return"(%3) : (i64) -> ()
+}
 -/
-#guard_msgs in #eval String.toFormat <| Com.toPrint [llvm| {
+#guard_msgs in #eval Com.printModule [llvm| {
   ^bb0(%cond: i1, %x: i64, %y: i64):
     %z = "llvm.select"(%cond, %x, %y) : (i1, i64, i64) -> (i64)
     "llvm.return"(%z) : (i64) -> ()
@@ -1086,13 +1086,13 @@ info: {
 
 /-! #### icmp -/
 /--
-info: builtin.module { ⏎
-^bb0(%0 : i64, %1 : i64):
-  %2 = "llvm.icmp"(%0, %1)eq : (i64, i64) -> (i1)
-  "llvm.return"(%2) : (i1) -> ()
- }
+info: builtin.module {
+  ^bb0(%0 : i64, %1 : i64):
+    %2 = "llvm.icmp.eq"(%0, %1)eq : (i64, i64) -> (i1)
+    "llvm.return"(%2) : (i1) -> ()
+}
 -/
-#guard_msgs in #eval String.toFormat <| Com.toPrint [llvm| {
+#guard_msgs in #eval Com.printModule [llvm| {
   ^bb0(%x: i64, %y: i64):
     %z = "llvm.icmp.eq"(%x, %y) : (i64, i64) -> (i1)
     "llvm.return"(%z) : (i1) -> ()
@@ -1124,13 +1124,13 @@ info: {
 
 /-! #### const -/
 /--
-info: builtin.module { ⏎
-^bb0():
-  %0 = "llvm."llvm.mlir.constant"() {value = 42 : i64}"() {value = 42 : i64} : () -> (i64)
-  "llvm.return"(%0) : (i64) -> ()
- }
+info: builtin.module {
+  ^bb0():
+    %0 = "llvm.const"(){value = 42 : i64} : () -> (i64)
+    "llvm.return"(%0) : (i64) -> ()
+}
 -/
-#guard_msgs in #eval String.toFormat <| Com.toPrint [llvm| {
+#guard_msgs in #eval Com.printModule [llvm| {
   ^bb0():
     %z = "llvm.mlir.constant"() {value = 42 : i64} : () -> (i64)
     "llvm.return"(%z) : (i64) -> ()

--- a/SSA/Projects/LLVMRiscV/LLVMAndRiscv.lean
+++ b/SSA/Projects/LLVMRiscV/LLVMAndRiscv.lean
@@ -48,11 +48,15 @@ abbrev LLVMPlusRiscV : Dialect where
   Op := Op
   Ty := Ty
 
+/-! ### Type Semantics -/
+
 @[simp]
 instance : TyDenote LLVMPlusRiscV.Ty where
   toType := fun
     | .llvm llvmTy => TyDenote.toType llvmTy
     | .riscv riscvTy => TyDenote.toType riscvTy
+
+/-! ### Operation Signatures -/
 
 @[simp]
 instance LLVMPlusRiscVSignature : DialectSignature LLVMPlusRiscV where
@@ -63,6 +67,8 @@ instance LLVMPlusRiscVSignature : DialectSignature LLVMPlusRiscV where
       {sig := [Ty.riscv .bv], returnTypes := [Ty.llvm (.bitvec w)], regSig := []}
   | .castLLVM w =>
       {sig := [Ty.llvm (.bitvec w)], returnTypes := [Ty.riscv .bv], regSig := []}
+
+/-! ### Printing -/
 
 instance : ToString LLVMPlusRiscV.Op  where
   toString := fun

--- a/SSA/Projects/LLVMRiscV/LLVMAndRiscv.lean
+++ b/SSA/Projects/LLVMRiscV/LLVMAndRiscv.lean
@@ -70,33 +70,34 @@ instance LLVMPlusRiscVSignature : DialectSignature LLVMPlusRiscV where
 
 /-! ### Printing -/
 
-instance : ToString LLVMPlusRiscV.Op  where
-  toString := fun
-  | .llvm llvm    => toString llvm
-  | .riscv riscv  => toString riscv
-  | .castLLVM _ => "builtin.unrealized_conversion_cast"
-  | .castRiscv _  => "builtin.unrealized_conversion_cast"
+-- instance : ToString LLVMPlusRiscV.Op  where
+--   toString := fun
+--   | .llvm llvm    => toString llvm
+--   | .riscv riscv  => toString riscv
+--   | .castLLVM _ => "builtin.unrealized_conversion_cast"
+--   | .castRiscv _  => "builtin.unrealized_conversion_cast"
 
-instance LLVMAndRiscvPrint : ToPrint (LLVMPlusRiscV) where
+open DialectPrint in
+instance LLVMAndRiscvPrint : DialectPrint LLVMPlusRiscV where
   printOpName
-    |.llvm llvmOp => ToPrint.printOpName llvmOp
-    |.riscv riscvOp => ToPrint.printOpName riscvOp
-    |_ => "builtin.unrealized_conversion_cast"
+    | .llvm llvmOp => printOpName llvmOp
+    | .riscv riscvOp => printOpName riscvOp
+    | _ => "builtin.unrealized_conversion_cast"
   printTy
-    | .llvm llvmTy => ToPrint.printTy llvmTy
-    | .riscv riscvTy => ToPrint.printTy riscvTy
+    | .llvm llvmTy => printTy llvmTy
+    | .riscv riscvTy => printTy riscvTy
   printAttributes
-    |.llvm llvmOp => ToPrint.printAttributes llvmOp
-    |.riscv riscvOp => ToPrint.printAttributes riscvOp
-    |_ => ""
-  printDialect := "riscv"
-  printReturn ty := match ty with
-    | [.llvm llvmTy] => ToPrint.printReturn [llvmTy]
-    | [.riscv riscvTy] =>  ToPrint.printReturn [riscvTy]
+    | .llvm llvmOp => printAttributes llvmOp
+    | .riscv riscvOp => printAttributes riscvOp
+    | _ => ""
+  dialectName := "riscv"
+  printReturn := fun
+    | [.llvm llvmTy] => printReturn [llvmTy]
+    | [.riscv riscvTy] =>  printReturn [riscvTy]
     | _ => s!"<ERROR: mallformed return>"
-  printFunc ty := match ty with
-    | [.llvm llvmTy]   => ToPrint.printFunc [llvmTy]
-    | [.riscv riscvTy] => ToPrint.printFunc [riscvTy]
+  printFunc := fun
+    | [.llvm llvmTy]   => printFunc [llvmTy]
+    | [.riscv riscvTy] => printFunc [riscvTy]
     | _ => s!"<ERROR: mallformed func>"
 
 instance : ToString LLVMPlusRiscV.Ty where

--- a/SSA/Projects/LLVMRiscV/ParseAndTransform.lean
+++ b/SSA/Projects/LLVMRiscV/ParseAndTransform.lean
@@ -44,7 +44,7 @@ def passriscv64 (fileName : String) : IO UInt32 := do
             `true` indicates pseudo variable lowering, `fuel` is 150-/
           let lowered := selectionPipeFuelWithCSE 150 c true
 
-          IO.println s!"{Com.toPrint (lowered) }"
+          IO.println <| lowered.printModule
           return 0
         | _ =>
         IO.println s!" debug: WRONG RETURN TYPE : expected Ty.llvm (Ty.bitvec 64) "
@@ -70,7 +70,7 @@ def passriscv64_optimized (fileName : String) : IO UInt32 := do
           /- calls to the optimized instruction selector defined in `InstructionLowering`,
           `true` indicates pseudo variable lowering, `fuel` is 150 -/
           let lowered := selectionPipeFuelWithCSEWithOpt 150 c true
-          IO.println s!"{Com.toPrint (lowered) }"
+          IO.println <| lowered.printModule
           return 0
         | _ =>
         IO.println s!" debug: WRONG RETURN TYPE : expected Ty.llvm (Ty.bitvec 64) "

--- a/SSA/Projects/RISCV64/Base.lean
+++ b/SSA/Projects/RISCV64/Base.lean
@@ -1,11 +1,13 @@
 import SSA.Projects.RISCV64.Semantics
 import SSA.Projects.RISCV64.PseudoOpSemantics
-import SSA.Core.Framework
+import SSA.Core
 
 open RV64Semantics
 open RV64PseudoOpSemantics
 
 namespace RISCV64
+open LeanMLIR
+
 /-! ## The `RISCV64` dialect -/
 
 /-! ## Dialect operation definitions -/
@@ -158,25 +160,17 @@ inductive Ty
   | bv : Ty
   deriving DecidableEq, Repr, Inhabited, Lean.ToExpr
 
-instance : ToString (Ty) where
-  toString t := match t with
-  | Ty.bv => "bv"
-
 /-!
 Connecting the `bv` type to its underlying Lean type `BitVec 64`. By providing a `TyDenote` instance,
 we define how the `RISCV64` types transalte into actual Lean types.
 -/
 instance : TyDenote Ty where
-  toType := fun
+  toType
   | Ty.bv => BitVec 64
 
 instance (ty : Ty) : Inhabited (TyDenote.toType ty) where
   default := match ty with
   | .bv  => 0#64
-
-instance : ToString (Ty) where
-  toString t :=  match t with
-  | Ty.bv => "!riscv.reg"
 
 /-! ## Dialect operation definitions-/
 /--
@@ -407,24 +401,29 @@ instance : DialectSignature RV64 where
 
 /-! ## Printing -/
 
-def opToString (op : RISCV64.Op) : String :=
+instance : ToString Ty where
+  toString
+  | Ty.bv => "!riscv.reg"
+
+open RISCV64.Op in
+def opName (op : RISCV64.Op) : String :=
   let op  : String := match op with
-  | .li (_imm : BitVec 64) => "li"
+  | .li _ => "li"
   | .mulh => "mulh"
   | .mulhu => "mulhu"
   | .mulhsu => "mulhsu"
   | .divu => "divu"
   | .remuw => "remuw"
   | .remu => "remu"
-  | .addiw (_imm : BitVec 12) => "addiw"
-  | .lui (_imm : BitVec 20) => "lui"
-  | .auipc (_imm : BitVec 20) => "auipc"
-  | .slliw (_shamt : BitVec 5) => "slliw"
-  | .srliw (_shamt : BitVec 5) => "srliw"
-  | .sraiw (_shamt : BitVec 5) => "sraiw"
-  | .slli (_shamt : BitVec 6) => "slli"
-  | .srli (_shamt : BitVec 6) => "srli"
-  | .srai (_shamt : BitVec 6) => "srai"
+  | .addiw _ => "addiw"
+  | .lui _ => "lui"
+  | .auipc _ => "auipc"
+  | .slliw _ => "slliw"
+  | .srliw _ => "srliw"
+  | .sraiw _ => "sraiw"
+  | .slli _ => "slli"
+  | .srli _ => "srli"
+  | .srai _ => "srai"
   | .addw => "addw"
   | .subw => "subw"
   | .sllw => "sllw"
@@ -447,68 +446,60 @@ def opToString (op : RISCV64.Op) : String :=
   | .div => "div"
   | .divw => "divw"
   | .divuw => "divuw"
-  | .addi (_imm : BitVec 12) => "addi"
-  | .slti (_imm : BitVec 12) => "slti"
-  | .sltiu (_imm : BitVec 12) => "sltiu"
-  | .andi (_imm : BitVec 12) => "andi"
-  | .ori (_imm : BitVec 12) => "ori"
-  | .xori (_imm : BitVec 12) => "xori"
-  | RISCV64.Op.czero.eqz => "czero.eqz"
-  | RISCV64.Op.czero.nez => "czero.nez"
+  | .addi _ => "addi"
+  | .slti _ => "slti"
+  | .sltiu _ => "sltiu"
+  | .andi _ => "andi"
+  | .ori _ => "ori"
+  | .xori _ => "xori"
+  | czero.eqz => "czero.eqz"
+  | czero.nez => "czero.nez"
   | .bclr => "bclr"
   | .bext => "bext"
   | .binv => "binv"
   | .bset => "bset"
-  | .bclri (_shamt : BitVec 6) => "bclri"
-  | .bexti (_shamt : BitVec 6) => "bexti"
-  | .binvi (_shamt : BitVec 6) => "binvi"
-  | .bseti (_shamt : BitVec 6) => "bseti"
-  | RISCV64.Op.add.uw => "add.uw"
-  | RISCV64.Op.sh1add.uw => "sh1add.uw"
-  | RISCV64.Op.sh2add.uw => "sh2add.uw"
-  | RISCV64.Op.sh3add.uw => "sh3add.uw"
+  | .bclri _ => "bclri"
+  | .bexti _ => "bexti"
+  | .binvi _ => "binvi"
+  | .bseti _ => "bseti"
+  | add.uw => "add.uw"
+  | sh1add.uw => "sh1add.uw"
+  | sh2add.uw => "sh2add.uw"
+  | sh3add.uw => "sh3add.uw"
   | .sh1add => "sh1add"
   | .sh2add => "sh2add"
   | .sh3add => "sh3add"
-  | RISCV64.Op.slli.uw (_shamt : BitVec 6) => "slli.uw"
+  | slli.uw _ => "slli.uw"
   | .andn => "andn"
   | .orn => "orn"
   | .xnor => "xnor"
-  -- | clz
-  -- | clzw
-  -- | ctz
-  -- | ctzw
-  -- | cpop
-  -- | cpopw
   | .max => "max"
   | .maxu => "maxu"
   | .min  => "min"
   | .minu  => "minu"
-  | RISCV64.Op.sext.b => "sext.b"
-  | RISCV64.Op.sext.h => "sext.h"
-  | RISCV64.Op.zext.h => "zext.h"
+  | sext.b => "sext.b"
+  | sext.h => "sext.h"
+  | zext.h => "zext.h"
   | .rol => "rol"
   | .rolw => "rolw"
   | .ror => "ror"
-  | .rori (_shamt : BitVec 5) => "rori"
-  | .roriw (_shamt : BitVec 5) => "roriw"
+  | .rori _ => "rori"
+  | .roriw _ => "roriw"
   | .rorw => "rorw"
-  -- orc.b
-  -- rev8
   -- pseudo-instructions
   | .mv => "mv"
   | .not => "not"
   | .neg => "neg"
   | .negw => "negw"
-  | RISCV64.Op.sext.w => "sext.w"
-  | RISCV64.Op.zext.b => "zext.b"
+  | sext.w => "sext.w"
+  | zext.b => "zext.b"
   | .seqz => "seqz"
   | .snez => "snez"
   | .sltz => "sltz"
   | .sgtz => "sgtz"
   op
 
-def attributesToPrint: RISCV64.Op → String
+def printAttributes: RISCV64.Op → String
   | .li imm => s! "\{immediate = { imm.toInt } : i64 }"
   | .addiw (imm : BitVec 12) => s!"\{immediate = { imm.toInt} : i12 }"
   | .lui (imm : BitVec 20) => s!"\{immediate = { imm.toInt} : i20 } "
@@ -534,15 +525,11 @@ def attributesToPrint: RISCV64.Op → String
   | .roriw (imm : BitVec 5) => s!"\{immediate = { imm.toInt} : i5 }"
   | _ => ""
 
-instance : ToString (Op) where
-  toString := opToString
-
-instance : ToPrint (RV64) where
-  printOpName
-  | op => "riscv." ++ toString op
+instance : DialectPrint RV64 where
+  printOpName op := "riscv." ++ opName op
   printTy := toString
-  printAttributes := attributesToPrint
-  printDialect:= "riscv"
+  printAttributes := printAttributes
+  dialectName := "riscv"
   printReturn _ := "riscv.ret"
   printFunc _ := "riscv_func.func @f"
 

--- a/SSA/Projects/RISCV64/Base.lean
+++ b/SSA/Projects/RISCV64/Base.lean
@@ -405,6 +405,8 @@ abbrev RV64 : Dialect where
 instance : DialectSignature RV64 where
   signature o := {sig := Op.sig o, returnTypes := [Op.outTy o], regSig := []}
 
+/-! ## Printing -/
+
 def opToString (op : RISCV64.Op) : String :=
   let op  : String := match op with
   | .li (_imm : BitVec 64) => "li"

--- a/SSA/Projects/RISCV64/ParseAndTransform.lean
+++ b/SSA/Projects/RISCV64/ParseAndTransform.lean
@@ -36,7 +36,7 @@ def parseAsRiscv (fileName : String ) : IO UInt32 := do
   match icom? with
   | none => return 1
   | some (Sigma.mk _Γ ⟨_eff, ⟨_retTy, c⟩⟩) => do
-    IO.println c.toPrintModule
+    IO.println c.printModule
     return 0
 
 private def test_simple := [RV64_com| {

--- a/SSA/Projects/RISCV64/ParseAndTransform.lean
+++ b/SSA/Projects/RISCV64/ParseAndTransform.lean
@@ -36,7 +36,7 @@ def parseAsRiscv (fileName : String ) : IO UInt32 := do
   match icom? with
   | none => return 1
   | some (Sigma.mk _Γ ⟨_eff, ⟨_retTy, c⟩⟩) => do
-    IO.println s!"{Com.toPrint c}"
+    IO.println c.toPrintModule
     return 0
 
 private def test_simple := [RV64_com| {


### PR DESCRIPTION
This PR cleans up printing via the `ToPrint` typeclass

* Firstly, we rename the class to `DialectPrint` and generally rename a lot of the methods with more informative names
* The class is also moved to the dedicated Print.lean file
* We add a lot more documentation
* We separate out a function which prints with an implicit `builtin.module`, which is now called `Com.printModule` and a function which prints normally, which is now called `Com.print`
* We remove a lot of unnecessary typeclass assumptions
* We refactor `Com.print` to return a `Format`, and use it internally to ensure consistent indentation and alignment.
* We change the LLVM dialect print instance to no longer double print the llvm. prefix, and fix the bug where flags were being printed as part of the Op name

For now, we don't touch the other two printing methods, but in future these will be unified, and the functions added in this PR will be the canonical implementation

