### PR TITLE
feat/blase: report Lean initialization time as a stat

### DIFF
--- a/Blase/BlasewuzlaMain.lean
+++ b/Blase/BlasewuzlaMain.lean
@@ -184,9 +184,13 @@ structure Solver where
   run : Config → Nondep.Term → MetaM SolverExitCode
 
 unsafe def runMetaMAsIO (m : MetaM α) : IO α := do
+  -- Loading the Lean environment (bit-blasting / SAT-solving modules) is a fixed per-invocation
+  -- cost of ~150-200ms, paid before any translation or solving. Time it so we can benchmark it.
+  let tInitStart ← IO.monoMsNow
   initSearchPath (← findSysroot)
   enableInitializersExecution
   let env ← importModules #[`Std.Tactic.BVDecide, `Init, `Std] {} 0 (loadExts := true)
+  IO.println s!"initialization-time: {(← IO.monoMsNow) - tInitStart} ms"
   let coreContext : Core.Context := { fileName := "blasewuzla", fileMap := default }
   let coreState : Core.State := { env }
   let ctxMeta : Meta.Context := {}
@@ -396,9 +400,13 @@ def kinduction : Solver where
     let fsm := termFsm.toFsmZext
     let tBuilt ← IO.monoMsNow
 
-    -- Set up Lean TermElabM environment for the SAT solver
+    -- Set up Lean TermElabM environment for the SAT solver. NOTE: this re-imports the environment
+    -- that runMetaMAsIO already loaded, so k-induction pays the initialization cost twice; both are
+    -- timed (a k-induction run emits two 'initialization-time' lines that sum to its total).
+    let tInitStart ← IO.monoMsNow
     initSearchPath (← findSysroot)
     let env ← importModules #[`Std.Tactic.BVDecide, `Init] {} 0 (loadExts := true)
+    IO.println s!"initialization-time: {(← IO.monoMsNow) - tInitStart} ms"
     let coreContext : Core.Context := { fileName := "blasewuzla", fileMap := FileMap.ofString "" }
     let coreState : Core.State := { env }
     let ctxMeta : Meta.Context := {}


### PR DESCRIPTION
## What

Prints a new `initialization-time: X ms` stat measuring how long it takes to load the Lean environment (the bit-blasting / SAT-solving modules via `importModules`) on each solver invocation.

## Why

The `translation-time` + `solve-time` split we report sums to well below the total `Time elapsed`. Investigating: every invocation pays a fixed ~150–200ms cost to `importModules #[Std.Tactic.BVDecide, Init, Std]` (in `runMetaMAsIO`) *before* the translation/solve phases begin. This is inherent to running the verified Lean solver as a standalone per-problem binary; it is neither translation nor solving. This patch times it so we can benchmark the delta ourselves.

## How

Bracket the `importModules` step with `IO.monoMsNow` and `IO.println` the delta, at both load sites:
- `runMetaMAsIO` — the universal env load paid by every backend.
- `k-induction` — which **re-imports** the environment `runMetaMAsIO` already loaded, so it pays the cost twice; a k-induction run emits two `initialization-time` lines that sum to its total setup.

Printed unconditionally (cheap, useful without `--stats`). Nothing else changes — `translation-time` / `solve-time` / `solver-time` / `Time elapsed` / exit codes are untouched (verified `unsat` still exits 20).

## Sample output

`rIC3` on an alive problem:
```
initialization-time: 131 ms
translation-time: 0 ms
solve-time: 7 ms
solver-time: 164 ms
Time elapsed: 166 ms
```
`k-induction` (two init lines, summing to ~its solver-time − translate − solve gap):
```
initialization-time: 133 ms
initialization-time: 268 ms
translation-time: 0 ms
solve-time: 264 ms
solver-time: 693 ms
```

## Note / possible follow-up

The two k-induction `initialization-time` lines make the redundant double-load explicit: it re-imports an environment `runMetaMAsIO` already loaded. Removing that redundancy (reusing the ambient environment) would save ~270ms/run, but its `decideIfZerosVerified` currently builds its own Core/Meta/Term context, so that's a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)