### PR TITLE
chore: import LeanMLIR.Tests from SSA.Tests

### DIFF
--- a/LeanMLIR/LeanMLIR/Tests/Dialects/LLVM/Print.lean
+++ b/LeanMLIR/LeanMLIR/Tests/Dialects/LLVM/Print.lean
@@ -1135,7 +1135,7 @@ info: builtin.module {
 /--
 info: {
   ^bb0(%0 : i64, %1 : i64):
-    %2 = "llvm.icmp.eq"(%0, %1)eq : (i64, i64) -> (i1)
+    %2 = "llvm.icmp.eq"(%0, %1) : (i64, i64) -> (i1)
     "llvm.return"(%2) : (i1) -> ()
 }
 -/
@@ -1147,7 +1147,7 @@ info: {
 /--
 info: {
   ^bb0(%0 : i64, %1 : i64):
-    %2 = "llvm.icmp.eq"(%0, %1)eq : (i64, i64) -> (i1)
+    %2 = "llvm.icmp.eq"(%0, %1) : (i64, i64) -> (i1)
     "llvm.return"(%2) : (i1) -> ()
 }
 -/

--- a/SSA/Tests.lean
+++ b/SSA/Tests.lean
@@ -1,4 +1,5 @@
 import SSA.Tests.Core.Tests
+import LeanMLIR.Tests
 
 import SSA.Projects.InstCombine.ScalingTest
 import SSA.Projects.SLLVM.Tests


### PR DESCRIPTION
This tests adds an import for `LeanMLIR.Tests` to the `SSA.Tests` file. It turns out only the latter was being run in CI, so this ensures we actually run our LeanMLIR/core tests as well.