### PR TITLE
refactor: extract HasUB class with helpers

### DIFF
--- a/SSA/Projects/SLLVM/Dialect/Semantics/ArithSemantics.lean
+++ b/SSA/Projects/SLLVM/Dialect/Semantics/ArithSemantics.lean
@@ -22,28 +22,28 @@ def Ptr : Type := PoisonOr Pointer
 @[simp_sllvm]
 def udiv (x y : LLVM.IntW w) (flag : LLVM.ExactFlag) : EffectM (LLVM.IntW w) := do
   if y.canBe 0#w then
-    .ub
+    throwUB
   else
     pure <| LLVM.udiv x y flag
 
 @[simp_sllvm]
 def sdiv (x y : LLVM.IntW w) (flag : LLVM.ExactFlag) : EffectM (LLVM.IntW w) := do
   if y.canBe 0#w then
-    .ub
+    throwUB
   else
     pure <| LLVM.sdiv x y flag
 
 @[simp_sllvm]
 def urem (x y : LLVM.IntW w) : EffectM (LLVM.IntW w) := do
   if y.canBe 0#w then
-    .ub
+    throwUB
   else
     pure <| LLVM.urem x y
 
 @[simp_sllvm]
 def srem (x y : LLVM.IntW w) : EffectM (LLVM.IntW w) := do
   if y.canBe 0#w then
-    .ub
+    throwUB
   else
     pure <| LLVM.srem x y
 

--- a/SSA/Projects/SLLVM/Dialect/Semantics/EffectM.lean
+++ b/SSA/Projects/SLLVM/Dialect/Semantics/EffectM.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 
 import LeanMLIR.Util.Poison
 import SSA.Projects.SLLVM.Tactic.SimpSet
+import SSA.Projects.SLLVM.Dialect.Semantics.HasUB
 import SSA.Projects.SLLVM.Dialect.Semantics.Memory
 
 namespace LeanMLIR
@@ -35,9 +36,11 @@ instance : MonadStateOf MemoryState EffectM where
 
 /-! ## Constructors -/
 
-abbrev ub : EffectM α := fun _ => PoisonOr.poison
 abbrev poison : EffectM (PoisonOr α) := pure PoisonOr.poison
 abbrev value (a : α) : EffectM (PoisonOr α) := pure (PoisonOr.value a)
+
+instance : HasUB EffectM where
+  throwUB := StateT.lift PoisonOr.poison
 
 /-! ## Lemmas -/
 
@@ -52,7 +55,7 @@ theorem bind_eq (x : EffectM α) (f : α → EffectM β) (s) :
 lemma run_pure : StateT.run (pure x : EffectM α) s = .value (x, s) := rfl
 
 @[simp, simp_denote, simp_sllvm]
-lemma run_ub : StateT.run (ub : EffectM α) s = .poison := rfl
+lemma run_ub : StateT.run (throwUB : EffectM α) s = .poison := rfl
 
 @[simp, simp_denote, simp_sllvm]
 lemma run_bind (x : EffectM α) :

--- a/SSA/Projects/SLLVM/Dialect/Semantics/HasUB.lean
+++ b/SSA/Projects/SLLVM/Dialect/Semantics/HasUB.lean
@@ -1,0 +1,55 @@
+import LeanMLIR.Util.Poison
+
+/-!
+# HasUB typeclass
+
+This file defines an `HasUB m` typeclass, which can be used to indicate that a
+monad `m` has a UB side-effect.
+-/
+
+namespace LeanMLIR
+
+class HasUB (m : Type u → Type v) where
+  /-- Undefined Behaviour effect -/
+  throwUB {α : Type u} : m α
+export HasUB (throwUB)
+
+variable {m} [HasUB m]
+
+/-- throw UB if `p` is true -/
+def throwUBIf [Pure m] (p : Prop) [Decidable p] : m Unit :=
+  if p then HasUB.throwUB else pure ()
+
+end LeanMLIR
+
+/-! ## Helpers on core types -/
+section CoreHelpers
+open LeanMLIR
+variable {m} [Pure m] [HasUB m]
+
+/-- `x.getOrUB` raises UB if `x` is poison. -/
+def PoisonOr.getOrUB  : PoisonOr α → m α
+  | .value x => pure x
+  | .poison => throwUB
+
+/-- `x.getOrUB` raises UB if `x` is `none` -/
+def Option.getOrUB : Option α → m α
+  | .some x => pure x
+  | .none => throwUB
+
+section Lemmas
+-- TODO: presumable we'll want lemmas about {PoisonOr,Option}.getOrUB applied to some/none/value/poison
+end Lemmas
+
+end CoreHelpers
+
+/-! ## Instances -/
+namespace LeanMLIR
+
+-- PoisonOr is the canonical monad with UB semantics
+instance : HasUB PoisonOr where
+  throwUB := .poison
+
+-- Alternatively, Option may also be used to model UB.
+instance : HasUB Option where
+  throwUB := none

--- a/SSA/Projects/SLLVM/Dialect/Semantics/Memory.lean
+++ b/SSA/Projects/SLLVM/Dialect/Semantics/Memory.lean
@@ -23,10 +23,16 @@ inductive Block where
   /-- A live piece of memory (i.e., has been allocated and not yet freed). -/
   | live (b : LiveBlock)
 
+/--
+`AllocState` keeps a counter of available blockIds
+-/
 structure AllocState where
   nextFreeBlock : Nat
   deriving Inhabited
 
+/--
+`MemoryState` tracks the *content* of memory blocks
+-/
 structure MemoryState where
   mem : Std.HashMap BlockId Block
   deriving Inhabited

--- a/SSA/Projects/SLLVM/Dialect/Semantics/MemorySemantics.lean
+++ b/SSA/Projects/SLLVM/Dialect/Semantics/MemorySemantics.lean
@@ -2,21 +2,10 @@
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
 
+import SSA.Projects.SLLVM.Dialect.Semantics.HasUB
 import SSA.Projects.SLLVM.Dialect.Semantics.EffectM
 import SSA.Projects.SLLVM.Dialect.Semantics.ArithSemantics
 import SSA.Projects.SLLVM.Tactic.SimpSet
-
-
-
-/-- `x.getOrUB` raises UB if `x` is poison. -/
-def PoisonOr.getOrUB  : PoisonOr α → LeanMLIR.EffectM α
-  | .value x => pure x
-  | .poison => .ub
-
-/-- `x.getOrUB` raises UB if `x` is `none` -/
-def Option.getOrUB : Option α → LeanMLIR.EffectM α
-  | .some x => pure x
-  | .none => .ub
 
 namespace LeanMLIR
 
@@ -32,13 +21,8 @@ Return the block pointed to by `p`, or throw UB if this block
 def getLiveBlockOrUB (p : Pointer) : EffectM LiveBlock := do
   let m ← getThe MemoryState
   let some (.live block) := m[p.id]?
-    | .ub
+    | throwUB
   return block
-
-/-- throw UB if `p` is true -/
-def throwUBIf (p : Prop) [Decidable p] : EffectM Unit :=
-  if p then .ub else pure ()
-
 
 /--
 `load p n` will load `n` bits from the location pointed to by `p`.


### PR DESCRIPTION
This PR extracts out a HasUB typeclass for monads which have a UB side-effect. This is in preperation for defining "pure" semantics for memory loads & stores