### PR TITLE
fix: remove duplicate icmp predicate printing

### DIFF
--- a/LeanMLIR/LeanMLIR/Dialects/LLVM/Basic.lean
+++ b/LeanMLIR/LeanMLIR/Dialects/LLVM/Basic.lean
@@ -420,7 +420,6 @@ def MetaLLVM.printAttributes : (MetaLLVM φ).Op → String
   | .or w ⟨true⟩ => s!"\{disjoint = true : {w}}"
   | .add _ f | .shl _ f | .sub _ f | .mul _ f => printOverflowFlags f
   | .udiv _ ⟨true⟩ | .sdiv _ ⟨true⟩ | .lshr _ ⟨true⟩ => "<{isExact}> "
-  | .icmp ty _ => s!"{ty}"
   | _ => ""
 where
   printOverflowFlags : NoWrapFlags → String

--- a/LeanMLIR/LeanMLIR/Tests/Dialects/LLVM/Print.lean
+++ b/LeanMLIR/LeanMLIR/Tests/Dialects/LLVM/Print.lean
@@ -1141,7 +1141,7 @@ info: {
 /--
 info: builtin.module {
   ^bb0(%0 : i64, %1 : i64):
-    %2 = "llvm.icmp.eq"(%0, %1)eq : (i64, i64) -> (i1)
+    %2 = "llvm.icmp.eq"(%0, %1) : (i64, i64) -> (i1)
     "llvm.return"(%2) : (i1) -> ()
 }
 -/
@@ -1172,6 +1172,19 @@ info: {
 #guard_msgs in #eval [llvm| {
   ^bb0(%x: i64, %y: i64):
     %z = "llvm.icmp.eq"(%x, %y) : (i64, i64) -> (i1)
+    "llvm.return"(%z) : (i1) -> ()
+}]
+
+/--
+info: builtin.module {
+  ^bb0(%0 : i64, %1 : i64):
+    %2 = "llvm.icmp.ne"(%0, %1) : (i64, i64) -> (i1)
+    "llvm.return"(%2) : (i1) -> ()
+}
+-/
+#guard_msgs in #eval Com.printModule [llvm| {
+  ^bb0(%x: i64, %y: i64):
+    %z = "llvm.icmp.ne"(%x, %y) : (i64, i64) -> (i1)
     "llvm.return"(%z) : (i1) -> ()
 }]
 

--- a/SSA/Projects/LLVMRiscV/Tests/Pipeline.lean
+++ b/SSA/Projects/LLVMRiscV/Tests/Pipeline.lean
@@ -4,7 +4,7 @@ import LeanMLIR.Framework.Print
 /--
 info:
 ^bb0(%0 : i32, %1 : i32):
-  %2 = "llvm.icmp.ugt"(%0, %1)ugt : (i32, i32) -> (i1)
+  %2 = "llvm.icmp.ugt"(%0, %1) : (i32, i32) -> (i1)
   %3 = "builtin.unrealized_conversion_cast"(%0) : (i32) -> (!riscv.reg)
   %4 = "builtin.unrealized_conversion_cast"(%1) : (i32) -> (!riscv.reg)
   %5 = "riscv.sltu"(%4, %3) : (!riscv.reg, !riscv.reg) -> (!riscv.reg)
@@ -18,7 +18,7 @@ info:
 /--
 info:
 ^bb0(%0 : i32, %1 : i32):
-  %2 = "llvm.icmp.uge"(%0, %1)uge : (i32, i32) -> (i1)
+  %2 = "llvm.icmp.uge"(%0, %1) : (i32, i32) -> (i1)
   %3 = "builtin.unrealized_conversion_cast"(%0) : (i32) -> (!riscv.reg)
   %4 = "builtin.unrealized_conversion_cast"(%1) : (i32) -> (!riscv.reg)
   %5 = "riscv.sltu"(%3, %4) : (!riscv.reg, !riscv.reg) -> (!riscv.reg)
@@ -33,7 +33,7 @@ info:
 /--
 info:
 ^bb0(%0 : i32, %1 : i32):
