### PR TITLE
feat/Blase: Keep width 1 non generalized

### DIFF
--- a/Blase/BlaseTest/BitVec.lean
+++ b/Blase/BlaseTest/BitVec.lean
@@ -9,6 +9,10 @@ theorem shiftl1 {v : Nat} (x : BitVec v) :
     x <<< 5 = x <<< 3 <<< 2 := by
   bv_multi_width
 
+/-- Check that by default, we understand width 1 bitvectors (ie, not specialized to width w). -/
+theorem width1_understood (x y : BitVec 1) : x + y = x ^^^ y := by
+  bv_multi_width
+
 
 /--
 error: CEX: Found exact counter-example at iteration 5 for predicate MultiWidth.Nondep.Predicate.binRel

--- a/Blase/README.md
+++ b/Blase/README.md
@@ -16,9 +16,11 @@ For stable releases, please change the `rev` to the desired version tag.
 
 #### Algorithms Improvements TODO
 
-- [ ] Add support for left shift by constant which will give us much better multiplication encoding.
-- [ ] Add support for setWidth
-- [ ] Add support for min/max of width
+- [ ] Add support for a generalization mode that keeps width 1 and geneeralizes all other widths. This is useful for problems
+      with boolean substructure.
+- [x] Add support for left shift by constant which will give us much better multiplication encoding.
+- [x] Add support for setWidth
+- [x] Add support for min/max of width
 - [ ] I think we can handle ROVER like problems, canonicalize multiplication via ac_nf, have rules for how to distribute multiplication wrt addition/zext/sext/subtraction/negation, and we are done?
 - [x] Write a tactic that takes a goal state with BVs and generalizes them to an arbitrary width. 
       Call this `bv_abstract`.


### PR DESCRIPTION
This should give us access to many more problems, which use 1 width bitvectors as a proxy for boolean reasoning. 