### PR TITLE
chore: update dead code elimination in RISCV instruction selection pipeline

### DIFF
--- a/SSA/Projects/LLVMRiscV/Pipeline/InstructionLowering.lean
+++ b/SSA/Projects/LLVMRiscV/Pipeline/InstructionLowering.lean
@@ -130,7 +130,7 @@ def selectionPipeFuelSafe {Γl : List LLVMPlusRiscV.Ty} (fuel : Nat) (prog : Com
 -/
 def selectionPipeFuelWithCSE {Γl : List LLVMPlusRiscV.Ty} (fuel : Nat) (prog : Com LLVMPlusRiscV
   (Ctxt.ofList Γl) .pure (.llvm (.bitvec w))) (pseudo : Bool):=
-  let rmInitialDeadCode :=  (DCE.dce' prog).val;
+  let rmInitialDeadCode :=  (DCE.repeatDce prog).val;
   let rmInitialDeadCode :=
   if pseudo then
     multiRewritePeephole fuel pseudo_match rmInitialDeadCode
@@ -142,14 +142,12 @@ def selectionPipeFuelWithCSE {Γl : List LLVMPlusRiscV.Ty} (fuel : Nat) (prog : 
     rewritingPatterns1  loweredConst;
   let lowerPart2 := multiRewritePeephole fuel
     rewritingPatterns0 lowerPart1;
-  let postLoweringDCE := (DCE.dce' lowerPart2).val;
-  let postReconcileCast := multiRewritePeephole fuel (reconcile_cast_pass) postLoweringDCE;
-  let remove_dead_Cast1 := (DCE.dce' postReconcileCast).val;
-  let remove_dead_Cast2 := (DCE.dce' remove_dead_Cast1).val;
-  let optimize_eq_cast := (CSE.cse' remove_dead_Cast2).val;
-  let out := (DCE.dce' optimize_eq_cast).val;
-  let out2 := (DCE.dce' out).val;
-  out2
+  let postLoweringDCE := (DCE.repeatDce lowerPart2).val;
+  let postReconcileCast := multiRewritePeephole fuel reconcile_cast_pass postLoweringDCE;
+  let remove_dead_cast := (DCE.repeatDce postReconcileCast).val;
+  let optimize_eq_cast := (CSE.cse' remove_dead_cast).val;
+  let out := (DCE.repeatDce optimize_eq_cast).val;
+  out
 
 /--
   Run the instruction selector pipeline with optimizations, resulting in the following pipeline:
@@ -167,7 +165,7 @@ def selectionPipeFuelWithCSE {Γl : List LLVMPlusRiscV.Ty} (fuel : Nat) (prog : 
 -/
 def selectionPipeFuelWithCSEWithOpt {Γl : List LLVMPlusRiscV.Ty} (fuel : Nat) (prog : Com LLVMPlusRiscV
     (Ctxt.ofList Γl) .pure (.llvm (.bitvec w))) (pseudo : Bool):=
-  let rmInitialDeadCode :=  (DCE.dce' prog).val;
+  let rmInitialDeadCode :=  (DCE.repeatDce prog).val;
   let rmInitialDeadCode :=
     if pseudo then
       multiRewritePeephole fuel pseudo_match rmInitialDeadCode
@@ -183,15 +181,14 @@ def selectionPipeFuelWithCSEWithOpt {Γl : List LLVMPlusRiscV.Ty} (fuel : Nat) (
     rewritingPatterns1  loweredConst;
   let lowerPart2 := multiRewritePeephole fuel
     rewritingPatterns0 lowerPart1;
-  let postLoweringDCE := (DCE.dce' lowerPart2).val;
+  let postLoweringDCE := (DCE.repeatDce lowerPart2).val;
   let postReconcileCast := multiRewritePeephole fuel (reconcile_cast_pass) postLoweringDCE;
-  let remove_dead_Cast1 := (DCE.dce' postReconcileCast).val;
-  let remove_dead_Cast2 := (DCE.dce' remove_dead_Cast1).val;
-  let optimize_eq_cast := (CSE.cse' remove_dead_Cast2).val;
-  let out := (DCE.dce' optimize_eq_cast).val;
-  let out2 := (DCE.dce' out).val;
+  let remove_dead_cast := (DCE.repeatDce postReconcileCast).val;
+  let optimize_eq_cast := (CSE.cse' remove_dead_cast).val;
+  let out := (DCE.repeatDce optimize_eq_cast).val;
   let optimize_final_1 := multiRewritePeephole 100
-    GLobalISelO0PreLegalizerCombiner out2;
+    GLobalISelO0PreLegalizerCombiner out;
   let optimize_final_2 := multiRewritePeephole 100
     GLobalISelPostLegalizerCombiner optimize_final_1;
-  optimize_final_2
+  let dce_final := (DCE.repeatDce optimize_final_2).val
+  dce_final


### PR DESCRIPTION
This PR replaces DCE with the novel DCE up-to-fixed-point (#1806) in the riscv64 lowerings. 