### PR TITLE
feat: add SelectionDAG optimizations patterns

### DIFF
--- a/SSA/Projects/InstCombine/LLVM/Opt.lean
+++ b/SSA/Projects/InstCombine/LLVM/Opt.lean
@@ -40,6 +40,9 @@ def runMainCmd (args : Cli.Parsed) : IO UInt32 := do
   if args.hasFlag "passriscv64_optimized" then -- lowering pass to a RISC-V 64 SSA-assembly IR
     let code ← passriscv64_optimized fileName
     return code
+  if args.hasFlag "passriscv64_selectiondag" then -- lowering pass to a RISC-V 64 SSA-assembly IR applying optimizations from SelectionDAG
+    let code ← passriscv64_selectiondag fileName
+    return code
   else
     let code ← wellformed fileName
     return code
@@ -52,6 +55,7 @@ def mainCmd := `[Cli|
       passriscv64; "Lowering pass to a RISC-V 64 SSA-assembly IR"
       riscv; "Allows to parse a file as a RISC-V 64 SSA-assembly IR"
       passriscv64_optimized; "Allows to parse a file as a RISC-V 64 SSA-assembly IR"
+      passriscv64_selectiondag; "Allows to parse a file as a RISC-V 64 SSA-assembly IR using SelectionDAG optimization patterns"
     ARGS:
       file: String; "Input filename"
     ]

--- a/SSA/Projects/InstCombine/LLVM/Opt.lean
+++ b/SSA/Projects/InstCombine/LLVM/Opt.lean
@@ -40,7 +40,7 @@ def runMainCmd (args : Cli.Parsed) : IO UInt32 := do
   if args.hasFlag "passriscv64_optimized" then -- lowering pass to a RISC-V 64 SSA-assembly IR
     let code ← passriscv64_optimized fileName
     return code
-  if args.hasFlag "passriscv64_selectiondag" then -- lowering pass to a RISC-V 64 SSA-assembly IR applying optimizations from SelectionDAG
+  if args.hasFlag "passriscv64_selectiondag" then -- lowering pass to RISC-V 64 SSA-assembly IR applying optimizations from SelectionDAG
     let code ← passriscv64_selectiondag fileName
     return code
   else
@@ -55,7 +55,7 @@ def mainCmd := `[Cli|
       passriscv64; "Lowering pass to a RISC-V 64 SSA-assembly IR"
       riscv; "Allows to parse a file as a RISC-V 64 SSA-assembly IR"
       passriscv64_optimized; "Allows to parse a file as a RISC-V 64 SSA-assembly IR"
-      passriscv64_selectiondag; "Allows to parse a file as a RISC-V 64 SSA-assembly IR using SelectionDAG optimization patterns"
+      passriscv64_selectiondag; "Lowering pass to RISC-V 64 SSA-assembly IR applying optimizations from SelectionDAG"
     ARGS:
       file: String; "Input filename"
     ]

--- a/SSA/Projects/LLVMRiscV/ParseAndTransform.lean
+++ b/SSA/Projects/LLVMRiscV/ParseAndTransform.lean
@@ -62,3 +62,29 @@ def passriscv64_optimized (fileName : String) : IO UInt32 := do
       | _ =>
       IO.println s!" debug: WRONG EFFECT KIND : expected pure program "
       return 1
+
+/-- `passriscv64_selectiondag` parses a `Com` from the file with name `fileName` as a `Com` of type
+  `LLVMAndRiscV`. Next, it calls the optimized instruction selection lowering function
+  `selectionPipeWithSelectionDAG` on the parsed `Com` and prints it to standart output.
+  This pass applies the optimization patterns from `SelectionDAG` on both LLVM and RISCV.
+  If any of the steps fails, we print an error message and return exit code 1. -/
+def passriscv64_selectiondag (fileName : String) : IO UInt32 := do
+    let icom? ← Com.parseFromFile LLVMPlusRiscV fileName
+    match icom? with
+    | none => return 1
+    | some (Sigma.mk _Γ ⟨eff, ⟨retTy, c⟩⟩) =>
+      match eff with
+      | EffectKind.pure =>
+        match retTy with
+        | [Ty.llvm (.bitvec _w)]  =>
+          /- calls to the optimized instruction selector defined in `InstructionLowering`,
+          `true` indicates pseudo variable lowering, `fuel` is 150 -/
+          let lowered := selectionPipeWithSelectionDAG 150 c true
+          IO.println <| lowered.printModule
+          return 0
+        | _ =>
+        IO.println s!" debug: WRONG RETURN TYPE : expected Ty.llvm (Ty.bitvec 64) "
+        return 1
+      | _ =>
+      IO.println s!" debug: WRONG EFFECT KIND : expected pure program "
+      return 1

--- a/SSA/Projects/LLVMRiscV/Pipeline/InstructionLowering.lean
+++ b/SSA/Projects/LLVMRiscV/Pipeline/InstructionLowering.lean
@@ -22,6 +22,7 @@ import SSA.Projects.LLVMRiscV.Pipeline.select
 import SSA.Projects.LLVMRiscV.Pipeline.pseudo
 import SSA.Projects.LLVMRiscV.Pipeline.freeze
 import SSA.Projects.LLVMRiscV.Pipeline.Combiners
+import SSA.Projects.LLVMRiscV.Pipeline.SelectionDAG
 
 import LeanMLIR.Transforms.DCE
 import LeanMLIR.Transforms.CSE
