### PR TITLE
fix: printing immediate as `toNat` for `slli.uw`

### DIFF
--- a/SSA/Projects/RISCV64/Base.lean
+++ b/SSA/Projects/RISCV64/Base.lean
@@ -509,7 +509,7 @@ def printAttributes: RISCV64.Op → String
   | .bexti (imm : BitVec 6) =>s!"\{immediate = { imm.toInt} : i6 }"
   | .binvi (imm : BitVec 6) => s!"\{immediate = { imm.toInt} : i6 }"
   | .bseti (imm : BitVec 6) => s!"\{immediate = { imm.toInt} : i6 }"
-  | .slliuw (imm : BitVec 6) => s!"\{immediate = { imm.toInt} : ui6 }"
+  | .slliuw (imm : BitVec 6) => s!"\{immediate = { imm.toNat} : ui6 }"
   | .rori (imm : BitVec 6) => s!"\{immediate = { imm.toInt} : i5 }"
   | .roriw (imm : BitVec 5) => s!"\{immediate = { imm.toInt} : i5 }"
   | _ => ""


### PR DESCRIPTION
We print the immediate argument of `slli.uw` as `toNat`.