### PR TITLE
feat: add mulh_to_lshr rewrite pattern

### DIFF
--- a/SSA/Projects/LLVMRiscV/PeepholeRefine.lean
+++ b/SSA/Projects/LLVMRiscV/PeepholeRefine.lean
@@ -42,3 +42,17 @@ def LLVMToRiscvPeepholeRewriteRefine.toPeepholeUNSOUND
     rhs := self.rhs
     correct := by sorry
   }
+
+@[simp_riscv] lemma toType_bv : TyDenote.toType (Ty.riscv (.bv)) = BitVec 64 := rfl
+@[simp_riscv] lemma id_eq1 {α : Type} (x y : α) :  @Eq (Id α) x y = (x = y):= by simp only
+
+structure RISCVPeepholeRewrite (Γ : List Ty) where
+  lhs : Com LLVMPlusRiscV Γ .pure [Ty.riscv .bv]
+  rhs : Com LLVMPlusRiscV Γ .pure [Ty.riscv .bv]
+  correct : lhs.denote = rhs.denote := by simp_lowering <;> bv_decide
+
+def RISCVPeepholeRewriteToRiscvPeephole (self : RISCVPeepholeRewrite Γ) :
+    PeepholeRewrite LLVMPlusRiscV Γ [Ty.riscv .bv] where
+  lhs := self.lhs
+  rhs := self.rhs
+  correct := self.correct

--- a/SSA/Projects/LLVMRiscV/Pipeline/Combiners.lean
+++ b/SSA/Projects/LLVMRiscV/Pipeline/Combiners.lean
@@ -14,20 +14,6 @@ open LLVMRiscV
   while some are target-dependent.
 -/
 
-@[simp_riscv] lemma toType_bv : TyDenote.toType (Ty.riscv (.bv)) = BitVec 64 := rfl
-@[simp_riscv] lemma id_eq1 {α : Type} (x y : α) :  @Eq (Id α) x y = (x = y):= by simp only
-
-structure RISCVPeepholeRewrite (Γ : List Ty) where
-  lhs : Com LLVMPlusRiscV Γ .pure [Ty.riscv .bv]
-  rhs : Com LLVMPlusRiscV Γ .pure [Ty.riscv .bv]
-  correct : lhs.denote = rhs.denote := by simp_lowering <;> bv_decide
-
-def RISCVPeepholeRewriteToRiscvPeephole (self : RISCVPeepholeRewrite Γ) :
-    PeepholeRewrite LLVMPlusRiscV Γ [Ty.riscv .bv] where
-  lhs := self.lhs
-  rhs := self.rhs
-  correct := self.correct
-
 /-!
   # Post-legalization optimizations
 
@@ -1944,7 +1930,8 @@ def LLVMIR_cast_combines_32 : List (Σ Γ, LLVMPeepholeRewriteRefine 32 Γ) := s
 def PostLegalizerCombiner_RISCV: List (Σ Γ,RISCVPeepholeRewrite  Γ) :=
     RISCV_identity_combines ++
     commute_int_constant_to_rhs ++
-    simplify_neg
+    simplify_neg ++
+    mulh_to_lshr
 
 /-- Post-legalization combine pass for LLVM specialized for i64 type -/
 def PostLegalizerCombiner_LLVMIR_64 : List (Σ Γ, LLVMPeepholeRewriteRefine 64  Γ) :=

--- a/SSA/Projects/LLVMRiscV/Pipeline/ConstantMatching.lean
+++ b/SSA/Projects/LLVMRiscV/Pipeline/ConstantMatching.lean
@@ -7,9 +7,24 @@ import SSA.Projects.LLVMRiscV.Pipeline.mkRewrite
 
 open LLVMRiscV
 
