### PR TITLE
chore: test ghcr.io vs nscr.io

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -112,6 +112,21 @@ jobs:
         run: |
           lake -R build
 
+  build-tools-ghcr:
+    name: use docker (runs on namespace, via ghcr.io)
+    runs-on: namespace-profile-leanmlir-docker-cached
+    needs: core-docker-img
+    container: "ghcr.io/lean-mlir:${{ github.sha }}"
+    defaults:
+      run:
+        working-directory: /code/lean-mlir
+    steps:
+      - name: Symlink .elan (to correct for GHA changing $HOME)
+        run: '[ -e ~/.elan ] || ln -s /root/.elan ~/.elan'
+      - name: Run lake build
+        run: |
+          lake -R build
+
   build-tools-github:
     name: use docker (runs on GitHub)
     runs-on: ubuntu-latest # Run on GH-provided runner

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -116,7 +116,7 @@ jobs:
     name: use docker (runs on namespace, via ghcr.io)
     runs-on: namespace-profile-leanmlir-docker-cached
     needs: core-docker-img
-    container: "ghcr.io/lean-mlir:${{ github.sha }}"
+    container: "ghcr.io/opencompl/lean-mlir:${{ github.sha }}"
     defaults:
       run:
         working-directory: /code/lean-mlir


### PR DESCRIPTION
This PR adds a third job that uses the docker image, this time running on namespace, but loading the image via ghcr.io, so we can more easily compare initialization numbers between the namespace and GH container registries.