### PR TITLE
chore: add a testcase that exposes a bug in elimValuation simproc

### DIFF
--- a/LeanMLIR/LeanMLIR/Tests.lean
+++ b/LeanMLIR/LeanMLIR/Tests.lean
@@ -1,1 +1,2 @@
 import LeanMLIR.Tests.Dialects.LLVM
+import LeanMLIR.Tests.Tactic.ElimValuation

--- a/LeanMLIR/LeanMLIR/Tests/Tactic/ElimValuation.lean
+++ b/LeanMLIR/LeanMLIR/Tests/Tactic/ElimValuation.lean
@@ -4,7 +4,7 @@ import LeanMLIR
 # ElimValuation simproc
 
 The following is an MWE extracted from `circomvent` (our LLZK experiments repo),
-where the `SSA.elimValuation` triggered a `(kernel) application type mismatch`
+where the `SSA.elimValuation` simproc triggered a `(kernel) application type mismatch`
 error.
 -/
 

--- a/LeanMLIR/LeanMLIR/Tests/Tactic/ElimValuation.lean
+++ b/LeanMLIR/LeanMLIR/Tests/Tactic/ElimValuation.lean
@@ -1,0 +1,33 @@
+import LeanMLIR
+
+/-!
+# ElimValuation simproc
+
+The following is an MWE extracted from `circomvent` (our LLZK experiments repo),
+where the `SSA.elimValuation` triggered a `(kernel) application type mismatch`
+error.
+-/
+
+namespace MWE
+open Ctxt (Valuation)
+
+inductive Ty
+  | felt
+
+def BabyBear := 2^31 - 2^27 + 1
+
+instance : TyDenote Ty where toType
+  | .felt => Fin BabyBear
+
+set_option warn.sorry false in
+example (i : Fin BabyBear) :
+    ∀ (os : Valuation ⟨[Ty.felt]⟩), ∃ (es' : Valuation ⟨[Ty.felt]⟩),
+      (Valuation.cons i <| .cons i <| .nil) = (os ++ es') := by
+  -- simp only [SSA.elimValuation]
+  -- ^^ uncomment the above to trigger a `(kernel) application type mismatch` error
+  stop
+  guard_target = ∀ (e : ⟦Ty.felt⟧), ∃ (es' : Valuation ⟨[Ty.felt]⟩),
+    (Valuation.cons i <| .cons i .nil) = (Valuation.cons e .nil ++ es')
+  sorry
+
+end MWE


### PR DESCRIPTION
This PR adds a minimized example from opencompl/circomvent where the `elimValuation` simproc generates a wrong proof, thus triggering a `(kernel) match application` error.

For now, the line that actually triggers the error is commented out, so that the test doesn't fail and we can merge this PR. When we get around to fixing this, we should uncomment the line so that the test becomes a regression test.