### PR TITLE
feat: add `hoist_logic_op_with_same_opcode_hands` rewrite pattern

### DIFF
--- a/SSA/Projects/LLVMRiscV/Pipeline/Combiners.lean
+++ b/SSA/Projects/LLVMRiscV/Pipeline/Combiners.lean
@@ -293,6 +293,432 @@ def right_identity_zero : List (Σ Γ, RISCVPeepholeRewrite  Γ) :=
   ⟨_, right_identity_zero_rol⟩,
   ⟨_, right_identity_zero_ror ⟩]
 
+/-! ### hoist_logic_op_with_same_opcode_hands -/
+
+/-
+Test the rewrite:
+ fold (sext(X) & sext(Y)) -> sext(X & Y)
+-/
+def AndSextSext : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 32), Ty.llvm (.bitvec 32)] where
+  lhs := [LV| {
+    ^entry (%x: i32, %y: i32):
+      %0 = llvm.sext %x : i32 to i64
+      %1 = llvm.sext %y : i32 to i64
+      %2 = llvm.and %0, %1 : i64
+      llvm.return %2 : i64
+  }]
+  rhs := [LV| {
+    ^entry (%x: i32, %y: i32):
+      %0 = llvm.and %x, %y : i32
+      %1 = llvm.sext %0 : i32 to i64
+      llvm.return %1 : i64
+  }]
+
+/-
+Test the rewrite:
+ fold (sext(X) | sext(Y)) -> sext(X | Y)
+-/
+def OrSextSext : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 32), Ty.llvm (.bitvec 32)] where
+  lhs := [LV| {
+    ^entry (%x: i32, %y: i32):
+      %0 = llvm.sext %x : i32 to i64
+      %1 = llvm.sext %y : i32 to i64
+      %2 = llvm.or %0, %1 : i64
+      llvm.return %2 : i64
+  }]
+  rhs := [LV| {
+    ^entry (%x: i32, %y: i32):
+      %0 = llvm.or %x, %y : i32
+      %1 = llvm.sext %0 : i32 to i64
+      llvm.return %1 : i64
+  }]
+
+/-
+Test the rewrite:
+ fold (sext(X) ^ sext(Y)) -> sext(X ^ Y)
+-/
+def XorSextSext : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 32), Ty.llvm (.bitvec 32)] where
+  lhs := [LV| {
+    ^entry (%x: i32, %y: i32):
+      %0 = llvm.sext %x : i32 to i64
+      %1 = llvm.sext %y : i32 to i64
+      %2 = llvm.xor %0, %1 : i64
+      llvm.return %2 : i64
+  }]
+  rhs := [LV| {
+    ^entry (%x: i32, %y: i32):
+      %0 = llvm.xor %x, %y : i32
+      %1 = llvm.sext %0 : i32 to i64
+      llvm.return %1 : i64
+  }]
+
+/-
+Test the rewrite:
+ fold (zext(X) & zext(Y)) -> zext(X & Y)
+-/
+def AndZextZext : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 32), Ty.llvm (.bitvec 32)] where
+  lhs := [LV| {
+    ^entry (%x: i32, %y: i32):
+      %0 = llvm.zext %x : i32 to i64
+      %1 = llvm.zext %y : i32 to i64
+      %2 = llvm.and %0, %1 : i64
+      llvm.return %2 : i64
+  }]
+  rhs := [LV| {
+    ^entry (%x: i32, %y: i32):
+      %0 = llvm.and %x, %y : i32
+      %1 = llvm.zext %0 : i32 to i64
+      llvm.return %1 : i64
+  }]
+
+/-
+Test the rewrite:
+ fold (zext(X) | zext(Y)) -> zext(X | Y)
+-/
+def OrZextZext : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 32), Ty.llvm (.bitvec 32)] where
+  lhs := [LV| {
+    ^entry (%x: i32, %y: i32):
+      %0 = llvm.zext %x : i32 to i64
+      %1 = llvm.zext %y : i32 to i64
+      %2 = llvm.or %0, %1 : i64
+      llvm.return %2 : i64
+  }]
+  rhs := [LV| {
+    ^entry (%x: i32, %y: i32):
+      %0 = llvm.or %x, %y : i32
+      %1 = llvm.zext %0 : i32 to i64
+      llvm.return %1 : i64
+  }]
+
+/-
+Test the rewrite:
+ fold (zext(X) ^ zext(Y)) -> zext(X ^ Y)
+-/
+def XorZextZext : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 32), Ty.llvm (.bitvec 32)] where
+  lhs := [LV| {
+    ^entry (%x: i32, %y: i32):
+      %0 = llvm.zext %x : i32 to i64
+      %1 = llvm.zext %y : i32 to i64
+      %2 = llvm.xor %0, %1 : i64
+      llvm.return %2 : i64
+  }]
+  rhs := [LV| {
+    ^entry (%x: i32, %y: i32):
+      %0 = llvm.xor %x, %y : i32
+      %1 = llvm.zext %0 : i32 to i64
+      llvm.return %1 : i64
+  }]
+
+/-
+Test the rewrite:
+ fold (trunc(X) & trunc(Y)) -> trunc(X & Y)
+-/
+def AndTruncTrunc : LLVMPeepholeRewriteRefine 32 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
+  lhs := [LV| {
+    ^entry (%x: i64, %y: i64):
+      %0 = llvm.trunc %x : i64 to i32
+      %1 = llvm.trunc %y : i64 to i32
+      %2 = llvm.and %0, %1 : i32
+      llvm.return %2 : i32
+  }]
+  rhs := [LV| {
+    ^entry (%x: i64, %y: i64):
+      %0 = llvm.and %x, %y : i64
+      %1 = llvm.trunc %0 : i64 to i32
+      llvm.return %1 : i32
+  }]
+
+/-
+Test the rewrite:
+ fold (trunc(X) | trunc(Y)) -> trunc(X | Y)
+-/
+def OrTruncTrunc : LLVMPeepholeRewriteRefine 32 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
+  lhs := [LV| {
+    ^entry (%x: i64, %y: i64):
+      %0 = llvm.trunc %x : i64 to i32
+      %1 = llvm.trunc %y : i64 to i32
+      %2 = llvm.or %0, %1 : i32
+      llvm.return %2 : i32
+  }]
+  rhs := [LV| {
+    ^entry (%x: i64, %y: i64):
+      %0 = llvm.or %x, %y : i64
+      %1 = llvm.trunc %0 : i64 to i32
+      llvm.return %1 : i32
+  }]
+
+/-
+Test the rewrite:
+ fold (trunc(X) ^ trunc(Y)) -> trunc(X ^ Y)
+-/
+def XorTruncTrunc : LLVMPeepholeRewriteRefine 32 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
+  lhs := [LV| {
+    ^entry (%x: i64, %y: i64):
+      %0 = llvm.trunc %x : i64 to i32
+      %1 = llvm.trunc %y : i64 to i32
+      %2 = llvm.xor %0, %1 : i32
+      llvm.return %2 : i32
+  }]
+  rhs := [LV| {
+    ^entry (%x: i64, %y: i64):
+      %0 = llvm.xor %x, %y : i64
+      %1 = llvm.trunc %0 : i64 to i32
+      llvm.return %1 : i32
+  }]
+
+/-
+Test the rewrite:
+ fold ((X << Z) & (Y << Z)) -> (X & Y) << Z
+-/
+def AndShlShl : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
+  lhs := [LV| {
+    ^entry (%x: i64, %y: i64, %z: i64):
+      %0 = llvm.shl %x, %z : i64
+      %1 = llvm.shl %y, %z : i64
+      %2 = llvm.and %0, %1 : i64
+      llvm.return %2 : i64
+  }]
+  rhs := [LV| {
+    ^entry (%x: i64, %y: i64, %z: i64):
+      %0 = llvm.and %x, %y : i64
+      %1 = llvm.shl %0, %z : i64
+      llvm.return %1 : i64
+  }]
+
+/-
+Test the rewrite:
+ fold ((X << Z) | (Y << Z)) -> (X | Y) << Z
+-/
+def OrShlShl : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
+  lhs := [LV| {
+    ^entry (%x: i64, %y: i64, %z: i64):
+      %0 = llvm.shl %x, %z : i64
+      %1 = llvm.shl %y, %z : i64
+      %2 = llvm.or %0, %1 : i64
+      llvm.return %2 : i64
+  }]
+  rhs := [LV| {
+    ^entry (%x: i64, %y: i64, %z: i64):
+      %0 = llvm.or %x, %y : i64
+      %1 = llvm.shl %0, %z : i64
+      llvm.return %1 : i64
+  }]
+
+/-
+Test the rewrite:
+ fold ((X << Z) ^ (Y << Z)) -> (X ^ Y) << Z
+-/
+def XorShlShl : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
+  lhs := [LV| {
+    ^entry (%x: i64, %y: i64, %z: i64):
+      %0 = llvm.shl %x, %z : i64
+      %1 = llvm.shl %y, %z : i64
+      %2 = llvm.xor %0, %1 : i64
+      llvm.return %2 : i64
+  }]
+  rhs := [LV| {
+    ^entry (%x: i64, %y: i64, %z: i64):
+      %0 = llvm.xor %x, %y : i64
+      %1 = llvm.shl %0, %z : i64
+      llvm.return %1 : i64
+  }]
+
+/-
+Test the rewrite:
+ fold ((X >> Z) & (Y >> Z)) -> (X & Y) >> Z (logical shift)
+-/
+def AndLshrLshr : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
+  lhs := [LV| {
+    ^entry (%x: i64, %y: i64, %z: i64):
+      %0 = llvm.lshr %x, %z : i64
+      %1 = llvm.lshr %y, %z : i64
+      %2 = llvm.and %0, %1 : i64
+      llvm.return %2 : i64
+  }]
+  rhs := [LV| {
+    ^entry (%x: i64, %y: i64, %z: i64):
+      %0 = llvm.and %x, %y : i64
+      %1 = llvm.lshr %0, %z : i64
+      llvm.return %1 : i64
+  }]
+
+/-
+Test the rewrite:
+ fold ((X >> Z) | (Y >> Z)) -> (X | Y) >> Z (logical shift)
+-/
+def OrLshrLshr : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
+  lhs := [LV| {
+    ^entry (%x: i64, %y: i64, %z: i64):
+      %0 = llvm.lshr %x, %z : i64
+      %1 = llvm.lshr %y, %z : i64
+      %2 = llvm.or %0, %1 : i64
+      llvm.return %2 : i64
+  }]
+  rhs := [LV| {
+    ^entry (%x: i64, %y: i64, %z: i64):
+      %0 = llvm.or %x, %y : i64
+      %1 = llvm.lshr %0, %z : i64
+      llvm.return %1 : i64
+  }]
+
+/-
+Test the rewrite:
+ fold ((X >> Z) ^ (Y >> Z)) -> (X ^ Y) >> Z (logical shift)
+-/
+def XorLshrLshr : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
+  lhs := [LV| {
+    ^entry (%x: i64, %y: i64, %z: i64):
+      %0 = llvm.lshr %x, %z : i64
+      %1 = llvm.lshr %y, %z : i64
+      %2 = llvm.xor %0, %1 : i64
+      llvm.return %2 : i64
+  }]
+  rhs := [LV| {
+    ^entry (%x: i64, %y: i64, %z: i64):
+      %0 = llvm.xor %x, %y : i64
+      %1 = llvm.lshr %0, %z : i64
+      llvm.return %1 : i64
+  }]
+
+/-
+Test the rewrite:
+ fold ((X >> Z) & (Y >> Z)) -> (X & Y) >> Z (arithmetic shift)
+-/
+def AndAshrAshr : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
+  lhs := [LV| {
+    ^entry (%x: i64, %y: i64, %z: i64):
+      %0 = llvm.ashr %x, %z : i64
+      %1 = llvm.ashr %y, %z : i64
+      %2 = llvm.and %0, %1 : i64
+      llvm.return %2 : i64
+  }]
+  rhs := [LV| {
+    ^entry (%x: i64, %y: i64, %z: i64):
+      %0 = llvm.and %x, %y : i64
+      %1 = llvm.ashr %0, %z : i64
+      llvm.return %1 : i64
+  }]
+
+/-
+Test the rewrite:
+ fold ((X >> Z) | (Y >> Z)) -> (X | Y) >> Z (arithmetic shift)
+-/
+def OrAshrAshr : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
+  lhs := [LV| {
+    ^entry (%x: i64, %y: i64, %z: i64):
+      %0 = llvm.ashr %x, %z : i64
+      %1 = llvm.ashr %y, %z : i64
+      %2 = llvm.or %0, %1 : i64
+      llvm.return %2 : i64
+  }]
+  rhs := [LV| {
+    ^entry (%x: i64, %y: i64, %z: i64):
+      %0 = llvm.or %x, %y : i64
+      %1 = llvm.ashr %0, %z : i64
+      llvm.return %1 : i64
+  }]
+
+/-
+Test the rewrite:
+ fold ((X >> Z) ^ (Y >> Z)) -> (X ^ Y) >> Z (arithmetic shift)
+-/
+def XorAshrAshr : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
+  lhs := [LV| {
+    ^entry (%x: i64, %y: i64, %z: i64):
+      %0 = llvm.ashr %x, %z : i64
+      %1 = llvm.ashr %y, %z : i64
+      %2 = llvm.xor %0, %1 : i64
+      llvm.return %2 : i64
+  }]
+  rhs := [LV| {
+    ^entry (%x: i64, %y: i64, %z: i64):
+      %0 = llvm.xor %x, %y : i64
+      %1 = llvm.ashr %0, %z : i64
+      llvm.return %1 : i64
+  }]
+
+/-
+Test the rewrite:
+ fold ((X & Z) & (Y & Z)) -> (X & Y) & Z
+-/
+def AndAndAnd : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
+  lhs := [LV| {
+    ^entry (%x: i64, %y: i64, %z: i64):
+      %0 = llvm.and %x, %z : i64
+      %1 = llvm.and %y, %z : i64
+      %2 = llvm.and %0, %1 : i64
+      llvm.return %2 : i64
+  }]
+  rhs := [LV| {
+    ^entry (%x: i64, %y: i64, %z: i64):
+      %0 = llvm.and %x, %y : i64
+      %1 = llvm.and %0, %z : i64
+      llvm.return %1 : i64
+  }]
+
+/-
+Test the rewrite:
+ fold ((X & Z) | (Y & Z)) -> (X | Y) & Z
+-/
+def OrAndAnd : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
+  lhs := [LV| {
+    ^entry (%x: i64, %y: i64, %z: i64):
+      %0 = llvm.and %x, %z : i64
+      %1 = llvm.and %y, %z : i64
+      %2 = llvm.or %0, %1 : i64
+      llvm.return %2 : i64
+  }]
+  rhs := [LV| {
+    ^entry (%x: i64, %y: i64, %z: i64):
+      %0 = llvm.or %x, %y : i64
+      %1 = llvm.and %0, %z : i64
+      llvm.return %1 : i64
+  }]
+
+/-
+Test the rewrite:
+ fold ((X & Z) ^ (Y & Z)) -> (X ^ Y) & Z
+-/
+def XorAndAnd : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
+  lhs := [LV| {
+    ^entry (%x: i64, %y: i64, %z: i64):
+      %0 = llvm.and %x, %z : i64
+      %1 = llvm.and %y, %z : i64
+      %2 = llvm.xor %0, %1 : i64
+      llvm.return %2 : i64
+  }]
+  rhs := [LV| {
+    ^entry (%x: i64, %y: i64, %z: i64):
+      %0 = llvm.xor %x, %y : i64
+      %1 = llvm.and %0, %z : i64
+      llvm.return %1 : i64
+  }]
+
+def hoist_logic_op_with_same_opcode_hands_32 : List (Σ Γ, LLVMPeepholeRewriteRefine 32 Γ) :=
+  [⟨_, AndTruncTrunc⟩,
+  ⟨_, OrTruncTrunc⟩,
+  ⟨_, XorTruncTrunc⟩]
+
+def hoist_logic_op_with_same_opcode_hands_64 : List (Σ Γ, LLVMPeepholeRewriteRefine 64 Γ) :=
+  [⟨_, AndSextSext⟩,
+  ⟨_, OrSextSext⟩,
+  ⟨_, XorSextSext⟩,
+  ⟨_, AndZextZext⟩,
+  ⟨_, OrZextZext⟩,
+  ⟨_, XorZextZext⟩,
+  ⟨_, AndShlShl⟩,
+  ⟨_, OrShlShl⟩,
+  ⟨_, XorShlShl⟩,
+  ⟨_, AndLshrLshr⟩,
+  ⟨_, OrLshrLshr⟩,
+  ⟨_, XorLshrLshr⟩,
+  ⟨_, AndAshrAshr⟩,
+  ⟨_, OrAshrAshr⟩,
+  ⟨_, XorAshrAshr⟩,
+  ⟨_, AndAndAnd⟩,
+  ⟨_, OrAndAnd⟩,
+  ⟨_, XorAndAnd⟩]
+
 /-- ### binop_same_val
   (x op x) → x
 -/
