### PR TITLE
feat: add `sub_add_reg` rewrite pattern

### DIFF
--- a/SSA/Projects/LLVMRiscV/Pipeline/Combiners.lean
+++ b/SSA/Projects/LLVMRiscV/Pipeline/Combiners.lean
@@ -1206,6 +1206,7 @@ def PostLegalizerCombiner_RISCV: List (Σ Γ,RISCVPeepholeRewrite  Γ) :=
 
 /-- Post-legalization combine pass for LLVM specialized for i64 type -/
 def PostLegalizerCombiner_LLVMIR_64 : List (Σ Γ, LLVMPeepholeRewriteRefine 64  Γ) :=
+  sub_add_reg ++
   sub_to_add ++
   redundant_and ++
   select_same_val ++

--- a/SSA/Projects/LLVMRiscV/Pipeline/Combiners.lean
+++ b/SSA/Projects/LLVMRiscV/Pipeline/Combiners.lean
@@ -997,6 +997,81 @@ def commute_int_constant_to_rhs: List (Σ Γ, RISCVPeepholeRewrite  Γ) :=
   ⟨_, commute_int_constant_to_rhs_xor⟩,
   ⟨_, commute_int_constant_to_rhs_mulhu⟩]
 
+/-! ### sub_add_reg -/
+
+/-
+Test the rewrite:
+  (x + y) - y -> x
+-/
+def sub_add_reg_x_add_y_sub_y : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
+  lhs := [LV| {
+    ^entry (%x: i64, %y: i64):
+      %1 = llvm.add %x, %y : i64
+      %2 = llvm.sub %1, %y : i64
+      llvm.return %2 : i64
+  }]
+  rhs := [LV| {
+    ^entry (%x: i64, %y: i64):
+      llvm.return %x : i64
+  }]
+
+/-
+Test the rewrite:
+  (x + y) - y -> x
+-/
+def sub_add_reg_x_add_y_sub_x : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
+  lhs := [LV| {
+    ^entry (%x: i64, %y: i64):
+      %1 = llvm.add %x, %y : i64
+      %2 = llvm.sub %1, %x : i64
+      llvm.return %2 : i64
+  }]
+  rhs := [LV| {
+    ^entry (%x: i64, %y: i64):
+      llvm.return %y : i64
+  }]
+
+/-
+Test the rewrite:
+  x - (y + x) -> 0 - y
+-/
+def sub_add_reg_x_sub_y_add_x : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
+  lhs := [LV| {
+    ^entry (%x: i64, %y: i64):
+      %1 = llvm.add %y, %x : i64
+      %2 = llvm.sub %x, %1 : i64
+      llvm.return %2 : i64
+  }]
+  rhs := [LV| {
+    ^entry (%x: i64, %y: i64):
+      %c = llvm.mlir.constant (0) : i64
+      %0 = llvm.sub %c, %y : i64
+      llvm.return %0 : i64
+  }]
+
+/-
+Test the rewrite:
+  x - (x + y) -> 0 - y
+-/
+def sub_add_reg_x_sub_x_add_y : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
+  lhs := [LV| {
+    ^entry (%x: i64, %y: i64):
+      %1 = llvm.add %x, %y : i64
+      %2 = llvm.sub %x, %1 : i64
+      llvm.return %2 : i64
+  }]
+  rhs := [LV| {
+    ^entry (%x: i64, %y: i64):
+      %c = llvm.mlir.constant (0) : i64
+      %0 = llvm.sub %c, %y : i64
+      llvm.return %0 : i64
+  }]
+
+def sub_add_reg : List (Σ Γ, LLVMPeepholeRewriteRefine 64 Γ) :=
+  [⟨_, sub_add_reg_x_add_y_sub_y⟩,
+  ⟨_, sub_add_reg_x_add_y_sub_x⟩,
+  ⟨_, sub_add_reg_x_sub_y_add_x⟩,
+  ⟨_, sub_add_reg_x_sub_x_add_y⟩]
 
 /- ### not_cmp_fold
   (a op b) ^^^ (-1) → (a op' b) where op' is the inverse of op

--- a/SSA/Projects/LLVMRiscV/Tests/Combiners.lean
+++ b/SSA/Projects/LLVMRiscV/Tests/Combiners.lean
@@ -4,6 +4,48 @@ import LeanMLIR.Framework.Print
 /--
 info: {
   ^bb0(%0 : i64, %1 : i64):
+    %2 = "llvm.add"(%0, %1)<{overflowFlags = #llvm.overflow<none>}> : (i64, i64) -> (i64)
+    "llvm.return"(%0) : (i64) -> ()
+}
+-/
+#guard_msgs in
+#eval! Com.print (DCE.dce' (multiRewritePeephole 100 GLobalISelPostLegalizerCombiner sub_add_reg_x_add_y_sub_y.lhs)).val
+
+/--
+info: {
+  ^bb0(%0 : i64, %1 : i64):
+    %2 = "llvm.add"(%0, %1)<{overflowFlags = #llvm.overflow<none>}> : (i64, i64) -> (i64)
+    "llvm.return"(%1) : (i64) -> ()
+}
+-/
+#guard_msgs in
+#eval! Com.print (DCE.dce' (multiRewritePeephole 100 GLobalISelPostLegalizerCombiner sub_add_reg_x_add_y_sub_x.lhs)).val
+
+/--
+info: {
+  ^bb0(%0 : i64, %1 : i64):
+    %2 = "llvm.const"(){value = 0 : i64} : () -> (i64)
+    %3 = "llvm.sub"(%2, %1)<{overflowFlags = #llvm.overflow<none>}> : (i64, i64) -> (i64)
+    "llvm.return"(%3) : (i64) -> ()
+}
+-/
+#guard_msgs in
+#eval! Com.print (DCE.dce' (DCE.dce' (multiRewritePeephole 100 GLobalISelPostLegalizerCombiner sub_add_reg_x_sub_y_add_x.lhs)).val).val
+
+/--
+info: {
+  ^bb0(%0 : i64, %1 : i64):
+    %2 = "llvm.const"(){value = 0 : i64} : () -> (i64)
+    %3 = "llvm.sub"(%2, %1)<{overflowFlags = #llvm.overflow<none>}> : (i64, i64) -> (i64)
+    "llvm.return"(%3) : (i64) -> ()
+}
+-/
+#guard_msgs in
+#eval! Com.print (DCE.dce' (DCE.dce' (multiRewritePeephole 100 GLobalISelPostLegalizerCombiner sub_add_reg_x_sub_x_add_y.lhs)).val).val
+
+/--
+info: {
+  ^bb0(%0 : i64, %1 : i64):
     %2 = "llvm.const"(){value = 1 : i1} : () -> (i1)
     "llvm.return"(%0) : (i64) -> ()
 }


### PR DESCRIPTION
This PR adds the rewrite pattern [sub_add_reg](https://github.com/llvm/llvm-project/blob/7e3080f0c197316ff06725c446bc59e67f80f069/llvm/include/llvm/Target/GlobalISel/Combine.td#L1455).