### PR TITLE
feat: Fix blase parser syntax

### DIFF
--- a/Blase/Blase/MultiWidth/Defs.lean
+++ b/Blase/Blase/MultiWidth/Defs.lean
@@ -222,6 +222,7 @@ inductive Term {wcard tcard : Nat} (bcard : Nat) (ncard : Nat) (icard : Nat) (pc
 | sext (a : Term bcard ncard icard pcard tctx (.bv w)) (v : WidthExpr wcard) : Term bcard ncard icard pcard tctx (.bv v)
 /-- convert a bool to a bitvector of width 1 -/
 | bvOfBool (b : Term bcard ncard icard pcard tctx .bool) : Term bcard ncard icard pcard tctx (.bv (.const 1))
+-- | bvOfProp (b : Term bcard ncard icard pcard tctx .prop) : Term bcard ncard icard pcard tctx (.bv (.const 1))
 -- | boolMsb (w : WidthExpr wcard) (x : Term bcard ncard icard pcard tctx (.bv w)) : Term bcard ncard icard pcard tctx .bool
 | boolConst (b : Bool) : Term bcard ncard icard pcard tctx .bool
 | boolVar (v : Fin bcard) : Term bcard ncard icard pcard tctx .bool

--- a/Blase/Blase/MultiWidth/Defs.lean
+++ b/Blase/Blase/MultiWidth/Defs.lean
@@ -1934,6 +1934,26 @@ def Nondep.Term.toSingleWidthNondepTermGo (maxWcard : Nat) (t : Nondep.Term) (wo
       -- AND cannot overflow, so we don't need to mask the result to the universe width.
       ((.band wo a' b'), true)
     else (.constZero wo, false)
+  | .bor _w a b =>
+    let (a', aresult) := a.toSingleWidthNondepTermGo maxWcard wo
+    let (b', bresult) := b.toSingleWidthNondepTermGo maxWcard wo
+    if aresult && bresult then
+      -- AND cannot overflow, so we don't need to mask the result to the universe width.
+      ((.bor wo a' b'), true)
+    else (.constZero wo, false)
+  | .bxor _w a b =>
+    let (a', aresult) := a.toSingleWidthNondepTermGo maxWcard wo
+    let (b', bresult) := b.toSingleWidthNondepTermGo maxWcard wo
+    if aresult && bresult then
+      -- AND cannot overflow, so we don't need to mask the result to the universe width.
+      ((.bxor wo a' b'), true)
+    else (.constZero wo, false)
+  | .bnot _w a =>
+    let (a', aresult) := a.toSingleWidthNondepTermGo maxWcard wo
+    if aresult then
+      -- NOT cannot overflow, so we don't need to mask the result to the universe width.
+      ((.bnot wo a'), true)
+    else (.constZero wo, false)
   | .mul w a b =>
     let (a', aresult) := a.toSingleWidthNondepTermGo maxWcard wo
     let (b', bresult) := b.toSingleWidthNondepTermGo maxWcard wo
@@ -1948,7 +1968,7 @@ def Nondep.Term.toSingleWidthNondepTermGo (maxWcard : Nat) (t : Nondep.Term) (wo
       (.band wo (.shiftl wo x' k) wmask, true) -- mask the result to the universe width.
     else (.constZero wo, false)
   | .boolConst _ => (t, true)
-  | .zext x wnew =>
+  | .zext x wnew | .setWidth x wnew =>
     let (x', xresult) := x.toSingleWidthNondepTermGo maxWcard wo
     let (wmask, wresult) := wnew.toSingleWidthMaskNondepTerm wo
     if xresult && wresult then
@@ -2039,8 +2059,17 @@ def Nondep.Term.toSingleWidthNondepTermGo (maxWcard : Nat) (t : Nondep.Term) (wo
     if aresult && bresult && wresult then
       (.band wo (.vshl wo a' b') wmask, true)
     else (.constZero wo, false)
-  | pvar _ | bvOfBool _ | boolVar _ | bnot .. | bxor .. | bor .. | setWidth .. | boolBinRel .. =>
+  | pvar _ | bvOfBool _ | boolVar _ | boolBinRel .. =>
     (.constZero wo, false)
+  where 
+   goBinop (a b : Nondep.Term) (w : Nondep.WidthExpr) (wo : Nondep.WidthExpr)
+     (binop : Nondep.WidthExpr → Nondep.Term → Nondep.Term → Nondep.Term) : Nondep.Term × Bool :=
+    let (a', aresult) := a.toSingleWidthNondepTermGo maxWcard wo
+    let (b', bresult) := b.toSingleWidthNondepTermGo maxWcard wo
+    let (wmask, wresult) := w.toSingleWidthMaskNondepTerm wo
+    if aresult && bresult && wresult then
+      (.band wo (binop wo a' b') wmask, true)
+    else (.constZero wo, false)
 
   -- | _ => (.constZero wo, false)
 

--- a/Blase/Blasewuzla/Parser.lean
+++ b/Blase/Blasewuzla/Parser.lean
@@ -259,13 +259,13 @@ partial def parseTerm (s : Sexp) : ParserM ParsedTerm := do
     return .bv (.sext at_ w) w
 
   -- pzero_extend: alias for zero_extend
-  | .expr [.expr [.atom "_", .atom "pzero_extend", wnew], a] =>
+  | .expr [.atom "pzero_extend", wnew, a] =>
     let w ← parseWidthExpr wnew
     let (at_, _aw) ← (← parseTerm a) |> expectBV (ctx := "pzero_extend")
     return .bv (.zext at_ w) w
 
   -- psign_extend: alias for sign_extend
-  | .expr [.expr [.atom "_", .atom "psign_extend", wnew], a] =>
+  | .expr [.atom "psign_extend", wnew, a] =>
     let w ← parseWidthExpr wnew
     let (at_, _aw) ← (← parseTerm a) |> expectBV (ctx := "psign_extend")
     return .bv (.sext at_ w) w
@@ -282,19 +282,24 @@ partial def parseTerm (s : Sexp) : ParserM ParsedTerm := do
     return .pred (.binWidthRel .eq wa wb)
 
   -- Comparisons (produce predicates)
-  | .expr [.atom "=", a, b] =>
-    let pa ← parseTerm a
-    let pb ← parseTerm b
-    match pa, pb with
-    | .bv at_ aw, .bv bt _bw =>
-      return .pred (.binRel .eq aw at_ bt)
-    | .pred at_, .pred bt =>
-      -- (a ↔ b) = (a → b) ∧ (b → a) = (¬a ∨ b) ∧ (¬b ∨ a)
-      let nat_ ← negateTerm at_
-      let nbt ← negateTerm bt
-      return .pred (.and (.or nat_ bt) (.or nbt at_))
-    | _, _ => ParserM.throwError s!"= : mismatched types between arguments"
-
+  | .expr [.atom "=", a, b] => do
+    try
+      let wa ← parseWidthExpr a 
+      let wb ← parseWidthExpr b 
+      return .pred (.binWidthRel .eq wa wb)
+    catch _ =>
+      let pa ← parseTerm a
+      let pb ← parseTerm b
+      match pa, pb with
+      | .bv at_ aw, .bv bt _bw =>
+        return .pred (.binRel .eq aw at_ bt)
+      | .pred at_, .pred bt =>
+        -- (a ↔ b) = (a → b) ∧ (b → a) = (¬a ∨ b) ∧ (¬b ∨ a)
+        let nat_ ← negateTerm at_
+        let nbt ← negateTerm bt
+        return .pred (.and (.or nat_ bt) (.or nbt at_))
+      | _, _ => 
+         ParserM.throwError s!"= : mismatched types between arguments"
   -- distinct is just (not (= a b))
   | .expr [.atom "distinct", a, b] =>
     let pa ← parseTerm a
@@ -348,7 +353,31 @@ partial def parseTerm (s : Sexp) : ParserM ParsedTerm := do
     let (at_, aw) ← (← parseTerm a) |> expectBV (ctx := "bvsge")
     let (bt, _bw) ← (← parseTerm b) |> expectBV (ctx := "bvsge")
     return .pred (.binRel .sle aw bt at_)  -- swap
-
+  -- width predicate: >
+  | .expr [.atom ">", a, b] =>
+    let (aw) ← parseWidthExpr a
+    let (bw) ← parseWidthExpr b
+    -- | a > b ↔ a ≥ b + 1 ↔ b + 1 ≤ a
+    return .pred (.binWidthRel  .le (Nondep.WidthExpr.addK bw 1) aw)
+  -- | width predicate: <
+  | .expr [.atom "<", a, b] =>
+    let (aw) ← parseWidthExpr a
+    let (bw) ← parseWidthExpr b
+    -- | a < b ↔ a + 1 ≤ b
+    return .pred (.binWidthRel  .le (Nondep.WidthExpr.addK aw 1) bw)
+  -- | width predicate: <=
+  | .expr [.atom "<=", a, b] =>
+    let (aw) ← parseWidthExpr a
+    let (bw) ← parseWidthExpr b
+    -- | a < b ↔ a + 1 ≤ b
+    return .pred (.binWidthRel  .le aw bw)
+  -- | width predicate: >=
+  -- a ≥ b ↔ b ≤ a
+  | .expr [.atom ">=", a, b] =>
+    let (aw) ← parseWidthExpr a
+    let (bw) ← parseWidthExpr b
+    -- | a < b ↔ a + 1 ≤ b
+    return .pred (.binWidthRel  .le bw aw)
   -- Propositional connectives
   | .expr (.atom "and" :: args) =>
     if args.length < 2 then

--- a/Blase/Blasewuzla/tests/unsat/alive-AndOrXor_1705_values_0.smt2
+++ b/Blase/Blasewuzla/tests/unsat/alive-AndOrXor_1705_values_0.smt2
@@ -1,0 +1,6 @@
+(set-logic ALL)
+(declare-const k Int)
+(declare-fun %A () (_ BitVec k))
+(declare-fun %B () (_ BitVec k))
+(assert (not (= (or (= %B (int_to_pbv k 0)) (bvugt %B %A)) (bvuge (bvadd %B (bvnot (int_to_pbv k 0))) %A))))
+(check-sat)

--- a/Blase/Blasewuzla/tests/unsat/sext_zext_eq_zext.smt2
+++ b/Blase/Blasewuzla/tests/unsat/sext_zext_eq_zext.smt2
@@ -6,5 +6,5 @@
 (declare-const x (_ BitVec w1))
 (assert (width_le (+ w1 1) w2))
 (assert (width_le w2 w3))
-(assert (not (= ((_ sign_extend w3) ((_ zero_extend w2) x)) ((_ zero_extend w3) x))))
+(assert (not (= (psign_extend w3 (pzero_extend w2 x)) (pzero_extend w3 x))))
 (check-sat)


### PR DESCRIPTION
We fix the parser for sign extend, zero extend, and width comparison operations. The next steps are to parse `ite` and `int_to_pbv` with the width variable being a real variable. 