### PR TITLE
chore: add tests for SMT-LIB printing and generalization

### DIFF
--- a/Blase/Blase.lean
+++ b/Blase/Blase.lean
@@ -3,4 +3,5 @@
 import Blase.Fast
 import Blase.SingleWidth.Tactic
 import Blase.MultiWidth.Tactic
+import Blase.WidthGeneralize.Tactic
 -- Jiggle.

--- a/Blase/Blase/WidthGeneralize/Tactic.lean
+++ b/Blase/Blase/WidthGeneralize/Tactic.lean
@@ -5,11 +5,13 @@ import Blase.MultiWidth.Preprocessing
 import Blase.KInduction.KInduction
 import Blase.AutoStructs.FormulaToAuto
 import Blase.ReflectMap
+import Lean
 
 initialize Lean.registerTraceClass `Blase.WidthGeneralize
 
 namespace WidthGeneralize
 namespace Tactic
+open Lean Meta Elab Tactic
 /-
 A tactic to generalize the width of BitVectors
 -/
@@ -150,26 +152,47 @@ def evalBvGeneralize : Tactic := fun
 
 -- TODO: the `bv_generalize` tactic fails when a bit vector is already width generic
 
-theorem test_bv_generalize_simple (x y : BitVec 32) (zs : List (BitVec 44)) : 
+/--
+error: unsolved goals
+⊢ ∀ (w w_1 : ℕ) (x y : BitVec w) (zs : List (BitVec w_1)), x = x
+---
+trace: ⊢ ∀ (w w_1 : ℕ) (x y : BitVec w) (zs : List (BitVec w_1)), x = x
+-/
+#guard_msgs in theorem test_bv_generalize_simple (x y : BitVec 32) (zs : List (BitVec 44)) : 
     x = x := by
   bv_generalize
-  bv_multi_width
+  trace_state
 
-theorem test_bv_generalize_simple_spec (x y : BitVec 32) (zs : List (BitVec 44)) : 
+/-- trace: ⊢ ∀ (x y : BitVec 1) (zs : List (BitVec 3)), x = x -/
+#guard_msgs in theorem test_bv_generalize_simple_spec (x y : BitVec 32) (zs : List (BitVec 44)) : 
     x = x := by
   bv_generalize +specialize
+  trace_state
   bv_decide
 
-theorem test_bv_generalize (x y : BitVec 32) (zs : List (BitVec 44)) (z : BitVec 10) (h : 52 + 10 = 42) (heq : x = y) : 
+/--
+error: unsolved goals
+⊢ ∀ (w w_1 w_2 : ℕ) (x y : BitVec w_1) (zs : List (BitVec w_2)) (z : BitVec w),
+    52 + 10 = 42 → x = y → BitVec.zeroExtend w x = BitVec.zeroExtend w y + 0
+---
+trace: ⊢ ∀ (w w_1 w_2 : ℕ) (x y : BitVec w_1) (zs : List (BitVec w_2)) (z : BitVec w),
+    52 + 10 = 42 → x = y → BitVec.zeroExtend w x = BitVec.zeroExtend w y + 0
+-/
+#guard_msgs in theorem test_bv_generalize (x y : BitVec 32) (zs : List (BitVec 44)) (z : BitVec 10) (h : 52 + 10 = 42) (heq : x = y) : 
     x.zeroExtend 10 = y.zeroExtend 10 + 0 := by
   bv_generalize
-  bv_multi_width
+  trace_state
 
-theorem test_bv_generalize_spec (x y : BitVec 32) (zs : List (BitVec 44)) (z : BitVec 10) (h : 52 + 10 = 42) (heq : x = y) : 
+/--
+trace: ⊢ ∀ (x y : BitVec 3) (zs : List (BitVec 5)) (z : BitVec 1),
+    52 + 10 = 42 → x = y → BitVec.zeroExtend 1 x = BitVec.zeroExtend 1 y + 0
+-/
+#guard_msgs in theorem test_bv_generalize_spec (x y : BitVec 32) (zs : List (BitVec 44)) (z : BitVec 10) (h : 52 + 10 = 42) (heq : x = y) : 
     x.zeroExtend 10 = y.zeroExtend 10 + 0 := by
   bv_generalize +specialize
+  trace_state
   bv_decide
 
-end WidthGeneralize
 end Tactic
+end WidthGeneralize
 

--- a/Blase/BlaseTest.lean
+++ b/Blase/BlaseTest.lean
@@ -5,3 +5,5 @@ import BlaseTest.Preprocessing1
 import BlaseTest.Preprocessing2
 import BlaseTest.Preprocessing3
 import BlaseTest.Preprocessing4
+import BlaseTest.WidthGeneralize
+import BlaseTest.PrintSmtLib

--- a/Blase/BlaseTest/PrintSmtLib.lean
+++ b/Blase/BlaseTest/PrintSmtLib.lean
@@ -1,0 +1,25 @@
+import Blase
+
+/--
+error: (bveq (var 0) (add (var 0) (zext (var 0 (var 1)) (var 0)) (var 1 (var 0))) (add (var 0) (var 1 (var 0)) (zext (var 0 (var 1)) (var 0))))
+-/
+#guard_msgs in theorem generalize1 (x : BitVec 3) (y : BitVec 4) : 
+      x.zeroExtend _ + y = y + x.zeroExtend _ := by
+  intros
+  bv_multi_width_print_smt_lib
+
+/-- error: (pvar 0) -/
+#guard_msgs in theorem generalize2 : 
+      ∀ (v w : Nat) (x : BitVec v) (y : BitVec w),
+      x.zeroExtend _ + y = y + x.zeroExtend _ := by
+  -- TODO: make this enter under binders with a with forallTelescoping.
+  bv_multi_width_print_smt_lib
+
+/--
+error: (bveq (var 0) (add (var 0) (zext (var 0 (var 1)) (var 0)) (var 1 (var 0))) (add (var 0) (var 1 (var 0)) (zext (var 0 (var 1)) (var 0))))
+-/
+#guard_msgs in theorem generalize3 : 
+      ∀ (v w : Nat) (x : BitVec v) (y : BitVec w),
+      x.zeroExtend _ + y = y + x.zeroExtend _ := by
+  intros
+  bv_multi_width_print_smt_lib

--- a/Blase/BlaseTest/WidthGeneralize.lean
+++ b/Blase/BlaseTest/WidthGeneralize.lean
@@ -1,0 +1,12 @@
+import Blase
+
+/--
+error: unsolved goals
+⊢ ∀ (w w_1 : ℕ) (x : BitVec w) (y : BitVec w_1), BitVec.zeroExtend w_1 x + y = y + BitVec.zeroExtend w_1 x
+---
+trace: ⊢ ∀ (w w_1 : ℕ) (x : BitVec w) (y : BitVec w_1), BitVec.zeroExtend w_1 x + y = y + BitVec.zeroExtend w_1 x
+-/
+#guard_msgs in theorem generalize (x : BitVec 3) (y : BitVec 4) : 
+      x.zeroExtend _ + y = y + x.zeroExtend _ := by
+  bv_generalize
+  trace_state


### PR DESCRIPTION
This tests our Blase code for SMT-LIB printing, which will be immediately used in https://github.com/opencompl/evaluation-multi-width-bv to fixup our printing. This will give us an end-to-end loop to print SMT-LIB style statements from test cases that we fail on.