### PR TITLE
feat: use namespace's container registry

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -101,7 +101,7 @@ jobs:
     name: use docker (runs on namespace)
     runs-on: namespace-profile-leanmlir-docker-cached
     needs: core-docker-img
-    container: "nscr.io/tenant_2411cf8f8l302/lean-mlir/lean-mlir:${{ github.sha }}"
+    container: "nscr.io/2411cf8f8l302/lean-mlir/lean-mlir:${{ github.sha }}"
     defaults:
       run:
         working-directory: /code/lean-mlir

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -101,7 +101,7 @@ jobs:
     name: use docker (runs on namespace)
     runs-on: namespace-profile-leanmlir-docker-cached
     needs: core-docker-img
-    container: "nscr.io/2411cf8f8l302/lean-mlir/lean-mlir:${{ github.sha }}"
+    container: "nscr.io/2411cf8f8l302/lean-mlir:${{ github.sha }}"
     defaults:
       run:
         working-directory: /code/lean-mlir

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -36,7 +36,9 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ghcr.io/opencompl/lean-mlir
+          images: |
+            ghcr.io/opencompl/lean-mlir
+            nscr.io/tenant_2411cf8f8l302/lean-mlir
           tags: |
             type=ref,event=branch
             type=ref,event=pr
@@ -99,7 +101,7 @@ jobs:
     name: use docker (runs on namespace)
     runs-on: namespace-profile-leanmlir-docker-cached
     needs: core-docker-img
-    container: "ghcr.io/opencompl/lean-mlir:${{ github.sha }}"
+    container: "nscr.io/tenant_2411cf8f8l302/lean-mlir/lean-mlir:${{ github.sha }}"
     defaults:
       run:
         working-directory: /code/lean-mlir

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           images: |
             ghcr.io/opencompl/lean-mlir
-            nscr.io/tenant_2411cf8f8l302/lean-mlir
+            nscr.io/2411cf8f8l302/lean-mlir
           tags: |
             type=ref,event=branch
             type=ref,event=pr


### PR DESCRIPTION
This PR pushes the build lean-mlir Docker image to namespace's registry (nscr.io) in addition to the current GH registry (ghcr.io), and switches the downstream action that runs on namespace to use the nscr.io as source for the docker image, in an attempt to bring down container initialization time.

The initialization time of a run [on this PR](https://github.com/opencompl/lean-mlir/actions/runs/17947887034/job/51039298989?pr=1692) was reported as 35 seconds, whereas the most recent [commit on main](https://github.com/opencompl/lean-mlir/actions/runs/17940181066/job/51014949255) reported 39 seconds.

It's hard to say whether that's just noise: it could be that by using namespace's cache it doesn't actually matter which registry the image is loaded from. Then again, it doesn't seem to negatively impact initialization time, and it seems more reliable then relying on the cache always, so I'll go ahead and merge regardless.

I do believe there is a credit cost associate with using nscr.io, so in the long-term we should consider moving back to ghcr.io if that cost turns out to be a problem. However, moving back is pretty easy, since we keep pushing to ghcr.io regardless.