### PR TITLE
feat: add new conversion patterns for sext/zext

### DIFF
--- a/SSA/Projects/LLVMRiscV/Pipeline/sext.lean
+++ b/SSA/Projects/LLVMRiscV/Pipeline/sext.lean
@@ -111,9 +111,8 @@ def llvm_sext_lower_riscv_i1_to_64 : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bit
 def sext_riscv_i8_to_i16 := [LV| {
   ^entry (%arg: i8):
     %0 = "builtin.unrealized_conversion_cast"(%arg) : (i8) -> (!i64)
-    %1 = slli %0, 56 : !i64
-    %2 = srai %1, 56 : !i64
-    %res = "builtin.unrealized_conversion_cast"(%2) : (!i64) -> (i16)
+    %1 = sext.b %0 : !i64
+    %res = "builtin.unrealized_conversion_cast"(%1) : (!i64) -> (i16)
     llvm.return %res : i16
   }]
 
@@ -134,9 +133,8 @@ def llvm_sext_lower_riscv_i8_to_i16 : LLVMPeepholeRewriteRefine 16 [Ty.llvm (.bi
 def sext_riscv_i8_to_32 := [LV| {
   ^entry (%arg: i8):
     %0 = "builtin.unrealized_conversion_cast"(%arg) : (i8) -> (!i64)
-    %1 = slli %0, 56 : !i64
-    %2 = srai %1, 56 : !i64
-    %res = "builtin.unrealized_conversion_cast"(%2) : (!i64) -> (i32)
+    %1 = sext.b %0 : !i64
+    %res = "builtin.unrealized_conversion_cast"(%1) : (!i64) -> (i32)
     llvm.return %res : i32
   }]
 
@@ -157,9 +155,8 @@ def llvm_sext_lower_riscv_i8_to_32 : LLVMPeepholeRewriteRefine 32 [Ty.llvm (.bit
 def sext_riscv_i8_to_64 := [LV| {
   ^entry (%arg: i8):
     %0 = "builtin.unrealized_conversion_cast"(%arg) : (i8) -> (!i64)
-    %1 = slli %0, 56 : !i64
-    %2 = srai %1, 56 : !i64
-    %res = "builtin.unrealized_conversion_cast"(%2) : (!i64) -> (i64)
+    %1 = sext.b %0 : !i64
+    %res = "builtin.unrealized_conversion_cast"(%1) : (!i64) -> (i64)
     llvm.return %res : i64
   }]
 
@@ -180,9 +177,8 @@ def llvm_sext_lower_riscv_i8_to_64 : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bit
 def sext_riscv_i16_to_32 := [LV| {
   ^entry (%arg: i16):
     %0 = "builtin.unrealized_conversion_cast"(%arg) : (i16) -> (!i64)
-    %1 = slli %0, 48 : !i64
-    %2 = srai %1, 48 : !i64
-    %res = "builtin.unrealized_conversion_cast"(%2) : (!i64) -> (i32)
+    %1 = sext.h %0 : !i64
+    %res = "builtin.unrealized_conversion_cast"(%1) : (!i64) -> (i32)
     llvm.return %res : i32
   }]
 
@@ -203,9 +199,8 @@ def llvm_sext_lower_riscv_i16_to_32 : LLVMPeepholeRewriteRefine 32 [Ty.llvm (.bi
 def sext_riscv_i16_to_64 := [LV| {
   ^entry (%arg: i16):
     %0 = "builtin.unrealized_conversion_cast"(%arg) : (i16) -> (!i64)
-    %1 = slli %0, 48 : !i64
-    %2 = srai %1, 48 : !i64
-    %res = "builtin.unrealized_conversion_cast"(%2) : (!i64) -> (i64)
+    %1 = sext.h %0 : !i64
+    %res = "builtin.unrealized_conversion_cast"(%1) : (!i64) -> (i64)
     llvm.return %res : i64
   }]
 
@@ -219,6 +214,28 @@ def sext_llvm_i16_to_64 := [LV| {
 def llvm_sext_lower_riscv_i16_to_64 : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 16)] :=
   {lhs:= sext_llvm_i16_to_64, rhs:= sext_riscv_i16_to_64}
 
+/-! ### i32 to i64 -/
+
+@[simp_denote]
+def sext_riscv_i32_to_64 := [LV| {
+  ^entry (%arg: i32):
+    %0 = "builtin.unrealized_conversion_cast"(%arg) : (i32) -> (!i64)
+    %1 = sext.w %0 : !i64
+    %res = "builtin.unrealized_conversion_cast"(%1) : (!i64) -> (i64)
+    llvm.return %res : i64
+  }]
+
+@[simp_denote]
+def sext_llvm_i32_to_64 := [LV| {
+  ^entry (%arg: i32):
+    %0 = llvm.sext %arg: i32 to i64
+    llvm.return %0: i64
+  }]
+
+def llvm_sext_lower_riscv_i32_to_64 : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 32)] :=
+  {lhs:= sext_llvm_i32_to_64, rhs:= sext_riscv_i32_to_64}
+
+
 def sext_match : List (Σ Γ, Σ ty, PeepholeRewrite LLVMPlusRiscV Γ ty) :=
   [  mkRewrite (LLVMToRiscvPeepholeRewriteRefine.toPeepholeUNSOUND llvm_sext_lower_riscv_i1_to_i8),
      mkRewrite (LLVMToRiscvPeepholeRewriteRefine.toPeepholeUNSOUND llvm_sext_lower_riscv_i1_to_i16),
@@ -229,4 +246,5 @@ def sext_match : List (Σ Γ, Σ ty, PeepholeRewrite LLVMPlusRiscV Γ ty) :=
      mkRewrite (LLVMToRiscvPeepholeRewriteRefine.toPeepholeUNSOUND llvm_sext_lower_riscv_i8_to_32),
      mkRewrite (LLVMToRiscvPeepholeRewriteRefine.toPeepholeUNSOUND llvm_sext_lower_riscv_i16_to_32),
      mkRewrite (LLVMToRiscvPeepholeRewriteRefine.toPeepholeUNSOUND llvm_sext_lower_riscv_i16_to_64),
+     mkRewrite (LLVMToRiscvPeepholeRewriteRefine.toPeepholeUNSOUND llvm_sext_lower_riscv_i32_to_64)
    ]

--- a/SSA/Projects/LLVMRiscV/Pipeline/trunc.lean
+++ b/SSA/Projects/LLVMRiscV/Pipeline/trunc.lean
@@ -9,6 +9,7 @@ open LLVMRiscV
   This file implements the lowering for the `llvm.trunc` instruction for truncation:
   - from i32 to i8
   - from i32 to i16
+  - from i64 to i1
   - from i64 to i32
 -/
 
@@ -108,6 +109,80 @@ def llvm_trunc_riscv_32_to_16 : LLVMPeepholeRewriteRefine 16 [Ty.llvm (.bitvec 3
   {lhs:=  trunc_llvm_32_to_16, rhs:= trunc_riscv_32_to_16
   }
 
+/-! ### i64 to i1 -/
+
+@[simp_denote]
+def trunc_llvm_64_to_1 := [LV| {
+  ^entry (%lhs: i64):
+    %0 = llvm.trunc %lhs : i64 to i1
+    llvm.return %0 : i1
+  }]
+
+@[simp_denote]
+def trunc_riscv_to_1 := [LV| {
+  ^entry (%lhs: i64):
+    %lhsr = "builtin.unrealized_conversion_cast"(%lhs) : (i64) -> (!i64)
+    %2= "builtin.unrealized_conversion_cast"(%lhsr) : (!i64) -> (i1)
+    llvm.return %2 : i1
+  }]
+
+def llvm_trunc_riscv_64_to_1 : LLVMPeepholeRewriteRefine 1 [Ty.llvm (.bitvec 64)] :=
+  {lhs:= trunc_llvm_64_to_1, rhs:= trunc_riscv_to_1}
+
+@[simp_denote]
+def trunc_llvm_64_to_1_nuw := [LV| {
+  ^entry (%lhs: i64):
+    %0 = llvm.trunc %lhs overflow<nuw> : i64 to i1
+    llvm.return %0 : i1
+  }]
+
+@[simp_denote]
+def trunc_riscv_to_1_nuw := [LV| {
+  ^entry (%lhs: i64 ):
+    %lhsr = "builtin.unrealized_conversion_cast"(%lhs) : (i64) -> (!i64)
+    %2= "builtin.unrealized_conversion_cast"(%lhsr) : (!i64) -> (i1)
+    llvm.return %2 : i1
+  }]
+
+def llvm_trunc_riscv_64_to_1_nuw : LLVMPeepholeRewriteRefine 1 [Ty.llvm (.bitvec 64)] :=
+  {lhs:= trunc_llvm_64_to_1_nuw, rhs:= trunc_riscv_to_1_nuw }
+
+@[simp_denote]
+def trunc_llvm_64_to_1_nsw := [LV| {
+  ^entry (%lhs: i64):
+    %0 = llvm.trunc %lhs overflow<nsw> : i64 to i1
+    llvm.return %0 : i1
+  }]
+
+@[simp_denote]
+def trunc_riscv_to_1_nsw := [LV| {
+  ^entry (%lhs: i64):
+    %lhsr = "builtin.unrealized_conversion_cast"(%lhs) : (i64) -> (!i64)
+    %2= "builtin.unrealized_conversion_cast"(%lhsr) : (!i64) -> (i1)
+    llvm.return %2 : i1
+  }]
+
+def llvm_trunc_riscv_64_to_1_nsw : LLVMPeepholeRewriteRefine 1 [Ty.llvm (.bitvec 64)] :=
+  {lhs:= trunc_llvm_64_to_1_nsw, rhs:= trunc_riscv_to_1_nsw }
+
+@[simp_denote]
+def trunc_llvm_64_to_1_nsw_nuw := [LV| {
+  ^entry (%lhs: i64):
+    %0 = llvm.trunc %lhs overflow<nsw,nuw> : i64 to i1
+    llvm.return %0 : i1
+  }]
+
+@[simp_denote]
+def trunc_riscv_to_1_nsw_nuw := [LV| {
+  ^entry (%lhs: i64):
+    %lhsr = "builtin.unrealized_conversion_cast"(%lhs) : (i64) -> (!i64)
+    %2= "builtin.unrealized_conversion_cast"(%lhsr) : (!i64) -> (i1)
+    llvm.return %2 : i1
+  }]
+
+def llvm_trunc_riscv_64_to_1_nuw_nsw : LLVMPeepholeRewriteRefine 1 [Ty.llvm (.bitvec 64)] :=
+  {lhs:= trunc_llvm_64_to_1_nsw_nuw, rhs:= trunc_riscv_to_1_nsw_nuw}
+
 
 /-! ### i64 to i32 -/
 
@@ -193,5 +268,9 @@ def trunc_match : List (Σ Γ, Σ ty, PeepholeRewrite LLVMPlusRiscV Γ ty) :=[
   mkRewrite (LLVMToRiscvPeepholeRewriteRefine.toPeepholeUNSOUND llvm_trunc_riscv_32_to_8_nuw_nsw),
   mkRewrite (LLVMToRiscvPeepholeRewriteRefine.toPeepholeUNSOUND llvm_trunc_riscv_32_to_8_nsw),
   mkRewrite (LLVMToRiscvPeepholeRewriteRefine.toPeepholeUNSOUND llvm_trunc_riscv_32_to_8_nuw),
-  mkRewrite (LLVMToRiscvPeepholeRewriteRefine.toPeepholeUNSOUND llvm_trunc_riscv_32_to_8)
+  mkRewrite (LLVMToRiscvPeepholeRewriteRefine.toPeepholeUNSOUND llvm_trunc_riscv_32_to_8),
+  mkRewrite (LLVMToRiscvPeepholeRewriteRefine.toPeepholeUNSOUND llvm_trunc_riscv_64_to_1_nuw_nsw),
+  mkRewrite (LLVMToRiscvPeepholeRewriteRefine.toPeepholeUNSOUND llvm_trunc_riscv_64_to_1_nsw),
+  mkRewrite (LLVMToRiscvPeepholeRewriteRefine.toPeepholeUNSOUND llvm_trunc_riscv_64_to_1_nuw),
+  mkRewrite (LLVMToRiscvPeepholeRewriteRefine.toPeepholeUNSOUND llvm_trunc_riscv_64_to_1)
 ]

--- a/SSA/Projects/LLVMRiscV/Pipeline/trunc.lean
+++ b/SSA/Projects/LLVMRiscV/Pipeline/trunc.lean
@@ -9,8 +9,8 @@ open LLVMRiscV
   This file implements the lowering for the `llvm.trunc` instruction for truncation:
   - from i32 to i8
   - from i32 to i16
-  - from i64 to i1
   - from i64 to i32
+  - from i64 to i1
 -/
 
 /-! ### i32 to i8 -/

--- a/SSA/Projects/LLVMRiscV/Pipeline/zext.lean
+++ b/SSA/Projects/LLVMRiscV/Pipeline/zext.lean
@@ -107,7 +107,7 @@ def llvm_zext_lower_riscv_1_to_64 : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitv
 def zext_riscv_8_to_16 := [LV| {
   ^entry (%arg: i8):
     %0 = "builtin.unrealized_conversion_cast"(%arg) : (i8) -> (!i64)
-    %1 = andi %0, 255 : !i64
+    %1 = zext.b %0 : !i64
     %res = "builtin.unrealized_conversion_cast"(%1) : (!i64) -> (i16)
     llvm.return %res : i16
   }]
@@ -128,7 +128,7 @@ def llvm_zext_lower_riscv_8_to_16 : LLVMPeepholeRewriteRefine 16 [Ty.llvm (.bitv
 def zext_riscv_8_to_32 := [LV| {
   ^entry (%arg: i8):
     %0 = "builtin.unrealized_conversion_cast"(%arg) : (i8) -> (!i64)
-    %1 = andi %0, 255 : !i64
+    %1 = zext.b %0 : !i64
     %res = "builtin.unrealized_conversion_cast"(%1) : (!i64) -> (i32)
     llvm.return %res : i32
   }]
@@ -149,7 +149,7 @@ def llvm_zext_lower_riscv_8_to_32 : LLVMPeepholeRewriteRefine 32 [Ty.llvm (.bitv
 def zext_riscv_8_to_64 := [LV| {
   ^entry (%arg: i8):
     %0 = "builtin.unrealized_conversion_cast"(%arg) : (i8) -> (!i64)
-    %1 = andi %0, 255 : !i64
+    %1 = zext.b %0 : !i64
     %res = "builtin.unrealized_conversion_cast"(%1) : (!i64) -> (i64)
     llvm.return %res : i64
   }]
@@ -208,6 +208,27 @@ def zext_llvm_16_to_64 := [LV| {
 def llvm_zext_lower_riscv_16_to_64 : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 16)] :=
   {lhs:= zext_llvm_16_to_64, rhs:= zext_riscv_16_to_64}
 
+/-! ### i32 to i64 -/
+
+@[simp_denote]
+def zext_riscv_32_to_64 := [LV| {
+  ^entry (%arg: i32):
+    %0 = "builtin.unrealized_conversion_cast"(%arg) : (i32) -> (!i64)
+    %1 = zext.w %0 : !i64
+    %res = "builtin.unrealized_conversion_cast"(%1) : (!i64) -> (i64)
+    llvm.return %res : i64
+  }]
+
+@[simp_denote]
+def zext_llvm_32_to_64 := [LV| {
+  ^entry (%arg: i32):
+    %0 = llvm.zext %arg: i32 to i64
+    llvm.return %0: i64
+  }]
+
+def llvm_zext_lower_riscv_32_to_64 : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 32)] :=
+  {lhs:= zext_llvm_32_to_64, rhs:= zext_riscv_32_to_64}
+
 def zext_match : List (Σ Γ, Σ ty, PeepholeRewrite LLVMPlusRiscV Γ ty) := [
   mkRewrite (LLVMToRiscvPeepholeRewriteRefine.toPeepholeUNSOUND llvm_zext_lower_riscv_1_to_8),
   mkRewrite (LLVMToRiscvPeepholeRewriteRefine.toPeepholeUNSOUND llvm_zext_lower_riscv_1_to_16),
@@ -218,4 +239,5 @@ def zext_match : List (Σ Γ, Σ ty, PeepholeRewrite LLVMPlusRiscV Γ ty) := [
   mkRewrite (LLVMToRiscvPeepholeRewriteRefine.toPeepholeUNSOUND llvm_zext_lower_riscv_8_to_32),
   mkRewrite (LLVMToRiscvPeepholeRewriteRefine.toPeepholeUNSOUND llvm_zext_lower_riscv_16_to_32),
   mkRewrite (LLVMToRiscvPeepholeRewriteRefine.toPeepholeUNSOUND llvm_zext_lower_riscv_16_to_64),
+  mkRewrite (LLVMToRiscvPeepholeRewriteRefine.toPeepholeUNSOUND llvm_zext_lower_riscv_32_to_64)
 ]

--- a/SSA/Projects/RISCV64/Base.lean
+++ b/SSA/Projects/RISCV64/Base.lean
@@ -136,6 +136,7 @@ inductive Op
   | negw
   | sext.w
   | zext.b
+  | zext.w
   | seqz
   | snez
   | sltz
@@ -276,6 +277,7 @@ def Op.sig : Op → List Ty
   | negw => [Ty.bv]
   | sext.w => [Ty.bv]
   | zext.b => [Ty.bv]
+  | zext.w => [Ty.bv]
   | seqz => [Ty.bv]
   | snez => [Ty.bv]
   | sltz => [Ty.bv]
@@ -381,6 +383,7 @@ def Op.outTy : Op  → Ty
   | negw => Ty.bv
   | sext.w => Ty.bv
   | zext.b => Ty.bv
+  | zext.w => Ty.bv
   | seqz => Ty.bv
   | snez => Ty.bv
   | sltz => Ty.bv
@@ -493,6 +496,7 @@ def opName (op : RISCV64.Op) : String :=
   | .negw => "negw"
   | sext.w => "sext.w"
   | zext.b => "zext.b"
+  | zext.w => "zext.w"
   | .seqz => "seqz"
   | .snez => "snez"
   | .sltz => "sltz"
@@ -644,6 +648,7 @@ abbrev Op.denote : (o : RV64.Op) → HVector toType o.sig → ⟦o.outTy⟧
   | .negw, regs => NEGW_pure64_pseudo (regs.getN 0)
   | RISCV64.Op.sext.w, regs => SEXTW_pure64_pseudo (regs.getN 0)
   | RISCV64.Op.zext.b, regs => ZEXTB_pure64_pseudo (regs.getN 0)
+  | RISCV64.Op.zext.w, regs => ZEXTW_pure64_pseudo (regs.getN 0)
   | .seqz, regs => SEQZ_pure64_pseudo (regs.getN 0)
   | .snez, regs => SNEZ_pure64_pseudo (regs.getN 0)
   | .sltz, regs => SLTZ_pure64_pseudo (regs.getN 0)

--- a/SSA/Projects/RISCV64/PrettyEDSL.lean
+++ b/SSA/Projects/RISCV64/PrettyEDSL.lean
@@ -86,6 +86,7 @@ syntax "neg" : MLIR.Pretty.uniform_op
 syntax "negw" : MLIR.Pretty.uniform_op
 syntax "sext.w" : MLIR.Pretty.uniform_op
 syntax "zext.b" : MLIR.Pretty.uniform_op
+syntax "zext.w" : MLIR.Pretty.uniform_op
 syntax "seqz" : MLIR.Pretty.uniform_op
 syntax "snez" : MLIR.Pretty.uniform_op
 syntax "sltz" : MLIR.Pretty.uniform_op

--- a/SSA/Projects/RISCV64/PseudoOpSemantics.lean
+++ b/SSA/Projects/RISCV64/PseudoOpSemantics.lean
@@ -42,6 +42,10 @@ def ZEXTB_pure64_pseudo (rs1_val : BitVec 64) : BitVec 64 :=
   RV64Semantics.ITYPE_pure64_RISCV_ANDI 255 rs1_val
 
 @[simp_riscv]
+def ZEXTW_pure64_pseudo (rs1_val : BitVec 64) : BitVec 64 :=
+  RV64Semantics.ZBA_RTYPEUW_pure64_RISCV_ADDUW 0 rs1_val
+
+@[simp_riscv]
 def SEQZ_pure64_pseudo (rs1_val : BitVec 64) : BitVec 64 :=
   RV64Semantics.ITYPE_pure64_RISCV_SLTIU 1 rs1_val
 

--- a/SSA/Projects/RISCV64/Syntax.lean
+++ b/SSA/Projects/RISCV64/Syntax.lean
@@ -87,6 +87,14 @@ def mkExpr (Γ : Ctxt _) (opStx : MLIR.AST.Op 0) :
                    .cons v₁ <| .nil,
                   .nil
                 ⟩⟩
+      | .bv, "zext.w" => do
+        return ⟨.pure, [.bv], ⟨
+                  RISCV64.Op.zext.w,
+                  rfl,
+                  by constructor,
+                   .cons v₁ <| .nil,
+                  .nil
+                ⟩⟩
       | .bv, "seqz" => do
         return ⟨.pure, [.bv], ⟨
                   .seqz,


### PR DESCRIPTION
This PR extends the RISC-V lowering logic for LLVM `llvm.sext`, `llvm.zext` and `llvm.trunc` operations. It replaces manual bit manipulation with dedicated RISC-V instructions/pseudo-instructions (`sext.b`, `sext.h`, `sext.w`, `zext.b`, `zext.w`), and adds support for 32-to-64 bit extension cases, using lowerings from llc 21.1.0, the newest llc version.

The changes also introduce the new [zext.w ](https://five-embeddev.com/riscv-bitmanip/1.0.0/bitmanip.html#insns-add_uw) operation to the RISC-V semantics.
