### PR TITLE
chore: do not download all of mathlib in docker CI

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,11 +1,11 @@
 name: Build & Evaluate (in Docker)
 on: 
   workflow_dispatch
-  # push:
-  #   branches:
-  #     - "main"
-  # pull_request:
-  # merge_group:
+  push:
+    branches:
+      - "main"
+  pull_request:
+  merge_group:
 
 # ^^ This workflow does not run automatically, to make sure we don't burn through too many
 # namespace.so credits. For now, it is only triggered manually if desired.

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,6 +1,6 @@
 name: Build & Evaluate (in Docker)
 on: 
-  workflow_dispatch
+  workflow_dispatch:
   push:
     branches:
       - "main"

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ RUN --mount=type=cache,target=$HOME/.cache/mathlib,sharing=private,uid=$UID \
   # \
   # Actual Build \
   # \
-  lake exe cache get && lake build && \
+  lake build && \
   # \
   # Persist .lake into Docker image \
   # \

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ RUN --mount=type=cache,target=$HOME/.cache/mathlib,sharing=private,uid=$UID \
   # \
   # Actual Build \
   # \
-  lake build && \
+  lake build --no-cache && \
   # \
   # Persist .lake into Docker image \
   # \

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ RUN --mount=type=cache,target=$HOME/.cache/mathlib,sharing=private,uid=$UID \
   # \
   # Actual Build \
   # \
-  lake build --no-cache && \
+  lake build && \
   # \
   # Persist .lake into Docker image \
   # \


### PR DESCRIPTION
Before this change the docker layer for `lake exe cache get; lake build` was 5.98GB. After dropping `lake exe cache get`, we are at 1.84GB. This reduces the "initialize container" time from `1m23s` to `41s`. Given that the lean install itself has 2GB in size, it may be difficult to go a lot below this.