### PR TITLE
chore: add +1, +k support for widths

### DIFF
--- a/Blase/Blase/MultiWidth/GoodFSM.lean
+++ b/Blase/Blase/MultiWidth/GoodFSM.lean
@@ -62,6 +62,10 @@ def mkWidthFSM (wcard : Nat) (tcard : Nat) (bcard : Nat) (pcard : Nat) (w : Nond
     { toFsm :=
         composeUnaryAux (FSM.repeatN true k)  (mkWidthFSM wcard tcard bcard pcard v).toFsm
     }
+  | .kadd k v =>
+    { toFsm :=
+        composeUnaryAux (FSM.repeatN true k)  (mkWidthFSM wcard tcard bcard pcard v).toFsm
+    }
 
 def IsGoodNatFSM_mkWidthFSM {wcard : Nat} (tcard : Nat) (bcard : Nat) (pcard : Nat)  (w : WidthExpr wcard) :
     HNatFSMToBitstream (mkWidthFSM wcard tcard bcard pcard (.ofDep w)) where
@@ -95,10 +99,17 @@ def IsGoodNatFSM_mkWidthFSM {wcard : Nat} (tcard : Nat) (bcard : Nat) (pcard : N
       ext i
       simp
     case addK v k hv =>
-      simp [mkWidthFSM]
+      simp only [Nondep.WidthExpr.ofDep_addK, mkWidthFSM, composeUnaryAux_eval, FSM.eval_repeatN,
+        Bool.if_true_left, WidthExpr.toNat_addK]
       rw [hv]
       ext i
       simp
+      simp only [decide_or_decide_eq_decide, decide_eq_decide]
+      omega
+    case kadd k v hv =>
+      simp [mkWidthFSM]
+      rw [hv]
+      ext i
       simp only [decide_or_decide_eq_decide, decide_eq_decide]
       omega
 

--- a/Blase/Blase/MultiWidth/Tactic.lean
+++ b/Blase/Blase/MultiWidth/Tactic.lean
@@ -185,7 +185,7 @@ def collectWidthAtom (state : CollectState) (e : Expr) :
         throwError m!"expected width to be a Nat, found: {indentD e}"
     -- If we do not want width abstraction, then try to interpret width as constant.
     if let .some n ← getNatValue? e then
-      match (← read).widthAbstraction with 
+      match (← read).widthAbstraction with
       | .never =>
         return (MultiWidth.Nondep.WidthExpr.const n, state)
       | .generalizeGeq cutoff =>
@@ -204,45 +204,51 @@ def collectWidthAtom (state : CollectState) (e : Expr) :
 
 partial def collectWidthExpr (state : CollectState) (e : Expr) :
     SolverM (MultiWidth.Nondep.WidthExpr × CollectState) := do
-  match_expr e with
-  | Nat.zero => return (.const 0, state)
-  | Nat.succ n =>
-    let (we, state) ← collectWidthExpr state n
-    return (.addK we 1, state)
-  | min nat _inst x y =>
-    match_expr nat with 
-    | Nat =>
-      let (wx, state) ← collectWidthExpr state x
-      let (wy, state) ← collectWidthExpr state y
-      return (.min wx wy, state)
-    | _ => mkAtom 
-  | max nat _inst x y =>
-    match_expr nat with
-    | Nat =>
-      let (wx, state) ← collectWidthExpr state x
-      let (wy, state) ← collectWidthExpr state y
-      return (.max wx wy, state)
-    | _ => mkAtom
-  | HAdd.hAdd _nat0 _nat1 _nat2 _inst a b =>
-    match_expr _nat0 with
-    | Nat =>
-      match_expr _nat1 with
+  if let some v ← getNatValue? e then
+    return (.const v, state)
+  else
+    match_expr e with
+    | Nat.succ n =>
+      let (we, state) ← collectWidthExpr state n
+      return (.addK we 1, state)
+    | min nat _inst x y =>
+      match_expr nat with
       | Nat =>
-        match_expr _nat2 with
-        | Nat => do
-          let (wa, state) ← collectWidthExpr state a
-          if let some b ← getNatValue? b then
-            return (.addK wa b, state)
-          else
-            mkAtom
+        let (wx, state) ← collectWidthExpr state x
+        let (wy, state) ← collectWidthExpr state y
+        return (.min wx wy, state)
+      | _ => mkAtom
+    | max nat _inst x y =>
+      match_expr nat with
+      | Nat =>
+        let (wx, state) ← collectWidthExpr state x
+        let (wy, state) ← collectWidthExpr state y
+        return (.max wx wy, state)
+      | _ => mkAtom
+    | HAdd.hAdd _nat0 _nat1 _nat2 _inst a b =>
+      match_expr _nat0 with
+      | Nat =>
+        match_expr _nat1 with
+        | Nat =>
+          match_expr _nat2 with
+          | Nat => do
+            if let some a ← getNatValue? a then
+              let (wb, state) ← collectWidthExpr state b
+              return (.kadd a wb, state)
+            else
+              let (wa, state) ← collectWidthExpr state a
+              if let some b ← getNatValue? b then
+                return (.addK wa b, state)
+              else
+                mkAtom
+          | _ => mkAtom
         | _ => mkAtom
       | _ => mkAtom
     | _ => mkAtom
-  | _ => mkAtom
-  where
-    mkAtom := do
-      let (we, state) ← collectWidthAtom state e
-      return (we, state)
+    where
+      mkAtom := do
+        let (we, state) ← collectWidthAtom state e
+        return (we, state)
 
 /-- info: Fin.mk {n : ℕ} (val : ℕ) (isLt : val < n) : Fin n -/
 #guard_msgs in #check Fin.mk
@@ -294,6 +300,11 @@ def mkWidthExpr (wcard : Nat) (ve : MultiWidth.Nondep.WidthExpr) :
   | .addK v k =>
     let out := mkAppN (mkConst ``MultiWidth.WidthExpr.addK)
       #[mkNatLit wcard, ← mkWidthExpr wcard v, mkNatLit k]
+    debugCheck out
+    return out
+  | .kadd k v =>
+    let out := mkAppN (mkConst ``MultiWidth.WidthExpr.kadd)
+      #[mkNatLit wcard, mkNatLit k, ← mkWidthExpr wcard v]
     debugCheck out
     return out
 

--- a/Blase/Blase/MultiWidth/Tactic.lean
+++ b/Blase/Blase/MultiWidth/Tactic.lean
@@ -223,6 +223,21 @@ partial def collectWidthExpr (state : CollectState) (e : Expr) :
       let (wy, state) ← collectWidthExpr state y
       return (.max wx wy, state)
     | _ => mkAtom
+  | HAdd.hAdd _nat0 _nat1 _nat2 _inst a b =>
+    match_expr _nat0 with
+    | Nat =>
+      match_expr _nat1 with
+      | Nat =>
+        match_expr _nat2 with
+        | Nat => do
+          let (wa, state) ← collectWidthExpr state a
+          if let some b ← getNatValue? b then
+            return (.addK wa b, state)
+          else
+            mkAtom
+        | _ => mkAtom
+      | _ => mkAtom
+    | _ => mkAtom
   | _ => mkAtom
   where
     mkAtom := do

--- a/Blase/Blase/MultiWidth/Tests.lean
+++ b/Blase/Blase/MultiWidth/Tests.lean
@@ -23,13 +23,10 @@ theorem abstract_prop {w : Nat} (p : Prop) (x : BitVec w) : p ∨ (x = x) := by
   bv_multi_width
 
 /--
-warning: abstracted non-variable width: ⏎
-  → 'x + 1'
----
-error: MAYCEX: Found possible counter-example at iteration 0 for predicate MultiWidth.Nondep.Predicate.binWidthRel
+error: CEX: Found exact counter-example at iteration 0 for predicate MultiWidth.Nondep.Predicate.binWidthRel
   (MultiWidth.WidthBinaryRelationKind.eq)
   (MultiWidth.Nondep.WidthExpr.var 0)
-  (MultiWidth.Nondep.WidthExpr.var 1)
+  (MultiWidth.Nondep.WidthExpr.addK (MultiWidth.Nondep.WidthExpr.var 0) 1)
 -/
 #guard_msgs in theorem abstract_prop_check_warn : ∀ (x : Nat), x = x + 1  := by
   -- | check that prop is abstracted.
@@ -364,6 +361,5 @@ theorem e_1 (x y : BitVec w) :
 
 theorem egZextMin (u v : Nat) (x : BitVec w) :
     u ≤ v → (x.zeroExtend v).zeroExtend u = x.zeroExtend u := by
-  fail_if_success bv_multi_width (config := { widthAbstraction := .never })
-  sorry
+  bv_multi_width (config := { widthAbstraction := .never })
 

--- a/Blase/BlaseTest/Preprocessing1.lean
+++ b/Blase/BlaseTest/Preprocessing1.lean
@@ -5,6 +5,8 @@
 -/
 import Blase
 import Blase.MultiWidth.Preprocessing
+set_option warn.sorry false
+
 open BitVec
 
 

--- a/Blase/BlaseTest/Preprocessing1.lean
+++ b/Blase/BlaseTest/Preprocessing1.lean
@@ -4,6 +4,7 @@
 -- test from: gnot_proof_test_invert_demorgan_logical_or_thm_extracted_1__6.lean
 -/
 import Blase
+import Blase.MultiWidth.Preprocessing
 open BitVec
 
 
@@ -11,4 +12,7 @@ theorem test_invert_demorgan_logical_or_thm.extracted_1._6 : ∀ (x x_1 : BitVec
   ¬ofBool (x_1 == 27#64) = 1#1 →
     ¬ofBool (x_1 != 27#64) = 1#1 →
       (ofBool (x_1 == 0#64) ||| ofBool (x == 0#64)) ^^^ 1#1 = ofBool (x_1 != 0#64) &&& 0#1 := by
-  bv_multi_width
+  intros
+  bv_multi_width_normalize
+  sorry
+  -- bv_multi_width

--- a/Blase/BlaseTest/Width.lean
+++ b/Blase/BlaseTest/Width.lean
@@ -20,3 +20,27 @@ theorem add_incr_left (x : BitVec v) :
   fail_if_success bv_multi_width
   sorry
 
+/-
+  {
+    "name": "add_assoc_1",
+    "preconditions": ["(>= q t)", "(>= u t)"],
+    "lhs": "(bw t ( + (bw u (+ (bw p a) (bw r b))) (bw s c)))",
+    "rhs": "(bw t ( + (bw p a) (bw q (+ (bw r b) (bw s c)))))"
+  },
+-/
+def bw (w : Nat) (x : BitVec v) : BitVec w := x.zeroExtend w
+
+def addMax (a : BitVec v) (b : BitVec w) : BitVec (max v w) :=
+   a.zeroExtend _ + b.zeroExtend _
+
+
+
+variable (w p q r s t : Nat)
+variable (a b : BitVec w)
+-- end preamble
+
+theorem add_assoc_1 (hq : q >= t) (hu : u >= t) :
+  (bw t (addMax (bw u (addMax (bw p a) (bw r b))) (bw s c)))  =
+  (bw t (addMax (bw p a) (bw q (addMax (bw r b) (bw s c))))) := by
+  simp only [bw, addMax]
+  bv_multi_width

--- a/Blase/BlaseTest/Width.lean
+++ b/Blase/BlaseTest/Width.lean
@@ -10,12 +10,11 @@ theorem width2 {v w : Nat} (x : BitVec v) :
     x.signExtend (max v (min v w)) = x.zeroExtend (max v (min v w)) := by
   bv_multi_width
 
-theorem add_incr_right (x : BitVec v) : 
+theorem add_incr_right (x : BitVec v) :
     x.zeroExtend (v + 2) = (x.zeroExtend (v + 1)).zeroExtend (v + 2) := by
-  fail_if_success bv_multi_width
-  sorry
+  bv_multi_width
 
-theorem add_incr_left (x : BitVec v) : 
+theorem add_incr_left (x : BitVec v) :
     x.zeroExtend (2 + v) = (x.zeroExtend (1 + v)).zeroExtend (2 + v) := by
   fail_if_success bv_multi_width
   sorry

--- a/Blase/BlaseTest/Width.lean
+++ b/Blase/BlaseTest/Width.lean
@@ -16,8 +16,7 @@ theorem add_incr_right (x : BitVec v) :
 
 theorem add_incr_left (x : BitVec v) :
     x.zeroExtend (2 + v) = (x.zeroExtend (1 + v)).zeroExtend (2 + v) := by
-  fail_if_success bv_multi_width
-  sorry
+  bv_multi_width
 
 /-
   {
@@ -35,11 +34,12 @@ def addMax (a : BitVec v) (b : BitVec w) : BitVec (max v w) :=
 
 
 variable (w p q r s t : Nat)
-variable (a b : BitVec w)
+variable (a : BitVec p) (b : BitVec r) (c : BitVec s)
 -- end preamble
 
 theorem add_assoc_1 (hq : q >= t) (hu : u >= t) :
   (bw t (addMax (bw u (addMax (bw p a) (bw r b))) (bw s c)))  =
   (bw t (addMax (bw p a) (bw q (addMax (bw r b) (bw s c))))) := by
   simp only [bw, addMax]
-  bv_multi_width
+  fail_if_success bv_multi_width
+  sorry


### PR DESCRIPTION
This will allow us to solve problems in ROVER that involve width `v >= w` which is lower to `v + 1 > w`. 