### PR TITLE
feat: SLLVM alloca instruction

### DIFF
--- a/LeanMLIR/LeanMLIR/MLIRSyntax/Transform/Utils.lean
+++ b/LeanMLIR/LeanMLIR/MLIRSyntax/Transform/Utils.lean
@@ -52,6 +52,18 @@ def getIntAttr (attr : String) : Except TransformError (Int × MLIRType φ) := d
         \t{attr}"
   return (val, ty)
 
+/--
+`op.getTypeAttr attr` returns the value of a type attribute.
+
+Throws an error if the attribute is not present, or if the value of the attribute
+has the wrong type.
+-/
+def getTypeAttr (attr : String) : Except TransformError (MLIRType φ) := do
+  let .type ty ← op.getAttr attr
+    | .error <| .generic s!"Expected attribute `{attr}` to be a type, but found a:\n\
+        \t{attr}"
+  return (ty)
+
 /-! ## Arguments -/
 
 /--

--- a/SSA/Projects/SLLVM/Dialect/Basic.lean
+++ b/SSA/Projects/SLLVM/Dialect/Basic.lean
@@ -196,7 +196,7 @@ instance : DialectPrint SLLVM where
     | _ => ""
   printTy
     | .arith llvmTy => printTy llvmTy
-    | .ptr => "ptr"
+    | .ptr => "!ptr"
   dialectName := "sllvm"
   printReturn _ := "llvm.return"
   printFunc _ := "^entry"

--- a/SSA/Projects/SLLVM/Dialect/Basic.lean
+++ b/SSA/Projects/SLLVM/Dialect/Basic.lean
@@ -187,9 +187,10 @@ open DialectPrint
 instance : DialectPrint SLLVM where
   printOpName
     | .arith llvmOp => printOpName llvmOp
-    | .store _ => "ptr.store"
-    | .load _ => "ptr.load"
-    | .ptradd => "ptr.add"
+    | .store _w   => "ptr.store"
+    | .load _w    => "ptr.load"
+    | .ptradd     => "ptr.add"
+    | .alloca _w  => "ptr.alloca"
   printAttributes
     | .arith llvmOp => printAttributes llvmOp
     | _ => ""

--- a/SSA/Projects/SLLVM/Dialect/Basic.lean
+++ b/SSA/Projects/SLLVM/Dialect/Basic.lean
@@ -193,6 +193,7 @@ instance : DialectPrint SLLVM where
     | .alloca _w  => "ptr.alloca"
   printAttributes
     | .arith llvmOp => printAttributes llvmOp
+    | .alloca w => s!"\{elem_type = i{w}}"
     | _ => ""
   printTy
     | .arith llvmTy => printTy llvmTy

--- a/SSA/Projects/SLLVM/Dialect/Basic.lean
+++ b/SSA/Projects/SLLVM/Dialect/Basic.lean
@@ -33,6 +33,7 @@ inductive SLLVMOp where
   | ptradd
   | load (w : Nat)
   | store (w : Nat)
+  | alloca (w : Nat)
   deriving DecidableEq, Lean.ToExpr
 
 inductive SLLVMTy where
@@ -56,11 +57,6 @@ instance : DecidableEq SLLVM.Op := by unfold SLLVM; infer_instance
 instance : DecidableEq SLLVM.Ty := by unfold SLLVM; infer_instance
 instance : Lean.ToExpr SLLVM.Op := by unfold SLLVM; infer_instance
 instance : Lean.ToExpr SLLVM.Ty := by unfold SLLVM; infer_instance
-
--- instance : ToString SLLVM.Op    := by unfold SLLVM; infer_instance
--- instance : ToString SLLVM.Ty    := by unfold SLLVM; infer_instance
--- instance : Repr SLLVM.Op        := by unfold SLLVM; infer_instance
--- instance : Repr SLLVM.Ty        := by unfold SLLVM; infer_instance
 
 instance : Monad SLLVM.m        := by unfold SLLVM; infer_instance
 instance : LawfulMonad SLLVM.m  := by unfold SLLVM; infer_instance
@@ -124,6 +120,7 @@ def_signature for SLLVM
   | .ptradd          => (ptr, bitvec 64) -> ptr
   | .load w          => (ptr) -[.impure]-> bitvec w
   | .store w         => (ptr, bitvec w) -[.impure]-> []