+@[simp_riscv] lemma toType_bv : TyDenote.toType (Ty.riscv (.bv)) = BitVec 64 := rfl
+@[simp_riscv] lemma id_eq1 {α : Type} (x y : α) :  @Eq (Id α) x y = (x = y):= by simp only
+
+structure RISCVPeepholeRewrite (Γ : List Ty) where
+  lhs : Com LLVMPlusRiscV Γ .pure [Ty.riscv .bv]
+  rhs : Com LLVMPlusRiscV Γ .pure [Ty.riscv .bv]
+  correct : lhs.denote = rhs.denote := by simp_lowering <;> bv_decide
+
+def RISCVPeepholeRewriteToRiscvPeephole (self : RISCVPeepholeRewrite Γ) :
+    PeepholeRewrite LLVMPlusRiscV Γ [Ty.riscv .bv] where
+  lhs := self.lhs
+  rhs := self.rhs
+  correct := self.correct
+
+
 /-! ### sub_to_add -/
 
-/--
+/-- 
 Test the rewrite:
   (sub x, C) → (add x, -C)
 -/
@@ -504,7 +519,7 @@ def urem_pow2_to_mask : List (Σ Γ, LLVMPeepholeRewriteRefine 64 Γ) :=
 
 /-! ### canonicalize_icmp -/
 
-/--
+/-- 
 Test the rewrite:
   (cmp C, x) → (cmp x, C)
 -/
@@ -2163,11 +2178,16 @@ def canonicalize_icmp : List (Σ Γ, LLVMPeepholeRewriteRefine 1 Γ) :=
   ]
 
 /-! ### mulh_to_lshr -/
