### PR TITLE
feat: show more failure reasons

### DIFF
--- a/Blase/Blase/MultiWidth/Preprocessing.lean
+++ b/Blase/Blase/MultiWidth/Preprocessing.lean
@@ -389,27 +389,27 @@ Boolean normalization:
   (BitVec.ofBool x &&& BitVec.ofBool y) = BitVec.ofBool (x && y) := by
     rcases x with rfl | rfl <;> rcases y with rfl | rfl <;> simp [BitVec.ofBool]
 
-@[bv_multi_width_normalize] theorem complement_ofBool_eq (x : Bool) : 
+@[bv_multi_width_normalize] theorem complement_ofBool_eq (x : Bool) :
   ~~~ (BitVec.ofBool x) = BitVec.ofBool (!x) := by
     rcases x with rfl | rfl <;> simp [BitVec.ofBool]
 
 
-@[bv_multi_width_normalize] theorem add_ofBool_eq (x y : Bool) : 
+@[bv_multi_width_normalize] theorem add_ofBool_eq (x y : Bool) :
   (BitVec.ofBool x) + (BitVec.ofBool y) = BitVec.ofBool (x ^^ y) := by
-    rcases x with rfl | rfl <;> 
+    rcases x with rfl | rfl <;>
     rcases y with rfl | rfl <;> simp [BitVec.ofBool]
 
-@[bv_multi_width_normalize] theorem sub_ofBool_eq (x y : Bool) : 
+@[bv_multi_width_normalize] theorem sub_ofBool_eq (x y : Bool) :
   (BitVec.ofBool x) - (BitVec.ofBool y) = BitVec.ofBool (x ^^ y) := by
-    rcases x with rfl | rfl <;> 
+    rcases x with rfl | rfl <;>
     rcases y with rfl | rfl <;> simp [BitVec.ofBool]
 
-@[bv_multi_width_normalize] theorem mul_ofBool_eq (x y : Bool) : 
+@[bv_multi_width_normalize] theorem mul_ofBool_eq (x y : Bool) :
   (BitVec.ofBool x) * (BitVec.ofBool y) = BitVec.ofBool (x && y) := by
-    rcases x with rfl | rfl <;> 
+    rcases x with rfl | rfl <;>
     rcases y with rfl | rfl <;> simp [BitVec.ofBool]
 
-@[bv_multi_width_normalize] theorem neg_ofBool_eq (x : Bool) : 
+@[bv_multi_width_normalize] theorem neg_ofBool_eq (x : Bool) :
   - (BitVec.ofBool x) = BitVec.ofBool x := by
     rcases x with rfl | rfl <;> simp [BitVec.ofBool]
 

--- a/Blase/BlaseTest.lean
+++ b/Blase/BlaseTest.lean
@@ -2,4 +2,6 @@ import Blase.SingleWidth.Tests
 import Blase.MultiWidth.Tests
 import BlaseTest.Preprocessing1
 import BlaseTest.Preprocessing2
+import BlaseTest.Preprocessing3
+import BlaseTest.Preprocessing4
 

--- a/Blase/BlaseTest/Preprocessing3.lean
+++ b/Blase/BlaseTest/Preprocessing3.lean
@@ -1,0 +1,19 @@
+
+/-
+-- auto-generated from 'SSA/Projects/InstCombine/scripts/extract-goals.py'
+-- glogicalhselecthinseltpoison_proof_bools_multi_uses2_logical_thm_extracted_1__37.lean
+-/
+import Blase
+open BitVec
+
+
+/-
+This test shows that we need special support for `ofBool`, and we should allow
+our solver to interpret 1-width bitvectors always.
+Otherwise, we end up not being able to close many boolean problems.
+This also exposes a TODO: where we should add `ofBool` support to the reflection.
+-/
+theorem bools_multi_uses2_logical_thm.extracted_1._37 : ∀ (x x_1 x_2 : BitVec 1),
+  ¬x_2 ^^^ 1#1 = 1#1 → ¬x_2 = 1#1 → ¬0#1 = 1#1 → x_1 = 1#1 → 0#1 = 0#1 ^^^ 0#1 := by
+  fail_if_success bv_multi_width +verbose?
+  sorry

--- a/Blase/BlaseTest/Preprocessing4.lean
+++ b/Blase/BlaseTest/Preprocessing4.lean
@@ -1,0 +1,17 @@
+
+/-
+-- auto-generated from 'SSA/Projects/InstCombine/scripts/extract-goals.py'
+-- gandhorhicmps_proof_logical_or_logical_or_icmps_comm1_thm_extracted_1__7.lean
+-/
+import Blase
+open BitVec
+
+-- This needs shift left support, and is also probably only provable given
+-- the fixed width. In particular, the constraint ¬ 'x_1 ≥ 8' seems a bit suspicious.
+-- We should refute this as a arbitrary width theorem, probably, with no abstracted variables.
+theorem logical_or_logical_or_icmps_comm1_thm.extracted_1._7 : ∀ (x x_1 x_2 : BitVec 8),
+  ¬x_1 ≥ ↑8 →
+    ¬(ofBool (x_2 &&& 1#8 <<< x_1 == 0#8) = 1#1 ∨ ofBool (x == 42#8) = 1#1) →
+      ¬(True ∧ 1#8 <<< x_1 >>> x_1 ≠ 1#8 ∨ x_1 ≥ ↑8) →
+        ¬ofBool (x_2 &&& 1#8 <<< x_1 == 0#8) = 1#1 → ofBool (x == 42#8) = 1#1 → ofBool (x_2 &&& 1#8 == 0#8) = 1#1 := by
+  bv_multi_width (config := { niter := 10 })

--- a/Blase/BlaseTest/Preprocessing4.lean
+++ b/Blase/BlaseTest/Preprocessing4.lean
@@ -14,4 +14,4 @@ theorem logical_or_logical_or_icmps_comm1_thm.extracted_1._7 : ∀ (x x_1 x_2 : 
     ¬(ofBool (x_2 &&& 1#8 <<< x_1 == 0#8) = 1#1 ∨ ofBool (x == 42#8) = 1#1) →
       ¬(True ∧ 1#8 <<< x_1 >>> x_1 ≠ 1#8 ∨ x_1 ≥ ↑8) →
         ¬ofBool (x_2 &&& 1#8 <<< x_1 == 0#8) = 1#1 → ofBool (x == 42#8) = 1#1 → ofBool (x_2 &&& 1#8 == 0#8) = 1#1 := by
-  bv_multi_width (config := { niter := 10 })
+  bv_multi_width (config := { niter := 20 })


### PR DESCRIPTION
These examples show two distinct reasons for falure:
1. We need `ofBool` support, and we should allow ourselves to use `Bool`.
2. We can solve problems with larger number of k-induction iterations, so we should make that a parameter.