### PR TITLE
chore: remove playground link from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ to enable workflows that include formal verification in the day-to-day of MLIR d
 
 - **Publication: [Verifying Peephole Rewriting In SSA Compiler IRs](https://arxiv.org/abs/2407.03685)**
 - [API Documentation (auto-generated)](https://opencompl.github.io/lean-mlir/)
-- Playground at [lean-mlir.grosser.es](https://lean-mlir.grosser.es)
 
 #### Installation
 


### PR DESCRIPTION
Removed playground link from the documentation section, since the server is down and we decided we don't have the resources to keep maintaining it