### PR TITLE
feat: assign min/max semantics to operations

### DIFF
--- a/SSA/Projects/LLVMRiscV/Pipeline/Combiners.lean
+++ b/SSA/Projects/LLVMRiscV/Pipeline/Combiners.lean
@@ -717,7 +717,6 @@ def simplify_neg_minmax : RISCVPeepholeRewrite [Ty.riscv (.bv) ] where
       %1 = max %x, %0 : !riscv.reg
       ret %1 : !riscv.reg
   }]
-  correct := by sorry
 
 def simplify_neg_maxmin : RISCVPeepholeRewrite [Ty.riscv (.bv) ] where
   lhs := [LV| {
@@ -733,7 +732,6 @@ def simplify_neg_maxmin : RISCVPeepholeRewrite [Ty.riscv (.bv) ] where
       %1 = min %x, %0 : !riscv.reg
       ret %1 : !riscv.reg
   }]
-  correct := by sorry
 
 def simplify_neg : List (Σ Γ, RISCVPeepholeRewrite Γ) :=
   [⟨_, simplify_neg_minmax⟩,

--- a/SSA/Projects/RISCV64/Base.lean
+++ b/SSA/Projects/RISCV64/Base.lean
@@ -622,10 +622,10 @@ abbrev Op.denote : (o : RV64.Op) → HVector toType o.sig → ⟦o.outTy⟧
   -- | ctzw
   -- | cpop
   -- | cpopw
-  | .max, regs => ZBB_RTYPE_pure_RISCV_MAX (regs.getN 1) (regs.getN 0)
-  | .maxu, regs => ZBB_RTYPE_pure_RISCV_MAXU (regs.getN 1) (regs.getN 0)
-  | .min, regs => ZBB_RTYPE_pure_RISCV_MIN (regs.getN 1) (regs.getN 0)
-  | .minu, regs => ZBB_RTYPE_pure_RISCV_MINU (regs.getN 1) (regs.getN 0)
+  | .max, regs => ZBB_RTYPE_pure_RISCV_MAX_bv (regs.getN 1) (regs.getN 0)
+  | .maxu, regs => ZBB_RTYPE_pure_RISCV_MAXU_bv (regs.getN 1) (regs.getN 0)
+  | .min, regs => ZBB_RTYPE_pure_RISCV_MIN_bv (regs.getN 1) (regs.getN 0)
+  | .minu, regs => ZBB_RTYPE_pure_RISCV_MINU_bv (regs.getN 1) (regs.getN 0)
   | RISCV64.Op.sext.b, reg => ZBB_EXTOP_pure64_RISCV_SEXTB (reg.getN 0)
   | RISCV64.Op.sext.h, reg => ZBB_EXTOP_pure64_RISCV_SEXTH (reg.getN 0)
   | RISCV64.Op.zext.h, reg => ZBB_EXTOP_pure64_RISCV_ZEXTH (reg.getN 0)

--- a/SSA/Projects/RISCV64/Semantics.lean
+++ b/SSA/Projects/RISCV64/Semantics.lean
@@ -978,6 +978,7 @@ def ZBA_RTYPE_pure64_RISCV_SH3ADD (rs2_val : BitVec 64) (rs1_val : BitVec 64) : 
 def ZBA_pure64_RISCV_SLLIUW (shamt : BitVec 6) (rs1_val : BitVec 64) : BitVec 64 :=
   (BitVec.setWidth 64 (BitVec.extractLsb 31 0 rs1_val)) <<< shamt
 
+@[simp_riscv]
 def ZBB_RTYPE_pure_RISCV_MIN_bv (rs2_val : BitVec 64) (rs1_val : BitVec 64) : BitVec 64 :=
   BitVec.extractLsb' 0 64 (if BitVec.sle rs1_val rs2_val then rs1_val else rs2_val)
 
@@ -987,6 +988,7 @@ theorem ZBB_RTYPE_pure_RISCV_MIN_eq_ZBB_RTYPE_pure_RISCV_MIN_bv (rs2_val : BitVe
   simp only [min_def, sle_iff_toInt_le]
   split_ifs <;> simp [BitVec.ofInt_toInt_eq_signExtend, setWidth_signExtend_eq_self (w := 64) (w' := 65) (by omega)]
 
+@[simp_riscv]
 def ZBB_RTYPE_pure_RISCV_MINU_bv (rs2_val : BitVec 64) (rs1_val : BitVec 64) : BitVec 64 :=
   BitVec.extractLsb' 0 64 (if BitVec.ule rs1_val rs2_val then rs1_val else rs2_val)
 
@@ -997,6 +999,7 @@ theorem ZBB_RTYPE_pure_RISCV_MINU_eq_ZBB_RTYPE_pure_RISCV_MINU_bv (rs2_val : Bit
   norm_cast
   split_ifs <;> simp
 
+@[simp_riscv]
 def ZBB_RTYPE_pure_RISCV_MAXU_bv (rs2_val : BitVec 64) (rs1_val : BitVec 64) : BitVec 64 :=
   BitVec.extractLsb' 0 64 (if BitVec.ule rs1_val rs2_val then rs2_val else rs1_val)
 
@@ -1007,6 +1010,7 @@ theorem ZBB_RTYPE_pure_RISCV_MAXU_eq_ZBB_RTYPE_pure_RISCV_MAXU_bv (rs2_val : Bit
   norm_cast
   split_ifs <;> simp
 
+@[simp_riscv]
 def ZBB_RTYPE_pure_RISCV_MAX_bv (rs2_val : BitVec 64) (rs1_val : BitVec 64) : BitVec 64 :=
   BitVec.extractLsb' 0 64 (if BitVec.sle rs1_val rs2_val then rs2_val else rs1_val)
 


### PR DESCRIPTION
PR #1726 introduced proofs establishing the equivalence of rewritten min/max semantics and Sail-based semantics. This PR assigns the rewritten semantics to RISC-V operations in Lean-MLIR.