### PR TITLE
feat: {load,store}Pure operations + purified semantics

### DIFF
--- a/LeanMLIR/LeanMLIR/HVector.lean
+++ b/LeanMLIR/LeanMLIR/HVector.lean
@@ -153,6 +153,9 @@ abbrev toSingle : HVector A [a₁] → A a₁ := toTuple
 abbrev toPair   : HVector A [a₁, a₂] → A a₁ × A a₂ := toTuple
 abbrev toTriple : HVector A [a₁, a₂, a₃] → A a₁ × A a₂ × A a₃ := toTuple
 
+def ofPair : (A a₁ × A a₂) → HVector A [a₁, a₂] :=
+  fun ⟨x, y⟩ => [x, y]ₕ
+
 /-! ## isEmpty-/
 
 @[grind =]

--- a/LeanMLIR/LeanMLIR/HVector.lean
+++ b/LeanMLIR/LeanMLIR/HVector.lean
@@ -116,6 +116,24 @@ abbrev getN (x : HVector A as) (i : Nat) (hi : i < as.length := by hvector_get_e
     A (as.get ⟨i, hi⟩) :=
   x.get ⟨i, hi⟩
 
+/-! ## Notation -/
+
+syntax "[" withoutPosition(term,*) "]ₕ"  : term
+-- Copied from core for List
+macro_rules
+  | `([ $elems,* ]ₕ) => do
+    let rec expandListLit (i : Nat) (skip : Bool) (result : Lean.TSyntax `term) : Lean.MacroM Lean.Syntax := do
+      match i, skip with
+      | 0,   _     => pure result
+      | i+1, true  => expandListLit i false result
+      | i+1, false => expandListLit i true  (← ``(HVector.cons $(⟨elems.elemsAndSeps[i]!⟩) $result))
+    if elems.elemsAndSeps.size < 64 then
+      expandListLit elems.elemsAndSeps.size false (← ``(HVector.nil))
+    else
+      `(%[ $elems,* | List.nil ])
+
+infixr:50 "::ₕ" => HVector.cons
+
 /-! ## ToTuple -/
 
 def ToTupleType (A : α → Type*) : List α → Type _
@@ -234,8 +252,6 @@ end Map'
 theorem eq_of_type_eq_nil {A : α → Type*} {l : List α}
     {t₁ t₂ : HVector A l} (h : l = []) : t₁ = t₂ := by
   cases h; cases t₁; cases t₂; rfl
-syntax "[" withoutPosition(term,*) "]ₕ"  : term
-
 
 @[ext] theorem ext {xs ys : HVector A as}
     (h : ∀ i, xs.get i = ys.get i) : xs = ys := by
@@ -245,21 +261,6 @@ syntax "[" withoutPosition(term,*) "]ₕ"  : term
     specialize ih (fun i => by simpa using h i.succ)
     specialize h (0 : Fin <| _ + 1)
     simp_all
-
--- Copied from core for List
-macro_rules
-  | `([ $elems,* ]ₕ) => do
-    let rec expandListLit (i : Nat) (skip : Bool) (result : Lean.TSyntax `term) : Lean.MacroM Lean.Syntax := do
-      match i, skip with
-      | 0,   _     => pure result
-      | i+1, true  => expandListLit i false result
-      | i+1, false => expandListLit i true  (← ``(HVector.cons $(⟨elems.elemsAndSeps[i]!⟩) $result))
-    if elems.elemsAndSeps.size < 64 then
-      expandListLit elems.elemsAndSeps.size false (← ``(HVector.nil))
-    else
-      `(%[ $elems,* | List.nil ])
-
-infixr:50 "::ₕ" => HVector.cons
 
 
 /-!


### PR DESCRIPTION
This PR add pure versions of the load and store operations to the SLLVM dialect, and slightly refactors the semantics of original load/store to support the semantics of purified load/store.

Stacked on top of #1735 