### PR TITLE
blase/feat: Change width represetation in monowidthizer to store widths as BV variables

### DIFF
--- a/Blase/Blase/Fast/BitStream.lean
+++ b/Blase/Blase/Fast/BitStream.lean
@@ -1597,6 +1597,10 @@ def maxUnary (x y : BitStream) : BitStream :=
 def addKUnary (x : BitStream) (k : Nat) : BitStream :=
   fun i => if i < k then true else x (i - k)
 
+/-- decrement by '-k' (saturating at 0 in unary). -/
+def subKUnary (x : BitStream) (k : Nat) : BitStream :=
+  fun i => x (i + k)
+
 /-- We have the values equal up to 'w + 1'. -/
 theorem ofBitVecZextMsb_EqualUpTo_ofBitVecSext
   (x : BitVec w) :

--- a/Blase/Blase/MultiWidth/.claude/settings.local.json
+++ b/Blase/Blase/MultiWidth/.claude/settings.local.json
@@ -1,0 +1,7 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(lake build:*)"
+    ]
+  }
+}

--- a/Blase/Blase/MultiWidth/Defs.lean
+++ b/Blase/Blase/MultiWidth/Defs.lean
@@ -46,6 +46,11 @@ inductive WidthExpr (wcard : Nat) : Type
 | max : (v w : WidthExpr wcard) → WidthExpr wcard
 | addK : (v : WidthExpr wcard) → (k : Nat) → WidthExpr wcard
 | kadd : (k : Nat) → (v : WidthExpr wcard) → WidthExpr wcard
+-- add two widths.
+| add (v w : WidthExpr wcard) : WidthExpr wcard
+-- subtract two widths.
+| sub (v w : WidthExpr wcard) : WidthExpr wcard
+
 
 
 /-- Cast the width expression along the fact that width is ≤. -/

