### PR TITLE
feat: add `idempotent_prop` rewrite pattern

### DIFF
--- a/SSA/Projects/LLVMRiscV/Tests/Combiners.lean
+++ b/SSA/Projects/LLVMRiscV/Tests/Combiners.lean
@@ -772,3 +772,13 @@ info: {
 -/
 #guard_msgs in
 #eval! Com.print (DCE.dce' (DCE.dce' (multiRewritePeephole 100 GLobalISelPostLegalizerCombiner select_0_f.lhs)).val).val
+
+/--
+info: {
+  ^bb0(%0 : i64):
+    %1 = "llvm.freeze"(%0) : (i64) -> (i64)
+    "llvm.return"(%1) : (i64) -> ()
+}
+-/
+#guard_msgs in
+#eval! Com.print (DCE.dce' (DCE.dce' (multiRewritePeephole 100 GLobalISelPostLegalizerCombiner idempotent_prop_freeze.lhs)).val).val


### PR DESCRIPTION
This PR adds the [idempotent_prop](https://github.com/llvm/llvm-project/blob/26db21400d5bfe87e2b3d386c8589b56b965b158/llvm/include/llvm/Target/GlobalISel/Combine.td#L233) GICombineGroup for freeze operation, excluding rules that require floating-point operations.