@@ -191,4 +192,42 @@ def selectionPipeFuelWithCSEWithOpt {Γl : List LLVMPlusRiscV.Ty} (fuel : Nat) (
   let optimize_final_2 := multiRewritePeephole 100
     GLobalISelPostLegalizerCombiner optimize_final_1;
   let dce_final := (DCE.repeatDce optimize_final_2).val
+  dce_final
+
+/--
+  Run the instruction selector pipeline with optimizations, resulting in the following pipeline:
+  - DCE
+  - Optimizations from SelectionDAG (on LLVM)
+  - lowering instructions in `rewritingPatterns1`
+  - lowering instructions in `rewritingPatterns0`
+  - DCE (to remove LLVM instructions)
+  - remove casting operations (`reconcile_casts`)
+  - DCE (dead code due to casting removal)
+  - CSE
+  - Optimizations from SelectionDAG (on RISCV assembly)
+-/
+def selectionPipeWithSelectionDAG {Γl : List LLVMPlusRiscV.Ty} (fuel : Nat) (prog : Com LLVMPlusRiscV
+    (Ctxt.ofList Γl) .pure (.llvm (.bitvec w))) (pseudo : Bool):=
+  let rmInitialDeadCode :=  (DCE.repeatDce prog).val;
+  let rmInitialDeadCode :=
+    if pseudo then
+      multiRewritePeephole fuel pseudo_match rmInitialDeadCode
+    else
+      rmInitialDeadCode
+  let optimize_initial := multiRewritePeephole fuel
+    SelectionDAGCombiner rmInitialDeadCode;
+  let loweredConst := multiRewritePeephole fuel
+    const_match optimize_initial;
+  let lowerPart1 := multiRewritePeephole fuel
+    rewritingPatterns1  loweredConst;
+  let lowerPart2 := multiRewritePeephole fuel
+    rewritingPatterns0 lowerPart1;
+  let postLoweringDCE := (DCE.repeatDce lowerPart2).val;
+  let postReconcileCast := multiRewritePeephole fuel (reconcile_cast_pass) postLoweringDCE;
+  let remove_dead_cast := (DCE.repeatDce postReconcileCast).val;
+  let optimize_eq_cast := (CSE.cse' remove_dead_cast).val;
+  let out := (DCE.repeatDce optimize_eq_cast).val;
+  let optimize_final := multiRewritePeephole 100
+    SelectionDAGCombiner out;
+  let dce_final := (DCE.repeatDce optimize_final).val
   dce_final

--- a/SSA/Projects/LLVMRiscV/Pipeline/SelectionDAG.lean
+++ b/SSA/Projects/LLVMRiscV/Pipeline/SelectionDAG.lean
@@ -1,0 +1,957 @@
+import SSA.Projects.LLVMRiscV.PeepholeRefine
+import SSA.Projects.LLVMRiscV.Simpproc
+import SSA.Projects.RISCV64.Tactic.SimpRiscV
+import SSA.Projects.LLVMRiscV.Pipeline.mkRewrite
+import SSA.Projects.LLVMRiscV.Pipeline.ConstantMatching
+
+open LLVMRiscV
+
+/- This file implements `DAGCombiner` patterns extracted from the LLVM Risc-V backend.
+  First, we implement the Lean structure that implements the rewrite patterns and then we implement
+  optimizations for LLVM IR and RISC-V.
+  In particular, we implement the patterns supported by LLVM's `GlobalIsel` for RISC-V.
+  Because `GlobalIsel` is hybrid, some of these patterns regard generic IR,
+  while some are target-dependent.
+-/
+
+@[simp_riscv] lemma toType_bv : TyDenote.toType (Ty.riscv (.bv)) = BitVec 64 := rfl
+@[simp_riscv] lemma id_eq1 {α : Type} (x y : α) :  @Eq (Id α) x y = (x = y):= by simp only
+
+structure RISCVPeepholeRewrite (Γ : List Ty) where
+  lhs : Com LLVMPlusRiscV Γ .pure [Ty.riscv .bv]
+  rhs : Com LLVMPlusRiscV Γ .pure [Ty.riscv .bv]
+  correct : lhs.denote = rhs.denote := by simp_lowering <;> bv_decide
+
+def RISCVPeepholeRewriteToRiscvPeephole (self : RISCVPeepholeRewrite Γ) :
+    PeepholeRewrite LLVMPlusRiscV Γ [Ty.riscv .bv] where
+  lhs := self.lhs
+  rhs := self.rhs
+  correct := self.correct
+
+/-! ### visitADD -/
+
+/-
+  (add x, 0) -> x
+-/
+def visitADD_0 : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64)] where
+  lhs := [LV| {
+    ^entry (%x: i64):
+      %c = llvm.mlir.constant (0) : i64
+      %0 = llvm.add  %x, %c : i64
+      llvm.return %0 : i64
+  }]
+  rhs := [LV| {
+    ^entry (%x: i64):
+      llvm.return %x : i64
+  }]
+
+/-
+  add (sext i1 X), 1 -> zext (not i1 X)
+-/
+def visitADD_sameop : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 1)] where
+  lhs := [LV| {
+    ^entry (%x: i1):
+      %c = llvm.mlir.constant (1) : i64
+      %0 = llvm.sext %x : i1 to i64
+      %1 = llvm.add %0, %c : i64
+      llvm.return %1 : i64
+  }]
+  rhs := [LV| {
+    ^entry (%x: i1):
+      %0 = llvm.not %x : i1
+      %1 = llvm.zext %0 : i1 to i64
+      llvm.return %1 : i64
+  }]
+
+/-
+  (and x, -1) -> x,
+-/
+def visitADD_minus1 : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64)] where
+  lhs := [LV| {
+    ^entry (%x: i64):
+      %c = llvm.mlir.constant (-1) : i64
+      %0 = llvm.and  %x, %c : i64
+      llvm.return %0 : i64
+  }]
+  rhs := [LV| {
+    ^entry (%x: i64):
+      llvm.return %x : i64
+  }]
+
+/-
+Test the rewrite:
+  fold ((0-A)+B) -> B-A
+-/
+def ZeroMinusAPlusB : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
+  lhs := [LV| {
+    ^entry (%a: i64, %b: i64):
+      %0 = llvm.mlir.constant (0) : i64
+      %1 = llvm.sub %0, %a : i64
+      %2 = llvm.add %1, %b : i64
+      llvm.return %2 : i64
+  }]
+  rhs := [LV| {
+    ^entry (%a: i64, %b: i64):
+      %0 = llvm.sub %b, %a : i64
+      llvm.return %0 : i64
+  }]
+
+/-
+Test the rewrite:
+  fold (A+(0-B)) -> A-B
+-/
+def APlusZeroMinusB : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
+  lhs := [LV| {
+    ^entry (%a: i64, %b: i64):
+      %0 = llvm.mlir.constant (0) : i64
+      %1 = llvm.sub %0, %b : i64
+      %2 = llvm.add %a, %1 : i64
+      llvm.return %2 : i64
+  }]
+  rhs := [LV| {
+    ^entry (%a: i64, %b: i64):
+      %0 = llvm.sub %a, %b : i64
+      llvm.return %0 : i64
+  }]
+
+/-
+Test the rewrite:
+ fold (A+(B-A)) -> B
+-/
+def APlusBMinusA : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
+  lhs := [LV| {
+    ^entry (%a: i64, %b: i64):
+      %0 = llvm.sub %b, %a : i64
+      %1 = llvm.add %a, %0 : i64
+      llvm.return %1 : i64
+  }]
+  rhs := [LV| {
+    ^entry (%a: i64, %b: i64):
+      llvm.return %b : i64
+  }]
+
+/-
+Test the rewrite:
+ fold ((B-A)+A) -> B
+-/
+def BMinusAPlusA : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
+  lhs := [LV| {
+    ^entry (%a: i64, %b: i64):
+      %0 = llvm.sub %b, %a : i64
+      %1 = llvm.add %0, %a : i64
+      llvm.return %1 : i64
+  }]
+  rhs := [LV| {
+    ^entry (%a: i64, %b: i64):
+      llvm.return %b : i64
+  }]
+
+/-
+Test the rewrite:
+ fold ((A-B)+(C-A)) -> (C-B)
+-/
+def AMinusBPlusCMinusA : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
+  lhs := [LV| {
+    ^entry (%a: i64, %b: i64, %c: i64):
+      %0 = llvm.sub %a, %b : i64
+      %1 = llvm.sub %c, %a : i64
+      %2 = llvm.add %0, %1 : i64
+      llvm.return %2 : i64
+  }]
+  rhs := [LV| {
+    ^entry (%a: i64, %b: i64, %c: i64):
+      %0 = llvm.sub %c, %b : i64
+      llvm.return %0 : i64
+  }]
+
+/-
+Test the rewrite:
+ fold ((A-B)+(B-C)) -> (A-C)
+-/
+def AMinusBPlusBMinusC : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
+  lhs := [LV| {
+    ^entry (%a: i64, %b: i64, %c: i64):
+      %0 = llvm.sub %a, %b : i64
+      %1 = llvm.sub %b, %c : i64
+      %2 = llvm.add %0, %1 : i64
+      llvm.return %2 : i64
+  }]
+  rhs := [LV| {
+    ^entry (%a: i64, %b: i64, %c: i64):
+      %0 = llvm.sub %a, %c : i64
+      llvm.return %0 : i64
+  }]
+
+/-
+Test the rewrite:
+ fold (A+(B-(A+C))) -> (B-C)
+-/
+def APlusBMinusAPlusC : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
+  lhs := [LV| {
+    ^entry (%a: i64, %b: i64, %c: i64):
+      %0 = llvm.add %a, %c : i64
+      %1 = llvm.sub %b, %0 : i64
+      %2 = llvm.add %a, %1 : i64
+      llvm.return %2 : i64
+  }]
+  rhs := [LV| {
+    ^entry (%a: i64, %b: i64, %c: i64):
+      %0 = llvm.sub %b, %c : i64
+      llvm.return %0 : i64
+  }]
+
+/-
+Test the rewrite:
+ fold (A+(B-(C+A))) -> (B-C)
+-/
+def APlusBMinusCPlusA : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
+  lhs := [LV| {
+    ^entry (%a: i64, %b: i64, %c: i64):
+      %0 = llvm.add %c, %a : i64
+      %1 = llvm.sub %b, %0 : i64
+      %2 = llvm.add %a, %1 : i64
+      llvm.return %2 : i64
+  }]
+  rhs := [LV| {
+    ^entry (%a: i64, %b: i64, %c: i64):
+      %0 = llvm.sub %b, %c : i64
+      llvm.return %0 : i64
+  }]
+
+/-
+Test the rewrite:
+ fold (add (xor a, -1), 1) -> (sub 0, a)
+-/
+def visitADD_XorMinus1Plus1 : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64)] where
+  lhs := [LV| {
+    ^entry (%a: i64):
+      %c = llvm.mlir.constant (-1) : i64
+      %0 = llvm.xor %a, %c : i64
+      %d = llvm.mlir.constant (1) : i64
+      %1 = llvm.add %0, %d : i64
+      llvm.return %1 : i64
+  }]
+  rhs := [LV| {
+    ^entry (%a: i64):
+      %c = llvm.mlir.constant (0) : i64
+      %0 = llvm.sub %c, %a : i64
+      llvm.return %0 : i64
+  }]
+
+/-
+Test the rewrite:
+ fold (add (add (xor a, -1), b), 1) -> (sub b, a)
+-/
+def visitADD_XorMinus1PlusBPlus1 : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
+  lhs := [LV| {
+    ^entry (%a: i64, %b: i64):
+      %c = llvm.mlir.constant (-1) : i64
+      %0 = llvm.xor %a, %c : i64
+      %1 = llvm.add %0, %b : i64
+      %d = llvm.mlir.constant (1) : i64
+      %2 = llvm.add %1, %d : i64
+      llvm.return %2 : i64
+  }]
+  rhs := [LV| {
+    ^entry (%a: i64, %b: i64):
+      %0 = llvm.sub %b, %a : i64
+      llvm.return %0 : i64
+  }]
+
+/-
+Test the rewrite:
+ (x - y) + -1  ->  add (xor y, -1), x
+-/
+def visitSUBPlusMinus1 : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
+  lhs := [LV| {
+    ^entry (%x: i64, %y: i64):
+      %0 = llvm.sub %x, %y : i64
+      %c = llvm.mlir.constant (-1) : i64
+      %1 = llvm.add %0, %c : i64
+      llvm.return %1 : i64
+  }]
+  rhs := [LV| {
+    ^entry (%x: i64, %y: i64):
+      %c = llvm.mlir.constant (-1) : i64
+      %0 = llvm.xor %y, %c : i64
+      %1 = llvm.add %0, %x : i64
+      llvm.return %1 : i64
+  }]
+
+def visitADD : List (Σ Γ, LLVMPeepholeRewriteRefine 64 Γ) :=
+[⟨_, visitADD_0⟩,
+ ⟨_, visitADD_sameop⟩,
+ ⟨_, visitADD_minus1⟩,
+ ⟨_, ZeroMinusAPlusB⟩,
+ ⟨_, APlusZeroMinusB⟩,
+ ⟨_, APlusBMinusA⟩,
+ ⟨_, BMinusAPlusA⟩,
+ ⟨_, AMinusBPlusCMinusA⟩,
+ ⟨_, AMinusBPlusBMinusC⟩,
+ ⟨_, APlusBMinusAPlusC⟩,
+ ⟨_, APlusBMinusCPlusA⟩,
+ ⟨_, visitADD_XorMinus1Plus1⟩,
+ ⟨_, visitADD_XorMinus1PlusBPlus1⟩,
+ ⟨_, visitSUBPlusMinus1⟩]
+
+/-! ### visitSUB -/
+
+/-
+  fold (sub x, x) -> 0
+-/
+def visitSUB_x_x : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64)] where
+  lhs := [LV| {
+    ^entry (%x: i64):
+      %0 = llvm.sub %x, %x : i64
+      llvm.return %0 : i64
+  }]
+  rhs := [LV| {
+    ^entry (%x: i64):
+      %c = llvm.mlir.constant (0) : i64
+      llvm.return %c : i64
+  }]
+
+/-
+  fold (sub x, 0) -> x
+-/
+def visitSUB_x_0 : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64)] where
+  lhs := [LV| {
+    ^entry (%x: i64):
+      %c = llvm.mlir.constant (0) : i64
+      %0 = llvm.sub %x, %c : i64
+      llvm.return %0 : i64
+  }]
+  rhs := [LV| {
+    ^entry (%x: i64):
+      llvm.return %x : i64
+  }]
+
+/-
+  0 - X --> 0 if the sub is NUW.
+-/
+def visitSUB_0_x_nuw : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64)] where
+  lhs := [LV| {
+    ^entry (%x: i64):
+      %c = llvm.mlir.constant (0) : i64
+      %0 = llvm.sub %c, %x overflow<nuw>: i64
+      llvm.return %0 : i64
+  }]
+  rhs := [LV| {
+    ^entry (%x: i64):
+      %c = llvm.mlir.constant (0) : i64
+      llvm.return %c : i64
+  }]
+
+/-
+  Canonicalize (sub -1, x) -> ~x, i.e. (xor x, -1)
+-/
+def visitSUB_minus1_x : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64)] where
+  lhs := [LV| {
+    ^entry (%x: i64):
+      %c = llvm.mlir.constant (-1) : i64
+      %0 = llvm.sub %c, %x : i64
+      llvm.return %0 : i64
+  }]
+  rhs := [LV| {
+    ^entry (%x: i64):
+      %c = llvm.mlir.constant (-1) : i64
+      %0 = llvm.xor %x, %c : i64
+      llvm.return %0 : i64
+  }]
+
+/-
+  fold (A-(0-B)) -> A+B
+-/
+def visitSUB_A_0_minus_B : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
+  lhs := [LV| {
+    ^entry (%a: i64, %b: i64):
+      %c = llvm.mlir.constant (0) : i64
+      %0 = llvm.sub %c, %b : i64
+      %1 = llvm.sub %a, %0 : i64
+      llvm.return %1 : i64
+  }]
+  rhs := [LV| {
+    ^entry (%a: i64, %b: i64):
+      %0 = llvm.add %a, %b : i64
+      llvm.return %0 : i64
+  }]
+
+/-
+  fold A-(A-B) -> B
+-/
+def visitSUB_A_A_minus_B : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
+  lhs := [LV| {
+    ^entry (%a: i64, %b: i64):
+      %0 = llvm.sub %a, %b : i64
+      %1 = llvm.sub %a, %0 : i64
+      llvm.return %1 : i64
+  }]
+  rhs := [LV| {
+    ^entry (%a: i64, %b: i64):
+      llvm.return %b : i64
+  }]
+
+/-
+  fold (A+B)-A -> B
+-/
+def visitSUB_A_plus_B_minus_A : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
+  lhs := [LV| {
+    ^entry (%a: i64, %b: i64):
+      %0 = llvm.add %a, %b : i64
+      %1 = llvm.sub %0, %a : i64
+      llvm.return %1 : i64
+  }]
+  rhs := [LV| {
+    ^entry (%a: i64, %b: i64):
+      llvm.return %b : i64
+  }]
+
+/-
+  fold (A+B)-B -> A
+-/
+def visitSUB_A_plus_B_minus_B : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
+  lhs := [LV| {
+    ^entry (%a: i64, %b: i64):
+      %0 = llvm.add %a, %b : i64
+      %1 = llvm.sub %0, %b : i64
+      llvm.return %1 : i64
+  }]
+  rhs := [LV| {
+    ^entry (%a: i64, %b: i64):
+      llvm.return %a : i64
+  }]
+
+/-
+  fold ((A+(B+C))-B) -> A+C
+-/
+def visitSUB_A_plus_B_plus_C_minus_B : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
+  lhs := [LV| {
+    ^entry (%a: i64, %b: i64, %c: i64):
+      %0 = llvm.add %b, %c : i64
+      %1 = llvm.add %a, %0 : i64
+      %2 = llvm.sub %1, %b : i64
+      llvm.return %2 : i64
+  }]
+  rhs := [LV| {
+    ^entry (%a: i64, %b: i64, %c: i64):
+      %0 = llvm.add %a, %c : i64
+      llvm.return %0 : i64
+  }]
+
+/-
+  fold ((A+(B-C))-B) -> A-C
+-/
+def visitSUB_A_plus_B_minus_C_minus_B : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
+  lhs := [LV| {
+    ^entry (%a: i64, %b: i64, %c: i64):
+      %0 = llvm.sub %b, %c : i64
+      %1 = llvm.add %a, %0 : i64
+      %2 = llvm.sub %1, %b : i64
+      llvm.return %2 : i64
+  }]
+  rhs := [LV| {
+    ^entry (%a: i64, %b: i64, %c: i64):
+      %0 = llvm.sub %a, %c : i64
+      llvm.return %0 : i64
+  }]
+
+/-
+  fold ((A-(B-C))-C) -> A-B
+-/
+def visitSUB_A_minus_B_minus_C_minus_C : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
+  lhs := [LV| {
+    ^entry (%a: i64, %b: i64, %c: i64):
+      %0 = llvm.sub %b, %c : i64
+      %1 = llvm.sub %a, %0 : i64
+      %2 = llvm.sub %1, %c : i64
+      llvm.return %2 : i64
+  }]
+  rhs := [LV| {
+    ^entry (%a: i64, %b: i64, %c: i64):
+      %0 = llvm.sub %a, %b : i64
+      llvm.return %0 : i64
+  }]
+
+/-
+  fold (A-(B-C)) -> A+(C-B)
+-/
+def visitSUB_A_minus_B_minus_C : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
+  lhs := [LV| {
+    ^entry (%a: i64, %b: i64, %c: i64):
+      %0 = llvm.sub %b, %c : i64
+      %1 = llvm.sub %a, %0 : i64
+      llvm.return %1 : i64
+  }]
+  rhs := [LV| {
+    ^entry (%a: i64, %b: i64, %c: i64):
+      %0 = llvm.sub %c, %b : i64
+      %1 = llvm.add %a, %0 : i64
+      llvm.return %1 : i64
+  }]
+
+/-
+  A - (A & B)  ->  A & (~B)
+-/
+def visitSUB_A_minus_A_and_B : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
+  lhs := [LV| {
+    ^entry (%a: i64, %b: i64):
+      %0 = llvm.and %a, %b : i64
+      %1 = llvm.sub %a, %0 : i64
+      llvm.return %1 : i64
+  }]
+  rhs := [LV| {
+    ^entry (%a: i64, %b: i64):
+      %0 = llvm.not %b : i64
+      %1 = llvm.and %a, %0 : i64
+      llvm.return %1 : i64
+  }]
+
+  def visitSUB : List (Σ Γ, LLVMPeepholeRewriteRefine 64 Γ) :=
+  [⟨_, visitSUB_x_x⟩,
+   ⟨_, visitSUB_x_0⟩,
+   ⟨_, visitSUB_0_x_nuw⟩,
+   ⟨_, visitSUB_minus1_x⟩,
+   ⟨_, visitSUB_A_0_minus_B⟩,
+   ⟨_, visitSUB_A_A_minus_B⟩,
+   ⟨_, visitSUB_A_plus_B_minus_A⟩,
+   ⟨_, visitSUB_A_plus_B_minus_B⟩,
+   ⟨_, visitSUB_A_plus_B_plus_C_minus_B⟩,
+   ⟨_, visitSUB_A_plus_B_minus_C_minus_B⟩,
+   ⟨_, visitSUB_A_minus_B_minus_C_minus_C⟩,
+   ⟨_, visitSUB_A_minus_B_minus_C⟩,
+   ⟨_, visitSUB_A_minus_A_and_B⟩]
+
+/-! ### visitAND -/
+
+/-
+  fold (mul x, 0) -> 0
+-/
+def visitMUL_x_0 : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64)] where
+  lhs := [LV| {
+    ^entry (%x: i64):
+      %c = llvm.mlir.constant (0) : i64
+      %0 = llvm.mul %x, %c : i64
+      llvm.return %0 : i64
+  }]
+  rhs := [LV| {
+    ^entry (%x: i64):
+      %c = llvm.mlir.constant (0) : i64
+      llvm.return %c : i64
+  }]
+
+/-
+  fold (mul x, 1) -> x
+-/
+def visitMUL_x_1 : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64)] where
+  lhs := [LV| {
+    ^entry (%x: i64):
+      %c = llvm.mlir.constant (1) : i64
+      %0 = llvm.mul %x, %c : i64
+      llvm.return %0 : i64
+  }]
+  rhs := [LV| {
+    ^entry (%x: i64):
+      llvm.return %x : i64
+  }]
+
+/-
+  fold (mul x, -1) -> 0-x
+-/
+def visitMUL_x_minus1 : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64)] where
+  lhs := [LV| {
+    ^entry (%x: i64):
+      %c = llvm.mlir.constant (-1) : i64
+      %0 = llvm.mul %x, %c : i64
+      llvm.return %0 : i64
+  }]
+  rhs := [LV| {
+    ^entry (%x: i64):
+      %c = llvm.mlir.constant (0) : i64
+      %0 = llvm.sub %c, %x : i64
+      llvm.return %0 : i64
+  }]
+
+/-
+  fold (mul x, (1 << c)) -> x << c
+-/
+def visitMUL_x_shift : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
+  lhs := [LV| {
+    ^entry (%x: i64, %y: i64):
+      %c = llvm.mlir.constant (1) : i64
+      %1 = llvm.shl %c, %y : i64
+      %0 = llvm.mul %x, %1 : i64
+      llvm.return %0 : i64
+  }]
+  rhs := [LV| {
+    ^entry (%x: i64, %y: i64):
+      %0 = llvm.shl %x, %y : i64
+      llvm.return %0 : i64
+  }]
+
+/-
+  fold (mul x, -(1 << c)) -> -(x << c) or (-x) << c
+-/
+def visitMUL_x_neg_shift : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
+  lhs := [LV| {
+    ^entry (%x: i64, %y: i64):
+      %c = llvm.mlir.constant (1) : i64
+      %1 = llvm.shl %c, %y : i64
+      %2 = llvm.neg %1 : i64
+      %3 = llvm.mul %x, %2 : i64
+      llvm.return %3 : i64
+  }]
+  rhs := [LV| {
+    ^entry (%x: i64, %y: i64):
+      %1 = llvm.shl %x, %y : i64
+      %2 = llvm.neg %1 : i64
+
+      llvm.return %2 : i64
+  }]
+
+def visitMUL : List (Σ Γ, LLVMPeepholeRewriteRefine 64 Γ) :=
+  [⟨_, visitMUL_x_0⟩,
+   ⟨_, visitMUL_x_1⟩,
+   ⟨_, visitMUL_x_minus1⟩,
+   ⟨_, visitMUL_x_shift⟩,
+   ⟨_, visitMUL_x_neg_shift⟩]
+
+/-! ### visitSDIV -/
+
+/-
+  fold (sdiv X, -1) -> 0-X
+-/
+def visitSDIV_x_minus1 : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64)] where
+  lhs := [LV| {
+    ^entry (%x: i64):
+      %c = llvm.mlir.constant (-1) : i64
+      %0 = llvm.sdiv %x, %c : i64
+      llvm.return %0 : i64
+  }]
+  rhs := [LV| {
+    ^entry (%x: i64):
+      %c = llvm.mlir.constant (0) : i64
+      %0 = llvm.sub %c, %x : i64
+      llvm.return %0 : i64
+  }]
+
+def visitSDIV : List (Σ Γ, LLVMPeepholeRewriteRefine 64 Γ) :=
+  [⟨_, visitSDIV_x_minus1⟩]
+
+
+/-! ### visitAND -/
+
+/-
+  x & x --> x
+-/
+def visitAND_sameop : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64)] where
+  lhs := [LV| {
+    ^entry (%x: i64):
+      %0 = llvm.and %x, %x : i64
+      llvm.return %0 : i64
+  }]
+  rhs := [LV| {
+    ^entry (%x: i64):
+      llvm.return %x : i64
+  }]
+
+/-
+  (and x, 0) -> 0,
+-/
+def visitAND_0 : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64)] where
+  lhs := [LV| {
+    ^entry (%x: i64):
+      %c = llvm.mlir.constant (0) : i64
+      %0 = llvm.and  %x, %c : i64
+      llvm.return %0 : i64
+  }]
+  rhs := [LV| {
+    ^entry (%x: i64):
+      %c = llvm.mlir.constant (0) : i64
+      llvm.return %c : i64
+  }]
+
+/-
+  (and x, -1) -> x,
+-/
+def visitAND_minus1 : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64)] where
+  lhs := [LV| {
+    ^entry (%x: i64):
+      %c = llvm.mlir.constant (-1) : i64
+      %0 = llvm.and  %x, %c : i64
+      llvm.return %0 : i64
+  }]
+  rhs := [LV| {
+    ^entry (%x: i64):
+      llvm.return %x : i64
+  }]
+
+def visitAND : List (Σ Γ, LLVMPeepholeRewriteRefine 64 Γ) :=
+  [⟨_, visitAND_sameop⟩,
+  ⟨_, visitAND_0⟩,
+  ⟨_, visitAND_minus1⟩]
+
+/-! ### visitOR -/
+
+/-
+  x | x --> x
+-/
+def visitOR_sameop : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64)] where
+  lhs := [LV| {
+    ^entry (%x: i64):
+      %0 = llvm.or %x, %x : i64
+      llvm.return %0 : i64
+  }]
+  rhs := [LV| {
+    ^entry (%x: i64):
+      llvm.return %x : i64
+  }]
+
+/-
+  fold (or x, 0) -> x
+-/
+def visitOR_0 : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64)] where
+  lhs := [LV| {
+    ^entry (%x: i64):
+      %c = llvm.mlir.constant (0) : i64
+      %0 = llvm.or %x, %c : i64
+      llvm.return %0 : i64
+  }]
+  rhs := [LV| {
+    ^entry (%x: i64):
+      llvm.return %x : i64
+  }]
+
+/-
+  fold (or x, -1) -> -1
+-/
+def visitOR_minus1 : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64)] where
+  lhs := [LV| {
+    ^entry (%x: i64):
+      %c = llvm.mlir.constant (-1) : i64
+      %0 = llvm.or %x, %c : i64
+      llvm.return %0 : i64
+  }]
+  rhs := [LV| {
+    ^entry (%x: i64):
+      %c = llvm.mlir.constant (-1) : i64
+      llvm.return %c : i64
+  }]
+
+/-
+  (or (and X, M), (and X, N)) -> (and X, (or M, N))
+-/
+def visitOR_and : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
+  lhs := [LV| {
+    ^entry (%x: i64, %m: i64, %n: i64):
+      %0 = llvm.and %x, %m : i64
+      %1 = llvm.and %x, %n : i64
+      %2 = llvm.or %0, %1 : i64
+      llvm.return %2 : i64
+  }]
+  rhs := [LV| {
+    ^entry (%x: i64, %m: i64, %n: i64):
+      %0 = llvm.or %m, %n : i64
+      %1 = llvm.and %x, %0 : i64
+      llvm.return %1 : i64
+  }]
+
+def visitOR : List (Σ Γ, LLVMPeepholeRewriteRefine 64 Γ) :=
+  [⟨_, visitOR_sameop⟩,
+   ⟨_, visitOR_0⟩,
+   ⟨_, visitOR_minus1⟩,
+   ⟨_, visitOR_and⟩]
+
+/-! ### visitXOR -/
+
+/-
+  fold (xor x, 0) -> x
+-/
+def visitXOR_0 : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64)] where
+  lhs := [LV| {
+    ^entry (%x: i64):
+      %c = llvm.mlir.constant (0) : i64
+      %0 = llvm.xor %x, %c : i64
+      llvm.return %0 : i64
+  }]
+  rhs := [LV| {
+    ^entry (%x: i64):
+      llvm.return %x : i64
+  }]
+
+/-
+  fold (xor x, x) -> 0
+-/
+def visitXOR_x : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64)] where
+  lhs := [LV| {
+    ^entry (%x: i64):
+      %0 = llvm.xor %x, %x : i64
+      llvm.return %0 : i64
+  }]
+  rhs := [LV| {
+    ^entry (%x: i64):
+      %c = llvm.mlir.constant (0) : i64
+      llvm.return %c : i64
+  }]
+
+/-
+  fold (not (add X, -1)) -> (neg X)
+-/
+def visitXOR_add_minus1 : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64)] where
+  lhs := [LV| {
+    ^entry (%x: i64):
+      %c = llvm.mlir.constant (-1) : i64
+      %0 = llvm.add %x, %c : i64
+      %1 = llvm.not %0 : i64
+      llvm.return %1 : i64
+  }]
+  rhs := [LV| {
+    ^entry (%x: i64):
+      %0 = llvm.neg %x : i64
+      llvm.return %0 : i64
+  }]
+
+/-
+  (not (neg x)) -> (add X, -1). (osman: )
+-/
+def visitXOR_not_neg : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64)] where
+  lhs := [LV| {
+    ^entry (%x: i64):
+      %0 = llvm.neg %x : i64
+      %1 = llvm.not %0 : i64
+      llvm.return %1 : i64
+  }]
+  rhs := [LV| {
+    ^entry (%x: i64):
+      %c = llvm.mlir.constant (-1) : i64
+      %0 = llvm.add %x, %c : i64
+      llvm.return %0 : i64
+  }]
+
+/-
+  fold (xor (and x, y), y) -> (and (not x), y)
+-/
+def visitXOR_xor_and : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
+  lhs := [LV| {
+    ^entry (%x: i64, %y: i64):
+      %0 = llvm.and %x, %y : i64
+      %1 = llvm.xor %0, %y : i64
+      llvm.return %1 : i64
+  }]
+  rhs := [LV| {
+    ^entry (%x: i64, %y: i64):
+      %0 = llvm.not %x : i64
+      %1 = llvm.and %0, %y : i64
+      llvm.return %1 : i64
+  }]
+
+def visitXOR : List (Σ Γ, LLVMPeepholeRewriteRefine 64 Γ) :=
+  [⟨_, visitXOR_0⟩,
+   ⟨_, visitXOR_x⟩,
+   ⟨_, visitXOR_add_minus1⟩,
+   ⟨_, visitXOR_not_neg⟩,
+   ⟨_, visitXOR_xor_and⟩]
+
+/-! ### visitSRA -/
+
+/-
+  fold (sra 0, x) -> 0
+-/
+def visitSRA_0 : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64)] where
+  lhs := [LV| {
+    ^entry (%x: i64):
+      %c = llvm.mlir.constant (0) : i64
+      %0 = llvm.ashr %c, %x : i64
+      llvm.return %0 : i64
+  }]
+  rhs := [LV| {
+    ^entry (%x: i64):
+      %c = llvm.mlir.constant (0) : i64
+      llvm.return %c : i64
+  }]
+
+/-
+  fold (sra -1, x) -> -1
+-/
+def visitSRA_minus1 : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64)] where
+  lhs := [LV| {
+    ^entry (%x: i64):
+      %c = llvm.mlir.constant (-1) : i64
+      %0 = llvm.ashr %c, %x : i64
+      llvm.return %0 : i64
+  }]
+  rhs := [LV| {
+    ^entry (%x: i64):
+      %c = llvm.mlir.constant (-1) : i64
+      llvm.return %c : i64
+  }]
+
+def visitSRA : List (Σ Γ, LLVMPeepholeRewriteRefine 64 Γ) :=
+  [⟨_, visitSRA_0⟩,
+   ⟨_, visitSRA_minus1⟩]
+
+/-! ### visitSELECT -/
+
+/-
+Test the rewrite:
+  select (not Cond), N1, N2 -> select Cond, N2, N1
+-/
+def select_constant_not_cond : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 1)] where
+  lhs := [LV| {
+    ^entry (%c: i1, %x: i64, %y: i64):
+      %0 = llvm.not %c : i1
+      %1 = llvm.select %0, %x, %y : i64
+      llvm.return %1 : i64
+  }]
+  rhs := [LV| {
+    ^entry (%c: i1, %x: i64, %y: i64):
+      %0 = llvm.select %c, %y, %x : i64
+      llvm.return %0 : i64
+  }]
+
+/-
+Test the rewrite:
+  (true ? x : y) -> x
+-/
+def select_constant_cmp_true : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
+  lhs := [LV| {
+    ^entry (%x: i64, %y: i64):
+      %0 = llvm.mlir.constant (1) : i1
+      %1 = llvm.select %0, %x, %y : i64
+      llvm.return %1 : i64
+  }]
+  rhs := [LV| {
+    ^entry (%x: i64, %y: i64):
+      llvm.return %x : i64
+  }]
+
+/-
+Test the rewrite:
+  (false ? x : y) -> y
+-/
+def select_constant_cmp_false : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
+  lhs := [LV| {
+    ^entry (%x: i64, %y: i64):
+      %0 = llvm.mlir.constant (0) : i1
+      %1 = llvm.select %0, %x, %y : i64
+      llvm.return %1 : i64
+  }]
+  rhs := [LV| {
+    ^entry (%x: i64, %y: i64):
+      llvm.return %y : i64
+  }]
+
+def visitSELECT : List (Σ Γ, LLVMPeepholeRewriteRefine 64 Γ) :=
+  [⟨_, select_constant_not_cond⟩,
+   ⟨_, select_constant_cmp_true⟩,
+   ⟨_, select_constant_cmp_false⟩]
+
+ /-! ### Grouped patterns -/
+
+def SelectionDAG_combines : List (Σ Γ, LLVMPeepholeRewriteRefine 64 Γ) :=
+  visitADD ++ visitAND ++ visitSUB ++ visitMUL ++ visitSDIV ++ visitOR ++ visitXOR ++ visitSRA ++
+  visitSELECT
+
+def SelectionDAGCombiner :
+    List (Σ Γ, Σ ty, PeepholeRewrite LLVMPlusRiscV Γ ty) :=
+  (List.map (fun ⟨_,y⟩ => mkRewrite (LLVMToRiscvPeepholeRewriteRefine.toPeepholeUNSOUND y))
+  SelectionDAG_combines)