--- a/Blase/Blase/MultiWidth/Defs.lean
+++ b/Blase/Blase/MultiWidth/Defs.lean
@@ -1824,11 +1824,21 @@ def Nondep.WidthExpr.toTwosComplementNondepTerm (w : Nondep.WidthExpr) (wo : Non
     let widthVal := Nondep.Term.var v wo
     (widthVal, true)
   | .max a b =>
-      -- TODO: I need if-then-else here.
-      (.constBad wo, false)
+    let (a', aresult) := a.toTwosComplementNondepTerm wo
+    let (b', bresult) := b.toTwosComplementNondepTerm wo
+    if aresult && bresult then
+      -- max(a, b) = ite(b ≤ a, a, b)
+      let cond := Nondep.Term.binRel .ule wo b' a'
+      (.bvIte cond a' b', true)
+    else (.constBad wo, false)
   | .min a b =>
-      -- TODO: I need if-then-else here.
-      (.constBad wo, false)
+    let (a', aresult) := a.toTwosComplementNondepTerm wo
+    let (b', bresult) := b.toTwosComplementNondepTerm wo
+    if aresult && bresult then
+      -- min(a, b) = ite(a ≤ b, a, b)
+      let cond := Nondep.Term.binRel .ule wo a' b'
+      (.bvIte cond a' b', true)
+    else (.constBad wo, false)
   | .addK a k =>
     let (aval, aresult) := a.toTwosComplementNondepTerm wo
     let kval := Nondep.Term.ofNat wo k

--- a/Blase/Blase/MultiWidth/Defs.lean
+++ b/Blase/Blase/MultiWidth/Defs.lean
@@ -46,10 +46,6 @@ inductive WidthExpr (wcard : Nat) : Type
 | max : (v w : WidthExpr wcard) → WidthExpr wcard
 | addK : (v : WidthExpr wcard) → (k : Nat) → WidthExpr wcard
 | kadd : (k : Nat) → (v : WidthExpr wcard) → WidthExpr wcard
--- add two widths.
-| add (v w : WidthExpr wcard) : WidthExpr wcard
--- subtract two widths.
-| sub (v w : WidthExpr wcard) : WidthExpr wcard
 
 
 
@@ -680,6 +676,8 @@ inductive WidthExpr where
 | addK : WidthExpr → Nat → WidthExpr
 | kadd : Nat → WidthExpr → WidthExpr
 | subK : WidthExpr → Nat → WidthExpr
+| add : WidthExpr → WidthExpr → WidthExpr
+| sub : WidthExpr → WidthExpr → WidthExpr
 deriving Inhabited, Repr, Hashable, DecidableEq, Lean.ToExpr
 
 open Std Lean in
@@ -693,6 +691,8 @@ def WidthExpr.wcard (w : WidthExpr) : Nat :=
   | .addK v k => v.wcard + k
   | .kadd k v => k + v.wcard
   | .subK v _k => v.wcard
+  | .add v w => Nat.max (v.wcard) (w.wcard)
+  | .sub v w => Nat.max (v.wcard) (w.wcard)
 
 def WidthExpr.ofDep {wcard : Nat}
     (w : MultiWidth.WidthExpr wcard) : WidthExpr :=
@@ -1447,6 +1447,8 @@ def WidthExpr.eval (wenv : Array Nat) : WidthExpr → Nat
   | .addK a k =>((a.eval wenv) + k)
   | .kadd k a =>(k + (a.eval wenv))
   | .subK a k =>((a.eval wenv) - k)
+  | .sub a b => ((a.eval wenv) - (b.eval wenv))
+  | .add a b => ((a.eval wenv) + (b.eval wenv))
 
 def _root_.Std.Tactic.BVDecide.BVExpr.width (_ : BVExpr w) : Nat := w
 
@@ -1798,50 +1800,67 @@ def Term.toSingleWidthNondepTerm.mkAllWidthPreconds (wo : Nondep.WidthExpr) (w :
     let precond := Term.toSingleWidthNondepTerm.mkWidthPrecond w' wo
     .and precond (Term.toSingleWidthNondepTerm.mkAllWidthPreconds wo w')
 
+/--
+Convert a width variable into a bitvector,
+which encodes it into a bitvector whose '.toNat' value is the width.
+-/
+def Nondep.WidthExpr.toTwosComplementNondepTerm (w : Nondep.WidthExpr) (wo : Nondep.WidthExpr) :
+    Nondep.Term × Bool :=
+  match w with
+  | .const c => (Nondep.Term.ofNat wo c, true) -- 2^0 = 1
+  | .var v =>
+    let widthVal := Nondep.Term.var v wo
+    (widthVal, true)
+  | .max a b =>
+      -- TODO: I need if-then-else here.
+      (.constBad wo, false)
+  | .min a b =>
+      -- TODO: I need if-then-else here.
+      (.constBad wo, false)
+  | .addK a k =>
+    let (aval, aresult) := a.toTwosComplementNondepTerm wo
+    let kval := Nondep.Term.ofNat wo k
+    if aresult then
+      (.add wo aval kval, true)
+    else (.constBad wo, false)
+  | .kadd k a =>
+    let (aval, aresult) := a.toTwosComplementNondepTerm wo
+    let kval := Nondep.Term.ofNat wo k
+    if aresult then
+      (.add wo kval aval, true)
+    else (.constBad wo, false)
+  | .add a b =>
+    let (a', aresult) := a.toTwosComplementNondepTerm wo
+    let (b', bresult) := b.toTwosComplementNondepTerm wo
+    if aresult && bresult then
+      (.add wo a' b', true) -- mask of add is the or of masks.
+    else (.constBad wo, false)
+  | .sub a b =>
+    let (a', aresult) := a.toTwosComplementNondepTerm wo
+    let (b', bresult) := b.toTwosComplementNondepTerm wo
+    if aresult && bresult then
+      (.sub wo a' b', true) -- mask of sub is the and of masks.
+    else (.constBad wo, false)
+  | .subK a k =>
+    let (amask, aresult) := a.toTwosComplementNondepTerm wo
+    let kval := Nondep.Term.ofNat wo k
+    if aresult then
+      (.sub wo amask kval, true)
+    else (.constBad wo, false)
 
 /--
 Convert a width variable into a bitvector,
 which encodes a mask of the form (1 << w) - 1, where w is the width variable.
 -/
-def Nondep.WidthExpr.toSingleWidthMaskNondepTerm (w : Nondep.WidthExpr) (wo : Nondep.WidthExpr) : Nondep.Term × Bool :=
-  match w with
-  | .const c => (Nondep.Term.ofNat wo ((1 <<< c) - 1), true) -- 2^0 = 1
-  | .var v =>
-    let widthVal := Nondep.Term.var v wo
+def Nondep.WidthExpr.toSingleWidthMaskNondepTerm (w : Nondep.WidthExpr) (wo : Nondep.WidthExpr)
+    : Nondep.Term × Bool :=
+  let (wval, wresult) := w.toTwosComplementNondepTerm wo
+  if wresult then
     let one := Nondep.Term.constOne wo
-    -- mask = (1 << widthVar) - 1
-    let pot := Nondep.Term.vshl wo one widthVal  -- 1 << widthVar = 2^widthVar
-    (Nondep.Term.sub wo pot one, true)            -- 2^widthVar - 1 = mask
-  | .max a b =>
-    let (a', aresult) := a.toSingleWidthMaskNondepTerm wo
-    let (b', bresult) := b.toSingleWidthMaskNondepTerm wo
-    if aresult && bresult then
-      (.bor wo a' b', true) -- mask of max is the and of masks.
-    else (.constBad wo, false)
-  | .min a b =>
-    let (a', aresult) := a.toSingleWidthMaskNondepTerm wo
-    let (b', bresult) := b.toSingleWidthMaskNondepTerm wo
-    if aresult && bresult then
-      (.band wo a' b', true) -- mask of min is the and of masks.
-    else (.constBad wo, false)
-  | .addK a k =>
-    let (amask, aresult) := a.toSingleWidthMaskNondepTerm wo
-    if aresult then
-      -- consider computing the power of two as 'amask ^ (amask <<< 1)`,
-      -- which should be cheaper as it does not need the ripple of the add.
-      ((amask.succ.shiftl wo k).pred, true)
-    else (.constBad wo, false)
-  | .kadd k a =>
-    let (amask, aresult) := a.toSingleWidthMaskNondepTerm wo
-    if aresult then
-      ((amask.succ.shiftl wo k).pred, true)
-    else (.constBad wo, false)
-  | .subK a k =>
-    let (amask, aresult) := a.toSingleWidthMaskNondepTerm wo
-    if aresult then
-      -- mask(w - k) = ((mask(w) + 1) >> k) - 1 = (2^w >> k) - 1 = 2^(w-k) - 1
-      ((amask.succ.shiftr wo k).pred, true)
-    else (.constBad wo, false)
+    let pot := Nondep.Term.vshl wo one wval  -- 1 << widthVar = 2^widthVar
+    let out := Nondep.Term.sub wo pot one-- 2^widthVar - 1 = mask
+    (out, true)
+  else (.constBad wo, false)
 
 /-#
 

--- a/Blase/Blase/MultiWidth/Defs.lean
+++ b/Blase/Blase/MultiWidth/Defs.lean
@@ -103,6 +103,7 @@ def WidthExpr.toNat_kadd (v : WidthExpr wcard) (k : Nat)
     (env : WidthExpr.Env wcard) :
     WidthExpr.toNat (.kadd k v) env = k + v.toNat env := rfl
 
+
 def WidthExpr.toBitStream (e : WidthExpr wcard)
   (bsEnv : StateSpace wcard tcard bcard ncard icard pcard → BitStream) : BitStream :=
   match e with
@@ -673,6 +674,7 @@ inductive WidthExpr where
 | min : WidthExpr → WidthExpr → WidthExpr
 | addK : WidthExpr → Nat → WidthExpr
 | kadd : Nat → WidthExpr → WidthExpr
+| subK : WidthExpr → Nat → WidthExpr
 deriving Inhabited, Repr, Hashable, DecidableEq, Lean.ToExpr
 
 open Std Lean in
@@ -684,6 +686,7 @@ def WidthExpr.toSmtLib : WidthExpr → SexprPBV.WidthExpr
 | .min v w => .min v.toSmtLib w.toSmtLib
 | .addK v k => .addK v.toSmtLib k
 | .kadd k v => .kadd k v.toSmtLib
+| .subK v k => .subK v.toSmtLib k
 
 
 def WidthExpr.wcard (w : WidthExpr) : Nat :=
@@ -694,6 +697,7 @@ def WidthExpr.wcard (w : WidthExpr) : Nat :=
   | .min v w => Nat.min (v.wcard) (w.wcard)
   | .addK v k => v.wcard + k
   | .kadd k v => k + v.wcard
+  | .subK v _k => v.wcard
 
 def WidthExpr.ofDep {wcard : Nat}
     (w : MultiWidth.WidthExpr wcard) : WidthExpr :=
@@ -733,6 +737,7 @@ def WidthExpr.ofDep_addK {wcard : Nat} {v : MultiWidth.WidthExpr wcard} {k : Nat
 def WidthExpr.ofDep_kadd {wcard : Nat} {v : MultiWidth.WidthExpr wcard} {k : Nat} :
     (WidthExpr.ofDep (MultiWidth.WidthExpr.kadd k v)) =
     (.kadd k (.ofDep v)) := rfl
+
 
 inductive Term
 | ofNat (w : WidthExpr) (n : Nat) : Term
@@ -1464,6 +1469,7 @@ def WidthExpr.eval (wenv : Array Nat) : WidthExpr → Nat
   | .min a b => (Nat.min (a.eval wenv) (b.eval wenv))
   | .addK a k =>((a.eval wenv) + k)
   | .kadd k a =>(k + (a.eval wenv))
+  | .subK a k =>((a.eval wenv) - k)
 
 def _root_.Std.Tactic.BVDecide.BVExpr.width (_ : BVExpr w) : Nat := w
 
@@ -1852,6 +1858,12 @@ def Nondep.WidthExpr.toSingleWidthMaskNondepTerm (w : Nondep.WidthExpr) (wo : No
     let (amask, aresult) := a.toSingleWidthMaskNondepTerm wo
     if aresult then
       ((amask.succ.shiftl wo k).pred, true)
+    else (.constBad wo, false)
+  | .subK a k =>
+    let (amask, aresult) := a.toSingleWidthMaskNondepTerm wo
+    if aresult then
+      -- mask(w - k) = ((mask(w) + 1) >> k) - 1 = (2^w >> k) - 1 = 2^(w-k) - 1
+      ((amask.succ.shiftr wo k).pred, true)
     else (.constBad wo, false)
 
 /-#

--- a/Blase/Blase/MultiWidth/Defs.lean
+++ b/Blase/Blase/MultiWidth/Defs.lean
@@ -679,16 +679,6 @@ deriving Inhabited, Repr, Hashable, DecidableEq, Lean.ToExpr
 
 open Std Lean in
 
-def WidthExpr.toSmtLib : WidthExpr → SexprPBV.WidthExpr
-| .const n => .const n
-| .var v => .var v
-| .max v w => .max v.toSmtLib w.toSmtLib
-| .min v w => .min v.toSmtLib w.toSmtLib
-| .addK v k => .addK v.toSmtLib k
-| .kadd k v => .kadd k v.toSmtLib
-| .subK v k => .subK v.toSmtLib k
-
-
 def WidthExpr.wcard (w : WidthExpr) : Nat :=
   match w with
   | .const _ => 0
@@ -772,24 +762,6 @@ inductive Term
 | vashr (w : WidthExpr) (a b : Term) : Term      -- variable arithmetic right shift
 | vshl (w : WidthExpr) (a b : Term) : Term       -- variable left shift
 deriving DecidableEq, Inhabited, Repr, Lean.ToExpr
-
-def Term.toSmtLib : Term → SexprPBV.Term
-| .ofNat w n => .ofNat w.toSmtLib n
-| .var v w => .var v w.toSmtLib
-| .add w a b => .add w.toSmtLib a.toSmtLib b.toSmtLib
-| .zext a wnew => .zext a.toSmtLib wnew.toSmtLib
-| .sext a wnew => .sext a.toSmtLib wnew.toSmtLib
-| .setWidth a wnew => .setWidth a.toSmtLib wnew.toSmtLib
-| .bor w a b => .bor w.toSmtLib a.toSmtLib b.toSmtLib
-| .band w a b => .band w.toSmtLib a.toSmtLib b.toSmtLib
-| .bxor w a b => .bxor w.toSmtLib a.toSmtLib b.toSmtLib
-| .bnot w a => .bnot w.toSmtLib a.toSmtLib
-| .boolVar v => .boolVar v
-| .boolConst b => .boolConst b
-| .shiftl w a k => .shiftl w.toSmtLib a.toSmtLib k
-| .bvOfBool _b => .junk ("bvOfBool")
-| .udiv .. | .urem .. | .vlshr .. | .vashr .. | .vshl .. => .junk "non-automata-bv"
-| _ => .junk "predicate"
 
 /-- Negate a predicate term by pushing `not` inward via De Morgan's laws.
     Returns `none` if the term cannot be negated (e.g., unrecognized atomic terms or
@@ -2078,7 +2050,7 @@ def Nondep.Term.toSingleWidthNondepTermGo (maxWcard : Nat) (t : Nondep.Term) (wo
     else (.constZero wo, false)
   | pvar _ | bvOfBool _ | boolVar _ | boolBinRel .. =>
     (.constZero wo, false)
-  where 
+  where
    goBinop (a b : Nondep.Term) (w : Nondep.WidthExpr) (wo : Nondep.WidthExpr)
      (binop : Nondep.WidthExpr → Nondep.Term → Nondep.Term → Nondep.Term) : Nondep.Term × Bool :=
     let (a', aresult) := a.toSingleWidthNondepTermGo maxWcard wo

--- a/Blase/Blase/MultiWidth/Defs.lean
+++ b/Blase/Blase/MultiWidth/Defs.lean
@@ -1802,12 +1802,8 @@ Also see that `unary mask = power of 2 - 1`.
 `m & (m + 1) = 0`.
 This also cleanly handles the case where `u` is `0`, since `u & u + 1 = 0`.
 -/
-def Term.toSingleWidthNondepTerm.mkWidthPrecond (w : Nat) (wo : Nondep.WidthExpr) : Nondep.Term :=
-    let m := Nondep.Term.var w wo
-    let mAndMSucc := Nondep.Term.band wo m.succ m
-    let rhs := Nondep.Term.constZero wo
-    let out := Nondep.Term.binRel .eq wo mAndMSucc rhs
-    out
+def Term.toSingleWidthNondepTerm.mkWidthPrecond (_w : Nat) (_wo : Nondep.WidthExpr) : Nondep.Term :=
+    .pTrue
 /--
 Make all the width preconditions of variables of indices [0..w),
 with universe width 'wo'.
@@ -1827,7 +1823,12 @@ which encodes a mask of the form (1 << w) - 1, where w is the width variable.
 def Nondep.WidthExpr.toSingleWidthMaskNondepTerm (w : Nondep.WidthExpr) (wo : Nondep.WidthExpr) : Nondep.Term × Bool :=
   match w with
   | .const c => (Nondep.Term.ofNat wo ((1 <<< c) - 1), true) -- 2^0 = 1
-  | .var v => (Nondep.Term.var v wo, true)
+  | .var v =>
+    let widthVal := Nondep.Term.var v wo
+    let one := Nondep.Term.constOne wo
+    -- mask = (1 << widthVar) - 1
+    let pot := Nondep.Term.vshl wo one widthVal  -- 1 << widthVar = 2^widthVar
+    (Nondep.Term.sub wo pot one, true)            -- 2^widthVar - 1 = mask
   | .max a b =>
     let (a', aresult) := a.toSingleWidthMaskNondepTerm wo
     let (b', bresult) := b.toSingleWidthMaskNondepTerm wo

--- a/Blase/Blase/MultiWidth/GoodFSM.lean
+++ b/Blase/Blase/MultiWidth/GoodFSM.lean
@@ -39,6 +39,9 @@ private theorem decide_or_decide_eq_decide {P Q : Prop}
 def mkWidthFSM (wcard : Nat) (tcard : Nat) (bcard : Nat) (ncard icard : Nat) (pcard : Nat) (w : Nondep.WidthExpr) :
     (NatFSM wcard tcard bcard ncard icard pcard w) :=
   match w with
+  | .sub .. | .add .. => {
+    toFsm := (FSM.repeatForever false).map Fin.elim0
+  }
   | .const nat => {
       toFsm := (FSM.trueUptoExcluding nat).map Fin.elim0
     }

--- a/Blase/Blase/MultiWidth/GoodFSM.lean
+++ b/Blase/Blase/MultiWidth/GoodFSM.lean
@@ -66,6 +66,8 @@ def mkWidthFSM (wcard : Nat) (tcard : Nat) (bcard : Nat) (ncard icard : Nat) (pc
     { toFsm :=
         composeUnaryAux (FSM.repeatN true k)  (mkWidthFSM wcard tcard bcard ncard icard pcard v).toFsm
     }
+  | .subK _v _k =>
+    { toFsm := (FSM.repeatForever false).map Fin.elim0 }
 
 def IsGoodNatFSM_mkWidthFSM {wcard : Nat} (tcard : Nat) (bcard : Nat) (ncard icard : Nat) (pcard : Nat)  (w : WidthExpr wcard) :
     HNatFSMToBitstream (mkWidthFSM wcard tcard bcard ncard icard pcard (.ofDep w)) where
@@ -1712,8 +1714,7 @@ def IsGoodTermFSM_mkTermFSM (wcard tcard bcard ncard icard pcard : Nat) {tctx : 
     grind only [Term.isLinearBitwise_mul_eq_false]
 
 /--
-info: 'MultiWidth.IsGoodTermFSM_mkTermFSM' depends on axioms:
-[propext, Classical.choice, Quot.sound]
+info: 'MultiWidth.IsGoodTermFSM_mkTermFSM' depends on axioms: [propext, Classical.choice, Quot.sound]
 -/
 #guard_msgs in #print axioms IsGoodTermFSM_mkTermFSM
 

--- a/Blase/Blase/MultiWidth/PROMPT.md
+++ b/Blase/Blase/MultiWidth/PROMPT.md
@@ -1,0 +1,13 @@
+for the function Nondep.Term.toSingleWidthNondepTermGo, Nondep.Term.toSingleWidthNondepTerm ,
+and related ones, edit these to change the translation, such that every width variable
+in the original problem becomes a new bitvector variable in the translated problem,
+whose denotation is the *actual* width value.
+
+Then, when we want to create the mask associated to a width variable, we simply perform
+`((1 << widthVar) - 1))`. This now means that width operations such as `+`, `-`, `*`, etc
+become normal bitvector operations, so we don't need extra logic to handle them.
+This should simplify the translation. 
+
+Please do this modularly, and edit the `toSingleWidthMaskNondepTerm` function
+to compute the value correctly based on the new representation of width variables.
+

--- a/Blase/Blase/MultiWidth/Tactic.lean
+++ b/Blase/Blase/MultiWidth/Tactic.lean
@@ -327,6 +327,11 @@ def mkWidthExpr (wcard : Nat) (ve : MultiWidth.Nondep.WidthExpr) :
       #[mkNatLit wcard, mkNatLit k, ← mkWidthExpr wcard v]
     debugCheck out
     return out
+  | .subK v k =>
+    let out := mkAppN (mkConst ``MultiWidth.WidthExpr.subK)
+      #[mkNatLit wcard, ← mkWidthExpr wcard v, mkNatLit k]
+    debugCheck out
+    return out
 
 /-- info: MultiWidth.Term.Ctx.empty (wcard : ℕ) : Term.Ctx wcard 0 -/
 #guard_msgs in #check MultiWidth.Term.Ctx.empty

--- a/Blase/Blase/MultiWidth/Tactic.lean
+++ b/Blase/Blase/MultiWidth/Tactic.lean
@@ -327,7 +327,7 @@ def mkWidthExpr (wcard : Nat) (ve : MultiWidth.Nondep.WidthExpr) :
       #[mkNatLit wcard, mkNatLit k, ← mkWidthExpr wcard v]
     debugCheck out
     return out
-  | .subK _v _k =>
+  | .subK _v _k | .sub .. | .add .. =>
     throwError "unhandled width expresion: '{repr ve}'"
 
 /-- info: MultiWidth.Term.Ctx.empty (wcard : ℕ) : Term.Ctx wcard 0 -/

--- a/Blase/Blase/MultiWidth/Tactic.lean
+++ b/Blase/Blase/MultiWidth/Tactic.lean
@@ -327,11 +327,8 @@ def mkWidthExpr (wcard : Nat) (ve : MultiWidth.Nondep.WidthExpr) :
       #[mkNatLit wcard, mkNatLit k, ← mkWidthExpr wcard v]
     debugCheck out
     return out
-  | .subK v k =>
-    let out := mkAppN (mkConst ``MultiWidth.WidthExpr.subK)
-      #[mkNatLit wcard, ← mkWidthExpr wcard v, mkNatLit k]
-    debugCheck out
-    return out
+  | .subK _v _k =>
+    throwError "unhandled width expresion: '{repr ve}'"
 
 /-- info: MultiWidth.Term.Ctx.empty (wcard : ℕ) : Term.Ctx wcard 0 -/
 #guard_msgs in #check MultiWidth.Term.Ctx.empty
@@ -1218,7 +1215,7 @@ def solve (gorig : MVarId) : SolverM Unit := do
     let ienv ← collect.mkIenvExpr
     let penv ← collect.mkPenvExpr
     if (← read).debugPrintSmtLib then
-      throwError (p.toSmtLib |>.toSexpr |> format)
+      throwError "unimplemented: toSmtLib" -- (p.toSmtLib |>.toSexpr |> format)
     let pExpr ← Expr.mkPredicateExpr collect.wcard collect.tcard collect.bcard collect.ncard collect.icard collect.pcard tctx p
     let pNondepExpr := Lean.ToExpr.toExpr p
     let termFsmNondep := mkTermFsmNondep collect.wcard collect.tcard collect.bcard collect.ncard collect.icard collect.pcard p

--- a/Blase/BlaseEval/get-problems-csv.py
+++ b/Blase/BlaseEval/get-problems-csv.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+import re
+import json
+
+def preprocess_lean_content(content):
+    """Removes comments from Lean code to prevent parsing errors."""
+    # 1. Remove block comments /- ... -/ (non-greedy)
+    content = re.sub(r'/-.*?(-/|$)', '', content, flags=re.DOTALL)
+    
+    # 2. Remove line comments -- ...
+    content = re.sub(r'--.*', '', content)
+
+    # 3. Remove 'import' lines (handles multi-line imports if they exist)
+    content = re.sub(r'^\s*import\s+.*$', '', content, flags=re.MULTILINE)
+    
+    # 4. Remove 'open' lines
+    content = re.sub(r'^\s*open\s+.*$', '', content, flags=re.MULTILINE)
+    
+    return content
+
+def convert_lean_to_csv(input_file_path, output_file_path):
+    # Regex pattern:
+    # Captures the theorem name and the statement block between ':' and ':='
+    theorem_pattern = re.compile(r"theorem\s+([\w\.]+)\s*:\s*(.*?)\s*:=\s*by", re.DOTALL)
+
+    extracted_data = []
+
+    try:
+        with open(input_file_path, 'r', encoding='utf-8') as f:
+            raw_content = f.read()
+
+        # Clean the content before extraction
+        clean_code = preprocess_lean_content(raw_content)
+
+        # Find all theorem matches
+        matches = theorem_pattern.findall(clean_code)
+
+        for name, statement in matches:
+            # Clean up whitespace and newlines within the statement
+            flat_statement = " ".join(statement.split())
+            extracted_data.append({
+                "theorem_name": name,
+                "statement": flat_statement
+            })
+
+        # Write to jsonl
+        with open(output_file_path, 'w', newline='', encoding='utf-8') as f:
+            for datum in extracted_data:
+                f.write(json.dumps(datum) + '\n')
+        print(f"Done! Extracted {len(extracted_data)} theorems to '{output_file_path}'.")
+
+    except FileNotFoundError:
+        print(f"Error: The file '{input_file}' was not found.")
+    except Exception as e:
+        print(f"An error occurred: {e}")
+
+if __name__ == "__main__":
+    # Update these filenames as needed
+    convert_lean_to_csv('instcombine-merged.lean', 'lean_dataset.jsonl')
+

--- a/Blase/BlaseTest/PrintSmtLib.lean
+++ b/Blase/BlaseTest/PrintSmtLib.lean
@@ -1,24 +1,24 @@
 import Blase
 
-/-- error: (bvjunk predicate) -/
+/-- error: unimplemented: toSmtLib -/
 #guard_msgs in theorem testConcrete (x y : BitVec 6) (z : BitVec 8) :
       x.zeroExtend _ + y.signExtend _ = z := by
   bv_multi_width_print_smt_lib
 
-/-- error: (bvjunk predicate) -/
+/-- error: unimplemented: toSmtLib -/
 #guard_msgs in theorem testConcrete2 (x : BitVec 3) (y : BitVec 4) :
       x.zeroExtend _ + y = y + x.zeroExtend _ := by
   intros
   bv_multi_width_print_smt_lib
 
-/-- error: (bvjunk predicate) -/
+/-- error: unimplemented: toSmtLib -/
 #guard_msgs in theorem generalize2 :
       ∀ (v w : Nat) (x : BitVec v) (y : BitVec w),
       x.zeroExtend _ + y = y + x.zeroExtend _ := by
   -- TODO: make this enter under binders with a with forallTelescoping.
   bv_multi_width_print_smt_lib
 
-/-- error: (bvjunk predicate) -/
+/-- error: unimplemented: toSmtLib -/
 #guard_msgs in theorem generalize3 :
       ∀ (v w : Nat) (x : BitVec v) (y : BitVec w),
       x.zeroExtend _ + y = y + x.zeroExtend _ := by

--- a/Blase/Blasewuzla/Parser.lean
+++ b/Blase/Blasewuzla/Parser.lean
@@ -88,6 +88,14 @@ def parseWidthExpr (s : Sexp) : ParserM Nondep.WidthExpr := do
     | _ =>
       let wb ← parseWidthExpr b
       return .sub wa wb
+  | .expr [.atom "max", a, b] =>
+    let wa ← parseWidthExpr a
+    let wb ← parseWidthExpr b
+    return .max wa wb
+  | .expr [.atom "min", a, b] =>
+    let wa ← parseWidthExpr a
+    let wb ← parseWidthExpr b
+    return .min wa wb
   | .expr _ => ParserM.throwError s!"unsupported compound width expression: '{s}'"
 
 /-- Parse a sort to extract a width expression. Handles `(_ BitVec w)`. -/

--- a/Blase/Blasewuzla/Parser.lean
+++ b/Blase/Blasewuzla/Parser.lean
@@ -71,11 +71,11 @@ def parseWidthExpr (s : Sexp) : ParserM Nondep.WidthExpr := do
       match nStr.toNat? with
       | some k => return .addK wa k
       | none =>
-        let _wb ← parseWidthExpr b
-        -- a + b where b is a variable: use addK with 0 as a workaround isn't right.
-        -- For now, only support constant offsets.
-        ParserM.throwError s!"width expression '+': second operand must be a constant, got '{b}'"
-    | _ => ParserM.throwError s!"width expression '+': second operand must be a constant, got '{b}'"
+        let wb ← parseWidthExpr b
+        return .add wa wb
+    | _ =>
+      let wb ← parseWidthExpr b
+      return .add wa wb
   | .expr [.atom "-", a, b] =>
     let wa ← parseWidthExpr a
     match b with
@@ -83,8 +83,11 @@ def parseWidthExpr (s : Sexp) : ParserM Nondep.WidthExpr := do
       match nStr.toNat? with
       | some k => return .subK wa k
       | none =>
-        ParserM.throwError s!"width expression '-': second operand must be a constant, got '{b}'"
-    | _ => ParserM.throwError s!"width expression '-': second operand must be a constant, got '{b}'"
+        let wb ← parseWidthExpr b
+        return .sub wa wb
+    | _ =>
+      let wb ← parseWidthExpr b
+      return .sub wa wb
   | .expr _ => ParserM.throwError s!"unsupported compound width expression: '{s}'"
 
 /-- Parse a sort to extract a width expression. Handles `(_ BitVec w)`. -/

--- a/Blase/Blasewuzla/Parser.lean
+++ b/Blase/Blasewuzla/Parser.lean
@@ -76,6 +76,15 @@ def parseWidthExpr (s : Sexp) : ParserM Nondep.WidthExpr := do
         -- For now, only support constant offsets.
         ParserM.throwError s!"width expression '+': second operand must be a constant, got '{b}'"
     | _ => ParserM.throwError s!"width expression '+': second operand must be a constant, got '{b}'"
+  | .expr [.atom "-", a, b] =>
+    let wa ← parseWidthExpr a
+    match b with
+    | .atom nStr =>
+      match nStr.toNat? with
+      | some k => return .subK wa k
+      | none =>
+        ParserM.throwError s!"width expression '-': second operand must be a constant, got '{b}'"
+    | _ => ParserM.throwError s!"width expression '-': second operand must be a constant, got '{b}'"
   | .expr _ => ParserM.throwError s!"unsupported compound width expression: '{s}'"
 
 /-- Parse a sort to extract a width expression. Handles `(_ BitVec w)`. -/

--- a/Blase/Blasewuzla/Parser.lean
+++ b/Blase/Blasewuzla/Parser.lean
@@ -293,8 +293,8 @@ partial def parseTerm (s : Sexp) : ParserM ParsedTerm := do
   -- Comparisons (produce predicates)
   | .expr [.atom "=", a, b] => do
     try
-      let wa ← parseWidthExpr a 
-      let wb ← parseWidthExpr b 
+      let wa ← parseWidthExpr a
+      let wb ← parseWidthExpr b
       return .pred (.binWidthRel .eq wa wb)
     catch _ =>
       let pa ← parseTerm a
@@ -307,7 +307,7 @@ partial def parseTerm (s : Sexp) : ParserM ParsedTerm := do
         let nat_ ← negateTerm at_
         let nbt ← negateTerm bt
         return .pred (.and (.or nat_ bt) (.or nbt at_))
-      | _, _ => 
+      | _, _ =>
          ParserM.throwError s!"= : mismatched types between arguments"
   -- distinct is just (not (= a b))
   | .expr [.atom "distinct", a, b] =>

--- a/Blase/Blasewuzla/tests/unsat/commutativity_mult.smt2
+++ b/Blase/Blasewuzla/tests/unsat/commutativity_mult.smt2
@@ -1,0 +1,25 @@
+; {
+;   "name": "commutativity_mult",
+;   "preconditions": [],
+;   "lhs": "(bw r ( * (bw p a) (bw q b)))",
+;   "rhs": "(bw r ( * (bw q b) (bw p a)))"
+; }
+(set-logic QF_BV)
+(declare-const p Int)
+(declare-const q Int)
+(declare-const r Int)
+
+(declare-const pq Int)
+(assert (= pq (+ p q))) ; TODO: add '+' and '-' for arbitrary width variables.
+
+;; --- END PREAMBLE ---
+
+(declare-const a (_ BitVec p))
+(declare-const b (_ BitVec q))
+
+(assert (not (=
+  (pzero_extend r (bvmul (pzero_extend pq a) (pzero_extend pq b)))
+  (pzero_extend r (bvmul (pzero_extend pq b) (pzero_extend pq a)))
+)))
+
+(check-sat)

--- a/Blase/Blasewuzla/tests/unsat/width_max_comm.smt2
+++ b/Blase/Blasewuzla/tests/unsat/width_max_comm.smt2
@@ -1,0 +1,7 @@
+; Prove: zext(max(p,q), x) = zext(max(q,p), x)  (commutativity of max in width)
+(set-logic QF_BV)
+(declare-const p Int)
+(declare-const q Int)
+(declare-const x (_ BitVec p))
+(assert (not (= (pzero_extend (max p q) x) (pzero_extend (max q p) x))))
+(check-sat)

--- a/Blase/Blasewuzla/tests/unsat/width_min_comm.smt2
+++ b/Blase/Blasewuzla/tests/unsat/width_min_comm.smt2
@@ -1,0 +1,7 @@
+; Prove: zext(min(p,q), x) = zext(min(q,p), x)  (commutativity of min in width)
+(set-logic QF_BV)
+(declare-const p Int)
+(declare-const q Int)
+(declare-const x (_ BitVec p))
+(assert (not (= (pzero_extend (min p q) x) (pzero_extend (min q p) x))))
+(check-sat)


### PR DESCRIPTION
This lets us perform operations such as width addition and width subtraction directly by lowering into BV.


Next major missing piece of infrastructure is `ite`, which requires preprocessing to lift `ite`s as fresh hypotheses. 