### PR TITLE
feat: DialectParse convenience class 

### DIFF
--- a/SSA/Core.lean
+++ b/SSA/Core.lean
@@ -10,5 +10,6 @@ import SSA.Core.Util
 
 import SSA.Core.MLIRSyntax
 import SSA.Core.MLIRSyntax.EDSL2
+import SSA.Core.MLIRSyntax.Transform.Utils
 
 import SSA.Core.Transforms.Rewrite

--- a/SSA/Core/Framework/Print.lean
+++ b/SSA/Core/Framework/Print.lean
@@ -206,8 +206,8 @@ variable {d} [DialectPrint d]
 
 namespace DialectPrint
 
-instance instToStringTy : ToString (Dialect.Ty d) where
-  toString := printTy
+instance instToStringTy : ToString (Dialect.Ty d) where toString := printTy
+instance instReprTy : Repr (Dialect.Ty d) where reprPrec t _ := printTy t
 
 /--
 Given the context `Γ` of a `Com`, print the arguments and their types of the

--- a/SSA/Core/MLIRSyntax/Transform.lean
+++ b/SSA/Core/MLIRSyntax/Transform.lean
@@ -73,6 +73,8 @@ class TransformTy (d : Dialect) (φ : outParam Nat) [DialectSignature d]  where
 class TransformExpr (d : Dialect) (φ : outParam Nat) [DialectSignature d] [TransformTy d φ]  where
   mkExpr   : (Γ : Ctxt d.Ty) → (opStx : AST.Op φ) → ReaderM d (Σ eff ty, Expr d Γ eff ty)
 
+/-- NOTE: You probably don't wan't to implement this class directly, consider
+implementing `LeanMLIR.DialectParse` instead! -/
 class TransformReturn (d : Dialect) (φ : outParam Nat) [DialectSignature d] [TransformTy d φ] where
   mkReturn : (Γ : Ctxt d.Ty) → (opStx : AST.Op φ) → ReaderM d (Σ eff ty, Com d Γ eff ty)
 

--- a/SSA/Tests/Core/Print.lean
+++ b/SSA/Tests/Core/Print.lean
@@ -1,0 +1,90 @@
+import SSA.Core
+import Qq
+
+/-!
+# Printing with Multiple return values
+
+This file has tests for printing expressions with multiple (or no) return
+values.
+-/
+namespace LeanMLIR.Tests
+
+/-!
+## Setup: Test Dialect
+To begin, we need to define a dialect to use in testing
+-/
+
+inductive Ty
+  | int
+  /-- a pair of ints -/
+  | int2
+  deriving DecidableEq, Lean.ToExpr
+
+inductive Op
+  | noop
+  | mkPair
+  | unPair
+  deriving Lean.ToExpr
+
+def TestDialect : Dialect where
+  Ty := Ty
+  Op := Op
+
+instance : TyDenote TestDialect.Ty where toType
+  | .int => Int
+  | .int2 => Int × Int
+
+def_signature for TestDialect
+  | .noop => () -> []
+  | .mkPair => (.int, .int) -> .int2
+  | .unPair => (.int2) -> [.int, .int]
+
+def_denote for TestDialect
+  | .noop => []ₕ
+  | .unPair => fun (x, y) => [x, y]ₕ
+  | .mkPair => fun x y => [(x, y)]ₕ
+
+/-! ### Printing -/
+
+instance : DialectPrint TestDialect where
+  printOpName
+    | .noop => "noop"
+    | .unPair => "un_pair"
+    | .mkPair => "pair"
+  printAttributes _ := ""
+  printTy
+    | .int => "int"
+    | .int2 => "int2"
+  dialectName := "test"
+  printReturn _ := "return"
+  printFunc _ := "^entry"
+
+/-! ### Parsing -/
+
+instance : DecidableEq TestDialect.Ty := by unfold TestDialect; infer_instance
+instance : DialectParse TestDialect 0 where
+  mkTy
+    | .undefined "int" => return .int
+    | .undefined "int2" => return .int2
+    | _ => throw .unsupportedType
+  isValidReturn _ stx := return (stx.name == "return")
+  mkExpr Γ opStx := do
+    let op : TestDialect.Op ← match opStx.name with
+      | "test.noop"     => pure .noop
+      | "test.un_pair"  => pure .unPair
+      | "test.pair"     => pure .mkPair
+      | opName => throw <| .unsupportedOp opName
+    opStx.mkExprOf Γ op
+
+/-! ### EDSL -/
+
+instance : Lean.ToExpr TestDialect.Op := by unfold TestDialect; infer_instance
+instance : Lean.ToExpr TestDialect.Ty := by unfold TestDialect; infer_instance
+
+open Qq in
+instance : DialectToExpr TestDialect where
+  toExprM := q(Id)
+  toExprDialect := q(TestDialect)
+
+elab "[test| "  reg:mlir_region "]" : term => do
+  SSA.elabIntoCom' reg TestDialect

--- a/SSA/Tests/Core/Tests.lean
+++ b/SSA/Tests/Core/Tests.lean
@@ -1,0 +1,2 @@
+import SSA.Tests.Core.Refinement
+import SSA.Tests.Core.Print

--- a/SSA/Tests/Tests.lean
+++ b/SSA/Tests/Tests.lean
@@ -1,1 +1,1 @@
-import SSA.Tests.Core.Refinement
+import SSA.Tests.Core.Tests


### PR DESCRIPTION
This PR adds `DialectParse` as a more convenient way to define a parser for a Dialect, and uses it to define a test dialect with multiple return values.

The goal was primarily building the test dialect, but the ergonomics of the `Transform` classes has been bothering me for a while, so I figured I might as well fix that, too.