### PR TITLE
feat/blase: Implement if-then-else

### DIFF
--- a/Blase/Blase/MultiWidth/Defs.lean
+++ b/Blase/Blase/MultiWidth/Defs.lean
@@ -1960,13 +1960,16 @@ def Nondep.Term.elimIte
     let ⟨cond, s⟩ := cond.elimIte s
     let ⟨t1, s⟩ := t1.elimIte s
     let ⟨t2, s⟩ := t2.elimIte s
-    -- cond = true → foo
+    -- cond = true → result = t1
     let ⟨thenPred, success⟩ := Nondep.Term.pimplies cond (.binRel .eq  w result t1)
     let s := s.addSuccess success
+    let s := s.addPrecondition thenPred
     let ⟨condNeg, success⟩ := Nondep.Term.pnegate cond
     let s := s.addSuccess success
+    -- ¬cond → result = t2
     let ⟨elsePred, success⟩ := Nondep.Term.pimplies  condNeg (.binRel .eq w result t2)
     let s := s.addSuccess success
+    let s := s.addPrecondition elsePred
     ⟨result, s⟩
   | .vshl w a b =>
     let ⟨a', s⟩ := a.elimIte s

--- a/Blase/Blase/MultiWidth/Defs.lean
+++ b/Blase/Blase/MultiWidth/Defs.lean
@@ -766,6 +766,7 @@ inductive Term
 | vlshr (w : WidthExpr) (a b : Term) : Term      -- variable logical right shift
 | vashr (w : WidthExpr) (a b : Term) : Term      -- variable arithmetic right shift
 | vshl (w : WidthExpr) (a b : Term) : Term       -- variable left shift
+| bvIte (cond : Term) (thenBv elseBv: Term) : Term -- if then else on bitvectors
 deriving DecidableEq, Inhabited, Repr, Lean.ToExpr
 
 def Term.toSmtLib : Term → SexprPBV.Term
@@ -816,7 +817,7 @@ def Term.pnegate (t : Term) : Term × Bool :=
     | .shiftr .. | .shiftl .. | .boolConst .. | .boolVar ..
     | .bnot .. | .bxor .. | .band .. | .bor .. | .setWidth .. | .sext .. | .zext ..
     | .mul .. | .add .. | .var .. | .ofNat ..
-    | .udiv .. | .urem .. | .vlshr .. | .vashr .. | .vshl .. =>
+    | .udiv .. | .urem .. | .vlshr .. | .vashr .. | .vshl .. | .bvIte .. =>
     dbg_trace "ERROR: could not negate term {repr t}"; (t, false)
 
 def Term.ofDepTerm {wcard tcard bcard : Nat}
@@ -897,6 +898,7 @@ def Term.width (t : Term) : WidthExpr :=
   | vlshr w _a _b => w
   | vashr w _a _b => w
   | vshl w _a _b => w
+  | .bvIte _cond thenBv _elseBv => thenBv.width
 
 /-- The width of the non-dependently typed 't' equals the width 'w',
 converting into the non-dependent version. -/
@@ -947,6 +949,8 @@ def Term.maxwcard (t : Term) : Nat :=
   | vlshr w a b => max w.wcard (max (Term.maxwcard a) (Term.maxwcard b))
   | vashr w a b => max w.wcard (max (Term.maxwcard a) (Term.maxwcard b))
   | vshl w a b => max w.wcard (max (Term.maxwcard a) (Term.maxwcard b))
+  | bvIte cond thenBv elseBv =>
+    max (Term.maxwcard cond) (max (Term.maxwcard thenBv) (Term.maxwcard elseBv))
 
 def Term.tcard (t : Term) : Nat :=
   match t with
@@ -979,6 +983,8 @@ def Term.tcard (t : Term) : Nat :=
   | vlshr _w a b => max (Term.tcard a) (Term.tcard b)
   | vashr _w a b => max (Term.tcard a) (Term.tcard b)
   | vshl _w a b => max (Term.tcard a) (Term.tcard b)
+  | bvIte cond thenBv elseBv =>
+    max (Term.tcard cond) (max (Term.tcard thenBv) (Term.tcard elseBv))
 
 def Term.bcard (t : Term) : Nat :=
   match t with
