### PR TITLE
feat: add instruction lowering comparisons

### DIFF
--- a/SSA/Projects/LLVMRiscV/Evaluation/compare-lowering-patterns/README.md
+++ b/SSA/Projects/LLVMRiscV/Evaluation/compare-lowering-patterns/README.md
@@ -1,0 +1,33 @@
+# Benchmarks Generation 
+
+### Dependencies 
+
+This evaluation relies on dependencies from both `Evaluation/benchmarks` and `Evaluation/mca-analysis`. Therefore `llc` and `evallib` must be in the path. Evallib is added to the path in the given `run_comparison.sh` script.
+
+### How to run
+
+Use the `run_comparison.sh` script to run the comparisons. First make the script executable by:
+
+```bash
+chmod +x ./run_comparison.sh
+```
+
+Then run the script by:
+```bash
+./run_comparison.sh
+```
+
+The results are logged in the `comparison.log` file. 
+
+### Results
+The comparison script performs a comprehensive analysis of instruction lowering patterns across multiple compilers and optimization levels, organized into three distinct phases.
+
+Phase 1: LLVM Compiler Consistency Check
+    The script begins by comparing SelectionDAG and GlobalISel. For each instruction variant, it examines all optimization levels (O0, O1, O2, O3) to verify consistency within each compiler. This internal consistency check ensures that the instruction lowering pattern remains stable across different optimization levels within the same compiler backend.
+Phase 2: Cross-Compiler Comparison (LLVM)
+    After that, the script performs a cross-compiler comparison between SelectionDAG and GlobalISel outputs. For each optimization level, it compares the generated instruction sequences from both frameworks. This comparison reveals whether the two instruction selection approaches produce identical or different lowering patterns for the same input.
+Phase 3: LEAN-MLIR vs LLVM Comparison
+    Finally, the script compares the LEAN-MLIR compiler outputs against LLVM's results at specific optimization levels. This comparison is performed in two stages:
+
+Unoptimized comparison: LEAN-MLIR output is compared against O0 outputs from both GlobalISel and SelectionDAG. 
+Optimized comparison: LEAN-MLIR-opt output is compared against O2 outputs from both GlobalISel and SelectionDAG.

--- a/SSA/Projects/LLVMRiscV/Evaluation/compare-lowering-patterns/compare_lowerings.py
+++ b/SSA/Projects/LLVMRiscV/Evaluation/compare-lowering-patterns/compare_lowerings.py
@@ -1,0 +1,440 @@
+#!/usr/bin/env python3
+
+import os
+import re
+import sys
+import argparse
+from pathlib import Path
+from collections import defaultdict, Counter
+import json
+import subprocess
+from datetime import datetime
+
+ROOT_DIR = (
+    subprocess.check_output(["git", "rev-parse", "--show-toplevel"])
+    .decode("utf-8")
+    .strip()
+)
+
+MCA_LEANMLIR_DIR = (
+    f"{ROOT_DIR}/SSA/Projects/LLVMRiscV/Evaluation/mca-analysis/results/LEANMLIR/"
+)
+MCA_LEANMLIR_opt_DIR = (
+    f"{ROOT_DIR}/SSA/Projects/LLVMRiscV/Evaluation/mca-analysis/results/LEANMLIR_opt/"
+)
+MCA_LLVM_globalisel_DIR = (
+    f"{ROOT_DIR}/SSA/Projects/LLVMRiscV/Evaluation/mca-analysis/results/LLVM_globalisel/"
+)
+MCA_LLVM_selectiondag_DIR = (
+    f"{ROOT_DIR}/SSA/Projects/LLVMRiscV/Evaluation/mca-analysis/results/LLVM_selectiondag/"
+)
+
+LOGS_DIR = f"{ROOT_DIR}/SSA/Projects/LLVMRiscV/Evaluation/compare-lowering-patterns"
+
+
+class Logger:
+    """Logger class to write to both console and file."""
+    
+    def __init__(self, log_file):
+        self.log_file = log_file
+        self.file_handle = None
+        
+    def __enter__(self):
+        # Create logs directory if it doesn't exist
+        os.makedirs(os.path.dirname(self.log_file), exist_ok=True)
+        self.file_handle = open(self.log_file, 'w')
+        return self
+        
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        if self.file_handle:
+            self.file_handle.close()
+    
+    def log(self, message):
+        """Write message to both console and file."""
+        print(message)
+        if self.file_handle:
+            self.file_handle.write(message + '\n')
+            self.file_handle.flush()
+
+
+def parse_instructions(filename):
+    """
+    Parse instructions from a compiler output file.
+    
+    Args:
+        filename: Path to the .out file
+        
+    Returns:
+        List of instruction names
+    """
+    instructions = []
+    in_instruction_section = False
+    
+    try:
+        with open(filename, 'r') as f:
+            for line in f:
+                if '[0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]    Instructions:' in line:
+                    in_instruction_section = True
+                    continue
+                if in_instruction_section and line.strip():
+                    parts = line.split()
+                    if len(parts) > 8:
+                        instruction = parts[8]  # inst name is in 9th column
+                        instructions.append(instruction)
+    except FileNotFoundError:
+        print(f"Warning: File not found: {filename}")
+        return []
+    except Exception as e:
+        print(f"Error parsing {filename}: {e}")
+        return []
+    
+    return instructions
+
+
+def collect_results_lean(base_dir):
+    results = {}
+    
+    if not os.path.exists(base_dir):
+        print(f"Warning: Directory not found: {base_dir}")
+        return results
+    
+    for filename in os.listdir(base_dir):
+        filepath = os.path.join(base_dir, filename)
+        basename = os.path.basename(filename)
+        pattern = r'llvm_(\w+)_(\d+)\.out'
+        match = re.match(pattern, basename)
+        
+        if match: 
+            instruction_name = match.group(1)
+            variant = int(match.group(2))
+            
+            instructions = parse_instructions(filepath)
+            
+            if instruction_name not in results:
+                results[instruction_name] = {}
+
+            results[instruction_name][variant] = instructions
+    
+    return results
+
+    
+    
+def collect_results_llvm(base_dir):
+    results = {}
+    
+    if not os.path.exists(base_dir):
+        print(f"Warning: Directory not found: {base_dir}")
+        return results
+    
+    for filename in os.listdir(base_dir):
+        filepath = os.path.join(base_dir, filename)
+        basename = os.path.basename(filename)
+        pattern = r'llvm_(\w+)_(\d+)_(O[0-3]|default)\.out'
+        match = re.match(pattern, basename)
+        
+        if match: 
+            instruction_name = match.group(1)
+            variant = int(match.group(2))
+            opt_level = match.group(3)
+            
+            instructions = parse_instructions(filepath)
+            
+            if instruction_name not in results:
+                results[instruction_name] = {}
+            if variant not in results[instruction_name]:
+                results[instruction_name][variant] = {}
+            
+            results[instruction_name][variant][opt_level] = instructions
+    
+    return results
+
+
+def log_instruction_diff(logger, instructions_list, labels):
+    """
+    Log detailed differences between instruction lists.
+    
+    Args:
+        logger: Logger instance
+        instructions_list: List of instruction lists to compare
+        labels: Labels for each instruction list
+    """
+    max_len = max(len(insts) for insts in instructions_list)
+    
+    logger.log("\n    Instruction-by-instruction comparison:")
+    logger.log("    " + "-" * 80)
+    
+    # Print header
+    header = f"    {'Index':<8}"
+    for label in labels:
+        header += f"{label:<25}"
+    logger.log(header)
+    logger.log("    " + "-" * 80)
+    
+    # Compare instruction by instruction
+    for i in range(max_len):
+        row = f"    {i:<8}"
+        instructions_at_i = []
+        
+        for insts in instructions_list:
+            if i < len(insts):
+                inst = insts[i]
+                instructions_at_i.append(inst)
+                row += f"{inst:<25}"
+            else:
+                instructions_at_i.append(None)
+                row += f"{'<missing>':<25}"
+        
+        # Highlight if instructions differ at this position
+        if len(set(inst for inst in instructions_at_i if inst is not None)) > 1:
+            logger.log(row + " DIFFERS")
+        else:
+            logger.log(row)
+    
+    logger.log("    " + "-" * 80)
+    
+    # Print summary
+    logger.log("\n    Summary:")
+    for label, insts in zip(labels, instructions_list):
+        logger.log(f"      {label}: {len(insts)} instructions")
+    logger.log("")
+
+
+def compare_in_compiler(logger, results, op, var, compiler_name):
+    """
+    Compare instruction sets across optimization levels within a single compiler.
+    
+    Args:
+        logger: Logger instance
+        results: List of instruction lists for different optimization levels
+        op: Operation name
+        var: Variant number
+        compiler_name: Name of the compiler
+    """
+    all_equal = all(lst == results[0] for lst in results)
+    
+    if all_equal:
+        logger.log(f"  ✓ All optimization levels produce the same instructions for "
+                   f"{compiler_name} llvm.{op} variant {var}")
+    else:
+        logger.log(f"\n  ✗ DIFFERENT instruction sets found across optimization levels for "
+                   f"{compiler_name} llvm.{op} variant {var}")
+        
+        # Create labels for each optimization level
+        opt_levels = ['O0', 'O1', 'O2', 'O3', 'default'][:len(results)]
+        log_instruction_diff(logger, results, opt_levels)
+
+
+def compare_llvm_compilers(logger, globalisel_results, selectiondag_results):
+    """
+    Compare instruction sets between GlobalISel and SelectionDAG compilers.
+    """
+    logger.log("\n" + "=" * 100)
+    logger.log("COMPARISON 1: GlobalISel vs SelectionDAG")
+    logger.log("=" * 100 + "\n")
+    
+    for operation in sorted(globalisel_results.keys()):
+        for variant in sorted(globalisel_results[operation].keys()):
+            logger.log(f"\n{'─' * 100}")
+            logger.log(f"Operation: llvm.{operation}, Variant: {variant}")
+            logger.log(f"{'─' * 100}")
+            
+            opt_results_globalisel = []
+            opt_results_selectiondag = []
+            opt_levels = sorted(globalisel_results[operation][variant].keys())
+            
+            # Compare across optimization levels
+            for opt_level in opt_levels:
+                globalisel_insts = globalisel_results[operation][variant][opt_level]
+                selectiondag_insts = selectiondag_results[operation][variant][opt_level]
+                
+                opt_results_globalisel.append(globalisel_insts)
+                opt_results_selectiondag.append(selectiondag_insts)
+                
+                if globalisel_insts == selectiondag_insts:
+                    logger.log(f"  ✓ Same instructions at {opt_level}")
+                else:
+                    logger.log(f"\n  ✗ DIFFERENT instructions at {opt_level}")
+                    log_instruction_diff(
+                        logger,
+                        [globalisel_insts, selectiondag_insts],
+                        [f"GlobalISel-{opt_level}", f"SelectionDAG-{opt_level}"]
+                    )
+            
+            # Compare within each compiler across optimization levels
+            logger.log("")
+            compare_in_compiler(logger, opt_results_globalisel, operation, variant, "GlobalISel")
+            compare_in_compiler(logger, opt_results_selectiondag, operation, variant, "SelectionDAG")
+
+
+def compare_lean_vs_llvm(logger, leanmlir_results, leanmlir_opt_results, 
+                         globalisel_results, selectiondag_results):
+    """
+    Compare LEAN compilers with LLVM compilers.
+    - LEANMLIR vs O0 of GlobalISel and SelectionDAG
+    - LEANMLIR_opt vs O2 of GlobalISel and SelectionDAG
+    """
+    logger.log("\n" + "=" * 100)
+    logger.log("COMPARISON 2: LEANMLIR vs LLVM at O0")
+    logger.log("=" * 100 + "\n")
+    
+    # Get all operations that exist in LEANMLIR
+    for operation in sorted(leanmlir_results.keys()):
+        for variant in sorted(leanmlir_results[operation].keys()):
+            logger.log(f"\n{'─' * 100}")
+            logger.log(f"Operation: llvm.{operation}, Variant: {variant}")
+            logger.log(f"{'─' * 100}")
+            
+            lean_insts = leanmlir_results[operation][variant]
+            
+            # Check if this operation/variant exists in LLVM results
+            if operation not in globalisel_results or variant not in globalisel_results[operation]:
+                logger.log(f" ✗ Operation/variant not found in GlobalISel results")
+                continue
+            
+            if operation not in selectiondag_results or variant not in selectiondag_results[operation]:
+                logger.log(f" ✗ Operation/variant not found in SelectionDAG results")
+                continue
+            
+            # Get O0 instructions from LLVM compilers
+            globalisel_o0 = globalisel_results[operation][variant].get('O0', [])
+            selectiondag_o0 = selectiondag_results[operation][variant].get('O0', [])
+            
+            if not globalisel_o0:
+                logger.log(f"  ✗  O0 results not found for GlobalISel")
+            if not selectiondag_o0:
+                logger.log(f"  ✗  O0 results not found for SelectionDAG")
+            
+            # Compare LEAN vs GlobalISel O0
+            if globalisel_o0:
+                if lean_insts == globalisel_o0:
+                    logger.log(f"  ✓ LEANMLIR matches GlobalISel-O0")
+                else:
+                    logger.log(f"\n  ✗ LEANMLIR DIFFERS from GlobalISel-O0")
+                    log_instruction_diff(
+                        logger,
+                        [lean_insts, globalisel_o0],
+                        ["LEANMLIR", "GlobalISel-O0"]
+                    )
+            
+            # Compare LEAN vs SelectionDAG O0
+            if selectiondag_o0:
+                if lean_insts == selectiondag_o0:
+                    logger.log(f"  ✓ LEANMLIR matches SelectionDAG-O0")
+                else:
+                    logger.log(f"\n  ✗ LEANMLIR DIFFERS from SelectionDAG-O0")
+                    log_instruction_diff(
+                        logger,
+                        [lean_insts, selectiondag_o0],
+                        ["LEANMLIR", "SelectionDAG-O0"]
+                    )
+            
+            # Compare all three at once for a comprehensive view
+            if globalisel_o0 and selectiondag_o0:
+                all_same = lean_insts == globalisel_o0 == selectiondag_o0
+                if all_same:
+                    logger.log(f"\n  ✓ All three produce IDENTICAL instructions (LEANMLIR, GlobalISel-O0, SelectionDAG-O0)")
+                else:
+                    logger.log(f"\n  Comprehensive comparison of all three:")
+                    log_instruction_diff(
+                        logger,
+                        [lean_insts, globalisel_o0, selectiondag_o0],
+                        ["LEANMLIR", "GlobalISel-O0", "SelectionDAG-O0"]
+                    )
+    
+    logger.log("\n" + "=" * 100)
+    logger.log("COMPARISON 3: LEANMLIR_opt vs LLVM at O2")
+    logger.log("=" * 100 + "\n")
+    
+    # Get all operations that exist in LEANMLIR_opt
+    for operation in sorted(leanmlir_opt_results.keys()):
+        for variant in sorted(leanmlir_opt_results[operation].keys()):
+            logger.log(f"\n{'─' * 100}")
+            logger.log(f"Operation: llvm.{operation}, Variant: {variant}")
+            logger.log(f"{'─' * 100}")
+            
+            lean_opt_insts = leanmlir_opt_results[operation][variant]
+            
+            # Check if this operation/variant exists in LLVM results
+            if operation not in globalisel_results or variant not in globalisel_results[operation]:
+                logger.log(f"  ✗  Operation/variant not found in GlobalISel results")
+                continue
+            
+            if operation not in selectiondag_results or variant not in selectiondag_results[operation]:
+                logger.log(f"  ✗  Operation/variant not found in SelectionDAG results")
+                continue
+            
+            # Get O2 instructions from LLVM compilers
+            globalisel_o2 = globalisel_results[operation][variant].get('O2', [])
+            selectiondag_o2 = selectiondag_results[operation][variant].get('O2', [])
+            
+            if not globalisel_o2:
+                logger.log(f"  ✗  O2 results not found for GlobalISel")
+            if not selectiondag_o2:
+                logger.log(f"  ✗  O2 results not found for SelectionDAG")
+            
+            # Compare LEAN_opt vs GlobalISel O2
+            if globalisel_o2:
+                if lean_opt_insts == globalisel_o2:
+                    logger.log(f"  ✓ LEANMLIR_opt matches GlobalISel-O2")
+                else:
+                    logger.log(f"\n  ✗ LEANMLIR_opt DIFFERS from GlobalISel-O2")
+                    log_instruction_diff(
+                        logger,
+                        [lean_opt_insts, globalisel_o2],
+                        ["LEANMLIR_opt", "GlobalISel-O2"]
+                    )
+            
+            # Compare LEAN_opt vs SelectionDAG O2
+            if selectiondag_o2:
+                if lean_opt_insts == selectiondag_o2:
+                    logger.log(f"  ✓ LEANMLIR_opt matches SelectionDAG-O2")
+                else:
+                    logger.log(f"\n  ✗ LEANMLIR_opt DIFFERS from SelectionDAG-O2")
+                    log_instruction_diff(
+                        logger,
+                        [lean_opt_insts, selectiondag_o2],
+                        ["LEANMLIR_opt", "SelectionDAG-O2"]
+                    )
+            
+            # Compare all three at once for a comprehensive view
+            if globalisel_o2 and selectiondag_o2:
+                all_same = lean_opt_insts == globalisel_o2 == selectiondag_o2
+                if all_same:
+                    logger.log(f"\n  ✓ All three produce IDENTICAL instructions (LEANMLIR_opt, GlobalISel-O2, SelectionDAG-O2)")
+                else:
+                    logger.log(f"\n  Comprehensive comparison of all three:")
+                    log_instruction_diff(
+                        logger,
+                        [lean_opt_insts, globalisel_o2, selectiondag_o2],
+                        ["LEANMLIR_opt", "GlobalISel-O2", "SelectionDAG-O2"]
+                    )
+
+
+def main():
+    log_file = os.path.join(LOGS_DIR, f"comparison.log")
+    
+    # Collect results from all compilers
+    print(f"Collecting results... (log will be saved to {log_file})")
+    
+    globalisel_results = collect_results_llvm(MCA_LLVM_globalisel_DIR)
+    selectiondag_results = collect_results_llvm(MCA_LLVM_selectiondag_DIR)
+    leanmlir_results = collect_results_lean(MCA_LEANMLIR_DIR)
+    leanmlir_opt_results = collect_results_lean(MCA_LEANMLIR_opt_DIR)
+    
+    # Use logger context manager
+    with Logger(log_file) as logger:        
+        # Compare LLVM compilers
+        compare_llvm_compilers(logger, globalisel_results, selectiondag_results)
+        
+        # Compare LEAN vs LLVM
+        compare_lean_vs_llvm(logger, leanmlir_results, leanmlir_opt_results, 
+                            globalisel_results, selectiondag_results)
+        
+        logger.log("\n" + "=" * 100)
+        logger.log("END OF ALL COMPARISONS")
+        logger.log("=" * 100 + "\n")
+    
+    print(f"\nLog file saved to: {log_file}")
+    
+if __name__ == "__main__":
+    main()

