### PR TITLE
chore: change default behavior for icmp lowering

### DIFF
--- a/SSA/Projects/LLVMRiscV/ParseAndTransform.lean
+++ b/SSA/Projects/LLVMRiscV/ParseAndTransform.lean
@@ -26,7 +26,7 @@ def passriscv64 (fileName : String) : IO UInt32 := do
         | [Ty.llvm (.bitvec _w)]  =>
           /- calls to the instruction selector defined in `InstructionLowering`,
             `true` indicates pseudo variable lowering, `fuel` is 150-/
-          let lowered := selectionPipeFuelWithCSE 150 c true
+          let lowered := selectionPipeFuelWithCSE 150 c false
 
           IO.println <| lowered.printModule
           return 0
@@ -53,7 +53,7 @@ def passriscv64_optimized (fileName : String) : IO UInt32 := do
         | [Ty.llvm (.bitvec _w)]  =>
           /- calls to the optimized instruction selector defined in `InstructionLowering`,
           `true` indicates pseudo variable lowering, `fuel` is 150 -/
-          let lowered := selectionPipeFuelWithCSEWithOpt 150 c true
+          let lowered := selectionPipeFuelWithCSEWithOpt 150 c false
           IO.println <| lowered.printModule
           return 0
         | _ =>

--- a/SSA/Projects/LLVMRiscV/Pipeline/icmp.lean
+++ b/SSA/Projects/LLVMRiscV/Pipeline/icmp.lean
@@ -198,11 +198,11 @@ def icmp_eq_llvm_32 : Com LLVMPlusRiscV ⟨[.llvm (.bitvec 32), .llvm (.bitvec 3
 @[simp_denote]
 def icmp_eq_riscv_32 := [LV| {
   ^entry (%lhs: i32, %rhs: i32):
-    %lhsr = "builtin.unrealized_conversion_cast"(%lhs) : (i32) -> (!i64)
-    %rhsr = "builtin.unrealized_conversion_cast"(%rhs) : (i32) -> (!i64)
-    %0 = xor    %lhsr, %rhsr : !i64
-    %1 = sltiu %0, 1 : !i64
-    %2 = "builtin.unrealized_conversion_cast"(%1) : (!i64) -> (i1)
+    %lhsr = "builtin.unrealized_conversion_cast"(%lhs) : (i32) -> (!riscv.reg)
+    %rhsr = "builtin.unrealized_conversion_cast"(%rhs) : (i32) -> (!riscv.reg)
+    %0 = xor    %lhsr, %rhsr : !riscv.reg
+    %1 = seqz    %0 : !riscv.reg
+    %2 = "builtin.unrealized_conversion_cast"(%1) : (!riscv.reg) -> (i1)
     llvm.return %2 : i1
   }]
 
@@ -220,12 +220,11 @@ def icmp_neq_llvm_32 : Com LLVMPlusRiscV ⟨[.llvm (.bitvec 32), .llvm (.bitvec 
 @[simp_denote]
 def icmp_neq_riscv_32 := [LV| {
   ^entry (%lhs: i32, %rhs: i32):
-    %lhsr = "builtin.unrealized_conversion_cast"(%lhs) : (i32) -> (!i64)
-    %rhsr = "builtin.unrealized_conversion_cast"(%rhs) : (i32) -> (!i64)
-    %0 = xor    %lhsr, %rhsr : !i64
-    %c0 = li (0) : !i64
-    %1 = sltu %c0, %0 : !i64
-    %2 = "builtin.unrealized_conversion_cast"(%1) : (!i64) -> (i1)
+    %lhsr = "builtin.unrealized_conversion_cast"(%lhs) : (i32) -> (!riscv.reg)
+    %rhsr = "builtin.unrealized_conversion_cast"(%rhs) : (i32) -> (!riscv.reg)
+    %0 = xor    %lhsr, %rhsr : !riscv.reg
+    %1 = snez    %0 : !riscv.reg
+    %2 = "builtin.unrealized_conversion_cast"(%1) : (!riscv.reg) -> (i1)
     llvm.return %2 : i1
   }]
 
@@ -429,11 +428,11 @@ def icmp_eq_llvm_64 : Com LLVMPlusRiscV ⟨[.llvm (.bitvec 64), .llvm (.bitvec 6
 @[simp_denote]
 def icmp_eq_riscv_64 := [LV| {
   ^entry (%lhs: i64, %rhs: i64):
-    %lhsr = "builtin.unrealized_conversion_cast"(%lhs) : (i64) -> (!i64)
-    %rhsr = "builtin.unrealized_conversion_cast"(%rhs) : (i64) -> (!i64)
-    %0 = xor    %lhsr, %rhsr : !i64
-    %1 = sltiu %0, 1 : !i64
-    %2 = "builtin.unrealized_conversion_cast"(%1) : (!i64) -> (i1)
+    %lhsr = "builtin.unrealized_conversion_cast"(%lhs) : (i64) -> (!riscv.reg)
+    %rhsr = "builtin.unrealized_conversion_cast"(%rhs) : (i64) -> (!riscv.reg)
+    %0 = xor    %lhsr, %rhsr : !riscv.reg
+    %1 = seqz    %0 : !riscv.reg
+    %2 = "builtin.unrealized_conversion_cast"(%1) : (!riscv.reg) -> (i1)
     llvm.return %2 : i1
   }]
 
@@ -449,19 +448,18 @@ def icmp_neq_llvm_64 : Com LLVMPlusRiscV ⟨[.llvm (.bitvec 64), .llvm (.bitvec 
   }]
 
 @[simp_denote]
-def icmp_neq_riscv_64 := [LV| {
+def icmp_ne_riscv_64 := [LV| {
   ^entry (%lhs: i64, %rhs: i64):
-    %lhsr = "builtin.unrealized_conversion_cast"(%lhs) : (i64) -> (!i64)
-    %rhsr = "builtin.unrealized_conversion_cast"(%rhs) : (i64) -> (!i64)
-    %0 = xor    %lhsr, %rhsr : !i64
-    %c0 = li (0) : !i64
-    %1 = sltu %c0, %0 : !i64
-    %2 = "builtin.unrealized_conversion_cast"(%1) : (!i64) -> (i1)
+    %lhsr = "builtin.unrealized_conversion_cast"(%lhs) : (i64) -> (!riscv.reg)
+    %rhsr = "builtin.unrealized_conversion_cast"(%rhs) : (i64) -> (!riscv.reg)
+    %0 = xor    %lhsr, %rhsr : !riscv.reg
+    %1 = snez    %0 : !riscv.reg
+    %2 = "builtin.unrealized_conversion_cast"(%1) : (!riscv.reg) -> (i1)
     llvm.return %2 : i1
   }]
 
 def icmp_neq_riscv_eq_icmp_neq_llvm_64 : LLVMPeepholeRewriteRefine 1 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] :=
-  {lhs:= icmp_neq_llvm_64, rhs:= icmp_neq_riscv_64}
+  {lhs:= icmp_neq_llvm_64, rhs:= icmp_ne_riscv_64}
 
 def icmp_match : List (Σ Γ, Σ ty, PeepholeRewrite LLVMPlusRiscV Γ ty) := [
   mkRewrite (LLVMToRiscvPeepholeRewriteRefine.toPeepholeUNSOUND icmp_uge_riscv_eq_icmp_uge_llvm_32),

--- a/SSA/Projects/LLVMRiscV/Pipeline/pseudo.lean
+++ b/SSA/Projects/LLVMRiscV/Pipeline/pseudo.lean
@@ -1,5 +1,4 @@
 import SSA.Projects.LLVMRiscV.PeepholeRefine
-import SSA.Projects.LLVMRiscV.PeepholeRefine
 import SSA.Projects.LLVMRiscV.Simpproc
 import SSA.Projects.RISCV64.Tactic.SimpRiscV
 import SSA.Projects.LLVMRiscV.Pipeline.mkRewrite
@@ -8,71 +7,76 @@ import SSA.Projects.LLVMRiscV.Pipeline.icmp
 open LLVMRiscV
 
 /-!
-  This file implements the lowering for the llvm pseudo-instructions for types i8, i16, i32, i64.
+  This file implements the lowering patterns that use pseudo-instructions by default.
+  The implementations here do not use pseudo-instructions, but directly implements patterns
+  in terms of the architectural instructions.
   For each pattern we only redefine the lowering, the source language pattern stays the same.
+
 -/
 
 /-! ### i32 -/
 
 @[simp_denote]
-def icmp_ne_riscv_32_pseudo := [LV| {
+def icmp_ne_riscv_32_no_pseudo := [LV| {
   ^entry (%lhs: i32, %rhs: i32):
-    %lhsr = "builtin.unrealized_conversion_cast"(%lhs) : (i32) -> (!riscv.reg)
-    %rhsr = "builtin.unrealized_conversion_cast"(%rhs) : (i32) -> (!riscv.reg)
-    %0 = xor    %lhsr, %rhsr : !riscv.reg
-    %1 = snez    %0 : !riscv.reg
-    %2 = "builtin.unrealized_conversion_cast"(%1) : (!riscv.reg) -> (i1)
+    %lhsr = "builtin.unrealized_conversion_cast"(%lhs) : (i32) -> (!i64)
+    %rhsr = "builtin.unrealized_conversion_cast"(%rhs) : (i32) -> (!i64)
+    %0 = xor    %lhsr, %rhsr : !i64
+    %c0 = li (0) : !i64
+    %1 = sltu %c0, %0 : !i64
+    %2 = "builtin.unrealized_conversion_cast"(%1) : (!i64) -> (i1)
     llvm.return %2 : i1
   }]
 
 @[simp_denote]
-def icmp_eq_riscv_32_pseudo := [LV| {
+def icmp_eq_riscv_32_no_pseudo := [LV| {
   ^entry (%lhs: i32, %rhs: i32):
-    %lhsr = "builtin.unrealized_conversion_cast"(%lhs) : (i32) -> (!riscv.reg)
-    %rhsr = "builtin.unrealized_conversion_cast"(%rhs) : (i32) -> (!riscv.reg)
-    %0 = xor    %lhsr, %rhsr : !riscv.reg
-    %1 = seqz    %0 : !riscv.reg
-    %2 = "builtin.unrealized_conversion_cast"(%1) : (!riscv.reg) -> (i1)
+    %lhsr = "builtin.unrealized_conversion_cast"(%lhs) : (i32) -> (!i64)
+    %rhsr = "builtin.unrealized_conversion_cast"(%rhs) : (i32) -> (!i64)
+    %0 = xor    %lhsr, %rhsr : !i64
+    %1 = sltiu %0, 1 : !i64
+    %2 = "builtin.unrealized_conversion_cast"(%1) : (!i64) -> (i1)
     llvm.return %2 : i1
   }]
 
-def icmp_ne_riscv_eq_icmp_ne_llvm_32_pseudo : LLVMPeepholeRewriteRefine 1 [Ty.llvm (.bitvec 32), Ty.llvm (.bitvec 32)] :=
-  {lhs:= icmp_neq_llvm_32, rhs:= icmp_ne_riscv_32_pseudo}
+def icmp_ne_riscv_eq_icmp_ne_llvm_32_no_pseudo : LLVMPeepholeRewriteRefine 1 [Ty.llvm (.bitvec 32), Ty.llvm (.bitvec 32)] :=
+  {lhs:= icmp_neq_llvm_32, rhs:= icmp_ne_riscv_32_no_pseudo}
 
-def icmp_eq_riscv_eq_icmp_eq_llvm_32_pseudo : LLVMPeepholeRewriteRefine 1 [Ty.llvm (.bitvec 32), Ty.llvm (.bitvec 32)] :=
-  {lhs:= icmp_eq_llvm_32, rhs:= icmp_eq_riscv_32_pseudo}
+def icmp_eq_riscv_eq_icmp_eq_llvm_32_no_pseudo : LLVMPeepholeRewriteRefine 1 [Ty.llvm (.bitvec 32), Ty.llvm (.bitvec 32)] :=
+  {lhs:= icmp_eq_llvm_32, rhs:= icmp_eq_riscv_32_no_pseudo}
 
 
 /-! ### i64 -/
 
 @[simp_denote]
-def icmp_eq_riscv_64_pseudo := [LV| {
+def icmp_eq_riscv_64_no_pseudo := [LV| {
   ^entry (%lhs: i64, %rhs: i64):
-    %lhsr = "builtin.unrealized_conversion_cast"(%lhs) : (i64) -> (!riscv.reg)
-    %rhsr = "builtin.unrealized_conversion_cast"(%rhs) : (i64) -> (!riscv.reg)
-    %0 = xor    %lhsr, %rhsr : !riscv.reg
-    %1 = seqz    %0 : !riscv.reg
-    %2 = "builtin.unrealized_conversion_cast"(%1) : (!riscv.reg) -> (i1)
+    %lhsr = "builtin.unrealized_conversion_cast"(%lhs) : (i64) -> (!i64)
+    %rhsr = "builtin.unrealized_conversion_cast"(%rhs) : (i64) -> (!i64)
+    %0 = xor    %lhsr, %rhsr : !i64
+    %1 = sltiu %0, 1 : !i64
+    %2 = "builtin.unrealized_conversion_cast"(%1) : (!i64) -> (i1)
     llvm.return %2 : i1
   }]
 
 def icmp_eq_riscv_eq_icmp_eq_llvm_64_pseudo : LLVMPeepholeRewriteRefine 1 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] :=
-  {lhs:= icmp_eq_llvm_64, rhs:= icmp_eq_riscv_64_pseudo}
+  {lhs:= icmp_eq_llvm_64, rhs:= icmp_eq_riscv_64_no_pseudo}
 
 
 @[simp_denote]
-def icmp_ne_riscv_64_pseudo := [LV| {
+def icmp_neq_riscv_64_no_pseudo := [LV| {
   ^entry (%lhs: i64, %rhs: i64):
-    %lhsr = "builtin.unrealized_conversion_cast"(%lhs) : (i64) -> (!riscv.reg)
-    %rhsr = "builtin.unrealized_conversion_cast"(%rhs) : (i64) -> (!riscv.reg)
-    %0 = xor    %lhsr, %rhsr : !riscv.reg
-    %1 = snez    %0 : !riscv.reg
-    %2 = "builtin.unrealized_conversion_cast"(%1) : (!riscv.reg) -> (i1)
+    %lhsr = "builtin.unrealized_conversion_cast"(%lhs) : (i64) -> (!i64)
+    %rhsr = "builtin.unrealized_conversion_cast"(%rhs) : (i64) -> (!i64)
+    %0 = xor    %lhsr, %rhsr : !i64
+    %c0 = li (0) : !i64
+    %1 = sltu %c0, %0 : !i64
+    %2 = "builtin.unrealized_conversion_cast"(%1) : (!i64) -> (i1)
     llvm.return %2 : i1
   }]
 
 def icmp_ne_riscv_eq_icmp_ne_llvm_64_pseudo : LLVMPeepholeRewriteRefine 1 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] :=
-  {lhs:= icmp_neq_llvm_64, rhs:= icmp_ne_riscv_64_pseudo}
+  {lhs:= icmp_neq_llvm_64, rhs:= icmp_neq_riscv_64_no_pseudo}
 
 def pseudo_match : List (Σ Γ, Σ ty, PeepholeRewrite LLVMPlusRiscV Γ ty) := [
    mkRewrite (LLVMToRiscvPeepholeRewriteRefine.toPeepholeUNSOUND icmp_eq_riscv_eq_icmp_eq_llvm_64_pseudo),


### PR DESCRIPTION
Currently, the optional pseudo-matching pass must be applied so that `icmp` instructions are lowered in the same manner as LLVM lowers them; without this pass, they are lowered to architectural instructions (whereas they should be lowered to pseudo-instructions). However, we should not require an additional pass for the default behaviour of LLVM. This PR makes LLVM's behaviour the default behaviour of our pipeline, and converts the pseudo-matching pass to lower LLVM instructions directly to architectural instructions, in case we need it in the future.