### PR TITLE
feat: cache-mount all subproject .lake folders in Docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,10 @@
 Dockerfile
+
+artifacts/
 *.pdf
-.venv/
-.lake/
+
+**/.venv/
+**/.lake/
 
 .devcontainer
 .dockerignore

--- a/.dockerscripts/cache.sh
+++ b/.dockerscripts/cache.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 if [[ -z "$CACHE_MOUNT" ]]; then
-    echo "error: \$CACHE not set"
+    echo "error: \$CACHE_MOUNT not set"
     exit 1
 fi
 

--- a/.dockerscripts/cache.sh
+++ b/.dockerscripts/cache.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+if [[ -z "$CACHE_MOUNT" ]]; then
+    echo "error: \$CACHE not set"
+    exit 1
+fi
+
+setup() {
+    for lakefile in {**,.}/lakefile.*; do
+        lake_dir="$(dirname "$lakefile")/.lake"
+        if [[ -L "$lake_dir" ]]; then
+            continue
+        fi
+
+        mkdir -p "$CACHE_MOUNT/$lake_dir"
+        ln -Ts "$CACHE_MOUNT/$lake_dir" "$lake_dir"
+    done
+}
+
+teardown() {
+    for lake_dir in {**,.}/.lake; do
+        if [[ -L "$lake_dir" ]]; then
+            rm "$lake_dir"
+            cp -TRa "$CACHE_MOUNT/$lake_dir" "$lake_dir"
+        fi
+    done
+}
+
+case "$1" in
+    setup) setup;;
+    teardown) teardown;;
+    *)
+        echo "error: unknown subcommand `$1`"
+        exit 1
+        ;;
+esac


### PR DESCRIPTION
This PR tweaks the Docker build to enable incremental caching (via cache-mount) of the .lake folder of all sub-projects as well.

In addition, we move the docker caching setup and teardown to a dedicated shell script, in a new `.dockerscripts` folder, to reduce caching-related noise in the Dockerfile.

This fixes #1687.