--- a/SSA/Projects/LLVMRiscV/Evaluation/compare-lowering-patterns/comparison.log
+++ b/SSA/Projects/LLVMRiscV/Evaluation/compare-lowering-patterns/comparison.log
@@ -1,0 +1,5370 @@
+
+====================================================================================================
+COMPARISON 1: GlobalISel vs SelectionDAG
+====================================================================================================
+
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+Operation: llvm.add, Variant: 0
+────────────────────────────────────────────────────────────────────────────────────────────────────
+  ✓ Same instructions at O0
+  ✓ Same instructions at O1
+  ✓ Same instructions at O2
+  ✓ Same instructions at O3
+
+  ✓ All optimization levels produce the same instructions for GlobalISel llvm.add variant 0
+  ✓ All optimization levels produce the same instructions for SelectionDAG llvm.add variant 0
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+Operation: llvm.add, Variant: 1
+────────────────────────────────────────────────────────────────────────────────────────────────────
+  ✓ Same instructions at O0
+  ✓ Same instructions at O1
+  ✓ Same instructions at O2
+  ✓ Same instructions at O3
+
+  ✓ All optimization levels produce the same instructions for GlobalISel llvm.add variant 1
+  ✓ All optimization levels produce the same instructions for SelectionDAG llvm.add variant 1
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+Operation: llvm.add, Variant: 2
+────────────────────────────────────────────────────────────────────────────────────────────────────
+  ✓ Same instructions at O0
+  ✓ Same instructions at O1
+  ✓ Same instructions at O2
+  ✓ Same instructions at O3
+
+  ✓ All optimization levels produce the same instructions for GlobalISel llvm.add variant 2
+  ✓ All optimization levels produce the same instructions for SelectionDAG llvm.add variant 2
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+Operation: llvm.and, Variant: 0
+────────────────────────────────────────────────────────────────────────────────────────────────────
+  ✓ Same instructions at O0
+  ✓ Same instructions at O1
+  ✓ Same instructions at O2
+  ✓ Same instructions at O3
+
+  ✓ All optimization levels produce the same instructions for GlobalISel llvm.and variant 0
+  ✓ All optimization levels produce the same instructions for SelectionDAG llvm.and variant 0
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+Operation: llvm.ashr, Variant: 0
+────────────────────────────────────────────────────────────────────────────────────────────────────
+  ✓ Same instructions at O0
+  ✓ Same instructions at O1
+  ✓ Same instructions at O2
+  ✓ Same instructions at O3
+
+  ✓ All optimization levels produce the same instructions for GlobalISel llvm.ashr variant 0
+  ✓ All optimization levels produce the same instructions for SelectionDAG llvm.ashr variant 0
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+Operation: llvm.icmp, Variant: 0
+────────────────────────────────────────────────────────────────────────────────────────────────────
+  ✓ Same instructions at O0
+  ✓ Same instructions at O1
+  ✓ Same instructions at O2
+  ✓ Same instructions at O3
+
+  ✓ All optimization levels produce the same instructions for GlobalISel llvm.icmp variant 0
+  ✓ All optimization levels produce the same instructions for SelectionDAG llvm.icmp variant 0
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+Operation: llvm.icmp, Variant: 1
+────────────────────────────────────────────────────────────────────────────────────────────────────
+  ✓ Same instructions at O0
+  ✓ Same instructions at O1
+  ✓ Same instructions at O2
+  ✓ Same instructions at O3
+
+  ✓ All optimization levels produce the same instructions for GlobalISel llvm.icmp variant 1
+  ✓ All optimization levels produce the same instructions for SelectionDAG llvm.icmp variant 1
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+Operation: llvm.icmp, Variant: 2
+────────────────────────────────────────────────────────────────────────────────────────────────────
+  ✓ Same instructions at O0
+  ✓ Same instructions at O1
+  ✓ Same instructions at O2
+  ✓ Same instructions at O3
+
+  ✓ All optimization levels produce the same instructions for GlobalISel llvm.icmp variant 2
+  ✓ All optimization levels produce the same instructions for SelectionDAG llvm.icmp variant 2
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+Operation: llvm.icmp, Variant: 3
+────────────────────────────────────────────────────────────────────────────────────────────────────
+  ✓ Same instructions at O0
+  ✓ Same instructions at O1
+  ✓ Same instructions at O2
+  ✓ Same instructions at O3
+
+  ✓ All optimization levels produce the same instructions for GlobalISel llvm.icmp variant 3
+  ✓ All optimization levels produce the same instructions for SelectionDAG llvm.icmp variant 3
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+Operation: llvm.icmp, Variant: 4
+────────────────────────────────────────────────────────────────────────────────────────────────────
+  ✓ Same instructions at O0
+  ✓ Same instructions at O1
+  ✓ Same instructions at O2
+  ✓ Same instructions at O3
+
+  ✓ All optimization levels produce the same instructions for GlobalISel llvm.icmp variant 4
+  ✓ All optimization levels produce the same instructions for SelectionDAG llvm.icmp variant 4
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+Operation: llvm.icmp, Variant: 5
+────────────────────────────────────────────────────────────────────────────────────────────────────
+  ✓ Same instructions at O0
+  ✓ Same instructions at O1
+  ✓ Same instructions at O2
+  ✓ Same instructions at O3
+
+  ✓ All optimization levels produce the same instructions for GlobalISel llvm.icmp variant 5
+  ✓ All optimization levels produce the same instructions for SelectionDAG llvm.icmp variant 5
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+Operation: llvm.icmp, Variant: 6
+────────────────────────────────────────────────────────────────────────────────────────────────────
+  ✓ Same instructions at O0
+  ✓ Same instructions at O1
+  ✓ Same instructions at O2
+  ✓ Same instructions at O3
+
+  ✓ All optimization levels produce the same instructions for GlobalISel llvm.icmp variant 6
+  ✓ All optimization levels produce the same instructions for SelectionDAG llvm.icmp variant 6
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+Operation: llvm.icmp, Variant: 7
+────────────────────────────────────────────────────────────────────────────────────────────────────
+  ✓ Same instructions at O0
+  ✓ Same instructions at O1
+  ✓ Same instructions at O2
+  ✓ Same instructions at O3
+
+  ✓ All optimization levels produce the same instructions for GlobalISel llvm.icmp variant 7
+  ✓ All optimization levels produce the same instructions for SelectionDAG llvm.icmp variant 7
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+Operation: llvm.icmp, Variant: 8
+────────────────────────────────────────────────────────────────────────────────────────────────────
+  ✓ Same instructions at O0
+  ✓ Same instructions at O1
+  ✓ Same instructions at O2
+  ✓ Same instructions at O3
+
+  ✓ All optimization levels produce the same instructions for GlobalISel llvm.icmp variant 8
+  ✓ All optimization levels produce the same instructions for SelectionDAG llvm.icmp variant 8
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+Operation: llvm.mul, Variant: 0
+────────────────────────────────────────────────────────────────────────────────────────────────────
+  ✓ Same instructions at O0
+  ✓ Same instructions at O1
+  ✓ Same instructions at O2
+  ✓ Same instructions at O3
+
+  ✓ All optimization levels produce the same instructions for GlobalISel llvm.mul variant 0
+  ✓ All optimization levels produce the same instructions for SelectionDAG llvm.mul variant 0
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+Operation: llvm.mul, Variant: 1
+────────────────────────────────────────────────────────────────────────────────────────────────────
+  ✓ Same instructions at O0
+  ✓ Same instructions at O1
+  ✓ Same instructions at O2
+  ✓ Same instructions at O3
+
+  ✓ All optimization levels produce the same instructions for GlobalISel llvm.mul variant 1
+  ✓ All optimization levels produce the same instructions for SelectionDAG llvm.mul variant 1
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+Operation: llvm.mul, Variant: 2
+────────────────────────────────────────────────────────────────────────────────────────────────────
+  ✓ Same instructions at O0
+  ✓ Same instructions at O1
+  ✓ Same instructions at O2
+  ✓ Same instructions at O3
+
+  ✓ All optimization levels produce the same instructions for GlobalISel llvm.mul variant 2
+  ✓ All optimization levels produce the same instructions for SelectionDAG llvm.mul variant 2
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+Operation: llvm.or, Variant: 0
+────────────────────────────────────────────────────────────────────────────────────────────────────
+  ✓ Same instructions at O0
+  ✓ Same instructions at O1
+  ✓ Same instructions at O2
+  ✓ Same instructions at O3
+
+  ✓ All optimization levels produce the same instructions for GlobalISel llvm.or variant 0
+  ✓ All optimization levels produce the same instructions for SelectionDAG llvm.or variant 0
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+Operation: llvm.rem, Variant: 0
+────────────────────────────────────────────────────────────────────────────────────────────────────
+  ✓ Same instructions at O0
+  ✓ Same instructions at O1
+  ✓ Same instructions at O2
+  ✓ Same instructions at O3
+
+  ✓ All optimization levels produce the same instructions for GlobalISel llvm.rem variant 0
+  ✓ All optimization levels produce the same instructions for SelectionDAG llvm.rem variant 0
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+Operation: llvm.sdiv, Variant: 0
+────────────────────────────────────────────────────────────────────────────────────────────────────
+  ✓ Same instructions at O0
+  ✓ Same instructions at O1
+  ✓ Same instructions at O2
+  ✓ Same instructions at O3
+
+  ✓ All optimization levels produce the same instructions for GlobalISel llvm.sdiv variant 0
+  ✓ All optimization levels produce the same instructions for SelectionDAG llvm.sdiv variant 0
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+Operation: llvm.select, Variant: 0
+────────────────────────────────────────────────────────────────────────────────────────────────────
+
+  ✗ DIFFERENT instructions at O0
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   GlobalISel-O0            SelectionDAG-O0          
+    --------------------------------------------------------------------------------
+    0       addi                     addi                     
+    1       sd                       sd                       
+    2       andi                     mv                        ⚠️  DIFFERS
+    3       sd                       andi                      ⚠️  DIFFERS
+    4       bnez                     sd                        ⚠️  DIFFERS
+    5       ld                       bnez                      ⚠️  DIFFERS
+    6       sd                       ld                        ⚠️  DIFFERS
+    7       ld                       sd                        ⚠️  DIFFERS
+    8       addi                     ld                        ⚠️  DIFFERS
+    9       ret                      addi                      ⚠️  DIFFERS
+    10      <missing>                ret                      
+    --------------------------------------------------------------------------------
+
+    Summary:
+      GlobalISel-O0: 10 instructions
+      SelectionDAG-O0: 11 instructions
+
+
+  ✗ DIFFERENT instructions at O1
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   GlobalISel-O1            SelectionDAG-O1          
+    --------------------------------------------------------------------------------
+    0       mv                       andi                      ⚠️  DIFFERS
+    1       mv                       mv                       
+    2       andi                     bnez                      ⚠️  DIFFERS
+    3       bnez                     mv                        ⚠️  DIFFERS
+    4       mv                       ret                       ⚠️  DIFFERS
+    5       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      GlobalISel-O1: 6 instructions
+      SelectionDAG-O1: 5 instructions
+
+
+  ✗ DIFFERENT instructions at O2
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   GlobalISel-O2            SelectionDAG-O2          
+    --------------------------------------------------------------------------------
+    0       mv                       andi                      ⚠️  DIFFERS
+    1       mv                       mv                       
+    2       andi                     bnez                      ⚠️  DIFFERS
+    3       bnez                     mv                        ⚠️  DIFFERS
+    4       mv                       ret                       ⚠️  DIFFERS
+    5       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      GlobalISel-O2: 6 instructions
+      SelectionDAG-O2: 5 instructions
+
+
+  ✗ DIFFERENT instructions at O3
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   GlobalISel-O3            SelectionDAG-O3          
+    --------------------------------------------------------------------------------
+    0       mv                       andi                      ⚠️  DIFFERS
+    1       mv                       mv                       
+    2       andi                     bnez                      ⚠️  DIFFERS
+    3       bnez                     mv                        ⚠️  DIFFERS
+    4       mv                       ret                       ⚠️  DIFFERS
+    5       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      GlobalISel-O3: 6 instructions
+      SelectionDAG-O3: 5 instructions
+
+
+
+  ✗ DIFFERENT instruction sets found across optimization levels for GlobalISel llvm.select variant 0
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   O0                       O1                       O2                       O3                       
+    --------------------------------------------------------------------------------
+    0       addi                     mv                       mv                       mv                        ⚠️  DIFFERS
+    1       sd                       mv                       mv                       mv                        ⚠️  DIFFERS
+    2       andi                     andi                     andi                     andi                     
+    3       sd                       bnez                     bnez                     bnez                      ⚠️  DIFFERS
+    4       bnez                     mv                       mv                       mv                        ⚠️  DIFFERS
+    5       ld                       ret                      ret                      ret                       ⚠️  DIFFERS
+    6       sd                       <missing>                <missing>                <missing>                
+    7       ld                       <missing>                <missing>                <missing>                
+    8       addi                     <missing>                <missing>                <missing>                
+    9       ret                      <missing>                <missing>                <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      O0: 10 instructions
+      O1: 6 instructions
+      O2: 6 instructions
+      O3: 6 instructions
+
+
+  ✗ DIFFERENT instruction sets found across optimization levels for SelectionDAG llvm.select variant 0
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   O0                       O1                       O2                       O3                       
+    --------------------------------------------------------------------------------
+    0       addi                     andi                     andi                     andi                      ⚠️  DIFFERS
+    1       sd                       mv                       mv                       mv                        ⚠️  DIFFERS
+    2       mv                       bnez                     bnez                     bnez                      ⚠️  DIFFERS
+    3       andi                     mv                       mv                       mv                        ⚠️  DIFFERS
+    4       sd                       ret                      ret                      ret                       ⚠️  DIFFERS
+    5       bnez                     <missing>                <missing>                <missing>                
+    6       ld                       <missing>                <missing>                <missing>                
+    7       sd                       <missing>                <missing>                <missing>                
+    8       ld                       <missing>                <missing>                <missing>                
+    9       addi                     <missing>                <missing>                <missing>                
+    10      ret                      <missing>                <missing>                <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      O0: 11 instructions
+      O1: 5 instructions
+      O2: 5 instructions
+      O3: 5 instructions
+
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+Operation: llvm.sext, Variant: 0
+────────────────────────────────────────────────────────────────────────────────────────────────────
+  ✓ Same instructions at O0
+  ✓ Same instructions at O1
+  ✓ Same instructions at O2
+  ✓ Same instructions at O3
+
+  ✓ All optimization levels produce the same instructions for GlobalISel llvm.sext variant 0
+  ✓ All optimization levels produce the same instructions for SelectionDAG llvm.sext variant 0
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+Operation: llvm.sext, Variant: 1
+────────────────────────────────────────────────────────────────────────────────────────────────────
+  ✓ Same instructions at O0
+  ✓ Same instructions at O1
+  ✓ Same instructions at O2
+  ✓ Same instructions at O3
+
+  ✓ All optimization levels produce the same instructions for GlobalISel llvm.sext variant 1
+  ✓ All optimization levels produce the same instructions for SelectionDAG llvm.sext variant 1
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+Operation: llvm.sext, Variant: 2
+────────────────────────────────────────────────────────────────────────────────────────────────────
+  ✓ Same instructions at O0
+  ✓ Same instructions at O1
+  ✓ Same instructions at O2
+  ✓ Same instructions at O3
+
+  ✓ All optimization levels produce the same instructions for GlobalISel llvm.sext variant 2
+  ✓ All optimization levels produce the same instructions for SelectionDAG llvm.sext variant 2
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+Operation: llvm.sext, Variant: 3
+────────────────────────────────────────────────────────────────────────────────────────────────────
+  ✓ Same instructions at O0
+  ✓ Same instructions at O1
+  ✓ Same instructions at O2
+  ✓ Same instructions at O3
+
+  ✓ All optimization levels produce the same instructions for GlobalISel llvm.sext variant 3
+  ✓ All optimization levels produce the same instructions for SelectionDAG llvm.sext variant 3
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+Operation: llvm.shl, Variant: 0
+────────────────────────────────────────────────────────────────────────────────────────────────────
+  ✓ Same instructions at O0
+  ✓ Same instructions at O1
+  ✓ Same instructions at O2
+  ✓ Same instructions at O3
+
+  ✓ All optimization levels produce the same instructions for GlobalISel llvm.shl variant 0
+  ✓ All optimization levels produce the same instructions for SelectionDAG llvm.shl variant 0
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+Operation: llvm.shl, Variant: 1
+────────────────────────────────────────────────────────────────────────────────────────────────────
+  ✓ Same instructions at O0
+  ✓ Same instructions at O1
+  ✓ Same instructions at O2
+  ✓ Same instructions at O3
+
+  ✓ All optimization levels produce the same instructions for GlobalISel llvm.shl variant 1
+  ✓ All optimization levels produce the same instructions for SelectionDAG llvm.shl variant 1
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+Operation: llvm.shl, Variant: 2
+────────────────────────────────────────────────────────────────────────────────────────────────────
+  ✓ Same instructions at O0
+  ✓ Same instructions at O1
+  ✓ Same instructions at O2
+  ✓ Same instructions at O3
+
+  ✓ All optimization levels produce the same instructions for GlobalISel llvm.shl variant 2
+  ✓ All optimization levels produce the same instructions for SelectionDAG llvm.shl variant 2
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+Operation: llvm.shl, Variant: 3
+────────────────────────────────────────────────────────────────────────────────────────────────────
+  ✓ Same instructions at O0
+  ✓ Same instructions at O1
+  ✓ Same instructions at O2
+  ✓ Same instructions at O3
+
+  ✓ All optimization levels produce the same instructions for GlobalISel llvm.shl variant 3
+  ✓ All optimization levels produce the same instructions for SelectionDAG llvm.shl variant 3
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+Operation: llvm.srl, Variant: 0
+────────────────────────────────────────────────────────────────────────────────────────────────────
+  ✓ Same instructions at O0
+  ✓ Same instructions at O1
+  ✓ Same instructions at O2
+  ✓ Same instructions at O3
+
+  ✓ All optimization levels produce the same instructions for GlobalISel llvm.srl variant 0
+  ✓ All optimization levels produce the same instructions for SelectionDAG llvm.srl variant 0
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+Operation: llvm.sub, Variant: 0
+────────────────────────────────────────────────────────────────────────────────────────────────────
+  ✓ Same instructions at O0
+  ✓ Same instructions at O1
+  ✓ Same instructions at O2
+  ✓ Same instructions at O3
+
+  ✓ All optimization levels produce the same instructions for GlobalISel llvm.sub variant 0
+  ✓ All optimization levels produce the same instructions for SelectionDAG llvm.sub variant 0
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+Operation: llvm.sub, Variant: 1
+────────────────────────────────────────────────────────────────────────────────────────────────────
+  ✓ Same instructions at O0
+  ✓ Same instructions at O1
+  ✓ Same instructions at O2
+  ✓ Same instructions at O3
+
+  ✓ All optimization levels produce the same instructions for GlobalISel llvm.sub variant 1
+  ✓ All optimization levels produce the same instructions for SelectionDAG llvm.sub variant 1
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+Operation: llvm.sub, Variant: 2
+────────────────────────────────────────────────────────────────────────────────────────────────────
+  ✓ Same instructions at O0
+  ✓ Same instructions at O1
+  ✓ Same instructions at O2
+  ✓ Same instructions at O3
+
+  ✓ All optimization levels produce the same instructions for GlobalISel llvm.sub variant 2
+  ✓ All optimization levels produce the same instructions for SelectionDAG llvm.sub variant 2
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+Operation: llvm.trunc, Variant: 0
+────────────────────────────────────────────────────────────────────────────────────────────────────
+  ✓ Same instructions at O0
+  ✓ Same instructions at O1
+  ✓ Same instructions at O2
+  ✓ Same instructions at O3
+
+  ✓ All optimization levels produce the same instructions for GlobalISel llvm.trunc variant 0
+  ✓ All optimization levels produce the same instructions for SelectionDAG llvm.trunc variant 0
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+Operation: llvm.udiv, Variant: 0
+────────────────────────────────────────────────────────────────────────────────────────────────────
+  ✓ Same instructions at O0
+  ✓ Same instructions at O1
+  ✓ Same instructions at O2
+  ✓ Same instructions at O3
+
+  ✓ All optimization levels produce the same instructions for GlobalISel llvm.udiv variant 0
+  ✓ All optimization levels produce the same instructions for SelectionDAG llvm.udiv variant 0
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+Operation: llvm.urem, Variant: 0
+────────────────────────────────────────────────────────────────────────────────────────────────────
+  ✓ Same instructions at O0
+  ✓ Same instructions at O1
+  ✓ Same instructions at O2
+  ✓ Same instructions at O3
+
+  ✓ All optimization levels produce the same instructions for GlobalISel llvm.urem variant 0
+  ✓ All optimization levels produce the same instructions for SelectionDAG llvm.urem variant 0
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+Operation: llvm.xor, Variant: 0
+────────────────────────────────────────────────────────────────────────────────────────────────────
+  ✓ Same instructions at O0
+  ✓ Same instructions at O1
+  ✓ Same instructions at O2
+  ✓ Same instructions at O3
+
+  ✓ All optimization levels produce the same instructions for GlobalISel llvm.xor variant 0
+  ✓ All optimization levels produce the same instructions for SelectionDAG llvm.xor variant 0
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+Operation: llvm.zext, Variant: 0
+────────────────────────────────────────────────────────────────────────────────────────────────────
+  ✓ Same instructions at O0
+  ✓ Same instructions at O1
+  ✓ Same instructions at O2
+  ✓ Same instructions at O3
+
+  ✓ All optimization levels produce the same instructions for GlobalISel llvm.zext variant 0
+  ✓ All optimization levels produce the same instructions for SelectionDAG llvm.zext variant 0
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+Operation: llvm.zext, Variant: 1
+────────────────────────────────────────────────────────────────────────────────────────────────────
+  ✓ Same instructions at O0
+  ✓ Same instructions at O1
+  ✓ Same instructions at O2
+  ✓ Same instructions at O3
+
+  ✓ All optimization levels produce the same instructions for GlobalISel llvm.zext variant 1
+  ✓ All optimization levels produce the same instructions for SelectionDAG llvm.zext variant 1
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+Operation: llvm.zext, Variant: 2
+────────────────────────────────────────────────────────────────────────────────────────────────────
+  ✓ Same instructions at O0
+  ✓ Same instructions at O1
+  ✓ Same instructions at O2
+  ✓ Same instructions at O3
+
+  ✓ All optimization levels produce the same instructions for GlobalISel llvm.zext variant 2
+  ✓ All optimization levels produce the same instructions for SelectionDAG llvm.zext variant 2
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+Operation: llvm.zext, Variant: 3
+────────────────────────────────────────────────────────────────────────────────────────────────────
+  ✓ Same instructions at O0
+  ✓ Same instructions at O1
+  ✓ Same instructions at O2
+  ✓ Same instructions at O3
+
+  ✓ All optimization levels produce the same instructions for GlobalISel llvm.zext variant 3
+  ✓ All optimization levels produce the same instructions for SelectionDAG llvm.zext variant 3
+
+====================================================================================================
+COMPARISON 2: LEANMLIR vs LLVM at O0
+====================================================================================================
+
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+Operation: llvm.add, Variant: 0
+────────────────────────────────────────────────────────────────────────────────────────────────────
+
+  ✗ LEANMLIR DIFFERS from GlobalISel-O0
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR                 GlobalISel-O0            
+    --------------------------------------------------------------------------------
+    0       mv                       add                       ⚠️  DIFFERS
+    1       mv                       ret                       ⚠️  DIFFERS
+    2       add                      <missing>                
+    3       mv                       <missing>                
+    4       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR: 5 instructions
+      GlobalISel-O0: 2 instructions
+
+
+  ✗ LEANMLIR DIFFERS from SelectionDAG-O0
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR                 SelectionDAG-O0          
+    --------------------------------------------------------------------------------
+    0       mv                       add                       ⚠️  DIFFERS
+    1       mv                       ret                       ⚠️  DIFFERS
+    2       add                      <missing>                
+    3       mv                       <missing>                
+    4       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR: 5 instructions
+      SelectionDAG-O0: 2 instructions
+
+
+  Comprehensive comparison of all three:
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR                 GlobalISel-O0            SelectionDAG-O0          
+    --------------------------------------------------------------------------------
+    0       mv                       add                      add                       ⚠️  DIFFERS
+    1       mv                       ret                      ret                       ⚠️  DIFFERS
+    2       add                      <missing>                <missing>                
+    3       mv                       <missing>                <missing>                
+    4       ret                      <missing>                <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR: 5 instructions
+      GlobalISel-O0: 2 instructions
+      SelectionDAG-O0: 2 instructions
+
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+Operation: llvm.add, Variant: 1
+────────────────────────────────────────────────────────────────────────────────────────────────────
+
+  ✗ LEANMLIR DIFFERS from GlobalISel-O0
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR                 GlobalISel-O0            
+    --------------------------------------------------------------------------------
+    0       mv                       add                       ⚠️  DIFFERS
+    1       mv                       ret                       ⚠️  DIFFERS
+    2       add                      <missing>                
+    3       mv                       <missing>                
+    4       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR: 5 instructions
+      GlobalISel-O0: 2 instructions
+
+
+  ✗ LEANMLIR DIFFERS from SelectionDAG-O0
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR                 SelectionDAG-O0          
+    --------------------------------------------------------------------------------
+    0       mv                       add                       ⚠️  DIFFERS
+    1       mv                       ret                       ⚠️  DIFFERS
+    2       add                      <missing>                
+    3       mv                       <missing>                
+    4       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR: 5 instructions
+      SelectionDAG-O0: 2 instructions
+
+
+  Comprehensive comparison of all three:
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR                 GlobalISel-O0            SelectionDAG-O0          
+    --------------------------------------------------------------------------------
+    0       mv                       add                      add                       ⚠️  DIFFERS
+    1       mv                       ret                      ret                       ⚠️  DIFFERS
+    2       add                      <missing>                <missing>                
+    3       mv                       <missing>                <missing>                
+    4       ret                      <missing>                <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR: 5 instructions
+      GlobalISel-O0: 2 instructions
+      SelectionDAG-O0: 2 instructions
+
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+Operation: llvm.add, Variant: 2
+────────────────────────────────────────────────────────────────────────────────────────────────────
+
+  ✗ LEANMLIR DIFFERS from GlobalISel-O0
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR                 GlobalISel-O0            
+    --------------------------------------------------------------------------------
+    0       mv                       add                       ⚠️  DIFFERS
+    1       mv                       ret                       ⚠️  DIFFERS
+    2       add                      <missing>                
+    3       mv                       <missing>                
+    4       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR: 5 instructions
+      GlobalISel-O0: 2 instructions
+
+
+  ✗ LEANMLIR DIFFERS from SelectionDAG-O0
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR                 SelectionDAG-O0          
+    --------------------------------------------------------------------------------
+    0       mv                       add                       ⚠️  DIFFERS
+    1       mv                       ret                       ⚠️  DIFFERS
+    2       add                      <missing>                
+    3       mv                       <missing>                
+    4       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR: 5 instructions
+      SelectionDAG-O0: 2 instructions
+
+
+  Comprehensive comparison of all three:
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR                 GlobalISel-O0            SelectionDAG-O0          
+    --------------------------------------------------------------------------------
+    0       mv                       add                      add                       ⚠️  DIFFERS
+    1       mv                       ret                      ret                       ⚠️  DIFFERS
+    2       add                      <missing>                <missing>                
+    3       mv                       <missing>                <missing>                
+    4       ret                      <missing>                <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR: 5 instructions
+      GlobalISel-O0: 2 instructions
+      SelectionDAG-O0: 2 instructions
+
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+Operation: llvm.and, Variant: 0
+────────────────────────────────────────────────────────────────────────────────────────────────────
+
+  ✗ LEANMLIR DIFFERS from GlobalISel-O0
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR                 GlobalISel-O0            
+    --------------------------------------------------------------------------------
+    0       mv                       and                       ⚠️  DIFFERS
+    1       mv                       ret                       ⚠️  DIFFERS
+    2       and                      <missing>                
+    3       mv                       <missing>                
+    4       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR: 5 instructions
+      GlobalISel-O0: 2 instructions
+
+
+  ✗ LEANMLIR DIFFERS from SelectionDAG-O0
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR                 SelectionDAG-O0          
+    --------------------------------------------------------------------------------
+    0       mv                       and                       ⚠️  DIFFERS
+    1       mv                       ret                       ⚠️  DIFFERS
+    2       and                      <missing>                
+    3       mv                       <missing>                
+    4       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR: 5 instructions
+      SelectionDAG-O0: 2 instructions
+
+
+  Comprehensive comparison of all three:
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR                 GlobalISel-O0            SelectionDAG-O0          
+    --------------------------------------------------------------------------------
+    0       mv                       and                      and                       ⚠️  DIFFERS
+    1       mv                       ret                      ret                       ⚠️  DIFFERS
+    2       and                      <missing>                <missing>                
+    3       mv                       <missing>                <missing>                
+    4       ret                      <missing>                <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR: 5 instructions
+      GlobalISel-O0: 2 instructions
+      SelectionDAG-O0: 2 instructions
+
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+Operation: llvm.ashr, Variant: 0
+────────────────────────────────────────────────────────────────────────────────────────────────────
+
+  ✗ LEANMLIR DIFFERS from GlobalISel-O0
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR                 GlobalISel-O0            
+    --------------------------------------------------------------------------------
+    0       mv                       sra                       ⚠️  DIFFERS
+    1       mv                       ret                       ⚠️  DIFFERS
+    2       sra                      <missing>                
+    3       mv                       <missing>                
+    4       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR: 5 instructions
+      GlobalISel-O0: 2 instructions
+
+
+  ✗ LEANMLIR DIFFERS from SelectionDAG-O0
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR                 SelectionDAG-O0          
+    --------------------------------------------------------------------------------
+    0       mv                       sra                       ⚠️  DIFFERS
+    1       mv                       ret                       ⚠️  DIFFERS
+    2       sra                      <missing>                
+    3       mv                       <missing>                
+    4       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR: 5 instructions
+      SelectionDAG-O0: 2 instructions
+
+
+  Comprehensive comparison of all three:
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR                 GlobalISel-O0            SelectionDAG-O0          
+    --------------------------------------------------------------------------------
+    0       mv                       sra                      sra                       ⚠️  DIFFERS
+    1       mv                       ret                      ret                       ⚠️  DIFFERS
+    2       sra                      <missing>                <missing>                
+    3       mv                       <missing>                <missing>                
+    4       ret                      <missing>                <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR: 5 instructions
+      GlobalISel-O0: 2 instructions
+      SelectionDAG-O0: 2 instructions
+
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+Operation: llvm.icmp, Variant: 0
+────────────────────────────────────────────────────────────────────────────────────────────────────
+
+  ✗ LEANMLIR DIFFERS from GlobalISel-O0
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR                 GlobalISel-O0            
+    --------------------------------------------------------------------------------
+    0       mv                       sltu                      ⚠️  DIFFERS
+    1       mv                       ret                       ⚠️  DIFFERS
+    2       sltu                     <missing>                
+    3       mv                       <missing>                
+    4       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR: 5 instructions
+      GlobalISel-O0: 2 instructions
+
+
+  ✗ LEANMLIR DIFFERS from SelectionDAG-O0
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR                 SelectionDAG-O0          
+    --------------------------------------------------------------------------------
+    0       mv                       sltu                      ⚠️  DIFFERS
+    1       mv                       ret                       ⚠️  DIFFERS
+    2       sltu                     <missing>                
+    3       mv                       <missing>                
+    4       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR: 5 instructions
+      SelectionDAG-O0: 2 instructions
+
+
+  Comprehensive comparison of all three:
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR                 GlobalISel-O0            SelectionDAG-O0          
+    --------------------------------------------------------------------------------
+    0       mv                       sltu                     sltu                      ⚠️  DIFFERS
+    1       mv                       ret                      ret                       ⚠️  DIFFERS
+    2       sltu                     <missing>                <missing>                
+    3       mv                       <missing>                <missing>                
+    4       ret                      <missing>                <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR: 5 instructions
+      GlobalISel-O0: 2 instructions
+      SelectionDAG-O0: 2 instructions
+
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+Operation: llvm.icmp, Variant: 1
+────────────────────────────────────────────────────────────────────────────────────────────────────
+
+  ✗ LEANMLIR DIFFERS from GlobalISel-O0
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR                 GlobalISel-O0            
+    --------------------------------------------------------------------------------
+    0       mv                       sltu                      ⚠️  DIFFERS
+    1       mv                       xori                      ⚠️  DIFFERS
+    2       sltu                     ret                       ⚠️  DIFFERS
+    3       xori                     <missing>                
+    4       mv                       <missing>                
+    5       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR: 6 instructions
+      GlobalISel-O0: 3 instructions
+
+
+  ✗ LEANMLIR DIFFERS from SelectionDAG-O0
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR                 SelectionDAG-O0          
+    --------------------------------------------------------------------------------
+    0       mv                       sltu                      ⚠️  DIFFERS
+    1       mv                       xori                      ⚠️  DIFFERS
+    2       sltu                     ret                       ⚠️  DIFFERS
+    3       xori                     <missing>                
+    4       mv                       <missing>                
+    5       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR: 6 instructions
+      SelectionDAG-O0: 3 instructions
+
+
+  Comprehensive comparison of all three:
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR                 GlobalISel-O0            SelectionDAG-O0          
+    --------------------------------------------------------------------------------
+    0       mv                       sltu                     sltu                      ⚠️  DIFFERS
+    1       mv                       xori                     xori                      ⚠️  DIFFERS
+    2       sltu                     ret                      ret                       ⚠️  DIFFERS
+    3       xori                     <missing>                <missing>                
+    4       mv                       <missing>                <missing>                
+    5       ret                      <missing>                <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR: 6 instructions
+      GlobalISel-O0: 3 instructions
+      SelectionDAG-O0: 3 instructions
+
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+Operation: llvm.icmp, Variant: 2
+────────────────────────────────────────────────────────────────────────────────────────────────────
+
+  ✗ LEANMLIR DIFFERS from GlobalISel-O0
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR                 GlobalISel-O0            
+    --------------------------------------------------------------------------------
+    0       mv                       sltu                      ⚠️  DIFFERS
+    1       mv                       ret                       ⚠️  DIFFERS
+    2       sltu                     <missing>                
+    3       mv                       <missing>                
+    4       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR: 5 instructions
+      GlobalISel-O0: 2 instructions
+
+
+  ✗ LEANMLIR DIFFERS from SelectionDAG-O0
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR                 SelectionDAG-O0          
+    --------------------------------------------------------------------------------
+    0       mv                       sltu                      ⚠️  DIFFERS
+    1       mv                       ret                       ⚠️  DIFFERS
+    2       sltu                     <missing>                
+    3       mv                       <missing>                
+    4       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR: 5 instructions
+      SelectionDAG-O0: 2 instructions
+
+
+  Comprehensive comparison of all three:
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR                 GlobalISel-O0            SelectionDAG-O0          
+    --------------------------------------------------------------------------------
+    0       mv                       sltu                     sltu                      ⚠️  DIFFERS
+    1       mv                       ret                      ret                       ⚠️  DIFFERS
+    2       sltu                     <missing>                <missing>                
+    3       mv                       <missing>                <missing>                
+    4       ret                      <missing>                <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR: 5 instructions
+      GlobalISel-O0: 2 instructions
+      SelectionDAG-O0: 2 instructions
+
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+Operation: llvm.icmp, Variant: 3
+────────────────────────────────────────────────────────────────────────────────────────────────────
+
+  ✗ LEANMLIR DIFFERS from GlobalISel-O0
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR                 GlobalISel-O0            
+    --------------------------------------------------------------------------------
+    0       mv                       sltu                      ⚠️  DIFFERS
+    1       mv                       xori                      ⚠️  DIFFERS
+    2       sltu                     ret                       ⚠️  DIFFERS
+    3       xori                     <missing>                
+    4       mv                       <missing>                
+    5       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR: 6 instructions
+      GlobalISel-O0: 3 instructions
+
+
+  ✗ LEANMLIR DIFFERS from SelectionDAG-O0
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR                 SelectionDAG-O0          
+    --------------------------------------------------------------------------------
+    0       mv                       sltu                      ⚠️  DIFFERS
+    1       mv                       xori                      ⚠️  DIFFERS
+    2       sltu                     ret                       ⚠️  DIFFERS
+    3       xori                     <missing>                
+    4       mv                       <missing>                
+    5       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR: 6 instructions
+      SelectionDAG-O0: 3 instructions
+
+
+  Comprehensive comparison of all three:
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR                 GlobalISel-O0            SelectionDAG-O0          
+    --------------------------------------------------------------------------------
+    0       mv                       sltu                     sltu                      ⚠️  DIFFERS
+    1       mv                       xori                     xori                      ⚠️  DIFFERS
+    2       sltu                     ret                      ret                       ⚠️  DIFFERS
+    3       xori                     <missing>                <missing>                
+    4       mv                       <missing>                <missing>                
+    5       ret                      <missing>                <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR: 6 instructions
+      GlobalISel-O0: 3 instructions
+      SelectionDAG-O0: 3 instructions
+
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+Operation: llvm.icmp, Variant: 4
+────────────────────────────────────────────────────────────────────────────────────────────────────
+
+  ✗ LEANMLIR DIFFERS from GlobalISel-O0
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR                 GlobalISel-O0            
+    --------------------------------------------------------------------------------
+    0       mv                       slt                       ⚠️  DIFFERS
+    1       mv                       ret                       ⚠️  DIFFERS
+    2       slt                      <missing>                
+    3       mv                       <missing>                
+    4       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR: 5 instructions
+      GlobalISel-O0: 2 instructions
+
+
+  ✗ LEANMLIR DIFFERS from SelectionDAG-O0
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR                 SelectionDAG-O0          
+    --------------------------------------------------------------------------------
+    0       mv                       slt                       ⚠️  DIFFERS
+    1       mv                       ret                       ⚠️  DIFFERS
+    2       slt                      <missing>                
+    3       mv                       <missing>                
+    4       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR: 5 instructions
+      SelectionDAG-O0: 2 instructions
+
+
+  Comprehensive comparison of all three:
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR                 GlobalISel-O0            SelectionDAG-O0          
+    --------------------------------------------------------------------------------
+    0       mv                       slt                      slt                       ⚠️  DIFFERS
+    1       mv                       ret                      ret                       ⚠️  DIFFERS
+    2       slt                      <missing>                <missing>                
+    3       mv                       <missing>                <missing>                
+    4       ret                      <missing>                <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR: 5 instructions
+      GlobalISel-O0: 2 instructions
+      SelectionDAG-O0: 2 instructions
+
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+Operation: llvm.icmp, Variant: 5
+────────────────────────────────────────────────────────────────────────────────────────────────────
+
+  ✗ LEANMLIR DIFFERS from GlobalISel-O0
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR                 GlobalISel-O0            
+    --------------------------------------------------------------------------------
+    0       mv                       slt                       ⚠️  DIFFERS
+    1       mv                       xori                      ⚠️  DIFFERS
+    2       slt                      ret                       ⚠️  DIFFERS
+    3       xori                     <missing>                
+    4       mv                       <missing>                
+    5       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR: 6 instructions
+      GlobalISel-O0: 3 instructions
+
+
+  ✗ LEANMLIR DIFFERS from SelectionDAG-O0
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR                 SelectionDAG-O0          
+    --------------------------------------------------------------------------------
+    0       mv                       slt                       ⚠️  DIFFERS
+    1       mv                       xori                      ⚠️  DIFFERS
+    2       slt                      ret                       ⚠️  DIFFERS
+    3       xori                     <missing>                
+    4       mv                       <missing>                
+    5       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR: 6 instructions
+      SelectionDAG-O0: 3 instructions
+
+
+  Comprehensive comparison of all three:
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR                 GlobalISel-O0            SelectionDAG-O0          
+    --------------------------------------------------------------------------------
+    0       mv                       slt                      slt                       ⚠️  DIFFERS
+    1       mv                       xori                     xori                      ⚠️  DIFFERS
+    2       slt                      ret                      ret                       ⚠️  DIFFERS
+    3       xori                     <missing>                <missing>                
+    4       mv                       <missing>                <missing>                
+    5       ret                      <missing>                <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR: 6 instructions
+      GlobalISel-O0: 3 instructions
+      SelectionDAG-O0: 3 instructions
+
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+Operation: llvm.icmp, Variant: 6
+────────────────────────────────────────────────────────────────────────────────────────────────────
+
+  ✗ LEANMLIR DIFFERS from GlobalISel-O0
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR                 GlobalISel-O0            
+    --------------------------------------------------------------------------------
+    0       mv                       slt                       ⚠️  DIFFERS
+    1       mv                       ret                       ⚠️  DIFFERS
+    2       slt                      <missing>                
+    3       mv                       <missing>                
+    4       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR: 5 instructions
+      GlobalISel-O0: 2 instructions
+
+
+  ✗ LEANMLIR DIFFERS from SelectionDAG-O0
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR                 SelectionDAG-O0          
+    --------------------------------------------------------------------------------
+    0       mv                       slt                       ⚠️  DIFFERS
+    1       mv                       ret                       ⚠️  DIFFERS
+    2       slt                      <missing>                
+    3       mv                       <missing>                
+    4       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR: 5 instructions
+      SelectionDAG-O0: 2 instructions
+
+
+  Comprehensive comparison of all three:
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR                 GlobalISel-O0            SelectionDAG-O0          
+    --------------------------------------------------------------------------------
+    0       mv                       slt                      slt                       ⚠️  DIFFERS
+    1       mv                       ret                      ret                       ⚠️  DIFFERS
+    2       slt                      <missing>                <missing>                
+    3       mv                       <missing>                <missing>                
+    4       ret                      <missing>                <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR: 5 instructions
+      GlobalISel-O0: 2 instructions
+      SelectionDAG-O0: 2 instructions
+
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+Operation: llvm.icmp, Variant: 7
+────────────────────────────────────────────────────────────────────────────────────────────────────
+
+  ✗ LEANMLIR DIFFERS from GlobalISel-O0
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR                 GlobalISel-O0            
+    --------------------------------------------------------------------------------
+    0       mv                       slt                       ⚠️  DIFFERS
+    1       mv                       xori                      ⚠️  DIFFERS
+    2       slt                      ret                       ⚠️  DIFFERS
+    3       xori                     <missing>                
+    4       mv                       <missing>                
+    5       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR: 6 instructions
+      GlobalISel-O0: 3 instructions
+
+
+  ✗ LEANMLIR DIFFERS from SelectionDAG-O0
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR                 SelectionDAG-O0          
+    --------------------------------------------------------------------------------
+    0       mv                       slt                       ⚠️  DIFFERS
+    1       mv                       xori                      ⚠️  DIFFERS
+    2       slt                      ret                       ⚠️  DIFFERS
+    3       xori                     <missing>                
+    4       mv                       <missing>                
+    5       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR: 6 instructions
+      SelectionDAG-O0: 3 instructions
+
+
+  Comprehensive comparison of all three:
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR                 GlobalISel-O0            SelectionDAG-O0          
+    --------------------------------------------------------------------------------
+    0       mv                       slt                      slt                       ⚠️  DIFFERS
+    1       mv                       xori                     xori                      ⚠️  DIFFERS
+    2       slt                      ret                      ret                       ⚠️  DIFFERS
+    3       xori                     <missing>                <missing>                
+    4       mv                       <missing>                <missing>                
+    5       ret                      <missing>                <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR: 6 instructions
+      GlobalISel-O0: 3 instructions
+      SelectionDAG-O0: 3 instructions
+
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+Operation: llvm.icmp, Variant: 8
+────────────────────────────────────────────────────────────────────────────────────────────────────
+
+  ✗ LEANMLIR DIFFERS from GlobalISel-O0
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR                 GlobalISel-O0            
+    --------------------------------------------------------------------------------
+    0       mv                       xor                       ⚠️  DIFFERS
+    1       mv                       seqz                      ⚠️  DIFFERS
+    2       xor                      ret                       ⚠️  DIFFERS
+    3       seqz                     <missing>                
+    4       mv                       <missing>                
+    5       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR: 6 instructions
+      GlobalISel-O0: 3 instructions
+
+
+  ✗ LEANMLIR DIFFERS from SelectionDAG-O0
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR                 SelectionDAG-O0          
+    --------------------------------------------------------------------------------
+    0       mv                       xor                       ⚠️  DIFFERS
+    1       mv                       seqz                      ⚠️  DIFFERS
+    2       xor                      ret                       ⚠️  DIFFERS
+    3       seqz                     <missing>                
+    4       mv                       <missing>                
+    5       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR: 6 instructions
+      SelectionDAG-O0: 3 instructions
+
+
+  Comprehensive comparison of all three:
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR                 GlobalISel-O0            SelectionDAG-O0          
+    --------------------------------------------------------------------------------
+    0       mv                       xor                      xor                       ⚠️  DIFFERS
+    1       mv                       seqz                     seqz                      ⚠️  DIFFERS
+    2       xor                      ret                      ret                       ⚠️  DIFFERS
+    3       seqz                     <missing>                <missing>                
+    4       mv                       <missing>                <missing>                
+    5       ret                      <missing>                <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR: 6 instructions
+      GlobalISel-O0: 3 instructions
+      SelectionDAG-O0: 3 instructions
+
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+Operation: llvm.mul, Variant: 0
+────────────────────────────────────────────────────────────────────────────────────────────────────
+
+  ✗ LEANMLIR DIFFERS from GlobalISel-O0
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR                 GlobalISel-O0            
+    --------------------------------------------------------------------------------
+    0       mv                       mul                       ⚠️  DIFFERS
+    1       mv                       ret                       ⚠️  DIFFERS
+    2       mul                      <missing>                
+    3       mv                       <missing>                
+    4       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR: 5 instructions
+      GlobalISel-O0: 2 instructions
+
+
+  ✗ LEANMLIR DIFFERS from SelectionDAG-O0
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR                 SelectionDAG-O0          
+    --------------------------------------------------------------------------------
+    0       mv                       mul                       ⚠️  DIFFERS
+    1       mv                       ret                       ⚠️  DIFFERS
+    2       mul                      <missing>                
+    3       mv                       <missing>                
+    4       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR: 5 instructions
+      SelectionDAG-O0: 2 instructions
+
+
+  Comprehensive comparison of all three:
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR                 GlobalISel-O0            SelectionDAG-O0          
+    --------------------------------------------------------------------------------
+    0       mv                       mul                      mul                       ⚠️  DIFFERS
+    1       mv                       ret                      ret                       ⚠️  DIFFERS
+    2       mul                      <missing>                <missing>                
+    3       mv                       <missing>                <missing>                
+    4       ret                      <missing>                <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR: 5 instructions
+      GlobalISel-O0: 2 instructions
+      SelectionDAG-O0: 2 instructions
+
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+Operation: llvm.mul, Variant: 1
+────────────────────────────────────────────────────────────────────────────────────────────────────
+
+  ✗ LEANMLIR DIFFERS from GlobalISel-O0
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR                 GlobalISel-O0            
+    --------------------------------------------------------------------------------
+    0       mv                       mul                       ⚠️  DIFFERS
+    1       mv                       ret                       ⚠️  DIFFERS
+    2       mul                      <missing>                
+    3       mv                       <missing>                
+    4       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR: 5 instructions
+      GlobalISel-O0: 2 instructions
+
+
+  ✗ LEANMLIR DIFFERS from SelectionDAG-O0
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR                 SelectionDAG-O0          
+    --------------------------------------------------------------------------------
+    0       mv                       mul                       ⚠️  DIFFERS
+    1       mv                       ret                       ⚠️  DIFFERS
+    2       mul                      <missing>                
+    3       mv                       <missing>                
+    4       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR: 5 instructions
+      SelectionDAG-O0: 2 instructions
+
+
+  Comprehensive comparison of all three:
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR                 GlobalISel-O0            SelectionDAG-O0          
+    --------------------------------------------------------------------------------
+    0       mv                       mul                      mul                       ⚠️  DIFFERS
+    1       mv                       ret                      ret                       ⚠️  DIFFERS
+    2       mul                      <missing>                <missing>                
+    3       mv                       <missing>                <missing>                
+    4       ret                      <missing>                <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR: 5 instructions
+      GlobalISel-O0: 2 instructions
+      SelectionDAG-O0: 2 instructions
+
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+Operation: llvm.mul, Variant: 2
+────────────────────────────────────────────────────────────────────────────────────────────────────
+
+  ✗ LEANMLIR DIFFERS from GlobalISel-O0
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR                 GlobalISel-O0            
+    --------------------------------------------------------------------------------
+    0       mv                       mul                       ⚠️  DIFFERS
+    1       mv                       ret                       ⚠️  DIFFERS
+    2       mul                      <missing>                
+    3       mv                       <missing>                
+    4       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR: 5 instructions
+      GlobalISel-O0: 2 instructions
+
+
+  ✗ LEANMLIR DIFFERS from SelectionDAG-O0
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR                 SelectionDAG-O0          
+    --------------------------------------------------------------------------------
+    0       mv                       mul                       ⚠️  DIFFERS
+    1       mv                       ret                       ⚠️  DIFFERS
+    2       mul                      <missing>                
+    3       mv                       <missing>                
+    4       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR: 5 instructions
+      SelectionDAG-O0: 2 instructions
+
+
+  Comprehensive comparison of all three:
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR                 GlobalISel-O0            SelectionDAG-O0          
+    --------------------------------------------------------------------------------
+    0       mv                       mul                      mul                       ⚠️  DIFFERS
+    1       mv                       ret                      ret                       ⚠️  DIFFERS
+    2       mul                      <missing>                <missing>                
+    3       mv                       <missing>                <missing>                
+    4       ret                      <missing>                <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR: 5 instructions
+      GlobalISel-O0: 2 instructions
+      SelectionDAG-O0: 2 instructions
+
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+Operation: llvm.or, Variant: 0
+────────────────────────────────────────────────────────────────────────────────────────────────────
+
+  ✗ LEANMLIR DIFFERS from GlobalISel-O0
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR                 GlobalISel-O0            
+    --------------------------------------------------------------------------------
+    0       mv                       or                        ⚠️  DIFFERS
+    1       mv                       ret                       ⚠️  DIFFERS
+    2       or                       <missing>                
+    3       mv                       <missing>                
+    4       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR: 5 instructions
+      GlobalISel-O0: 2 instructions
+
+
+  ✗ LEANMLIR DIFFERS from SelectionDAG-O0
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR                 SelectionDAG-O0          
+    --------------------------------------------------------------------------------
+    0       mv                       or                        ⚠️  DIFFERS
+    1       mv                       ret                       ⚠️  DIFFERS
+    2       or                       <missing>                
+    3       mv                       <missing>                
+    4       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR: 5 instructions
+      SelectionDAG-O0: 2 instructions
+
+
+  Comprehensive comparison of all three:
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR                 GlobalISel-O0            SelectionDAG-O0          
+    --------------------------------------------------------------------------------
+    0       mv                       or                       or                        ⚠️  DIFFERS
+    1       mv                       ret                      ret                       ⚠️  DIFFERS
+    2       or                       <missing>                <missing>                
+    3       mv                       <missing>                <missing>                
+    4       ret                      <missing>                <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR: 5 instructions
+      GlobalISel-O0: 2 instructions
+      SelectionDAG-O0: 2 instructions
+
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+Operation: llvm.rem, Variant: 0
+────────────────────────────────────────────────────────────────────────────────────────────────────
+
+  ✗ LEANMLIR DIFFERS from GlobalISel-O0
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR                 GlobalISel-O0            
+    --------------------------------------------------------------------------------
+    0       mv                       rem                       ⚠️  DIFFERS
+    1       mv                       ret                       ⚠️  DIFFERS
+    2       rem                      <missing>                
+    3       mv                       <missing>                
+    4       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR: 5 instructions
+      GlobalISel-O0: 2 instructions
+
+
+  ✗ LEANMLIR DIFFERS from SelectionDAG-O0
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR                 SelectionDAG-O0          
+    --------------------------------------------------------------------------------
+    0       mv                       rem                       ⚠️  DIFFERS
+    1       mv                       ret                       ⚠️  DIFFERS
+    2       rem                      <missing>                
+    3       mv                       <missing>                
+    4       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR: 5 instructions
+      SelectionDAG-O0: 2 instructions
+
+
+  Comprehensive comparison of all three:
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR                 GlobalISel-O0            SelectionDAG-O0          
+    --------------------------------------------------------------------------------
+    0       mv                       rem                      rem                       ⚠️  DIFFERS
+    1       mv                       ret                      ret                       ⚠️  DIFFERS
+    2       rem                      <missing>                <missing>                
+    3       mv                       <missing>                <missing>                
+    4       ret                      <missing>                <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR: 5 instructions
+      GlobalISel-O0: 2 instructions
+      SelectionDAG-O0: 2 instructions
+
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+Operation: llvm.sdiv, Variant: 0
+────────────────────────────────────────────────────────────────────────────────────────────────────
+
+  ✗ LEANMLIR DIFFERS from GlobalISel-O0
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR                 GlobalISel-O0            
+    --------------------------------------------------------------------------------
+    0       mv                       div                       ⚠️  DIFFERS
+    1       mv                       ret                       ⚠️  DIFFERS
+    2       div                      <missing>                
+    3       mv                       <missing>                
+    4       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR: 5 instructions
+      GlobalISel-O0: 2 instructions
+
+
+  ✗ LEANMLIR DIFFERS from SelectionDAG-O0
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR                 SelectionDAG-O0          
+    --------------------------------------------------------------------------------
+    0       mv                       div                       ⚠️  DIFFERS
+    1       mv                       ret                       ⚠️  DIFFERS
+    2       div                      <missing>                
+    3       mv                       <missing>                
+    4       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR: 5 instructions
+      SelectionDAG-O0: 2 instructions
+
+
+  Comprehensive comparison of all three:
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR                 GlobalISel-O0            SelectionDAG-O0          
+    --------------------------------------------------------------------------------
+    0       mv                       div                      div                       ⚠️  DIFFERS
+    1       mv                       ret                      ret                       ⚠️  DIFFERS
+    2       div                      <missing>                <missing>                
+    3       mv                       <missing>                <missing>                
+    4       ret                      <missing>                <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR: 5 instructions
+      GlobalISel-O0: 2 instructions
+      SelectionDAG-O0: 2 instructions
+
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+Operation: llvm.select, Variant: 0
+────────────────────────────────────────────────────────────────────────────────────────────────────
+
+  ✗ LEANMLIR DIFFERS from GlobalISel-O0
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR                 GlobalISel-O0            
+    --------------------------------------------------------------------------------
+    0       <missing>                addi                     
+    1       <missing>                sd                       
+    2       <missing>                andi                     
+    3       <missing>                sd                       
+    4       <missing>                bnez                     
+    5       <missing>                ld                       
+    6       <missing>                sd                       
+    7       <missing>                ld                       
+    8       <missing>                addi                     
+    9       <missing>                ret                      
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR: 0 instructions
+      GlobalISel-O0: 10 instructions
+
+
+  ✗ LEANMLIR DIFFERS from SelectionDAG-O0
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR                 SelectionDAG-O0          
+    --------------------------------------------------------------------------------
+    0       <missing>                addi                     
+    1       <missing>                sd                       
+    2       <missing>                mv                       
+    3       <missing>                andi                     
+    4       <missing>                sd                       
+    5       <missing>                bnez                     
+    6       <missing>                ld                       
+    7       <missing>                sd                       
+    8       <missing>                ld                       
+    9       <missing>                addi                     
+    10      <missing>                ret                      
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR: 0 instructions
+      SelectionDAG-O0: 11 instructions
+
+
+  Comprehensive comparison of all three:
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR                 GlobalISel-O0            SelectionDAG-O0          
+    --------------------------------------------------------------------------------
+    0       <missing>                addi                     addi                     
+    1       <missing>                sd                       sd                       
+    2       <missing>                andi                     mv                        ⚠️  DIFFERS
+    3       <missing>                sd                       andi                      ⚠️  DIFFERS
+    4       <missing>                bnez                     sd                        ⚠️  DIFFERS
+    5       <missing>                ld                       bnez                      ⚠️  DIFFERS
+    6       <missing>                sd                       ld                        ⚠️  DIFFERS
+    7       <missing>                ld                       sd                        ⚠️  DIFFERS
+    8       <missing>                addi                     ld                        ⚠️  DIFFERS
+    9       <missing>                ret                      addi                      ⚠️  DIFFERS
+    10      <missing>                <missing>                ret                      
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR: 0 instructions
+      GlobalISel-O0: 10 instructions
+      SelectionDAG-O0: 11 instructions
+
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+Operation: llvm.sext, Variant: 0
+────────────────────────────────────────────────────────────────────────────────────────────────────
+
+  ✗ LEANMLIR DIFFERS from GlobalISel-O0
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR                 GlobalISel-O0            
+    --------------------------------------------------------------------------------
+    0       <missing>                slli                     
+    1       <missing>                srai                     
+    2       <missing>                ret                      
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR: 0 instructions
+      GlobalISel-O0: 3 instructions
+
+
+  ✗ LEANMLIR DIFFERS from SelectionDAG-O0
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR                 SelectionDAG-O0          
+    --------------------------------------------------------------------------------
+    0       <missing>                slli                     
+    1       <missing>                srai                     
+    2       <missing>                ret                      
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR: 0 instructions
+      SelectionDAG-O0: 3 instructions
+
+
+  Comprehensive comparison of all three:
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR                 GlobalISel-O0            SelectionDAG-O0          
+    --------------------------------------------------------------------------------
+    0       <missing>                slli                     slli                     
+    1       <missing>                srai                     srai                     
+    2       <missing>                ret                      ret                      
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR: 0 instructions
+      GlobalISel-O0: 3 instructions
+      SelectionDAG-O0: 3 instructions
+
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+Operation: llvm.sext, Variant: 1
+────────────────────────────────────────────────────────────────────────────────────────────────────
+
+  ✗ LEANMLIR DIFFERS from GlobalISel-O0
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR                 GlobalISel-O0            
+    --------------------------------------------------------------------------------
+    0       <missing>                sext.b                   
+    1       <missing>                ret                      
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR: 0 instructions
+      GlobalISel-O0: 2 instructions
+
+
+  ✗ LEANMLIR DIFFERS from SelectionDAG-O0
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR                 SelectionDAG-O0          
+    --------------------------------------------------------------------------------
+    0       <missing>                sext.b                   
+    1       <missing>                ret                      
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR: 0 instructions
+      SelectionDAG-O0: 2 instructions
+
+
+  Comprehensive comparison of all three:
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR                 GlobalISel-O0            SelectionDAG-O0          
+    --------------------------------------------------------------------------------
+    0       <missing>                sext.b                   sext.b                   
+    1       <missing>                ret                      ret                      
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR: 0 instructions
+      GlobalISel-O0: 2 instructions
+      SelectionDAG-O0: 2 instructions
+
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+Operation: llvm.sext, Variant: 2
+────────────────────────────────────────────────────────────────────────────────────────────────────
+
+  ✗ LEANMLIR DIFFERS from GlobalISel-O0
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR                 GlobalISel-O0            
+    --------------------------------------------------------------------------------
+    0       <missing>                sext.h                   
+    1       <missing>                ret                      
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR: 0 instructions
+      GlobalISel-O0: 2 instructions
+
+
+  ✗ LEANMLIR DIFFERS from SelectionDAG-O0
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR                 SelectionDAG-O0          
+    --------------------------------------------------------------------------------
+    0       <missing>                sext.h                   
+    1       <missing>                ret                      
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR: 0 instructions
+      SelectionDAG-O0: 2 instructions
+
+
+  Comprehensive comparison of all three:
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR                 GlobalISel-O0            SelectionDAG-O0          
+    --------------------------------------------------------------------------------
+    0       <missing>                sext.h                   sext.h                   
+    1       <missing>                ret                      ret                      
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR: 0 instructions
+      GlobalISel-O0: 2 instructions
+      SelectionDAG-O0: 2 instructions
+
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+Operation: llvm.sext, Variant: 3
+────────────────────────────────────────────────────────────────────────────────────────────────────
+
+  ✗ LEANMLIR DIFFERS from GlobalISel-O0
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR                 GlobalISel-O0            
+    --------------------------------------------------------------------------------
+    0       <missing>                sext.w                   
+    1       <missing>                ret                      
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR: 0 instructions
+      GlobalISel-O0: 2 instructions
+
+
+  ✗ LEANMLIR DIFFERS from SelectionDAG-O0
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR                 SelectionDAG-O0          
+    --------------------------------------------------------------------------------
+    0       <missing>                sext.w                   
+    1       <missing>                ret                      
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR: 0 instructions
+      SelectionDAG-O0: 2 instructions
+
+
+  Comprehensive comparison of all three:
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR                 GlobalISel-O0            SelectionDAG-O0          
+    --------------------------------------------------------------------------------
+    0       <missing>                sext.w                   sext.w                   
+    1       <missing>                ret                      ret                      
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR: 0 instructions
+      GlobalISel-O0: 2 instructions
+      SelectionDAG-O0: 2 instructions
+
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+Operation: llvm.shl, Variant: 0
+────────────────────────────────────────────────────────────────────────────────────────────────────
+
+  ✗ LEANMLIR DIFFERS from GlobalISel-O0
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR                 GlobalISel-O0            
+    --------------------------------------------------------------------------------
+    0       mv                       sll                       ⚠️  DIFFERS
+    1       mv                       ret                       ⚠️  DIFFERS
+    2       sll                      <missing>                
+    3       mv                       <missing>                
+    4       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR: 5 instructions
+      GlobalISel-O0: 2 instructions
+
+
+  ✗ LEANMLIR DIFFERS from SelectionDAG-O0
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR                 SelectionDAG-O0          
+    --------------------------------------------------------------------------------
+    0       mv                       sll                       ⚠️  DIFFERS
+    1       mv                       ret                       ⚠️  DIFFERS
+    2       sll                      <missing>                
+    3       mv                       <missing>                
+    4       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR: 5 instructions
+      SelectionDAG-O0: 2 instructions
+
+
+  Comprehensive comparison of all three:
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR                 GlobalISel-O0            SelectionDAG-O0          
+    --------------------------------------------------------------------------------
+    0       mv                       sll                      sll                       ⚠️  DIFFERS
+    1       mv                       ret                      ret                       ⚠️  DIFFERS
+    2       sll                      <missing>                <missing>                
+    3       mv                       <missing>                <missing>                
+    4       ret                      <missing>                <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR: 5 instructions
+      GlobalISel-O0: 2 instructions
+      SelectionDAG-O0: 2 instructions
+
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+Operation: llvm.shl, Variant: 1
+────────────────────────────────────────────────────────────────────────────────────────────────────
+
+  ✗ LEANMLIR DIFFERS from GlobalISel-O0
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR                 GlobalISel-O0            
+    --------------------------------------------------------------------------------
+    0       mv                       sll                       ⚠️  DIFFERS
+    1       mv                       ret                       ⚠️  DIFFERS
+    2       sll                      <missing>                
+    3       mv                       <missing>                
+    4       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR: 5 instructions
+      GlobalISel-O0: 2 instructions
+
+
+  ✗ LEANMLIR DIFFERS from SelectionDAG-O0
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR                 SelectionDAG-O0          
+    --------------------------------------------------------------------------------
+    0       mv                       sll                       ⚠️  DIFFERS
+    1       mv                       ret                       ⚠️  DIFFERS
+    2       sll                      <missing>                
+    3       mv                       <missing>                
+    4       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR: 5 instructions
+      SelectionDAG-O0: 2 instructions
+
+
+  Comprehensive comparison of all three:
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR                 GlobalISel-O0            SelectionDAG-O0          
+    --------------------------------------------------------------------------------
+    0       mv                       sll                      sll                       ⚠️  DIFFERS
+    1       mv                       ret                      ret                       ⚠️  DIFFERS
+    2       sll                      <missing>                <missing>                
+    3       mv                       <missing>                <missing>                
+    4       ret                      <missing>                <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR: 5 instructions
+      GlobalISel-O0: 2 instructions
+      SelectionDAG-O0: 2 instructions
+
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+Operation: llvm.shl, Variant: 2
+────────────────────────────────────────────────────────────────────────────────────────────────────
+
+  ✗ LEANMLIR DIFFERS from GlobalISel-O0
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR                 GlobalISel-O0            
+    --------------------------------------------------------------------------------
+    0       mv                       sll                       ⚠️  DIFFERS
+    1       mv                       ret                       ⚠️  DIFFERS
+    2       sll                      <missing>                
+    3       mv                       <missing>                
+    4       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR: 5 instructions
+      GlobalISel-O0: 2 instructions
+
+
+  ✗ LEANMLIR DIFFERS from SelectionDAG-O0
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR                 SelectionDAG-O0          
+    --------------------------------------------------------------------------------
+    0       mv                       sll                       ⚠️  DIFFERS
+    1       mv                       ret                       ⚠️  DIFFERS
+    2       sll                      <missing>                
+    3       mv                       <missing>                
+    4       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR: 5 instructions
+      SelectionDAG-O0: 2 instructions
+
+
+  Comprehensive comparison of all three:
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR                 GlobalISel-O0            SelectionDAG-O0          
+    --------------------------------------------------------------------------------
+    0       mv                       sll                      sll                       ⚠️  DIFFERS
+    1       mv                       ret                      ret                       ⚠️  DIFFERS
+    2       sll                      <missing>                <missing>                
+    3       mv                       <missing>                <missing>                
+    4       ret                      <missing>                <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR: 5 instructions
+      GlobalISel-O0: 2 instructions
+      SelectionDAG-O0: 2 instructions
+
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+Operation: llvm.shl, Variant: 3
+────────────────────────────────────────────────────────────────────────────────────────────────────
+
+  ✗ LEANMLIR DIFFERS from GlobalISel-O0
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR                 GlobalISel-O0            
+    --------------------------------------------------------------------------------
+    0       mv                       sll                       ⚠️  DIFFERS
+    1       mv                       ret                       ⚠️  DIFFERS
+    2       sll                      <missing>                
+    3       mv                       <missing>                
+    4       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR: 5 instructions
+      GlobalISel-O0: 2 instructions
+
+
+  ✗ LEANMLIR DIFFERS from SelectionDAG-O0
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR                 SelectionDAG-O0          
+    --------------------------------------------------------------------------------
+    0       mv                       sll                       ⚠️  DIFFERS
+    1       mv                       ret                       ⚠️  DIFFERS
+    2       sll                      <missing>                
+    3       mv                       <missing>                
+    4       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR: 5 instructions
+      SelectionDAG-O0: 2 instructions
+
+
+  Comprehensive comparison of all three:
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR                 GlobalISel-O0            SelectionDAG-O0          
+    --------------------------------------------------------------------------------
+    0       mv                       sll                      sll                       ⚠️  DIFFERS
+    1       mv                       ret                      ret                       ⚠️  DIFFERS
+    2       sll                      <missing>                <missing>                
+    3       mv                       <missing>                <missing>                
+    4       ret                      <missing>                <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR: 5 instructions
+      GlobalISel-O0: 2 instructions
+      SelectionDAG-O0: 2 instructions
+
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+Operation: llvm.srl, Variant: 0
+────────────────────────────────────────────────────────────────────────────────────────────────────
+
+  ✗ LEANMLIR DIFFERS from GlobalISel-O0
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR                 GlobalISel-O0            
+    --------------------------------------------------------------------------------
+    0       mv                       srl                       ⚠️  DIFFERS
+    1       mv                       ret                       ⚠️  DIFFERS
+    2       srl                      <missing>                
+    3       mv                       <missing>                
+    4       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR: 5 instructions
+      GlobalISel-O0: 2 instructions
+
+
+  ✗ LEANMLIR DIFFERS from SelectionDAG-O0
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR                 SelectionDAG-O0          
+    --------------------------------------------------------------------------------
+    0       mv                       srl                       ⚠️  DIFFERS
+    1       mv                       ret                       ⚠️  DIFFERS
+    2       srl                      <missing>                
+    3       mv                       <missing>                
+    4       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR: 5 instructions
+      SelectionDAG-O0: 2 instructions
+
+
+  Comprehensive comparison of all three:
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR                 GlobalISel-O0            SelectionDAG-O0          
+    --------------------------------------------------------------------------------
+    0       mv                       srl                      srl                       ⚠️  DIFFERS
+    1       mv                       ret                      ret                       ⚠️  DIFFERS
+    2       srl                      <missing>                <missing>                
+    3       mv                       <missing>                <missing>                
+    4       ret                      <missing>                <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR: 5 instructions
+      GlobalISel-O0: 2 instructions
+      SelectionDAG-O0: 2 instructions
+
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+Operation: llvm.sub, Variant: 0
+────────────────────────────────────────────────────────────────────────────────────────────────────
+
+  ✗ LEANMLIR DIFFERS from GlobalISel-O0
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR                 GlobalISel-O0            
+    --------------------------------------------------------------------------------
+    0       mv                       sub                       ⚠️  DIFFERS
+    1       mv                       ret                       ⚠️  DIFFERS
+    2       sub                      <missing>                
+    3       mv                       <missing>                
+    4       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR: 5 instructions
+      GlobalISel-O0: 2 instructions
+
+
+  ✗ LEANMLIR DIFFERS from SelectionDAG-O0
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR                 SelectionDAG-O0          
+    --------------------------------------------------------------------------------
+    0       mv                       sub                       ⚠️  DIFFERS
+    1       mv                       ret                       ⚠️  DIFFERS
+    2       sub                      <missing>                
+    3       mv                       <missing>                
+    4       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR: 5 instructions
+      SelectionDAG-O0: 2 instructions
+
+
+  Comprehensive comparison of all three:
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR                 GlobalISel-O0            SelectionDAG-O0          
+    --------------------------------------------------------------------------------
+    0       mv                       sub                      sub                       ⚠️  DIFFERS
+    1       mv                       ret                      ret                       ⚠️  DIFFERS
+    2       sub                      <missing>                <missing>                
+    3       mv                       <missing>                <missing>                
+    4       ret                      <missing>                <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR: 5 instructions
+      GlobalISel-O0: 2 instructions
+      SelectionDAG-O0: 2 instructions
+
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+Operation: llvm.sub, Variant: 1
+────────────────────────────────────────────────────────────────────────────────────────────────────
+
+  ✗ LEANMLIR DIFFERS from GlobalISel-O0
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR                 GlobalISel-O0            
+    --------------------------------------------------------------------------------
+    0       mv                       sub                       ⚠️  DIFFERS
+    1       mv                       ret                       ⚠️  DIFFERS
+    2       sub                      <missing>                
+    3       mv                       <missing>                
+    4       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR: 5 instructions
+      GlobalISel-O0: 2 instructions
+
+
+  ✗ LEANMLIR DIFFERS from SelectionDAG-O0
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR                 SelectionDAG-O0          
+    --------------------------------------------------------------------------------
+    0       mv                       sub                       ⚠️  DIFFERS
+    1       mv                       ret                       ⚠️  DIFFERS
+    2       sub                      <missing>                
+    3       mv                       <missing>                
+    4       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR: 5 instructions
+      SelectionDAG-O0: 2 instructions
+
+
+  Comprehensive comparison of all three:
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR                 GlobalISel-O0            SelectionDAG-O0          
+    --------------------------------------------------------------------------------
+    0       mv                       sub                      sub                       ⚠️  DIFFERS
+    1       mv                       ret                      ret                       ⚠️  DIFFERS
+    2       sub                      <missing>                <missing>                
+    3       mv                       <missing>                <missing>                
+    4       ret                      <missing>                <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR: 5 instructions
+      GlobalISel-O0: 2 instructions
+      SelectionDAG-O0: 2 instructions
+
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+Operation: llvm.sub, Variant: 2
+────────────────────────────────────────────────────────────────────────────────────────────────────
+
+  ✗ LEANMLIR DIFFERS from GlobalISel-O0
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR                 GlobalISel-O0            
+    --------------------------------------------------------------------------------
+    0       mv                       sub                       ⚠️  DIFFERS
+    1       mv                       ret                       ⚠️  DIFFERS
+    2       sub                      <missing>                
+    3       mv                       <missing>                
+    4       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR: 5 instructions
+      GlobalISel-O0: 2 instructions
+
+
+  ✗ LEANMLIR DIFFERS from SelectionDAG-O0
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR                 SelectionDAG-O0          
+    --------------------------------------------------------------------------------
+    0       mv                       sub                       ⚠️  DIFFERS
+    1       mv                       ret                       ⚠️  DIFFERS
+    2       sub                      <missing>                
+    3       mv                       <missing>                
+    4       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR: 5 instructions
+      SelectionDAG-O0: 2 instructions
+
+
+  Comprehensive comparison of all three:
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR                 GlobalISel-O0            SelectionDAG-O0          
+    --------------------------------------------------------------------------------
+    0       mv                       sub                      sub                       ⚠️  DIFFERS
+    1       mv                       ret                      ret                       ⚠️  DIFFERS
+    2       sub                      <missing>                <missing>                
+    3       mv                       <missing>                <missing>                
+    4       ret                      <missing>                <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR: 5 instructions
+      GlobalISel-O0: 2 instructions
+      SelectionDAG-O0: 2 instructions
+
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+Operation: llvm.trunc, Variant: 0
+────────────────────────────────────────────────────────────────────────────────────────────────────
+
+  ✗ LEANMLIR DIFFERS from GlobalISel-O0
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR                 GlobalISel-O0            
+    --------------------------------------------------------------------------------
+    0       mv                       ret                       ⚠️  DIFFERS
+    1       mv                       <missing>                
+    2       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR: 3 instructions
+      GlobalISel-O0: 1 instructions
+
+
+  ✗ LEANMLIR DIFFERS from SelectionDAG-O0
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR                 SelectionDAG-O0          
+    --------------------------------------------------------------------------------
+    0       mv                       ret                       ⚠️  DIFFERS
+    1       mv                       <missing>                
+    2       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR: 3 instructions
+      SelectionDAG-O0: 1 instructions
+
+
+  Comprehensive comparison of all three:
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR                 GlobalISel-O0            SelectionDAG-O0          
+    --------------------------------------------------------------------------------
+    0       mv                       ret                      ret                       ⚠️  DIFFERS
+    1       mv                       <missing>                <missing>                
+    2       ret                      <missing>                <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR: 3 instructions
+      GlobalISel-O0: 1 instructions
+      SelectionDAG-O0: 1 instructions
+
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+Operation: llvm.udiv, Variant: 0
+────────────────────────────────────────────────────────────────────────────────────────────────────
+
+  ✗ LEANMLIR DIFFERS from GlobalISel-O0
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR                 GlobalISel-O0            
+    --------------------------------------------------------------------------------
+    0       mv                       divu                      ⚠️  DIFFERS
+    1       mv                       ret                       ⚠️  DIFFERS
+    2       divu                     <missing>                
+    3       mv                       <missing>                
+    4       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR: 5 instructions
+      GlobalISel-O0: 2 instructions
+
+
+  ✗ LEANMLIR DIFFERS from SelectionDAG-O0
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR                 SelectionDAG-O0          
+    --------------------------------------------------------------------------------
+    0       mv                       divu                      ⚠️  DIFFERS
+    1       mv                       ret                       ⚠️  DIFFERS
+    2       divu                     <missing>                
+    3       mv                       <missing>                
+    4       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR: 5 instructions
+      SelectionDAG-O0: 2 instructions
+
+
+  Comprehensive comparison of all three:
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR                 GlobalISel-O0            SelectionDAG-O0          
+    --------------------------------------------------------------------------------
+    0       mv                       divu                     divu                      ⚠️  DIFFERS
+    1       mv                       ret                      ret                       ⚠️  DIFFERS
+    2       divu                     <missing>                <missing>                
+    3       mv                       <missing>                <missing>                
+    4       ret                      <missing>                <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR: 5 instructions
+      GlobalISel-O0: 2 instructions
+      SelectionDAG-O0: 2 instructions
+
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+Operation: llvm.urem, Variant: 0
+────────────────────────────────────────────────────────────────────────────────────────────────────
+
+  ✗ LEANMLIR DIFFERS from GlobalISel-O0
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR                 GlobalISel-O0            
+    --------------------------------------------------------------------------------
+    0       mv                       divu                      ⚠️  DIFFERS
+    1       mv                       ret                       ⚠️  DIFFERS
+    2       divu                     <missing>                
+    3       mv                       <missing>                
+    4       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR: 5 instructions
+      GlobalISel-O0: 2 instructions
+
+
+  ✗ LEANMLIR DIFFERS from SelectionDAG-O0
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR                 SelectionDAG-O0          
+    --------------------------------------------------------------------------------
+    0       mv                       divu                      ⚠️  DIFFERS
+    1       mv                       ret                       ⚠️  DIFFERS
+    2       divu                     <missing>                
+    3       mv                       <missing>                
+    4       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR: 5 instructions
+      SelectionDAG-O0: 2 instructions
+
+
+  Comprehensive comparison of all three:
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR                 GlobalISel-O0            SelectionDAG-O0          
+    --------------------------------------------------------------------------------
+    0       mv                       divu                     divu                      ⚠️  DIFFERS
+    1       mv                       ret                      ret                       ⚠️  DIFFERS
+    2       divu                     <missing>                <missing>                
+    3       mv                       <missing>                <missing>                
+    4       ret                      <missing>                <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR: 5 instructions
+      GlobalISel-O0: 2 instructions
+      SelectionDAG-O0: 2 instructions
+
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+Operation: llvm.xor, Variant: 0
+────────────────────────────────────────────────────────────────────────────────────────────────────
+
+  ✗ LEANMLIR DIFFERS from GlobalISel-O0
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR                 GlobalISel-O0            
+    --------------------------------------------------------------------------------
+    0       mv                       xor                       ⚠️  DIFFERS
+    1       mv                       ret                       ⚠️  DIFFERS
+    2       xor                      <missing>                
+    3       mv                       <missing>                
+    4       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR: 5 instructions
+      GlobalISel-O0: 2 instructions
+
+
+  ✗ LEANMLIR DIFFERS from SelectionDAG-O0
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR                 SelectionDAG-O0          
+    --------------------------------------------------------------------------------
+    0       mv                       xor                       ⚠️  DIFFERS
+    1       mv                       ret                       ⚠️  DIFFERS
+    2       xor                      <missing>                
+    3       mv                       <missing>                
+    4       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR: 5 instructions
+      SelectionDAG-O0: 2 instructions
+
+
+  Comprehensive comparison of all three:
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR                 GlobalISel-O0            SelectionDAG-O0          
+    --------------------------------------------------------------------------------
+    0       mv                       xor                      xor                       ⚠️  DIFFERS
+    1       mv                       ret                      ret                       ⚠️  DIFFERS
+    2       xor                      <missing>                <missing>                
+    3       mv                       <missing>                <missing>                
+    4       ret                      <missing>                <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR: 5 instructions
+      GlobalISel-O0: 2 instructions
+      SelectionDAG-O0: 2 instructions
+
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+Operation: llvm.zext, Variant: 0
+────────────────────────────────────────────────────────────────────────────────────────────────────
+
+  ✗ LEANMLIR DIFFERS from GlobalISel-O0
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR                 GlobalISel-O0            
+    --------------------------------------------------------------------------------
+    0       mv                       andi                      ⚠️  DIFFERS
+    1       andi                     ret                       ⚠️  DIFFERS
+    2       mv                       <missing>                
+    3       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR: 4 instructions
+      GlobalISel-O0: 2 instructions
+
+
+  ✗ LEANMLIR DIFFERS from SelectionDAG-O0
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR                 SelectionDAG-O0          
+    --------------------------------------------------------------------------------
+    0       mv                       andi                      ⚠️  DIFFERS
+    1       andi                     ret                       ⚠️  DIFFERS
+    2       mv                       <missing>                
+    3       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR: 4 instructions
+      SelectionDAG-O0: 2 instructions
+
+
+  Comprehensive comparison of all three:
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR                 GlobalISel-O0            SelectionDAG-O0          
+    --------------------------------------------------------------------------------
+    0       mv                       andi                     andi                      ⚠️  DIFFERS
+    1       andi                     ret                      ret                       ⚠️  DIFFERS
+    2       mv                       <missing>                <missing>                
+    3       ret                      <missing>                <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR: 4 instructions
+      GlobalISel-O0: 2 instructions
+      SelectionDAG-O0: 2 instructions
+
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+Operation: llvm.zext, Variant: 1
+────────────────────────────────────────────────────────────────────────────────────────────────────
+
+  ✗ LEANMLIR DIFFERS from GlobalISel-O0
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR                 GlobalISel-O0            
+    --------------------------------------------------------------------------------
+    0       mv                       andi                      ⚠️  DIFFERS
+    1       andi                     ret                       ⚠️  DIFFERS
+    2       mv                       <missing>                
+    3       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR: 4 instructions
+      GlobalISel-O0: 2 instructions
+
+
+  ✗ LEANMLIR DIFFERS from SelectionDAG-O0
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR                 SelectionDAG-O0          
+    --------------------------------------------------------------------------------
+    0       mv                       andi                      ⚠️  DIFFERS
+    1       andi                     ret                       ⚠️  DIFFERS
+    2       mv                       <missing>                
+    3       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR: 4 instructions
+      SelectionDAG-O0: 2 instructions
+
+
+  Comprehensive comparison of all three:
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR                 GlobalISel-O0            SelectionDAG-O0          
+    --------------------------------------------------------------------------------
+    0       mv                       andi                     andi                      ⚠️  DIFFERS
+    1       andi                     ret                      ret                       ⚠️  DIFFERS
+    2       mv                       <missing>                <missing>                
+    3       ret                      <missing>                <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR: 4 instructions
+      GlobalISel-O0: 2 instructions
+      SelectionDAG-O0: 2 instructions
+
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+Operation: llvm.zext, Variant: 2
+────────────────────────────────────────────────────────────────────────────────────────────────────
+
+  ✗ LEANMLIR DIFFERS from GlobalISel-O0
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR                 GlobalISel-O0            
+    --------------------------------------------------------------------------------
+    0       mv                       zext.h                    ⚠️  DIFFERS
+    1       zext.h                   ret                       ⚠️  DIFFERS
+    2       mv                       <missing>                
+    3       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR: 4 instructions
+      GlobalISel-O0: 2 instructions
+
+
+  ✗ LEANMLIR DIFFERS from SelectionDAG-O0
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR                 SelectionDAG-O0          
+    --------------------------------------------------------------------------------
+    0       mv                       zext.h                    ⚠️  DIFFERS
+    1       zext.h                   ret                       ⚠️  DIFFERS
+    2       mv                       <missing>                
+    3       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR: 4 instructions
+      SelectionDAG-O0: 2 instructions
+
+
+  Comprehensive comparison of all three:
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR                 GlobalISel-O0            SelectionDAG-O0          
+    --------------------------------------------------------------------------------
+    0       mv                       zext.h                   zext.h                    ⚠️  DIFFERS
+    1       zext.h                   ret                      ret                       ⚠️  DIFFERS
+    2       mv                       <missing>                <missing>                
+    3       ret                      <missing>                <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR: 4 instructions
+      GlobalISel-O0: 2 instructions
+      SelectionDAG-O0: 2 instructions
+
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+Operation: llvm.zext, Variant: 3
+────────────────────────────────────────────────────────────────────────────────────────────────────
+
+  ✗ LEANMLIR DIFFERS from GlobalISel-O0
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR                 GlobalISel-O0            
+    --------------------------------------------------------------------------------
+    0       <missing>                zext.w                   
+    1       <missing>                ret                      
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR: 0 instructions
+      GlobalISel-O0: 2 instructions
+
+
+  ✗ LEANMLIR DIFFERS from SelectionDAG-O0
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR                 SelectionDAG-O0          
+    --------------------------------------------------------------------------------
+    0       <missing>                zext.w                   
+    1       <missing>                ret                      
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR: 0 instructions
+      SelectionDAG-O0: 2 instructions
+
+
+  Comprehensive comparison of all three:
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR                 GlobalISel-O0            SelectionDAG-O0          
+    --------------------------------------------------------------------------------
+    0       <missing>                zext.w                   zext.w                   
+    1       <missing>                ret                      ret                      
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR: 0 instructions
+      GlobalISel-O0: 2 instructions
+      SelectionDAG-O0: 2 instructions
+
+
+====================================================================================================
+COMPARISON 3: LEANMLIR_opt vs LLVM at O2
+====================================================================================================
+
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+Operation: llvm.add, Variant: 0
+────────────────────────────────────────────────────────────────────────────────────────────────────
+
+  ✗ LEANMLIR_opt DIFFERS from GlobalISel-O2
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR_opt             GlobalISel-O2            
+    --------------------------------------------------------------------------------
+    0       mv                       add                       ⚠️  DIFFERS
+    1       mv                       ret                       ⚠️  DIFFERS
+    2       add                      <missing>                
+    3       mv                       <missing>                
+    4       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR_opt: 5 instructions
+      GlobalISel-O2: 2 instructions
+
+
+  ✗ LEANMLIR_opt DIFFERS from SelectionDAG-O2
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR_opt             SelectionDAG-O2          
+    --------------------------------------------------------------------------------
+    0       mv                       add                       ⚠️  DIFFERS
+    1       mv                       ret                       ⚠️  DIFFERS
+    2       add                      <missing>                
+    3       mv                       <missing>                
+    4       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR_opt: 5 instructions
+      SelectionDAG-O2: 2 instructions
+
+
+  Comprehensive comparison of all three:
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR_opt             GlobalISel-O2            SelectionDAG-O2          
+    --------------------------------------------------------------------------------
+    0       mv                       add                      add                       ⚠️  DIFFERS
+    1       mv                       ret                      ret                       ⚠️  DIFFERS
+    2       add                      <missing>                <missing>                
+    3       mv                       <missing>                <missing>                
+    4       ret                      <missing>                <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR_opt: 5 instructions
+      GlobalISel-O2: 2 instructions
+      SelectionDAG-O2: 2 instructions
+
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+Operation: llvm.add, Variant: 1
+────────────────────────────────────────────────────────────────────────────────────────────────────
+
+  ✗ LEANMLIR_opt DIFFERS from GlobalISel-O2
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR_opt             GlobalISel-O2            
+    --------------------------------------------------------------------------------
+    0       mv                       add                       ⚠️  DIFFERS
+    1       mv                       ret                       ⚠️  DIFFERS
+    2       add                      <missing>                
+    3       mv                       <missing>                
+    4       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR_opt: 5 instructions
+      GlobalISel-O2: 2 instructions
+
+
+  ✗ LEANMLIR_opt DIFFERS from SelectionDAG-O2
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR_opt             SelectionDAG-O2          
+    --------------------------------------------------------------------------------
+    0       mv                       add                       ⚠️  DIFFERS
+    1       mv                       ret                       ⚠️  DIFFERS
+    2       add                      <missing>                
+    3       mv                       <missing>                
+    4       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR_opt: 5 instructions
+      SelectionDAG-O2: 2 instructions
+
+
+  Comprehensive comparison of all three:
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR_opt             GlobalISel-O2            SelectionDAG-O2          
+    --------------------------------------------------------------------------------
+    0       mv                       add                      add                       ⚠️  DIFFERS
+    1       mv                       ret                      ret                       ⚠️  DIFFERS
+    2       add                      <missing>                <missing>                
+    3       mv                       <missing>                <missing>                
+    4       ret                      <missing>                <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR_opt: 5 instructions
+      GlobalISel-O2: 2 instructions
+      SelectionDAG-O2: 2 instructions
+
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+Operation: llvm.add, Variant: 2
+────────────────────────────────────────────────────────────────────────────────────────────────────
+
+  ✗ LEANMLIR_opt DIFFERS from GlobalISel-O2
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR_opt             GlobalISel-O2            
+    --------------------------------------------------------------------------------
+    0       mv                       add                       ⚠️  DIFFERS
+    1       mv                       ret                       ⚠️  DIFFERS
+    2       add                      <missing>                
+    3       mv                       <missing>                
+    4       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR_opt: 5 instructions
+      GlobalISel-O2: 2 instructions
+
+
+  ✗ LEANMLIR_opt DIFFERS from SelectionDAG-O2
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR_opt             SelectionDAG-O2          
+    --------------------------------------------------------------------------------
+    0       mv                       add                       ⚠️  DIFFERS
+    1       mv                       ret                       ⚠️  DIFFERS
+    2       add                      <missing>                
+    3       mv                       <missing>                
+    4       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR_opt: 5 instructions
+      SelectionDAG-O2: 2 instructions
+
+
+  Comprehensive comparison of all three:
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR_opt             GlobalISel-O2            SelectionDAG-O2          
+    --------------------------------------------------------------------------------
+    0       mv                       add                      add                       ⚠️  DIFFERS
+    1       mv                       ret                      ret                       ⚠️  DIFFERS
+    2       add                      <missing>                <missing>                
+    3       mv                       <missing>                <missing>                
+    4       ret                      <missing>                <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR_opt: 5 instructions
+      GlobalISel-O2: 2 instructions
+      SelectionDAG-O2: 2 instructions
+
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+Operation: llvm.and, Variant: 0
+────────────────────────────────────────────────────────────────────────────────────────────────────
+
+  ✗ LEANMLIR_opt DIFFERS from GlobalISel-O2
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR_opt             GlobalISel-O2            
+    --------------------------------------------------------------------------------
+    0       mv                       and                       ⚠️  DIFFERS
+    1       mv                       ret                       ⚠️  DIFFERS
+    2       and                      <missing>                
+    3       mv                       <missing>                
+    4       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR_opt: 5 instructions
+      GlobalISel-O2: 2 instructions
+
+
+  ✗ LEANMLIR_opt DIFFERS from SelectionDAG-O2
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR_opt             SelectionDAG-O2          
+    --------------------------------------------------------------------------------
+    0       mv                       and                       ⚠️  DIFFERS
+    1       mv                       ret                       ⚠️  DIFFERS
+    2       and                      <missing>                
+    3       mv                       <missing>                
+    4       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR_opt: 5 instructions
+      SelectionDAG-O2: 2 instructions
+
+
+  Comprehensive comparison of all three:
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR_opt             GlobalISel-O2            SelectionDAG-O2          
+    --------------------------------------------------------------------------------
+    0       mv                       and                      and                       ⚠️  DIFFERS
+    1       mv                       ret                      ret                       ⚠️  DIFFERS
+    2       and                      <missing>                <missing>                
+    3       mv                       <missing>                <missing>                
+    4       ret                      <missing>                <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR_opt: 5 instructions
+      GlobalISel-O2: 2 instructions
+      SelectionDAG-O2: 2 instructions
+
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+Operation: llvm.ashr, Variant: 0
+────────────────────────────────────────────────────────────────────────────────────────────────────
+
+  ✗ LEANMLIR_opt DIFFERS from GlobalISel-O2
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR_opt             GlobalISel-O2            
+    --------------------------------------------------------------------------------
+    0       mv                       sra                       ⚠️  DIFFERS
+    1       mv                       ret                       ⚠️  DIFFERS
+    2       sra                      <missing>                
+    3       mv                       <missing>                
+    4       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR_opt: 5 instructions
+      GlobalISel-O2: 2 instructions
+
+
+  ✗ LEANMLIR_opt DIFFERS from SelectionDAG-O2
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR_opt             SelectionDAG-O2          
+    --------------------------------------------------------------------------------
+    0       mv                       sra                       ⚠️  DIFFERS
+    1       mv                       ret                       ⚠️  DIFFERS
+    2       sra                      <missing>                
+    3       mv                       <missing>                
+    4       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR_opt: 5 instructions
+      SelectionDAG-O2: 2 instructions
+
+
+  Comprehensive comparison of all three:
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR_opt             GlobalISel-O2            SelectionDAG-O2          
+    --------------------------------------------------------------------------------
+    0       mv                       sra                      sra                       ⚠️  DIFFERS
+    1       mv                       ret                      ret                       ⚠️  DIFFERS
+    2       sra                      <missing>                <missing>                
+    3       mv                       <missing>                <missing>                
+    4       ret                      <missing>                <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR_opt: 5 instructions
+      GlobalISel-O2: 2 instructions
+      SelectionDAG-O2: 2 instructions
+
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+Operation: llvm.icmp, Variant: 0
+────────────────────────────────────────────────────────────────────────────────────────────────────
+
+  ✗ LEANMLIR_opt DIFFERS from GlobalISel-O2
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR_opt             GlobalISel-O2            
+    --------------------------------------------------------------------------------
+    0       mv                       sltu                      ⚠️  DIFFERS
+    1       mv                       ret                       ⚠️  DIFFERS
+    2       sltu                     <missing>                
+    3       mv                       <missing>                
+    4       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR_opt: 5 instructions
+      GlobalISel-O2: 2 instructions
+
+
+  ✗ LEANMLIR_opt DIFFERS from SelectionDAG-O2
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR_opt             SelectionDAG-O2          
+    --------------------------------------------------------------------------------
+    0       mv                       sltu                      ⚠️  DIFFERS
+    1       mv                       ret                       ⚠️  DIFFERS
+    2       sltu                     <missing>                
+    3       mv                       <missing>                
+    4       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR_opt: 5 instructions
+      SelectionDAG-O2: 2 instructions
+
+
+  Comprehensive comparison of all three:
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR_opt             GlobalISel-O2            SelectionDAG-O2          
+    --------------------------------------------------------------------------------
+    0       mv                       sltu                     sltu                      ⚠️  DIFFERS
+    1       mv                       ret                      ret                       ⚠️  DIFFERS
+    2       sltu                     <missing>                <missing>                
+    3       mv                       <missing>                <missing>                
+    4       ret                      <missing>                <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR_opt: 5 instructions
+      GlobalISel-O2: 2 instructions
+      SelectionDAG-O2: 2 instructions
+
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+Operation: llvm.icmp, Variant: 1
+────────────────────────────────────────────────────────────────────────────────────────────────────
+
+  ✗ LEANMLIR_opt DIFFERS from GlobalISel-O2
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR_opt             GlobalISel-O2            
+    --------------------------------------------------------------------------------
+    0       mv                       sltu                      ⚠️  DIFFERS
+    1       mv                       xori                      ⚠️  DIFFERS
+    2       sltu                     ret                       ⚠️  DIFFERS
+    3       xori                     <missing>                
+    4       mv                       <missing>                
+    5       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR_opt: 6 instructions
+      GlobalISel-O2: 3 instructions
+
+
+  ✗ LEANMLIR_opt DIFFERS from SelectionDAG-O2
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR_opt             SelectionDAG-O2          
+    --------------------------------------------------------------------------------
+    0       mv                       sltu                      ⚠️  DIFFERS
+    1       mv                       xori                      ⚠️  DIFFERS
+    2       sltu                     ret                       ⚠️  DIFFERS
+    3       xori                     <missing>                
+    4       mv                       <missing>                
+    5       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR_opt: 6 instructions
+      SelectionDAG-O2: 3 instructions
+
+
+  Comprehensive comparison of all three:
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR_opt             GlobalISel-O2            SelectionDAG-O2          
+    --------------------------------------------------------------------------------
+    0       mv                       sltu                     sltu                      ⚠️  DIFFERS
+    1       mv                       xori                     xori                      ⚠️  DIFFERS
+    2       sltu                     ret                      ret                       ⚠️  DIFFERS
+    3       xori                     <missing>                <missing>                
+    4       mv                       <missing>                <missing>                
+    5       ret                      <missing>                <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR_opt: 6 instructions
+      GlobalISel-O2: 3 instructions
+      SelectionDAG-O2: 3 instructions
+
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+Operation: llvm.icmp, Variant: 2
+────────────────────────────────────────────────────────────────────────────────────────────────────
+
+  ✗ LEANMLIR_opt DIFFERS from GlobalISel-O2
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR_opt             GlobalISel-O2            
+    --------------------------------------------------------------------------------
+    0       mv                       sltu                      ⚠️  DIFFERS
+    1       mv                       ret                       ⚠️  DIFFERS
+    2       sltu                     <missing>                
+    3       mv                       <missing>                
+    4       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR_opt: 5 instructions
+      GlobalISel-O2: 2 instructions
+
+
+  ✗ LEANMLIR_opt DIFFERS from SelectionDAG-O2
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR_opt             SelectionDAG-O2          
+    --------------------------------------------------------------------------------
+    0       mv                       sltu                      ⚠️  DIFFERS
+    1       mv                       ret                       ⚠️  DIFFERS
+    2       sltu                     <missing>                
+    3       mv                       <missing>                
+    4       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR_opt: 5 instructions
+      SelectionDAG-O2: 2 instructions
+
+
+  Comprehensive comparison of all three:
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR_opt             GlobalISel-O2            SelectionDAG-O2          
+    --------------------------------------------------------------------------------
+    0       mv                       sltu                     sltu                      ⚠️  DIFFERS
+    1       mv                       ret                      ret                       ⚠️  DIFFERS
+    2       sltu                     <missing>                <missing>                
+    3       mv                       <missing>                <missing>                
+    4       ret                      <missing>                <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR_opt: 5 instructions
+      GlobalISel-O2: 2 instructions
+      SelectionDAG-O2: 2 instructions
+
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+Operation: llvm.icmp, Variant: 3
+────────────────────────────────────────────────────────────────────────────────────────────────────
+
+  ✗ LEANMLIR_opt DIFFERS from GlobalISel-O2
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR_opt             GlobalISel-O2            
+    --------------------------------------------------------------------------------
+    0       mv                       sltu                      ⚠️  DIFFERS
+    1       mv                       xori                      ⚠️  DIFFERS
+    2       sltu                     ret                       ⚠️  DIFFERS
+    3       xori                     <missing>                
+    4       mv                       <missing>                
+    5       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR_opt: 6 instructions
+      GlobalISel-O2: 3 instructions
+
+
+  ✗ LEANMLIR_opt DIFFERS from SelectionDAG-O2
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR_opt             SelectionDAG-O2          
+    --------------------------------------------------------------------------------
+    0       mv                       sltu                      ⚠️  DIFFERS
+    1       mv                       xori                      ⚠️  DIFFERS
+    2       sltu                     ret                       ⚠️  DIFFERS
+    3       xori                     <missing>                
+    4       mv                       <missing>                
+    5       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR_opt: 6 instructions
+      SelectionDAG-O2: 3 instructions
+
+
+  Comprehensive comparison of all three:
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR_opt             GlobalISel-O2            SelectionDAG-O2          
+    --------------------------------------------------------------------------------
+    0       mv                       sltu                     sltu                      ⚠️  DIFFERS
+    1       mv                       xori                     xori                      ⚠️  DIFFERS
+    2       sltu                     ret                      ret                       ⚠️  DIFFERS
+    3       xori                     <missing>                <missing>                
+    4       mv                       <missing>                <missing>                
+    5       ret                      <missing>                <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR_opt: 6 instructions
+      GlobalISel-O2: 3 instructions
+      SelectionDAG-O2: 3 instructions
+
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+Operation: llvm.icmp, Variant: 4
+────────────────────────────────────────────────────────────────────────────────────────────────────
+
+  ✗ LEANMLIR_opt DIFFERS from GlobalISel-O2
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR_opt             GlobalISel-O2            
+    --------------------------------------------------------------------------------
+    0       mv                       slt                       ⚠️  DIFFERS
+    1       mv                       ret                       ⚠️  DIFFERS
+    2       slt                      <missing>                
+    3       mv                       <missing>                
+    4       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR_opt: 5 instructions
+      GlobalISel-O2: 2 instructions
+
+
+  ✗ LEANMLIR_opt DIFFERS from SelectionDAG-O2
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR_opt             SelectionDAG-O2          
+    --------------------------------------------------------------------------------
+    0       mv                       slt                       ⚠️  DIFFERS
+    1       mv                       ret                       ⚠️  DIFFERS
+    2       slt                      <missing>                
+    3       mv                       <missing>                
+    4       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR_opt: 5 instructions
+      SelectionDAG-O2: 2 instructions
+
+
+  Comprehensive comparison of all three:
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR_opt             GlobalISel-O2            SelectionDAG-O2          
+    --------------------------------------------------------------------------------
+    0       mv                       slt                      slt                       ⚠️  DIFFERS
+    1       mv                       ret                      ret                       ⚠️  DIFFERS
+    2       slt                      <missing>                <missing>                
+    3       mv                       <missing>                <missing>                
+    4       ret                      <missing>                <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR_opt: 5 instructions
+      GlobalISel-O2: 2 instructions
+      SelectionDAG-O2: 2 instructions
+
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+Operation: llvm.icmp, Variant: 5
+────────────────────────────────────────────────────────────────────────────────────────────────────
+
+  ✗ LEANMLIR_opt DIFFERS from GlobalISel-O2
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR_opt             GlobalISel-O2            
+    --------------------------------------------------------------------------------
+    0       mv                       slt                       ⚠️  DIFFERS
+    1       mv                       xori                      ⚠️  DIFFERS
+    2       slt                      ret                       ⚠️  DIFFERS
+    3       xori                     <missing>                
+    4       mv                       <missing>                
+    5       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR_opt: 6 instructions
+      GlobalISel-O2: 3 instructions
+
+
+  ✗ LEANMLIR_opt DIFFERS from SelectionDAG-O2
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR_opt             SelectionDAG-O2          
+    --------------------------------------------------------------------------------
+    0       mv                       slt                       ⚠️  DIFFERS
+    1       mv                       xori                      ⚠️  DIFFERS
+    2       slt                      ret                       ⚠️  DIFFERS
+    3       xori                     <missing>                
+    4       mv                       <missing>                
+    5       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR_opt: 6 instructions
+      SelectionDAG-O2: 3 instructions
+
+
+  Comprehensive comparison of all three:
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR_opt             GlobalISel-O2            SelectionDAG-O2          
+    --------------------------------------------------------------------------------
+    0       mv                       slt                      slt                       ⚠️  DIFFERS
+    1       mv                       xori                     xori                      ⚠️  DIFFERS
+    2       slt                      ret                      ret                       ⚠️  DIFFERS
+    3       xori                     <missing>                <missing>                
+    4       mv                       <missing>                <missing>                
+    5       ret                      <missing>                <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR_opt: 6 instructions
+      GlobalISel-O2: 3 instructions
+      SelectionDAG-O2: 3 instructions
+
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+Operation: llvm.icmp, Variant: 6
+────────────────────────────────────────────────────────────────────────────────────────────────────
+
+  ✗ LEANMLIR_opt DIFFERS from GlobalISel-O2
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR_opt             GlobalISel-O2            
+    --------------------------------------------------------------------------------
+    0       mv                       slt                       ⚠️  DIFFERS
+    1       mv                       ret                       ⚠️  DIFFERS
+    2       slt                      <missing>                
+    3       mv                       <missing>                
+    4       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR_opt: 5 instructions
+      GlobalISel-O2: 2 instructions
+
+
+  ✗ LEANMLIR_opt DIFFERS from SelectionDAG-O2
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR_opt             SelectionDAG-O2          
+    --------------------------------------------------------------------------------
+    0       mv                       slt                       ⚠️  DIFFERS
+    1       mv                       ret                       ⚠️  DIFFERS
+    2       slt                      <missing>                
+    3       mv                       <missing>                
+    4       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR_opt: 5 instructions
+      SelectionDAG-O2: 2 instructions
+
+
+  Comprehensive comparison of all three:
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR_opt             GlobalISel-O2            SelectionDAG-O2          
+    --------------------------------------------------------------------------------
+    0       mv                       slt                      slt                       ⚠️  DIFFERS
+    1       mv                       ret                      ret                       ⚠️  DIFFERS
+    2       slt                      <missing>                <missing>                
+    3       mv                       <missing>                <missing>                
+    4       ret                      <missing>                <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR_opt: 5 instructions
+      GlobalISel-O2: 2 instructions
+      SelectionDAG-O2: 2 instructions
+
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+Operation: llvm.icmp, Variant: 7
+────────────────────────────────────────────────────────────────────────────────────────────────────
+
+  ✗ LEANMLIR_opt DIFFERS from GlobalISel-O2
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR_opt             GlobalISel-O2            
+    --------------------------------------------------------------------------------
+    0       mv                       slt                       ⚠️  DIFFERS
+    1       mv                       xori                      ⚠️  DIFFERS
+    2       slt                      ret                       ⚠️  DIFFERS
+    3       xori                     <missing>                
+    4       mv                       <missing>                
+    5       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR_opt: 6 instructions
+      GlobalISel-O2: 3 instructions
+
+
+  ✗ LEANMLIR_opt DIFFERS from SelectionDAG-O2
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR_opt             SelectionDAG-O2          
+    --------------------------------------------------------------------------------
+    0       mv                       slt                       ⚠️  DIFFERS
+    1       mv                       xori                      ⚠️  DIFFERS
+    2       slt                      ret                       ⚠️  DIFFERS
+    3       xori                     <missing>                
+    4       mv                       <missing>                
+    5       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR_opt: 6 instructions
+      SelectionDAG-O2: 3 instructions
+
+
+  Comprehensive comparison of all three:
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR_opt             GlobalISel-O2            SelectionDAG-O2          
+    --------------------------------------------------------------------------------
+    0       mv                       slt                      slt                       ⚠️  DIFFERS
+    1       mv                       xori                     xori                      ⚠️  DIFFERS
+    2       slt                      ret                      ret                       ⚠️  DIFFERS
+    3       xori                     <missing>                <missing>                
+    4       mv                       <missing>                <missing>                
+    5       ret                      <missing>                <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR_opt: 6 instructions
+      GlobalISel-O2: 3 instructions
+      SelectionDAG-O2: 3 instructions
+
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+Operation: llvm.icmp, Variant: 8
+────────────────────────────────────────────────────────────────────────────────────────────────────
+
+  ✗ LEANMLIR_opt DIFFERS from GlobalISel-O2
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR_opt             GlobalISel-O2            
+    --------------------------------------------------------------------------------
+    0       mv                       xor                       ⚠️  DIFFERS
+    1       mv                       seqz                      ⚠️  DIFFERS
+    2       xor                      ret                       ⚠️  DIFFERS
+    3       seqz                     <missing>                
+    4       mv                       <missing>                
+    5       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR_opt: 6 instructions
+      GlobalISel-O2: 3 instructions
+
+
+  ✗ LEANMLIR_opt DIFFERS from SelectionDAG-O2
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR_opt             SelectionDAG-O2          
+    --------------------------------------------------------------------------------
+    0       mv                       xor                       ⚠️  DIFFERS
+    1       mv                       seqz                      ⚠️  DIFFERS
+    2       xor                      ret                       ⚠️  DIFFERS
+    3       seqz                     <missing>                
+    4       mv                       <missing>                
+    5       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR_opt: 6 instructions
+      SelectionDAG-O2: 3 instructions
+
+
+  Comprehensive comparison of all three:
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR_opt             GlobalISel-O2            SelectionDAG-O2          
+    --------------------------------------------------------------------------------
+    0       mv                       xor                      xor                       ⚠️  DIFFERS
+    1       mv                       seqz                     seqz                      ⚠️  DIFFERS
+    2       xor                      ret                      ret                       ⚠️  DIFFERS
+    3       seqz                     <missing>                <missing>                
+    4       mv                       <missing>                <missing>                
+    5       ret                      <missing>                <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR_opt: 6 instructions
+      GlobalISel-O2: 3 instructions
+      SelectionDAG-O2: 3 instructions
+
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+Operation: llvm.mul, Variant: 0
+────────────────────────────────────────────────────────────────────────────────────────────────────
+
+  ✗ LEANMLIR_opt DIFFERS from GlobalISel-O2
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR_opt             GlobalISel-O2            
+    --------------------------------------------------------------------------------
+    0       mv                       mul                       ⚠️  DIFFERS
+    1       mv                       ret                       ⚠️  DIFFERS
+    2       mul                      <missing>                
+    3       mv                       <missing>                
+    4       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR_opt: 5 instructions
+      GlobalISel-O2: 2 instructions
+
+
+  ✗ LEANMLIR_opt DIFFERS from SelectionDAG-O2
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR_opt             SelectionDAG-O2          
+    --------------------------------------------------------------------------------
+    0       mv                       mul                       ⚠️  DIFFERS
+    1       mv                       ret                       ⚠️  DIFFERS
+    2       mul                      <missing>                
+    3       mv                       <missing>                
+    4       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR_opt: 5 instructions
+      SelectionDAG-O2: 2 instructions
+
+
+  Comprehensive comparison of all three:
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR_opt             GlobalISel-O2            SelectionDAG-O2          
+    --------------------------------------------------------------------------------
+    0       mv                       mul                      mul                       ⚠️  DIFFERS
+    1       mv                       ret                      ret                       ⚠️  DIFFERS
+    2       mul                      <missing>                <missing>                
+    3       mv                       <missing>                <missing>                
+    4       ret                      <missing>                <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR_opt: 5 instructions
+      GlobalISel-O2: 2 instructions
+      SelectionDAG-O2: 2 instructions
+
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+Operation: llvm.mul, Variant: 1
+────────────────────────────────────────────────────────────────────────────────────────────────────
+
+  ✗ LEANMLIR_opt DIFFERS from GlobalISel-O2
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR_opt             GlobalISel-O2            
+    --------------------------------------------------------------------------------
+    0       mv                       mul                       ⚠️  DIFFERS
+    1       mv                       ret                       ⚠️  DIFFERS
+    2       mul                      <missing>                
+    3       mv                       <missing>                
+    4       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR_opt: 5 instructions
+      GlobalISel-O2: 2 instructions
+
+
+  ✗ LEANMLIR_opt DIFFERS from SelectionDAG-O2
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR_opt             SelectionDAG-O2          
+    --------------------------------------------------------------------------------
+    0       mv                       mul                       ⚠️  DIFFERS
+    1       mv                       ret                       ⚠️  DIFFERS
+    2       mul                      <missing>                
+    3       mv                       <missing>                
+    4       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR_opt: 5 instructions
+      SelectionDAG-O2: 2 instructions
+
+
+  Comprehensive comparison of all three:
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR_opt             GlobalISel-O2            SelectionDAG-O2          
+    --------------------------------------------------------------------------------
+    0       mv                       mul                      mul                       ⚠️  DIFFERS
+    1       mv                       ret                      ret                       ⚠️  DIFFERS
+    2       mul                      <missing>                <missing>                
+    3       mv                       <missing>                <missing>                
+    4       ret                      <missing>                <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR_opt: 5 instructions
+      GlobalISel-O2: 2 instructions
+      SelectionDAG-O2: 2 instructions
+
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+Operation: llvm.mul, Variant: 2
+────────────────────────────────────────────────────────────────────────────────────────────────────
+
+  ✗ LEANMLIR_opt DIFFERS from GlobalISel-O2
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR_opt             GlobalISel-O2            
+    --------------------------------------------------------------------------------
+    0       mv                       mul                       ⚠️  DIFFERS
+    1       mv                       ret                       ⚠️  DIFFERS
+    2       mul                      <missing>                
+    3       mv                       <missing>                
+    4       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR_opt: 5 instructions
+      GlobalISel-O2: 2 instructions
+
+
+  ✗ LEANMLIR_opt DIFFERS from SelectionDAG-O2
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR_opt             SelectionDAG-O2          
+    --------------------------------------------------------------------------------
+    0       mv                       mul                       ⚠️  DIFFERS
+    1       mv                       ret                       ⚠️  DIFFERS
+    2       mul                      <missing>                
+    3       mv                       <missing>                
+    4       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR_opt: 5 instructions
+      SelectionDAG-O2: 2 instructions
+
+
+  Comprehensive comparison of all three:
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR_opt             GlobalISel-O2            SelectionDAG-O2          
+    --------------------------------------------------------------------------------
+    0       mv                       mul                      mul                       ⚠️  DIFFERS
+    1       mv                       ret                      ret                       ⚠️  DIFFERS
+    2       mul                      <missing>                <missing>                
+    3       mv                       <missing>                <missing>                
+    4       ret                      <missing>                <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR_opt: 5 instructions
+      GlobalISel-O2: 2 instructions
+      SelectionDAG-O2: 2 instructions
+
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+Operation: llvm.or, Variant: 0
+────────────────────────────────────────────────────────────────────────────────────────────────────
+
+  ✗ LEANMLIR_opt DIFFERS from GlobalISel-O2
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR_opt             GlobalISel-O2            
+    --------------------------------------------------------------------------------
+    0       mv                       or                        ⚠️  DIFFERS
+    1       mv                       ret                       ⚠️  DIFFERS
+    2       or                       <missing>                
+    3       mv                       <missing>                
+    4       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR_opt: 5 instructions
+      GlobalISel-O2: 2 instructions
+
+
+  ✗ LEANMLIR_opt DIFFERS from SelectionDAG-O2
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR_opt             SelectionDAG-O2          
+    --------------------------------------------------------------------------------
+    0       mv                       or                        ⚠️  DIFFERS
+    1       mv                       ret                       ⚠️  DIFFERS
+    2       or                       <missing>                
+    3       mv                       <missing>                
+    4       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR_opt: 5 instructions
+      SelectionDAG-O2: 2 instructions
+
+
+  Comprehensive comparison of all three:
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR_opt             GlobalISel-O2            SelectionDAG-O2          
+    --------------------------------------------------------------------------------
+    0       mv                       or                       or                        ⚠️  DIFFERS
+    1       mv                       ret                      ret                       ⚠️  DIFFERS
+    2       or                       <missing>                <missing>                
+    3       mv                       <missing>                <missing>                
+    4       ret                      <missing>                <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR_opt: 5 instructions
+      GlobalISel-O2: 2 instructions
+      SelectionDAG-O2: 2 instructions
+
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+Operation: llvm.rem, Variant: 0
+────────────────────────────────────────────────────────────────────────────────────────────────────
+
+  ✗ LEANMLIR_opt DIFFERS from GlobalISel-O2
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR_opt             GlobalISel-O2            
+    --------------------------------------------------------------------------------
+    0       mv                       rem                       ⚠️  DIFFERS
+    1       mv                       ret                       ⚠️  DIFFERS
+    2       rem                      <missing>                
+    3       mv                       <missing>                
+    4       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR_opt: 5 instructions
+      GlobalISel-O2: 2 instructions
+
+
+  ✗ LEANMLIR_opt DIFFERS from SelectionDAG-O2
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR_opt             SelectionDAG-O2          
+    --------------------------------------------------------------------------------
+    0       mv                       rem                       ⚠️  DIFFERS
+    1       mv                       ret                       ⚠️  DIFFERS
+    2       rem                      <missing>                
+    3       mv                       <missing>                
+    4       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR_opt: 5 instructions
+      SelectionDAG-O2: 2 instructions
+
+
+  Comprehensive comparison of all three:
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR_opt             GlobalISel-O2            SelectionDAG-O2          
+    --------------------------------------------------------------------------------
+    0       mv                       rem                      rem                       ⚠️  DIFFERS
+    1       mv                       ret                      ret                       ⚠️  DIFFERS
+    2       rem                      <missing>                <missing>                
+    3       mv                       <missing>                <missing>                
+    4       ret                      <missing>                <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR_opt: 5 instructions
+      GlobalISel-O2: 2 instructions
+      SelectionDAG-O2: 2 instructions
+
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+Operation: llvm.sdiv, Variant: 0
+────────────────────────────────────────────────────────────────────────────────────────────────────
+
+  ✗ LEANMLIR_opt DIFFERS from GlobalISel-O2
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR_opt             GlobalISel-O2            
+    --------------------------------------------------------------------------------
+    0       mv                       div                       ⚠️  DIFFERS
+    1       mv                       ret                       ⚠️  DIFFERS
+    2       div                      <missing>                
+    3       mv                       <missing>                
+    4       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR_opt: 5 instructions
+      GlobalISel-O2: 2 instructions
+
+
+  ✗ LEANMLIR_opt DIFFERS from SelectionDAG-O2
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR_opt             SelectionDAG-O2          
+    --------------------------------------------------------------------------------
+    0       mv                       div                       ⚠️  DIFFERS
+    1       mv                       ret                       ⚠️  DIFFERS
+    2       div                      <missing>                
+    3       mv                       <missing>                
+    4       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR_opt: 5 instructions
+      SelectionDAG-O2: 2 instructions
+
+
+  Comprehensive comparison of all three:
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR_opt             GlobalISel-O2            SelectionDAG-O2          
+    --------------------------------------------------------------------------------
+    0       mv                       div                      div                       ⚠️  DIFFERS
+    1       mv                       ret                      ret                       ⚠️  DIFFERS
+    2       div                      <missing>                <missing>                
+    3       mv                       <missing>                <missing>                
+    4       ret                      <missing>                <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR_opt: 5 instructions
+      GlobalISel-O2: 2 instructions
+      SelectionDAG-O2: 2 instructions
+
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+Operation: llvm.select, Variant: 0
+────────────────────────────────────────────────────────────────────────────────────────────────────
+
+  ✗ LEANMLIR_opt DIFFERS from GlobalISel-O2
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR_opt             GlobalISel-O2            
+    --------------------------------------------------------------------------------
+    0       <missing>                mv                       
+    1       <missing>                mv                       
+    2       <missing>                andi                     
+    3       <missing>                bnez                     
+    4       <missing>                mv                       
+    5       <missing>                ret                      
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR_opt: 0 instructions
+      GlobalISel-O2: 6 instructions
+
+
+  ✗ LEANMLIR_opt DIFFERS from SelectionDAG-O2
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR_opt             SelectionDAG-O2          
+    --------------------------------------------------------------------------------
+    0       <missing>                andi                     
+    1       <missing>                mv                       
+    2       <missing>                bnez                     
+    3       <missing>                mv                       
+    4       <missing>                ret                      
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR_opt: 0 instructions
+      SelectionDAG-O2: 5 instructions
+
+
+  Comprehensive comparison of all three:
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR_opt             GlobalISel-O2            SelectionDAG-O2          
+    --------------------------------------------------------------------------------
+    0       <missing>                mv                       andi                      ⚠️  DIFFERS
+    1       <missing>                mv                       mv                       
+    2       <missing>                andi                     bnez                      ⚠️  DIFFERS
+    3       <missing>                bnez                     mv                        ⚠️  DIFFERS
+    4       <missing>                mv                       ret                       ⚠️  DIFFERS
+    5       <missing>                ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR_opt: 0 instructions
+      GlobalISel-O2: 6 instructions
+      SelectionDAG-O2: 5 instructions
+
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+Operation: llvm.sext, Variant: 0
+────────────────────────────────────────────────────────────────────────────────────────────────────
+
+  ✗ LEANMLIR_opt DIFFERS from GlobalISel-O2
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR_opt             GlobalISel-O2            
+    --------------------------------------------------------------------------------
+    0       <missing>                slli                     
+    1       <missing>                srai                     
+    2       <missing>                ret                      
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR_opt: 0 instructions
+      GlobalISel-O2: 3 instructions
+
+
+  ✗ LEANMLIR_opt DIFFERS from SelectionDAG-O2
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR_opt             SelectionDAG-O2          
+    --------------------------------------------------------------------------------
+    0       <missing>                slli                     
+    1       <missing>                srai                     
+    2       <missing>                ret                      
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR_opt: 0 instructions
+      SelectionDAG-O2: 3 instructions
+
+
+  Comprehensive comparison of all three:
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR_opt             GlobalISel-O2            SelectionDAG-O2          
+    --------------------------------------------------------------------------------
+    0       <missing>                slli                     slli                     
+    1       <missing>                srai                     srai                     
+    2       <missing>                ret                      ret                      
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR_opt: 0 instructions
+      GlobalISel-O2: 3 instructions
+      SelectionDAG-O2: 3 instructions
+
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+Operation: llvm.sext, Variant: 1
+────────────────────────────────────────────────────────────────────────────────────────────────────
+
+  ✗ LEANMLIR_opt DIFFERS from GlobalISel-O2
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR_opt             GlobalISel-O2            
+    --------------------------------------------------------------------------------
+    0       <missing>                sext.b                   
+    1       <missing>                ret                      
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR_opt: 0 instructions
+      GlobalISel-O2: 2 instructions
+
+
+  ✗ LEANMLIR_opt DIFFERS from SelectionDAG-O2
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR_opt             SelectionDAG-O2          
+    --------------------------------------------------------------------------------
+    0       <missing>                sext.b                   
+    1       <missing>                ret                      
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR_opt: 0 instructions
+      SelectionDAG-O2: 2 instructions
+
+
+  Comprehensive comparison of all three:
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR_opt             GlobalISel-O2            SelectionDAG-O2          
+    --------------------------------------------------------------------------------
+    0       <missing>                sext.b                   sext.b                   
+    1       <missing>                ret                      ret                      
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR_opt: 0 instructions
+      GlobalISel-O2: 2 instructions
+      SelectionDAG-O2: 2 instructions
+
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+Operation: llvm.sext, Variant: 2
+────────────────────────────────────────────────────────────────────────────────────────────────────
+
+  ✗ LEANMLIR_opt DIFFERS from GlobalISel-O2
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR_opt             GlobalISel-O2            
+    --------------------------------------------------------------------------------
+    0       <missing>                sext.h                   
+    1       <missing>                ret                      
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR_opt: 0 instructions
+      GlobalISel-O2: 2 instructions
+
+
+  ✗ LEANMLIR_opt DIFFERS from SelectionDAG-O2
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR_opt             SelectionDAG-O2          
+    --------------------------------------------------------------------------------
+    0       <missing>                sext.h                   
+    1       <missing>                ret                      
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR_opt: 0 instructions
+      SelectionDAG-O2: 2 instructions
+
+
+  Comprehensive comparison of all three:
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR_opt             GlobalISel-O2            SelectionDAG-O2          
+    --------------------------------------------------------------------------------
+    0       <missing>                sext.h                   sext.h                   
+    1       <missing>                ret                      ret                      
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR_opt: 0 instructions
+      GlobalISel-O2: 2 instructions
+      SelectionDAG-O2: 2 instructions
+
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+Operation: llvm.sext, Variant: 3
+────────────────────────────────────────────────────────────────────────────────────────────────────
+
+  ✗ LEANMLIR_opt DIFFERS from GlobalISel-O2
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR_opt             GlobalISel-O2            
+    --------------------------------------------------------------------------------
+    0       <missing>                sext.w                   
+    1       <missing>                ret                      
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR_opt: 0 instructions
+      GlobalISel-O2: 2 instructions
+
+
+  ✗ LEANMLIR_opt DIFFERS from SelectionDAG-O2
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR_opt             SelectionDAG-O2          
+    --------------------------------------------------------------------------------
+    0       <missing>                sext.w                   
+    1       <missing>                ret                      
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR_opt: 0 instructions
+      SelectionDAG-O2: 2 instructions
+
+
+  Comprehensive comparison of all three:
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR_opt             GlobalISel-O2            SelectionDAG-O2          
+    --------------------------------------------------------------------------------
+    0       <missing>                sext.w                   sext.w                   
+    1       <missing>                ret                      ret                      
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR_opt: 0 instructions
+      GlobalISel-O2: 2 instructions
+      SelectionDAG-O2: 2 instructions
+
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+Operation: llvm.shl, Variant: 0
+────────────────────────────────────────────────────────────────────────────────────────────────────
+
+  ✗ LEANMLIR_opt DIFFERS from GlobalISel-O2
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR_opt             GlobalISel-O2            
+    --------------------------------------------------------------------------------
+    0       mv                       sll                       ⚠️  DIFFERS
+    1       mv                       ret                       ⚠️  DIFFERS
+    2       sll                      <missing>                
+    3       mv                       <missing>                
+    4       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR_opt: 5 instructions
+      GlobalISel-O2: 2 instructions
+
+
+  ✗ LEANMLIR_opt DIFFERS from SelectionDAG-O2
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR_opt             SelectionDAG-O2          
+    --------------------------------------------------------------------------------
+    0       mv                       sll                       ⚠️  DIFFERS
+    1       mv                       ret                       ⚠️  DIFFERS
+    2       sll                      <missing>                
+    3       mv                       <missing>                
+    4       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR_opt: 5 instructions
+      SelectionDAG-O2: 2 instructions
+
+
+  Comprehensive comparison of all three:
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR_opt             GlobalISel-O2            SelectionDAG-O2          
+    --------------------------------------------------------------------------------
+    0       mv                       sll                      sll                       ⚠️  DIFFERS
+    1       mv                       ret                      ret                       ⚠️  DIFFERS
+    2       sll                      <missing>                <missing>                
+    3       mv                       <missing>                <missing>                
+    4       ret                      <missing>                <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR_opt: 5 instructions
+      GlobalISel-O2: 2 instructions
+      SelectionDAG-O2: 2 instructions
+
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+Operation: llvm.shl, Variant: 1
+────────────────────────────────────────────────────────────────────────────────────────────────────
+
+  ✗ LEANMLIR_opt DIFFERS from GlobalISel-O2
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR_opt             GlobalISel-O2            
+    --------------------------------------------------------------------------------
+    0       mv                       sll                       ⚠️  DIFFERS
+    1       mv                       ret                       ⚠️  DIFFERS
+    2       sll                      <missing>                
+    3       mv                       <missing>                
+    4       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR_opt: 5 instructions
+      GlobalISel-O2: 2 instructions
+
+
+  ✗ LEANMLIR_opt DIFFERS from SelectionDAG-O2
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR_opt             SelectionDAG-O2          
+    --------------------------------------------------------------------------------
+    0       mv                       sll                       ⚠️  DIFFERS
+    1       mv                       ret                       ⚠️  DIFFERS
+    2       sll                      <missing>                
+    3       mv                       <missing>                
+    4       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR_opt: 5 instructions
+      SelectionDAG-O2: 2 instructions
+
+
+  Comprehensive comparison of all three:
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR_opt             GlobalISel-O2            SelectionDAG-O2          
+    --------------------------------------------------------------------------------
+    0       mv                       sll                      sll                       ⚠️  DIFFERS
+    1       mv                       ret                      ret                       ⚠️  DIFFERS
+    2       sll                      <missing>                <missing>                
+    3       mv                       <missing>                <missing>                
+    4       ret                      <missing>                <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR_opt: 5 instructions
+      GlobalISel-O2: 2 instructions
+      SelectionDAG-O2: 2 instructions
+
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+Operation: llvm.shl, Variant: 2
+────────────────────────────────────────────────────────────────────────────────────────────────────
+
+  ✗ LEANMLIR_opt DIFFERS from GlobalISel-O2
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR_opt             GlobalISel-O2            
+    --------------------------------------------------------------------------------
+    0       mv                       sll                       ⚠️  DIFFERS
+    1       mv                       ret                       ⚠️  DIFFERS
+    2       sll                      <missing>                
+    3       mv                       <missing>                
+    4       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR_opt: 5 instructions
+      GlobalISel-O2: 2 instructions
+
+
+  ✗ LEANMLIR_opt DIFFERS from SelectionDAG-O2
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR_opt             SelectionDAG-O2          
+    --------------------------------------------------------------------------------
+    0       mv                       sll                       ⚠️  DIFFERS
+    1       mv                       ret                       ⚠️  DIFFERS
+    2       sll                      <missing>                
+    3       mv                       <missing>                
+    4       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR_opt: 5 instructions
+      SelectionDAG-O2: 2 instructions
+
+
+  Comprehensive comparison of all three:
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR_opt             GlobalISel-O2            SelectionDAG-O2          
+    --------------------------------------------------------------------------------
+    0       mv                       sll                      sll                       ⚠️  DIFFERS
+    1       mv                       ret                      ret                       ⚠️  DIFFERS
+    2       sll                      <missing>                <missing>                
+    3       mv                       <missing>                <missing>                
+    4       ret                      <missing>                <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR_opt: 5 instructions
+      GlobalISel-O2: 2 instructions
+      SelectionDAG-O2: 2 instructions
+
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+Operation: llvm.shl, Variant: 3
+────────────────────────────────────────────────────────────────────────────────────────────────────
+
+  ✗ LEANMLIR_opt DIFFERS from GlobalISel-O2
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR_opt             GlobalISel-O2            
+    --------------------------------------------------------------------------------
+    0       mv                       sll                       ⚠️  DIFFERS
+    1       mv                       ret                       ⚠️  DIFFERS
+    2       sll                      <missing>                
+    3       mv                       <missing>                
+    4       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR_opt: 5 instructions
+      GlobalISel-O2: 2 instructions
+
+
+  ✗ LEANMLIR_opt DIFFERS from SelectionDAG-O2
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR_opt             SelectionDAG-O2          
+    --------------------------------------------------------------------------------
+    0       mv                       sll                       ⚠️  DIFFERS
+    1       mv                       ret                       ⚠️  DIFFERS
+    2       sll                      <missing>                
+    3       mv                       <missing>                
+    4       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR_opt: 5 instructions
+      SelectionDAG-O2: 2 instructions
+
+
+  Comprehensive comparison of all three:
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR_opt             GlobalISel-O2            SelectionDAG-O2          
+    --------------------------------------------------------------------------------
+    0       mv                       sll                      sll                       ⚠️  DIFFERS
+    1       mv                       ret                      ret                       ⚠️  DIFFERS
+    2       sll                      <missing>                <missing>                
+    3       mv                       <missing>                <missing>                
+    4       ret                      <missing>                <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR_opt: 5 instructions
+      GlobalISel-O2: 2 instructions
+      SelectionDAG-O2: 2 instructions
+
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+Operation: llvm.srl, Variant: 0
+────────────────────────────────────────────────────────────────────────────────────────────────────
+
+  ✗ LEANMLIR_opt DIFFERS from GlobalISel-O2
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR_opt             GlobalISel-O2            
+    --------------------------------------------------------------------------------
+    0       mv                       srl                       ⚠️  DIFFERS
+    1       mv                       ret                       ⚠️  DIFFERS
+    2       srl                      <missing>                
+    3       mv                       <missing>                
+    4       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR_opt: 5 instructions
+      GlobalISel-O2: 2 instructions
+
+
+  ✗ LEANMLIR_opt DIFFERS from SelectionDAG-O2
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR_opt             SelectionDAG-O2          
+    --------------------------------------------------------------------------------
+    0       mv                       srl                       ⚠️  DIFFERS
+    1       mv                       ret                       ⚠️  DIFFERS
+    2       srl                      <missing>                
+    3       mv                       <missing>                
+    4       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR_opt: 5 instructions
+      SelectionDAG-O2: 2 instructions
+
+
+  Comprehensive comparison of all three:
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR_opt             GlobalISel-O2            SelectionDAG-O2          
+    --------------------------------------------------------------------------------
+    0       mv                       srl                      srl                       ⚠️  DIFFERS
+    1       mv                       ret                      ret                       ⚠️  DIFFERS
+    2       srl                      <missing>                <missing>                
+    3       mv                       <missing>                <missing>                
+    4       ret                      <missing>                <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR_opt: 5 instructions
+      GlobalISel-O2: 2 instructions
+      SelectionDAG-O2: 2 instructions
+
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+Operation: llvm.sub, Variant: 0
+────────────────────────────────────────────────────────────────────────────────────────────────────
+
+  ✗ LEANMLIR_opt DIFFERS from GlobalISel-O2
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR_opt             GlobalISel-O2            
+    --------------------------------------------------------------------------------
+    0       mv                       sub                       ⚠️  DIFFERS
+    1       mv                       ret                       ⚠️  DIFFERS
+    2       sub                      <missing>                
+    3       mv                       <missing>                
+    4       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR_opt: 5 instructions
+      GlobalISel-O2: 2 instructions
+
+
+  ✗ LEANMLIR_opt DIFFERS from SelectionDAG-O2
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR_opt             SelectionDAG-O2          
+    --------------------------------------------------------------------------------
+    0       mv                       sub                       ⚠️  DIFFERS
+    1       mv                       ret                       ⚠️  DIFFERS
+    2       sub                      <missing>                
+    3       mv                       <missing>                
+    4       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR_opt: 5 instructions
+      SelectionDAG-O2: 2 instructions
+
+
+  Comprehensive comparison of all three:
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR_opt             GlobalISel-O2            SelectionDAG-O2          
+    --------------------------------------------------------------------------------
+    0       mv                       sub                      sub                       ⚠️  DIFFERS
+    1       mv                       ret                      ret                       ⚠️  DIFFERS
+    2       sub                      <missing>                <missing>                
+    3       mv                       <missing>                <missing>                
+    4       ret                      <missing>                <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR_opt: 5 instructions
+      GlobalISel-O2: 2 instructions
+      SelectionDAG-O2: 2 instructions
+
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+Operation: llvm.sub, Variant: 1
+────────────────────────────────────────────────────────────────────────────────────────────────────
+
+  ✗ LEANMLIR_opt DIFFERS from GlobalISel-O2
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR_opt             GlobalISel-O2            
+    --------------------------------------------------------------------------------
+    0       mv                       sub                       ⚠️  DIFFERS
+    1       mv                       ret                       ⚠️  DIFFERS
+    2       sub                      <missing>                
+    3       mv                       <missing>                
+    4       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR_opt: 5 instructions
+      GlobalISel-O2: 2 instructions
+
+
+  ✗ LEANMLIR_opt DIFFERS from SelectionDAG-O2
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR_opt             SelectionDAG-O2          
+    --------------------------------------------------------------------------------
+    0       mv                       sub                       ⚠️  DIFFERS
+    1       mv                       ret                       ⚠️  DIFFERS
+    2       sub                      <missing>                
+    3       mv                       <missing>                
+    4       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR_opt: 5 instructions
+      SelectionDAG-O2: 2 instructions
+
+
+  Comprehensive comparison of all three:
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR_opt             GlobalISel-O2            SelectionDAG-O2          
+    --------------------------------------------------------------------------------
+    0       mv                       sub                      sub                       ⚠️  DIFFERS
+    1       mv                       ret                      ret                       ⚠️  DIFFERS
+    2       sub                      <missing>                <missing>                
+    3       mv                       <missing>                <missing>                
+    4       ret                      <missing>                <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR_opt: 5 instructions
+      GlobalISel-O2: 2 instructions
+      SelectionDAG-O2: 2 instructions
+
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+Operation: llvm.sub, Variant: 2
+────────────────────────────────────────────────────────────────────────────────────────────────────
+
+  ✗ LEANMLIR_opt DIFFERS from GlobalISel-O2
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR_opt             GlobalISel-O2            
+    --------------------------------------------------------------------------------
+    0       mv                       sub                       ⚠️  DIFFERS
+    1       mv                       ret                       ⚠️  DIFFERS
+    2       sub                      <missing>                
+    3       mv                       <missing>                
+    4       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR_opt: 5 instructions
+      GlobalISel-O2: 2 instructions
+
+
+  ✗ LEANMLIR_opt DIFFERS from SelectionDAG-O2
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR_opt             SelectionDAG-O2          
+    --------------------------------------------------------------------------------
+    0       mv                       sub                       ⚠️  DIFFERS
+    1       mv                       ret                       ⚠️  DIFFERS
+    2       sub                      <missing>                
+    3       mv                       <missing>                
+    4       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR_opt: 5 instructions
+      SelectionDAG-O2: 2 instructions
+
+
+  Comprehensive comparison of all three:
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR_opt             GlobalISel-O2            SelectionDAG-O2          
+    --------------------------------------------------------------------------------
+    0       mv                       sub                      sub                       ⚠️  DIFFERS
+    1       mv                       ret                      ret                       ⚠️  DIFFERS
+    2       sub                      <missing>                <missing>                
+    3       mv                       <missing>                <missing>                
+    4       ret                      <missing>                <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR_opt: 5 instructions
+      GlobalISel-O2: 2 instructions
+      SelectionDAG-O2: 2 instructions
+
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+Operation: llvm.trunc, Variant: 0
+────────────────────────────────────────────────────────────────────────────────────────────────────
+
+  ✗ LEANMLIR_opt DIFFERS from GlobalISel-O2
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR_opt             GlobalISel-O2            
+    --------------------------------------------------------------------------------
+    0       mv                       ret                       ⚠️  DIFFERS
+    1       mv                       <missing>                
+    2       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR_opt: 3 instructions
+      GlobalISel-O2: 1 instructions
+
+
+  ✗ LEANMLIR_opt DIFFERS from SelectionDAG-O2
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR_opt             SelectionDAG-O2          
+    --------------------------------------------------------------------------------
+    0       mv                       ret                       ⚠️  DIFFERS
+    1       mv                       <missing>                
+    2       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR_opt: 3 instructions
+      SelectionDAG-O2: 1 instructions
+
+
+  Comprehensive comparison of all three:
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR_opt             GlobalISel-O2            SelectionDAG-O2          
+    --------------------------------------------------------------------------------
+    0       mv                       ret                      ret                       ⚠️  DIFFERS
+    1       mv                       <missing>                <missing>                
+    2       ret                      <missing>                <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR_opt: 3 instructions
+      GlobalISel-O2: 1 instructions
+      SelectionDAG-O2: 1 instructions
+
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+Operation: llvm.udiv, Variant: 0
+────────────────────────────────────────────────────────────────────────────────────────────────────
+
+  ✗ LEANMLIR_opt DIFFERS from GlobalISel-O2
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR_opt             GlobalISel-O2            
+    --------------------------------------------------------------------------------
+    0       mv                       divu                      ⚠️  DIFFERS
+    1       mv                       ret                       ⚠️  DIFFERS
+    2       divu                     <missing>                
+    3       mv                       <missing>                
+    4       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR_opt: 5 instructions
+      GlobalISel-O2: 2 instructions
+
+
+  ✗ LEANMLIR_opt DIFFERS from SelectionDAG-O2
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR_opt             SelectionDAG-O2          
+    --------------------------------------------------------------------------------
+    0       mv                       divu                      ⚠️  DIFFERS
+    1       mv                       ret                       ⚠️  DIFFERS
+    2       divu                     <missing>                
+    3       mv                       <missing>                
+    4       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR_opt: 5 instructions
+      SelectionDAG-O2: 2 instructions
+
+
+  Comprehensive comparison of all three:
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR_opt             GlobalISel-O2            SelectionDAG-O2          
+    --------------------------------------------------------------------------------
+    0       mv                       divu                     divu                      ⚠️  DIFFERS
+    1       mv                       ret                      ret                       ⚠️  DIFFERS
+    2       divu                     <missing>                <missing>                
+    3       mv                       <missing>                <missing>                
+    4       ret                      <missing>                <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR_opt: 5 instructions
+      GlobalISel-O2: 2 instructions
+      SelectionDAG-O2: 2 instructions
+
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+Operation: llvm.urem, Variant: 0
+────────────────────────────────────────────────────────────────────────────────────────────────────
+
+  ✗ LEANMLIR_opt DIFFERS from GlobalISel-O2
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR_opt             GlobalISel-O2            
+    --------------------------------------------------------------------------------
+    0       mv                       divu                      ⚠️  DIFFERS
+    1       mv                       ret                       ⚠️  DIFFERS
+    2       divu                     <missing>                
+    3       mv                       <missing>                
+    4       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR_opt: 5 instructions
+      GlobalISel-O2: 2 instructions
+
+
+  ✗ LEANMLIR_opt DIFFERS from SelectionDAG-O2
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR_opt             SelectionDAG-O2          
+    --------------------------------------------------------------------------------
+    0       mv                       divu                      ⚠️  DIFFERS
+    1       mv                       ret                       ⚠️  DIFFERS
+    2       divu                     <missing>                
+    3       mv                       <missing>                
+    4       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR_opt: 5 instructions
+      SelectionDAG-O2: 2 instructions
+
+
+  Comprehensive comparison of all three:
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR_opt             GlobalISel-O2            SelectionDAG-O2          
+    --------------------------------------------------------------------------------
+    0       mv                       divu                     divu                      ⚠️  DIFFERS
+    1       mv                       ret                      ret                       ⚠️  DIFFERS
+    2       divu                     <missing>                <missing>                
+    3       mv                       <missing>                <missing>                
+    4       ret                      <missing>                <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR_opt: 5 instructions
+      GlobalISel-O2: 2 instructions
+      SelectionDAG-O2: 2 instructions
+
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+Operation: llvm.xor, Variant: 0
+────────────────────────────────────────────────────────────────────────────────────────────────────
+
+  ✗ LEANMLIR_opt DIFFERS from GlobalISel-O2
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR_opt             GlobalISel-O2            
+    --------------------------------------------------------------------------------
+    0       mv                       xor                       ⚠️  DIFFERS
+    1       mv                       ret                       ⚠️  DIFFERS
+    2       xor                      <missing>                
+    3       mv                       <missing>                
+    4       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR_opt: 5 instructions
+      GlobalISel-O2: 2 instructions
+
+
+  ✗ LEANMLIR_opt DIFFERS from SelectionDAG-O2
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR_opt             SelectionDAG-O2          
+    --------------------------------------------------------------------------------
+    0       mv                       xor                       ⚠️  DIFFERS
+    1       mv                       ret                       ⚠️  DIFFERS
+    2       xor                      <missing>                
+    3       mv                       <missing>                
+    4       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR_opt: 5 instructions
+      SelectionDAG-O2: 2 instructions
+
+
+  Comprehensive comparison of all three:
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR_opt             GlobalISel-O2            SelectionDAG-O2          
+    --------------------------------------------------------------------------------
+    0       mv                       xor                      xor                       ⚠️  DIFFERS
+    1       mv                       ret                      ret                       ⚠️  DIFFERS
+    2       xor                      <missing>                <missing>                
+    3       mv                       <missing>                <missing>                
+    4       ret                      <missing>                <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR_opt: 5 instructions
+      GlobalISel-O2: 2 instructions
+      SelectionDAG-O2: 2 instructions
+
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+Operation: llvm.zext, Variant: 0
+────────────────────────────────────────────────────────────────────────────────────────────────────
+
+  ✗ LEANMLIR_opt DIFFERS from GlobalISel-O2
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR_opt             GlobalISel-O2            
+    --------------------------------------------------------------------------------
+    0       mv                       andi                      ⚠️  DIFFERS
+    1       andi                     ret                       ⚠️  DIFFERS
+    2       mv                       <missing>                
+    3       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR_opt: 4 instructions
+      GlobalISel-O2: 2 instructions
+
+
+  ✗ LEANMLIR_opt DIFFERS from SelectionDAG-O2
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR_opt             SelectionDAG-O2          
+    --------------------------------------------------------------------------------
+    0       mv                       andi                      ⚠️  DIFFERS
+    1       andi                     ret                       ⚠️  DIFFERS
+    2       mv                       <missing>                
+    3       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR_opt: 4 instructions
+      SelectionDAG-O2: 2 instructions
+
+
+  Comprehensive comparison of all three:
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR_opt             GlobalISel-O2            SelectionDAG-O2          
+    --------------------------------------------------------------------------------
+    0       mv                       andi                     andi                      ⚠️  DIFFERS
+    1       andi                     ret                      ret                       ⚠️  DIFFERS
+    2       mv                       <missing>                <missing>                
+    3       ret                      <missing>                <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR_opt: 4 instructions
+      GlobalISel-O2: 2 instructions
+      SelectionDAG-O2: 2 instructions
+
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+Operation: llvm.zext, Variant: 1
+────────────────────────────────────────────────────────────────────────────────────────────────────
+
+  ✗ LEANMLIR_opt DIFFERS from GlobalISel-O2
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR_opt             GlobalISel-O2            
+    --------------------------------------------------------------------------------
+    0       mv                       andi                      ⚠️  DIFFERS
+    1       andi                     ret                       ⚠️  DIFFERS
+    2       mv                       <missing>                
+    3       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR_opt: 4 instructions
+      GlobalISel-O2: 2 instructions
+
+
+  ✗ LEANMLIR_opt DIFFERS from SelectionDAG-O2
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR_opt             SelectionDAG-O2          
+    --------------------------------------------------------------------------------
+    0       mv                       andi                      ⚠️  DIFFERS
+    1       andi                     ret                       ⚠️  DIFFERS
+    2       mv                       <missing>                
+    3       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR_opt: 4 instructions
+      SelectionDAG-O2: 2 instructions
+
+
+  Comprehensive comparison of all three:
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR_opt             GlobalISel-O2            SelectionDAG-O2          
+    --------------------------------------------------------------------------------
+    0       mv                       andi                     andi                      ⚠️  DIFFERS
+    1       andi                     ret                      ret                       ⚠️  DIFFERS
+    2       mv                       <missing>                <missing>                
+    3       ret                      <missing>                <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR_opt: 4 instructions
+      GlobalISel-O2: 2 instructions
+      SelectionDAG-O2: 2 instructions
+
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+Operation: llvm.zext, Variant: 2
+────────────────────────────────────────────────────────────────────────────────────────────────────
+
+  ✗ LEANMLIR_opt DIFFERS from GlobalISel-O2
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR_opt             GlobalISel-O2            
+    --------------------------------------------------------------------------------
+    0       mv                       zext.h                    ⚠️  DIFFERS
+    1       zext.h                   ret                       ⚠️  DIFFERS
+    2       mv                       <missing>                
+    3       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR_opt: 4 instructions
+      GlobalISel-O2: 2 instructions
+
+
+  ✗ LEANMLIR_opt DIFFERS from SelectionDAG-O2
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR_opt             SelectionDAG-O2          
+    --------------------------------------------------------------------------------
+    0       mv                       zext.h                    ⚠️  DIFFERS
+    1       zext.h                   ret                       ⚠️  DIFFERS
+    2       mv                       <missing>                
+    3       ret                      <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR_opt: 4 instructions
+      SelectionDAG-O2: 2 instructions
+
+
+  Comprehensive comparison of all three:
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR_opt             GlobalISel-O2            SelectionDAG-O2          
+    --------------------------------------------------------------------------------
+    0       mv                       zext.h                   zext.h                    ⚠️  DIFFERS
+    1       zext.h                   ret                      ret                       ⚠️  DIFFERS
+    2       mv                       <missing>                <missing>                
+    3       ret                      <missing>                <missing>                
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR_opt: 4 instructions
+      GlobalISel-O2: 2 instructions
+      SelectionDAG-O2: 2 instructions
+
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+Operation: llvm.zext, Variant: 3
+────────────────────────────────────────────────────────────────────────────────────────────────────
+
+  ✗ LEANMLIR_opt DIFFERS from GlobalISel-O2
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR_opt             GlobalISel-O2            
+    --------------------------------------------------------------------------------
+    0       <missing>                zext.w                   
+    1       <missing>                ret                      
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR_opt: 0 instructions
+      GlobalISel-O2: 2 instructions
+
+
+  ✗ LEANMLIR_opt DIFFERS from SelectionDAG-O2
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR_opt             SelectionDAG-O2          
+    --------------------------------------------------------------------------------
+    0       <missing>                zext.w                   
+    1       <missing>                ret                      
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR_opt: 0 instructions
+      SelectionDAG-O2: 2 instructions
+
+
+  Comprehensive comparison of all three:
+
+    Instruction-by-instruction comparison:
+    --------------------------------------------------------------------------------
+    Index   LEANMLIR_opt             GlobalISel-O2            SelectionDAG-O2          
+    --------------------------------------------------------------------------------
+    0       <missing>                zext.w                   zext.w                   
+    1       <missing>                ret                      ret                      
+    --------------------------------------------------------------------------------
+
+    Summary:
+      LEANMLIR_opt: 0 instructions
+      GlobalISel-O2: 2 instructions
+      SelectionDAG-O2: 2 instructions
+
+
+====================================================================================================
+END OF ALL COMPARISONS
+====================================================================================================
+

