### PR TITLE
feat: add more default targets to make opt, LLVMRisCV, mlirnatural part of base build so this is cached

### DIFF
--- a/lakefile.toml
+++ b/lakefile.toml
@@ -1,6 +1,6 @@
 name = "SSA"
 # precompileModules = true # Ensure that reflective code that uses native_decide runs compiled code, not in the ir_interpreter.
-defaultTargets = ["SSA"]
+defaultTargets = ["SSA", "opt", "mlirnatural"]
 moreLeanArgs = ["--tstack=400000"]
 moreServerArgs = ["--tstack=400000"]
 


### PR DESCRIPTION
Investigated by looking at CI runner log @
https://github.com/opencompl/lean-mlir/actions/runs/20103919721/job/57682362336.

This shows that we spend 3min + 6min + 1min building targets that ought
to be cached in the base layer.

To ensure caching, we instead add these as default targets, so the
toplevel `lake -R build` builds all of these.
