### PR TITLE
feat/blase: align parser semantics to parse sext/zext into extended widths from SMT-LIB.

### DIFF
--- a/Blase/Blasewuzla/Parser.lean
+++ b/Blase/Blasewuzla/Parser.lean
@@ -312,26 +312,34 @@ partial def parseTerm (s : Sexp) : ParserM ParsedTerm := do
   -- zero_extend: ((_ zero_extend wnew) a)
   | .expr [.expr [.atom "_", .atom "zero_extend", wnew], a] =>
     let w ← parseWidthExpr wnew
-    let (at_, _aw) ← (← parseTerm a) |> expectBV (ctx := "zero_extend")
-    return .bv (.zext at_ w) w
+    let (at_, aw) ← (← parseTerm a) |> expectBV (ctx := "zero_extend")
+    let outw := aw.add w
+    return .bv (.zext at_ outw) outw
 
   -- sign_extend: ((_ sign_extend wnew) a)
   | .expr [.expr [.atom "_", .atom "sign_extend", wnew], a] =>
     let w ← parseWidthExpr wnew
-    let (at_, _aw) ← (← parseTerm a) |> expectBV (ctx := "sign_extend")
-    return .bv (.sext at_ w) w
+    let (at_, aw) ← (← parseTerm a) |> expectBV (ctx := "sign_extend")
+    let outw := aw.add w
+    return .bv (.sext at_ outw) outw
 
   -- pzero_extend: alias for zero_extend
+  -- Recall that is SMT2, zero/sign extension says how many bits to add,
+  -- not the total number of vits.
   | .expr [.atom "pzero_extend", wnew, a] =>
     let w ← parseWidthExpr wnew
-    let (at_, _aw) ← (← parseTerm a) |> expectBV (ctx := "pzero_extend")
-    return .bv (.zext at_ w) w
+    let (at_, aw) ← (← parseTerm a) |> expectBV (ctx := "pzero_extend")
+    let outw := aw.add w
+    return .bv (.zext at_ outw) outw
 
-  -- psign_extend: alias for sign_extend
+  -- psign_extend: alias for sign_extend.
+  -- Recall that is SMT2, zero/sign extension says how many bits to add,
+  -- not the total number of vits.
   | .expr [.atom "psign_extend", wnew, a] =>
     let w ← parseWidthExpr wnew
-    let (at_, _aw) ← (← parseTerm a) |> expectBV (ctx := "psign_extend")
-    return .bv (.sext at_ w) w
+    let (at_, aw) ← (← parseTerm a) |> expectBV (ctx := "psign_extend")
+    let outw := aw.add w
+    return .bv (.sext at_ outw) outw
 
   -- Width relation predicates
   | .expr [.atom "width_le", a, b] =>

--- a/Blase/Blasewuzla/tests/unsat/sign_extend.smt2
+++ b/Blase/Blasewuzla/tests/unsat/sign_extend.smt2
@@ -1,5 +1,5 @@
 (set-logic ALL)
 (declare-const k Int)
 (declare-fun %a () (_ BitVec k))
-(assert (not (= (psign_extend k %a) %a)))
+(assert (not (= (psign_extend 0 %a) %a)))
 (check-sat)

--- a/Blase/README.md
+++ b/Blase/README.md
@@ -90,10 +90,13 @@ pow2          | pow2      | Int → Int
 
 #### Algorithms Improvements TODO
 
+- [ ] Add two options: one that adds the subtraction preconditions, and one that eliminates the subtraction by introducing 
+      fresh variables plus addition. For naive BMC, we just want to add the preconditions, since it's cheapter to enumerate and check.
+      For k-induction and other solvers, we want to eliminate the subtraction, since our solvers only natively support addition.
+- [ ] Finish implementing new cases in 'toSingleWidthNondepTermGo'.
 - [ ] Remove redundancy in parser; Don't need to store bitvector widths, can just compute it if needed.
 - [ ] Add an error printer of Term that prints only upto k level and then prints '..' for the rest.
-- [ ] add slt/sle support into QF_BV translation
-- [ ] Finish implementing new cases in 'toSingleWidthNondepTermGo'.
+- [x] add slt/sle support into QF_BV translation
 - [x] Add a Nondep to BVExpr conversion
 - [x] Use Nondep -> BV to implement naive enumerative bitblasting.
 - [x] Use SingleWidth -> Nondep -> BV to implement single width bounded bitblasting.

--- a/Blase/README.md
+++ b/Blase/README.md
@@ -90,6 +90,7 @@ pow2          | pow2      | Int → Int
 
 #### Algorithms Improvements TODO
 
+- [ ] Remove redundancy in parser; Don't need to store bitvector widths, can just compute it if needed.
 - [ ] Add an error printer of Term that prints only upto k level and then prints '..' for the rest.
 - [ ] add slt/sle support into QF_BV translation
 - [ ] Finish implementing new cases in 'toSingleWidthNondepTermGo'.


### PR DESCRIPTION
This fixes our encoding of pzero_extend and psign_extend to align with SMT-LIB standard.