### PR TITLE
ci: run docker eval on namespace

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -96,8 +96,8 @@ jobs:
   # Evaluation & test jobs
   #
   build-tools:
-    name: tools, scaling, and auto-generated stmts
-    runs-on: namespace-profile-leanmlir-docker-cached (runs on NS)
+    name: use docker (runs on namespace)
+    runs-on: namespace-profile-leanmlir-docker-cached
     needs: core-docker-img
     container: "ghcr.io/opencompl/lean-mlir:${{ github.sha }}"
     defaults:
@@ -115,7 +115,7 @@ jobs:
           lake -R build opt
 
   build-tools-github:
-    name: tools, scaling, and auto-generated stmts (runs on GH)
+    name: use docker (runs on GitHub)
     runs-on: ubuntu-latest # Run on GH-provided runner
     needs: core-docker-img
     container: "ghcr.io/opencompl/lean-mlir:${{ github.sha }}"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -97,7 +97,7 @@ jobs:
   #
   build-tools:
     name: tools, scaling, and auto-generated stmts
-    runs-on: namespace-profile-leanmlir-docker-cached
+    runs-on: namespace-profile-leanmlir-docker-cached (runs on NS)
     needs: core-docker-img
     container: "ghcr.io/opencompl/lean-mlir:${{ github.sha }}"
     defaults:
@@ -115,7 +115,7 @@ jobs:
           lake -R build opt
 
   build-tools-github:
-    name: tools, scaling, and auto-generated stmts
+    name: tools, scaling, and auto-generated stmts (runs on GH)
     runs-on: ubuntu-latest # Run on GH-provided runner
     needs: core-docker-img
     container: "ghcr.io/opencompl/lean-mlir:${{ github.sha }}"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -114,6 +114,25 @@ jobs:
         run: |
           lake -R build opt
 
+  build-tools-github:
+    name: tools, scaling, and auto-generated stmts
+    runs-on: ubuntu-latest # Run on GH-provided runner
+    needs: core-docker-img
+    container: "ghcr.io/opencompl/lean-mlir:${{ github.sha }}"
+    defaults:
+      run:
+        working-directory: /code/lean-mlir
+    steps:
+      - name: Symlink .elan (to correct for GHA changing $HOME)
+        run: '[ -e ~/.elan ] || ln -s /root/.elan ~/.elan'
+      - name: Compile `mlirnatural` Executable 🧐
+        run: |
+          lake -R build mlirnatural
+
+      - name: Compile `opt` Executable 🧐
+        run: |
+          lake -R build opt
+
 #      This broke the build during a recent update
 #      - name: LLVM opt round trip test
 #        run: |

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -106,13 +106,9 @@ jobs:
     steps:
       - name: Symlink .elan (to correct for GHA changing $HOME)
         run: '[ -e ~/.elan ] || ln -s /root/.elan ~/.elan'
-      - name: Compile `mlirnatural` Executable 🧐
+      - name: Run lake build
         run: |
-          lake -R build mlirnatural
-
-      - name: Compile `opt` Executable 🧐
-        run: |
-          lake -R build opt
+          lake -R build
 
   build-tools-github:
     name: use docker (runs on GitHub)
@@ -125,22 +121,9 @@ jobs:
     steps:
       - name: Symlink .elan (to correct for GHA changing $HOME)
         run: '[ -e ~/.elan ] || ln -s /root/.elan ~/.elan'
-      - name: Compile `mlirnatural` Executable 🧐
+      - name: Run lake build
         run: |
-          lake -R build mlirnatural
-
-      - name: Compile `opt` Executable 🧐
-        run: |
-          lake -R build opt
-
-#      This broke the build during a recent update
-#      - name: LLVM opt round trip test
-#        run: |
-#          lake exec opt test/LLVMDialect/InstCombine/bb0.mlir
-
-      - name: Compile Alive Scaling
-        run: |
-          lake -R build SSA.Projects.InstCombine.ScalingTest
+          lake -R build
 
 #   alive-check-changes:
 #     name: Check for changes in AliveStatements

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -97,7 +97,7 @@ jobs:
   #
   build-tools:
     name: tools, scaling, and auto-generated stmts
-    runs-on: ubuntu-latest # Run on GH-provided runner
+    runs-on: namespace-profile-leanmlir-docker-cached
     needs: core-docker-img
     container: "ghcr.io/opencompl/lean-mlir:${{ github.sha }}"
     defaults:


### PR DESCRIPTION
This should benefit from namespace's docker caching.