@@ -1131,6 +1557,7 @@ def PostLegalizerCombiner_RISCV: List (Σ Γ,RISCVPeepholeRewrite  Γ) :=
 
 /-- Post-legalization combine pass for LLVM specialized for i64 type -/
 def PostLegalizerCombiner_LLVMIR_64 : List (Σ Γ, LLVMPeepholeRewriteRefine 64  Γ) :=
+  hoist_logic_op_with_same_opcode_hands_64 ++
   sub_to_add ++
   redundant_and ++
   select_same_val ++
@@ -1138,6 +1565,7 @@ def PostLegalizerCombiner_LLVMIR_64 : List (Σ Γ, LLVMPeepholeRewriteRefine 64 
 
 /-- Post-legalization combine pass for LLVM specialized for i64 type -/
 def PostLegalizerCombiner_LLVMIR_32 : List (Σ Γ, LLVMPeepholeRewriteRefine 32  Γ) :=
+  hoist_logic_op_with_same_opcode_hands_32 ++
   LLVMIR_identity_combines_32
 
 /-- We group all the rewrites that form the pre-legalization optimizations in GlobalISel-/

--- a/SSA/Projects/LLVMRiscV/Tests/Combiners.lean
+++ b/SSA/Projects/LLVMRiscV/Tests/Combiners.lean
@@ -332,3 +332,234 @@ info: {
 -/
 #guard_msgs in
 #eval! Com.print (DCE.dce' (multiRewritePeephole 100 GLobalISelPostLegalizerCombiner urem_pow2_to_mask_1024.lhs)).val
+
+/--
+info: {
+  ^bb0(%0 : i32, %1 : i32):
+    %2 = "llvm.and"(%0, %1) : (i32, i32) -> (i32)
+    %3 = "llvm.sext"(%2) : (i32) -> (i64)
+    "llvm.return"(%3) : (i64) -> ()
+}
+-/
+#guard_msgs in
+#eval! Com.print (DCE.dce' (DCE.dce' (multiRewritePeephole 100 GLobalISelPostLegalizerCombiner AndSextSext.lhs)).val).val
+
+/--
+info: {
+  ^bb0(%0 : i32, %1 : i32):
+    %2 = "llvm.or"(%0, %1) : (i32, i32) -> (i32)
+    %3 = "llvm.sext"(%2) : (i32) -> (i64)
+    "llvm.return"(%3) : (i64) -> ()
+}
+-/
+#guard_msgs in
+#eval! Com.print (DCE.dce' (DCE.dce' (multiRewritePeephole 100 GLobalISelPostLegalizerCombiner OrSextSext.lhs)).val).val
+
+/--
+info: {
+  ^bb0(%0 : i32, %1 : i32):
+    %2 = "llvm.xor"(%0, %1) : (i32, i32) -> (i32)
+    %3 = "llvm.sext"(%2) : (i32) -> (i64)
+    "llvm.return"(%3) : (i64) -> ()
+}
+-/
+#guard_msgs in
+#eval! Com.print (DCE.dce' (DCE.dce' (multiRewritePeephole 100 GLobalISelPostLegalizerCombiner XorSextSext.lhs)).val).val
+
+/--
+info: {
+  ^bb0(%0 : i32, %1 : i32):
+    %2 = "llvm.and"(%0, %1) : (i32, i32) -> (i32)
+    %3 = "llvm.zext"(%2) : (i32) -> (i64)
+    "llvm.return"(%3) : (i64) -> ()
+}
+-/
+#guard_msgs in
+#eval! Com.print (DCE.dce' (DCE.dce' (multiRewritePeephole 100 GLobalISelPostLegalizerCombiner AndZextZext.lhs)).val).val
+
+/--
+info: {
+  ^bb0(%0 : i32, %1 : i32):
+    %2 = "llvm.or"(%0, %1) : (i32, i32) -> (i32)
+    %3 = "llvm.zext"(%2) : (i32) -> (i64)
+    "llvm.return"(%3) : (i64) -> ()
+}
+-/
+#guard_msgs in
+#eval! Com.print (DCE.dce' (DCE.dce' (multiRewritePeephole 100 GLobalISelPostLegalizerCombiner OrZextZext.lhs)).val).val
+
+/--
+info: {
+  ^bb0(%0 : i32, %1 : i32):
+    %2 = "llvm.xor"(%0, %1) : (i32, i32) -> (i32)
+    %3 = "llvm.zext"(%2) : (i32) -> (i64)
+    "llvm.return"(%3) : (i64) -> ()
+}
+-/
+#guard_msgs in
+#eval! Com.print (DCE.dce' (DCE.dce' (multiRewritePeephole 100 GLobalISelPostLegalizerCombiner XorZextZext.lhs)).val).val
+
+/--
+info: {
+  ^bb0(%0 : i64, %1 : i64):
+    %2 = "llvm.and"(%0, %1) : (i64, i64) -> (i64)
+    %3 = "llvm.trunc"(%2) : (i64) -> (i32)
+    "llvm.return"(%3) : (i32) -> ()
+}
+-/
+#guard_msgs in
+#eval! Com.print (DCE.dce' (DCE.dce' (multiRewritePeephole 100 GLobalISelPostLegalizerCombiner AndTruncTrunc.lhs)).val).val
+
+/--
+info: {
+  ^bb0(%0 : i64, %1 : i64):
+    %2 = "llvm.or"(%0, %1) : (i64, i64) -> (i64)
+    %3 = "llvm.trunc"(%2) : (i64) -> (i32)
+    "llvm.return"(%3) : (i32) -> ()
+}
+-/
+#guard_msgs in
+#eval! Com.print (DCE.dce' (DCE.dce' (multiRewritePeephole 100 GLobalISelPostLegalizerCombiner OrTruncTrunc.lhs)).val).val
+
+/--
+info: {
+  ^bb0(%0 : i64, %1 : i64):
+    %2 = "llvm.xor"(%0, %1) : (i64, i64) -> (i64)
+    %3 = "llvm.trunc"(%2) : (i64) -> (i32)
+    "llvm.return"(%3) : (i32) -> ()
+}
+-/
+#guard_msgs in
+#eval! Com.print (DCE.dce' (DCE.dce' (multiRewritePeephole 100 GLobalISelPostLegalizerCombiner XorTruncTrunc.lhs)).val).val
+
+/--
+info: {
+  ^bb0(%0 : i64, %1 : i64, %2 : i64):
+    %3 = "llvm.and"(%0, %1) : (i64, i64) -> (i64)
+    %4 = "llvm.shl"(%3, %2)<{overflowFlags = #llvm.overflow<none>}> : (i64, i64) -> (i64)
+    "llvm.return"(%4) : (i64) -> ()
+}
+-/
+#guard_msgs in
+#eval! Com.print (DCE.dce' (DCE.dce' (multiRewritePeephole 100 GLobalISelPostLegalizerCombiner AndShlShl.lhs)).val).val
+
+/--
+info: {
+  ^bb0(%0 : i64, %1 : i64, %2 : i64):
+    %3 = "llvm.or"(%0, %1) : (i64, i64) -> (i64)
+    %4 = "llvm.shl"(%3, %2)<{overflowFlags = #llvm.overflow<none>}> : (i64, i64) -> (i64)
+    "llvm.return"(%4) : (i64) -> ()
+}
+-/
+#guard_msgs in
+#eval! Com.print (DCE.dce' (DCE.dce' (multiRewritePeephole 100 GLobalISelPostLegalizerCombiner OrShlShl.lhs)).val).val
+
+/--
+info: {
+  ^bb0(%0 : i64, %1 : i64, %2 : i64):
+    %3 = "llvm.xor"(%0, %1) : (i64, i64) -> (i64)
+    %4 = "llvm.shl"(%3, %2)<{overflowFlags = #llvm.overflow<none>}> : (i64, i64) -> (i64)
+    "llvm.return"(%4) : (i64) -> ()
+}
+-/
+#guard_msgs in
+#eval! Com.print (DCE.dce' (DCE.dce' (multiRewritePeephole 100 GLobalISelPostLegalizerCombiner XorShlShl.lhs)).val).val
+
+/--
+info: {
+  ^bb0(%0 : i64, %1 : i64, %2 : i64):
+    %3 = "llvm.and"(%0, %1) : (i64, i64) -> (i64)
+    %4 = "llvm.lshr"(%3, %2) : (i64, i64) -> (i64)
+    "llvm.return"(%4) : (i64) -> ()
+}
+-/
+#guard_msgs in
+#eval! Com.print (DCE.dce' (DCE.dce' (multiRewritePeephole 100 GLobalISelPostLegalizerCombiner AndLshrLshr.lhs)).val).val
+
+/--
+info: {
+  ^bb0(%0 : i64, %1 : i64, %2 : i64):
+    %3 = "llvm.or"(%0, %1) : (i64, i64) -> (i64)
+    %4 = "llvm.lshr"(%3, %2) : (i64, i64) -> (i64)
+    "llvm.return"(%4) : (i64) -> ()
+}
+-/
+#guard_msgs in
+#eval! Com.print (DCE.dce' (DCE.dce' (multiRewritePeephole 100 GLobalISelPostLegalizerCombiner OrLshrLshr.lhs)).val).val
+
+/--
+info: {
+  ^bb0(%0 : i64, %1 : i64, %2 : i64):
+    %3 = "llvm.xor"(%0, %1) : (i64, i64) -> (i64)
+    %4 = "llvm.lshr"(%3, %2) : (i64, i64) -> (i64)
+    "llvm.return"(%4) : (i64) -> ()
+}
+-/
+#guard_msgs in
+#eval! Com.print (DCE.dce' (DCE.dce' (multiRewritePeephole 100 GLobalISelPostLegalizerCombiner XorLshrLshr.lhs)).val).val
+
+/--
+info: {
+  ^bb0(%0 : i64, %1 : i64, %2 : i64):
+    %3 = "llvm.and"(%0, %1) : (i64, i64) -> (i64)
+    %4 = "llvm.ashr"(%3, %2) : (i64, i64) -> (i64)
+    "llvm.return"(%4) : (i64) -> ()
+}
+-/
+#guard_msgs in
+#eval! Com.print (DCE.dce' (DCE.dce' (multiRewritePeephole 100 GLobalISelPostLegalizerCombiner AndAshrAshr.lhs)).val).val
+
+/--
+info: {
+  ^bb0(%0 : i64, %1 : i64, %2 : i64):
+    %3 = "llvm.or"(%0, %1) : (i64, i64) -> (i64)
+    %4 = "llvm.ashr"(%3, %2) : (i64, i64) -> (i64)
+    "llvm.return"(%4) : (i64) -> ()
+}
+-/
+#guard_msgs in
+#eval! Com.print (DCE.dce' (DCE.dce' (multiRewritePeephole 100 GLobalISelPostLegalizerCombiner OrAshrAshr.lhs)).val).val
+
+/--
+info: {
+  ^bb0(%0 : i64, %1 : i64, %2 : i64):
+    %3 = "llvm.xor"(%0, %1) : (i64, i64) -> (i64)
+    %4 = "llvm.ashr"(%3, %2) : (i64, i64) -> (i64)
+    "llvm.return"(%4) : (i64) -> ()
+}
+-/
+#guard_msgs in
+#eval! Com.print (DCE.dce' (DCE.dce' (multiRewritePeephole 100 GLobalISelPostLegalizerCombiner XorAshrAshr.lhs)).val).val
+
+/--
+info: {
+  ^bb0(%0 : i64, %1 : i64, %2 : i64):
+    %3 = "llvm.and"(%0, %1) : (i64, i64) -> (i64)
+    %4 = "llvm.and"(%3, %2) : (i64, i64) -> (i64)
+    "llvm.return"(%4) : (i64) -> ()
+}
+-/
+#guard_msgs in
+#eval! Com.print (DCE.dce' (DCE.dce' (multiRewritePeephole 100 GLobalISelPostLegalizerCombiner AndAndAnd.lhs)).val).val
+
+/--
+info: {
+  ^bb0(%0 : i64, %1 : i64, %2 : i64):
+    %3 = "llvm.or"(%0, %1) : (i64, i64) -> (i64)
+    %4 = "llvm.and"(%3, %2) : (i64, i64) -> (i64)
+    "llvm.return"(%4) : (i64) -> ()
+}
+-/
+#guard_msgs in
+#eval! Com.print (DCE.dce' (DCE.dce' (multiRewritePeephole 100 GLobalISelPostLegalizerCombiner OrAndAnd.lhs)).val).val
+
+/--
+info: {
+  ^bb0(%0 : i64, %1 : i64, %2 : i64):
+    %3 = "llvm.xor"(%0, %1) : (i64, i64) -> (i64)
+    %4 = "llvm.and"(%3, %2) : (i64, i64) -> (i64)
+    "llvm.return"(%4) : (i64) -> ()
+}
+-/
+#guard_msgs in
+#eval! Com.print (DCE.dce' (DCE.dce' (multiRewritePeephole 100 GLobalISelPostLegalizerCombiner XorAndAnd.lhs)).val).val


### PR DESCRIPTION
This PR adds the rewrite pattern [hoist_logic_op_with_same_opcode_hands](https://github.com/llvm/llvm-project/blob/7e3080f0c197316ff06725c446bc59e67f80f069/llvm/include/llvm/Target/GlobalISel/Combine.td#L754).

These patterns require checking that arguments are used only once, which is currently not supported in lean-mlir. Without this check, using these rewrites in larger programs may increase the number of instructions.