--- a/SSA/Projects/LLVMRiscV/Evaluation/compare-lowering-patterns/isolated_instructions/llvm_add.mlir
+++ b/SSA/Projects/LLVMRiscV/Evaluation/compare-lowering-patterns/isolated_instructions/llvm_add.mlir
@@ -1,0 +1,21 @@
+// llvm.add
+module {
+  func.func @main(%arg0: i64, %arg1: i64) -> i64 {
+    %0 = llvm.add %arg0, %arg1 overflow<nsw> : i64
+    return %0 : i64
+  }
+}
+// -----
+module {
+  func.func @main(%arg0: i64, %arg1: i64) -> i64 {
+    %0 = llvm.add %arg0, %arg1 overflow<nuw> : i64
+    return %0 : i64
+  }
+}
+// -----
+module {
+  func.func @main(%arg0: i64, %arg1: i64) -> i64 {
+    %0 = llvm.add %arg0, %arg1 overflow<nsw,nuw> : i64
+    return %0 : i64
+  }
+}

--- a/SSA/Projects/LLVMRiscV/Evaluation/compare-lowering-patterns/isolated_instructions/llvm_and.mlir
+++ b/SSA/Projects/LLVMRiscV/Evaluation/compare-lowering-patterns/isolated_instructions/llvm_and.mlir
@@ -1,0 +1,7 @@
+// llvm.and
+module {
+  func.func @main(%arg0: i64, %arg1: i64) -> i64 {
+    %0 = llvm.and %arg0, %arg1 : i64
+    return %0 : i64
+  }
+}