--- a/SSA/Projects/LLVMRiscV/Pipeline/SelectionDAG.lean
+++ b/SSA/Projects/LLVMRiscV/Pipeline/SelectionDAG.lean
@@ -66,7 +66,7 @@ def visitADD_sameop : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 1)] where
 /-
   (and x, -1) -> x,
 -/
-def visitADD_minus1 : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64)] where
+def visitADD_Neg1 : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64)] where
   lhs := [LV| {
     ^entry (%x: i64):
       %c = llvm.mlir.constant (-1) : i64
@@ -82,7 +82,7 @@ def visitADD_minus1 : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64)] where
 Test the rewrite:
   fold ((0-A)+B) -> B-A
 -/
-def ZeroMinusAPlusB : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
+def ZeroNegAPlusB : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
   lhs := [LV| {
     ^entry (%a: i64, %b: i64):
       %0 = llvm.mlir.constant (0) : i64
@@ -100,7 +100,7 @@ def ZeroMinusAPlusB : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llv
 Test the rewrite:
   fold (A+(0-B)) -> A-B
 -/
-def APlusZeroMinusB : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
+def APlusZeroNegB : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
   lhs := [LV| {
     ^entry (%a: i64, %b: i64):
       %0 = llvm.mlir.constant (0) : i64
@@ -118,7 +118,7 @@ def APlusZeroMinusB : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llv
 Test the rewrite:
  fold (A+(B-A)) -> B
 -/
-def APlusBMinusA : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
+def APlusBNegA : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
   lhs := [LV| {
     ^entry (%a: i64, %b: i64):
       %0 = llvm.sub %b, %a : i64
@@ -134,7 +134,7 @@ def APlusBMinusA : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (
 Test the rewrite:
  fold ((B-A)+A) -> B
 -/
-def BMinusAPlusA : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
+def BNegAPlusA : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
   lhs := [LV| {
     ^entry (%a: i64, %b: i64):
       %0 = llvm.sub %b, %a : i64
@@ -150,7 +150,7 @@ def BMinusAPlusA : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (
 Test the rewrite:
  fold ((A-B)+(C-A)) -> (C-B)
 -/
-def AMinusBPlusCMinusA : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
+def ANegBPlusCNegA : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
   lhs := [LV| {
     ^entry (%a: i64, %b: i64, %c: i64):
       %0 = llvm.sub %a, %b : i64
@@ -168,7 +168,7 @@ def AMinusBPlusCMinusA : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.
 Test the rewrite:
  fold ((A-B)+(B-C)) -> (A-C)
 -/
-def AMinusBPlusBMinusC : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
+def ANegBPlusBNegC : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
   lhs := [LV| {
     ^entry (%a: i64, %b: i64, %c: i64):
       %0 = llvm.sub %a, %b : i64
@@ -186,7 +186,7 @@ def AMinusBPlusBMinusC : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.
 Test the rewrite:
  fold (A+(B-(A+C))) -> (B-C)
 -/
-def APlusBMinusAPlusC : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
+def APlusBNegAPlusC : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
   lhs := [LV| {
     ^entry (%a: i64, %b: i64, %c: i64):
       %0 = llvm.add %a, %c : i64
@@ -204,7 +204,7 @@ def APlusBMinusAPlusC : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.l
 Test the rewrite:
  fold (A+(B-(C+A))) -> (B-C)
 -/
-def APlusBMinusCPlusA : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
+def APlusBNegCPlusA : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
   lhs := [LV| {
     ^entry (%a: i64, %b: i64, %c: i64):
       %0 = llvm.add %c, %a : i64
@@ -222,7 +222,7 @@ def APlusBMinusCPlusA : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.l
 Test the rewrite:
  fold (add (xor a, -1), 1) -> (sub 0, a)
 -/
-def visitADD_XorMinus1Plus1 : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64)] where
+def visitADD_XorNeg1Plus1 : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64)] where
   lhs := [LV| {
     ^entry (%a: i64):
       %c = llvm.mlir.constant (-1) : i64
@@ -242,7 +242,7 @@ def visitADD_XorMinus1Plus1 : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64)
 Test the rewrite:
  fold (add (add (xor a, -1), b), 1) -> (sub b, a)
 -/
-def visitADD_XorMinus1PlusBPlus1 : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
+def visitADD_XorNeg1PlusBPlus1 : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
   lhs := [LV| {
     ^entry (%a: i64, %b: i64):
       %c = llvm.mlir.constant (-1) : i64
@@ -262,7 +262,7 @@ def visitADD_XorMinus1PlusBPlus1 : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitve
 Test the rewrite:
  (x - y) + -1  ->  add (xor y, -1), x
 -/
-def visitSUBPlusMinus1 : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
+def visitSUBPlusNeg1 : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
   lhs := [LV| {
     ^entry (%x: i64, %y: i64):
       %0 = llvm.sub %x, %y : i64
@@ -281,18 +281,18 @@ def visitSUBPlusMinus1 : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.
 def visitADD : List (Σ Γ, LLVMPeepholeRewriteRefine 64 Γ) :=
 [⟨_, visitADD_0⟩,
  ⟨_, visitADD_sameop⟩,
- ⟨_, visitADD_minus1⟩,
- ⟨_, ZeroMinusAPlusB⟩,
- ⟨_, APlusZeroMinusB⟩,
- ⟨_, APlusBMinusA⟩,
- ⟨_, BMinusAPlusA⟩,
- ⟨_, AMinusBPlusCMinusA⟩,
- ⟨_, AMinusBPlusBMinusC⟩,
- ⟨_, APlusBMinusAPlusC⟩,
- ⟨_, APlusBMinusCPlusA⟩,
- ⟨_, visitADD_XorMinus1Plus1⟩,
- ⟨_, visitADD_XorMinus1PlusBPlus1⟩,
- ⟨_, visitSUBPlusMinus1⟩]
+ ⟨_, visitADD_Neg1⟩,
+ ⟨_, ZeroNegAPlusB⟩,
+ ⟨_, APlusZeroNegB⟩,
+ ⟨_, APlusBNegA⟩,
+ ⟨_, BNegAPlusA⟩,
+ ⟨_, ANegBPlusCNegA⟩,
+ ⟨_, ANegBPlusBNegC⟩,
+ ⟨_, APlusBNegAPlusC⟩,
+ ⟨_, APlusBNegCPlusA⟩,
+ ⟨_, visitADD_XorNeg1Plus1⟩,
+ ⟨_, visitADD_XorNeg1PlusBPlus1⟩,
+ ⟨_, visitSUBPlusNeg1⟩]
 
 /-! ### visitSUB -/
 
@@ -345,7 +345,7 @@ def visitSUB_0_x_nuw : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64)] where
 /-
   Canonicalize (sub -1, x) -> ~x, i.e. (xor x, -1)
 -/
-def visitSUB_minus1_x : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64)] where
+def visitSUB_Neg1_x : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64)] where
   lhs := [LV| {
     ^entry (%x: i64):
       %c = llvm.mlir.constant (-1) : i64
@@ -362,7 +362,7 @@ def visitSUB_minus1_x : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64)] wher
 /-
   fold (A-(0-B)) -> A+B
 -/
-def visitSUB_A_0_minus_B : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
+def visitSUB_A_0_Neg_B : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
   lhs := [LV| {
     ^entry (%a: i64, %b: i64):
       %c = llvm.mlir.constant (0) : i64
@@ -379,7 +379,7 @@ def visitSUB_A_0_minus_B : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), T
 /-
   fold A-(A-B) -> B
 -/
-def visitSUB_A_A_minus_B : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
+def visitSUB_A_A_Neg_B : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
   lhs := [LV| {
     ^entry (%a: i64, %b: i64):
       %0 = llvm.sub %a, %b : i64
@@ -394,7 +394,7 @@ def visitSUB_A_A_minus_B : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), T
 /-
   fold (A+B)-A -> B
 -/
-def visitSUB_A_plus_B_minus_A : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
+def visitSUB_A_plus_B_Neg_A : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
   lhs := [LV| {
     ^entry (%a: i64, %b: i64):
       %0 = llvm.add %a, %b : i64
@@ -409,7 +409,7 @@ def visitSUB_A_plus_B_minus_A : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 6
 /-
   fold (A+B)-B -> A
 -/
-def visitSUB_A_plus_B_minus_B : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
+def visitSUB_A_plus_B_Neg_B : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
   lhs := [LV| {
     ^entry (%a: i64, %b: i64):
       %0 = llvm.add %a, %b : i64
@@ -424,7 +424,7 @@ def visitSUB_A_plus_B_minus_B : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 6
 /-
   fold ((A+(B+C))-B) -> A+C
 -/
-def visitSUB_A_plus_B_plus_C_minus_B : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
+def visitSUB_A_plus_B_plus_C_Neg_B : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
   lhs := [LV| {
     ^entry (%a: i64, %b: i64, %c: i64):
       %0 = llvm.add %b, %c : i64
@@ -441,7 +441,7 @@ def visitSUB_A_plus_B_plus_C_minus_B : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.b
 /-
   fold ((A+(B-C))-B) -> A-C
 -/
-def visitSUB_A_plus_B_minus_C_minus_B : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
+def visitSUB_A_plus_B_Neg_C_Neg_B : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
   lhs := [LV| {
     ^entry (%a: i64, %b: i64, %c: i64):
       %0 = llvm.sub %b, %c : i64
@@ -458,7 +458,7 @@ def visitSUB_A_plus_B_minus_C_minus_B : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.
 /-
   fold ((A-(B-C))-C) -> A-B
 -/
-def visitSUB_A_minus_B_minus_C_minus_C : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
+def visitSUB_A_Neg_B_Neg_C_Neg_C : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
   lhs := [LV| {
     ^entry (%a: i64, %b: i64, %c: i64):
       %0 = llvm.sub %b, %c : i64
@@ -475,7 +475,7 @@ def visitSUB_A_minus_B_minus_C_minus_C : LLVMPeepholeRewriteRefine 64 [Ty.llvm (
 /-
   fold (A-(B-C)) -> A+(C-B)
 -/
-def visitSUB_A_minus_B_minus_C : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
+def visitSUB_A_Neg_B_Neg_C : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
   lhs := [LV| {
     ^entry (%a: i64, %b: i64, %c: i64):
       %0 = llvm.sub %b, %c : i64
@@ -492,7 +492,7 @@ def visitSUB_A_minus_B_minus_C : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 
 /-
   A - (A & B)  ->  A & (~B)
 -/
-def visitSUB_A_minus_A_and_B : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
+def visitSUB_A_Neg_A_and_B : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
   lhs := [LV| {
     ^entry (%a: i64, %b: i64):
       %0 = llvm.and %a, %b : i64
@@ -510,16 +510,16 @@ def visitSUB_A_minus_A_and_B : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64
   [⟨_, visitSUB_x_x⟩,
    ⟨_, visitSUB_x_0⟩,
    ⟨_, visitSUB_0_x_nuw⟩,
-   ⟨_, visitSUB_minus1_x⟩,
-   ⟨_, visitSUB_A_0_minus_B⟩,
-   ⟨_, visitSUB_A_A_minus_B⟩,
-   ⟨_, visitSUB_A_plus_B_minus_A⟩,
-   ⟨_, visitSUB_A_plus_B_minus_B⟩,
-   ⟨_, visitSUB_A_plus_B_plus_C_minus_B⟩,
-   ⟨_, visitSUB_A_plus_B_minus_C_minus_B⟩,
-   ⟨_, visitSUB_A_minus_B_minus_C_minus_C⟩,
-   ⟨_, visitSUB_A_minus_B_minus_C⟩,
-   ⟨_, visitSUB_A_minus_A_and_B⟩]
+   ⟨_, visitSUB_Neg1_x⟩,
+   ⟨_, visitSUB_A_0_Neg_B⟩,
+   ⟨_, visitSUB_A_A_Neg_B⟩,
+   ⟨_, visitSUB_A_plus_B_Neg_A⟩,
+   ⟨_, visitSUB_A_plus_B_Neg_B⟩,
+   ⟨_, visitSUB_A_plus_B_plus_C_Neg_B⟩,
+   ⟨_, visitSUB_A_plus_B_Neg_C_Neg_B⟩,
+   ⟨_, visitSUB_A_Neg_B_Neg_C_Neg_C⟩,
+   ⟨_, visitSUB_A_Neg_B_Neg_C⟩,
+   ⟨_, visitSUB_A_Neg_A_and_B⟩]
 
 /-! ### visitAND -/
 
@@ -557,7 +557,7 @@ def visitMUL_x_1 : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64)] where
 /-
   fold (mul x, -1) -> 0-x
 -/
-def visitMUL_x_minus1 : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64)] where
+def visitMUL_x_Neg1 : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64)] where
   lhs := [LV| {
     ^entry (%x: i64):
       %c = llvm.mlir.constant (-1) : i64
@@ -611,7 +611,7 @@ def visitMUL_x_neg_shift : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), T
 def visitMUL : List (Σ Γ, LLVMPeepholeRewriteRefine 64 Γ) :=
   [⟨_, visitMUL_x_0⟩,
    ⟨_, visitMUL_x_1⟩,
-   ⟨_, visitMUL_x_minus1⟩,
+   ⟨_, visitMUL_x_Neg1⟩,
    ⟨_, visitMUL_x_shift⟩,
    ⟨_, visitMUL_x_neg_shift⟩]
 
@@ -620,7 +620,7 @@ def visitMUL : List (Σ Γ, LLVMPeepholeRewriteRefine 64 Γ) :=
 /-
   fold (sdiv X, -1) -> 0-X
 -/
-def visitSDIV_x_minus1 : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64)] where
+def visitSDIV_x_Neg1 : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64)] where
   lhs := [LV| {
     ^entry (%x: i64):
       %c = llvm.mlir.constant (-1) : i64
@@ -635,7 +635,7 @@ def visitSDIV_x_minus1 : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64)] whe
   }]
 
 def visitSDIV : List (Σ Γ, LLVMPeepholeRewriteRefine 64 Γ) :=
-  [⟨_, visitSDIV_x_minus1⟩]
+  [⟨_, visitSDIV_x_Neg1⟩]
 
 
 /-! ### visitAND -/
@@ -673,7 +673,7 @@ def visitAND_0 : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64)] where
 /-
   (and x, -1) -> x,
 -/
-def visitAND_minus1 : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64)] where
+def visitAND_Neg1 : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64)] where
   lhs := [LV| {
     ^entry (%x: i64):
       %c = llvm.mlir.constant (-1) : i64
@@ -688,7 +688,7 @@ def visitAND_minus1 : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64)] where
 def visitAND : List (Σ Γ, LLVMPeepholeRewriteRefine 64 Γ) :=
   [⟨_, visitAND_sameop⟩,
   ⟨_, visitAND_0⟩,
-  ⟨_, visitAND_minus1⟩]
+  ⟨_, visitAND_Neg1⟩]
 
 /-! ### visitOR -/
 
@@ -724,7 +724,7 @@ def visitOR_0 : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64)] where
 /-
   fold (or x, -1) -> -1
 -/
-def visitOR_minus1 : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64)] where
+def visitOR_Neg1 : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64)] where
   lhs := [LV| {
     ^entry (%x: i64):
       %c = llvm.mlir.constant (-1) : i64
@@ -758,7 +758,7 @@ def visitOR_and : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.
 def visitOR : List (Σ Γ, LLVMPeepholeRewriteRefine 64 Γ) :=
   [⟨_, visitOR_sameop⟩,
    ⟨_, visitOR_0⟩,
-   ⟨_, visitOR_minus1⟩,
+   ⟨_, visitOR_Neg1⟩,
    ⟨_, visitOR_and⟩]
 
 /-! ### visitXOR -/
@@ -796,7 +796,7 @@ def visitXOR_x : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64)] where
 /-
   fold (not (add X, -1)) -> (neg X)
 -/
-def visitXOR_add_minus1 : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64)] where
+def visitXOR_add_Neg1 : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64)] where
   lhs := [LV| {
     ^entry (%x: i64):
       %c = llvm.mlir.constant (-1) : i64
@@ -847,7 +847,7 @@ def visitXOR_xor_and : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.ll
 def visitXOR : List (Σ Γ, LLVMPeepholeRewriteRefine 64 Γ) :=
   [⟨_, visitXOR_0⟩,
    ⟨_, visitXOR_x⟩,
-   ⟨_, visitXOR_add_minus1⟩,
+   ⟨_, visitXOR_add_Neg1⟩,
    ⟨_, visitXOR_not_neg⟩,
    ⟨_, visitXOR_xor_and⟩]
 
@@ -872,7 +872,7 @@ def visitSRA_0 : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64)] where
 /-
   fold (sra -1, x) -> -1
 -/
-def visitSRA_minus1 : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64)] where
+def visitSRA_Neg1 : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64)] where
   lhs := [LV| {
     ^entry (%x: i64):
       %c = llvm.mlir.constant (-1) : i64
@@ -887,7 +887,7 @@ def visitSRA_minus1 : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64)] where
 
 def visitSRA : List (Σ Γ, LLVMPeepholeRewriteRefine 64 Γ) :=
   [⟨_, visitSRA_0⟩,
-   ⟨_, visitSRA_minus1⟩]
+   ⟨_, visitSRA_Neg1⟩]
 
 /-! ### visitSELECT -/
 

