### PR TITLE
feat: add `right_identity_zero_or`

### DIFF
--- a/SSA/Projects/LLVMRiscV/Pipeline/Combiners.lean
+++ b/SSA/Projects/LLVMRiscV/Pipeline/Combiners.lean
@@ -199,14 +199,14 @@ def right_identity_zero_add : RISCVPeepholeRewrite [Ty.riscv (.bv)] where
 
 def right_identity_zero_or : RISCVPeepholeRewrite [Ty.riscv (.bv)] where
   lhs := [LV| {
-  ^entry (%x: !riscv.reg):
-    %c = li (0) : !riscv.reg
-    %0 = or %x, %c : !riscv.reg
-  ret %0 : !riscv.reg
+    ^entry (%x: !riscv.reg):
+      %c = li (0) : !riscv.reg
+      %0 = or %x, %c : !riscv.reg
+      ret %0 : !riscv.reg
   }]
   rhs := [LV| {
-  ^entry (%x: !riscv.reg):
-  ret %x : !riscv.reg
+    ^entry (%x: !riscv.reg):
+      ret %x : !riscv.reg
   }]
 
 def right_identity_zero_xor : RISCVPeepholeRewrite [Ty.riscv (.bv)] where

--- a/SSA/Projects/LLVMRiscV/Pipeline/Combiners.lean
+++ b/SSA/Projects/LLVMRiscV/Pipeline/Combiners.lean
@@ -137,7 +137,7 @@ def select_same_val : List (Σ Γ, LLVMPeepholeRewriteRefine 64  Γ) :=
 
 /-! ### select_constant_cmp -/
 
-/- 
+/-
 Test the rewrite:
   (true ? x : y) -> x
   (false ? x : y) -> y
@@ -190,6 +190,18 @@ def right_identity_zero_add : RISCVPeepholeRewrite [Ty.riscv (.bv)] where
   ^entry (%x: !riscv.reg):
     %c = li (0) : !riscv.reg
     %0 = add %x, %c : !riscv.reg
+  ret %0 : !riscv.reg
+  }]
+  rhs := [LV| {
+  ^entry (%x: !riscv.reg):
+  ret %x : !riscv.reg
+  }]
+
+def right_identity_zero_or : RISCVPeepholeRewrite [Ty.riscv (.bv)] where
+  lhs := [LV| {
+  ^entry (%x: !riscv.reg):
+    %c = li (0) : !riscv.reg
+    %0 = or %x, %c : !riscv.reg
   ret %0 : !riscv.reg
   }]
   rhs := [LV| {

--- a/SSA/Projects/LLVMRiscV/Pipeline/Combiners.lean
+++ b/SSA/Projects/LLVMRiscV/Pipeline/Combiners.lean
@@ -285,6 +285,7 @@ def right_identity_zero_ror : RISCVPeepholeRewrite [Ty.riscv (.bv)] where
 def right_identity_zero : List (Σ Γ, RISCVPeepholeRewrite  Γ) :=
   [⟨_, right_identity_zero_sub⟩,
   ⟨_, right_identity_zero_add⟩,
+  ⟨_, right_identity_zero_or⟩,
   ⟨_, right_identity_zero_xor⟩,
   ⟨_, right_identity_zero_shl⟩,
   ⟨_, right_identity_zero_ashr⟩,


### PR DESCRIPTION
This PR adds the missing `or` case to the `right_identity_zero` rewrite pattern.