+  | .alloca _w       => () -[.impure]-> ptr
   -- LLVM operations with modified effect signature
   | Op.urem w        => (bitvec w, bitvec w) -[.impure]-> bitvec w
   | Op.srem w        => (bitvec w, bitvec w) -[.impure]-> bitvec w
@@ -157,6 +154,7 @@ def_denote for SLLVM
   | .ptradd   => fun p x => [SLLVM.ptradd p x]ₕ
   | .load w   => fun p   => ([·]ₕ) <$> SLLVM.load p w
   | .store _  => fun p x => (fun _ => []ₕ) <$> SLLVM.store p x
+  | .alloca w => ([·]ₕ) <$> SLLVM.alloca w
   -- LLVM operations with modified effect signature
   | Op.udiv _w flag => fun x y => ([·]ₕ) <$> SLLVM.udiv x y flag
   | Op.sdiv _w flag => fun x y => ([·]ₕ) <$> SLLVM.sdiv x y flag

--- a/SSA/Projects/SLLVM/Dialect/Semantics/Memory.lean
+++ b/SSA/Projects/SLLVM/Dialect/Semantics/Memory.lean
@@ -31,6 +31,10 @@ structure MemoryState where
   mem : Std.HashMap BlockId Block
   deriving Inhabited
 
+structure GlobalState where
+  alloc : AllocState
+  mem : MemoryState
+
 structure Pointer where
   id : BlockId
   /-- Offset in bytes -/
@@ -52,7 +56,6 @@ def Pointer.offsetInBits (p : Pointer) : Nat :=
 /-! ## Refinement -/
 section Refinement
 
-@[simp_sllvm]
 instance : Refinement AllocState where
   IsRefinedBy s t := s = t
 
@@ -60,9 +63,28 @@ instance : Refinement MemoryState where
   IsRefinedBy s t := ∀ (id : BlockId),
     s[id]? = t[id]?
 
+instance : Refinement GlobalState where
+  IsRefinedBy s t :=
+    s.alloc ⊑ t.alloc ∧ s.mem ⊑ t.mem
+
+
+
+section Lemmas
+
+@[simp_sllvm]
+theorem GlobalState.isRefinedBy_iff (s t : GlobalState) :
+    s ⊑ t ↔ s.alloc ⊑ t.alloc ∧ s.mem ⊑ t.mem := by
+  rfl
+
+@[simp_sllvm]
+theorem AllocState.isRefinedBy_rfl (s : AllocState) :
+    s ⊑ s := by
+  rfl
+
 @[simp_sllvm]
 theorem MemoryState.isRefinedBy_rfl (s : MemoryState) :
     s ⊑ s := by
   intro id; rfl
 
+end Lemmas
 end Refinement

--- a/SSA/Projects/SLLVM/Dialect/Semantics/Memory.lean
+++ b/SSA/Projects/SLLVM/Dialect/Semantics/Memory.lean
@@ -23,9 +23,12 @@ inductive Block where
   /-- A live piece of memory (i.e., has been allocated and not yet freed). -/
   | live (b : LiveBlock)
 
+structure AllocState where
+  nextFreeBlock : Nat
+  deriving Inhabited
+
 structure MemoryState where
   mem : Std.HashMap BlockId Block
-  nextFreeBlock : Nat
   deriving Inhabited
 
 structure Pointer where
@@ -48,6 +51,10 @@ def Pointer.offsetInBits (p : Pointer) : Nat :=
 
 /-! ## Refinement -/
 section Refinement
+
+@[simp_sllvm]
+instance : Refinement AllocState where
+  IsRefinedBy s t := s = t
 
 instance : Refinement MemoryState where
   IsRefinedBy s t := ∀ (id : BlockId),

--- a/SSA/Projects/SLLVM/Dialect/Syntax/Parser.lean
+++ b/SSA/Projects/SLLVM/Dialect/Syntax/Parser.lean
@@ -82,8 +82,11 @@ instance : DialectParse SLLVM 0 where
     | "ptr.store" => do
         let args ← args.assumeArity 2
         mkExprOf <| .store (← getIntWidth args[1])
