### PR TITLE
chore: drop "Compile Project Tests" CI job, as it overlaps with "Test Core Library"

### DIFF
--- a/.github/workflows/evaluation.yml
+++ b/.github/workflows/evaluation.yml
@@ -270,10 +270,6 @@ jobs:
         run: |
           lake -R build ISL
 
-      - name: Compile Project Tests
-        run: |
-          lake -R build SSA.Tests
-
       - name: Check for changes in AliveStatements
         run: |
           lake build AliveExamples


### PR DESCRIPTION
There were two steps in separate jobs which both ran `lake build SSA.Tests`, so I removed the step from the slowest one, given that it's redundant.