### PR TITLE
fix: add support for `true`/`false` constant values

### DIFF
--- a/LeanMLIR/LeanMLIR/MLIRSyntax/GenericParser.lean
+++ b/LeanMLIR/LeanMLIR/MLIRSyntax/GenericParser.lean
@@ -621,11 +621,6 @@ macro_rules
     `(AttrValue.int $x [mlir_type| $t])
 
 macro_rules
-| `([mlir_attr_val| true ]) => `(AttrValue.bool True)
-| `([mlir_attr_val| false ]) => `(AttrValue.bool False)
-
-
-macro_rules
 | `([mlir_attr_val| # $dialect:ident <$xs ,* > ]) => do
   let initList : TSyntax `term  <- `([])
   let vals : TSyntax `term <- xs.getElems.foldlM (init := initList) fun (xs : TSyntax `term) (x : TSyntax `mlir_attr_val) =>
@@ -652,6 +647,8 @@ macro_rules
         let vals <- xs.getElems.foldlM (init := initList) fun xs x =>
             `($xs ++ [[mlir_attr_val| $x]])
         `(AttrValue.list $vals)
+  | `([mlir_attr_val| true ]) => `(AttrValue.bool True)
+  | `([mlir_attr_val| false ]) => `(AttrValue.bool False)
   | `([mlir_attr_val| $i:ident]) => `(AttrValue.type [mlir_type| $i:ident])
   | `([mlir_attr_val| $ty:mlir_type]) => `(AttrValue.type [mlir_type| $ty])
 

--- a/LeanMLIR/LeanMLIR/MLIRSyntax/Transform/Utils.lean
+++ b/LeanMLIR/LeanMLIR/MLIRSyntax/Transform/Utils.lean
@@ -45,9 +45,16 @@ def getBoolAttr (attr : String) : Except TransformError Bool := do
 
 Throws an error if the attribute is not present, or if the value of the attribute
 has the wrong type.
+
+If `coeBool` is true, then an attribute of Boolean type is automatically coerced
+to a 1-bit (signless) integer, where `true` maps to `1` and `false` to `0`.
 -/
-def getIntAttr (attr : String) : Except TransformError (Int × MLIRType φ) := do
-  let .int val ty ← op.getAttr attr
+def getIntAttr (attr : String) (coeBool : Bool := true) : Except TransformError (Int × MLIRType φ) := do
+  let attrVal ← op.getAttr attr
+  if coeBool then if let .bool b := attrVal then
+    return (if b then 1 else 0, .int .Signless (.concrete 1))
+
+  let .int val ty := attrVal
     | .error <| .generic s!"Expected attribute `{attr}` to be of type Int, but found:\n\
         \t{attr}"
   return (val, ty)

--- a/LeanMLIR/LeanMLIR/Tests/Dialects/LLVM/Print.lean
+++ b/LeanMLIR/LeanMLIR/Tests/Dialects/LLVM/Print.lean
@@ -1207,3 +1207,29 @@ info: {
     %z = "llvm.mlir.constant"() {value = 42 : i64} : () -> (i64)
     "llvm.return"(%z) : (i64) -> ()
 }]
+
+/--
+info: {
+  ^bb0():
+    %0 = "llvm.mlir.constant"(){value = 1 : i1} : () -> (i1)
+    "llvm.return"(%0) : (i1) -> ()
+}
+-/
+#guard_msgs in #eval [llvm| {
+  ^bb0():
+    %z = "llvm.mlir.constant"() {value = true} : () -> (i1)
+    "llvm.return"(%z) : (i1) -> ()
+}]
+
+/--
+info: {
+  ^bb0():
+    %0 = "llvm.mlir.constant"(){value = 0 : i1} : () -> (i1)
+    "llvm.return"(%0) : (i1) -> ()
+}
+-/
+#guard_msgs in #eval [llvm| {
+  ^bb0():
+    %z = "llvm.mlir.constant"() {value = false} : () -> (i1)
+    "llvm.return"(%z) : (i1) -> ()
+}]


### PR DESCRIPTION
This PR fixes an error in the generic MLIR syntax parser where `true` and `false` attribute values were being parsed wrongly. Furthermore, we then added an option to the `getIntValue` helper which enables automatic coercion of boolean attribute values into 1-bit signless integers, which enables `true` and `false` values for the `llvm.mlir.constant` operation -- where they are interpreted as values `1` and `0` of type `i1`, respectively.

Note that the generic parser error had to do with `true` and `false` being parsed as identifiers, and this being translated to, e.g., `AttrValue.type [mlir_type| true]`, which then of course complains about being unable to parse `true` as a `type`. This got fixed by moving the relevant `macro_rules` arms into the same `macro_rules` block as other identifiers, and *before* the general identifier rule, to ensure the proper `true`/`false` translation takes precedence.