-    | "ptr.alloca" => mkExprOf <| .alloca 8
-    -- ^^ TODO: `llvm.alloca` ought to have an attribute `elem_type` which indicates the type being allocated
+    | "ptr.alloca" =>
+        let t ← opStx.getTypeAttr "elem_type"
+        let .int _ w := t
+          | throw <| .generic s!"Expected value of attribute `elem_type` to be an integer type"
+        mkExprOf <| .alloca w.toConcrete
     -- Ternary Operations
     | "llvm.select" =>
         let args ← args.assumeArity 3

--- a/SSA/Projects/SLLVM/Dialect/Syntax/Parser.lean
+++ b/SSA/Projects/SLLVM/Dialect/Syntax/Parser.lean
@@ -16,20 +16,21 @@ private abbrev ReaderM := MLIR.AST.ReaderM SLLVM
 
 def mkTy : MLIRType 0 → ExceptM SLLVM SLLVM.Ty
   | .int .Signless w => return Ty.bitvec w.toConcrete
+  | .undefined "ptr" => return Ty.ptr
   | _ => throw .unsupportedType
 
 instance : TransformTy SLLVM 0 where
   mkTy := mkTy
 
 
-def getOutputWidth (opStx : MLIR.AST.Op 0) (op : String) :
+def getOutputWidth (opStx : MLIR.AST.Op 0) :
     Except TransformError Nat := do
   match opStx.res with
   | res::[] =>
     match res.2 with
     | .int _ (.concrete w) => pure w
-    | _ => throw <| .generic s!"The operation {op} must output an integer type"
-  | _ => throw <| .generic s!"The operation {op} must have a single output"
+    | _ => throw <| .generic s!"The operation {opStx.name} must output an integer type"
+  | _ => throw <| .generic s!"The operation {opStx.name} must have a single output"
 
 /-- Given a variable of arbitrary type, return its width.
 
@@ -54,7 +55,9 @@ def parseOverflowFlags (op : AST.Op 0) : ReaderM LLVM.NoWrapFlags :=
     | _ => throw <| .generic s!"Unrecognised overflow flag found: {MLIR.AST.docAttrVal y}. \
         We currently support nsw (no signed wrap) and nuw (no unsigned wrap)"
 
-instance : TransformExpr SLLVM 0 where
+instance : DialectParse SLLVM 0 where
+  isValidReturn Γ opStx := return opStx.name == "llvm.return"
+
   mkExpr (Γ : Ctxt SLLVM.Ty) (opStx : MLIR.AST.Op 0) := do
   let args ← opStx.parseArgs Γ
 
@@ -69,8 +72,18 @@ instance : TransformExpr SLLVM 0 where
     let args ← args.assumeArity 1
     getIntWidth args[0]
 
+  let getOutputWidth := getOutputWidth opStx
+
   let mkExprOf := opStx.mkExprOf (args? := args) Γ
   match opStx.name with
+    -- new SLLVM operations
+    | "ptr.add" => mkExprOf <| .ptradd
+    | "ptr.load" => mkExprOf <| .load (← getOutputWidth)
+    | "ptr.store" => do
+        let args ← args.assumeArity 2
+        mkExprOf <| .store (← getIntWidth args[1])
+    | "ptr.alloca" => mkExprOf <| .alloca 8
+    -- ^^ TODO: `llvm.alloca` ought to have an attribute `elem_type` which indicates the type being allocated
     -- Ternary Operations
     | "llvm.select" =>
         let args ← args.assumeArity 3
@@ -104,9 +117,9 @@ instance : TransformExpr SLLVM 0 where
     | "llvm.not"   => mkExprOf <| Op.not (← unW)
     | "llvm.neg"   => mkExprOf <| Op.neg (← unW)
     | "llvm.copy"  => mkExprOf <| Op.copy (← unW)
-    | "llvm.zext"  => mkExprOf <| Op.zext (← unW) (← getOutputWidth opStx "zext") ⟨ opStx.hasAttr "nonNeg" ⟩
-    | "llvm.sext"  => mkExprOf <| Op.sext (← unW) (← getOutputWidth opStx "sext")
-    | "llvm.trunc" => mkExprOf <| Op.trunc (← unW) (← getOutputWidth opStx "trunc") (← parseOverflowFlags opStx)
+    | "llvm.zext"  => mkExprOf <| Op.zext (← unW) (← getOutputWidth) ⟨ opStx.hasAttr "nonNeg" ⟩
+    | "llvm.sext"  => mkExprOf <| Op.sext (← unW) (← getOutputWidth)
+    | "llvm.trunc" => mkExprOf <| Op.trunc (← unW) (← getOutputWidth) (← parseOverflowFlags opStx)
     -- Constant
     | "llvm.mlir.constant" => do
       let ⟨val, ty⟩ ← opStx.getIntAttr "value"