--- a/SSA/Projects/LLVMRiscV/Pipeline/SelectionDAG.lean
+++ b/SSA/Projects/LLVMRiscV/Pipeline/SelectionDAG.lean
@@ -6,27 +6,9 @@ import SSA.Projects.LLVMRiscV.Pipeline.ConstantMatching
 
 open LLVMRiscV
 
-/- This file implements `DAGCombiner` patterns extracted from the LLVM Risc-V backend.
-  First, we implement the Lean structure that implements the rewrite patterns and then we implement
-  optimizations for LLVM IR and RISC-V.
-  In particular, we implement the patterns supported by LLVM's `GlobalIsel` for RISC-V.
-  Because `GlobalIsel` is hybrid, some of these patterns regard generic IR,
-  while some are target-dependent.
+/-
+This file implements `DAGCombiner` patterns extracted from the LLVM SelectionDAG.
 -/
-
-@[simp_riscv] lemma toType_bv : TyDenote.toType (Ty.riscv (.bv)) = BitVec 64 := rfl
-@[simp_riscv] lemma id_eq1 {α : Type} (x y : α) :  @Eq (Id α) x y = (x = y):= by simp only
-
-structure RISCVPeepholeRewrite (Γ : List Ty) where
-  lhs : Com LLVMPlusRiscV Γ .pure [Ty.riscv .bv]
-  rhs : Com LLVMPlusRiscV Γ .pure [Ty.riscv .bv]
-  correct : lhs.denote = rhs.denote := by simp_lowering <;> bv_decide
-
-def RISCVPeepholeRewriteToRiscvPeephole (self : RISCVPeepholeRewrite Γ) :
-    PeepholeRewrite LLVMPlusRiscV Γ [Ty.riscv .bv] where
-  lhs := self.lhs
-  rhs := self.rhs
-  correct := self.correct
 
 /-! ### visitADD -/
 

