### PR TITLE
feat: Add `add_shift` rewrite pattern

### DIFF
--- a/SSA/Projects/LLVMRiscV/Tests/Combiners.lean
+++ b/SSA/Projects/LLVMRiscV/Tests/Combiners.lean
@@ -959,3 +959,25 @@ info: {
 -/
 #guard_msgs in
 #eval! Com.print (DCE.repeatDce (multiRewritePeephole 100 GLobalISelPostLegalizerCombiner select_to_iminmax_sle.lhs)).val
+
+/--
+info: {
+  ^bb0(%0 : i64, %1 : i64, %2 : i64):
+    %3 = "llvm.shl"(%1, %2)<{overflowFlags = #llvm.overflow<none>}> : (i64, i64) -> (i64)
+    %4 = "llvm.sub"(%0, %3)<{overflowFlags = #llvm.overflow<none>}> : (i64, i64) -> (i64)
+    "llvm.return"(%4) : (i64) -> ()
+}
+-/
+#guard_msgs in
+#eval! Com.print (DCE.repeatDce (multiRewritePeephole 100 GLobalISelPostLegalizerCombiner add_shift.lhs)).val
+
+/--
+info: {
+  ^bb0(%0 : i64, %1 : i64, %2 : i64):
+    %3 = "llvm.shl"(%1, %2)<{overflowFlags = #llvm.overflow<none>}> : (i64, i64) -> (i64)
+    %4 = "llvm.sub"(%0, %3)<{overflowFlags = #llvm.overflow<none>}> : (i64, i64) -> (i64)
+    "llvm.return"(%4) : (i64) -> ()
+}
+-/
+#guard_msgs in
+#eval! Com.print (DCE.repeatDce (multiRewritePeephole 100 GLobalISelPostLegalizerCombiner add_shift_commute.lhs)).val


### PR DESCRIPTION
This PR adds the `add_shift` rewrite pattern. Implemented in [SelectionDAG](https://github.com/llvm/llvm-project/blame/fcba3040107944604904aeb146c26ec0628160f4/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp#L3367) and PR'd for [GlobalISel](https://github.com/llvm/llvm-project/pull/177371).