-  %2 = "llvm.icmp.ult"(%0, %1)ult : (i32, i32) -> (i1)
+  %2 = "llvm.icmp.ult"(%0, %1) : (i32, i32) -> (i1)
   %3 = "builtin.unrealized_conversion_cast"(%0) : (i32) -> (!riscv.reg)
   %4 = "builtin.unrealized_conversion_cast"(%1) : (i32) -> (!riscv.reg)
   %5 = "riscv.sltu"(%3, %4) : (!riscv.reg, !riscv.reg) -> (!riscv.reg)
@@ -47,7 +47,7 @@ info:
 /--
 info:
 ^bb0(%0 : i32, %1 : i32):
-  %2 = "llvm.icmp.ule"(%0, %1)ule : (i32, i32) -> (i1)
+  %2 = "llvm.icmp.ule"(%0, %1) : (i32, i32) -> (i1)
   %3 = "builtin.unrealized_conversion_cast"(%0) : (i32) -> (!riscv.reg)
   %4 = "builtin.unrealized_conversion_cast"(%1) : (i32) -> (!riscv.reg)
   %5 = "riscv.sltu"(%4, %3) : (!riscv.reg, !riscv.reg) -> (!riscv.reg)
@@ -62,7 +62,7 @@ info:
 /--
 info:
 ^bb0(%0 : i32, %1 : i32):
-  %2 = "llvm.icmp.sgt"(%0, %1)sgt : (i32, i32) -> (i1)
+  %2 = "llvm.icmp.sgt"(%0, %1) : (i32, i32) -> (i1)
   %3 = "builtin.unrealized_conversion_cast"(%0) : (i32) -> (!riscv.reg)
   %4 = "builtin.unrealized_conversion_cast"(%1) : (i32) -> (!riscv.reg)
   %5 = "riscv.slt"(%4, %3) : (!riscv.reg, !riscv.reg) -> (!riscv.reg)
@@ -75,7 +75,7 @@ info:
 /--
 info:
 ^bb0(%0 : i32, %1 : i32):
-  %2 = "llvm.icmp.sge"(%0, %1)sge : (i32, i32) -> (i1)
+  %2 = "llvm.icmp.sge"(%0, %1) : (i32, i32) -> (i1)
   %3 = "builtin.unrealized_conversion_cast"(%0) : (i32) -> (!riscv.reg)
   %4 = "builtin.unrealized_conversion_cast"(%1) : (i32) -> (!riscv.reg)
   %5 = "riscv.slt"(%3, %4) : (!riscv.reg, !riscv.reg) -> (!riscv.reg)
@@ -89,7 +89,7 @@ info:
 /--
 info:
 ^bb0(%0 : i32, %1 : i32):
-  %2 = "llvm.icmp.slt"(%0, %1)slt : (i32, i32) -> (i1)
+  %2 = "llvm.icmp.slt"(%0, %1) : (i32, i32) -> (i1)
   %3 = "builtin.unrealized_conversion_cast"(%0) : (i32) -> (!riscv.reg)
   %4 = "builtin.unrealized_conversion_cast"(%1) : (i32) -> (!riscv.reg)
   %5 = "riscv.slt"(%3, %4) : (!riscv.reg, !riscv.reg) -> (!riscv.reg)
@@ -102,7 +102,7 @@ info:
 /--
 info:
 ^bb0(%0 : i32, %1 : i32):
-  %2 = "llvm.icmp.sle"(%0, %1)sle : (i32, i32) -> (i1)
+  %2 = "llvm.icmp.sle"(%0, %1) : (i32, i32) -> (i1)
   %3 = "builtin.unrealized_conversion_cast"(%0) : (i32) -> (!riscv.reg)
   %4 = "builtin.unrealized_conversion_cast"(%1) : (i32) -> (!riscv.reg)
   %5 = "riscv.slt"(%4, %3) : (!riscv.reg, !riscv.reg) -> (!riscv.reg)
@@ -116,7 +116,7 @@ info:
 /--
 info:
 ^bb0(%0 : i32, %1 : i32):