--- a/SSA/Projects/LLVMRiscV/Pipeline/SelectionDAG.lean
+++ b/SSA/Projects/LLVMRiscV/Pipeline/SelectionDAG.lean
@@ -877,7 +877,7 @@ def visitSRA : List (Σ Γ, LLVMPeepholeRewriteRefine 64 Γ) :=
 Test the rewrite:
   select (not Cond), N1, N2 -> select Cond, N2, N1
 -/
-def select_constant_not_cond : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 1)] where
+def visitSELECT_constant_not_cond : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 1)] where
   lhs := [LV| {
     ^entry (%c: i1, %x: i64, %y: i64):
       %0 = llvm.not %c : i1
@@ -894,7 +894,7 @@ def select_constant_not_cond : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64
 Test the rewrite:
   (true ? x : y) -> x
 -/
-def select_constant_cmp_true : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
+def visitSELECT_constant_cmp_true : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
   lhs := [LV| {
     ^entry (%x: i64, %y: i64):
       %0 = llvm.mlir.constant (1) : i1
@@ -910,7 +910,7 @@ def select_constant_cmp_true : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64
 Test the rewrite:
   (false ? x : y) -> y
 -/
-def select_constant_cmp_false : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
+def visitSELECT_constant_cmp_false : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
   lhs := [LV| {
     ^entry (%x: i64, %y: i64):
       %0 = llvm.mlir.constant (0) : i1
@@ -923,9 +923,9 @@ def select_constant_cmp_false : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 6
   }]
 
 def visitSELECT : List (Σ Γ, LLVMPeepholeRewriteRefine 64 Γ) :=
-  [⟨_, select_constant_not_cond⟩,
-   ⟨_, select_constant_cmp_true⟩,
-   ⟨_, select_constant_cmp_false⟩]
+  [⟨_, visitSELECT_constant_not_cond⟩,
+   ⟨_, visitSELECT_constant_cmp_true⟩,
+   ⟨_, visitSELECT_constant_cmp_false⟩]
 
  /-! ### Grouped patterns -/
 

--- a/SSA/Projects/LLVMRiscV/Pipeline/SelectionDAG.lean
+++ b/SSA/Projects/LLVMRiscV/Pipeline/SelectionDAG.lean
@@ -30,7 +30,7 @@ def visitADD_0 : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64)] where
 /-
   add (sext i1 X), 1 -> zext (not i1 X)
 -/
-def visitADD_sameop : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 1)] where
+def visitADD_Sameop : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 1)] where
   lhs := [LV| {
     ^entry (%x: i1):
       %c = llvm.mlir.constant (1) : i64
@@ -64,7 +64,7 @@ def visitADD_Neg1 : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64)] where
 Test the rewrite:
   fold ((0-A)+B) -> B-A
 -/