--- a/SSA/Projects/LLVMRiscV/Evaluation/compare-lowering-patterns/isolated_instructions/llvm_ashr.mlir
+++ b/SSA/Projects/LLVMRiscV/Evaluation/compare-lowering-patterns/isolated_instructions/llvm_ashr.mlir
@@ -1,0 +1,7 @@
+// llvm.ashr
+module {
+  func.func @main(%arg0: i64, %arg1: i64) -> i64 {
+    %0 = llvm.ashr %arg0, %arg1 : i64
+    return %0 : i64
+  }
+}

--- a/SSA/Projects/LLVMRiscV/Evaluation/compare-lowering-patterns/isolated_instructions/llvm_icmp.mlir
+++ b/SSA/Projects/LLVMRiscV/Evaluation/compare-lowering-patterns/isolated_instructions/llvm_icmp.mlir
@@ -1,0 +1,70 @@
+// llvm.icmp
+module {
+  func.func @main(%arg0: i64, %arg1: i64) -> i1 {
+    %0 = llvm.icmp "ugt" %arg0, %arg1  : i64
+    return %0 : i1
+  }
+}
+// -----
+module {
+  func.func @main(%arg0: i64, %arg1: i64) -> i1 {
+    %0 = llvm.icmp "uge" %arg0, %arg1  : i64
+    return %0 : i1
+  }
+}
+// -----
+module {
+  func.func @main(%arg0: i64, %arg1: i64) -> i1 {
+    %0 = llvm.icmp "ult" %arg0, %arg1  : i64
+    return %0 : i1
+  }
+}
+// -----
+module {
+  func.func @main(%arg0: i64, %arg1: i64) -> i1 {
+    %0 = llvm.icmp "ule" %arg0, %arg1  : i64
+    return %0 : i1
+  }
+}
+// -----
+module {
+  func.func @main(%arg0: i64, %arg1: i64) -> i1 {
+    %0 = llvm.icmp "sgt" %arg0, %arg1  : i64
+    return %0 : i1
+  }
+}
+// -----
+module {
+  func.func @main(%arg0: i64, %arg1: i64) -> i1 {
+    %0 = llvm.icmp "sge" %arg0, %arg1  : i64
+    return %0 : i1
+  }
+}
+// -----
+module {
+  func.func @main(%arg0: i64, %arg1: i64) -> i1 {
+    %0 = llvm.icmp "slt" %arg0, %arg1  : i64
+    return %0 : i1
+  }
+}
+// -----
+module {
+  func.func @main(%arg0: i64, %arg1: i64) -> i1 {
+    %0 = llvm.icmp "sle" %arg0, %arg1  : i64
+    return %0 : i1
+  }
+}
+// -----
+module {
+  func.func @main(%arg0: i64, %arg1: i64) -> i1 {
+    %0 = llvm.icmp "eq" %arg0, %arg1  : i64
+    return %0 : i1
+  }
+}
+// -----
+module {
+  func.func @main(%arg0: i64, %arg1: i64) -> i1 {
+    %0 = llvm.icmp "neq" %arg0, %arg1  : i64
+    return %0 : i1
+  }
+}