-  %2 = "llvm.icmp.eq"(%0, %1)eq : (i32, i32) -> (i1)
+  %2 = "llvm.icmp.eq"(%0, %1) : (i32, i32) -> (i1)
   %3 = "builtin.unrealized_conversion_cast"(%0) : (i32) -> (!riscv.reg)
   %4 = "builtin.unrealized_conversion_cast"(%1) : (i32) -> (!riscv.reg)
   %5 = "riscv.xor"(%3, %4) : (!riscv.reg, !riscv.reg) -> (!riscv.reg)
@@ -130,7 +130,7 @@ info:
 /--
 info:
 ^bb0(%0 : i32, %1 : i32):
-  %2 = "llvm.icmp.ne"(%0, %1)ne : (i32, i32) -> (i1)
+  %2 = "llvm.icmp.ne"(%0, %1) : (i32, i32) -> (i1)
   %3 = "builtin.unrealized_conversion_cast"(%0) : (i32) -> (!riscv.reg)
   %4 = "builtin.unrealized_conversion_cast"(%1) : (i32) -> (!riscv.reg)
   %5 = "riscv.xor"(%3, %4) : (!riscv.reg, !riscv.reg) -> (!riscv.reg)
@@ -145,7 +145,7 @@ info:
 /--
 info:
 ^bb0(%0 : i64, %1 : i64):
-  %2 = "llvm.icmp.ugt"(%0, %1)ugt : (i64, i64) -> (i1)
+  %2 = "llvm.icmp.ugt"(%0, %1) : (i64, i64) -> (i1)
   %3 = "builtin.unrealized_conversion_cast"(%0) : (i64) -> (!riscv.reg)
   %4 = "builtin.unrealized_conversion_cast"(%1) : (i64) -> (!riscv.reg)
   %5 = "riscv.sltu"(%4, %3) : (!riscv.reg, !riscv.reg) -> (!riscv.reg)
@@ -158,7 +158,7 @@ info:
 /--
 info:
 ^bb0(%0 : i64, %1 : i64):
-  %2 = "llvm.icmp.uge"(%0, %1)uge : (i64, i64) -> (i1)
+  %2 = "llvm.icmp.uge"(%0, %1) : (i64, i64) -> (i1)
   %3 = "builtin.unrealized_conversion_cast"(%0) : (i64) -> (!riscv.reg)
   %4 = "builtin.unrealized_conversion_cast"(%1) : (i64) -> (!riscv.reg)
   %5 = "riscv.sltu"(%3, %4) : (!riscv.reg, !riscv.reg) -> (!riscv.reg)
@@ -172,7 +172,7 @@ info:
 /--
 info:
 ^bb0(%0 : i64, %1 : i64):
-  %2 = "llvm.icmp.ult"(%0, %1)ult : (i64, i64) -> (i1)
+  %2 = "llvm.icmp.ult"(%0, %1) : (i64, i64) -> (i1)
   %3 = "builtin.unrealized_conversion_cast"(%0) : (i64) -> (!riscv.reg)
   %4 = "builtin.unrealized_conversion_cast"(%1) : (i64) -> (!riscv.reg)
   %5 = "riscv.sltu"(%3, %4) : (!riscv.reg, !riscv.reg) -> (!riscv.reg)
@@ -185,7 +185,7 @@ info:
 /--
 info:
 ^bb0(%0 : i64, %1 : i64):
-  %2 = "llvm.icmp.ule"(%0, %1)ule : (i64, i64) -> (i1)
+  %2 = "llvm.icmp.ule"(%0, %1) : (i64, i64) -> (i1)
   %3 = "builtin.unrealized_conversion_cast"(%0) : (i64) -> (!riscv.reg)
   %4 = "builtin.unrealized_conversion_cast"(%1) : (i64) -> (!riscv.reg)
   %5 = "riscv.sltu"(%4, %3) : (!riscv.reg, !riscv.reg) -> (!riscv.reg)
@@ -199,7 +199,7 @@ info:
 /--
 info:
 ^bb0(%0 : i64, %1 : i64):
