### PR TITLE
feat/blase: implement SMT2 int semantics in our model by adding width precondition checks

### DIFF
--- a/Blase/Blase/MultiWidth/Defs.lean
+++ b/Blase/Blase/MultiWidth/Defs.lean
@@ -778,8 +778,9 @@ deriving DecidableEq, Inhabited, Repr, Lean.ToExpr
 /-- Smart constructor for a pextract operation, desugaring a pextract to lo=0 into a zeroExtend,
 since our zeroExtend also encodes truncates. -/
 def Term.mkPExtract (hi lo : Nondep.WidthExpr) (t : Nondep.Term) : Nondep.Term :=
+  -- .pextract t lo hi
     match lo with
-    | .const 0 => .zext t hi
+    | .const 0 => .zext t (.addK hi 1) -- extract from (w-1) to 0 is the same as zext to w.
     | _ => .pextract t lo hi
 
 
@@ -883,7 +884,7 @@ def Term.width (t : Term) : WidthExpr :=
   | .shiftl w _a _k => w
   | .shiftr w _a _k => w
   | .ashr w _a _k => w
-  | .pextract _a lo hi => (hi.sub lo).add (.const 1) -- hi - lo + 1
+  | .pextract _a lo hi => ((hi.add (.const 1)).sub lo) -- hi - lo + 1
   | .bvOfBool _b => WidthExpr.const 1
   | binWidthRel _k _wa _wb => WidthExpr.const 0
   | binRel _k w _a _b => w