--- a/SSA/Projects/LLVMRiscV/Evaluation/compare-lowering-patterns/isolated_instructions/llvm_mul.mlir
+++ b/SSA/Projects/LLVMRiscV/Evaluation/compare-lowering-patterns/isolated_instructions/llvm_mul.mlir
@@ -1,0 +1,21 @@
+// llvm.mul
+module {
+  func.func @main(%arg0: i64, %arg1: i64) -> i64 {
+    %0 = llvm.mul %arg0, %arg1 overflow<nsw>  : i64
+    return %0 : i64
+  }
+}
+// -----
+module {
+  func.func @main(%arg0: i64, %arg1: i64) -> i64 {
+    %0 = llvm.mul %arg0, %arg1 overflow<nuw>  : i64
+    return %0 : i64
+  }
+}
+// -----
+module {
+  func.func @main(%arg0: i64, %arg1: i64) -> i64 {
+    %0 = llvm.mul %arg0, %arg1 overflow<nsw,nuw>  : i64
+    return %0 : i64
+  }
+}

--- a/SSA/Projects/LLVMRiscV/Evaluation/compare-lowering-patterns/isolated_instructions/llvm_or.mlir
+++ b/SSA/Projects/LLVMRiscV/Evaluation/compare-lowering-patterns/isolated_instructions/llvm_or.mlir
@@ -1,0 +1,7 @@
+// llvm.or
+module {
+  func.func @main(%arg0: i64, %arg1: i64) -> i64 {
+    %0 = llvm.or %arg0, %arg1 : i64
+    return %0 : i64
+  }
+}