-  %2 = "llvm.icmp.sgt"(%0, %1)sgt : (i64, i64) -> (i1)
+  %2 = "llvm.icmp.sgt"(%0, %1) : (i64, i64) -> (i1)
   %3 = "builtin.unrealized_conversion_cast"(%0) : (i64) -> (!riscv.reg)
   %4 = "builtin.unrealized_conversion_cast"(%1) : (i64) -> (!riscv.reg)
   %5 = "riscv.slt"(%4, %3) : (!riscv.reg, !riscv.reg) -> (!riscv.reg)
@@ -212,7 +212,7 @@ info:
 /--
 info:
 ^bb0(%0 : i64, %1 : i64):
-  %2 = "llvm.icmp.sge"(%0, %1)sge : (i64, i64) -> (i1)
+  %2 = "llvm.icmp.sge"(%0, %1) : (i64, i64) -> (i1)
   %3 = "builtin.unrealized_conversion_cast"(%0) : (i64) -> (!riscv.reg)
   %4 = "builtin.unrealized_conversion_cast"(%1) : (i64) -> (!riscv.reg)
   %5 = "riscv.slt"(%3, %4) : (!riscv.reg, !riscv.reg) -> (!riscv.reg)
@@ -227,7 +227,7 @@ info:
 /--
 info:
 ^bb0(%0 : i64, %1 : i64):
-  %2 = "llvm.icmp.slt"(%0, %1)slt : (i64, i64) -> (i1)
+  %2 = "llvm.icmp.slt"(%0, %1) : (i64, i64) -> (i1)
   %3 = "builtin.unrealized_conversion_cast"(%0) : (i64) -> (!riscv.reg)
   %4 = "builtin.unrealized_conversion_cast"(%1) : (i64) -> (!riscv.reg)
   %5 = "riscv.slt"(%3, %4) : (!riscv.reg, !riscv.reg) -> (!riscv.reg)
@@ -240,7 +240,7 @@ info:
 /--
 info:
 ^bb0(%0 : i64, %1 : i64):
-  %2 = "llvm.icmp.sle"(%0, %1)sle : (i64, i64) -> (i1)
+  %2 = "llvm.icmp.sle"(%0, %1) : (i64, i64) -> (i1)
   %3 = "builtin.unrealized_conversion_cast"(%0) : (i64) -> (!riscv.reg)
   %4 = "builtin.unrealized_conversion_cast"(%1) : (i64) -> (!riscv.reg)
   %5 = "riscv.slt"(%4, %3) : (!riscv.reg, !riscv.reg) -> (!riscv.reg)
@@ -254,7 +254,7 @@ info:
 /--
 info:
 ^bb0(%0 : i64, %1 : i64):
-  %2 = "llvm.icmp.eq"(%0, %1)eq : (i64, i64) -> (i1)
+  %2 = "llvm.icmp.eq"(%0, %1) : (i64, i64) -> (i1)
   %3 = "builtin.unrealized_conversion_cast"(%0) : (i64) -> (!riscv.reg)
   %4 = "builtin.unrealized_conversion_cast"(%1) : (i64) -> (!riscv.reg)
   %5 = "riscv.xor"(%3, %4) : (!riscv.reg, !riscv.reg) -> (!riscv.reg)
@@ -268,7 +268,7 @@ info:
 /--
 info:
 ^bb0(%0 : i64, %1 : i64):
-  %2 = "llvm.icmp.ne"(%0, %1)ne : (i64, i64) -> (i1)
+  %2 = "llvm.icmp.ne"(%0, %1) : (i64, i64) -> (i1)
   %3 = "builtin.unrealized_conversion_cast"(%0) : (i64) -> (!riscv.reg)
   %4 = "builtin.unrealized_conversion_cast"(%1) : (i64) -> (!riscv.reg)
   %5 = "riscv.xor"(%3, %4) : (!riscv.reg, !riscv.reg) -> (!riscv.reg)


### PR DESCRIPTION
This PR removes the icmp predicate from being printed as an attribute. This is because the predicate is already part of the operation, e.g., we write `llvm.icmp.eq`, so having it also be printed as an attribute is redundant.