-def ZeroNegAPlusB : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
+def visitADD_ZeroNegAPlusB : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
   lhs := [LV| {
     ^entry (%a: i64, %b: i64):
       %0 = llvm.mlir.constant (0) : i64
@@ -82,7 +82,7 @@ def ZeroNegAPlusB : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm 
 Test the rewrite:
   fold (A+(0-B)) -> A-B
 -/
-def APlusZeroNegB : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
+def visitADD_APlusZeroNegB : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
   lhs := [LV| {
     ^entry (%a: i64, %b: i64):
       %0 = llvm.mlir.constant (0) : i64
@@ -100,7 +100,7 @@ def APlusZeroNegB : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm 
 Test the rewrite:
  fold (A+(B-A)) -> B
 -/
-def APlusBNegA : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
+def visitADD_APlusBNegA : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
   lhs := [LV| {
     ^entry (%a: i64, %b: i64):
       %0 = llvm.sub %b, %a : i64
@@ -116,7 +116,7 @@ def APlusBNegA : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.b
 Test the rewrite:
  fold ((B-A)+A) -> B
 -/
-def BNegAPlusA : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
+def visitADD_BNegAPlusA : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
   lhs := [LV| {
     ^entry (%a: i64, %b: i64):
       %0 = llvm.sub %b, %a : i64
@@ -132,7 +132,7 @@ def BNegAPlusA : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.b
 Test the rewrite:
  fold ((A-B)+(C-A)) -> (C-B)
 -/
-def ANegBPlusCNegA : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
+def visitADD_ANegBPlusCNegA : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
   lhs := [LV| {
     ^entry (%a: i64, %b: i64, %c: i64):
       %0 = llvm.sub %a, %b : i64
@@ -150,7 +150,7 @@ def ANegBPlusCNegA : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm
 Test the rewrite:
  fold ((A-B)+(B-C)) -> (A-C)
 -/
-def ANegBPlusBNegC : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
+def visitADD_ANegBPlusBNegC : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
   lhs := [LV| {
     ^entry (%a: i64, %b: i64, %c: i64):
       %0 = llvm.sub %a, %b : i64
@@ -168,7 +168,7 @@ def ANegBPlusBNegC : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm
 Test the rewrite:
  fold (A+(B-(A+C))) -> (B-C)
 -/
-def APlusBNegAPlusC : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
+def visitADD_APlusBNegAPlusC : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
   lhs := [LV| {
     ^entry (%a: i64, %b: i64, %c: i64):
       %0 = llvm.add %a, %c : i64
@@ -186,7 +186,7 @@ def APlusBNegAPlusC : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llv
 Test the rewrite:
  fold (A+(B-(C+A))) -> (B-C)
 -/
-def APlusBNegCPlusA : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
+def visitADD_APlusBNegCPlusA : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
   lhs := [LV| {
     ^entry (%a: i64, %b: i64, %c: i64):
       %0 = llvm.add %c, %a : i64
@@ -244,7 +244,7 @@ def visitADD_XorNeg1PlusBPlus1 : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 
 Test the rewrite:
  (x - y) + -1  ->  add (xor y, -1), x
 -/
-def visitSUBPlusNeg1 : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
+def visitADD_PlusNeg1 : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
   lhs := [LV| {
     ^entry (%x: i64, %y: i64):
       %0 = llvm.sub %x, %y : i64
@@ -262,26 +262,26 @@ def visitSUBPlusNeg1 : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.ll
 
 def visitADD : List (Σ Γ, LLVMPeepholeRewriteRefine 64 Γ) :=
 [⟨_, visitADD_0⟩,
- ⟨_, visitADD_sameop⟩,
+ ⟨_, visitADD_Sameop⟩,
  ⟨_, visitADD_Neg1⟩,
- ⟨_, ZeroNegAPlusB⟩,
- ⟨_, APlusZeroNegB⟩,
- ⟨_, APlusBNegA⟩,
- ⟨_, BNegAPlusA⟩,
- ⟨_, ANegBPlusCNegA⟩,
- ⟨_, ANegBPlusBNegC⟩,
- ⟨_, APlusBNegAPlusC⟩,
- ⟨_, APlusBNegCPlusA⟩,
+ ⟨_, visitADD_ZeroNegAPlusB⟩,
+ ⟨_, visitADD_APlusZeroNegB⟩,
+ ⟨_, visitADD_APlusBNegA⟩,
+ ⟨_, visitADD_BNegAPlusA⟩,
+ ⟨_, visitADD_ANegBPlusCNegA⟩,
+ ⟨_, visitADD_ANegBPlusBNegC⟩,
+ ⟨_, visitADD_APlusBNegAPlusC⟩,
+ ⟨_, visitADD_APlusBNegCPlusA⟩,
  ⟨_, visitADD_XorNeg1Plus1⟩,
  ⟨_, visitADD_XorNeg1PlusBPlus1⟩,
- ⟨_, visitSUBPlusNeg1⟩]
+ ⟨_, visitADD_PlusNeg1⟩]
 
 /-! ### visitSUB -/
 
 /-
   fold (sub x, x) -> 0
 -/
-def visitSUB_x_x : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64)] where
+def visitSUB_XX : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64)] where
   lhs := [LV| {
     ^entry (%x: i64):
       %0 = llvm.sub %x, %x : i64
@@ -296,7 +296,7 @@ def visitSUB_x_x : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64)] where
 /-
   fold (sub x, 0) -> x
 -/
-def visitSUB_x_0 : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64)] where
+def visitSUB_X0 : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64)] where
   lhs := [LV| {
     ^entry (%x: i64):
       %c = llvm.mlir.constant (0) : i64
@@ -311,7 +311,7 @@ def visitSUB_x_0 : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64)] where
 /-
   0 - X --> 0 if the sub is NUW.
 -/
-def visitSUB_0_x_nuw : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64)] where
+def visitSUB_0NegXNuw : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64)] where
   lhs := [LV| {
     ^entry (%x: i64):
       %c = llvm.mlir.constant (0) : i64
@@ -327,7 +327,7 @@ def visitSUB_0_x_nuw : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64)] where
 /-
   Canonicalize (sub -1, x) -> ~x, i.e. (xor x, -1)
 -/
-def visitSUB_Neg1_x : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64)] where
+def visitSUB_Neg1X : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64)] where
   lhs := [LV| {
     ^entry (%x: i64):
       %c = llvm.mlir.constant (-1) : i64
@@ -344,7 +344,7 @@ def visitSUB_Neg1_x : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64)] where
 /-
   fold (A-(0-B)) -> A+B
 -/
-def visitSUB_A_0_Neg_B : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
+def visitSUB_A0NegB : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
   lhs := [LV| {
     ^entry (%a: i64, %b: i64):
       %c = llvm.mlir.constant (0) : i64
@@ -361,7 +361,7 @@ def visitSUB_A_0_Neg_B : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.
 /-
   fold A-(A-B) -> B
 -/
-def visitSUB_A_A_Neg_B : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
+def visitSUB_AANegB : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
   lhs := [LV| {
     ^entry (%a: i64, %b: i64):
       %0 = llvm.sub %a, %b : i64
@@ -376,7 +376,7 @@ def visitSUB_A_A_Neg_B : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.
 /-
   fold (A+B)-A -> B
 -/
-def visitSUB_A_plus_B_Neg_A : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
+def visitSUB_APlusBNegA : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
   lhs := [LV| {
     ^entry (%a: i64, %b: i64):
       %0 = llvm.add %a, %b : i64
@@ -391,7 +391,7 @@ def visitSUB_A_plus_B_Neg_A : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64)
 /-
   fold (A+B)-B -> A
 -/
-def visitSUB_A_plus_B_Neg_B : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
+def visitSUB_APlusBNegB : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
   lhs := [LV| {
     ^entry (%a: i64, %b: i64):
       %0 = llvm.add %a, %b : i64
@@ -406,7 +406,7 @@ def visitSUB_A_plus_B_Neg_B : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64)
 /-
   fold ((A+(B+C))-B) -> A+C
 -/
-def visitSUB_A_plus_B_plus_C_Neg_B : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
+def visitSUB_APlusBPlusCNegB : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
   lhs := [LV| {
     ^entry (%a: i64, %b: i64, %c: i64):
       %0 = llvm.add %b, %c : i64
@@ -423,7 +423,7 @@ def visitSUB_A_plus_B_plus_C_Neg_B : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bit
 /-
   fold ((A+(B-C))-B) -> A-C
 -/
-def visitSUB_A_plus_B_Neg_C_Neg_B : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
+def visitSUB_APlusBNegCNegB : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
   lhs := [LV| {
     ^entry (%a: i64, %b: i64, %c: i64):
       %0 = llvm.sub %b, %c : i64
@@ -440,7 +440,7 @@ def visitSUB_A_plus_B_Neg_C_Neg_B : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitv
 /-
   fold ((A-(B-C))-C) -> A-B
 -/
-def visitSUB_A_Neg_B_Neg_C_Neg_C : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
+def visitSUB_ANegBNegCNegC : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
   lhs := [LV| {
     ^entry (%a: i64, %b: i64, %c: i64):
       %0 = llvm.sub %b, %c : i64
@@ -457,7 +457,7 @@ def visitSUB_A_Neg_B_Neg_C_Neg_C : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitve
 /-
   fold (A-(B-C)) -> A+(C-B)
 -/
-def visitSUB_A_Neg_B_Neg_C : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
+def visitSUB_ANegBNegC : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
   lhs := [LV| {
     ^entry (%a: i64, %b: i64, %c: i64):
       %0 = llvm.sub %b, %c : i64
@@ -474,7 +474,7 @@ def visitSUB_A_Neg_B_Neg_C : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64),
 /-
   A - (A & B)  ->  A & (~B)
 -/
-def visitSUB_A_Neg_A_and_B : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
+def visitSUB_ANegAAndB : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
   lhs := [LV| {
     ^entry (%a: i64, %b: i64):
       %0 = llvm.and %a, %b : i64
@@ -488,27 +488,27 @@ def visitSUB_A_Neg_A_and_B : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64),
       llvm.return %1 : i64
   }]
 
-  def visitSUB : List (Σ Γ, LLVMPeepholeRewriteRefine 64 Γ) :=
-  [⟨_, visitSUB_x_x⟩,
-   ⟨_, visitSUB_x_0⟩,
-   ⟨_, visitSUB_0_x_nuw⟩,
-   ⟨_, visitSUB_Neg1_x⟩,
-   ⟨_, visitSUB_A_0_Neg_B⟩,
-   ⟨_, visitSUB_A_A_Neg_B⟩,
-   ⟨_, visitSUB_A_plus_B_Neg_A⟩,
-   ⟨_, visitSUB_A_plus_B_Neg_B⟩,
-   ⟨_, visitSUB_A_plus_B_plus_C_Neg_B⟩,
-   ⟨_, visitSUB_A_plus_B_Neg_C_Neg_B⟩,
-   ⟨_, visitSUB_A_Neg_B_Neg_C_Neg_C⟩,
-   ⟨_, visitSUB_A_Neg_B_Neg_C⟩,
-   ⟨_, visitSUB_A_Neg_A_and_B⟩]
+def visitSUB : List (Σ Γ, LLVMPeepholeRewriteRefine 64 Γ) :=
+  [⟨_, visitSUB_XX⟩,
+   ⟨_, visitSUB_X0⟩,
+   ⟨_, visitSUB_0NegXNuw⟩,
+   ⟨_, visitSUB_Neg1X⟩,
+   ⟨_, visitSUB_A0NegB⟩,
+   ⟨_, visitSUB_AANegB⟩,
+   ⟨_, visitSUB_APlusBNegA⟩,
+   ⟨_, visitSUB_APlusBNegB⟩,
+   ⟨_, visitSUB_APlusBPlusCNegB⟩,
+   ⟨_, visitSUB_APlusBNegCNegB⟩,
+   ⟨_, visitSUB_ANegBNegCNegC⟩,
+   ⟨_, visitSUB_ANegBNegC⟩,
+   ⟨_, visitSUB_ANegAAndB⟩]
 
 /-! ### visitAND -/
 
 /-
   fold (mul x, 0) -> 0
 -/
-def visitMUL_x_0 : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64)] where
+def visitMUL_X0 : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64)] where
   lhs := [LV| {
     ^entry (%x: i64):
       %c = llvm.mlir.constant (0) : i64
@@ -524,7 +524,7 @@ def visitMUL_x_0 : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64)] where
 /-
   fold (mul x, 1) -> x
 -/
-def visitMUL_x_1 : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64)] where
+def visitMUL_X1 : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64)] where
   lhs := [LV| {
     ^entry (%x: i64):
       %c = llvm.mlir.constant (1) : i64
@@ -539,7 +539,7 @@ def visitMUL_x_1 : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64)] where
 /-
   fold (mul x, -1) -> 0-x
 -/
-def visitMUL_x_Neg1 : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64)] where
+def visitMUL_XNeg1 : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64)] where
   lhs := [LV| {
     ^entry (%x: i64):
       %c = llvm.mlir.constant (-1) : i64
@@ -556,7 +556,7 @@ def visitMUL_x_Neg1 : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64)] where
 /-
   fold (mul x, (1 << c)) -> x << c
 -/
-def visitMUL_x_shift : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
+def visitMUL_XShift : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
   lhs := [LV| {
     ^entry (%x: i64, %y: i64):
       %c = llvm.mlir.constant (1) : i64
@@ -573,7 +573,7 @@ def visitMUL_x_shift : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.ll
 /-
   fold (mul x, -(1 << c)) -> -(x << c) or (-x) << c
 -/
-def visitMUL_x_neg_shift : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
+def visitMUL_XNegShift : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
   lhs := [LV| {
     ^entry (%x: i64, %y: i64):
       %c = llvm.mlir.constant (1) : i64
@@ -591,18 +591,18 @@ def visitMUL_x_neg_shift : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), T
   }]
 
 def visitMUL : List (Σ Γ, LLVMPeepholeRewriteRefine 64 Γ) :=
-  [⟨_, visitMUL_x_0⟩,
-   ⟨_, visitMUL_x_1⟩,
-   ⟨_, visitMUL_x_Neg1⟩,
-   ⟨_, visitMUL_x_shift⟩,
-   ⟨_, visitMUL_x_neg_shift⟩]
+  [⟨_, visitMUL_X0⟩,
+   ⟨_, visitMUL_X1⟩,
+   ⟨_, visitMUL_XNeg1⟩,
+   ⟨_, visitMUL_XShift⟩,
+   ⟨_, visitMUL_XNegShift⟩]
 
 /-! ### visitSDIV -/
 
 /-
   fold (sdiv X, -1) -> 0-X
 -/
-def visitSDIV_x_Neg1 : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64)] where
+def visitSDIV_XNeg1 : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64)] where
   lhs := [LV| {
     ^entry (%x: i64):
       %c = llvm.mlir.constant (-1) : i64
@@ -617,7 +617,7 @@ def visitSDIV_x_Neg1 : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64)] where
   }]
 
 def visitSDIV : List (Σ Γ, LLVMPeepholeRewriteRefine 64 Γ) :=
