### PR TITLE
feat/blase: Produce error messages on failures in Blase

### DIFF
--- a/Blase/Blase/MultiWidth/Defs.lean
+++ b/Blase/Blase/MultiWidth/Defs.lean
@@ -775,35 +775,37 @@ deriving DecidableEq, Inhabited, Repr, Lean.ToExpr
 /-- Negate a predicate term by pushing `not` inward via De Morgan's laws.
     Returns `none` if the term cannot be negated (e.g., unrecognized atomic terms or
     width relations whose negations cannot be expressed in the Term language). -/
-def Term.pnegate (t : Term) : Term × Bool :=
+def Term.pnegate (t : Term) : Term × Bool × Lean.Format :=
   match t with
   | .and p q =>
-    let (p', result) := p.pnegate
-    let (q', result') := q.pnegate
-    (.or p' q', result && result')
+    let (p', result, perr) := p.pnegate
+    let (q', result', qerr) := q.pnegate
+    (.or p' q', result && result', perr ++ qerr)
   | .or p q =>
-    let (p', result) := p.pnegate
-    let (q', result') := q.pnegate
-    (.and p' q', result && result')
-  | .binRel .eq w a b => (.binRel .ne w a b, true)
-  | .binRel .ne w a b => (.binRel .eq w a b, true)
-  | .binRel .ult w a b => (.binRel .ule w b a, true)
-  | .binRel .ule w a b => (.binRel .ult w b a, true)
-  | .binRel .slt w a b => (.binRel .sle w b a, true)
-  | .binRel .sle w a b => (.binRel .slt w b a, true)
-  | .pTrue => (.pFalse, true)
+    let (p', result, perr) := p.pnegate
+    let (q', result', qerr) := q.pnegate
+    (.and p' q', result && result', perr ++ qerr)
+  | .binRel .eq w a b => (.binRel .ne w a b, true, .nil)
+  | .binRel .ne w a b => (.binRel .eq w a b, true, .nil)
+  | .binRel .ult w a b => (.binRel .ule w b a, true, .nil)
+  | .binRel .ule w a b => (.binRel .ult w b a, true, .nil)
+  | .binRel .slt w a b => (.binRel .sle w b a, true, .nil)
+  | .binRel .sle w a b => (.binRel .slt w b a, true, .nil)
+  | .pTrue => (.pFalse, true, .nil)
   -- ¬(wa ≤ wb) ↔ wb + 1 ≤ wa (i.e., wa > wb, since these are naturals)
-  | .binWidthRel .le wa wb => (.binWidthRel .le (.addK wb 1) wa, true)
+  | .binWidthRel .le wa wb => (.binWidthRel .le (.addK wb 1) wa, true, .nil)
   -- ¬(wa = wb) ↔ wa < wb ∨ wb < wa ↔ (wa+1 ≤ wb) ∨ (wb+1 ≤ wa)
   | .binWidthRel .eq wa wb =>
-    (.or (.binWidthRel .le (.addK wa 1) wb) (.binWidthRel .le (.addK wb 1) wa), true)
-  | .pFalse => (.pTrue, true)
+    (.or (.binWidthRel .le (.addK wa 1) wb) (.binWidthRel .le (.addK wb 1) wa), true, .nil)
+  | .pFalse => (.pTrue, true, .nil)
   | .boolBinRel .. | .pvar .. | .bvOfBool ..
     | .shiftr .. | .shiftl .. | .ashr .. | .pextract .. | .boolConst .. | .boolVar ..
     | .bnot .. | .bxor .. | .band .. | .bor .. | .setWidth .. | .sext .. | .zext ..
     | .mul .. | .add .. | .var .. | .ofNat ..
     | .udiv .. | .urem .. | .vlshr .. | .vashr .. | .vshl .. | .bvIte .. | .intToPbv .. =>
-    dbg_trace "ERROR: could not negate term {repr t}"; (t, false)
+    let errMsg := s!"pnegate: could not negate term: {repr t}"
+    dbg_trace errMsg
+    (t, false, .text errMsg)
 
 def Term.ofDepTerm {wcard tcard bcard : Nat}
     {tctx : Term.Ctx wcard tcard}
@@ -1529,9 +1531,15 @@ def Term.toBVExpr (wenv : Array Nat) (t : Term) : (BVExpr (t.width.eval wenv)) �
       if hb : b'.width = w then
          if aresult && bresult then
           (.bin (a'.cast ha) .add (b'.cast hb), true, .nil)
-        else (.const (88#_), false, aerr ++ berr)
-      else (.const (88#_), false, aerr ++ berr)
-    else (.const (88#_), false, aerr ++ berr)
+        else
+          let errMsg := s!"toBVExpr: failed to translate operands of add\n{aerr}\n{berr}"
+          (dbg_trace errMsg; .const (88#_), false, .text errMsg)
+      else
+        let errMsg := s!"toBVExpr: width mismatch in add (b.width={b'.width} ≠ {w})\n{aerr}\n{berr}"
+        (dbg_trace errMsg; .const (88#_), false, .text errMsg)
+    else
+      let errMsg := s!"toBVExpr: width mismatch in add (a.width={a'.width} ≠ {w})\n{aerr}\n{berr}"
+      (dbg_trace errMsg; .const (88#_), false, .text errMsg)
   | .mul we a b =>
     let (a', aresult, aerr) := a.toBVExpr wenv
     let (b', bresult, berr) := b.toBVExpr wenv
@@ -1540,9 +1548,15 @@ def Term.toBVExpr (wenv : Array Nat) (t : Term) : (BVExpr (t.width.eval wenv)) �
       if hb : b'.width = w then
         if aresult && bresult then
           (.bin (a'.cast ha) .mul (b'.cast hb), true, .nil)
-        else (.const (88#_), false, aerr ++ berr)
-      else (.const (88#_), false, aerr ++ berr)
-    else (.const (88#_), false, aerr ++ berr)
+        else
+          let errMsg := s!"toBVExpr: failed to translate operands of mul\n{aerr}\n{berr}"
+          (dbg_trace errMsg; .const (88#_), false, .text errMsg)
+      else
+        let errMsg := s!"toBVExpr: width mismatch in mul (b.width={b'.width} ≠ {w})\n{aerr}\n{berr}"
+        (dbg_trace errMsg; .const (88#_), false, .text errMsg)
+    else
+      let errMsg := s!"toBVExpr: width mismatch in mul (a.width={a'.width} ≠ {w})\n{aerr}\n{berr}"
+      (dbg_trace errMsg; .const (88#_), false, .text errMsg)
   | .band we a b =>
     let (a', aresult, aerr) := a.toBVExpr wenv
     let (b', bresult, berr) := b.toBVExpr wenv
@@ -1551,9 +1565,15 @@ def Term.toBVExpr (wenv : Array Nat) (t : Term) : (BVExpr (t.width.eval wenv)) �
       if hb : b'.width = w then
         if aresult && bresult then
           (.bin (a'.cast ha) .and (b'.cast hb), true, .nil)
-        else (.const (88#_), false, aerr ++ berr)
-      else (.const (88#_), false, aerr ++ berr)
-    else (.const (88#_), false, aerr ++ berr)
+        else
+          let errMsg := s!"toBVExpr: failed to translate operands of band\n{aerr}\n{berr}"
+          (dbg_trace errMsg; .const (88#_), false, .text errMsg)
+      else
+        let errMsg := s!"toBVExpr: width mismatch in band (b.width={b'.width} ≠ {w})\n{aerr}\n{berr}"
+        (dbg_trace errMsg; .const (88#_), false, .text errMsg)
+    else
+      let errMsg := s!"toBVExpr: width mismatch in band (a.width={a'.width} ≠ {w})\n{aerr}\n{berr}"
+      (dbg_trace errMsg; .const (88#_), false, .text errMsg)
   | .bor we a b =>
     let (a', aresult, aerr) := a.toBVExpr wenv
     let (b', bresult, berr) := b.toBVExpr wenv
@@ -1562,9 +1582,15 @@ def Term.toBVExpr (wenv : Array Nat) (t : Term) : (BVExpr (t.width.eval wenv)) �
       if hb : b'.width = w then
         if aresult && bresult then
           (.bin (a'.cast ha) .or (b'.cast hb), true, .nil)
-        else (.const (88#_), false, aerr ++ berr)
-      else (.const (88#_), false, aerr ++ berr)
-    else (.const (88#_), false, aerr ++ berr)
+        else
+          let errMsg := s!"toBVExpr: failed to translate operands of bor\n{aerr}\n{berr}"
+          (dbg_trace errMsg; .const (88#_), false, .text errMsg)
+      else
+        let errMsg := s!"toBVExpr: width mismatch in bor (b.width={b'.width} ≠ {w})\n{aerr}\n{berr}"
+        (dbg_trace errMsg; .const (88#_), false, .text errMsg)
+    else
+      let errMsg := s!"toBVExpr: width mismatch in bor (a.width={a'.width} ≠ {w})\n{aerr}\n{berr}"
+      (dbg_trace errMsg; .const (88#_), false, .text errMsg)
   | .bxor we a b =>
     let (a', aresult, aerr) := a.toBVExpr wenv
     let (b', bresult, berr) := b.toBVExpr wenv
@@ -1573,58 +1599,86 @@ def Term.toBVExpr (wenv : Array Nat) (t : Term) : (BVExpr (t.width.eval wenv)) �
       if hb : b'.width = w then
         if aresult && bresult then
           (.bin (a'.cast ha) .xor (b'.cast hb), true, .nil)
-        else (.const (88#_), false, aerr ++ berr)
-      else (.const (88#_), false, aerr ++ berr)
-    else (.const (88#_), false, aerr ++ berr)
+        else
+          let errMsg := s!"toBVExpr: failed to translate operands of bxor\n{aerr}\n{berr}"
+          (dbg_trace errMsg; .const (88#_), false, .text errMsg)
+      else
+        let errMsg := s!"toBVExpr: width mismatch in bxor (b.width={b'.width} ≠ {w})\n{aerr}\n{berr}"
+        (dbg_trace errMsg; .const (88#_), false, .text errMsg)
+    else
+      let errMsg := s!"toBVExpr: width mismatch in bxor (a.width={a'.width} ≠ {w})\n{aerr}\n{berr}"
+      (dbg_trace errMsg; .const (88#_), false, .text errMsg)
   | .bnot we a =>
     let (a', aresult, aerr) := a.toBVExpr wenv
     let w := we.eval wenv
     if ha : a'.width = w then
       if aresult then
         (.un .not (a'.cast ha), true, .nil)
-      else (.const (89#_), false, aerr)
-    else (.const (90#_), false, aerr)
+      else
+        let errMsg := s!"toBVExpr: failed to translate operand of bnot\n{aerr}"
+        (dbg_trace errMsg; .const (88#_), false, .text errMsg)
+    else
+      let errMsg := s!"toBVExpr: width mismatch in bnot (a.width={a'.width} ≠ {w})\n{aerr}"
+      (dbg_trace errMsg; .const (88#_), false, .text errMsg)
   | .shiftl we a k =>
     let (a', aresult, aerr) := a.toBVExpr wenv
     let w := we.eval wenv
     if ha : a'.width = w then
       if aresult then
         (.shiftLeft (a'.cast ha) (.const (BitVec.ofNat w k)), true, .nil)
-      else (.const (88#_), false, aerr)
-    else (.const (88#_), false, aerr)
+      else
+        let errMsg := s!"toBVExpr: failed to translate operand of shiftl\n{aerr}"
+        (dbg_trace errMsg; .const (88#_), false, .text errMsg)
+    else
+      let errMsg := s!"toBVExpr: width mismatch in shiftl (a.width={a'.width} ≠ {w})\n{aerr}"
+      (dbg_trace errMsg; .const (88#_), false, .text errMsg)
   | .shiftr w a k =>
     let (a', aresult, aerr) := a.toBVExpr wenv
     let w := w.eval wenv
     if ha : a'.width = w then
       if aresult then
         (.shiftRight (a'.cast ha) (.const (BitVec.ofNat w k)), true, .nil)
-      else (.const (88#_), false, aerr)
-    else (.const (88#_), false, aerr)
+      else
+        let errMsg := s!"toBVExpr: failed to translate operand of shiftr\n{aerr}"
+        (dbg_trace errMsg; .const (88#_), false, .text errMsg)
+    else
+      let errMsg := s!"toBVExpr: width mismatch in shiftr (a.width={a'.width} ≠ {w})\n{aerr}"
+      (dbg_trace errMsg; .const (88#_), false, .text errMsg)
   | .ashr w a k =>
     let (a', aresult, aerr) := a.toBVExpr wenv
     let w := w.eval wenv
     if ha : a'.width = w then
       if aresult then
         (.arithShiftRight (a'.cast ha) (.const (BitVec.ofNat w k)), true, .nil)
-      else (.const (88#_), false, aerr)
-    else (.const (88#_), false, aerr)
+      else
+        let errMsg := s!"toBVExpr: failed to translate operand of ashr\n{aerr}"
+        (dbg_trace errMsg; .const (88#_), false, .text errMsg)
+    else
+      let errMsg := s!"toBVExpr: width mismatch in ashr (a.width={a'.width} ≠ {w})\n{aerr}"
+      (dbg_trace errMsg; .const (88#_), false, .text errMsg)
   | .pextract a lo hi =>
     let (a', aresult, aerr) := a.toBVExpr wenv
     if aresult then
       (.extract lo (hi - lo + 1) a', true, .nil)
-    else (.const (88#_), false, aerr)
+    else
+      let errMsg := s!"toBVExpr: failed to translate operand of pextract\n{aerr}"
+      (dbg_trace errMsg; .const (88#_), false, .text errMsg)
   | .zext x we =>
     let (x', xresult, xerr) := x.toBVExpr wenv
     let w := we.eval wenv
     if xresult then
       (BVExpr.zeroExtend x' w, true, .nil)
-    else (.const (88#_), false, xerr)
+    else
+      let errMsg := s!"toBVExpr: failed to translate operand of zext\n{xerr}"
+      (dbg_trace errMsg; .const (88#_), false, .text errMsg)
   | .sext x we =>
     let (x', xresult, xerr) := x.toBVExpr wenv
     let w := we.eval wenv
     if xresult then
       (BVExpr.signExtend x' w, true, .nil)
-    else (.const (88#_), false, xerr)
+    else
+      let errMsg := s!"toBVExpr: failed to translate operand of sext\n{xerr}"
+      (dbg_trace errMsg; .const (88#_), false, .text errMsg)
   | .udiv we a b =>
     let (a', aresult, aerr) := a.toBVExpr wenv
     let (b', bresult, berr) := b.toBVExpr wenv
@@ -1633,9 +1687,15 @@ def Term.toBVExpr (wenv : Array Nat) (t : Term) : (BVExpr (t.width.eval wenv)) �
       if hb : b'.width = w then
         if aresult && bresult then
           (.bin (a'.cast ha) .udiv (b'.cast hb), true, .nil)
-        else (.const (88#_), false, aerr ++ berr)
-      else (.const (88#_), false, aerr ++ berr)
-    else (.const (88#_), false, aerr ++ berr)
+        else
+          let errMsg := s!"toBVExpr: failed to translate operands of udiv\n{aerr}\n{berr}"
+          (dbg_trace errMsg; .const (88#_), false, .text errMsg)
+      else
+        let errMsg := s!"toBVExpr: width mismatch in udiv (b.width={b'.width} ≠ {w})\n{aerr}\n{berr}"
+        (dbg_trace errMsg; .const (88#_), false, .text errMsg)
+    else
+      let errMsg := s!"toBVExpr: width mismatch in udiv (a.width={a'.width} ≠ {w})\n{aerr}\n{berr}"
+      (dbg_trace errMsg; .const (88#_), false, .text errMsg)
   | .urem we a b =>
     let (a', aresult, aerr) := a.toBVExpr wenv
     let (b', bresult, berr) := b.toBVExpr wenv
@@ -1644,9 +1704,15 @@ def Term.toBVExpr (wenv : Array Nat) (t : Term) : (BVExpr (t.width.eval wenv)) �
       if hb : b'.width = w then
         if aresult && bresult then
           (.bin (a'.cast ha) .umod (b'.cast hb), true, .nil)
-        else (.const (88#_), false, aerr ++ berr)
-      else (.const (88#_), false, aerr ++ berr)
-    else (.const (88#_), false, aerr ++ berr)
+        else
+          let errMsg := s!"toBVExpr: failed to translate operands of urem\n{aerr}\n{berr}"
+          (dbg_trace errMsg; .const (88#_), false, .text errMsg)
+      else
+        let errMsg := s!"toBVExpr: width mismatch in urem (b.width={b'.width} ≠ {w})\n{aerr}\n{berr}"
+        (dbg_trace errMsg; .const (88#_), false, .text errMsg)
+    else
+      let errMsg := s!"toBVExpr: width mismatch in urem (a.width={a'.width} ≠ {w})\n{aerr}\n{berr}"
+      (dbg_trace errMsg; .const (88#_), false, .text errMsg)
   | .vlshr we a b =>
     let (a', aresult, aerr) := a.toBVExpr wenv
     let (b', bresult, berr) := b.toBVExpr wenv
@@ -1655,9 +1721,15 @@ def Term.toBVExpr (wenv : Array Nat) (t : Term) : (BVExpr (t.width.eval wenv)) �
       if hb : b'.width = w then
         if aresult && bresult then
           (.shiftRight (a'.cast ha) (b'.cast hb), true, .nil)
-        else (.const (88#_), false, aerr ++ berr)
-      else (.const (88#_), false, aerr ++ berr)
-    else (.const (88#_), false, aerr ++ berr)
+        else
+          let errMsg := s!"toBVExpr: failed to translate operands of vlshr\n{aerr}\n{berr}"
+          (dbg_trace errMsg; .const (88#_), false, .text errMsg)
+      else
+        let errMsg := s!"toBVExpr: width mismatch in vlshr (b.width={b'.width} ≠ {w})\n{aerr}\n{berr}"
+        (dbg_trace errMsg; .const (88#_), false, .text errMsg)
+    else
+      let errMsg := s!"toBVExpr: width mismatch in vlshr (a.width={a'.width} ≠ {w})\n{aerr}\n{berr}"
+      (dbg_trace errMsg; .const (88#_), false, .text errMsg)
   | .vashr we a b =>
     let (a', aresult, aerr) := a.toBVExpr wenv
     let (b', bresult, berr) := b.toBVExpr wenv
@@ -1666,9 +1738,15 @@ def Term.toBVExpr (wenv : Array Nat) (t : Term) : (BVExpr (t.width.eval wenv)) �
       if hb : b'.width = w then
         if aresult && bresult then
           (.arithShiftRight (a'.cast ha) (b'.cast hb), true, .nil)
-        else (.const (88#_), false, aerr ++ berr)
-      else (.const (88#_), false, aerr ++ berr)
-    else (.const (88#_), false, aerr ++ berr)
+        else
+          let errMsg := s!"toBVExpr: failed to translate operands of vashr\n{aerr}\n{berr}"
+          (dbg_trace errMsg; .const (88#_), false, .text errMsg)
+      else
+        let errMsg := s!"toBVExpr: width mismatch in vashr (b.width={b'.width} ≠ {w})\n{aerr}\n{berr}"
+        (dbg_trace errMsg; .const (88#_), false, .text errMsg)
+    else
+      let errMsg := s!"toBVExpr: width mismatch in vashr (a.width={a'.width} ≠ {w})\n{aerr}\n{berr}"
+      (dbg_trace errMsg; .const (88#_), false, .text errMsg)
   | .vshl we a b =>
     let (a', aresult, aerr) := a.toBVExpr wenv
     let (b', bresult, berr) := b.toBVExpr wenv
@@ -1677,9 +1755,15 @@ def Term.toBVExpr (wenv : Array Nat) (t : Term) : (BVExpr (t.width.eval wenv)) �
       if hb : b'.width = w then
         if aresult && bresult then
           (.shiftLeft (a'.cast ha) (b'.cast hb), true, .nil)
-        else (.const (88#_), false, aerr ++ berr)
-      else (.const (88#_), false, aerr ++ berr)
-    else (.const (88#_), false, aerr ++ berr)
+        else
+          let errMsg := s!"toBVExpr: failed to translate operands of vshl\n{aerr}\n{berr}"
+          (dbg_trace errMsg; .const (88#_), false, .text errMsg)
+      else
+        let errMsg := s!"toBVExpr: width mismatch in vshl (b.width={b'.width} ≠ {w})\n{aerr}\n{berr}"
+        (dbg_trace errMsg; .const (88#_), false, .text errMsg)
+    else
+      let errMsg := s!"toBVExpr: width mismatch in vshl (a.width={a'.width} ≠ {w})\n{aerr}\n{berr}"
+      (dbg_trace errMsg; .const (88#_), false, .text errMsg)
   | .intToPbv w v =>
      let w := w.eval wenv
      let v := v.eval wenv
@@ -1845,9 +1929,9 @@ def Nondep.Term.sub (w : WidthExpr) (a b : Term) : Term :=
   .add w a (b.neg)
 
 /-- p1 → p2 iff ¬p1 ∨ p2.-/
-def Nondep.Term.pimplies (p1 p2 : Nondep.Term) : Nondep.Term × Bool:=
-  let (p1, success) := p1.pnegate
-  (Nondep.Term.or p1 p2, success)
+def Nondep.Term.pimplies (p1 p2 : Nondep.Term) : Nondep.Term × Bool × Lean.Format :=
+  let (p1, success, err) := p1.pnegate
+  (Nondep.Term.or p1 p2, success, err)
 
 
 /-- Compute `a + 1`. -/
@@ -1863,58 +1947,58 @@ Convert a width variable into a bitvector,
 which encodes it into a bitvector whose '.toNat' value is the width.
 -/
 def Nondep.WidthExpr.toTwosComplementNondepTerm (w : Nondep.WidthExpr) (wo : Nondep.WidthExpr) :
-    Nondep.Term × Bool :=
+    Nondep.Term × Bool × Lean.Format :=
   match w with
-  | .const c => (Nondep.Term.ofNat wo c, true) -- 2^0 = 1
+  | .const c => (Nondep.Term.ofNat wo c, true, .nil)
   | .var v =>
     let widthVal := Nondep.Term.var v wo
-    (widthVal, true)
+    (widthVal, true, .nil)
   | .max a b =>
-    let (a', aresult) := a.toTwosComplementNondepTerm wo
-    let (b', bresult) := b.toTwosComplementNondepTerm wo
+    let (a', aresult, aerr) := a.toTwosComplementNondepTerm wo
+    let (b', bresult, berr) := b.toTwosComplementNondepTerm wo
     if aresult && bresult then
       -- max(a, b) = ite(b ≤ a, a, b)
       let cond := Nondep.Term.binRel .ule wo b' a'
-      (.bvIte cond a' b', true)
-    else (.constBad wo, false)
+      (.bvIte cond a' b', true, .nil)
+    else (.constBad wo, false, aerr ++ berr)
   | .min a b =>
-    let (a', aresult) := a.toTwosComplementNondepTerm wo
-    let (b', bresult) := b.toTwosComplementNondepTerm wo
+    let (a', aresult, aerr) := a.toTwosComplementNondepTerm wo
+    let (b', bresult, berr) := b.toTwosComplementNondepTerm wo
     if aresult && bresult then
       -- min(a, b) = ite(a ≤ b, a, b)
       let cond := Nondep.Term.binRel .ule wo a' b'
-      (.bvIte cond a' b', true)
-    else (.constBad wo, false)
+      (.bvIte cond a' b', true, .nil)
+    else (.constBad wo, false, aerr ++ berr)
   | .addK a k =>
-    let (aval, aresult) := a.toTwosComplementNondepTerm wo
+    let (aval, aresult, aerr) := a.toTwosComplementNondepTerm wo
     let kval := Nondep.Term.ofNat wo k
     if aresult then
-      (.add wo aval kval, true)
-    else (.constBad wo, false)
+      (.add wo aval kval, true, .nil)
+    else (.constBad wo, false, aerr)
   | .kadd k a =>
-    let (aval, aresult) := a.toTwosComplementNondepTerm wo
+    let (aval, aresult, aerr) := a.toTwosComplementNondepTerm wo
     let kval := Nondep.Term.ofNat wo k
     if aresult then
-      (.add wo kval aval, true)
-    else (.constBad wo, false)
+      (.add wo kval aval, true, .nil)
+    else (.constBad wo, false, aerr)
   | .add a b =>
-    let (a', aresult) := a.toTwosComplementNondepTerm wo
-    let (b', bresult) := b.toTwosComplementNondepTerm wo
+    let (a', aresult, aerr) := a.toTwosComplementNondepTerm wo
+    let (b', bresult, berr) := b.toTwosComplementNondepTerm wo
     if aresult && bresult then
-      (.add wo a' b', true) -- mask of add is the or of masks.
-    else (.constBad wo, false)
+      (.add wo a' b', true, .nil)
+    else (.constBad wo, false, aerr ++ berr)
   | .sub a b =>
-    let (a', aresult) := a.toTwosComplementNondepTerm wo
-    let (b', bresult) := b.toTwosComplementNondepTerm wo
+    let (a', aresult, aerr) := a.toTwosComplementNondepTerm wo
+    let (b', bresult, berr) := b.toTwosComplementNondepTerm wo
     if aresult && bresult then
-      (.sub wo a' b', true) -- mask of sub is the and of masks.
-    else (.constBad wo, false)
+      (.sub wo a' b', true, .nil)
+    else (.constBad wo, false, aerr ++ berr)
   | .subK a k =>
-    let (amask, aresult) := a.toTwosComplementNondepTerm wo
+    let (amask, aresult, aerr) := a.toTwosComplementNondepTerm wo
     let kval := Nondep.Term.ofNat wo k
     if aresult then
-      (.sub wo amask kval, true)
-    else (.constBad wo, false)
+      (.sub wo amask kval, true, .nil)
+    else (.constBad wo, false, aerr)
 
 /--
 Create preconditions that say that the width is inbounds.
@@ -1956,14 +2040,14 @@ Convert a width variable into a bitvector,
 which encodes a mask of the form (1 << w) - 1, where w is the width variable.
 -/
 def Nondep.WidthExpr.toSingleWidthMaskNondepTerm (w : Nondep.WidthExpr) (wo : Nondep.WidthExpr)
-    : Nondep.Term × Bool :=
-  let (wval, wresult) := w.toTwosComplementNondepTerm wo
+    : Nondep.Term × Bool × Lean.Format :=
+  let (wval, wresult, werr) := w.toTwosComplementNondepTerm wo
   if wresult then
     let one := Nondep.Term.constOne wo
     let pot := Nondep.Term.vshl wo one wval  -- 1 << widthVar = 2^widthVar
     let out := Nondep.Term.sub wo pot one-- 2^widthVar - 1 = mask
-    (out, true)
-  else (.constBad wo, false)
+    (out, true, .nil)
+  else (.constBad wo, false, werr)
 
 /-#
 
@@ -2005,14 +2089,14 @@ which extracts just the top bit of a unary mask
 Compute MSB of `x` at width mask `mask`.
 -/
 def Nondep.Term.toSingleWidthNondepMsb (x : Nondep.Term) (wx : Nondep.WidthExpr) (wo : Nondep.WidthExpr) :
-    Nondep.Term × Bool :=
-  let (mask, maskResult) := wx.toSingleWidthMaskNondepTerm wo
+    Nondep.Term × Bool × Lean.Format :=
+  let (mask, maskResult, maskErr) := wx.toSingleWidthMaskNondepTerm wo
   if maskResult then
     let maskSucc := mask.succ -- mask + 1 = 100000
     let msbIx := maskSucc.shiftr wo 1 -- (mask + 1) >>> 1 = 010000
     let msb := x.band wo msbIx
-    (msb, true)
-  else (.constBad wo, false)
+    (msb, true, .nil)
+  else (.constBad wo, false, maskErr)
 
 
 structure ElimIteState where
@@ -2022,6 +2106,8 @@ structure ElimIteState where
   freshTermIndex : Nat
   /-- Did the pass succeed? -/
   success : Bool := true
+  /-- Accumulated error messages from failed sub-steps. -/
+  errors : Lean.Format := .nil
 
 def ElimIteState.newState (freshTermIndex : Nat) : ElimIteState :=
    { freshTermIndex := freshTermIndex }
@@ -2032,11 +2118,12 @@ def ElimIteState.freshBV (s : ElimIteState) (w : Nondep.WidthExpr) : Nondep.Term
      preconditions := s.preconditions
      freshTermIndex := s.freshTermIndex + 1
      success := true
+     errors := s.errors
     }⟩
 
-/-- Add a success into the trail of successes. We only succeed if every step succeeds. -/
-def ElimIteState.addSuccess (s : ElimIteState) (b : Bool) : ElimIteState :=
-  { s with success := s.success && b }
+/-- Add a success/failure into the trail, merging in the associated error messages. -/
+def ElimIteState.addSuccess (s : ElimIteState) (b : Bool) (err : Lean.Format) : ElimIteState :=
+  { s with success := s.success && b, errors := s.errors ++ err }
 
 def ElimIteState.addPrecondition (s : ElimIteState) (t : Nondep.Term) : ElimIteState :=
   { s with preconditions := t :: s.preconditions }
@@ -2045,12 +2132,13 @@ def ElimIteState.addPrecondition (s : ElimIteState) (t : Nondep.Term) : ElimIteS
 Build `preconds → term` from an `ElimIteState`.
 If there are no preconditions, the term is returned unchanged.
 -/
-def ElimIteState.toImplication (s : ElimIteState) (t : Nondep.Term) : Nondep.Term × Bool :=
+def ElimIteState.toImplication (s : ElimIteState) (t : Nondep.Term) : Nondep.Term × Bool × Lean.Format :=
   match s.preconditions with
-  | []    => (t, true)
+  | []    => (t, true, s.errors)
   | precs =>
     let precConj := Nondep.Term.andPredicates precs
-    Nondep.Term.pimplies precConj t
+    let (result, success, err) := Nondep.Term.pimplies precConj t
+    (result, success, s.errors ++ err)
 
 def Nondep.Term.elimIte
     (t : Nondep.Term)
@@ -2063,14 +2151,14 @@ def Nondep.Term.elimIte
     let ⟨t1, s⟩ := t1.elimIte s
     let ⟨t2, s⟩ := t2.elimIte s
     -- cond = true → result = t1
-    let ⟨thenPred, success⟩ := Nondep.Term.pimplies cond (.binRel .eq  w result t1)
-    let s := s.addSuccess success
+    let ⟨thenPred, success, err⟩ := Nondep.Term.pimplies cond (.binRel .eq w result t1)
+    let s := s.addSuccess success err
     let s := s.addPrecondition thenPred
-    let ⟨condNeg, success⟩ := Nondep.Term.pnegate cond
-    let s := s.addSuccess success
+    let ⟨condNeg, success, err⟩ := Nondep.Term.pnegate cond
+    let s := s.addSuccess success err
     -- ¬cond → result = t2
-    let ⟨elsePred, success⟩ := Nondep.Term.pimplies  condNeg (.binRel .eq w result t2)
-    let s := s.addSuccess success
+    let ⟨elsePred, success, err⟩ := Nondep.Term.pimplies condNeg (.binRel .eq w result t2)
+    let s := s.addSuccess success err
     let s := s.addPrecondition elsePred
     ⟨result, s⟩
   | .vshl w a b =>
@@ -2389,9 +2477,9 @@ def Nondep.Term.elimSub (t : Nondep.Term) (initialFreshWidthIndex : Nat) : ElimS
 Build `preconds → term` from an `ElimSubResult`.
 If there are no preconditions, the term is returned unchanged.
 -/
-def ElimSubResult.toImplication (r : ElimSubResult) : Nondep.Term × Bool :=
+def ElimSubResult.toImplication (r : ElimSubResult) : Nondep.Term × Bool × Lean.Format :=
   match r.preconds with
-  | []    => (r.term, true)
+  | []    => (r.term, true, .nil)
   | precs =>
     let precConj := Nondep.Term.andPredicates precs
     Nondep.Term.pimplies precConj r.term
@@ -2401,194 +2489,203 @@ TODO: refactor into `SingleWidth → Nondep.Term × Bool`, since it's better typ
 Then this function will be `Nondep.Term → SingleWidth → Nondep.Term × Bool`, and the preconditions can be generated separately.
 For the `Nondep.Term → SingleWidth` translation, change type to `Nondep.Term → SingleWidth × Bool`.
 -/
-def Nondep.Term.toSingleWidthNondepTermGo (maxWcard : Nat) (t : Nondep.Term) (wo : Nondep.WidthExpr) : Nondep.Term × Bool :=
+def Nondep.Term.toSingleWidthNondepTermGo (maxWcard : Nat) (t : Nondep.Term) (wo : Nondep.WidthExpr) : Nondep.Term × Bool × Lean.Format :=
   match t with
   | .var v w =>
     -- bitvector variables become bitvectors,
     -- masked with the width value.
     let x := Nondep.Term.var (v + maxWcard) wo
-    let (wmask, wresult) := w.toSingleWidthMaskNondepTerm wo
+    let (wmask, wresult, werr) := w.toSingleWidthMaskNondepTerm wo
     if wresult then
-      (.band wo x wmask, true) -- mask the variable to the universe width.
-    else (.constBad wo, false)
+      (.band wo x wmask, true, .nil)
+    else (.constBad wo, false, werr)
   | .ofNat w n =>
-      let (wmask, wresult) := w.toSingleWidthMaskNondepTerm wo
+      let (wmask, wresult, werr) := w.toSingleWidthMaskNondepTerm wo
       let bv := Nondep.Term.ofNat wo n
       if wresult then
-        (.band wo bv wmask, true) -- mask the constant to the universe width.
-      else (.constBad wo, false)
+        (.band wo bv wmask, true, .nil)
+      else (.constBad wo, false, werr)
   | .add w a b =>
-    let (a', aresult) := a.toSingleWidthNondepTermGo maxWcard wo
-    let (b', bresult) := b.toSingleWidthNondepTermGo maxWcard wo
-    let (wmask, wresult) := w.toSingleWidthMaskNondepTerm wo
+    let (a', aresult, aerr) := a.toSingleWidthNondepTermGo maxWcard wo
+    let (b', bresult, berr) := b.toSingleWidthNondepTermGo maxWcard wo
+    let (wmask, wresult, werr) := w.toSingleWidthMaskNondepTerm wo
     if aresult && bresult && wresult then
-      (.band wo (.add wo a' b') wmask, true) -- mask the result to the universe width.
-    else (.constBad wo, false)
+      (.band wo (.add wo a' b') wmask, true, .nil)
+    else (.constBad wo, false, aerr ++ berr ++ werr)
   | .band _w a b =>
-    let (a', aresult) := a.toSingleWidthNondepTermGo maxWcard wo
-    let (b', bresult) := b.toSingleWidthNondepTermGo maxWcard wo
+    let (a', aresult, aerr) := a.toSingleWidthNondepTermGo maxWcard wo
+    let (b', bresult, berr) := b.toSingleWidthNondepTermGo maxWcard wo
     if aresult && bresult then
       -- AND cannot overflow, so we don't need to mask the result to the universe width.
-      ((.band wo a' b'), true)
-    else (.constZero wo, false)
+      (.band wo a' b', true, .nil)
+    else (.constZero wo, false, aerr ++ berr)
   | .bor _w a b =>
-    let (a', aresult) := a.toSingleWidthNondepTermGo maxWcard wo
-    let (b', bresult) := b.toSingleWidthNondepTermGo maxWcard wo
+    let (a', aresult, aerr) := a.toSingleWidthNondepTermGo maxWcard wo
+    let (b', bresult, berr) := b.toSingleWidthNondepTermGo maxWcard wo
     if aresult && bresult then
       -- OR cannot overflow, so we don't need to mask the result to the universe width.
-      ((.bor wo a' b'), true)
-    else (.constZero wo, false)
+      (.bor wo a' b', true, .nil)
+    else (.constZero wo, false, aerr ++ berr)
   | .bxor _w a b =>
-    let (a', aresult) := a.toSingleWidthNondepTermGo maxWcard wo
-    let (b', bresult) := b.toSingleWidthNondepTermGo maxWcard wo
+    let (a', aresult, aerr) := a.toSingleWidthNondepTermGo maxWcard wo
+    let (b', bresult, berr) := b.toSingleWidthNondepTermGo maxWcard wo
     if aresult && bresult then
       -- XOR cannot overflow, so we don't need to mask the result to the universe width.
-      ((.bxor wo a' b'), true)
-    else (.constZero wo, false)
+      (.bxor wo a' b', true, .nil)
+    else (.constZero wo, false, aerr ++ berr)
   | .bnot w a =>
-    let (a', aresult) := a.toSingleWidthNondepTermGo maxWcard wo
-    let (wmask, wresult) := w.toSingleWidthMaskNondepTerm wo
+    let (a', aresult, aerr) := a.toSingleWidthNondepTermGo maxWcard wo
+    let (wmask, wresult, werr) := w.toSingleWidthMaskNondepTerm wo
     if aresult && wresult then
       -- NOT flips the high bits (w..wo-1) from 0 to 1, violating the single-width
       -- encoding invariant. We must mask the result back to width w.
-      (.band wo (.bnot wo a') wmask, true)
-    else (.constZero wo, false)
+      (.band wo (.bnot wo a') wmask, true, .nil)
+    else (.constZero wo, false, aerr ++ werr)
   | .mul w a b =>
-    let (a', aresult) := a.toSingleWidthNondepTermGo maxWcard wo
-    let (b', bresult) := b.toSingleWidthNondepTermGo maxWcard wo
-    let (wmask, wresult) := w.toSingleWidthMaskNondepTerm wo
+    let (a', aresult, aerr) := a.toSingleWidthNondepTermGo maxWcard wo
+    let (b', bresult, berr) := b.toSingleWidthNondepTermGo maxWcard wo
+    let (wmask, wresult, werr) := w.toSingleWidthMaskNondepTerm wo
     if aresult && bresult && wresult then
-      (.band wo (.mul wo a' b') wmask, true) -- mask the result to the universe width.
-    else (.constBad wo, false)
+      (.band wo (.mul wo a' b') wmask, true, .nil)
+    else (.constBad wo, false, aerr ++ berr ++ werr)
   | .shiftl w x k =>
-    let (x', xresult) := x.toSingleWidthNondepTermGo maxWcard wo
-    let (wmask, wresult) := w.toSingleWidthMaskNondepTerm wo
+    let (x', xresult, xerr) := x.toSingleWidthNondepTermGo maxWcard wo
+    let (wmask, wresult, werr) := w.toSingleWidthMaskNondepTerm wo
     if xresult && wresult then
-      (.band wo (.shiftl wo x' k) wmask, true) -- mask the result to the universe width.
-    else (.constBad wo, false)
-  | .boolConst _ => (t, true)
+      (.band wo (.shiftl wo x' k) wmask, true, .nil)
+    else (.constBad wo, false, xerr ++ werr)
+  | .boolConst _ => (t, true, .nil)
   | .zext x wnew | .setWidth x wnew =>
-    let (x', xresult) := x.toSingleWidthNondepTermGo maxWcard wo
-    let (wmask, wresult) := wnew.toSingleWidthMaskNondepTerm wo
+    let (x', xresult, xerr) := x.toSingleWidthNondepTermGo maxWcard wo
+    let (wmask, wresult, werr) := wnew.toSingleWidthMaskNondepTerm wo
     if xresult && wresult then
-      (.band wo x' wmask, true)
-    else (.constBad wo, false)
+      (.band wo x' wmask, true, .nil)
+    else (.constBad wo, false, xerr ++ werr)
   | .sext x wnew =>
       let w := x.width
-      let (wmaskNew, wnewResult) := wnew.toSingleWidthMaskNondepTerm wo
-      let (x', xresult) := x.toSingleWidthNondepTermGo maxWcard wo
-      let (msb, msbResult) := x'.toSingleWidthNondepMsb w wo
+      let (wmaskNew, wnewResult, wnewErr) := wnew.toSingleWidthMaskNondepTerm wo
+      let (x', xresult, xerr) := x.toSingleWidthNondepTermGo maxWcard wo
+      let (msb, msbResult, msbErr) := x'.toSingleWidthNondepMsb w wo
       -- x' ^ msb - msb
       let y := (Nondep.Term.sub wo (Nondep.Term.bxor wo x' msb) msb)
       let ymasked := Nondep.Term.band wo y wmaskNew
       if xresult && msbResult && wnewResult then
-        (ymasked, true)
-      else (.constBad wo, false)
+        (ymasked, true, .nil)
+      else (.constBad wo, false, xerr ++ msbErr ++ wnewErr)
   | .and p q =>
-    let (p', presult) := p.toSingleWidthNondepTermGo maxWcard wo
-    let (q', qresult) := q.toSingleWidthNondepTermGo maxWcard wo
+    let (p', presult, perr) := p.toSingleWidthNondepTermGo maxWcard wo
+    let (q', qresult, qerr) := q.toSingleWidthNondepTermGo maxWcard wo
     if presult && qresult then
-      (.and p' q', true)
-    else (.constBad wo, false)
+      (.and p' q', true, .nil)
+    else (.constBad wo, false, perr ++ qerr)
   | .or p q =>
-    let (p', presult) := p.toSingleWidthNondepTermGo maxWcard wo
-    let (q', qresult) := q.toSingleWidthNondepTermGo maxWcard wo
+    let (p', presult, perr) := p.toSingleWidthNondepTermGo maxWcard wo
+    let (q', qresult, qerr) := q.toSingleWidthNondepTermGo maxWcard wo
     if presult && qresult then
-      (.or p' q', true)
-    else (.constBad wo, false)
-  | .pTrue => (.pTrue, true)
-  | .pFalse => (.pFalse, true)
+      (.or p' q', true, .nil)
+    else (.constBad wo, false, perr ++ qerr)
+  | .pTrue => (.pTrue, true, .nil)
+  | .pFalse => (.pFalse, true, .nil)
   | .binRel k w x y =>
-    let (x', xresult) := x.toSingleWidthNondepTermGo maxWcard wo
-    let (y', yresult) := y.toSingleWidthNondepTermGo maxWcard wo
-    let (wmask, wresult) := w.toSingleWidthMaskNondepTerm wo
+    let (x', xresult, xerr) := x.toSingleWidthNondepTermGo maxWcard wo
+    let (y', yresult, yerr) := y.toSingleWidthNondepTermGo maxWcard wo
+    let (wmask, wresult, werr) := w.toSingleWidthMaskNondepTerm wo
     if xresult && yresult && wresult then
       let xMasked := .band wo x' wmask
       let yMasked := .band wo y' wmask
       match k with
-      | .eq => (.binRel .eq wo xMasked yMasked, true)
-      | .ne => (.binRel .ne wo xMasked yMasked, true)
-      | .ult => (.binRel .ult wo xMasked yMasked, true)
-      | .ule => (.binRel .ule wo xMasked yMasked, true)
-      | _ => (.constBad wo, false)
-    else (.constBad wo, false)
+      | .eq => (.binRel .eq wo xMasked yMasked, true, .nil)
+      | .ne => (.binRel .ne wo xMasked yMasked, true, .nil)
+      | .ult => (.binRel .ult wo xMasked yMasked, true, .nil)
+      | .ule => (.binRel .ule wo xMasked yMasked, true, .nil)
+      | _ =>
+        let errMsg := s!"toSingleWidthNondepTermGo: unsupported binRel kind {repr k} (only eq/ne/ult/ule supported)"
+        dbg_trace errMsg
+        (.constBad wo, false, .text errMsg)
+    else (.constBad wo, false, xerr ++ yerr ++ werr)
   | .binWidthRel k wa wb =>
-    let (wa', waresult) := wa.toTwosComplementNondepTerm wo
-    let (wb', wbresult) := wb.toTwosComplementNondepTerm wo
+    let (wa', waresult, waerr) := wa.toTwosComplementNondepTerm wo
+    let (wb', wbresult, wberr) := wb.toTwosComplementNondepTerm wo
     if waresult && wbresult then
       match k with
-      | .eq => (.binRel .eq wo wa' wb', true)
-      | .le => (.binRel .ule wo wa' wb', true)
-    else (.constBad wo, false)
+      | .eq => (.binRel .eq wo wa' wb', true, .nil)
+      | .le => (.binRel .ule wo wa' wb', true, .nil)
+    else (.constBad wo, false, waerr ++ wberr)
   | .shiftr w x k =>
-    let (x', xresult) := x.toSingleWidthNondepTermGo maxWcard wo
-    let (wmask, wresult) := w.toSingleWidthMaskNondepTerm wo
+    let (x', xresult, xerr) := x.toSingleWidthNondepTermGo maxWcard wo
+    let (wmask, wresult, werr) := w.toSingleWidthMaskNondepTerm wo
     if xresult && wresult then
-      (.band wo (.shiftr wo x' k) wmask, true) -- mask the result to the universe width.
-    else (.constBad wo, false)
+      (.band wo (.shiftr wo x' k) wmask, true, .nil)
+    else (.constBad wo, false, xerr ++ werr)
   | .udiv w a b =>
-    let (a', aresult) := a.toSingleWidthNondepTermGo maxWcard wo
-    let (b', bresult) := b.toSingleWidthNondepTermGo maxWcard wo
-    let (wmask, wresult) := w.toSingleWidthMaskNondepTerm wo
+    let (a', aresult, aerr) := a.toSingleWidthNondepTermGo maxWcard wo
+    let (b', bresult, berr) := b.toSingleWidthNondepTermGo maxWcard wo
+    let (wmask, wresult, werr) := w.toSingleWidthMaskNondepTerm wo
     if aresult && bresult && wresult then
-      (.band wo (.udiv wo a' b') wmask, true)
-    else (.constBad wo, false)
+      (.band wo (.udiv wo a' b') wmask, true, .nil)
+    else (.constBad wo, false, aerr ++ berr ++ werr)
   | .urem w a b =>
-    let (a', aresult) := a.toSingleWidthNondepTermGo maxWcard wo
-    let (b', bresult) := b.toSingleWidthNondepTermGo maxWcard wo
-    let (wmask, wresult) := w.toSingleWidthMaskNondepTerm wo
+    let (a', aresult, aerr) := a.toSingleWidthNondepTermGo maxWcard wo
+    let (b', bresult, berr) := b.toSingleWidthNondepTermGo maxWcard wo
+    let (wmask, wresult, werr) := w.toSingleWidthMaskNondepTerm wo
     if aresult && bresult && wresult then
-      (.band wo (.urem wo a' b') wmask, true)
-    else (.constBad wo, false)
+      (.band wo (.urem wo a' b') wmask, true, .nil)
+    else (.constBad wo, false, aerr ++ berr ++ werr)
   | .vlshr w a b =>
-    let (a', aresult) := a.toSingleWidthNondepTermGo maxWcard wo
-    let (b', bresult) := b.toSingleWidthNondepTermGo maxWcard wo
-    let (wmask, wresult) := w.toSingleWidthMaskNondepTerm wo
+    let (a', aresult, aerr) := a.toSingleWidthNondepTermGo maxWcard wo
+    let (b', bresult, berr) := b.toSingleWidthNondepTermGo maxWcard wo
+    let (wmask, wresult, werr) := w.toSingleWidthMaskNondepTerm wo
     if aresult && bresult && wresult then
-      (.band wo (.vlshr wo a' b') wmask, true)
-    else (.constBad wo, false)
+      (.band wo (.vlshr wo a' b') wmask, true, .nil)
+    else (.constBad wo, false, aerr ++ berr ++ werr)
   | .vashr _w _a _b =>
     -- Arithmetic right shift in single-width encoding is complex (needs sign extension).
-    -- Return unsupported for now.
-    (.constBad wo, false)
+    let errMsg := s!"toSingleWidthNondepTermGo: vashr (variable arithmetic right shift) unsupported: {repr t}"
+    dbg_trace errMsg
+    (.constBad wo, false, .text errMsg)
   | .ashr _w _a _k =>
     -- Constant arithmetic right shift in single-width encoding is complex (needs sign extension).
-    -- Return unsupported for now.
-    (.constBad wo, false)
+    let errMsg := s!"toSingleWidthNondepTermGo: ashr (constant arithmetic right shift) unsupported: {repr t}"
+    dbg_trace errMsg
+    (.constBad wo, false, .text errMsg)
   | .pextract _a _lo _hi =>
     -- Bit extraction in single-width encoding requires masking and shifting; stub for now.
-    (.constBad wo, false)
+    let errMsg := s!"toSingleWidthNondepTermGo: pextract (bit extraction) unsupported: {repr t}"
+    dbg_trace errMsg
+    (.constBad wo, false, .text errMsg)
   | .vshl w a b =>
-    let (a', aresult) := a.toSingleWidthNondepTermGo maxWcard wo
-    let (b', bresult) := b.toSingleWidthNondepTermGo maxWcard wo
-    let (wmask, wresult) := w.toSingleWidthMaskNondepTerm wo
+    let (a', aresult, aerr) := a.toSingleWidthNondepTermGo maxWcard wo
+    let (b', bresult, berr) := b.toSingleWidthNondepTermGo maxWcard wo
+    let (wmask, wresult, werr) := w.toSingleWidthMaskNondepTerm wo
     if aresult && bresult && wresult then
-      (.band wo (.vshl wo a' b') wmask, true)
-    else (.constZero wo, false)
+      (.band wo (.vshl wo a' b') wmask, true, .nil)
+    else (.constZero wo, false, aerr ++ berr ++ werr)
   | .bvIte cond thenBv elseBv =>
-    let (cond', condresult) := cond.toSingleWidthNondepTermGo maxWcard wo
-    let (thenBv', thenBvresult) := thenBv.toSingleWidthNondepTermGo maxWcard wo
-    let (elseBv', elseBvresult) := elseBv.toSingleWidthNondepTermGo maxWcard wo
+    let (cond', condresult, conderr) := cond.toSingleWidthNondepTermGo maxWcard wo
+    let (thenBv', thenBvresult, thenErr) := thenBv.toSingleWidthNondepTermGo maxWcard wo
+    let (elseBv', elseBvresult, elseErr) := elseBv.toSingleWidthNondepTermGo maxWcard wo
     if condresult && thenBvresult && elseBvresult then
-      (.bvIte cond' thenBv' elseBv', true)
-    else (.constBad wo, false)
+      (.bvIte cond' thenBv' elseBv', true, .nil)
+    else (.constBad wo, false, conderr ++ thenErr ++ elseErr)
   | pvar _ | bvOfBool _ | boolVar _ | boolBinRel .. =>
-    (.constZero wo, false)
+    let errMsg := s!"toSingleWidthNondepTermGo: unsupported operation in single-width translation: {repr t}"
+    dbg_trace errMsg
+    (.constZero wo, false, .text errMsg)
   | .intToPbv w v =>
-    let (v', vresult) := v.toTwosComplementNondepTerm wo
-    let (wmask, wresult) := w.toSingleWidthMaskNondepTerm wo
+    let (v', vresult, verr) := v.toTwosComplementNondepTerm wo
+    let (wmask, wresult, werr) := w.toSingleWidthMaskNondepTerm wo
     if vresult && wresult then
-      (.band wo v' wmask, true)
-    else (.constBad wo, false)
+      (.band wo v' wmask, true, .nil)
+    else (.constBad wo, false, verr ++ werr)
   where
    goBinop (a b : Nondep.Term) (w : Nondep.WidthExpr) (wo : Nondep.WidthExpr)
-     (binop : Nondep.WidthExpr → Nondep.Term → Nondep.Term → Nondep.Term) : Nondep.Term × Bool :=
-    let (a', aresult) := a.toSingleWidthNondepTermGo maxWcard wo
-    let (b', bresult) := b.toSingleWidthNondepTermGo maxWcard wo
-    let (wmask, wresult) := w.toSingleWidthMaskNondepTerm wo
+     (binop : Nondep.WidthExpr → Nondep.Term → Nondep.Term → Nondep.Term) : Nondep.Term × Bool × Lean.Format :=
+    let (a', aresult, aerr) := a.toSingleWidthNondepTermGo maxWcard wo
+    let (b', bresult, berr) := b.toSingleWidthNondepTermGo maxWcard wo
+    let (wmask, wresult, werr) := w.toSingleWidthMaskNondepTerm wo
     if aresult && bresult && wresult then
-      (.band wo (binop wo a' b') wmask, true)
-    else (.constZero wo, false)
+      (.band wo (binop wo a' b') wmask, true, .nil)
+    else (.constZero wo, false, aerr ++ berr ++ werr)
 
   -- | _ => (.constBad wo, false)
 
@@ -2596,19 +2693,20 @@ def Nondep.Term.toSingleWidthNondepTermGo (maxWcard : Nat) (t : Nondep.Term) (wo
 Given a term, convert it to a single-width term by converting all width expressions to their corresponding single-width terms,
 -/
 def Nondep.Term.toSingleWidthNondepTerm (t : Nondep.Term)
-   (wo : Nondep.WidthExpr): Nondep.Term × Bool :=
-  let (tSingle, tSingleResult) : Nondep.Term × Bool := t.toSingleWidthNondepTermGo t.maxwcard wo
+   (wo : Nondep.WidthExpr): Nondep.Term × Bool × Lean.Format :=
+  let (tSingle, tSingleResult, tSingleErr) := t.toSingleWidthNondepTermGo t.maxwcard wo
   let (iteElim, iteState) : Nondep.Term × ElimIteState := tSingle.elimIte
      (.newState <| tSingle.tcard + 1000)
   -- | TODO: what about overflow in this representation when we add?
   let preconds := Term.toSingleWidthNondepTerm.mkAllWidthPreconds wo t.maxwcard
-  let (implies, impliesResult) :=
+  let (implies, impliesResult, impliesErr) :=
     Term.pimplies
       (.and preconds (Nondep.Term.andPredicates iteState.preconditions))
       iteElim
+  let allErrors := tSingleErr ++ iteState.errors ++ impliesErr
   if impliesResult && tSingleResult && iteState.success then
-    (implies, true)
-  else (implies, false)
+    (implies, true, allErrors)
+  else (implies, false, allErrors)
 
 end ToSingleWidth
 

--- a/Blase/Blase/MultiWidth/Defs.lean
+++ b/Blase/Blase/MultiWidth/Defs.lean
@@ -1515,262 +1515,297 @@ def _root_.Std.Tactic.BVDecide.BVExpr.signExtend (x : BVExpr w) (wnew : Nat) : B
 
 /-- Convert a BV-producing `Nondep.Term` to a `BVExpr` at monomorphization width `w`.
 `wenv` provides concrete width assignments for width variables.
-Returns 'true' if the translation succeeded.
+Returns 'true' if the translation succeeded, along with accumulated error messages.
 -/
-def Term.toBVExpr (wenv : Array Nat) (t : Term) : (BVExpr (t.width.eval wenv)) × Bool :=
+def Term.toBVExpr (wenv : Array Nat) (t : Term) : (BVExpr (t.width.eval wenv)) × Bool × Lean.Format :=
    match _ht : t with
-  | .var v _ => (BVExpr.var v, true)
-  | .ofNat w n => (.const (BitVec.ofNat (w.eval wenv) n), true)
+  | .var v _ => (BVExpr.var v, true, .nil)
+  | .ofNat w n => (.const (BitVec.ofNat (w.eval wenv) n), true, .nil)
   | .add we a b =>
-    let (a', aresult) := a.toBVExpr wenv
-    let (b', bresult) := b.toBVExpr wenv
+    let (a', aresult, aerr) := a.toBVExpr wenv
+    let (b', bresult, berr) := b.toBVExpr wenv
     let w := we.eval wenv
     if ha : a'.width = w then
       if hb : b'.width = w then
          if aresult && bresult then
-          (.bin (a'.cast ha) .add (b'.cast hb), true)
-        else (.const (88#_), false)
-      else (.const (88#_), false)
-    else (.const (88#_), false)
+          (.bin (a'.cast ha) .add (b'.cast hb), true, .nil)
+        else (.const (88#_), false, aerr ++ berr)
+      else (.const (88#_), false, aerr ++ berr)
+    else (.const (88#_), false, aerr ++ berr)
   | .mul we a b =>
-    let (a', aresult) := a.toBVExpr wenv
-    let (b', bresult) := b.toBVExpr wenv
+    let (a', aresult, aerr) := a.toBVExpr wenv
+    let (b', bresult, berr) := b.toBVExpr wenv
     let w := we.eval wenv
     if ha : a'.width = w then
       if hb : b'.width = w then
         if aresult && bresult then
-          (.bin (a'.cast ha) .mul (b'.cast hb), true)
-        else (.const (88#_), false)
-      else (.const (88#_), false)
-    else (.const (88#_), false)
+          (.bin (a'.cast ha) .mul (b'.cast hb), true, .nil)
+        else (.const (88#_), false, aerr ++ berr)
+      else (.const (88#_), false, aerr ++ berr)
+    else (.const (88#_), false, aerr ++ berr)
   | .band we a b =>
-    let (a', aresult) := a.toBVExpr wenv
-    let (b', bresult) := b.toBVExpr wenv
+    let (a', aresult, aerr) := a.toBVExpr wenv
+    let (b', bresult, berr) := b.toBVExpr wenv
     let w := we.eval wenv
     if ha : a'.width = w then
       if hb : b'.width = w then
         if aresult && bresult then
-          (.bin (a'.cast ha) .and (b'.cast hb), true)
-        else (.const (88#_), false)
-      else (.const (88#_), false)
-    else (.const (88#_), false)
+          (.bin (a'.cast ha) .and (b'.cast hb), true, .nil)
+        else (.const (88#_), false, aerr ++ berr)
+      else (.const (88#_), false, aerr ++ berr)
+    else (.const (88#_), false, aerr ++ berr)
   | .bor we a b =>
-    let (a', aresult) := a.toBVExpr wenv
-    let (b', bresult) := b.toBVExpr wenv
+    let (a', aresult, aerr) := a.toBVExpr wenv
+    let (b', bresult, berr) := b.toBVExpr wenv
     let w := we.eval wenv
     if ha : a'.width = w then
       if hb : b'.width = w then
         if aresult && bresult then
-          (.bin (a'.cast ha) .or (b'.cast hb), true)
-        else (.const (88#_), false)
-      else (.const (88#_), false)
-    else (.const (88#_), false)
+          (.bin (a'.cast ha) .or (b'.cast hb), true, .nil)
+        else (.const (88#_), false, aerr ++ berr)
+      else (.const (88#_), false, aerr ++ berr)
+    else (.const (88#_), false, aerr ++ berr)
   | .bxor we a b =>
-    let (a', aresult) := a.toBVExpr wenv
-    let (b', bresult) := b.toBVExpr wenv
+    let (a', aresult, aerr) := a.toBVExpr wenv
+    let (b', bresult, berr) := b.toBVExpr wenv
     let w := we.eval wenv
     if ha : a'.width = w then
       if hb : b'.width = w then
         if aresult && bresult then
-          (.bin (a'.cast ha) .xor (b'.cast hb), true)
-        else (.const (88#_), false)
-      else (.const (88#_), false)
-    else (.const (88#_), false)
+          (.bin (a'.cast ha) .xor (b'.cast hb), true, .nil)
+        else (.const (88#_), false, aerr ++ berr)
+      else (.const (88#_), false, aerr ++ berr)
+    else (.const (88#_), false, aerr ++ berr)
   | .bnot we a =>
-    let (a', aresult) := a.toBVExpr wenv
+    let (a', aresult, aerr) := a.toBVExpr wenv
     let w := we.eval wenv
     if ha : a'.width = w then
       if aresult then
-        (.un .not (a'.cast ha), true)
-      else (.const (89#_), false)
-    else (.const (90#_), false)
+        (.un .not (a'.cast ha), true, .nil)
+      else (.const (89#_), false, aerr)
+    else (.const (90#_), false, aerr)
   | .shiftl we a k =>
-    let (a', aresult) := a.toBVExpr wenv
+    let (a', aresult, aerr) := a.toBVExpr wenv
     let w := we.eval wenv
     if ha : a'.width = w then
       if aresult then
-        (.shiftLeft (a'.cast ha) (.const (BitVec.ofNat w k)), true)
-      else (.const (88#_), false)
-    else (.const (88#_), false)
+        (.shiftLeft (a'.cast ha) (.const (BitVec.ofNat w k)), true, .nil)
+      else (.const (88#_), false, aerr)
+    else (.const (88#_), false, aerr)
   | .shiftr w a k =>
-    let (a', aresult) := a.toBVExpr wenv
+    let (a', aresult, aerr) := a.toBVExpr wenv
     let w := w.eval wenv
     if ha : a'.width = w then
       if aresult then
-        (.shiftRight (a'.cast ha) (.const (BitVec.ofNat w k)), true)
-      else (.const (88#_), false)
-    else (.const (88#_), false)
+        (.shiftRight (a'.cast ha) (.const (BitVec.ofNat w k)), true, .nil)
+      else (.const (88#_), false, aerr)
+    else (.const (88#_), false, aerr)
   | .ashr w a k =>
-    let (a', aresult) := a.toBVExpr wenv
+    let (a', aresult, aerr) := a.toBVExpr wenv
     let w := w.eval wenv
     if ha : a'.width = w then
       if aresult then
-        (.arithShiftRight (a'.cast ha) (.const (BitVec.ofNat w k)), true)
-      else (.const (88#_), false)
-    else (.const (88#_), false)
+        (.arithShiftRight (a'.cast ha) (.const (BitVec.ofNat w k)), true, .nil)
+      else (.const (88#_), false, aerr)
+    else (.const (88#_), false, aerr)
   | .pextract a lo hi =>
-    let (a', aresult) := a.toBVExpr wenv
+    let (a', aresult, aerr) := a.toBVExpr wenv
     if aresult then
-      (.extract lo (hi - lo + 1) a', true)
-    else (.const (88#_), false)
+      (.extract lo (hi - lo + 1) a', true, .nil)
+    else (.const (88#_), false, aerr)
   | .zext x we =>
-    let (x', xresult) := x.toBVExpr wenv
+    let (x', xresult, xerr) := x.toBVExpr wenv
     let w := we.eval wenv
     if xresult then
-      (BVExpr.zeroExtend x' w, true)
-    else (.const (88#_), false)
+      (BVExpr.zeroExtend x' w, true, .nil)
+    else (.const (88#_), false, xerr)
   | .sext x we =>
-    let (x', xresult) := x.toBVExpr wenv
+    let (x', xresult, xerr) := x.toBVExpr wenv
     let w := we.eval wenv
     if xresult then
-      (BVExpr.signExtend x' w, true)
-    else (.const (88#_), false)
+      (BVExpr.signExtend x' w, true, .nil)
+    else (.const (88#_), false, xerr)
   | .udiv we a b =>
-    let (a', aresult) := a.toBVExpr wenv
-    let (b', bresult) := b.toBVExpr wenv
+    let (a', aresult, aerr) := a.toBVExpr wenv
+    let (b', bresult, berr) := b.toBVExpr wenv
     let w := we.eval wenv
     if ha : a'.width = w then
       if hb : b'.width = w then
         if aresult && bresult then
-          (.bin (a'.cast ha) .udiv (b'.cast hb), true)
-        else (.const (88#_), false)
-      else (.const (88#_), false)
-    else (.const (88#_), false)
+          (.bin (a'.cast ha) .udiv (b'.cast hb), true, .nil)
+        else (.const (88#_), false, aerr ++ berr)
+      else (.const (88#_), false, aerr ++ berr)
+    else (.const (88#_), false, aerr ++ berr)
   | .urem we a b =>
-    let (a', aresult) := a.toBVExpr wenv
-    let (b', bresult) := b.toBVExpr wenv
+    let (a', aresult, aerr) := a.toBVExpr wenv
+    let (b', bresult, berr) := b.toBVExpr wenv
     let w := we.eval wenv
     if ha : a'.width = w then
       if hb : b'.width = w then
         if aresult && bresult then
-          (.bin (a'.cast ha) .umod (b'.cast hb), true)
-        else (.const (88#_), false)
-      else (.const (88#_), false)
-    else (.const (88#_), false)
+          (.bin (a'.cast ha) .umod (b'.cast hb), true, .nil)
+        else (.const (88#_), false, aerr ++ berr)
+      else (.const (88#_), false, aerr ++ berr)
+    else (.const (88#_), false, aerr ++ berr)
   | .vlshr we a b =>
-    let (a', aresult) := a.toBVExpr wenv
-    let (b', bresult) := b.toBVExpr wenv
+    let (a', aresult, aerr) := a.toBVExpr wenv
+    let (b', bresult, berr) := b.toBVExpr wenv
     let w := we.eval wenv
     if ha : a'.width = w then
       if hb : b'.width = w then
         if aresult && bresult then
-          (.shiftRight (a'.cast ha) (b'.cast hb), true)
-        else (.const (88#_), false)
-      else (.const (88#_), false)
-    else (.const (88#_), false)
+          (.shiftRight (a'.cast ha) (b'.cast hb), true, .nil)
+        else (.const (88#_), false, aerr ++ berr)
+      else (.const (88#_), false, aerr ++ berr)
+    else (.const (88#_), false, aerr ++ berr)
   | .vashr we a b =>
-    let (a', aresult) := a.toBVExpr wenv
-    let (b', bresult) := b.toBVExpr wenv
+    let (a', aresult, aerr) := a.toBVExpr wenv
+    let (b', bresult, berr) := b.toBVExpr wenv
     let w := we.eval wenv
     if ha : a'.width = w then
       if hb : b'.width = w then
         if aresult && bresult then
-          (.arithShiftRight (a'.cast ha) (b'.cast hb), true)
-        else (.const (88#_), false)
-      else (.const (88#_), false)
-    else (.const (88#_), false)
+          (.arithShiftRight (a'.cast ha) (b'.cast hb), true, .nil)
+        else (.const (88#_), false, aerr ++ berr)
+      else (.const (88#_), false, aerr ++ berr)
+    else (.const (88#_), false, aerr ++ berr)
   | .vshl we a b =>
-    let (a', aresult) := a.toBVExpr wenv
-    let (b', bresult) := b.toBVExpr wenv
+    let (a', aresult, aerr) := a.toBVExpr wenv
+    let (b', bresult, berr) := b.toBVExpr wenv
     let w := we.eval wenv
     if ha : a'.width = w then
       if hb : b'.width = w then
         if aresult && bresult then
-          (.shiftLeft (a'.cast ha) (b'.cast hb), true)
-        else (.const (88#_), false)
-      else (.const (88#_), false)
-    else (.const (88#_), false)
+          (.shiftLeft (a'.cast ha) (b'.cast hb), true, .nil)
+        else (.const (88#_), false, aerr ++ berr)
+      else (.const (88#_), false, aerr ++ berr)
+    else (.const (88#_), false, aerr ++ berr)
   | .intToPbv w v =>
      let w := w.eval wenv
      let v := v.eval wenv
-     (.const (BitVec.ofNat w v), true)
+     (.const (BitVec.ofNat w v), true, .nil)
   | .boolBinRel .. | .pvar .. | .and .. | .or ..| .binRel .. | .binWidthRel ..
     | .bvOfBool .. | .boolConst .. | .boolVar .. | .setWidth ..
     | .pFalse | .pTrue =>
-    (.const (88#_), false) -- these are not BV expressions, so we return a dummy value and false to indicate failure.
+    let errMsg := s!"toBVExpr: unsupported operation (not a BV expression): {repr t}"
+    dbg_trace errMsg
+    (.const (88#_), false, .text errMsg)
   | .bvIte .. =>
      -- ITE should have been eliminated!
-     (.const (99#_), false)
+     let errMsg := s!"toBVExpr: bvIte should have been eliminated before QF_BV translation, got: {repr t}"
+     dbg_trace errMsg
+     (.const (99#_), false, .text errMsg)
 
 /-- Convert a predicate-producing `Nondep.Term` to a `BVLogicalExpr`.
 `wenv` provides concrete width assignments for width variables.
 Uses `Term.toBVExpr` for BV subterms within predicates.
 `ule a b` is encoded as `¬(ult b a)`, `ne` as `¬(eq)`.
-Returns 'true' if the translation succeeded.
+Returns 'true' if the translation succeeded, along with accumulated error messages.
 -/
-def Term.toBVLogicalExpr (wenv : Array Nat) : Term → BVLogicalExpr × Bool
-  | .pTrue => (.const true, true)
-  | .boolConst b => (.const b, true)
+def Term.toBVLogicalExpr (wenv : Array Nat) (t : Term) : BVLogicalExpr × Bool × Lean.Format :=
+  match t with
+  | .pTrue => (.const true, true, .nil)
+  | .boolConst b => (.const b, true, .nil)
   | .binRel .eq we a b =>
-    let (a', aresult) := a.toBVExpr wenv
-    let (b', bresult) := b.toBVExpr wenv
+    let (a', aresult, aerr) := a.toBVExpr wenv
+    let (b', bresult, berr) := b.toBVExpr wenv
     let w := we.eval wenv
     if ha : a'.width = w then
       if hb : b'.width = w then
         if aresult && bresult then
-          (.literal (.bin (a'.cast ha) .eq (b'.cast hb)), true)
-        else (dbg_trace "ERROR 1"; .const false, false)
-      else (dbg_trace "ERROR 2"; .const false, false)
-    else (dbg_trace "ERROR 3"; .const false, false)
+          (.literal (.bin (a'.cast ha) .eq (b'.cast hb)), true, .nil)
+        else
+          let errMsg := s!"toBVLogicalExpr: failed to translate operands of = relation\n{aerr}\n{berr}"
+          (dbg_trace errMsg; .const false, false, .text errMsg)
+      else
+        let errMsg := s!"toBVLogicalExpr: width mismatch in = relation (b.width={b'.width} ≠ {w})\n{aerr}\n{berr}"
+        (dbg_trace errMsg; .const false, false, .text errMsg)
+    else
+      let errMsg := s!"toBVLogicalExpr: width mismatch in = relation (a.width={a'.width} ≠ {w})\n{aerr}\n{berr}"
+      (dbg_trace errMsg; .const false, false, .text errMsg)
   | .binRel .ne we a b =>
-    let (a', aresult) := a.toBVExpr wenv
-    let (b', bresult) := b.toBVExpr wenv
+    let (a', aresult, aerr) := a.toBVExpr wenv
+    let (b', bresult, berr) := b.toBVExpr wenv
     let w := we.eval wenv
     if ha : a'.width = w then
       if hb : b'.width = w then
         if aresult && bresult then
-          (.not (.literal (.bin (a'.cast ha) .eq (b'.cast hb))), true)
-        else (dbg_trace "ERROR 4"; .const false, false)
-      else (dbg_trace "ERROR 5"; .const false, false)
-    else (dbg_trace "ERROR 6"; .const false, false)
+          (.not (.literal (.bin (a'.cast ha) .eq (b'.cast hb))), true, .nil)
+        else
+          let errMsg := s!"toBVLogicalExpr: failed to translate operands of ≠ relation\n{aerr}\n{berr}"
+          (dbg_trace errMsg; .const false, false, .text errMsg)
+      else
+        let errMsg := s!"toBVLogicalExpr: width mismatch in ≠ relation (b.width={b'.width} ≠ {w})\n{aerr}\n{berr}"
+        (dbg_trace errMsg; .const false, false, .text errMsg)
+    else
+      let errMsg := s!"toBVLogicalExpr: width mismatch in ≠ relation (a.width={a'.width} ≠ {w})\n{aerr}\n{berr}"
+      (dbg_trace errMsg; .const false, false, .text errMsg)
   | .binRel .ult we a b =>
-    let (a', aresult) := a.toBVExpr wenv
-    let (b', bresult) := b.toBVExpr wenv
+    let (a', aresult, aerr) := a.toBVExpr wenv
+    let (b', bresult, berr) := b.toBVExpr wenv
     let w := we.eval wenv
     if ha : a'.width = w then
       if hb : b'.width = w then
         if aresult && bresult then
-          (.literal (.bin (a'.cast ha) .ult (b'.cast hb)), true)
-        else (dbg_trace "ERROR 7"; .const false, false)
-      else (dbg_trace "ERROR 8"; .const false, false)
-    else (dbg_trace "ERROR 9"; .const false, false)
+          (.literal (.bin (a'.cast ha) .ult (b'.cast hb)), true, .nil)
+        else
+          let errMsg := s!"toBVLogicalExpr: failed to translate operands of ult relation\n{aerr}\n{berr}"
+          (dbg_trace errMsg; .const false, false, .text errMsg)
+      else
+        let errMsg := s!"toBVLogicalExpr: width mismatch in ult relation (b.width={b'.width} ≠ {w})\n{aerr}\n{berr}"
+        (dbg_trace errMsg; .const false, false, .text errMsg)
+    else
+      let errMsg := s!"toBVLogicalExpr: width mismatch in ult relation (a.width={a'.width} ≠ {w})\n{aerr}\n{berr}"
+      (dbg_trace errMsg; .const false, false, .text errMsg)
   | .binRel .ule we a b =>
-    let (a', aresult) := a.toBVExpr wenv
-    let (b', bresult) := b.toBVExpr wenv
+    let (a', aresult, aerr) := a.toBVExpr wenv
+    let (b', bresult, berr) := b.toBVExpr wenv
     let w := we.eval wenv
     if ha : a'.width = w then
       if hb : b'.width = w then
         if aresult && bresult then
-          (.not (.literal (.bin (b'.cast hb) .ult (a'.cast ha))), true)
-        else (dbg_trace "ERROR 10";.const false, false)
-      else (dbg_trace "ERROR 11"; .const false, false)
-    else (dbg_trace "ERROR 12"; .const false, false)
+          (.not (.literal (.bin (b'.cast hb) .ult (a'.cast ha))), true, .nil)
+        else
+          let errMsg := s!"toBVLogicalExpr: failed to translate operands of ule relation\n{aerr}\n{berr}"
+          (dbg_trace errMsg; .const false, false, .text errMsg)
+      else
+        let errMsg := s!"toBVLogicalExpr: width mismatch in ule relation (b.width={b'.width} ≠ {w})\n{aerr}\n{berr}"
+        (dbg_trace errMsg; .const false, false, .text errMsg)
+    else
+      let errMsg := s!"toBVLogicalExpr: width mismatch in ule relation (a.width={a'.width} ≠ {w})\n{aerr}\n{berr}"
+      (dbg_trace errMsg; .const false, false, .text errMsg)
   | .and p1 p2 =>
-    let (p1', p1result) := p1.toBVLogicalExpr wenv
-    let (p2', p2result) := p2.toBVLogicalExpr wenv
+    let (p1', p1result, p1err) := p1.toBVLogicalExpr wenv
+    let (p2', p2result, p2err) := p2.toBVLogicalExpr wenv
     if p1result && p2result then
-      (.gate .and p1' p2', true)
-    else (dbg_trace "ERROR 13"; .const false, false)
+      (.gate .and p1' p2', true, .nil)
+    else
+      let errMsg := s!"toBVLogicalExpr: failed to translate operands of ∧\n{p1err}\n{p2err}"
+      (dbg_trace errMsg; .const false, false, .text errMsg)
   | .or p1 p2 =>
-    let (p1', p1result) := p1.toBVLogicalExpr wenv
-    let (p2', p2result) := p2.toBVLogicalExpr wenv
+    let (p1', p1result, p1err) := p1.toBVLogicalExpr wenv
+    let (p2', p2result, p2err) := p2.toBVLogicalExpr wenv
     if p1result && p2result then
-      (.gate .or p1' p2', true)
-    else (dbg_trace "ERROR 14"; .const false, false)
+      (.gate .or p1' p2', true, .nil)
+    else
+      let errMsg := s!"toBVLogicalExpr: failed to translate operands of ∨\n{p1err}\n{p2err}"
+      (dbg_trace errMsg; .const false, false, .text errMsg)
   | .binWidthRel .eq ew1 ew2 =>
     let w1 := ew1.eval wenv
     let w2 := ew2.eval wenv
-    (.const (w1 = w2), true)
+    (.const (w1 = w2), true, .nil)
   | .binWidthRel .le ew1 ew2 =>
     let w1 := ew1.eval wenv
     let w2 := ew2.eval wenv
-    (.const (w1 ≤ w2), true)
-  | .pFalse => (.const false, true)
+    (.const (w1 ≤ w2), true, .nil)
+  | .pFalse => (.const false, true, .nil)
   | .pvar .. | .binRel .. | .bvOfBool .. | .shiftr .. | .ashr .. | .pextract ..
     | .shiftl .. | .boolVar .. | .bnot .. | .bxor .. | .band .. | .bor .. | .sext .. | .setWidth ..
     | .zext .. | .mul .. | .add .. | .ofNat .. | .var .. | .boolBinRel ..
     | .udiv .. | .urem .. | .vlshr .. | .vashr .. | .vshl .. | .bvIte .. | .intToPbv .. =>
-    (dbg_trace "ERROR 15"; .const false, false) -- these are not predicate expressions, so we return a dummy value and false to indicate failure.
+    let errMsg := s!"toBVLogicalExpr: unsupported operation, unable to translate into QF_BV: {repr t}"
+    dbg_trace errMsg
+    (.const false, false, .text errMsg)
 
 end Nondep
 

--- a/Blase/Blasewuzla/Parser.lean
+++ b/Blase/Blasewuzla/Parser.lean
@@ -129,8 +129,8 @@ def expectPred (pt : ParsedTerm) (ctx : String := "") : ParserM Nondep.Term := d
 /-- Negate a predicate term, throwing a parser error if negation is not supported. -/
 private def negateTerm (t : Nondep.Term) : ParserM Nondep.Term :=
   match t.pnegate with
-  | (t', true) => return t'
-  | _ => ParserM.throwError s!"cannot negate term: {repr t}"
+  | (t', true, _err) => return t'
+  | (_, false, err) => ParserM.throwError s!"cannot negate term, error: '{err}'. Term is '{repr t}'"
 
 /-- Parse a term from an S-expression. -/
 partial def parseTerm (s : Sexp) : ParserM ParsedTerm := do
@@ -549,13 +549,13 @@ def parseSmt2Query (input : String) : Except String ParseResult := do
         | p :: ps => ps.foldl (init := p) fun acc q => .and acc q
       -- Negate to match UNSAT semantics
       match conjoined.pnegate with
-      | (negated, true) =>
+      | (negated, true, _) =>
         .ok {
           predicate := negated
           wcard := st.nextWidthIdx
           tcard := st.nextTermIdx
         }
-      | _ => .error s!"cannot negate conjoined term: {repr conjoined}"
+      | (_, false, err) => .error s!"cannot negate final assertion term. Error: {err}. Term: {repr conjoined}"
   | .error e _ => .error e
 where
   go (cmds : List Sexp) : ParserM (List Nondep.Term) := do

--- a/Blase/BlasewuzlaMain.lean
+++ b/Blase/BlasewuzlaMain.lean
@@ -145,8 +145,9 @@ unsafe def monoBMC : Solver where
         IO.eprintln "  input:\n{repr singleWidthTerm}"
       return .unknown
 
-    let (qfbv, true) := singleWidthNegated.toBVLogicalExpr #[]
-      | return .error (s!"formula contains unsupported operation for QF_BV translation." ++ if config.verbose then "\n{repr result.predicate}" else "")
+    let (qfbv, success?, translationErrors) := singleWidthNegated.toBVLogicalExpr #[]
+    if !success? then
+      return .error (s!"formula contains unsupported operation for QF_BV translation.\nTranslation errors:\n{translationErrors}" ++ if config.verbose then "\n{repr result.predicate}" else "")
 
     if config.verbose then
       IO.eprintln s!"qfbv formula to be checked for UNSAT:\n{qfbv.toString}"
@@ -212,10 +213,10 @@ def naiveBMC : Solver where
     if config.verbose then
       IO.eprintln s!"Running naivebmc at width {config.bound}..."
     for widths in cartesianProductRange config.bound result.wcard do
-      let (qfbv, success?) : Std.Tactic.BVDecide.BVLogicalExpr × Bool := negatedPredicate.toBVLogicalExpr widths
+      let (qfbv, success?, translationErrors) := negatedPredicate.toBVLogicalExpr widths
 
       if !success? then
-        return .error s!"formula contains unsupported operation, unable to translate into QF_BV.\n{repr negatedPredicate}"
+        return .error s!"formula contains unsupported operation, unable to translate into QF_BV.\nTranslation errors:\n{translationErrors}\nPredicate:\n{repr negatedPredicate}"
 
       if config.verbose then
         IO.eprintln s!"{qfbv.toString}"

--- a/Blase/BlasewuzlaMain.lean
+++ b/Blase/BlasewuzlaMain.lean
@@ -126,10 +126,10 @@ unsafe def monoBMC : Solver where
     if config.verbose then
       IO.eprintln s!"Running {monoBMC.name} at width {config.bound}..."
 
-    let (singleWidthTerm, success?) := result.predicate.toSingleWidthNondepTerm (.const config.bound)
+    let (singleWidthTerm, success?, singleWidthErrors) := result.predicate.toSingleWidthNondepTerm (.const config.bound)
 
      if ! success? then
-      IO.eprintln s!"{monoBMC.name}: Unable to translate term to single-width."
+      IO.eprintln s!"{monoBMC.name}: Unable to translate term to single-width.\nErrors:\n{singleWidthErrors}"
       if config.verbose then
         IO.eprintln "  input:\n{repr result.predicate}\noutput:\n{repr singleWidthTerm}"
       return .unknown
@@ -138,9 +138,9 @@ unsafe def monoBMC : Solver where
       if config.verbose then
         IO.eprintln "  input:\n{repr result.predicate}\noutput:\n{repr singleWidthTerm}"
 
-    let (singleWidthNegated, success?) := singleWidthTerm.pnegate
+    let (singleWidthNegated, success?, negateErrors) := singleWidthTerm.pnegate
     if ! success? then
-      IO.eprintln s!"{monoBMC.name}: Unable to negate single-width term."
+      IO.eprintln s!"{monoBMC.name}: Unable to negate single-width term.\nErrors:\n{negateErrors}"
       if config.verbose then
         IO.eprintln "  input:\n{repr singleWidthTerm}"
       return .unknown
@@ -176,17 +176,17 @@ def elimItePreprocessing (result : ParseResult) : Except String Nondep.Term := d
   let (predElimIte, iteState) := result.predicate.elimIte
     (.newState <| result.predicate.tcard + 1)
   if !iteState.success then
-    .error "ite elimination failed for predicate"
-  let (predWithPrec, iteImplSuccess) := iteState.toImplication predElimIte
+    .error s!"ite elimination failed for predicate. Errors:\n{iteState.errors}"
+  let (predWithPrec, iteImplSuccess, iteImplErrors) := iteState.toImplication predElimIte
   if !iteImplSuccess then
-    .error "ite implication failed for predicate"
+    .error s!"ite implication failed for predicate. Errors:\n{iteImplErrors}"
   return predWithPrec
 
 def elimSubPreprocessing (pred : Nondep.Term) (wcard : Nat) : Except String Nondep.Term := do
   let subResult := pred.elimSub wcard
-  let (predElimSub, subImplSuccess) := subResult.toImplication
+  let (predElimSub, subImplSuccess, subImplErrors) := subResult.toImplication
   if !subImplSuccess then
-    .error "sub implication failed for predicate"
+    .error s!"sub implication failed for predicate. Errors:\n{subImplErrors}"
   return predElimSub
 
 def naiveBMC : Solver where
@@ -207,8 +207,9 @@ def naiveBMC : Solver where
         | .ok t => pure t
       else
         pure predAfterIte
-    let (negatedPredicate, true) := predAfterSub.pnegate
-      | throwError "unable to negate predicate. {repr result.predicate}"
+    let (negatedPredicate, success?, negateErrors) := predAfterSub.pnegate
+    if !success? then
+      throwError "unable to negate predicate. Errors:\n{negateErrors}\n{repr result.predicate}"
     -- naivebmc backend: translate to single-width and call bv_decide at a fixed width
     if config.verbose then
       IO.eprintln s!"Running naivebmc at width {config.bound}..."


### PR DESCRIPTION
This lets us debug what goes wrong instead of printing cryptic 'parse error' messages.