--- a/SSA/Projects/LLVMRiscV/Evaluation/compare-lowering-patterns/isolated_instructions/llvm_rem.mlir
+++ b/SSA/Projects/LLVMRiscV/Evaluation/compare-lowering-patterns/isolated_instructions/llvm_rem.mlir
@@ -1,0 +1,7 @@
+// llvm.rem
+module {
+  func.func @main(%arg0: i64, %arg1: i64) -> i64 {
+    %0 = llvm.srem %arg0, %arg1 : i64
+    return %0 : i64
+  }
+}

--- a/SSA/Projects/LLVMRiscV/Evaluation/compare-lowering-patterns/isolated_instructions/llvm_sdiv.mlir
+++ b/SSA/Projects/LLVMRiscV/Evaluation/compare-lowering-patterns/isolated_instructions/llvm_sdiv.mlir
@@ -1,0 +1,7 @@
+// llvm.sdiv
+module {
+  func.func @main(%arg0: i64, %arg1: i64) -> i64 {
+    %0 = llvm.sdiv %arg0, %arg1 : i64
+    return %0 : i64
+  }
+}

--- a/SSA/Projects/LLVMRiscV/Evaluation/compare-lowering-patterns/isolated_instructions/llvm_select.mlir
+++ b/SSA/Projects/LLVMRiscV/Evaluation/compare-lowering-patterns/isolated_instructions/llvm_select.mlir
@@ -1,0 +1,7 @@
+// llvm.select
+module {
+  func.func @main(%cond : i1, %arg0: i64, %arg1: i64) -> i64 {
+    %0 = llvm.select %cond, %arg0, %arg1 : i1, i64
+    return %0 : i64
+  }
+}