-  [⟨_, visitSDIV_x_Neg1⟩]
+  [⟨_, visitSDIV_XNeg1⟩]
 
 
 /-! ### visitAND -/
@@ -625,7 +625,7 @@ def visitSDIV : List (Σ Γ, LLVMPeepholeRewriteRefine 64 Γ) :=
 /-
   x & x --> x
 -/
-def visitAND_sameop : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64)] where
+def visitAND_Sameop : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64)] where
   lhs := [LV| {
     ^entry (%x: i64):
       %0 = llvm.and %x, %x : i64
@@ -668,16 +668,16 @@ def visitAND_Neg1 : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64)] where
   }]
 
 def visitAND : List (Σ Γ, LLVMPeepholeRewriteRefine 64 Γ) :=
-  [⟨_, visitAND_sameop⟩,
-  ⟨_, visitAND_0⟩,
-  ⟨_, visitAND_Neg1⟩]
+  [⟨_, visitAND_Sameop⟩,
+   ⟨_, visitAND_0⟩,
+   ⟨_, visitAND_Neg1⟩]
 
 /-! ### visitOR -/
 
 /-
   x | x --> x
 -/
-def visitOR_sameop : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64)] where
+def visitOR_Sameop : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64)] where
   lhs := [LV| {
     ^entry (%x: i64):
       %0 = llvm.or %x, %x : i64
@@ -722,7 +722,7 @@ def visitOR_Neg1 : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64)] where
 /-
   (or (and X, M), (and X, N)) -> (and X, (or M, N))
 -/
