### PR TITLE
chore: run SLLVM tests in CI

### DIFF
--- a/.github/workflows/evaluation.yml
+++ b/.github/workflows/evaluation.yml
@@ -318,7 +318,7 @@ jobs:
 
       - name: Test Core Library
         run: |
-          lake -R build SSA.Tests.Tests
+          lake -R build SSA.Tests
 
       - name: Test InstCombine (unit-tests)
         run: |

--- a/.github/workflows/evaluation.yml
+++ b/.github/workflows/evaluation.yml
@@ -270,9 +270,9 @@ jobs:
         run: |
           lake -R build ISL
 
-      - name: Compile Alive Scaling
+      - name: Compile Project Tests
         run: |
-          lake -R build SSA.Projects.InstCombine.ScalingTest
+          lake -R build SSA.Tests
 
       - name: Check for changes in AliveStatements
         run: |

--- a/SSA/Projects/SLLVM/Tests.lean
+++ b/SSA/Projects/SLLVM/Tests.lean
@@ -1,0 +1,1 @@
+import SSA.Projects.SLLVM.Tests.Print

--- a/SSA/Tests.lean
+++ b/SSA/Tests.lean
@@ -1,0 +1,4 @@
+import SSA.Tests.Core.Tests
+
+import SSA.Projects.InstCombine.ScalingTest
+import SSA.Projects.SLLVM.Tests

--- a/SSA/Tests/Tests.lean
+++ b/SSA/Tests/Tests.lean
@@ -1,1 +1,0 @@
-import SSA.Tests.Core.Tests

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -65,10 +65,6 @@ name = "ssaLLVMEnumerator"
 root = "SSA.Projects.InstCombine.LLVM.Enumerator"
 
 [[lean_lib]]
-name = "Tests"
-root = "SSA.Tests.Tests"
-
-[[lean_lib]]
 name = "CIRCT"
 roots = ["SSA.Projects.CIRCT.CIRCT"]
 


### PR DESCRIPTION
This PR adds the SLLVM tests as an import to the SSA.Tests module, to ensure they run in CI.

Rather than adding a separate CI job for each project in `SSA.Projects`, let's standardized on importing all such tests in `SSA.Tests`. Formal lake sub-projects (such as LeanMLIR) can still have their own test build targets, to maintain separation.