@@ -116,15 +129,6 @@ instance : TransformExpr SLLVM 0 where
       mkExprOf <| Op.const w val
     -- Fallback
     | opName => throw <| .unsupportedOp opName
-
-instance : TransformReturn SLLVM 0 where
-  mkReturn (Γ : Ctxt SLLVM.Ty) (opStx : MLIR.AST.Op 0) := do
-  if opStx.name ≠ "llvm.return" then
-    throw <| .unsupportedOp s!"Tried to build return out of non-return statement {opStx.name}"
-  else
-    let args ← (← opStx.parseArgs Γ).assumeArity 1
-    let ⟨ty, v⟩ := args[0]
-    return ⟨.pure, [ty], Com.ret v⟩
 
 elab "[sllvm| " reg:mlir_region "]" : term =>
   SSA.elabIntoCom' reg SLLVM

--- a/SSA/Projects/SLLVM/Evaluation/AliveAutoGeneratedCopy.lean
+++ b/SSA/Projects/SLLVM/Evaluation/AliveAutoGeneratedCopy.lean
@@ -3061,8 +3061,6 @@ def alive_275_tgt  :=
   llvm.return %v3 : i5
 }]
 
--- attribute [simp_denote] bind_pure bind_pure_comp map_pure pure_bind
-
 theorem alive_275   : alive_275_src ⊑ alive_275_tgt := by
   unfold alive_275_src alive_275_tgt
   simp_peephole

--- a/SSA/Projects/SLLVM/Tests/Print.lean
+++ b/SSA/Projects/SLLVM/Tests/Print.lean
@@ -1,0 +1,59 @@
+import SSA.Projects.SLLVM.Dialect
+
+/-!
+# SLLVM dialect printing
+-/
+
+/-! ## SLLVM dialect print tests -/
+
+/--
+info: builtin.module {
+  ^entry(%0 : !ptr, %1 : i64):
+    %2 = "ptr.add"(%0, %1) : (!ptr, i64) -> (!ptr)
+    "llvm.return"(%2) : (!ptr) -> ()
+}
+-/
+#guard_msgs in #eval Com.printModule [sllvm| {
+  ^entry(%p: !ptr, %x: i64):
+    %q = "ptr.add"(%p, %x) : (!ptr, i64) -> (!ptr)
+    "llvm.return"(%q) : (!ptr) -> ()
+}]
+
+/--
+info: builtin.module {
+  ^entry(%0 : !ptr):
+    %1 = "ptr.load"(%0) : (!ptr) -> (i64)
+    "llvm.return"(%1) : (i64) -> ()
+}
+-/
+#guard_msgs in #eval Com.printModule [sllvm| {
+  ^entry(%p: !ptr):
+    %x = "ptr.load"(%p) : (!ptr) -> (i64)
+    "llvm.return"(%x) : (i64) -> ()
+}]
+
+/--
+info: builtin.module {
+  ^entry(%0 : !ptr, %1 : i64):
+    "ptr.store"(%0, %1) : (!ptr, i64) -> ()
+    "llvm.return"() : () -> ()
+}
+-/
+#guard_msgs in #eval Com.printModule [sllvm| {
+  ^entry(%p: !ptr, %x: i64):
+    "ptr.store"(%p, %x) : (!ptr, i64) -> ()
+    "llvm.return"() : () -> ()
+}]
+
+/--
+info: builtin.module {
+  ^entry():
+    %0 = "ptr.alloca"() : () -> (!ptr)
+    "llvm.return"(%0) : (!ptr) -> ()
+}
+-/
+#guard_msgs in #eval Com.printModule [sllvm| {
+  ^entry():
+    %p = "ptr.alloca"() : () -> (!ptr)
+    "llvm.return"(%p) : (!ptr) -> ()
+}]

