### PR TITLE
feat: expand mapping functionailty in core

### DIFF
--- a/LeanMLIR/LeanMLIR/ErasedContext.lean
+++ b/LeanMLIR/LeanMLIR/ErasedContext.lean
@@ -809,7 +809,7 @@ theorem Valuation.ofPair_snd {t₁ t₂ : Ty} (v₁: ⟦t₁⟧) (v₂ : ⟦t₂
 
 /-- Transport a valuation for `Γ` to a valuation for any mapped context `Γ.map f`.
 The value of each variable is transformed according to `f'`. -/
-def toMap {f : Ty → Ty'} (f' : ∀ t, ⟦t⟧ → ⟦f t⟧) : Valuation Γ → Valuation (Γ.map f)
+def Valuation.toMap {f : Ty → Ty'} (f' : ∀ t, ⟦t⟧ → ⟦f t⟧) : Valuation Γ → Valuation (Γ.map f)
 | val, t, ⟨i, h⟩ =>
   have : i < Γ.length := by rw [←length_map]; exact Var.mk i h |>.lt_length
   have heq : t = f Γ[i] := by
@@ -819,7 +819,7 @@ def toMap {f : Ty → Ty'} (f' : ∀ t, ⟦t⟧ → ⟦f t⟧) : Valuation Γ �
 
 /-- Transport a valuation for any mapped context `Γ.map f` to a valuation for `Γ`.
 The value of each variable is transformed according to `f'`. -/
-def fromMap {f : Ty → Ty'} (f' : ∀ t, ⟦f t⟧ → ⟦t⟧) : Valuation (Γ.map f) → Valuation Γ
+def Valuation.fromMap {f : Ty → Ty'} (f' : ∀ t, ⟦f t⟧ → ⟦t⟧) : Valuation (Γ.map f) → Valuation Γ
 | val, t, var => f' t <| val.eval var.toMap
 
 /-! ### Valuation Pullback (comap) -/

--- a/LeanMLIR/LeanMLIR/ErasedContext.lean
+++ b/LeanMLIR/LeanMLIR/ErasedContext.lean
@@ -914,6 +914,20 @@ def Valuation.recOn {motive : ∀ {Γ : Ctxt Ty}, Γ.Valuation → Sort*}
 def Valuation.cast {Γ Δ : Ctxt Ty} (h : Γ = Δ) (V : Valuation Γ) : Valuation Δ :=
   fun _ v => V <| v.castCtxt h.symm
 
+/-- Cast a valuation to a mapped context when the type denotations are equal.
+In situations where we get `h_elem` for free by definitional equality,
+this is the same as `toMap fun _ => id`. -/
+def Valuation.castToMap {f : Ty → Ty'} (h_elem : ∀ {t}, (⟦t⟧ : Type) = (⟦f t⟧ : Type)) :
+    Valuation Γ → Valuation (Γ.map f) :=
+  toMap fun _ => h_elem ▸ id
+
+/-- Cast a valuation from a mapped context when the type denotations are equal.
+In situations where we get `h_elem` for free by definitional equality,
+this is the same as `fromMap fun _ => id`. -/
+def Valuation.castFromMap {f : Ty → Ty'} (h_elem : ∀ {t}, (⟦t⟧ : Type) = (⟦f t⟧ : Type)) :
+    Valuation (Γ.map f) → Valuation Γ :=
+  fromMap fun _ => h_elem ▸ id
+
 @[simp] theorem Valuation.cast_rfl {Γ : Ctxt Ty} (h : Γ = Γ) (V : Valuation Γ) : V.cast h = V := rfl
 
 @[simp] theorem Valuation.cast_apply {Γ : Ctxt Ty} (h : Γ = Δ) (V : Γ.Valuation) (v : Δ.Var t) :

--- a/LeanMLIR/LeanMLIR/Framework/Basic.lean
+++ b/LeanMLIR/LeanMLIR/Framework/Basic.lean
@@ -173,9 +173,15 @@ end
 abbrev Expr.outContext (_ : Expr d Γ eff ts) : Ctxt d.Ty :=
   ts ++ Γ
 
+theorem Expr.outContext_eq : ∀ expr : Expr d Γ eff tys, expr.outContext = tys ++ Γ :=
+  fun _ => rfl
+
 /-! ### Regions -/
+abbrev Region (regSigElem : Ctxt d.Ty × List d.Ty) : Type :=
+  Com d regSigElem.1 .impure regSigElem.2
+
 abbrev Regions (regSig : RegionSignature d.Ty) : Type :=
-  HVector (fun t => Com d t.1 .impure t.2) regSig
+  HVector (Region d) regSig
 
 /-! ### Lets -/
 
@@ -1057,8 +1063,11 @@ We can map between different dialects
 
 section Map
 
+abbrev RegionSignature.mapElem (f : Ty → Ty') : Ctxt Ty × List Ty → Ctxt Ty' × List Ty' :=
+  fun ⟨Γ, ty⟩ => (Γ.map f, ty.map f)
+
 def RegionSignature.map (f : Ty → Ty') : RegionSignature Ty → RegionSignature Ty' :=
-  List.map fun ⟨Γ, ty⟩ => (Γ.map f, ty.map f)
+  List.map (mapElem f)
 
 instance : Functor RegionSignature where
   map := RegionSignature.map

--- a/LeanMLIR/LeanMLIR/HVector.lean
+++ b/LeanMLIR/LeanMLIR/HVector.lean
@@ -393,6 +393,22 @@ def cast {A : α → Type u} {B : β → Type u} {as : List α} {bs : List β}
                         (fun i => by simpa using h_elem i.succ)
       (h₀ ▸ x) ::ₕ xs
 
+/-- A version of `cast` where the result index list is a mapping of the original index list.
+In situations where we get `h_elem` for free by definitional equality,
+this is the same as `map' f fun _ => id`. -/
+def castMap {A : α → Type u} {B : β → Type u} {l : List α} (f : α → β)
+    (h_elem : ∀ a, A a = B (f a)) :
+    HVector A l → HVector B (l.map f) :=
+  cast (List.length_map f).symm fun i h => List.getElem_map f ▸ h_elem l[i]
+
+/-- A version of `cast` where the original index list is a mapping of the result index list.
+In situations where we get `h_elem` for free by definitional equality,
+this is the same as `fromMap' f fun _ => id`. -/
+def castFromMap {A : α → Type u} {B : β → Type u} {l : List β} (f : β → α)
+    (h_elem : ∀ b, A (f b) = B b) :
+    HVector A (l.map f) → HVector B l :=
+  cast (List.length_map f) fun i h => List.getElem_map f ▸ h_elem (l[i]'(List.length_map f ▸ h))
+
 /-!
 ## Find
 -/

--- a/LeanMLIR/LeanMLIR/HVector.lean
+++ b/LeanMLIR/LeanMLIR/HVector.lean
@@ -42,6 +42,12 @@ def map' {A : α → Type*} {B : β → Type*} (f' : α → β) (f : ∀ (a : α
   | [],   .nil        => .nil
   | t::_, .cons a as  => .cons (f t a) (map' f' f as)
 
+/-- An alternative to `map` which also undoes a mapped function over the index list -/
+def fromMap' {A : α → Type*} {B : β → Type*} (f' : β → α) (f : ∀ (b : β), A (f' b) → B b) :
+    ∀ {l : List β}, HVector A (l.map f') → HVector B l
+  | [],   .nil        => .nil
+  | t::_, .cons a as  => .cons (f t a) (fromMap' f' f as)
+
 def mapM [Monad m] {α : Type 0} {A : α → Type} {B : α → Type}
     (f : ∀ (a : α), A a → m (B a)) :
     ∀ {l : List α}, HVector A l → m (HVector B l)
@@ -235,6 +241,8 @@ section Map'
 
 @[simp] theorem map'_cons : map' f g (cons x xs) = cons (g _ x) (map' f g xs) := rfl
 @[simp] theorem map'_nil : map' f g nil = nil := rfl
+@[simp] theorem fromMap'_cons : fromMap' f g (cons x xs) = cons (g _ x) (fromMap' f g xs) := rfl
+@[simp] theorem fromMap'_nil : fromMap' f g nil = nil := rfl
 
 end Map'
 

--- a/LeanMLIR/LeanMLIR/HVector.lean
+++ b/LeanMLIR/LeanMLIR/HVector.lean
@@ -397,17 +397,17 @@ def cast {A : α → Type u} {B : β → Type u} {as : List α} {bs : List β}
 In situations where we get `h_elem` for free by definitional equality,
 this is the same as `map' f fun _ => id`. -/
 def castMap {A : α → Type u} {B : β → Type u} {l : List α} (f : α → β)
-    (h_elem : ∀ a, A a = B (f a)) :
+    (h_elem : ∀ {a}, A a = B (f a)) :
     HVector A l → HVector B (l.map f) :=
-  cast (List.length_map f).symm fun i h => List.getElem_map f ▸ h_elem l[i]
+  cast (List.length_map f).symm fun _ _ => List.getElem_map f ▸ h_elem
 
 /-- A version of `cast` where the original index list is a mapping of the result index list.
 In situations where we get `h_elem` for free by definitional equality,
 this is the same as `fromMap' f fun _ => id`. -/
 def castFromMap {A : α → Type u} {B : β → Type u} {l : List β} (f : β → α)
-    (h_elem : ∀ b, A (f b) = B b) :
+    (h_elem : ∀ {b}, A (f b) = B b) :
     HVector A (l.map f) → HVector B l :=
-  cast (List.length_map f) fun i h => List.getElem_map f ▸ h_elem (l[i]'(List.length_map f ▸ h))
+  cast (List.length_map f) fun _ _ => List.getElem_map f ▸ h_elem
 
 /-!
 ## Find


### PR DESCRIPTION
Mapping HVectors:
- defined `fromMap'`, which is like `toMap'`, except it maps FROM an HVector with a mapped index list instead of TO.
- defined `castToMap` and `castFromMap` for the special case where the transformation is `id`

Mapping valuations:
- defined `toMap` and `fromMap` for mapping valuations according to a transformation `f'` to and from contexts mapped by `f`
- defined `castToMap` and `castFromMap` for the special case where the transformation is `id`
- proved variable application lemmas

Mapping region signatures:
- defined abbreviations for operations on elements of region signatures
- defined `mapElem` abbreviation for mapping just those elements, as opposed to entire region signatures

Additionally:
- definitional equality lemma `Expr.outContext_eq`