### PR TITLE
fix: disable closed term extraction for `opt`

### DIFF
--- a/SSA/Projects/InstCombine/LLVM/Opt.lean
+++ b/SSA/Projects/InstCombine/LLVM/Opt.lean
@@ -2,6 +2,8 @@ import Cli
 import SSA.Projects.LLVMRiscV.ParseAndTransform
 import SSA.Projects.RISCV64.ParseAndTransform
 
+set_option compiler.extract_closed false
+
 /-- `verbose_flag` takes in a filename and assuming the file is wellformed,
  prints verbose output to the command line. Additionally it prints
  a string indicating that the verbose flag was set. If the parsing fails,

--- a/SSA/Projects/RISCV64/ParseAndTransform.lean
+++ b/SSA/Projects/RISCV64/ParseAndTransform.lean
@@ -3,6 +3,8 @@ import SSA.Projects.InstCombine.LLVM.Parser
 import SSA.Projects.RISCV64.Base
 import SSA.Projects.LLVMRiscV.Pipeline.InstructionLowering
 
+set_option compiler.extract_closed false
+
 open MLIR AST InstCombine
 open RISCV64
 open LeanMLIR.SingleReturnCompat


### PR DESCRIPTION
This PR fixes a SEGFAULT in the `opt` binary that got triggered by #1722, but that seems rooted in the closed term extraction performed by the Lean compiler. By disabling said closed term extraction, `opt` seems to function again.