+
+/-- 
+Test the rewrite:
+  (mulh x, n^2) → (sra x, (64-n))
+-/
 def mulh_to_lshr_2 : RISCVPeepholeRewrite [Ty.riscv (.bv)] where
   lhs := [LV| {
     ^entry (%x: !riscv.reg):
       %c = li (2) : !riscv.reg
-      %0 = mulh %x, %c : !riscv.reg
+      %0 = mulh %c, %x : !riscv.reg
       ret %0 : !riscv.reg
   }]
   rhs := [LV| {

--- a/SSA/Projects/LLVMRiscV/Pipeline/ConstantMatching.lean
+++ b/SSA/Projects/LLVMRiscV/Pipeline/ConstantMatching.lean
@@ -7,24 +7,10 @@ import SSA.Projects.LLVMRiscV.Pipeline.mkRewrite
 
 open LLVMRiscV
 
-@[simp_riscv] lemma toType_bv : TyDenote.toType (Ty.riscv (.bv)) = BitVec 64 := rfl
-@[simp_riscv] lemma id_eq1 {α : Type} (x y : α) :  @Eq (Id α) x y = (x = y):= by simp only
-
-structure RISCVPeepholeRewrite (Γ : List Ty) where
-  lhs : Com LLVMPlusRiscV Γ .pure [Ty.riscv .bv]
-  rhs : Com LLVMPlusRiscV Γ .pure [Ty.riscv .bv]
-  correct : lhs.denote = rhs.denote := by simp_lowering <;> bv_decide
-
-def RISCVPeepholeRewriteToRiscvPeephole (self : RISCVPeepholeRewrite Γ) :
-    PeepholeRewrite LLVMPlusRiscV Γ [Ty.riscv .bv] where
-  lhs := self.lhs
-  rhs := self.rhs
-  correct := self.correct
-
 
 /-! ### sub_to_add -/
 
-/-- 
+/--
 Test the rewrite:
   (sub x, C) → (add x, -C)
 -/
@@ -519,7 +505,7 @@ def urem_pow2_to_mask : List (Σ Γ, LLVMPeepholeRewriteRefine 64 Γ) :=
 
 /-! ### canonicalize_icmp -/
 
-/-- 
+/--
 Test the rewrite:
   (cmp C, x) → (cmp x, C)
 -/
@@ -2179,7 +2165,7 @@ def canonicalize_icmp : List (Σ Γ, LLVMPeepholeRewriteRefine 1 Γ) :=
 
 /-! ### mulh_to_lshr -/
 
-/-- 
+/--
 Test the rewrite:
   (mulh x, n^2) → (sra x, (64-n))
 -/

--- a/SSA/Projects/LLVMRiscV/Pipeline/ConstantMatching.lean
+++ b/SSA/Projects/LLVMRiscV/Pipeline/ConstantMatching.lean
@@ -7,10 +7,9 @@ import SSA.Projects.LLVMRiscV.Pipeline.mkRewrite
 
 open LLVMRiscV
 
-
 /-! ### sub_to_add -/
 
-/-- 
+/--
 Test the rewrite:
   (sub x, C) → (add x, -C)
 -/
@@ -505,7 +504,7 @@ def urem_pow2_to_mask : List (Σ Γ, LLVMPeepholeRewriteRefine 64 Γ) :=
 
 /-! ### canonicalize_icmp -/
 
-/-- 
+/--
 Test the rewrite:
   (cmp C, x) → (cmp x, C)
 -/
@@ -2161,4 +2160,144 @@ def canonicalize_icmp : List (Σ Γ, LLVMPeepholeRewriteRefine 1 Γ) :=
     ⟨_, canonicalize_icmp_sge_5⟩,
     ⟨_, canonicalize_icmp_slt_5⟩,
     ⟨_, canonicalize_icmp_sle_5⟩
+  ]
+
+/-! ### mulh_to_lshr -/
+def mulh_to_lshr_2 : RISCVPeepholeRewrite [Ty.riscv (.bv)] where
+  lhs := [LV| {
+    ^entry (%x: !riscv.reg):
+      %c = li (2) : !riscv.reg
+      %0 = mulh %x, %c : !riscv.reg
+      ret %0 : !riscv.reg
+  }]
+  rhs := [LV| {
+    ^entry (%x: !riscv.reg):
+      %c = li (63) : !riscv.reg
+      %0 = sra %x, %c : !riscv.reg
+      ret %0 : !riscv.reg
+  }]
+
+def mulh_to_lshr_4 : RISCVPeepholeRewrite [Ty.riscv (.bv)] where
+  lhs := [LV| {
+    ^entry (%x: !riscv.reg):
+      %c = li (4) : !riscv.reg
+      %0 = mulh %c, %x : !riscv.reg
+      ret %0 : !riscv.reg
+  }]
+  rhs := [LV| {
+    ^entry (%x: !riscv.reg):
+      %c = li (62) : !riscv.reg
+      %0 = sra %x, %c : !riscv.reg
+      ret %0 : !riscv.reg
+  }]
+
+def mulh_to_lshr_8 : RISCVPeepholeRewrite [Ty.riscv (.bv)] where
+  lhs := [LV| {
+    ^entry (%x: !riscv.reg):
+      %c = li (8) : !riscv.reg
+      %0 = mulh %c, %x : !riscv.reg
+      ret %0 : !riscv.reg
+  }]
+  rhs := [LV| {
+    ^entry (%x: !riscv.reg):
+      %c = li (61) : !riscv.reg
+      %0 = sra %x, %c : !riscv.reg
+      ret %0 : !riscv.reg
+  }]
+
+def mulh_to_lshr_16 : RISCVPeepholeRewrite [Ty.riscv (.bv)] where
+  lhs := [LV| {
+    ^entry (%x: !riscv.reg):
+      %c = li (16) : !riscv.reg
+      %0 = mulh %c, %x : !riscv.reg
+      ret %0 : !riscv.reg
+  }]
+  rhs := [LV| {
+    ^entry (%x: !riscv.reg):
+      %c = li (60) : !riscv.reg
+      %0 = sra %x, %c : !riscv.reg
+      ret %0 : !riscv.reg
+  }]
+
+def mulh_to_lshr_32 : RISCVPeepholeRewrite [Ty.riscv (.bv)] where
+  lhs := [LV| {
+    ^entry (%x: !riscv.reg):
+      %c = li (32) : !riscv.reg
+      %0 = mulh %c, %x : !riscv.reg
+      ret %0 : !riscv.reg
+  }]
+  rhs := [LV| {
+    ^entry (%x: !riscv.reg):
+      %c = li (59) : !riscv.reg
+      %0 = sra %x, %c : !riscv.reg
+      ret %0 : !riscv.reg
+  }]
+
+def mulh_to_lshr_64 : RISCVPeepholeRewrite [Ty.riscv (.bv)] where
+  lhs := [LV| {
+    ^entry (%x: !riscv.reg):
+      %c = li (64) : !riscv.reg
+      %0 = mulh %c, %x : !riscv.reg
+      ret %0 : !riscv.reg
+  }]
+  rhs := [LV| {
+    ^entry (%x: !riscv.reg):
+      %c = li (58) : !riscv.reg
+      %0 = sra %x, %c : !riscv.reg
+      ret %0 : !riscv.reg
+  }]
+
+def mulh_to_lshr_128 : RISCVPeepholeRewrite [Ty.riscv (.bv)] where
+  lhs := [LV| {
+    ^entry (%x: !riscv.reg):
+      %c = li (128) : !riscv.reg
+      %0 = mulh %c, %x : !riscv.reg
+      ret %0 : !riscv.reg
+  }]
+  rhs := [LV| {
+    ^entry (%x: !riscv.reg):
+      %c = li (57) : !riscv.reg
+      %0 = sra %x, %c : !riscv.reg
+      ret %0 : !riscv.reg
+  }]
+
+def mulh_to_lshr_256 : RISCVPeepholeRewrite [Ty.riscv (.bv)] where
+  lhs := [LV| {
+    ^entry (%x: !riscv.reg):
+      %c = li (256) : !riscv.reg
+      %0 = mulh %c, %x : !riscv.reg
+      ret %0 : !riscv.reg
+  }]
+  rhs := [LV| {
+    ^entry (%x: !riscv.reg):
+      %c = li (56) : !riscv.reg
+      %0 = sra %x, %c : !riscv.reg
+      ret %0 : !riscv.reg
+  }]
+
+def mulh_to_lshr_512 : RISCVPeepholeRewrite [Ty.riscv (.bv)] where
+  lhs := [LV| {
+    ^entry (%x: !riscv.reg):
+      %c = li (512) : !riscv.reg
+      %0 = mulh %c, %x : !riscv.reg
+      ret %0 : !riscv.reg
+  }]
+  rhs := [LV| {
+    ^entry (%x: !riscv.reg):
+      %c = li (55) : !riscv.reg
+      %0 = sra %x, %c : !riscv.reg
+      ret %0 : !riscv.reg
+  }]
+
+def mulh_to_lshr : List (Σ Γ, RISCVPeepholeRewrite Γ) :=
+  [
+    ⟨_, mulh_to_lshr_2⟩,
+    ⟨_, mulh_to_lshr_4⟩,
+    ⟨_, mulh_to_lshr_8⟩,
+    ⟨_, mulh_to_lshr_16⟩,
+    ⟨_, mulh_to_lshr_32⟩,
+    ⟨_, mulh_to_lshr_64⟩,
+    ⟨_, mulh_to_lshr_128⟩,
+    ⟨_, mulh_to_lshr_256⟩,
+    ⟨_, mulh_to_lshr_512⟩
   ]

--- a/SSA/Projects/LLVMRiscV/Pipeline/ConstantMatching.lean
+++ b/SSA/Projects/LLVMRiscV/Pipeline/ConstantMatching.lean
@@ -10,7 +10,7 @@ open LLVMRiscV
 
 /-! ### sub_to_add -/
 
-/--
+/-- 
 Test the rewrite:
   (sub x, C) → (add x, -C)
 -/
@@ -505,7 +505,7 @@ def urem_pow2_to_mask : List (Σ Γ, LLVMPeepholeRewriteRefine 64 Γ) :=
 
 /-! ### canonicalize_icmp -/
 
-/--
+/-- 
 Test the rewrite:
   (cmp C, x) → (cmp x, C)
 -/

--- a/SSA/Projects/LLVMRiscV/Pipeline/scripts/generate_constants.py
+++ b/SSA/Projects/LLVMRiscV/Pipeline/scripts/generate_constants.py
@@ -16,6 +16,20 @@ import SSA.Projects.LLVMRiscV.Pipeline.mkRewrite
 
 open LLVMRiscV
 
+@[simp_riscv] lemma toType_bv : TyDenote.toType (Ty.riscv (.bv)) = BitVec 64 := rfl
+@[simp_riscv] lemma id_eq1 {α : Type} (x y : α) :  @Eq (Id α) x y = (x = y):= by simp only
+
+structure RISCVPeepholeRewrite (Γ : List Ty) where
+  lhs : Com LLVMPlusRiscV Γ .pure [Ty.riscv .bv]
+  rhs : Com LLVMPlusRiscV Γ .pure [Ty.riscv .bv]
+  correct : lhs.denote = rhs.denote := by simp_lowering <;> bv_decide
+
+def RISCVPeepholeRewriteToRiscvPeephole (self : RISCVPeepholeRewrite Γ) :
+    PeepholeRewrite LLVMPlusRiscV Γ [Ty.riscv .bv] where
+  lhs := self.lhs
+  rhs := self.rhs
+  correct := self.correct
+
 """
 
 @dataclass
@@ -393,11 +407,48 @@ Test the rewrite:
         comment=comment
     )
     
+def generate_mulh_to_lshr(powers: List[int]) -> RewriteGroup:
+    patterns = []
+    group_name = "mulh_to_lshr"
+    comment = """
+/-! ### mulh_to_lshr -/
+""" 
+    for n in powers:
+        power_of_2 = 2 ** n
+        
+        definition = f"""def {group_name}_{power_of_2} : RISCVPeepholeRewrite [Ty.riscv (.bv)] where
+  lhs := [LV| {{
+    ^entry (%x: !riscv.reg):
+      %c = li ({power_of_2}) : !riscv.reg
+      %0 = mulh %c, %x : !riscv.reg
+      ret %0 : !riscv.reg
+  }}]
+  rhs := [LV| {{
+    ^entry (%x: !riscv.reg):
+      %c = li ({64 - n}) : !riscv.reg
+      %0 = sra %x, %c : !riscv.reg
+      ret %0 : !riscv.reg
+  }}]
+"""
+        
+        patterns.append(RewritePattern(
+            name=f"{group_name}_{power_of_2}",
+            definition=definition
+        ))
+    
+    return RewriteGroup(
+        group_name=group_name,
+        patterns=patterns,
+        type_signature="RISCVPeepholeRewrite Γ",
+        comment=comment
+    )
+    
 REWRITE_GENERATORS = [
     lambda: generate_sub_to_add_rewrites(max_val=5),
     lambda: generate_mul_to_shl_rewrites(powers=list(range(0, 10))),
     lambda: generate_urem_pow2_rewrites(powers=list(range(0, 10))),
     lambda: generate_canonicalize_icmp(max_val=5),
+    lambda: generate_mulh_to_lshr(powers=list(range(1, 10))),
 ]
 
 def generate_all_rewrites() -> str:

--- a/SSA/Projects/LLVMRiscV/Pipeline/scripts/generate_constants.py
+++ b/SSA/Projects/LLVMRiscV/Pipeline/scripts/generate_constants.py
@@ -412,6 +412,11 @@ def generate_mulh_to_lshr(powers: List[int]) -> RewriteGroup:
     group_name = "mulh_to_lshr"
     comment = """
 /-! ### mulh_to_lshr -/
+
+/-- 
+Test the rewrite:
+  (mulh x, n^2) → (sra x, (64-n))
+-/
 """ 
     for n in powers:
         power_of_2 = 2 ** n

--- a/SSA/Projects/LLVMRiscV/Pipeline/scripts/generate_constants.py
+++ b/SSA/Projects/LLVMRiscV/Pipeline/scripts/generate_constants.py
@@ -16,20 +16,6 @@ import SSA.Projects.LLVMRiscV.Pipeline.mkRewrite
 
 open LLVMRiscV
 
-@[simp_riscv] lemma toType_bv : TyDenote.toType (Ty.riscv (.bv)) = BitVec 64 := rfl
-@[simp_riscv] lemma id_eq1 {α : Type} (x y : α) :  @Eq (Id α) x y = (x = y):= by simp only
-
-structure RISCVPeepholeRewrite (Γ : List Ty) where
-  lhs : Com LLVMPlusRiscV Γ .pure [Ty.riscv .bv]
-  rhs : Com LLVMPlusRiscV Γ .pure [Ty.riscv .bv]
-  correct : lhs.denote = rhs.denote := by simp_lowering <;> bv_decide
-
-def RISCVPeepholeRewriteToRiscvPeephole (self : RISCVPeepholeRewrite Γ) :
-    PeepholeRewrite LLVMPlusRiscV Γ [Ty.riscv .bv] where
-  lhs := self.lhs
-  rhs := self.rhs
-  correct := self.correct
-
 """
 
 @dataclass

--- a/SSA/Projects/LLVMRiscV/Tests/Combiners.lean
+++ b/SSA/Projects/LLVMRiscV/Tests/Combiners.lean
@@ -752,3 +752,47 @@ info: {
 -/
 #guard_msgs in
 #eval! Com.print (DCE.repeatDce (multiRewritePeephole 100 GLobalISelPostLegalizerCombiner idempotent_prop_freeze.lhs)).val
+
+/--
+info: {
+  riscv_func.func @f(%0 : !riscv.reg):
+    %1 = "riscv.li"(){immediate = 63 : i64 } : () -> (!riscv.reg)
+    %2 = "riscv.sra"(%0, %1) : (!riscv.reg, !riscv.reg) -> (!riscv.reg)
+    "riscv.ret"(%2) : (!riscv.reg) -> ()
+}
+-/
+#guard_msgs in
+#eval! Com.print (DCE.repeatDce (multiRewritePeephole 100 GLobalISelPostLegalizerCombiner mulh_to_lshr_2.lhs)).val
+
+/--
+info: {
+  riscv_func.func @f(%0 : !riscv.reg):
+    %1 = "riscv.li"(){immediate = 62 : i64 } : () -> (!riscv.reg)
+    %2 = "riscv.sra"(%0, %1) : (!riscv.reg, !riscv.reg) -> (!riscv.reg)
+    "riscv.ret"(%2) : (!riscv.reg) -> ()
+}
+-/
+#guard_msgs in
+#eval! Com.print (DCE.repeatDce (multiRewritePeephole 100 GLobalISelPostLegalizerCombiner mulh_to_lshr_4.lhs)).val
+
+/--
+info: {
+  riscv_func.func @f(%0 : !riscv.reg):
+    %1 = "riscv.li"(){immediate = 61 : i64 } : () -> (!riscv.reg)
+    %2 = "riscv.sra"(%0, %1) : (!riscv.reg, !riscv.reg) -> (!riscv.reg)
+    "riscv.ret"(%2) : (!riscv.reg) -> ()
+}
+-/
+#guard_msgs in
+#eval! Com.print (DCE.repeatDce (multiRewritePeephole 100 GLobalISelPostLegalizerCombiner mulh_to_lshr_8.lhs)).val
+
+/--
+info: {
+  riscv_func.func @f(%0 : !riscv.reg):
+    %1 = "riscv.li"(){immediate = 60 : i64 } : () -> (!riscv.reg)
+    %2 = "riscv.sra"(%0, %1) : (!riscv.reg, !riscv.reg) -> (!riscv.reg)
+    "riscv.ret"(%2) : (!riscv.reg) -> ()
+}
+-/
+#guard_msgs in
+#eval! Com.print (DCE.repeatDce (multiRewritePeephole 100 GLobalISelPostLegalizerCombiner mulh_to_lshr_16.lhs)).val


### PR DESCRIPTION
This PR adds the rewrite pattern [mulh_to_lshr](https://github.com/llvm/llvm-project/blob/e65b36c640b781be724f587085056c2819c7ad00/llvm/include/llvm/Target/GlobalISel/Combine.td#L1289), which transforms a mulh by pow2 operation into a right shift operation. 

The PR also moves the RISCV Peephole rewrite structures into `PeepholeRefine.lean` file, enabling ConstantMatching.lean to use the definition. Without this change, both `ConstantMatching.lean` and `Combiners.lean` files imported each other, resulting in circular import dependency.