### PR TITLE
feat: add new patterns from LLVM GlobalISel

### DIFF
--- a/SSA/Projects/LLVMRiscV/Pipeline/MIRCombines.lean
+++ b/SSA/Projects/LLVMRiscV/Pipeline/MIRCombines.lean
@@ -317,6 +317,36 @@ def add_sub_reg_1 : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm 
       llvm.return %0 : i64
   }]
 
+/-- ### APlusBMinusCMinusB -/
+def APlusBMinusCMinusB : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
+  lhs := [LV| {
+    ^entry (%0: i64, %1: i64, %2: i64):
+      %3 = llvm.sub %1, %2 : i64
+      %4 = llvm.add %0, %3 : i64
+      %5 = llvm.sub %4, %1 : i64
+      llvm.return %5 : i64
+  }]
+  rhs := [LV| {
+    ^entry (%0: i64, %1: i64, %2: i64):
+      %3 = llvm.sub %0, %2 : i64
+      llvm.return %3 : i64
+  }]
+
+/-- ### AMinusBMinusCMinusC -/
+def AMinusBMinusCMinusC : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
+  lhs := [LV| {
+    ^entry (%0: i64, %1: i64, %2: i64):
+      %3 = llvm.sub %1, %2 : i64
+      %4 = llvm.sub %0, %3 : i64
+      %5 = llvm.sub %4, %2 : i64
+      llvm.return %5 : i64
+  }]
+  rhs := [LV| {
+    ^entry (%0: i64, %1: i64, %2: i64):
+      %3 = llvm.sub %0, %1 : i64
+      llvm.return %3 : i64
+  }]
+
 /-- ### ZeroMinusAPlusB -/
 def ZeroMinusAPlusB : LLVMPeepholeRewriteRefine 64 [Ty.llvm (.bitvec 64), Ty.llvm (.bitvec 64)] where
   lhs := [LV| {
@@ -458,6 +488,8 @@ def mir_pattern_combines : List (Σ Γ, LLVMPeepholeRewriteRefine 64 Γ) :=
    ⟨_, mul_by_neg_one⟩,
    ⟨_, add_sub_reg_0⟩,
    ⟨_, add_sub_reg_1⟩,
+   ⟨_, APlusBMinusCMinusB⟩,
+   ⟨_, AMinusBMinusCMinusC⟩,
    ⟨_, ZeroMinusAPlusB⟩,
    ⟨_, APlusZeroMinusB⟩,
    ⟨_, APlusBMinusB⟩,

--- a/SSA/Projects/LLVMRiscV/Pipeline/scripts/auto_mir_rewrites.py
+++ b/SSA/Projects/LLVMRiscV/Pipeline/scripts/auto_mir_rewrites.py
@@ -220,6 +220,8 @@ class Parser:
     def _parse_operand(self, t: str) -> Optional[Operand]:
         t = t.strip()
         
+        if m := re.match(r'\(GITypeOf<"\$\w+">\s+(-?\d+)\)', t):
+            return Operand(name="", is_imm=True, imm_val=int(m.group(1)))
         if m := re.match(r'\((\w+)\s+(-?\d+)\)', t):
             return Operand(name="", ty=m.group(1), is_imm=True, imm_val=int(m.group(2)))
         if re.match(r'^-?\d+$', t):
@@ -448,6 +450,12 @@ class Generator:
                 if inst.op == 'GIReplaceReg' and len(inst.operands) >= 2:
                     op = inst.operands[1]
                     rhs_var = self.emitter.vars.get(op.name)
+                elif inst.op == 'COPY' and len(inst.operands) >= 2:
+                    src = inst.operands[1]
+                    if src.is_imm:
+                        rhs_var = self.emitter.const(src.imm_val)
+                    elif src.name in self.emitter.vars:
+                        rhs_var = self.emitter.vars[src.name]
                 elif inst.op not in BUILTIN_OPS:
                     rhs_var = self.emitter.emit(inst, consts)
         


### PR DESCRIPTION
This PR adds new rewrites from GlobalISel, and introduces `GITypeOf` keyword from MIR patterns to the automization script.

Added rewrites: https://github.com/llvm/llvm-project/pull/177931