@@ -1011,6 +1017,8 @@ def Term.bcard (t : Term) : Nat :=
   | vlshr _w a b => max (Term.bcard a) (Term.bcard b)
   | vashr _w a b => max (Term.bcard a) (Term.bcard b)
   | vshl _w a b => max (Term.bcard a) (Term.bcard b)
+  | bvIte cond thenBv elseBv =>
+    max (Term.bcard cond) (max (Term.bcard thenBv) (Term.bcard elseBv))
 
 /-- Returns true if the term can be decided by the automata-based procedure.
 Multiplication is NOT automata decidable. -/
@@ -1040,6 +1048,7 @@ def Term.isAutomtaDecidable : Term → Bool
 | .pvar _ => true
 | .boolBinRel _ a b => a.isAutomtaDecidable && b.isAutomtaDecidable
 | .udiv .. | .urem .. | .vlshr .. | .vashr .. | .vshl .. => false
+| bvIte ..=> false
 
 end Nondep
 
@@ -1659,6 +1668,9 @@ def Term.toBVExpr (wenv : Array Nat) (t : Term) : (BVExpr (t.width.eval wenv)) �
     | .bvOfBool .. | .boolConst .. | .boolVar .. | .setWidth ..
     | .pFalse | .pTrue =>
     (.const (88#_), false) -- these are not BV expressions, so we return a dummy value and false to indicate failure.
+  | .bvIte .. =>
+     -- ITE should have been eliminated!
+     (.const (99#_), false)
 
 /-- Convert a predicate-producing `Nondep.Term` to a `BVLogicalExpr`.
 `wenv` provides concrete width assignments for width variables.
@@ -1737,7 +1749,7 @@ def Term.toBVLogicalExpr (wenv : Array Nat) : Term → BVLogicalExpr × Bool
   | .pvar .. | .binRel .. | .bvOfBool .. | .shiftr ..
     | .shiftl .. | .boolVar .. | .bnot .. | .bxor .. | .band .. | .bor .. | .sext .. | .setWidth ..
     | .zext .. | .mul .. | .add .. | .ofNat .. | .var .. | .boolBinRel ..
-    | .udiv .. | .urem .. | .vlshr .. | .vashr .. | .vshl .. =>
+    | .udiv .. | .urem .. | .vlshr .. | .vashr .. | .vshl .. | .bvIte .. =>
     (dbg_trace "ERROR 15"; .const false, false) -- these are not predicate expressions, so we return a dummy value and false to indicate failure.
 
 end Nondep
@@ -1818,6 +1830,15 @@ def Term.toSingleWidthNondepTerm.mkAllWidthPreconds (wo : Nondep.WidthExpr) (w :
   | w' + 1 =>
     let precond := Term.toSingleWidthNondepTerm.mkWidthPrecond w' wo
     .and precond (Term.toSingleWidthNondepTerm.mkAllWidthPreconds wo w')
+
+/-- create a conjunction of predicates -/
+def Nondep.Term.andPredicates
+   (ps : List Nondep.Term)
+   (default : Nondep.Term := .pTrue) : Nondep.Term :=
+  match ps with
+  | [] => default
+  | [p] => p
+  | p :: ps => .and p (Term.andPredicates ps)
 
 
 /--
@@ -1901,6 +1922,137 @@ def Nondep.Term.toSingleWidthNondepMsb (x : Nondep.Term) (wx : Nondep.WidthExpr)
     let msb := x.band wo msbIx
     (msb, true)
   else (.constBad wo, false)
+
+
+structure ElimIteState where
+  /-- Preconditions added from ite elimination pass. -/
+  preconditions : List Nondep.Term := []
+  /-- Index of fresh variable that will be added for ite-elimination. -/
+  freshTermIndex : Nat
+  /-- Did the pass succeed? -/
+  success : Bool := true
+
+def ElimIteState.newState (freshTermIndex : Nat) : ElimIteState :=
+   { freshTermIndex := freshTermIndex }
+
+/-- Generate a fresh bitvector variable index. -/
+def ElimIteState.freshBV (s : ElimIteState) (w : Nondep.WidthExpr) : Nondep.Term × ElimIteState :=
+   ⟨Nondep.Term.var s.freshTermIndex w, {
+     preconditions := s.preconditions
+     freshTermIndex := s.freshTermIndex + 1
+     success := true
+    }⟩
+
+/-- Add a success into the trail of successes. We only succeed if every step succeeds. -/
+def ElimIteState.addSuccess (s : ElimIteState) (b : Bool) : ElimIteState :=
+  { s with success := s.success && b }
+
+def ElimIteState.addPrecondition (s : ElimIteState) (t : Nondep.Term) : ElimIteState :=
+  { s with preconditions := t :: s.preconditions }
+
+def Nondep.Term.elimIte
+    (t : Nondep.Term)
+    (s : ElimIteState) :  Nondep.Term × ElimIteState :=
+  match t with
+  | .bvIte cond t1 t2 =>
+    let w := t1.width
+    let ⟨result, s⟩ := s.freshBV w -- fresh value of the result
+    let ⟨cond, s⟩ := cond.elimIte s
+    let ⟨t1, s⟩ := t1.elimIte s
+    let ⟨t2, s⟩ := t2.elimIte s
+    -- cond = true → foo
+    let ⟨thenPred, success⟩ := Nondep.Term.pimplies cond (.binRel .eq  w result t1)
+    let s := s.addSuccess success
+    let ⟨condNeg, success⟩ := Nondep.Term.pnegate cond
+    let s := s.addSuccess success
+    let ⟨elsePred, success⟩ := Nondep.Term.pimplies  condNeg (.binRel .eq w result t2)
+    let s := s.addSuccess success
+    ⟨result, s⟩
+  | .vshl w a b =>
+    let ⟨a', s⟩ := a.elimIte s
+    let ⟨b', s⟩ := b.elimIte s
+    (.vshl w a' b', s)
+  | .vlshr w a b=>
+    let ⟨a', s⟩ := a.elimIte s
+    let ⟨b', s⟩ := b.elimIte s
+    (.vlshr w a' b', s)
+  | .vashr w a b =>
+    let ⟨a', s⟩ := a.elimIte s
+    let ⟨b', s⟩ := b.elimIte s
+    (.vashr w a' b', s)
+  | .binRel k w a b =>
+    let ⟨a', s⟩ := a.elimIte s
+    let ⟨b', s⟩ := b.elimIte s
+    (.binRel k w a' b', s)
+  | .urem w a b =>
+    let ⟨a', s⟩ := a.elimIte s
+    let ⟨b', s⟩ := b.elimIte s
+    (.urem w a' b', s)
+  | .udiv w a b =>
+    let ⟨a', s⟩ := a.elimIte s
+    let ⟨b', s⟩ := b.elimIte s
+    (.udiv w a' b', s)
+  | .pFalse => ⟨.pFalse, s⟩
+  | .pTrue => ⟨.pTrue, s⟩
+  | .boolBinRel k a b =>
+    let ⟨a', s⟩ := a.elimIte s
+    let ⟨b', s⟩ := b.elimIte s
+    (.boolBinRel k a' b', s)
+  | .pvar p => ⟨.pvar p, s⟩
+  | .and a b =>
+    let ⟨a', s⟩ := a.elimIte s
+    let ⟨b', s⟩ := b.elimIte s
+    (.and a' b', s)
+  | .or a b =>
+    let ⟨a', s⟩ := a.elimIte s
+    let ⟨b', s⟩ := b.elimIte s
+    (.or a' b', s)
+  | .binWidthRel k u v =>
+    (.binWidthRel k u v, s)
+  | .bvOfBool b => ⟨.bvOfBool b, s⟩
+  | .shiftr w a k =>
+    let ⟨a', s⟩ := a.elimIte s
+    (.shiftr w a' k, s)
+  | .shiftl w a k =>
+    let ⟨a', s⟩ := a.elimIte s
+    (.shiftl w a' k, s)
+  | .boolConst b => ⟨.boolConst b, s⟩
+  | .boolVar b => ⟨.boolVar b, s⟩
+  | .bnot w a =>
+      let ⟨a', s⟩ := a.elimIte s
+      (.bnot w a', s)
+  | .bxor w a b =>
+    let ⟨a', s⟩ := a.elimIte s
+    let ⟨b', s⟩ := b.elimIte s
+    (.bxor w a' b', s)
+  | .band w a b =>
+    let ⟨a', s⟩ := a.elimIte s
+    let ⟨b', s⟩ := b.elimIte s
+    (.band w a' b', s)
+  | .bor w a b =>
+    let ⟨a', s⟩ := a.elimIte s
+    let ⟨b', s⟩ := b.elimIte s
+    (.bor w a' b', s)
+  | .sext a w =>
+    let ⟨a', s⟩ := a.elimIte s
+    (.sext a' w, s)
+  | .setWidth a w =>
+    let ⟨a', s⟩ := a.elimIte s
+    (.setWidth a' w, s)
+  | .zext a w =>
+    let ⟨a', s⟩ := a.elimIte s
+    (.zext a' w, s)
+  | .mul w a b =>
+    let ⟨a', s⟩ := a.elimIte s
+    let ⟨b', s⟩ := b.elimIte s
+    (.mul w a' b', s)
+  | .add w a b =>
+    let ⟨a', s⟩ := a.elimIte s
+    let ⟨b', s⟩ := b.elimIte s
+    (.add w a' b', s)
+  | .var v w => ⟨.var v w, s⟩
+  | .ofNat w n => ⟨.ofNat w n, s⟩
+
 
 
 /--
@@ -2063,17 +2215,24 @@ def Nondep.Term.toSingleWidthNondepTermGo (maxWcard : Nat) (t : Nondep.Term) (wo
     if aresult && bresult && wresult then
       (.band wo (.vshl wo a' b') wmask, true)
     else (.constZero wo, false)
+  | .bvIte cond thenBv elseBv =>
+    let (cond', condresult) := cond.toSingleWidthNondepTermGo maxWcard wo
+    let (thenBv', thenBvresult) := thenBv.toSingleWidthNondepTermGo maxWcard wo
+    let (elseBv', elseBvresult) := elseBv.toSingleWidthNondepTermGo maxWcard wo
+    if condresult && thenBvresult && elseBvresult then
+      (.bvIte cond' thenBv' elseBv', true)
+    else (.constBad wo, false)
   | pvar _ | bvOfBool _ | boolVar _ | boolBinRel .. =>
     (.constZero wo, false)
-  where 
-   goBinop (a b : Nondep.Term) (w : Nondep.WidthExpr) (wo : Nondep.WidthExpr)
-     (binop : Nondep.WidthExpr → Nondep.Term → Nondep.Term → Nondep.Term) : Nondep.Term × Bool :=
-    let (a', aresult) := a.toSingleWidthNondepTermGo maxWcard wo
-    let (b', bresult) := b.toSingleWidthNondepTermGo maxWcard wo
-    let (wmask, wresult) := w.toSingleWidthMaskNondepTerm wo
-    if aresult && bresult && wresult then
-      (.band wo (binop wo a' b') wmask, true)
-    else (.constZero wo, false)
+  where
+    goBinop (a b : Nondep.Term) (w : Nondep.WidthExpr) (wo : Nondep.WidthExpr)
+      (binop : Nondep.WidthExpr → Nondep.Term → Nondep.Term → Nondep.Term) : Nondep.Term × Bool :=
+     let (a', aresult) := a.toSingleWidthNondepTermGo maxWcard wo
+     let (b', bresult) := b.toSingleWidthNondepTermGo maxWcard wo
+     let (wmask, wresult) := w.toSingleWidthMaskNondepTerm wo
+     if aresult && bresult && wresult then
+       (.band wo (binop wo a' b') wmask, true)
+     else (.constZero wo, false)
 
   -- | _ => (.constBad wo, false)
 
@@ -2083,8 +2242,13 @@ Given a term, convert it to a single-width term by converting all width expressi
 def Nondep.Term.toSingleWidthNondepTerm (t : Nondep.Term) (wo : Nondep.WidthExpr): Nondep.Term × Bool :=
   let preconds := Term.toSingleWidthNondepTerm.mkAllWidthPreconds wo t.maxwcard
   let (rhs, rhsResult) : Nondep.Term × Bool := t.toSingleWidthNondepTermGo t.maxwcard wo
-  let (implies, impliesResult) := Term.pimplies preconds rhs
-  if rhsResult && impliesResult then
+  let (rhsIteElim, iteState) : Nondep.Term × ElimIteState := rhs.elimIte
+     (.newState <| rhs.tcard + 1)
+  let (implies, impliesResult) :=
+    Term.pimplies
+      (preconds.andPredicates iteState.preconditions)
+      rhsIteElim
+  if rhsResult && impliesResult && iteState.success then
     (implies, true)
   else (implies, false)
 

--- a/Blase/Blase/MultiWidth/GoodFSM.lean
+++ b/Blase/Blase/MultiWidth/GoodFSM.lean
@@ -1225,7 +1225,7 @@ info: 'MultiWidth.eval_fsmTermSle_eq_decide_sle' depends on axioms:
 def mkTermFSM (wcard tcard bcard ncard icard pcard : Nat) (t : Nondep.Term) :
     (TermFSM wcard tcard bcard ncard icard pcard t) :=
   match t with
-  | .shiftr .. | .pTrue | .pFalse => {
+  | .shiftr .. | .pTrue | .pFalse | .bvIte .. => {
         toFsmZext := (FSM.repeatForever true).map Fin.elim0,
         width := NatFSM.mk <| (FSM.repeatForever true).map Fin.elim0,
   }

--- a/Blase/Blasewuzla/Parser.lean
+++ b/Blase/Blasewuzla/Parser.lean
@@ -418,6 +418,20 @@ partial def parseTerm (s : Sexp) : ParserM ParsedTerm := do
     let pnota ← negateTerm pa
     let pnotb ← negateTerm pb
     return .pred (.or (.and pnota pb) (.and pa pnotb))
+  -- ite: (ite cond then else)
+  | .expr [.atom "ite", cond, thenBranch, elseBranch] =>
+    let pcond ← expectPred (← parseTerm cond) (ctx := "ite")
+    let pthen ← parseTerm thenBranch
+    let pelse ← parseTerm elseBranch
+    match pthen, pelse with
+    | .bv thenT thenW, .bv elseT _elseW =>
+      return .bv (.bvIte pcond thenT elseT) thenW
+    | .pred thenP, .pred elseP =>
+      -- (ite c a b) = (c ∧ a) ∨ (¬c ∧ b)
+      let ncond ← negateTerm pcond
+      return .pred (.or (.and pcond thenP) (.and ncond elseP))
+    | _, _ => ParserM.throwError "ite: mismatched types between then/else branches"
+
   -- let bindings
   | .expr [.atom "let", .expr bindings, body] =>
     let st ← get

--- a/Blase/Blasewuzla/tests/unsat/Select_720_values_0.smt2
+++ b/Blase/Blasewuzla/tests/unsat/Select_720_values_0.smt2
@@ -1,0 +1,8 @@
+(set-logic ALL)
+(declare-const k Int)
+(declare-fun C1 () (_ BitVec k))
+(declare-fun %A () (_ BitVec k))
+(declare-fun C2 () (_ BitVec k))
+(assert (let ((_let_0 (ite (bvuge %A C1) %A C1))) (and (bvugt C1 C2) (not (= (ite (bvuge _let_0 C2) _let_0 C2) _let_0)))))
+(check-sat)
+

--- a/Blase/BlasewuzlaMain.lean
+++ b/Blase/BlasewuzlaMain.lean
@@ -158,7 +158,19 @@ def naiveBMC : Solver where
   name := "naivebmc"
   run (config : Config) (result : ParseResult) : MetaM SolverExitCode := do
 
-    let (negatedPredicate, true) := result.predicate.pnegate
+    -- Eliminate ite nodes before negation
+    let (predElimIte, iteState) := result.predicate.elimIte
+      (.newState <| result.predicate.tcard + 1)
+    if !iteState.success then
+      return .error s!"ite elimination failed for predicate"
+    -- Conjoin ite preconditions with the predicate
+    let predWithPrec := match iteState.preconditions with
+      | [] => predElimIte
+      | precs =>
+        let precConj := Nondep.Term.andPredicates precs
+        let (implied, _) := Nondep.Term.pimplies precConj predElimIte
+        implied
+    let (negatedPredicate, true) := predWithPrec.pnegate
       | throwError "unable to negate predicate. {repr result.predicate}"
     -- naivebmc backend: translate to single-width and call bv_decide at a fixed width
     if config.verbose then


### PR DESCRIPTION
This needs the implementation of an if-then-else elimination pass, which we add into Blase so we can eliminate the `ite` by collecting preconditions. 