### PR TITLE
feat/blase: report automaton state-space size in bits

### DIFF
--- a/Blase/Blase/Fast/FiniteStateMachine.lean
+++ b/Blase/Blase/Fast/FiniteStateMachine.lean
@@ -84,6 +84,13 @@ instance : Std.Associative Nat.add where
 def stateSpaceSize : Nat := Nat.pow 2 (FinEnum.card p.α)
 
 /--
+The number of state bits of the finite state machine, i.e. the number of
+registers/latches. This is the log-base-2 of `stateSpaceSize`, and is the
+honest, width-independent notion of "how large is the automaton's state space",
+as opposed to `circuitSize`, which counts the gates of the transition circuit. -/
+def numStateBits : Nat := FinEnum.card p.α
+
+/--
 Return the total size of the FSM as a function of all of its circuits.
 Note that this implicitly counts the size of the state space of the FSM,
 and consequently, is the natural notion of complexity of the FSM.

--- a/Blase/BlasewuzlaMain.lean
+++ b/Blase/BlasewuzlaMain.lean
@@ -455,7 +455,9 @@ Compute and print, to stdout, the sizes of the SAT/automaton problems built from
 - `mono-qfbv`: the predicate lowered to single width then translated to QF_BV.
 - `automaton`: the parametric FSM built for the k-induction/external backends.
 
-Each formula reports a structural node count and a post-bitblast AIG node count.
+Each QF_BV formula reports a structural node count and a post-bitblast AIG node count.
+For the automaton we report its state-space size in bits (number of registers/latches),
+its transition-circuit gate count, and its post-bitblast AIG node count.
 QF_BV sizes are computed at width `config.bound`; the automaton is width-independent.
 Out-of-fragment / non-translatable cases print `N/A`.
 -/
@@ -478,7 +480,8 @@ def printStats (config : Config) (predicate : Nondep.Term) : IO Unit := do
   IO.println s!"input-qfbv-aig-size: {fmtSize <| inputQfbv?.map bvLogicalExprAigSize}"
   IO.println s!"mono-qfbv-structural-size: {fmtSize <| monoQfbv?.map bvLogicalExprSize}"
   IO.println s!"mono-qfbv-aig-size: {fmtSize <| monoQfbv?.map bvLogicalExprAigSize}"
-  IO.println s!"automaton-structural-size: {fmtSize <| fsm?.map (·.circuitSize)}"
+  IO.println s!"automaton-state-bits: {fmtSize <| fsm?.map (·.numStateBits)}"
+  IO.println s!"automaton-circuit-size: {fmtSize <| fsm?.map (·.circuitSize)}"
   IO.println s!"automaton-aig-size: {fmtSize <| fsm?.map (·.toAiger.aig.aig.decls.size)}"
 where
   /-- Adapt the codebase's `(value, success?, errors)` result convention to `Option value`. -/


### PR DESCRIPTION
## What

The `dryrun` backend printed `automaton-structural-size`, which was actually the transition-circuit **gate count** (`FSM.circuitSize`) — not a state-space size, despite being reported (and used in the paper's evaluation table) as the "automaton state space size."

This PR makes the reported quantity honest:

- Rename the misleading field `automaton-structural-size` → **`automaton-circuit-size`** (it is a gate count; kept for our own diagnostics).
- Additionally print **`automaton-state-bits`**: the automaton's state-space size *in bits*, i.e. the number of registers/latches (`FinEnum.card α`). This is the width-independent notion of "how large is the automaton's state space," and is what the evaluation table now reports.
- Add `FSM.numStateBits` next to the existing `FSM.stateSpaceSize` (which is `2^numStateBits`).

## Example (`rover/add_assoc_2.smt2`, `--backend dryrun`)

```
automaton-state-bits: 163
automaton-circuit-size: 3964
automaton-aig-size: 317
```

## Testing

`lake build blasewuzla` succeeds; smoke-tested `--backend dryrun` prints the three automaton fields. No behavioral change to any solver backend or exit codes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)