### PR TITLE
feat: add `double_icmp_zero` rewrite pattern

### DIFF
--- a/SSA/Projects/LLVMRiscV/Pipeline/Combiners.lean
+++ b/SSA/Projects/LLVMRiscV/Pipeline/Combiners.lean
@@ -1185,6 +1185,54 @@ def not_cmp_fold : List (Σ Γ, LLVMPeepholeRewriteRefine 1 Γ) :=
   ⟨_, not_cmp_fold_sge⟩,
   ⟨_, not_cmp_fold_sge⟩]
 
+/-! ### double_icmp_zero_combine -/
+
+/-
+Test the rewrite:
+  Transform: (X == 0 & Y == 0) -> (X | Y) == 0
+-/
+def double_icmp_zero_and_combine : LLVMPeepholeRewriteRefine 1 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
+  lhs := [LV| {
+    ^entry (%x: i64, %y: i64):
+      %c = llvm.mlir.constant (0) : i64
+      %0 = llvm.icmp.eq %x, %c : i64
+      %1 = llvm.icmp.eq %y, %c : i64
+      %2 = llvm.and %0, %1 : i1
+      llvm.return %2 : i1
+  }]
+  rhs := [LV| {
+    ^entry (%x: i64, %y: i64):
+      %c = llvm.mlir.constant (0) : i64
+      %0 = llvm.or %x, %y : i64
+      %1 = llvm.icmp.eq %0, %c : i64
+      llvm.return %1 : i1
+  }]
+
+/-
+Test the rewrite:
+  Transform: (X == 0 & Y == 0) -> (X | Y) == 0
+-/
+def double_icmp_zero_or_combine : LLVMPeepholeRewriteRefine 1 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
+  lhs := [LV| {
+    ^entry (%x: i64, %y: i64):
+      %c = llvm.mlir.constant (0) : i64
+      %0 = llvm.icmp.ne %x, %c : i64
+      %1 = llvm.icmp.ne %y, %c : i64
+      %2 = llvm.or %0, %1 : i1
+      llvm.return %2 : i1
+  }]
+  rhs := [LV| {
+    ^entry (%x: i64, %y: i64):
+      %c = llvm.mlir.constant (0) : i64
+      %0 = llvm.or %x, %y : i64
+      %1 = llvm.icmp.ne %0, %c : i64
+      llvm.return %1 : i1
+  }]
+
+def double_icmp_zero_combine : List (Σ Γ, LLVMPeepholeRewriteRefine 1 Γ) :=
+  [⟨_, double_icmp_zero_and_combine⟩,
+  ⟨_, double_icmp_zero_or_combine⟩]
+
  /-! ### Grouped patterns -/
 
 /-- We assemble the `identity_combines` patterns for RISCV as in GlobalISel -/
@@ -1221,6 +1269,9 @@ def GLobalISelO0PreLegalizerCombiner :
     List (Σ Γ, Σ ty, PeepholeRewrite LLVMPlusRiscV Γ ty) :=
   (List.map (fun ⟨_,y⟩ => mkRewrite (LLVMToRiscvPeepholeRewriteRefine.toPeepholeUNSOUND y))
   not_cmp_fold)
+  ++
+  (List.map (fun ⟨_,y⟩ => mkRewrite (LLVMToRiscvPeepholeRewriteRefine.toPeepholeUNSOUND y))
+  double_icmp_zero_combine)
   ++
   (List.map (fun ⟨_,y⟩ => mkRewrite (LLVMToRiscvPeepholeRewriteRefine.toPeepholeUNSOUND y))
    mul_by_neg_one)

--- a/SSA/Projects/LLVMRiscV/Pipeline/Combiners.lean
+++ b/SSA/Projects/LLVMRiscV/Pipeline/Combiners.lean
@@ -1210,7 +1210,7 @@ def double_icmp_zero_and_combine : LLVMPeepholeRewriteRefine 1 [Ty.llvm (.bitvec
 
 /-
 Test the rewrite:
-  Transform: (X == 0 & Y == 0) -> (X | Y) == 0
+  Transform: (X != 0 & Y != 0) -> (X | Y) != 0
 -/
 def double_icmp_zero_or_combine : LLVMPeepholeRewriteRefine 1 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
   lhs := [LV| {

--- a/SSA/Projects/LLVMRiscV/Tests/Combiners.lean
+++ b/SSA/Projects/LLVMRiscV/Tests/Combiners.lean
@@ -172,3 +172,29 @@ info: {
 -/
 #guard_msgs in
 #eval! Com.print (DCE.dce' (multiRewritePeephole 100 GLobalISelPostLegalizerCombiner urem_pow2_to_mask_1024.lhs)).val
+
+/--
+info: {
+  ^bb0(%0 : i64, %1 : i64):
+    %2 = "llvm.mlir.constant"(){value = 0 : i64} : () -> (i64)
+    %3 = "llvm.mlir.constant"(){value = 0 : i64} : () -> (i64)
+    %4 = "llvm.or"(%0, %1) : (i64, i64) -> (i64)
+    %5 = "llvm.icmp.eq"(%4, %3) : (i64, i64) -> (i1)
+    "llvm.return"(%5) : (i1) -> ()
+}
+-/
+#guard_msgs in
+#eval! Com.print (DCE.dce' (DCE.dce' (multiRewritePeephole 100 GLobalISelO0PreLegalizerCombiner double_icmp_zero_and_combine.lhs)).val).val
+
+/--
+info: {
+  ^bb0(%0 : i64, %1 : i64):
+    %2 = "llvm.mlir.constant"(){value = 0 : i64} : () -> (i64)
+    %3 = "llvm.mlir.constant"(){value = 0 : i64} : () -> (i64)
+    %4 = "llvm.or"(%0, %1) : (i64, i64) -> (i64)
+    %5 = "llvm.icmp.ne"(%4, %3) : (i64, i64) -> (i1)
+    "llvm.return"(%5) : (i1) -> ()
+}
+-/
+#guard_msgs in
+#eval! Com.print (DCE.dce' (DCE.dce' (multiRewritePeephole 100 GLobalISelO0PreLegalizerCombiner double_icmp_zero_or_combine.lhs)).val).val


### PR DESCRIPTION
This PR adds [rewrites](https://github.com/llvm/llvm-project/blob/1d3ad74667e86a1ba19285e58d14156cce3de89d/llvm/include/llvm/Target/GlobalISel/Combine.td#L1110) `double_icmp_zero_and_combine` and `double_icmp_zero_or_combine`. 