### PR TITLE
fix: print "llvm.mlir.constant" rather than "llvm.const"

### DIFF
--- a/LeanMLIR/LeanMLIR/Dialects/LLVM/Basic.lean
+++ b/LeanMLIR/LeanMLIR/Dialects/LLVM/Basic.lean
@@ -413,7 +413,7 @@ def MetaLLVM.opName : (MetaLLVM φ).Op → String
   | .sdiv _ _   => "llvm.sdiv"
   | .udiv _ _   => "llvm.udiv"
   | .icmp ty _  => s!"llvm.icmp.{ty}"
-  | .const _ _  => "llvm.const"
+  | .const _ _  => "llvm.mlir.constant"
 
 def MetaLLVM.printAttributes : (MetaLLVM φ).Op → String
   | .const w v => s!"\{value = {v} : {w}}"

--- a/LeanMLIR/LeanMLIR/Tests/Dialects/LLVM/Print.lean
+++ b/LeanMLIR/LeanMLIR/Tests/Dialects/LLVM/Print.lean
@@ -1174,7 +1174,7 @@ info: builtin.module {
 /--
 info: builtin.module {
   ^bb0():
-    %0 = "llvm.const"(){value = 42 : i64} : () -> (i64)
+    %0 = "llvm.mlir.constant"(){value = 42 : i64} : () -> (i64)
     "llvm.return"(%0) : (i64) -> ()
 }
 -/
@@ -1186,7 +1186,7 @@ info: builtin.module {
 /--
 info: {
   ^bb0():
-    %0 = "llvm.const"(){value = 42 : i64} : () -> (i64)
+    %0 = "llvm.mlir.constant"(){value = 42 : i64} : () -> (i64)
     "llvm.return"(%0) : (i64) -> ()
 }
 -/
@@ -1198,7 +1198,7 @@ info: {
 /--
 info: {
   ^bb0():
-    %0 = "llvm.const"(){value = 42 : i64} : () -> (i64)
+    %0 = "llvm.mlir.constant"(){value = 42 : i64} : () -> (i64)
     "llvm.return"(%0) : (i64) -> ()
 }
 -/


### PR DESCRIPTION
Our code was printing `llvm.const`, but the correct name of the operation is `llvm.mlir.constant`