### PR TITLE
feat: hardware addition circuit

### DIFF
--- a/SSA/Projects/CIRCT/HandshakeToHW/add.lean
+++ b/SSA/Projects/CIRCT/HandshakeToHW/add.lean
@@ -1,0 +1,95 @@
+import SSA.Projects.CIRCT.Stream.Basic
+import SSA.Projects.CIRCT.Stream.Lemmas
+import SSA.Projects.CIRCT.Register.Basic
+import SSA.Projects.CIRCT.Register.Lemmas
+
+namespace HandshakeStream
+
+/-
+Handshake program (https://github.com/opencompl/DC-semantics-simulation-evaluation/blob/main/benchmarks/add_naive/handshake.mlir) :
+
+handshake.func @add(%a : i32, %b : i32) -> i32{
+    %add1 = comb.add %a, %a : i32
+    %add2 = comb.add %add1, %b : i32
+    return %add2: i32
+}
+
+Lowered program (https://github.com/opencompl/DC-semantics-simulation-evaluation/blob/main/benchmarks/add_naive/hw-esi-hw.mlir):
+
+module {
+  hw.module @add(in %a : i32, in %a_valid : i1, in %b : i32, in %b_valid : i1, in %clk : !seq.clock, in %rst : i1, in %out0_ready : i1, out a_ready : i1, out b_ready : i1, out out0 : i32, out out0_valid : i1) {
+    %false = hw.constant false
+    %c0_i0 = hw.constant 0 : i0
+    %c0_i0_0 = hw.constant 0 : i0
+    %c0_i0_1 = hw.constant 0 : i0
+    %false_2 = hw.constant false
+    %true = hw.constant true
+    %0 = comb.xor %12, %true : i1
+    %1 = comb.and %5, %0 : i1
+    %emitted_0 = seq.compreg sym @emitted_0 %1, %clk reset %rst, %false_2 : i1
+    %2 = comb.xor %emitted_0, %true : i1
+    %3 = comb.and %2, %a_valid : i1
+    %4 = comb.and %16, %3 : i1
+    %5 = comb.or %4, %emitted_0 {sv.namehint = "done0"} : i1
+    %6 = comb.xor %12, %true : i1
+    %7 = comb.and %11, %6 : i1
+    %emitted_1 = seq.compreg sym @emitted_1 %7, %clk reset %rst, %false_2 : i1
+    %8 = comb.xor %emitted_1, %true : i1
+    %9 = comb.and %8, %a_valid : i1
+    %10 = comb.and %16, %9 : i1
+    %11 = comb.or %10, %emitted_1 {sv.namehint = "done1"} : i1
+    %12 = comb.and %5, %11 {sv.namehint = "allDone"} : i1
+    %13 = comb.extract %a from 0 : (i32) -> i31
+    %14 = comb.concat %13, %false : i31, i1
+    %c0_i0_3 = hw.constant 0 : i0
+    %c0_i0_4 = hw.constant 0 : i0
+    %15 = comb.and %b_valid, %9, %3 : i1
+    %16 = comb.and %out0_ready, %15 : i1
+    %17 = comb.add %14, %b : i32
+    hw.output %12, %16, %17, %15 : i1, i1, i32, i1
+  }
+}
+-/
+
+
+
+/--
+  `add` performs two additions given inputs `a` and `b`: (a + a) + b
+
+  The hardware (lowered) module is a function over the `Stream'` type,
+  which does not contain `Option` values, because at this level
+  of abstractions the content of streams has been concretized.
+-/
+def add
+  (xst : Stream' (wiresStruc 2 3)) :
+    Stream' (wiresStruc 1 3) :=
+  register_wrapper_generalized
+              (inputs := xst)
+              (init_regs := {result := #v[], signals := #v[0#1, 0#1]})
+              (outops := 1)
+              (outsigs := 3)
+              (update_fun :=
+                        fun (inp, regs) =>
+                            let v2 := BitVec.xor regs.signals[0] 1#1
+                            let v8 := BitVec.xor regs.signals[1] 1#1
+                            let v3 := BitVec.and v2 inp.signals[0] -- inp a_valid
+                            let v9 := BitVec.and v8 inp.signals[0] -- inp a_valid
+                            let v15 := BitVec.and inp.signals[1] (BitVec.and v9 v3) -- inp b_valid
+                            let v16 := BitVec.and inp.signals[2] v15 --inp out_ready
+                            let v10 := BitVec.and v16 v9
+                            let v4 := BitVec.and v16 v3
+                            let v11 := BitVec.or v10 regs.signals[1] -- emitted_1
+                            let v5 := BitVec.or v4 regs.signals[0] -- emitted_0
+                            let v12 := BitVec.and v5 v11
+                            let v0 := BitVec.xor v12 1#1
+                            let v1 := BitVec.and v5 v0
+                            let v6 := BitVec.xor v12 1#1
+                            let v7 := BitVec.and v11 v6
+                            let v13 := BitVec.extractLsb' 0 31 inp.result[0] -- a
+                            let v14 := BitVec.concat v13 false
+                            let v17 : BitVec 32 := BitVec.add v14 inp.result[1] -- b
+                            let updated_reg0 := v1
+                            let updated_reg1 := v7
+                           ⟨{result := #v[v17], signals := #v[v12, v16, v15]},
+                            {result := #v[], signals := #v[updated_reg0, updated_reg1]}⟩
+                )

--- a/SSA/Projects/CIRCT/HandshakeToHW/fork.lean
+++ b/SSA/Projects/CIRCT/HandshakeToHW/fork.lean
@@ -5,7 +5,7 @@ import SSA.Projects.CIRCT.Register.Lemmas
 
 namespace HandshakeStream
 
-/--
+/-!
   Handshake program:
 
     handshake.func @test_fork(%arg0: none, %arg1: none, ...) -> (none, none, none) {

--- a/SSA/Projects/CIRCT/HandshakeToHW/fork.lean
+++ b/SSA/Projects/CIRCT/HandshakeToHW/fork.lean
@@ -5,11 +5,8 @@ import SSA.Projects.CIRCT.Register.Lemmas
 
 namespace HandshakeStream
 
-/-- We define the module as a function with inputs and outputs.
-  we use `Stream'` type, which does not contain `Option` values, because at this level
-  of abstractions the content of streams has been concretized
-
-  Initial handshake program:
+/--
+  Handshake program:
 
     handshake.func @test_fork(%arg0: none, %arg1: none, ...) -> (none, none, none) {
       %0:2 = fork [2] %arg0 : none
@@ -45,7 +42,14 @@ namespace HandshakeStream
       hw.output %chanOutput, %chanOutput_1, %arg1 : !esi.channel<i0>, !esi.channel<i0>, !esi.channel<i0>
     }
   }
+-/
 
+/--
+  `fork` replicates the content of an input stream and dispatches it to two channels.
+
+  The hardware (lowered) module is a function over the `Stream'` type,
+  which does not contain `Option` values, because at this level
+  of abstractions the content of streams has been concretized.
 -/
 def fork
       (arg_0 : Stream' (BitVec 1))

--- a/SSA/Projects/CIRCT/Register/Basic.lean
+++ b/SSA/Projects/CIRCT/Register/Basic.lean
@@ -104,6 +104,7 @@ structure wiresStruc (nops nsig : Nat) where
   result : Vector (BitVec 32) nops
   signals : Vector (BitVec 1) nsig
 
+
 /-- We define a more general `register_wrapper` that operates on both streams of signals (`BitVec 1`)
   as well as streams of operands (`BitVec 32`) -/
 def register_wrapper_generalized

--- a/SSA/Projects/CIRCT/Register/Basic.lean
+++ b/SSA/Projects/CIRCT/Register/Basic.lean
@@ -100,57 +100,37 @@ def register_wrapper
   we introduce an ad-hoc structure for the input and output of the circuit in case it contains both
   signals (`BitVec 1`) and data (`BitVec 32`).
 -/
-structure wiresStruc {nops nsig : Nat} where
-  result : Stream' (Vector (BitVec 32) nops)
-  signals : Stream' (Vector (BitVec 1) nsig)
-
+structure wiresStruc (nops nsig : Nat) where
+  result : Vector (BitVec 32) nops
+  signals : Vector (BitVec 1) nsig
 
 /-- We define a more general `register_wrapper` that operates on both streams of signals (`BitVec 1`)
   as well as streams of operands (`BitVec 32`) -/
 def register_wrapper_generalized
-    (inputs_ops : Stream' (Vector (BitVec 32) nop))
-    (inputs_sig : Stream' (Vector (BitVec 1) nsig))
+    (inputs : Stream' (wiresStruc inops insigs))
+    (init_regs : wiresStruc regops regsigs)
     -- the generalized wrapper supports registers for both operands and signals
-    (init_regs_ops : Vector (BitVec 32) nregop)
-    (init_regs_sig : Vector (BitVec 1) nregsig)
-    (update_fun : (Vector (BitVec 32) nop × Vector (BitVec 1) nsig × Vector (BitVec 32) nregop × Vector (BitVec 1) nregsig) →
-                  (Vector (BitVec 32) noutop × Vector (BitVec 1) noutsig × Vector (BitVec 32) nregop × Vector (BitVec 1) nregsig))
-      : Vector (BitVec 32) noutop × Vector (BitVec 1) noutsig :=
-  let β := (Stream' (Vector (BitVec 32) nop)) × (Stream' (Vector (BitVec 1) nsig)) ×
-            (Vector (BitVec 32) nregop) × Vector (BitVec 1) nregsig ×
-            Option (Vector (BitVec 32) nregop) × Option (Vector (BitVec 1) nregsig)
-  let f : β → Vector (BitVec 32) noutop × Vector (BitVec 1) noutsig :=
-    fun (input_stream_ops, input_stresm_sig, current_regs_ops, current_regs_sig,
-          init_regs_ops, init_regs_sig) =>
-      match init_regs_ops with
-      | some ivop => match init_regs_sig with
-                | some ivsig => let ⟨outputop, outputsig, _, _⟩  := update_fun
-                                    (input_stream_ops.head, input_stresm_sig.head, ivop, ivsig)
-                  ⟨outputop, outputsig⟩
-                | none => sorry
-      | _ =>  match init_regs_sig with
-                | some ivsig => sorry
-                | none => let ⟨outputop, outputsig, _, _⟩  := update_fun
-                                    (input_stream_ops.head, input_stresm_sig.head, current_regs_ops, current_regs_sig)
-                          ⟨outputop, outputsig⟩
+    (update_fun : (wiresStruc inops insigs × wiresStruc regops regsigs) →
+                  (wiresStruc outops outsigs × wiresStruc regops regsigs))
+      : Stream' (wiresStruc outops outsigs) :=
+  let β := Stream' (wiresStruc inops insigs) × -- inputs
+            wiresStruc regops regsigs × -- feedback signals
+            Option (wiresStruc regops regsigs) -- registers' initial value
+  let f : β → wiresStruc outops outsigs :=
+    fun (inputs, regs, init_regs) =>
+      match init_regs with
+      | some init => let ⟨out, _⟩ := update_fun (inputs.head, init)
+                    out
+      | none => let ⟨out, _⟩  := update_fun  (inputs.head, regs)
+                out
   let g : β → β :=
-    fun (input_stream_ops, input_stresm_sig, current_regs_ops, current_regs_sig,
-          init_regs_ops, init_regs_sig) =>
-      match init_regs_ops with
-      | some ivops =>
-                  match init_regs_sig with
-                  | some ivsig => sorry
-                    -- let (_, _, output_feedback_op, output_feedback_sig) :=
-                    --                   update_fun (input_stream_ops.head, input_stresm_sig.head, current_regs_ops, current_regs_sig)
-                    --   ⟨input_stream_ops.tail, input_stresm_sig.tail, output_feedbackop, output_feedback_sig, none, none⟩
-                    -- sorry
-                  | none => sorry
-      | none =>
-                match init_regs_sig with
-                | some ivsig => sorry
-                | none => sorry
-  Stream'.corec (β := β) (f := f) (g := g) -- (inputs_ops, inputs_sig, init_regs_ops, init_regs_sig, none, none)
-
+    fun (inputs, regs, init_regs) =>
+      match init_regs with
+      | some init => let ⟨_, regs_out⟩ := update_fun (inputs.head, init)
+                    ⟨inputs.tail, regs_out, none⟩
+      | none =>  let ⟨_, regs_out⟩  := update_fun (inputs.head, regs)
+              ⟨inputs.tail, regs_out, none⟩
+  Stream'.corec f g  (inputs, init_regs, none)
 
 /--
   We define an isomorphism from a streams `a` to a stream of their product BitVec 1.


### PR DESCRIPTION
This PR adds the semantics of a  circuit for addition lowered with CIRCT. 
To manipulate the data, we define a new `register_wrapper_generalized`, whose update functions can manage both signal and data (assumed `BitVec 1` and `BitVec 32` for now, respectively). 