### PR TITLE
feat: move the use-docker jobs to small runner

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -99,7 +99,7 @@ jobs:
   #
   build-tools:
     name: use docker (runs on namespace)
-    runs-on: namespace-profile-leanmlir-docker-cached
+    runs-on: namespace-profile-leanmlir-small
     needs: core-docker-img
     container: "nscr.io/2411cf8f8l302/lean-mlir:${{ github.sha }}"
     defaults:
@@ -114,7 +114,7 @@ jobs:
 
   build-tools-ghcr:
     name: use docker (runs on namespace, via ghcr.io)
-    runs-on: namespace-profile-leanmlir-docker-cached
+    runs-on: namespace-profile-leanmlir-small
     needs: core-docker-img
     container: "ghcr.io/opencompl/lean-mlir:${{ github.sha }}"
     defaults:


### PR DESCRIPTION
This PR moves jobs which use the docker image on namespace runners to a smaller profile (4 vCPUs): these jobs don't actually compute anything so the extra cores are mostly unused By reducing the core count, we can run more jobs concurrently before hitting the concurrency limit (and it reduces our credit spend).

Note that the extra cores aren't *entirely* unused. By moving from 16 vCPUs to 4, the initialization time when pulling from nscr.io increase from 20s to 22s. I believe part of the initialization is also unpacking a compressed payload, where the extra CPUs are actually used. Still, the concurrency limit is annoying so I'm going ahead and merging this