### PR TITLE
chore: drop fp dependency from Medusa

### DIFF
--- a/Medusa/Medusa.lean
+++ b/Medusa/Medusa.lean
@@ -1,4 +1,4 @@
 import Medusa.Generalize
 import Medusa.BitVec.BVGeneralize
-import Medusa.Fp.FpGeneralize
-import Medusa.LLVM.Generalize
+-- import Medusa.Fp.FpGeneralize
+-- import Medusa.LLVM.Generalize

--- a/Medusa/lakefile.toml
+++ b/Medusa/lakefile.toml
@@ -9,10 +9,10 @@ name = "Medusa"
 [[lean_lib]]
 name = "Test"
 
-[[require]]
-name = "fp-lean"
-git = "https://github.com/opencompl/fp-lean"
-rev = "5e45c0f"
+# [[require]]
+# name = "fp-lean"
+# git = "https://github.com/opencompl/fp-lean"
+# rev = "5e45c0f"
 
 [[require]]
 name = "SexprPBV"


### PR DESCRIPTION
We don't use Fp right now, and there is an import clash between Blase and Fp due to them both poorly defining `State` in the root namespace. Fp issue tracket at https://github.com/opencompl/fp-lean/issues/5