-def visitOR_and : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
+def visitOR_And : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
   lhs := [LV| {
     ^entry (%x: i64, %m: i64, %n: i64):
       %0 = llvm.and %x, %m : i64
@@ -738,10 +738,10 @@ def visitOR_and : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.
   }]
 
 def visitOR : List (Σ Γ, LLVMPeepholeRewriteRefine 64 Γ) :=
-  [⟨_, visitOR_sameop⟩,
+  [⟨_, visitOR_Sameop⟩,
    ⟨_, visitOR_0⟩,
    ⟨_, visitOR_Neg1⟩,
-   ⟨_, visitOR_and⟩]
+   ⟨_, visitOR_And⟩]
 
 /-! ### visitXOR -/
 
@@ -763,7 +763,7 @@ def visitXOR_0 : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64)] where
 /-
   fold (xor x, x) -> 0
 -/
-def visitXOR_x : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64)] where
+def visitXOR_X : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64)] where
   lhs := [LV| {
     ^entry (%x: i64):
       %0 = llvm.xor %x, %x : i64
@@ -778,7 +778,7 @@ def visitXOR_x : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64)] where
 /-
   fold (not (add X, -1)) -> (neg X)
 -/
-def visitXOR_add_Neg1 : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64)] where
+def visitXOR_AddNeg1 : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64)] where
   lhs := [LV| {
     ^entry (%x: i64):
       %c = llvm.mlir.constant (-1) : i64
@@ -795,7 +795,7 @@ def visitXOR_add_Neg1 : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64)] wher
 /-
   (not (neg x)) -> (add X, -1). (osman: )
 -/
-def visitXOR_not_neg : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64)] where
+def visitXOR_NotNeg : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64)] where
   lhs := [LV| {
     ^entry (%x: i64):
       %0 = llvm.neg %x : i64
@@ -812,7 +812,7 @@ def visitXOR_not_neg : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64)] where
 /-
   fold (xor (and x, y), y) -> (and (not x), y)
 -/
-def visitXOR_xor_and : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
+def visitXOR_AndXY : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
   lhs := [LV| {
     ^entry (%x: i64, %y: i64):
       %0 = llvm.and %x, %y : i64
@@ -828,10 +828,10 @@ def visitXOR_xor_and : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.ll
 
 def visitXOR : List (Σ Γ, LLVMPeepholeRewriteRefine 64 Γ) :=
   [⟨_, visitXOR_0⟩,
-   ⟨_, visitXOR_x⟩,
-   ⟨_, visitXOR_add_Neg1⟩,
-   ⟨_, visitXOR_not_neg⟩,
-   ⟨_, visitXOR_xor_and⟩]
+   ⟨_, visitXOR_X⟩,
+   ⟨_, visitXOR_AddNeg1⟩,
+   ⟨_, visitXOR_NotNeg⟩,
+   ⟨_, visitXOR_AndXY⟩]
 
 /-! ### visitSRA -/
 
@@ -877,7 +877,7 @@ def visitSRA : List (Σ Γ, LLVMPeepholeRewriteRefine 64 Γ) :=
 Test the rewrite:
   select (not Cond), N1, N2 -> select Cond, N2, N1
 -/
-def visitSELECT_constant_not_cond : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 1)] where
+def visitSELECT_ConstantNotCond : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 1)] where
   lhs := [LV| {
     ^entry (%c: i1, %x: i64, %y: i64):
       %0 = llvm.not %c : i1
@@ -894,7 +894,7 @@ def visitSELECT_constant_not_cond : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitv
 Test the rewrite:
   (true ? x : y) -> x
 -/
-def visitSELECT_constant_cmp_true : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
+def visitSELECT_ConstantCmpTrue : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
   lhs := [LV| {
     ^entry (%x: i64, %y: i64):
       %0 = llvm.mlir.constant (1) : i1
@@ -910,7 +910,7 @@ def visitSELECT_constant_cmp_true : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitv
 Test the rewrite:
   (false ? x : y) -> y
 -/
-def visitSELECT_constant_cmp_false : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
+def visitSELECT_ConstantCmpFalse : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
   lhs := [LV| {
     ^entry (%x: i64, %y: i64):
       %0 = llvm.mlir.constant (0) : i1
@@ -923,15 +923,16 @@ def visitSELECT_constant_cmp_false : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bit
   }]
 
 def visitSELECT : List (Σ Γ, LLVMPeepholeRewriteRefine 64 Γ) :=
-  [⟨_, visitSELECT_constant_not_cond⟩,
-   ⟨_, visitSELECT_constant_cmp_true⟩,
-   ⟨_, visitSELECT_constant_cmp_false⟩]
+  [⟨_, visitSELECT_ConstantNotCond⟩,
+   ⟨_, visitSELECT_ConstantCmpTrue⟩,
+   ⟨_, visitSELECT_ConstantCmpFalse⟩]
 
  /-! ### Grouped patterns -/
 
 def SelectionDAG_combines : List (Σ Γ, LLVMPeepholeRewriteRefine 64 Γ) :=
-  visitADD ++ visitAND ++ visitSUB ++ visitMUL ++ visitSDIV ++ visitOR ++ visitXOR ++ visitSRA ++
-  visitSELECT
+  visitADD ++ visitAND ++ visitSUB ++ visitMUL ++ visitSDIV ++ visitOR
+  ++ visitXOR ++ visitSRA ++ visitSELECT
+
 
 def SelectionDAGCombiner :
     List (Σ Γ, Σ ty, PeepholeRewrite LLVMPlusRiscV Γ ty) :=


### PR DESCRIPTION
This PR introduces a new RISC-V 64 lowering pass that applies SelectionDAG optimization patterns to both LLVM IR. The main changes include verification of optimization rewrites from SelectionDAG and the implementation of the corresponding pipeline.

List of implemented patterns:

- [visitADD](https://github.com/llvm/llvm-project/blob/bc0d0cf3ac9b5f1c2ec33d22aba8e7ece7d08ed2/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp#L3175)
- [visitAND](https://github.com/llvm/llvm-project/blob/bc0d0cf3ac9b5f1c2ec33d22aba8e7ece7d08ed2/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp#L7457)
- [visitMUL](https://github.com/llvm/llvm-project/blob/bc0d0cf3ac9b5f1c2ec33d22aba8e7ece7d08ed2/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp#L4702)
- [visitOR](https://github.com/llvm/llvm-project/blob/bc0d0cf3ac9b5f1c2ec33d22aba8e7ece7d08ed2/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp#L8391)
- [visitSDIV](https://github.com/llvm/llvm-project/blob/bc0d0cf3ac9b5f1c2ec33d22aba8e7ece7d08ed2/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp#L5100)
- [visitSELECT](https://github.com/llvm/llvm-project/blob/bc0d0cf3ac9b5f1c2ec33d22aba8e7ece7d08ed2/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp#L12354)
- [visitSUB](https://github.com/llvm/llvm-project/blob/bc0d0cf3ac9b5f1c2ec33d22aba8e7ece7d08ed2/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp#L4126)
- [visitSRA](https://github.com/llvm/llvm-project/blob/bc0d0cf3ac9b5f1c2ec33d22aba8e7ece7d08ed2/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp#L10926)
- [visitXOR](https://github.com/llvm/llvm-project/blob/bc0d0cf3ac9b5f1c2ec33d22aba8e7ece7d08ed2/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp#L9936)