### PR TITLE
chore: mark check for changes in AliveStatements as continue-on-error

### DIFF
--- a/.github/workflows/evaluation.yml
+++ b/.github/workflows/evaluation.yml
@@ -248,7 +248,7 @@ jobs:
       - name: Build Lean-MLIR (should be all in cache)
         run: |
           lake -R build
-          
+
       - name: Compile `mlirnatural` Executable 🧐
         run: |
           lake -R build mlirnatural
@@ -257,7 +257,7 @@ jobs:
         run: |
           lake -R build opt
 
-      - name: Compile `LLVMRiscV` Tests 
+      - name: Compile `LLVMRiscV` Tests
         run: |
           lake -R build SSA.Projects.LLVMRiscV.Tests.Tests
 
@@ -265,7 +265,7 @@ jobs:
 #      - name: LLVM opt round trip test
 #        run: |
 #          lake exec opt test/LLVMDialect/InstCombine/bb0.mlir
-      
+
       - name: Compile ISL
         run: |
           lake -R build ISL
@@ -275,11 +275,13 @@ jobs:
           lake -R build SSA.Projects.InstCombine.ScalingTest
 
       - name: Check for changes in AliveStatements
+        # continue on error, because this is flaky due to parallelism?
+        continue-on-error: true
         run: |
           lake build AliveExamples
           (cd SSA/Projects/InstCombine/; ./update_alive_statements.py)
           bash -c '! git diff | grep .'  # iff git diff is empty, 'grep .' fails, '!' inverts the failure, and in the forced bash
-          
+
   test-core-library:
     name: Test Core Library
     runs-on: ubuntu-latest


### PR DESCRIPTION
CC @alexkeizer @tobiasgrosser 

This prevents the flakiness of the AliveStatements regression from taking down all of the CI 