### PR TITLE
feat: don't use lake cache in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ RUN --mount=type=cache,target=$HOME/.cache/mathlib,sharing=private,uid=$UID \
   # \
   # Actual Build \
   # \
-  lake exe cache get && lake build && \
+  lake build && \
   # \
   # Persist .lake into Docker image \
   # \


### PR DESCRIPTION
This pulls out the change from #1691 to drop `lake exe cache get` and build Mathlib from source instead.

The reason *not* to use the lake cache is that download *all* of Mathlib, which weighs in at around 5GB, and is thus the majority of the size of the Docker image. By making the image smaller, we improve the "container initialization" time. We pull out this change in a standalone PR so that we can isolate the effect of reduced image size from the effect of a separate layer.

Do note that this change will likely make downstream project builds slower, if they use Mathlib imports which aren't used in the main `lake build` target. #1691 fixes that.

This drops the container initialization time to 20s on the namespace runner, and 43 seconds on the GH-runner