### PR TITLE
chore: fix argument in generation

### DIFF
--- a/SSA/Projects/LLVMRiscV/Evaluation/benchmarks/README.md
+++ b/SSA/Projects/LLVMRiscV/Evaluation/benchmarks/README.md
@@ -29,7 +29,7 @@ This will be the starting point of the conversion.
 
 To generate the remaining benchmarks, run: 
 ```
-python3 generate.py --num --jobs
+python3 generate.py --num --jobs --llvm_opt
 ```
 
 The script `generate.py` populates the folders in `benchmarks` by running the following: 

--- a/SSA/Projects/LLVMRiscV/Evaluation/benchmarks/generate.py
+++ b/SSA/Projects/LLVMRiscV/Evaluation/benchmarks/generate.py
@@ -577,13 +577,14 @@ def main():
         "-llvm", "--llvm_opt", 
         help="Optimization level for LLVM.",
         nargs="+",
-        choices=["O3", "O2", "O1", "O0", "default"]
+        choices=["O3", "O2", "O1", "O0", "default"], 
+        default="default"
     )
     
     args = parser.parse_args()
     
     opts_to_evaluate = (
-        ["O3", "Os", "default"] if "all" in args.llvm_opt else args.llvm_opt
+        ["O3", "O2", "O1", "O0", "default"] if "all" in args.llvm_opt else args.llvm_opt
     )
 
 

--- a/SSA/Projects/LLVMRiscV/Evaluation/benchmarks/generate.py
+++ b/SSA/Projects/LLVMRiscV/Evaluation/benchmarks/generate.py
@@ -577,7 +577,7 @@ def main():
         "-llvm", "--llvm_opt", 
         help="Optimization level for LLVM.",
         nargs="+",
-        choices=["O3", "O2", "O1", "O0" "default"]
+        choices=["O3", "O2", "O1", "O0", "default"]
     )
     
     args = parser.parse_args()

--- a/SSA/Projects/LLVMRiscV/ParseAndTransform.lean
+++ b/SSA/Projects/LLVMRiscV/ParseAndTransform.lean
@@ -7,7 +7,6 @@ import SSA.Projects.LLVMRiscV.Pipeline.InstructionLowering
 
 open MLIR AST InstCombine
 open LLVMRiscV
-
 /-!
   This file extends the `opt` tool, to specifically support the `LLVMPlusRiscV` dialect.
 -/

--- a/SSA/Projects/LLVMRiscV/ParseAndTransform.lean
+++ b/SSA/Projects/LLVMRiscV/ParseAndTransform.lean
@@ -7,6 +7,7 @@ import SSA.Projects.LLVMRiscV.Pipeline.InstructionLowering
 
 open MLIR AST InstCombine
 open LLVMRiscV
+
 /-!
   This file extends the `opt` tool, to specifically support the `LLVMPlusRiscV` dialect.
 -/


### PR DESCRIPTION
This PR fixes the `default` argument for the generation of benchmarks and removes the `Os` argument (which is illegal with llc to the best of my knowledge). We also update the `README` accordingly.