--- a/SSA/Projects/LLVMRiscV/Evaluation/compare-lowering-patterns/isolated_instructions/llvm_sext.mlir
+++ b/SSA/Projects/LLVMRiscV/Evaluation/compare-lowering-patterns/isolated_instructions/llvm_sext.mlir
@@ -1,0 +1,28 @@
+// llvm.sext
+module {
+  func.func @main(%arg0: i1) -> i64 {
+    %0 = llvm.sext %arg0 : i1 to i64
+    return %0 : i64
+  }
+}
+// -----
+module {
+  func.func @main(%arg0: i8) -> i64 {
+    %0 = llvm.sext %arg0 : i8 to i64
+    return %0 : i64
+  }
+}
+// -----
+module {
+  func.func @main(%arg0: i16) -> i64 {
+    %0 = llvm.sext %arg0 : i16 to i64
+    return %0 : i64
+  }
+}
+// -----
+module {
+  func.func @main(%arg0: i32) -> i64 {
+    %0 = llvm.sext %arg0 : i32 to i64
+    return %0 : i64
+  }
+}

--- a/SSA/Projects/LLVMRiscV/Evaluation/compare-lowering-patterns/isolated_instructions/llvm_shl.mlir
+++ b/SSA/Projects/LLVMRiscV/Evaluation/compare-lowering-patterns/isolated_instructions/llvm_shl.mlir
@@ -1,0 +1,28 @@
+// llvm.shl
+module {
+  func.func @main(%arg0: i64, %arg1: i64) -> i64 {
+    %0 = llvm.shl %arg0, %arg1 : i64
+    return %0 : i64
+  }
+}
+// -----
+module {
+  func.func @main(%arg0: i64, %arg1: i64) -> i64 {
+    %0 = llvm.shl %arg0, %arg1 overflow<nsw> : i64
+    return %0 : i64
+  }
+}
+// -----
+module {
+  func.func @main(%arg0: i64, %arg1: i64) -> i64 {
+    %0 = llvm.shl %arg0, %arg1 overflow<nuw> : i64
+    return %0 : i64
+  }
+}
+// -----
+module {
+  func.func @main(%arg0: i64, %arg1: i64) -> i64 {
+    %0 = llvm.shl %arg0, %arg1 overflow<nsw,nuw> : i64
+    return %0 : i64
+  }
+}

