### PR TITLE
fix: increase `maxHeartbeats` limit in elaboration

### DIFF
--- a/LeanMLIR/LeanMLIR/MLIRSyntax/Parser.lean
+++ b/LeanMLIR/LeanMLIR/MLIRSyntax/Parser.lean
@@ -51,7 +51,7 @@ unsafe def elabIntoEIO {α : Type} (env : Lean.Environment) (typeName : Lean.Exp
   fun s =>
     let resE : EIO Exception α :=
         elabIntoCore (α := α) typeName stx |>.run'
-        {fileName := "parserHack", fileMap := default} {env := env}
+        {fileName := "parserHack", fileMap := default, maxHeartbeats := 0} {env := env}
     match resE s with
     | .ok a s => .ok a s
     | .error exception s =>


### PR DESCRIPTION
This PR sets the `maxHeartbeats` limit in `elabIntoEIO` to 0, which effectively disables the limit (previous default was 200000).

Co-authored-by: Léo Stefanesco [leo.stefanesco@gmail.com](mailto:leo.stefanesco@gmail.com)