### PR TITLE
feat: add `mulo_by_2` rewrite pattern

### DIFF
--- a/SSA/Projects/LLVMRiscV/Pipeline/Combiners.lean
+++ b/SSA/Projects/LLVMRiscV/Pipeline/Combiners.lean
@@ -997,6 +997,21 @@ def commute_int_constant_to_rhs: List (Σ Γ, RISCVPeepholeRewrite  Γ) :=
   ⟨_, commute_int_constant_to_rhs_xor⟩,
   ⟨_, commute_int_constant_to_rhs_mulhu⟩]
 
+
+def matchMulOBy2 : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64)] where
+  lhs := [LV| {
+    ^entry (%x: i64):
+      %c = llvm.mlir.constant (2) : i64
+      %0 = llvm.mul %x, %c overflow<nsw, nuw> : i64
+      llvm.return %0 : i64
+  }]
+  rhs := [LV| {
+    ^entry (%x: i64):
+      %0 = llvm.add %x, %x overflow<nsw, nuw> : i64
+      llvm.return %0 : i64
+  }]
+
+
 /-! ### sub_add_reg -/
 
 /-

--- a/SSA/Projects/LLVMRiscV/Pipeline/Combiners.lean
+++ b/SSA/Projects/LLVMRiscV/Pipeline/Combiners.lean
@@ -997,8 +997,14 @@ def commute_int_constant_to_rhs: List (Σ Γ, RISCVPeepholeRewrite  Γ) :=
   ⟨_, commute_int_constant_to_rhs_xor⟩,
   ⟨_, commute_int_constant_to_rhs_mulhu⟩]
 
+/-! ### matchMulOBy2 -/
 
-def matchMulOBy2 : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64)] where
+/-
+Test the rewrite:
+  (G_UMULO x, 2) -> (G_UADDO x, x)
+  (G_SMULO x, 2) -> (G_SADDO x, x)
+-/
+def mulo_by_2 : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64)] where
   lhs := [LV| {
     ^entry (%x: i64):
       %c = llvm.mlir.constant (2) : i64
@@ -1011,6 +1017,8 @@ def matchMulOBy2 : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64)] where
       llvm.return %0 : i64
   }]
 
+def matchMulO: List (Σ Γ, LLVMPeepholeRewriteRefine 64 Γ) :=
+  [⟨_, mulo_by_2⟩]
 
 /-! ### sub_add_reg -/
 
@@ -1225,6 +1233,7 @@ def PostLegalizerCombiner_LLVMIR_64 : List (Σ Γ, LLVMPeepholeRewriteRefine 64 
   sub_to_add ++
   redundant_and ++
   select_same_val ++
+  matchMulO ++
   LLVMIR_identity_combines_64
 
 /-- Post-legalization combine pass for LLVM specialized for i64 type -/

--- a/SSA/Projects/LLVMRiscV/Tests/Combiners.lean
+++ b/SSA/Projects/LLVMRiscV/Tests/Combiners.lean
@@ -172,3 +172,33 @@ info: {
 -/
 #guard_msgs in
 #eval! Com.print (DCE.dce' (multiRewritePeephole 100 GLobalISelPostLegalizerCombiner urem_pow2_to_mask_1024.lhs)).val
+
+/--
+info: {
+  ^bb0(%0 : i64):
+    %1 = "llvm.add"(%0, %0)<{overflowFlags = #llvm.overflow<nsw,nuw>}> : (i64, i64) -> (i64)
+    "llvm.return"(%1) : (i64) -> ()
+}
+-/
+#guard_msgs in
+#eval! Com.print (DCE.dce' (DCE.dce' (multiRewritePeephole 100 GLobalISelPostLegalizerCombiner mulo_by_2_unsigned_signed.lhs)).val).val
+
+/--
+info: {
+  ^bb0(%0 : i64):
+    %1 = "llvm.add"(%0, %0)<{overflowFlags = #llvm.overflow<nuw>}> : (i64, i64) -> (i64)
+    "llvm.return"(%1) : (i64) -> ()
+}
+-/
+#guard_msgs in
+#eval! Com.print (DCE.dce' (DCE.dce' (multiRewritePeephole 100 GLobalISelPostLegalizerCombiner mulo_by_2_unsigned.lhs)).val).val
+
+/--
+info: {
+  ^bb0(%0 : i64):
+    %1 = "llvm.add"(%0, %0)<{overflowFlags = #llvm.overflow<nsw>}> : (i64, i64) -> (i64)
+    "llvm.return"(%1) : (i64) -> ()
+}
+-/
+#guard_msgs in
+#eval! Com.print (DCE.dce' (DCE.dce' (multiRewritePeephole 100 GLobalISelPostLegalizerCombiner mulo_by_2_signed.lhs)).val).val

--- a/SSA/Projects/LLVMRiscV/Tests/Combiners.lean
+++ b/SSA/Projects/LLVMRiscV/Tests/Combiners.lean
@@ -566,7 +566,7 @@ info: {
 
 /--
 info: {
-^bb0(%0 : i64):
+  ^bb0(%0 : i64):
     %1 = "llvm.add"(%0, %0)<{overflowFlags = #llvm.overflow<nsw,nuw>}> : (i64, i64) -> (i64)
     "llvm.return"(%1) : (i64) -> ()
 }


### PR DESCRIPTION
This PR adds the rewrite  pattern [mulo_by_2](https://github.com/llvm/llvm-project/blob/1d3ad74667e86a1ba19285e58d14156cce3de89d/llvm/include/llvm/Target/GlobalISel/Combine.td#L1266).