@@ -1673,7 +1674,7 @@ def Term.toBVExpr (wenv : Array Nat) (t : Term) : (BVExpr (t.width.eval wenv)) �
     let hi := whi.eval wenv
     let (a', aresult, aerr) := a.toBVExpr wenv
     if aresult then
-      (.extract lo (hi - lo + 1) a', true, .nil)
+      (.extract lo (hi + 1 - lo) a', true, .nil)
     else
       let errMsg := s!"toBVExpr: failed to translate operand of pextract\n{aerr}"
       (.const (88#_), false, .text errMsg)
@@ -2432,24 +2433,26 @@ def Nondep.WidthExpr.elimSubAux (w : Nondep.WidthExpr) (s : ElimSubState) :
   | .subK v k =>
     -- Recurse into v first so nested subtractions are also eliminated.
     let (v', s) := v.elimSubAux s
-    let (result, s) := s.freshWidth
+    -- let (result, s) := s.freshWidth
     -- Precondition: v' - k = result ↔ v' = k + result
-    let prec1 := Nondep.Term.binWidthRel .eq (.addK result k) v'
-    let s := s.addPrecondition prec1
+    -- let prec1 := Nondep.Term.binWidthRel .eq (.addK result k) v'
+    -- let s := s.addPrecondition prec1
     -- Precondition 2, that we don't "overflow" and get negative numbers anywhere in the computation.
     let prec2 := Nondep.Term.binWidthRel .le (.const k) v'
     let s := s.addPrecondition prec2
+    let result := .subK v' k
     (result, s)
   | .sub a b =>
     let (a', s) := a.elimSubAux s
     let (b', s) := b.elimSubAux s
-    let (result, s) := s.freshWidth
+    -- let (result, s) := s.freshWidth
     -- Precondition: result = a' - b' ↔ result + b' = a'.
-    let prec1 := Nondep.Term.binWidthRel .eq (.add result b') a'
-    let s := s.addPrecondition prec1
+    -- let prec1 := Nondep.Term.binWidthRel .eq (.add result b') a'
+    -- let s := s.addPrecondition prec1
     -- Precondition 2, that we don't "overflow" and get negative numbers anywhere in the computation.
     let prec2 := Nondep.Term.binWidthRel .le b' a'
     let s := s.addPrecondition prec2
+    let result := .sub a' b'
     (result, s)
   | .const n => (.const n, s)
   | .var i   => (.var i, s)

--- a/Blase/Blase/MultiWidth/Defs.lean
+++ b/Blase/Blase/MultiWidth/Defs.lean
@@ -2404,13 +2404,22 @@ structure ElimSubState where
   preconditions : List Nondep.Term := []
   /-- Index of next fresh width variable to introduce. -/
   freshWidthIndex : Nat
+  /-- maps from eliminated subtractions to their corresponding fresh width variables -/
+  eliminiatedSubtractions : Std.HashMap (Nondep.WidthExpr × Nondep.WidthExpr) Nat := ∅
 
 def ElimSubState.newState (freshWidthIndex : Nat) : ElimSubState :=
   { freshWidthIndex := freshWidthIndex }
 
 /-- Allocate a fresh width variable and advance the counter. -/
-def ElimSubState.freshWidth (s : ElimSubState) : Nondep.WidthExpr × ElimSubState :=
-  ⟨.var s.freshWidthIndex, { s with freshWidthIndex := s.freshWidthIndex + 1 }⟩
+def ElimSubState.freshWidth (s : ElimSubState) (a b : Nondep.WidthExpr) : Nondep.WidthExpr × ElimSubState :=
+  if let some k := s.eliminiatedSubtractions.get? (a, b) then
+    -- If we've already eliminated this subtraction, reuse the same variable.
+    (.var k, s)
+  else
+    ⟨.var s.freshWidthIndex, { s with
+      freshWidthIndex := s.freshWidthIndex + 1
+      eliminiatedSubtractions := s.eliminiatedSubtractions.insert (a, b) s.freshWidthIndex
+    }⟩
 
 def ElimSubState.addPrecondition (s : ElimSubState) (t : Nondep.Term) : ElimSubState :=
   { s with preconditions := t :: s.preconditions }
@@ -2427,66 +2436,73 @@ Recursively eliminate `.subK` and `.sub` from a `Nondep.WidthExpr`.
 Each subtraction `a - b` is replaced by a fresh width variable `k` together with
 a precondition `.binWidthRel .eq (.add k b) a`  (i.e. `k + b = a`).
 -/
-def Nondep.WidthExpr.elimSubAux (w : Nondep.WidthExpr) (s : ElimSubState) :
+def Nondep.WidthExpr.elimSubAux (w : Nondep.WidthExpr) (s : ElimSubState) (precond? : Bool) (eliminate? : Bool) :
     Nondep.WidthExpr × ElimSubState :=
   match w with
   | .subK v k =>
     -- Recurse into v first so nested subtractions are also eliminated.
-    let (v', s) := v.elimSubAux s
-    -- let (result, s) := s.freshWidth
-    -- Precondition: v' - k = result ↔ v' = k + result
-    -- let prec1 := Nondep.Term.binWidthRel .eq (.addK result k) v'
-    -- let s := s.addPrecondition prec1
-    -- Precondition 2, that we don't "overflow" and get negative numbers anywhere in the computation.
+    let (v', s) := v.elimSubAux s precond? eliminate?
     let prec2 := Nondep.Term.binWidthRel .le (.const k) v'
-    let s := s.addPrecondition prec2
-    let result := .subK v' k
+    let s := if precond? then s.addPrecondition prec2 else s
+    if eliminate? then
+      let (result, s) := s.freshWidth v' (.const k)
+      -- Precondition: v' - k = result ↔ v' = k + result
+      let prec1 := Nondep.Term.binWidthRel .eq (.addK result k) v'
+      (result, s)
+    else
+      let result := .subK v' k
     (result, s)
   | .sub a b =>
-    let (a', s) := a.elimSubAux s
-    let (b', s) := b.elimSubAux s
-    -- let (result, s) := s.freshWidth
-    -- Precondition: result = a' - b' ↔ result + b' = a'.
-    -- let prec1 := Nondep.Term.binWidthRel .eq (.add result b') a'
-    -- let s := s.addPrecondition prec1
-    -- Precondition 2, that we don't "overflow" and get negative numbers anywhere in the computation.
+    let (a', s) := a.elimSubAux s precond? eliminate?
+    let (b', s) := b.elimSubAux s precond? eliminate?
     let prec2 := Nondep.Term.binWidthRel .le b' a'
-    let s := s.addPrecondition prec2
-    let result := .sub a' b'
-    (result, s)
+    let s := if precond? then s.addPrecondition prec2 else s
+
+    if eliminate? then
+      let (result, s) := s.freshWidth a' b'
+    -- Precondition: result = a' - b' ↔ result + b' = a'.
+      let prec1 := Nondep.Term.binWidthRel .eq (.add result b') a'
+      let s := if precond? then s.addPrecondition prec1 else s
+      (result, s)
+    else
+      let result := .sub a' b'
+      (result, s)
   | .const n => (.const n, s)
   | .var i   => (.var i, s)
   | .max a b =>
-    let (a', s) := a.elimSubAux s
-    let (b', s) := b.elimSubAux s
+    let (a', s) := a.elimSubAux s precond? eliminate?
+    let (b', s) := b.elimSubAux s precond? eliminate?
     (.max a' b', s)
   | .min a b =>
-    let (a', s) := a.elimSubAux s
-    let (b', s) := b.elimSubAux s
+    let (a', s) := a.elimSubAux s precond? eliminate?
+    let (b', s) := b.elimSubAux s precond? eliminate?
     (.min a' b', s)
   | .addK a k =>
-    let (a', s) := a.elimSubAux s
+    let (a', s) := a.elimSubAux s precond? eliminate?
     (.addK a' k, s)
   | .kadd k a =>
-    let (a', s) := a.elimSubAux s
+    let (a', s) := a.elimSubAux s precond? eliminate?
     (.kadd k a', s)
   | .add a b =>
-    let (a', s) := a.elimSubAux s
-    let (b', s) := b.elimSubAux s
+    let (a', s) := a.elimSubAux s precond? eliminate?
+    let (b', s) := b.elimSubAux s precond? eliminate?
     (.add a' b', s)
   | .mul a b =>
-    let (a', s) := a.elimSubAux s
-    let (b', s) := b.elimSubAux s
+    let (a', s) := a.elimSubAux s precond? eliminate?
+    let (b', s) := b.elimSubAux s precond? eliminate?
     (.mul a' b', s)
 
 /--
 Walk a `Nondep.Term`, eliminating subtraction from every embedded `Nondep.WidthExpr`
 via `WidthExpr.elimSubAux`.
+If 'eliminiate?' is false, the `.sub` and `.subK`
+nodes are left in place, but preconditions are added.
+but their subterms are still rewritten.
 -/
-partial def Nondep.Term.elimSubAux (t : Nondep.Term) (s : ElimSubState) :
+partial def Nondep.Term.elimSubAux (t : Nondep.Term) (s : ElimSubState) (precond? : Bool) (eliminate? : Bool := true) :
     Nondep.Term × ElimSubState :=
   -- Helper to also eliminate sub in a WidthExpr embedded in a term.
-  let elW (w : Nondep.WidthExpr) (s : ElimSubState) := w.elimSubAux s
+  let elW (w : Nondep.WidthExpr) (s : ElimSubState) := w.elimSubAux s precond? eliminate?
   match t with
   | .var v w =>
     let (w', s) := elW w s
@@ -2499,112 +2515,112 @@ partial def Nondep.Term.elimSubAux (t : Nondep.Term) (s : ElimSubState) :
     (.intToPbv w' v, s)
   | .add w a b =>
     let (w', s) := elW w s
-    let (a', s) := a.elimSubAux s
-    let (b', s) := b.elimSubAux s
+    let (a', s) := a.elimSubAux s precond? eliminate?
+    let (b', s) := b.elimSubAux s precond? eliminate?
     (.add w' a' b', s)
   | .mul w a b =>
     let (w', s) := elW w s
-    let (a', s) := a.elimSubAux s
-    let (b', s) := b.elimSubAux s
+    let (a', s) := a.elimSubAux s precond? eliminate?
+    let (b', s) := b.elimSubAux s precond? eliminate?
     (.mul w' a' b', s)
   | .zext a wn =>
-    let (a', s) := a.elimSubAux s
+    let (a', s) := a.elimSubAux s precond? eliminate?
     let (wn', s) := elW wn s
     (.zext a' wn', s)
   | .setWidth a wn =>
-    let (a', s) := a.elimSubAux s
+    let (a', s) := a.elimSubAux s precond? eliminate?
     let (wn', s) := elW wn s
     (.setWidth a' wn', s)
   | .sext a wn =>
-    let (a', s) := a.elimSubAux s
+    let (a', s) := a.elimSubAux s precond? eliminate?
     let (wn', s) := elW wn s
     (.sext a' wn', s)
   | .bor w a b =>
     let (w', s) := elW w s
-    let (a', s) := a.elimSubAux s
-    let (b', s) := b.elimSubAux s
+    let (a', s) := a.elimSubAux s precond? eliminate?
+    let (b', s) := b.elimSubAux s precond? eliminate?
     (.bor w' a' b', s)
   | .band w a b =>
     let (w', s) := elW w s
-    let (a', s) := a.elimSubAux s
-    let (b', s) := b.elimSubAux s
+    let (a', s) := a.elimSubAux s precond? eliminate?
+    let (b', s) := b.elimSubAux s precond? eliminate?
     (.band w' a' b', s)
   | .bxor w a b =>
     let (w', s) := elW w s
-    let (a', s) := a.elimSubAux s
-    let (b', s) := b.elimSubAux s
+    let (a', s) := a.elimSubAux s precond? eliminate?
+    let (b', s) := b.elimSubAux s precond? eliminate?
     (.bxor w' a' b', s)
   | .bnot w a =>
     let (w', s) := elW w s
-    let (a', s) := a.elimSubAux s
+    let (a', s) := a.elimSubAux s precond? eliminate?
     (.bnot w' a', s)
   | .shiftl w a k =>
     let (w', s) := elW w s
-    let (a', s) := a.elimSubAux s
+    let (a', s) := a.elimSubAux s precond? eliminate?
     (.shiftl w' a' k, s)
   | .shiftr w a k =>
     let (w', s) := elW w s
-    let (a', s) := a.elimSubAux s
+    let (a', s) := a.elimSubAux s precond? eliminate?
     (.shiftr w' a' k, s)
   | .ashr w a k =>
     let (w', s) := elW w s
-    let (a', s) := a.elimSubAux s
+    let (a', s) := a.elimSubAux s precond? eliminate?
     (.ashr w' a' k, s)
   | .vshl w a b =>
     let (w', s) := elW w s
-    let (a', s) := a.elimSubAux s
-    let (b', s) := b.elimSubAux s
+    let (a', s) := a.elimSubAux s precond? eliminate?
+    let (b', s) := b.elimSubAux s precond? eliminate?
     (.vshl w' a' b', s)
   | .vlshr w a b =>
     let (w', s) := elW w s
-    let (a', s) := a.elimSubAux s
-    let (b', s) := b.elimSubAux s
+    let (a', s) := a.elimSubAux s precond? eliminate?
+    let (b', s) := b.elimSubAux s precond? eliminate?
     (.vlshr w' a' b', s)
   | .vashr w a b =>
     let (w', s) := elW w s
-    let (a', s) := a.elimSubAux s
-    let (b', s) := b.elimSubAux s
+    let (a', s) := a.elimSubAux s precond? eliminate?
+    let (b', s) := b.elimSubAux s precond? eliminate?
     (.vashr w' a' b', s)
   | .udiv w a b =>
     let (w', s) := elW w s
-    let (a', s) := a.elimSubAux s
-    let (b', s) := b.elimSubAux s
+    let (a', s) := a.elimSubAux s precond? eliminate?
+    let (b', s) := b.elimSubAux s precond? eliminate?
     (.udiv w' a' b', s)
   | .urem w a b =>
     let (w', s) := elW w s
-    let (a', s) := a.elimSubAux s
-    let (b', s) := b.elimSubAux s
+    let (a', s) := a.elimSubAux s precond? eliminate?
+    let (b', s) := b.elimSubAux s precond? eliminate?
     (.urem w' a' b', s)
   | .pextract a lo hi =>
     let s := s.addPrecondition (Term.binWidthRel .le lo hi) -- add the precondition for pextract being valid.
-    let (a', s) := a.elimSubAux s
+    let (a', s) := a.elimSubAux s precond? eliminate?
     -- this needs another precondition.
     (.pextract a' lo hi, s)
   | .binRel k w a b =>
     let (w', s) := elW w s
-    let (a', s) := a.elimSubAux s
-    let (b', s) := b.elimSubAux s
+    let (a', s) := a.elimSubAux s precond? eliminate?
+    let (b', s) := b.elimSubAux s precond? eliminate?
     (.binRel k w' a' b', s)
   | .binWidthRel k wa wb =>
     let (wa', s) := elW wa s
     let (wb', s) := elW wb s
     (.binWidthRel k wa' wb', s)
   | .and a b =>
-    let (a', s) := a.elimSubAux s
-    let (b', s) := b.elimSubAux s
+    let (a', s) := a.elimSubAux s precond? eliminate?
+    let (b', s) := b.elimSubAux s precond? eliminate?
     (.and a' b', s)
   | .or a b =>
-    let (a', s) := a.elimSubAux s
-    let (b', s) := b.elimSubAux s
+    let (a', s) := a.elimSubAux s precond? eliminate?
+    let (b', s) := b.elimSubAux s precond? eliminate?
     (.or a' b', s)
   | .bvIte cond t1 t2 =>
-    let (cond', s) := cond.elimSubAux s
-    let (t1', s)   := t1.elimSubAux s
-    let (t2', s)   := t2.elimSubAux s
+    let (cond', s) := cond.elimSubAux s precond? eliminate?
+    let (t1', s)   := t1.elimSubAux s precond? eliminate?
+    let (t2', s)   := t2.elimSubAux s precond? eliminate?
     (.bvIte cond' t1' t2', s)
   | .boolBinRel k a b =>
-    let (a', s) := a.elimSubAux s
-    let (b', s) := b.elimSubAux s
+    let (a', s) := a.elimSubAux s precond? eliminate?
+    let (b', s) := b.elimSubAux s precond? eliminate?
     (.boolBinRel k a' b', s)
   | .pTrue        => (.pTrue, s)
   | .pFalse       => (.pFalse, s)
@@ -2617,10 +2633,10 @@ partial def Nondep.Term.elimSubAux (t : Nondep.Term) (s : ElimSubState) :
 Top-level sub elimination.  Runs `elimSubAux` on `t`, then builds the implication
 `preconds → t'`:  if there are no preconditions, returns `t'` unchanged.
 -/
-def Nondep.Term.elimSub (t : Nondep.Term) : ElimSubResult :=
+def Nondep.Term.elimSub (t : Nondep.Term) (precond? : Bool) (eliminate? : Bool) : ElimSubResult :=
   let initNumWidths := t.maxwcard
   let s := ElimSubState.newState t.maxwcard
-  let (t', s') := t.elimSubAux s
+  let (t', s') := t.elimSubAux s precond? eliminate?
   { term             := t'
     preconds         := s'.preconditions
     freshWidthCount  := s'.freshWidthIndex - initNumWidths }

--- a/Blase/Blase/MultiWidth/Defs.lean
+++ b/Blase/Blase/MultiWidth/Defs.lean
@@ -69,7 +69,7 @@ def WidthExpr.Env.cons (env : WidthExpr.Env wcard) (w : Nat) :
   WidthExpr.Env (wcard + 1) :=
   fun v => v.cases w env
 
-def WidthExpr.toNat 
+def WidthExpr.toNat
   (e : WidthExpr wcard) (env : WidthExpr.Env wcard) : Nat :=
   match e with
   | .const n => n
@@ -775,10 +775,10 @@ inductive Term
 | intToPbv (w : WidthExpr) (val : WidthExpr ): Term  -- coerct an integer 'val' into a PBV.
 deriving DecidableEq, Inhabited, Repr, Lean.ToExpr
 
-/-- Smart constructor for a pextract operation, desugaring a pextract to lo=0 into a zeroExtend, 
+/-- Smart constructor for a pextract operation, desugaring a pextract to lo=0 into a zeroExtend,
 since our zeroExtend also encodes truncates. -/
-def Term.mkPExtract (hi lo : Nondep.WidthExpr) (t : Nondep.Term) : Nondep.Term := 
-    match lo with 
+def Term.mkPExtract (hi lo : Nondep.WidthExpr) (t : Nondep.Term) : Nondep.Term :=
+    match lo with
     | .const 0 => .zext t hi
     | _ => .pextract t lo hi
 
@@ -1669,7 +1669,7 @@ def Term.toBVExpr (wenv : Array Nat) (t : Term) : (BVExpr (t.width.eval wenv)) �
       let errMsg := s!"toBVExpr: width mismatch in ashr (a.width={a'.width} ≠ {w})\n{aerr}"
       (.const (88#_), false, .text errMsg)
   | .pextract a wlo whi =>
-    let lo := wlo.eval wenv 
+    let lo := wlo.eval wenv
     let hi := whi.eval wenv
     let (a', aresult, aerr) := a.toBVExpr wenv
     if aresult then
@@ -1794,13 +1794,86 @@ def Term.toBVExpr (wenv : Array Nat) (t : Term) : (BVExpr (t.width.eval wenv)) �
      dbg_trace errMsg
      (.const (99#_), false, .text errMsg)
 
+
+-- (bvIte _ _ _)
+-- (pextract _ _ _)
+-- (ashr _ _ _)
+-- (vshl _ _ _)
+-- (vashr _ _ _)
+-- (vlshr _ _ _)
+-- (urem _ _ _)
+-- (udiv _ _ _)
+-- (boolBinRel BoolBinaryRelationKind.eq _ _)
+-- (pvar _)
+-- (bvOfBool _)
+-- (shiftr _ _ _)
+-- (shiftl _ _ _)
+-- (boolConst true)
+-- (boolConst false)
+-- (boolVar _)
+-- (bnot _ _)
+-- (bxor _ _ _)
+-- (band _ _ _)
+-- (bor _ _ _)
+-- (sext _ _)
+-- (setWidth _ _)
+-- (zext _ _)
+-- (mul _ _ _)
+-- (add _ _ _)
+-- (var _ _)
+-- (ofNat _ _)
+
+/--
+Produce a term that has just the width contraints, and no bitvector constraints.
+This allows us to check if a term satisfies its widths constraints before evaluating
+its bitvector constraints.
+If the width constraints fail, then we should skip trying the BV fragment,
+as we may produce ill-typed BV terms otherwise.
+-/
+def Term.toWidthLogicalExpr (t : Term) : Term :=
+  match t with
+  | .binWidthRel .. => t
+  | .and a b => .and (a.toWidthLogicalExpr) (b.toWidthLogicalExpr)
+  | .or a b => .or (a.toWidthLogicalExpr) (b.toWidthLogicalExpr)
+  | .binRel .. => pTrue
+  | .boolBinRel .. => pTrue
+  | .pTrue => .pTrue
+  | .pFalse => .pFalse
+  | .intToPbv .. | .band .. | .bor .. | .bxor .. | .mul .. | .add .. | .zext .. | .setWidth ..
+    | .bvIte .. | pextract .. | .ashr .. | .vshl .. | .vashr .. | .vlshr ..
+    | .urem .. | .udiv .. | .bvOfBool .. | .shiftr .. | .shiftl .. | .boolConst ..
+    | .var .. | .ofNat .. | .sext .. | .bnot .. | .boolVar .. | .pvar .. => t
+
+/--
+Evaluate a logical expression that has been promised to only have width expressions. -/
+def Term.evalWidthLogicalExpr (t : Term) (wenv: Array Nat) : Except String Bool := do
+  match t with
+  | .binWidthRel k a b =>
+    let wa := a.eval wenv
+    let wb := b.eval wenv
+    let out := match k with
+      | .eq =>  wa == wb
+      | .le => wa ≤ wb
+    return out
+  | .and p q => return (← p.evalWidthLogicalExpr wenv)  && (← q.evalWidthLogicalExpr wenv)
+  | .or p q => return (← p.evalWidthLogicalExpr wenv) || (← q.evalWidthLogicalExpr wenv)
+  | .pTrue => return true
+  | .pFalse => return false
+  | .intToPbv .. | .band .. | .bor .. | .bxor .. | .mul .. | .add .. | .zext .. | .setWidth ..
+    | .bvIte .. | pextract .. | .ashr .. | .vshl .. | .vashr .. | .vlshr ..
+    | .urem .. | .udiv .. | .bvOfBool .. | .shiftr .. | .shiftl .. | .boolConst ..
+    | .var .. | .ofNat .. | .sext .. | .bnot .. | .boolVar .. | .binRel .. | .pvar ..
+    | .boolBinRel .. =>
+      .error s!"unexpected term '{repr t}' in a width logical expression evaluation"
+
+
 /-- Convert a predicate-producing `Nondep.Term` to a `BVLogicalExpr`.
 `wenv` provides concrete width assignments for width variables.
 Uses `Term.toBVExpr` for BV subterms within predicates.
 `ule a b` is encoded as `¬(ult b a)`, `ne` as `¬(eq)`.
 Returns 'true' if the translation succeeded, along with accumulated error messages.
 -/
-def Term.toBVLogicalExpr (wenv : Array Nat) (t : Term) : 
+def Term.toBVLogicalExpr (wenv : Array Nat) (t : Term) :
     BVLogicalExpr × Bool × Lean.Format :=
   match t with
   | .pTrue => (.const true, true, .nil)

--- a/Blase/Blase/MultiWidth/Defs.lean
+++ b/Blase/Blase/MultiWidth/Defs.lean
@@ -1796,34 +1796,6 @@ def Term.toBVExpr (wenv : Array Nat) (t : Term) : (BVExpr (t.width.eval wenv)) Ã
      (.const (99#_), false, .text errMsg)
 
 
--- (bvIte _ _ _)
--- (pextract _ _ _)
--- (ashr _ _ _)
--- (vshl _ _ _)
--- (vashr _ _ _)
--- (vlshr _ _ _)
--- (urem _ _ _)
--- (udiv _ _ _)
--- (boolBinRel BoolBinaryRelationKind.eq _ _)
--- (pvar _)
--- (bvOfBool _)
--- (shiftr _ _ _)
--- (shiftl _ _ _)
--- (boolConst true)
--- (boolConst false)
--- (boolVar _)
--- (bnot _ _)
--- (bxor _ _ _)
--- (band _ _ _)
--- (bor _ _ _)
--- (sext _ _)
--- (setWidth _ _)
--- (zext _ _)
--- (mul _ _ _)
--- (add _ _ _)
--- (var _ _)
--- (ofNat _ _)
-
 /--
 Produce a term that has just the width contraints, and no bitvector constraints.
 This allows us to check if a term satisfies its widths constraints before evaluating

--- a/Blase/Blase/MultiWidth/Defs.lean
+++ b/Blase/Blase/MultiWidth/Defs.lean
@@ -2433,17 +2433,23 @@ def Nondep.WidthExpr.elimSubAux (w : Nondep.WidthExpr) (s : ElimSubState) :
     -- Recurse into v first so nested subtractions are also eliminated.
     let (v', s) := v.elimSubAux s
     let (result, s) := s.freshWidth
-    -- Precondition: result + k = v'  ↔  v' - k = result
-    let prec := Nondep.Term.binWidthRel .eq (.addK result k) v'
-    let s := s.addPrecondition prec
+    -- Precondition: v' - k = result ↔ v' = k + result
+    let prec1 := Nondep.Term.binWidthRel .eq (.addK result k) v'
+    let s := s.addPrecondition prec1
+    -- Precondition 2, that we don't "overflow" and get negative numbers anywhere in the computation.
+    let prec2 := Nondep.Term.binWidthRel .le (.const k) v'
+    let s := s.addPrecondition prec2
     (result, s)
   | .sub a b =>
     let (a', s) := a.elimSubAux s
     let (b', s) := b.elimSubAux s
     let (result, s) := s.freshWidth
-    -- Precondition: result = a' - b' ↔  a' = result + b'
-    let prec := Nondep.Term.binWidthRel .eq (.add result b') a'
-    let s := s.addPrecondition prec
+    -- Precondition: result = a' - b' ↔ result + b' = a'.
+    let prec1 := Nondep.Term.binWidthRel .eq (.add result b') a'
+    let s := s.addPrecondition prec1
+    -- Precondition 2, that we don't "overflow" and get negative numbers anywhere in the computation.
+    let prec2 := Nondep.Term.binWidthRel .le b' a'
+    let s := s.addPrecondition prec2
     (result, s)
   | .const n => (.const n, s)
   | .var i   => (.var i, s)
@@ -2567,7 +2573,9 @@ partial def Nondep.Term.elimSubAux (t : Nondep.Term) (s : ElimSubState) :
     let (b', s) := b.elimSubAux s
     (.urem w' a' b', s)
   | .pextract a lo hi =>
+    let s := s.addPrecondition (Term.binWidthRel .le lo hi) -- add the precondition for pextract being valid.
     let (a', s) := a.elimSubAux s
+    -- this needs another precondition.
     (.pextract a' lo hi, s)
   | .binRel k w a b =>
     let (w', s) := elW w s
@@ -2606,12 +2614,13 @@ partial def Nondep.Term.elimSubAux (t : Nondep.Term) (s : ElimSubState) :
 Top-level sub elimination.  Runs `elimSubAux` on `t`, then builds the implication
 `preconds → t'`:  if there are no preconditions, returns `t'` unchanged.
 -/
-def Nondep.Term.elimSub (t : Nondep.Term) (initialFreshWidthIndex : Nat) : ElimSubResult :=
-  let s := ElimSubState.newState initialFreshWidthIndex
+def Nondep.Term.elimSub (t : Nondep.Term) : ElimSubResult :=
+  let initNumWidths := t.maxwcard
+  let s := ElimSubState.newState t.maxwcard
   let (t', s') := t.elimSubAux s
   { term             := t'
     preconds         := s'.preconditions
-    freshWidthCount  := s'.freshWidthIndex - initialFreshWidthIndex }
+    freshWidthCount  := s'.freshWidthIndex - initNumWidths }
 
 /--
 Build `preconds → term` from an `ElimSubResult`.

--- a/Blase/Blase/MultiWidth/Defs.lean
+++ b/Blase/Blase/MultiWidth/Defs.lean
@@ -2420,6 +2420,7 @@ def Nondep.WidthExpr.elimSubAux (w : Nondep.WidthExpr) (s : ElimSubState) (preco
       let (result, s) := s.freshWidth v' (.const k)
       -- Precondition: v' - k = result ↔ v' = k + result
       let prec1 := Nondep.Term.binWidthRel .eq (.addK result k) v'
+      let s := s.addPrecondition prec1
       (result, s)
     else
       let result := .subK v' k
@@ -2429,12 +2430,11 @@ def Nondep.WidthExpr.elimSubAux (w : Nondep.WidthExpr) (s : ElimSubState) (preco
     let (b', s) := b.elimSubAux s precond? eliminate?
     let prec2 := Nondep.Term.binWidthRel .le b' a'
     let s := if precond? then s.addPrecondition prec2 else s
-
     if eliminate? then
       let (result, s) := s.freshWidth a' b'
     -- Precondition: result = a' - b' ↔ result + b' = a'.
       let prec1 := Nondep.Term.binWidthRel .eq (.add result b') a'
-      let s := if precond? then s.addPrecondition prec1 else s
+      let s := s.addPrecondition prec1
       (result, s)
     else
       let result := .sub a' b'

--- a/Blase/Blasewuzla/Parser.lean
+++ b/Blase/Blasewuzla/Parser.lean
@@ -312,26 +312,34 @@ partial def parseTerm (s : Sexp) : ParserM ParsedTerm := do
   -- zero_extend: ((_ zero_extend wnew) a)
   | .expr [.expr [.atom "_", .atom "zero_extend", wnew], a] =>
     let w ← parseWidthExpr wnew
-    let (at_, _aw) ← (← parseTerm a) |> expectBV (ctx := "zero_extend")
-    return .bv (.zext at_ w) w
+    let (at_, aw) ← (← parseTerm a) |> expectBV (ctx := "zero_extend")
+    let outw := aw.add w
+    return .bv (.zext at_ outw) outw
 
   -- sign_extend: ((_ sign_extend wnew) a)
   | .expr [.expr [.atom "_", .atom "sign_extend", wnew], a] =>
     let w ← parseWidthExpr wnew
-    let (at_, _aw) ← (← parseTerm a) |> expectBV (ctx := "sign_extend")
-    return .bv (.sext at_ w) w
+    let (at_, aw) ← (← parseTerm a) |> expectBV (ctx := "sign_extend")
+    let outw := aw.add w
+    return .bv (.sext at_ outw) outw
 
   -- pzero_extend: alias for zero_extend
+  -- Recall that is SMT2, zero/sign extension says how many bits to add,
+  -- not the total number of vits.
   | .expr [.atom "pzero_extend", wnew, a] =>
     let w ← parseWidthExpr wnew
-    let (at_, _aw) ← (← parseTerm a) |> expectBV (ctx := "pzero_extend")
-    return .bv (.zext at_ w) w
+    let (at_, aw) ← (← parseTerm a) |> expectBV (ctx := "pzero_extend")
+    let outw := aw.add w
+    return .bv (.zext at_ outw) outw
 
-  -- psign_extend: alias for sign_extend
+  -- psign_extend: alias for sign_extend.
+  -- Recall that is SMT2, zero/sign extension says how many bits to add,
+  -- not the total number of vits.
   | .expr [.atom "psign_extend", wnew, a] =>
     let w ← parseWidthExpr wnew
-    let (at_, _aw) ← (← parseTerm a) |> expectBV (ctx := "psign_extend")
-    return .bv (.sext at_ w) w
+    let (at_, aw) ← (← parseTerm a) |> expectBV (ctx := "psign_extend")
+    let outw := aw.add w
+    return .bv (.sext at_ outw) outw
 
   -- Width relation predicates
   | .expr [.atom "width_le", a, b] =>

--- a/Blase/BlasewuzlaMain.lean
+++ b/Blase/BlasewuzlaMain.lean
@@ -193,7 +193,7 @@ def naiveBMC : Solver where
   name := "naivebmc"
   run (config : Config) (result : Nondep.Term) : MetaM SolverExitCode := do
     let (negatedPredicate, success?, negateErrors) := result.pnegate
-    let widthConstraints := result.toWidthLogicalExpr
+    let widthConstraints := negatedPredicate.toWidthLogicalExpr
 
     if !success? then
       throwError "unable to negate predicate. Errors:\n{negateErrors}\n{repr result}"

--- a/Blase/BlasewuzlaMain.lean
+++ b/Blase/BlasewuzlaMain.lean
@@ -417,7 +417,8 @@ unsafe def blasewuzlaCmd : Cli.Cmd := `[Cli|
     timeout : Nat;             "SAT solver timeout for SAT based methods."
     backend : String;          "Backend solver: 'k-induction' (default), 'rIC3', 'abc', 'monobmc', 'naivebmc', or 'dryrun'."
     elimIte;                   "Run ite-elimination preprocessing pass (off by default)."
-    subPrecondition;             "Run width-subtraction elimination preprocessing pass (off by default)."
+    elimSub;                   "Run sub-elimination preprocessing pass (off by default). This adds many variables (one per subtraction), but ensures that no subtractions remain in the formula."
+    subPrecondition;           "Runsubtraction precondition preprocessing pass (off by default). This adds a precondition that the subtraction does not produce a negative number."
 
   ARGS:
     input : String;            "Path to the .smt2 file."

--- a/Blase/BlasewuzlaMain.lean
+++ b/Blase/BlasewuzlaMain.lean
@@ -101,6 +101,8 @@ structure Config where
   timeout : Nat
   /-- Run ite-elimination preprocessing pass. -/
   elimIte : Bool
+  /-- Run width-subtraction preprocessing that adds subtraction preconditions . -/
+  subPrecondition : Bool
   /-- Run width-subtraction elimination preprocessing pass. -/
   elimSub : Bool
 
@@ -182,12 +184,12 @@ def elimItePreprocessing (predicate : Nondep.Term) : Except String Nondep.Term :
     .error s!"ite implication failed for predicate. Errors:\n{iteImplErrors}"
   return predWithPrec
 
-def elimSubPreprocessing (pred : Nondep.Term) : Except String Nondep.Term := do
-  let subResult := pred.elimSub
-  let (predElimSub, subImplSuccess, subImplErrors) := subResult.toImplication
+def addSubPreconditionPreprocessing (pred : Nondep.Term) (precond? : Bool) (eliminate? : Bool) : Except String Nondep.Term := do
+  let subResult := pred.elimSub (precond? := precond?) (eliminate? := eliminate?)
+  let (predaddSubPrecondition, subImplSuccess, subImplErrors) := subResult.toImplication
   if !subImplSuccess then
     .error s!"sub implication failed for predicate. Errors:\n{subImplErrors}"
-  return predElimSub
+  return predaddSubPrecondition
 
 def naiveBMC : Solver where
   name := "naivebmc"
@@ -343,6 +345,7 @@ unsafe def runBlasewuzla (p : Cli.Parsed) : IO UInt32 := do
   let backend : String := p.flag! "backend" |>.as! String
   let timeout : Nat := p.flag! "timeout" |>.as! Nat
   let elimIte : Bool := p.hasFlag "elimIte"
+  let subPrecondition : Bool := p.hasFlag "subPrecondition"
   let elimSub : Bool := p.hasFlag "elimSub"
 
   let config : Config := {
@@ -353,6 +356,7 @@ unsafe def runBlasewuzla (p : Cli.Parsed) : IO UInt32 := do
     bound,
     timeout,
     elimIte,
+    subPrecondition,
     elimSub
   }
   -- Read and parse the SMT2 file
@@ -383,8 +387,8 @@ unsafe def runBlasewuzla (p : Cli.Parsed) : IO UInt32 := do
       pure predicate
 
   let predicate ← do
-    if config.elimSub then
-      match elimSubPreprocessing predicate with
+    if config.subPrecondition || config.elimSub then
+      match addSubPreconditionPreprocessing predicate (precond? := config.subPrecondition) (eliminate? := config.elimSub) with
       | .error e =>
         IO.eprintln e
         return SolverExitCode.toUInt32 .error
@@ -413,7 +417,7 @@ unsafe def blasewuzlaCmd : Cli.Cmd := `[Cli|
     timeout : Nat;             "SAT solver timeout for SAT based methods."
     backend : String;          "Backend solver: 'k-induction' (default), 'rIC3', 'abc', 'monobmc', 'naivebmc', or 'dryrun'."
     elimIte;                   "Run ite-elimination preprocessing pass (off by default)."
-    elimSub;                   "Run width-subtraction elimination preprocessing pass (off by default)."
+    subPrecondition;             "Run width-subtraction elimination preprocessing pass (off by default)."
 
   ARGS:
     input : String;            "Path to the .smt2 file."

--- a/Blase/BlasewuzlaMain.lean
+++ b/Blase/BlasewuzlaMain.lean
@@ -213,7 +213,7 @@ def naiveBMC : Solver where
       | .ok false =>
         if config.verbose then
           IO.eprintln s!"⟨{widths.toList}⟩ width precondition sufficed to prove UNSAT."
-          continue
+        continue
       | .ok true =>
         if config.verbose then
           IO.eprintln s!"⟨{widths.toList}⟩ widths not sufficient to prove UNSAT. Width precondition: {repr widthConstraints} querying QF_BV..."

--- a/Blase/BlasewuzlaMain.lean
+++ b/Blase/BlasewuzlaMain.lean
@@ -192,6 +192,7 @@ def elimSubPreprocessing (pred : Nondep.Term) (wcard : Nat) : Except String Nond
 def naiveBMC : Solver where
   name := "naivebmc"
   run (config : Config) (result : Nondep.Term) : MetaM SolverExitCode := do
+    let widthConstraints := result.toWidthLogicalExpr
     let (negatedPredicate, success?, negateErrors) := result.pnegate
     if !success? then
       throwError "unable to negate predicate. Errors:\n{negateErrors}\n{repr result}"
@@ -199,6 +200,25 @@ def naiveBMC : Solver where
     if config.verbose then
       IO.eprintln s!"Running naivebmc at width {config.bound}..."
     for widths in cartesianProductRange config.bound result.maxwcard do
+      /-
+        First check if the widths lead to a satisfying assignment of the width constraints.
+        If they do, then proceed to create a model. If they do not, then bail out,
+        as we cannot guarantee a legal QF_BV expression being created, as the semantics
+        are a promise-based semantics.
+      -/
+      match widthConstraints.evalWidthLogicalExpr widths with
+      | .ok true =>
+        if config.verbose then
+          IO.eprintln s!"⟨{widths.toList}⟩ succeeded width precondition check."
+
+      | .ok false =>
+        if config.verbose then
+        IO.eprintln s!"⟨{widths.toList}⟩ skipped as width constraints fail."
+      | .error err =>
+        return .error s!"unable to evaluate width constraints '{widths}' for QF_BV formula construction.\n{err}"
+      /-
+      Width constraints succeed, so now continue trying to evaluate.
+      -/
       let (qfbv, success?, translationErrors) := negatedPredicate.toBVLogicalExpr widths
 
       if !success? then
@@ -350,7 +370,7 @@ unsafe def runBlasewuzla (p : Cli.Parsed) : IO UInt32 := do
   let predicate ← do
     if config.elimIte then
       match elimItePreprocessing predicate with
-      | .error e => 
+      | .error e =>
         IO.eprintln e
         return SolverExitCode.toUInt32 .error
       | .ok t => pure t
@@ -360,7 +380,7 @@ unsafe def runBlasewuzla (p : Cli.Parsed) : IO UInt32 := do
   let predicate ← do
     if config.elimSub then
       match elimSubPreprocessing predicate result.wcard with
-      | .error e => 
+      | .error e =>
         IO.eprintln e
         return SolverExitCode.toUInt32 .error
       | .ok t => pure t

--- a/Blase/BlasewuzlaMain.lean
+++ b/Blase/BlasewuzlaMain.lean
@@ -182,8 +182,8 @@ def elimItePreprocessing (predicate : Nondep.Term) : Except String Nondep.Term :
     .error s!"ite implication failed for predicate. Errors:\n{iteImplErrors}"
   return predWithPrec
 
-def elimSubPreprocessing (pred : Nondep.Term) (wcard : Nat) : Except String Nondep.Term := do
-  let subResult := pred.elimSub wcard
+def elimSubPreprocessing (pred : Nondep.Term) : Except String Nondep.Term := do
+  let subResult := pred.elimSub
   let (predElimSub, subImplSuccess, subImplErrors) := subResult.toImplication
   if !subImplSuccess then
     .error s!"sub implication failed for predicate. Errors:\n{subImplErrors}"
@@ -192,14 +192,17 @@ def elimSubPreprocessing (pred : Nondep.Term) (wcard : Nat) : Except String Nond
 def naiveBMC : Solver where
   name := "naivebmc"
   run (config : Config) (result : Nondep.Term) : MetaM SolverExitCode := do
-    let widthConstraints := result.toWidthLogicalExpr
     let (negatedPredicate, success?, negateErrors) := result.pnegate
+    let widthConstraints := result.toWidthLogicalExpr
+
     if !success? then
       throwError "unable to negate predicate. Errors:\n{negateErrors}\n{repr result}"
     -- naivebmc backend: translate to single-width and call bv_decide at a fixed width
     if config.verbose then
-      IO.eprintln s!"Running naivebmc at width {config.bound}..."
+      IO.eprintln s!"Running naivebmc at width {config.bound} for #widths {result.maxwcard}..."
     for widths in cartesianProductRange config.bound result.maxwcard do
+      if config.verbose then
+        IO.println s!"width configuration ⟨{widths}⟩"
       /-
         First check if the widths lead to a satisfying assignment of the width constraints.
         If they do, then proceed to create a model. If they do not, then bail out,
@@ -207,22 +210,23 @@ def naiveBMC : Solver where
         are a promise-based semantics.
       -/
       match widthConstraints.evalWidthLogicalExpr widths with
-      | .ok true =>
-        if config.verbose then
-          IO.eprintln s!"⟨{widths.toList}⟩ succeeded width precondition check."
-
       | .ok false =>
         if config.verbose then
-        IO.eprintln s!"⟨{widths.toList}⟩ skipped as width constraints fail."
+          IO.eprintln s!"⟨{widths.toList}⟩ width precondition sufficed to prove UNSAT."
+          continue
+      | .ok true =>
+        if config.verbose then
+          IO.eprintln s!"⟨{widths.toList}⟩ widths not sufficient to prove UNSAT. Width precondition: {repr widthConstraints} querying QF_BV..."
       | .error err =>
         return .error s!"unable to evaluate width constraints '{widths}' for QF_BV formula construction.\n{err}"
+
       /-
       Width constraints succeed, so now continue trying to evaluate.
       -/
       let (qfbv, success?, translationErrors) := negatedPredicate.toBVLogicalExpr widths
 
       if !success? then
-        return .error s!"formula contains unsupported operation, unable to translate into QF_BV.\nTranslation errors:\n{translationErrors}\nPredicate:\n{repr negatedPredicate}"
+        return .error s!"unable to translate into QF_BV at widths '{widths}'.\n{translationErrors}\nPredicate:\n{repr negatedPredicate}"
 
       if config.verbose then
         IO.eprintln s!"{qfbv.toString}"
@@ -352,6 +356,7 @@ unsafe def runBlasewuzla (p : Cli.Parsed) : IO UInt32 := do
     elimSub
   }
   -- Read and parse the SMT2 file
+  let timeStart ← IO.monoMsNow
   let contents ← IO.FS.readFile inputPath
   let result ← match Blasewuzla.parseSmt2Query contents with
     | .ok r => pure r
@@ -379,7 +384,7 @@ unsafe def runBlasewuzla (p : Cli.Parsed) : IO UInt32 := do
 
   let predicate ← do
     if config.elimSub then
-      match elimSubPreprocessing predicate result.wcard with
+      match elimSubPreprocessing predicate with
       | .error e =>
         IO.eprintln e
         return SolverExitCode.toUInt32 .error
@@ -389,7 +394,6 @@ unsafe def runBlasewuzla (p : Cli.Parsed) : IO UInt32 := do
 
   let solver : Solver :=
     allSolvers.get? backend |>.getD solverErrorUknown
-  let timeStart ← IO.monoMsNow
   let out ← runMetaMAsIO <| solver.run config predicate
   let timeEnd ← IO.monoMsNow
 

--- a/Blase/BlasewuzlaMain.lean
+++ b/Blase/BlasewuzlaMain.lean
@@ -102,7 +102,7 @@ structure Config where
   /-- Run ite-elimination preprocessing pass. -/
   elimIte : Bool
   /-- Run width-subtraction preprocessing that adds subtraction preconditions . -/
-  subPrecondition : Bool
+  preconditionSub : Bool
   /-- Run width-subtraction elimination preprocessing pass. -/
   elimSub : Bool
 
@@ -345,7 +345,7 @@ unsafe def runBlasewuzla (p : Cli.Parsed) : IO UInt32 := do
   let backend : String := p.flag! "backend" |>.as! String
   let timeout : Nat := p.flag! "timeout" |>.as! Nat
   let elimIte : Bool := p.hasFlag "elimIte"
-  let subPrecondition : Bool := p.hasFlag "subPrecondition"
+  let preconditionSub : Bool := p.hasFlag "preconditionSub"
   let elimSub : Bool := p.hasFlag "elimSub"
 
   let config : Config := {
@@ -356,7 +356,7 @@ unsafe def runBlasewuzla (p : Cli.Parsed) : IO UInt32 := do
     bound,
     timeout,
     elimIte,
-    subPrecondition,
+    preconditionSub,
     elimSub
   }
   -- Read and parse the SMT2 file
@@ -387,8 +387,8 @@ unsafe def runBlasewuzla (p : Cli.Parsed) : IO UInt32 := do
       pure predicate
 
   let predicate ← do
-    if config.subPrecondition || config.elimSub then
-      match addSubPreconditionPreprocessing predicate (precond? := config.subPrecondition) (eliminate? := config.elimSub) with
+    if config.preconditionSub || config.elimSub then
+      match addSubPreconditionPreprocessing predicate (precond? := config.preconditionSub) (eliminate? := config.elimSub) with
       | .error e =>
         IO.eprintln e
         return SolverExitCode.toUInt32 .error
@@ -418,7 +418,7 @@ unsafe def blasewuzlaCmd : Cli.Cmd := `[Cli|
     backend : String;          "Backend solver: 'k-induction' (default), 'rIC3', 'abc', 'monobmc', 'naivebmc', or 'dryrun'."
     elimIte;                   "Run ite-elimination preprocessing pass (off by default)."
     elimSub;                   "Run sub-elimination preprocessing pass (off by default). This adds many variables (one per subtraction), but ensures that no subtractions remain in the formula."
-    subPrecondition;           "Runsubtraction precondition preprocessing pass (off by default). This adds a precondition that the subtraction does not produce a negative number."
+    preconditionSub;           "Runs subtraction precondition preprocessing pass (off by default). This adds a precondition that the subtraction does not produce a negative number."
 
   ARGS:
     input : String;            "Path to the .smt2 file."

--- a/Blase/README.md
+++ b/Blase/README.md
@@ -90,6 +90,7 @@ pow2          | pow2      | Int → Int
 
 #### Algorithms Improvements TODO
 
+- [ ] Fix parameter order in pextract, make it `hi` then `lo` to match SMT-LIB. it's super confusing as-is.
 - [ ] Remove redundancy in parser; Don't need to store bitvector widths, can just compute it if needed.
 - [ ] Add an error printer of Term that prints only upto k level and then prints '..' for the rest.
 - [ ] add slt/sle support into QF_BV translation

--- a/Blase/README.md
+++ b/Blase/README.md
@@ -90,6 +90,8 @@ pow2          | pow2      | Int → Int
 
 #### Algorithms Improvements TODO
 
+
+- [ ] rename 'elimSub' into 'addSubPreconditions'
 - [ ] Fix parameter order in pextract, make it `hi` then `lo` to match SMT-LIB. it's super confusing as-is.
 - [ ] Remove redundancy in parser; Don't need to store bitvector widths, can just compute it if needed.
 - [ ] Add an error printer of Term that prints only upto k level and then prints '..' for the rest.

--- a/Blase/README.md
+++ b/Blase/README.md
@@ -90,6 +90,7 @@ pow2          | pow2      | Int → Int
 
 #### Algorithms Improvements TODO
 
+- [ ] Remove redundancy in parser; Don't need to store bitvector widths, can just compute it if needed.
 - [ ] Add an error printer of Term that prints only upto k level and then prints '..' for the rest.
 - [ ] add slt/sle support into QF_BV translation
 - [ ] Finish implementing new cases in 'toSingleWidthNondepTermGo'.


### PR DESCRIPTION
SMT-LIB defines its semantics of PBV over `Int`, and makes zero extend, sign extend, and extract partial functions when the widths are negative. In contract, we define our semantics of PBV over nat.

To bridge this gap, we define an interpretation of the SMT-LIB semantics where all subtractions are assumed to not result in negative numbers. That is, for any subterm `(w - v)`, we introduce a width precondition `w >= v`. Under this regime, our naive BMC solver correctly provides UNSAT for all of the PBV Alive dataset, showing that this is a sensible semantics. The PBV solver, leaves the cases when these happen as uninterpreted, one assumes, as per their spec. 

Moreover, this strategy of adding preconditions.

Stacked on https://github.com/opencompl/lean-mlir/pull/1975.  