### PR TITLE
feat/blase: add support for '(_ bv<X> <W>)

### DIFF
--- a/Blase/Blasewuzla/Parser.lean
+++ b/Blase/Blasewuzla/Parser.lean
@@ -165,6 +165,19 @@ partial def parseTerm (s : Sexp) : ParserM ParsedTerm := do
     catch _ =>
       let n ← parseWidthExpr nAtom
       return .bv (.intToPbv w n) w
+  -- (_ bv<val> <width>): SMT2 indexed bitvector literal, shorthand for int_to_pbv
+  | .expr [.atom "_", .atom name, wAtom] =>
+    if name.startsWith "bv" then
+      let valStr := (name.drop 2).toString
+      let w ← parseWidthExpr wAtom
+      match valStr.toNat? with
+      | some n => return .bv (.ofNat w n) w
+      | none =>
+        let v ← parseWidthExpr (.atom valStr)
+        return .bv (.intToPbv w v) w
+    else
+      ParserM.throwError s!"unsupported indexed identifier: '(_ {name} ...)'"
+
   | .expr [.atom "bvadd", a, b] =>
     let (at_, aw) ← (← parseTerm a) |> expectBV (ctx := "bvadd")
     let (bt, _bw) ← (← parseTerm b) |> expectBV (ctx := "bvadd")

--- a/Blase/README.md
+++ b/Blase/README.md
@@ -90,6 +90,9 @@ pow2          | pow2      | Int → Int
 
 #### Algorithms Improvements TODO
 
+- [ ] Add an error printer of Term that prints only upto k level and then prints '..' for the rest.
+- [ ] add slt/sle support into QF_BV translation
+- [ ] Finish implementing new cases in 'toSingleWidthNondepTermGo'.
 - [x] Add a Nondep to BVExpr conversion
 - [x] Use Nondep -> BV to implement naive enumerative bitblasting.
 - [x] Use SingleWidth -> Nondep -> BV to implement single width bounded bitblasting.


### PR DESCRIPTION
Add support for parsing `(bvk w)` that occurs in alive, to build an `int_to_pbv` of width `k`, value `w`.