--- a/SSA/Projects/SLLVM/Tests/Print.lean
+++ b/SSA/Projects/SLLVM/Tests/Print.lean
@@ -54,7 +54,20 @@ info: builtin.module {
 -/
 #guard_msgs in #eval Com.printModule [sllvm| {
   ^entry():
-    %p = "ptr.alloca"() : () -> (!ptr)
+    %p = "ptr.alloca"() {elem_type = i8} : () -> (!ptr)
+    "llvm.return"(%p) : (!ptr) -> ()
+}]
+
+/--
+info: builtin.module {
+  ^entry():
+    %0 = "ptr.alloca"(){elem_type = i16} : () -> (!ptr)
+    "llvm.return"(%0) : (!ptr) -> ()
+}
+-/
+#guard_msgs in #eval Com.printModule [sllvm| {
+  ^entry():
+    %p = "ptr.alloca"() {elem_type = i16} : () -> (!ptr)
     "llvm.return"(%p) : (!ptr) -> ()
 }]
 

--- a/SSA/Projects/SLLVM/Tests/Print.lean
+++ b/SSA/Projects/SLLVM/Tests/Print.lean
@@ -48,7 +48,7 @@ info: builtin.module {
 /--
 info: builtin.module {
   ^entry():
-    %0 = "ptr.alloca"() : () -> (!ptr)
+    %0 = "ptr.alloca"(){elem_type = i8} : () -> (!ptr)
     "llvm.return"(%0) : (!ptr) -> ()
 }
 -/

--- a/SSA/Projects/SLLVM/Tests/Print.lean
+++ b/SSA/Projects/SLLVM/Tests/Print.lean
@@ -57,3 +57,55 @@ info: builtin.module {
     %p = "ptr.alloca"() : () -> (!ptr)
     "llvm.return"(%p) : (!ptr) -> ()
 }]
+
+/--
+info: builtin.module {
+  ^entry(%0 : i64, %1 : i64):
+    %2 = "llvm.add"(%0, %1)<{overflowFlags = #llvm.overflow<none>}> : (i64, i64) -> (i64)
+    "llvm.return"(%2) : (i64) -> ()
+}
+-/
+#guard_msgs in #eval Com.printModule [sllvm| {
+  ^entry(%x: i64, %y: i64):
+    %z = "llvm.add"(%x, %y) : (i64, i64) -> (i64)
+    "llvm.return"(%z) : (i64) -> ()
+}]
+
+/--
+info: builtin.module {
+  ^entry(%0 : i64, %1 : i64):
+    %2 = "llvm.add"(%0, %1)<{overflowFlags = #llvm.overflow<nsw,nuw>}> : (i64, i64) -> (i64)
+    "llvm.return"(%2) : (i64) -> ()
+}
+-/
+#guard_msgs in #eval Com.printModule [sllvm| {
+  ^entry(%x: i64, %y: i64):
+    %z = "llvm.add"(%x, %y) {overflowFlags = #llvm.overflow<"nsw","nuw">} : (i64, i64) -> (i64)
+    "llvm.return"(%z) : (i64) -> ()
+}]
+
+/--
+info: builtin.module {
+  ^entry(%0 : i64, %1 : i64):
+    %2 = "llvm.udiv"(%0, %1) : (i64, i64) -> (i64)
+    "llvm.return"(%2) : (i64) -> ()
+}
+-/
+#guard_msgs in #eval Com.printModule [sllvm| {
+  ^entry(%x: i64, %y: i64):
+    %z = "llvm.udiv"(%x, %y) : (i64, i64) -> (i64)
+    "llvm.return"(%z) : (i64) -> ()
+}]
+
+/--
+info: builtin.module {
+  ^entry(%0 : i64, %1 : i64):
+    %2 = "llvm.udiv"(%0, %1)<{isExact}>  : (i64, i64) -> (i64)
+    "llvm.return"(%2) : (i64) -> ()
+}
+-/
+#guard_msgs in #eval Com.printModule [sllvm| {
+  ^entry(%x: i64, %y: i64):
+    %z = "llvm.udiv"(%x, %y) {isExact} : (i64, i64) -> (i64)
+    "llvm.return"(%z) : (i64) -> ()
+}]


### PR DESCRIPTION
This PR separates the allocation state (a counter of the next available blockId) from the memory state (the actual contents of blocks), and implements an alloca instruction.