--- a/SSA/Projects/LLVMRiscV/Evaluation/compare-lowering-patterns/isolated_instructions/llvm_srl.mlir
+++ b/SSA/Projects/LLVMRiscV/Evaluation/compare-lowering-patterns/isolated_instructions/llvm_srl.mlir
@@ -1,0 +1,7 @@
+// llvm.srl
+module {
+  func.func @main(%arg0: i64, %arg1: i64) -> i64 {
+    %0 = llvm.lshr %arg0, %arg1 : i64
+    return %0 : i64
+  }
+}

--- a/SSA/Projects/LLVMRiscV/Evaluation/compare-lowering-patterns/isolated_instructions/llvm_sub.mlir
+++ b/SSA/Projects/LLVMRiscV/Evaluation/compare-lowering-patterns/isolated_instructions/llvm_sub.mlir
@@ -1,0 +1,21 @@
+// llvm.sub
+module {
+  func.func @main(%arg0: i64, %arg1: i64) -> i64 {
+    %0 = llvm.sub %arg0, %arg1 overflow<nsw> : i64
+    return %0 : i64
+  }
+}
+// -----
+module {
+  func.func @main(%arg0: i64, %arg1: i64) -> i64 {
+    %0 = llvm.sub %arg0, %arg1 overflow<nuw> : i64
+    return %0 : i64
+  }
+}
+// -----
+module {
+  func.func @main(%arg0: i64, %arg1: i64) -> i64 {
+    %0 = llvm.sub %arg0, %arg1 overflow<nsw,nuw> : i64
+    return %0 : i64
+  }
+}

--- a/SSA/Projects/LLVMRiscV/Evaluation/compare-lowering-patterns/isolated_instructions/llvm_trunc.mlir
+++ b/SSA/Projects/LLVMRiscV/Evaluation/compare-lowering-patterns/isolated_instructions/llvm_trunc.mlir
@@ -1,0 +1,7 @@
+// llvm.trunc
+module {
+  func.func @main(%arg0: i64) -> i32 {
+    %0 = llvm.trunc %arg0 : i64 to i32
+    return %0 : i32
+  }
+}

--- a/SSA/Projects/LLVMRiscV/Evaluation/compare-lowering-patterns/isolated_instructions/llvm_udiv.mlir
+++ b/SSA/Projects/LLVMRiscV/Evaluation/compare-lowering-patterns/isolated_instructions/llvm_udiv.mlir
@@ -1,0 +1,7 @@
+// llvm.udiv
+module {
+  func.func @main(%arg0: i64, %arg1: i64) -> i64 {
+    %0 = llvm.udiv %arg0, %arg1 : i64
+    return %0 : i64
+  }
+}

--- a/SSA/Projects/LLVMRiscV/Evaluation/compare-lowering-patterns/isolated_instructions/llvm_urem.mlir
+++ b/SSA/Projects/LLVMRiscV/Evaluation/compare-lowering-patterns/isolated_instructions/llvm_urem.mlir
@@ -1,0 +1,7 @@
+// llvm.urem
+module {
+  func.func @main(%arg0: i64, %arg1: i64) -> i64 {
+    %0 = llvm.udiv %arg0, %arg1 : i64
+    return %0 : i64
+  }
+}

--- a/SSA/Projects/LLVMRiscV/Evaluation/compare-lowering-patterns/isolated_instructions/llvm_xor.mlir
+++ b/SSA/Projects/LLVMRiscV/Evaluation/compare-lowering-patterns/isolated_instructions/llvm_xor.mlir
@@ -1,0 +1,7 @@
+// llvm.xor
+module {
+  func.func @main(%arg0: i64, %arg1: i64) -> i64 {
+    %0 = llvm.xor %arg0, %arg1 : i64
+    return %0 : i64
+  }
+}

--- a/SSA/Projects/LLVMRiscV/Evaluation/compare-lowering-patterns/isolated_instructions/llvm_zext.mlir
+++ b/SSA/Projects/LLVMRiscV/Evaluation/compare-lowering-patterns/isolated_instructions/llvm_zext.mlir
@@ -1,0 +1,28 @@
+// llvm.zext
+module {
+  func.func @main(%arg0: i1) -> i64 {
+    %0 = llvm.zext %arg0 : i1 to i64
+    return %0 : i64
+  }
+}
+// -----
+module {
+  func.func @main(%arg0: i8) -> i64 {
+    %0 = llvm.zext %arg0 : i8 to i64
+    return %0 : i64
+  }
+}
+// -----
+module {
+  func.func @main(%arg0: i16) -> i64 {
+    %0 = llvm.zext %arg0 : i16 to i64
+    return %0 : i64
+  }
+}
+// -----
+module {
+  func.func @main(%arg0: i32) -> i64 {
+    %0 = llvm.zext %arg0 : i32 to i64
+    return %0 : i64
+  }
+}

--- a/SSA/Projects/LLVMRiscV/Evaluation/compare-lowering-patterns/run_comparison.sh
+++ b/SSA/Projects/LLVMRiscV/Evaluation/compare-lowering-patterns/run_comparison.sh
@@ -1,0 +1,5 @@
+#! /bin/bash
+export PYTHONPATH=$PYTHONPATH:~/lean-mlir
+python3 ../benchmarks/generate.py --num 10 --jobs 30 --llvm_opt all -l
+python3 ../mca-analysis/run_mca.py 
+python3 compare_lowerings.py


### PR DESCRIPTION
This PR adds a new script to compare instruction selection patterns between SelectionDAG, GlobalISel and Lean-MLIR.
