### PR TITLE
feat: make external Blase proofs use custom axiom

### DIFF
--- a/Blase/Blase/Fast/Aiger.lean
+++ b/Blase/Blase/Fast/Aiger.lean
@@ -6,6 +6,14 @@ import Valaig.External
 import Lean
 open Std Sat AIG Valaig
 
+universe u
+
+/--
+An axiom marking that the result of an external Aiger solver is assumed correct, although
+this is not actually verified.
+-/
+axiom valaigExternalSolverAx (α : Sort u) : α
+
 def _root_.FSM.toAiger {arity : Type}
     [Hashable arity] [Fintype arity] [DecidableEq arity]
     (fsm : FSM arity) : Aiger :=

--- a/Blase/Blase/MultiWidth/Tactic.lean
+++ b/Blase/Blase/MultiWidth/Tactic.lean
@@ -1187,7 +1187,8 @@ def solve (gorig : MVarId) : SolverM Unit := do
       | .error err => throwError s!"UNKNOWN: {err}"
       | .ok .counterexample=> throwError "CEX: external solver found a counter-example"
       | .ok .proof =>
-        let prf ← mkSorry (synthetic := true) (← g.getType)
+        let type ← g.getType
+        let prf := mkApp (mkConst ``valaigExternalSolverAx [←getLevel type]) type
         let _ ← g.apply prf
         return
     | .kinduction =>


### PR DESCRIPTION
The goal is to subsequently make this axiom free through certificate validation, but for now this
prevents a load of sorry warnings when trying to evaluate the tactic.
