### PR TITLE
feat: add `select_constant_cmp` rewrite pattern

### DIFF
--- a/SSA/Projects/LLVMRiscV/Pipeline/Combiners.lean
+++ b/SSA/Projects/LLVMRiscV/Pipeline/Combiners.lean
@@ -135,12 +135,10 @@ def select_same_val_self : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 1), Ty
 def select_same_val : List (Σ Γ, LLVMPeepholeRewriteRefine 64  Γ) :=
   [⟨_, select_same_val_self⟩]
 
-
 /-- ### select_constant_cmp
   (true ? x : y) -> x
   (false ? x : y) -> y
 -/
-
 def select_constant_cmp_true : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
   lhs := [LV| {
   ^entry (%x: i64, %y: i64):

--- a/SSA/Projects/LLVMRiscV/Pipeline/Combiners.lean
+++ b/SSA/Projects/LLVMRiscV/Pipeline/Combiners.lean
@@ -135,7 +135,10 @@ def select_same_val_self : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 1), Ty
 def select_same_val : List (Σ Γ, LLVMPeepholeRewriteRefine 64  Γ) :=
   [⟨_, select_same_val_self⟩]
 
-/-- ### select_constant_cmp
+/-! ### select_constant_cmp -/
+
+/- 
+Test the rewrite:
   (true ? x : y) -> x
   (false ? x : y) -> y
 -/

--- a/SSA/Projects/LLVMRiscV/Tests/Combiners.lean
+++ b/SSA/Projects/LLVMRiscV/Tests/Combiners.lean
@@ -5,8 +5,7 @@ import LeanMLIR.Framework.Print
 info:
 ^bb0(%0 : i64, %1 : i64):
   %2 = "llvm.const"(){value = 1 : i1} : () -> (i1)
-  %3 = "llvm.select"(%2, %0, %1) : (i1, i64, i64) -> (i64)
   "llvm.return"(%0) : (i64) -> ()
 -/
 #guard_msgs in
-#eval! Com.print (multiRewritePeephole 100 GLobalISelPostLegalizerCombiner select_constant_cmp_true.lhs)
+#eval! Com.print (DCE.dce' (multiRewritePeephole 100 GLobalISelPostLegalizerCombiner select_constant_cmp_true.lhs)).val

--- a/SSA/Projects/LLVMRiscV/Tests/Combiners.lean
+++ b/SSA/Projects/LLVMRiscV/Tests/Combiners.lean
@@ -4,7 +4,9 @@ import LeanMLIR.Framework.Print
 /--
 info:
 ^bb0(%0 : i64, %1 : i64):
+  %2 = "llvm.const"(){value = 1 : i1} : () -> (i1)
+  %3 = "llvm.select"(%2, %0, %1) : (i1, i64, i64) -> (i64)
   "llvm.return"(%0) : (i64) -> ()
 -/
 #guard_msgs in
-#eval! Com.print (DCE.dce' (multiRewritePeephole 100 GLobalISelPostLegalizerCombiner select_constant_cmp_true.lhs)).val
+#eval! Com.print (multiRewritePeephole 100 GLobalISelPostLegalizerCombiner select_constant_cmp_true.lhs)

--- a/SSA/Projects/LLVMRiscV/Tests/Combiners.lean
+++ b/SSA/Projects/LLVMRiscV/Tests/Combiners.lean
@@ -1,0 +1,10 @@
+import SSA.Projects.InstCombine.LLVM.Opt
+import LeanMLIR.Framework.Print
+
+/--
+info:
+^bb0(%0 : i64, %1 : i64):
+  "llvm.return"(%0) : (i64) -> ()
+-/
+#guard_msgs in
+#eval! Com.print (DCE.dce' (multiRewritePeephole 100 GLobalISelPostLegalizerCombiner select_constant_cmp_true.lhs)).val

--- a/SSA/Projects/LLVMRiscV/Tests/Tests.lean
+++ b/SSA/Projects/LLVMRiscV/Tests/Tests.lean
@@ -1,1 +1,2 @@
+import SSA.Projects.LLVMRiscV.Tests.Combiners
 import SSA.Projects.LLVMRiscV.Tests.Pipeline


### PR DESCRIPTION
This PR adds a new rewrite pattern, [select_constant_cmp](https://github.com/llvm/llvm-project/blob/cae73be8a6c2d39e5a827fd31848676d52062a94/llvm/include/llvm/Target/GlobalISel/Combine.td#L518). 

The pattern rewrites cases where select is given constant inputs (_true_ or _false_), simplifying it to the first or second input value accordingly.

In the current test case, the expected output still contains the input given to the rewriter. Ideally, this should be eliminated by DCE, which is not applied in this PR.

Co-authored-by: Luisa Cicolini luisacicolini@gmail.com